### PR TITLE
Fix issue with config option not being respected in `tailwind build`

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -75,7 +75,7 @@ program.command('build')
       process.exit(1)
     }
 
-    buildTailwind(inputFile, loadConfig(program.config), writeStrategy(options))
+    buildTailwind(inputFile, loadConfig(options.config), writeStrategy(options))
       .then(function () {
         process.exit()
       })


### PR DESCRIPTION
Same issue as we were seeing with output files, I'm a dummy for missing
this and tagging.