### PR TITLE
Fix directive name

### DIFF
--- a/docs/source/docs/functions-and-directives.blade.md
+++ b/docs/source/docs/functions-and-directives.blade.md
@@ -9,7 +9,7 @@ Tailwind exposes a few custom CSS functions and directives that can be used in y
 
 ### `@@tailwind`
 
-Use the `@@tailwind` directive to insert Tailwind's `reset` and `utilities` styles into your CSS. Here's a full example of how you might do this:
+Use the `@@tailwind` directive to insert Tailwind's `preflight` and `utilities` styles into your CSS. Here's a full example of how you might do this:
 
 ```less
 /**


### PR DESCRIPTION
My impression is that the name got changed to `preflight` but wasn't updated here. If that's not the case and `reset` was intentional, this PR can be closed.