### PR TITLE
Build dist assets on prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   "scripts": {
     "prebabelify": "rimraf lib",
     "babelify": "babel src --out-dir lib",
-    "prepare": "npm run babelify",
-    "build": "npm run babelify && babel-node src/build.js",
+    "prepare": "npm run babelify && babel-node src/build.js",
     "watch": "nodemon -e js,css --watch src --exec 'babel-node src/build.js'",
     "test": "jest"
   },


### PR DESCRIPTION
Removes the separate build command and just always builds our dist files on `npm run prepare`.

This makes sure we never accidentally publish a release that doesn't have up to date dist files for CDNs like unpkg and jsdelivr.