### PR TITLE
fix typo on border radius section rounding sides separately docs

### DIFF
--- a/docs/source/docs/border-radius.blade.md
+++ b/docs/source/docs/border-radius.blade.md
@@ -146,7 +146,7 @@ Use the `.rounded-t`, `.rounded-r`, `.rounded-b`, or `.rounded-l` utilities to o
 <div class="rounded-t"></div>
 <div class="rounded-r"></div>
 <div class="rounded-b"></div>
-<div class="rounded-t"></div>
+<div class="rounded-l"></div>
 @endslot
 @endcomponent
 


### PR DESCRIPTION
fix a little typo `rounded-t` instead `rounded-l`