### PR TITLE
Dash in comments is wrong

### DIFF
--- a/defaultConfig.js
+++ b/defaultConfig.js
@@ -609,7 +609,7 @@ module.exports = {
   | common use-cases like "1px". You can, of course, modify these
   | values as needed.
   |
-  | Class name: .p{-side?}-{size}
+  | Class name: .p{side?}-{size}
   |
   */
 
@@ -636,7 +636,7 @@ module.exports = {
   | common use-cases like "1px". You can, of course, modify these
   | values as needed.
   |
-  | Class name: .m{-side?}-{size}
+  | Class name: .m{side?}-{size}
   |
   */
 
@@ -663,7 +663,7 @@ module.exports = {
   | generally get used together. You can, of course, modify these
   | values as needed.
   |
-  | Class name: .-m{-side?}-{size}
+  | Class name: .-m{side?}-{size}
   |
   */
 


### PR DESCRIPTION
For margin/padding utilities there is a dash in the comment.
The rendered css-classes look like that: ```.mt-4``` so i think the comments are wrong.