### PR TITLE
Fix apostrophes

### DIFF
--- a/docs/source/docs/adding-new-utilities.blade.md
+++ b/docs/source/docs/adding-new-utilities.blade.md
@@ -84,7 +84,7 @@ If you'd like to create responsive versions of your own utilities based on the b
 }
 ```
 
-Tailwind will intelligently group the responsive versions into it's existing media queries which are output at the very end of the stylesheet. This ensures that any responsive utilities will always take precedence over unprefixed utilities.
+Tailwind will intelligently group the responsive versions into its existing media queries which are output at the very end of the stylesheet. This ensures that any responsive utilities will always take precedence over unprefixed utilities.
 
 The above code would generate CSS that looks something like this:
 

--- a/docs/source/docs/flexbox-flex-grow-shrink.blade.md
+++ b/docs/source/docs/flexbox-flex-grow-shrink.blade.md
@@ -29,17 +29,17 @@ title: "Flex, Grow, & Shrink - Flexbox"
             <tr>
                 <td class="p-2 border-t border-smoke font-mono text-xs text-purple-dark">.flex-initial</td>
                 <td class="p-2 border-t border-smoke font-mono text-xs text-blue-dark">flex: initial;</td>
-                <td class="p-2 border-t border-smoke text-sm text-grey-darker">Allow a flex item to shrink but not grow, taking into account it's initial size.</td>
+                <td class="p-2 border-t border-smoke text-sm text-grey-darker">Allow a flex item to shrink but not grow, taking into account its initial size.</td>
             </tr>
             <tr>
                 <td class="p-2 border-t border-smoke-light font-mono text-xs text-purple-dark">.flex-1</td>
                 <td class="p-2 border-t border-smoke-light font-mono text-xs text-blue-dark">flex: 1;</td>
-                <td class="p-2 border-t border-smoke-light text-sm text-grey-darker">Allow a flex item to grow and shrink as needed, ignoring it's initial size.</td>
+                <td class="p-2 border-t border-smoke-light text-sm text-grey-darker">Allow a flex item to grow and shrink as needed, ignoring its initial size.</td>
             </tr>
             <tr>
                 <td class="p-2 border-t border-smoke-light font-mono text-xs text-purple-dark">.flex-auto</td>
                 <td class="p-2 border-t border-smoke-light font-mono text-xs text-blue-dark">flex: auto;</td>
-                <td class="p-2 border-t border-smoke-light text-sm text-grey-darker">Allow a flex item to grow and shrink, taking into account it's initial size.</td>
+                <td class="p-2 border-t border-smoke-light text-sm text-grey-darker">Allow a flex item to grow and shrink, taking into account its initial size.</td>
             </tr>
             <tr>
                 <td class="p-2 border-t border-smoke-light font-mono text-xs text-purple-dark">.flex-none</td>
@@ -72,7 +72,7 @@ title: "Flex, Grow, & Shrink - Flexbox"
 
 ### Initial <span class="ml-2 font-semibold text-slate-light text-sm uppercase tracking-wide">Default</span>
 
-Use `.flex-initial` to allow a flex item to shrink but not grow, taking into account it's initial size:
+Use `.flex-initial` to allow a flex item to shrink but not grow, taking into account its initial size:
 
 @component('_partials.code-sample')
 <p class="text-sm text-slate-light mb-1">Items don't grow when there's extra space</p>
@@ -124,7 +124,7 @@ Use `.flex-initial` to allow a flex item to shrink but not grow, taking into acc
 
 ### Flex 1
 
-Use `.flex-1` to allow a flex item to grow and shrink as needed, ignoring it's initial size:
+Use `.flex-1` to allow a flex item to grow and shrink as needed, ignoring its initial size:
 
 @component('_partials.code-sample')
 <p class="text-sm text-slate-light mb-1">Default behavior</p>
@@ -169,7 +169,7 @@ Use `.flex-1` to allow a flex item to grow and shrink as needed, ignoring it's i
 
 ### Auto
 
-Use `.flex-auto` to allow a flex item to grow and shrink, taking into account it's initial size:
+Use `.flex-auto` to allow a flex item to grow and shrink, taking into account its initial size:
 
 @component('_partials.code-sample')
 <p class="text-sm text-slate-light mb-1">Default behavior</p>
@@ -294,7 +294,7 @@ Use `.flex-no-shrink` to prevent a flex item from shrinking:
         Item that can shrink if needed
     </div>
     <div class="flex-no-shrink text-slate-dark text-center bg-smoke-dark px-4 py-2 m-2">
-        Item that cannot shrink below it's initial size
+        Item that cannot shrink below its initial size
     </div>
     <div class="flex-shrink text-slate text-center bg-smoke px-4 py-2 m-2">
         Item that can shrink if needed

--- a/docs/source/docs/flexbox.blade.md
+++ b/docs/source/docs/flexbox.blade.md
@@ -407,7 +407,7 @@ Use `.content-around` to distribute lines in a flex container such that there is
 
 ### 1
 
-Use `.flex-1` to allow a flex item to grow and shrink as needed, ignoring it's initial size:
+Use `.flex-1` to allow a flex item to grow and shrink as needed, ignoring its initial size:
 
 @component('_partials.code-sample')
 <p class="text-sm text-slate-light mb-1">Default behavior</p>
@@ -452,7 +452,7 @@ Use `.flex-1` to allow a flex item to grow and shrink as needed, ignoring it's i
 
 ### Auto
 
-Use `.flex-auto` to allow a flex item to grow and shrink, taking into account it's initial size:
+Use `.flex-auto` to allow a flex item to grow and shrink, taking into account its initial size:
 
 @component('_partials.code-sample')
 <p class="text-sm text-slate-light mb-1">Default behavior</p>
@@ -515,7 +515,7 @@ Use `.flex-none` to prevent a flex item from growing or shrinking:
 
 ### Initial
 
-Use `.flex-initial` to allow a flex item to shrink but not grow, taking into account it's initial size *(this is also the default behavior)*:
+Use `.flex-initial` to allow a flex item to shrink but not grow, taking into account its initial size *(this is also the default behavior)*:
 
 @component('_partials.code-sample')
 <p class="text-sm text-slate-light mb-1">Items don't grow when there's extra space</p>
@@ -637,7 +637,7 @@ Use `.flex-no-shrink` to prevent a flex item from shrinking:
         Item that can shrink if needed
     </div>
     <div class="flex-no-shrink text-slate-dark text-center bg-smoke-dark px-4 py-2 m-2">
-        Item that cannot shrink below it's initial size
+        Item that cannot shrink below its initial size
     </div>
     <div class="flex-shrink text-slate text-center bg-smoke px-4 py-2 m-2">
         Item that can shrink if needed

--- a/docs/source/docs/visibility.blade.md
+++ b/docs/source/docs/visibility.blade.md
@@ -57,7 +57,7 @@ Use `.visible` to make an element visible. This will typically be used as a rese
 
 ### Invisible
 
-Use `.invisible` to hide an element, but still maintain it's space.
+Use `.invisible` to hide an element, but still maintain its space.
 
 @component('_partials.code-sample', ['class' => 'flex justify-center'])
 <div class="invisible bg-smoke w-24 h-24 rounded-full"></div>


### PR DESCRIPTION
Apostrophes not needed when indicating possession