### PR TITLE
Clear up wording of the Advanced screens section.

### DIFF
--- a/docs/source/docs/responsive-design.blade.md
+++ b/docs/source/docs/responsive-design.blade.md
@@ -122,8 +122,8 @@ screens: {
   'sm': '500px',
   'md': [
     // Sidebar appears at 768px, so revert to `sm:` styles between 768px
-    // and 868px, which is when the main content area is wide enough to
-    // apply `md:` styles again.
+    // and 868px, after which the main content area is wide enough again to
+    // apply the `md:` styles.
     {'min': '668px', 'max': '767px'},
     {'min': '868px'}
   ],


### PR DESCRIPTION
First of all, thank you for the amazing work guys. I've been waiting for the premier for a while now and I'm crazy excited about it! Going through the docs and intend to put this into use ASAP.

Secondly, I didn't know if it's okay to PR against master or I should have created a feature branch (not sure what's the best practice for this project) so I apologise for potential mistake :).

Lastly:

The initial form of the comment seemed to claim that main content area is wide enough to apply md: styles between 768px and 868px, which is not what you guys meant. I'm not a native speaker, but I think I've cleared up the wording, because the sentence seemed to contradict itself. Of course, you can still improve my change with even better wording.

I understand that the example shown says:
Apply sm from 500px upwards.
Apply md from 668px to 767px.
Revert to sm here.
Apply md from 868px upwards.

Thanks!