### PR TITLE
[0.2] Simplify margin auto utilities

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -2959,36 +2959,6 @@ button,
   margin: 2rem;
 }
 
-.mt-px {
-  margin-top: 1px;
-}
-
-.mr-px {
-  margin-right: 1px;
-}
-
-.mb-px {
-  margin-bottom: 1px;
-}
-
-.ml-px {
-  margin-left: 1px;
-}
-
-.mx-px {
-  margin-left: 1px;
-  margin-right: 1px;
-}
-
-.my-px {
-  margin-top: 1px;
-  margin-bottom: 1px;
-}
-
-.m-px {
-  margin: 1px;
-}
-
 .mt-auto {
   margin-top: auto;
 }
@@ -3017,6 +2987,36 @@ button,
 
 .m-auto {
   margin: auto;
+}
+
+.mt-px {
+  margin-top: 1px;
+}
+
+.mr-px {
+  margin-right: 1px;
+}
+
+.mb-px {
+  margin-bottom: 1px;
+}
+
+.ml-px {
+  margin-left: 1px;
+}
+
+.mx-px {
+  margin-left: 1px;
+  margin-right: 1px;
+}
+
+.my-px {
+  margin-top: 1px;
+  margin-bottom: 1px;
+}
+
+.m-px {
+  margin: 1px;
 }
 
 .-mt-0 {
@@ -5919,36 +5919,6 @@ button,
     margin: 2rem;
   }
 
-  .sm\:mt-px {
-    margin-top: 1px;
-  }
-
-  .sm\:mr-px {
-    margin-right: 1px;
-  }
-
-  .sm\:mb-px {
-    margin-bottom: 1px;
-  }
-
-  .sm\:ml-px {
-    margin-left: 1px;
-  }
-
-  .sm\:mx-px {
-    margin-left: 1px;
-    margin-right: 1px;
-  }
-
-  .sm\:my-px {
-    margin-top: 1px;
-    margin-bottom: 1px;
-  }
-
-  .sm\:m-px {
-    margin: 1px;
-  }
-
   .sm\:mt-auto {
     margin-top: auto;
   }
@@ -5977,6 +5947,36 @@ button,
 
   .sm\:m-auto {
     margin: auto;
+  }
+
+  .sm\:mt-px {
+    margin-top: 1px;
+  }
+
+  .sm\:mr-px {
+    margin-right: 1px;
+  }
+
+  .sm\:mb-px {
+    margin-bottom: 1px;
+  }
+
+  .sm\:ml-px {
+    margin-left: 1px;
+  }
+
+  .sm\:mx-px {
+    margin-left: 1px;
+    margin-right: 1px;
+  }
+
+  .sm\:my-px {
+    margin-top: 1px;
+    margin-bottom: 1px;
+  }
+
+  .sm\:m-px {
+    margin: 1px;
   }
 
   .sm\:-mt-0 {
@@ -8880,36 +8880,6 @@ button,
     margin: 2rem;
   }
 
-  .md\:mt-px {
-    margin-top: 1px;
-  }
-
-  .md\:mr-px {
-    margin-right: 1px;
-  }
-
-  .md\:mb-px {
-    margin-bottom: 1px;
-  }
-
-  .md\:ml-px {
-    margin-left: 1px;
-  }
-
-  .md\:mx-px {
-    margin-left: 1px;
-    margin-right: 1px;
-  }
-
-  .md\:my-px {
-    margin-top: 1px;
-    margin-bottom: 1px;
-  }
-
-  .md\:m-px {
-    margin: 1px;
-  }
-
   .md\:mt-auto {
     margin-top: auto;
   }
@@ -8938,6 +8908,36 @@ button,
 
   .md\:m-auto {
     margin: auto;
+  }
+
+  .md\:mt-px {
+    margin-top: 1px;
+  }
+
+  .md\:mr-px {
+    margin-right: 1px;
+  }
+
+  .md\:mb-px {
+    margin-bottom: 1px;
+  }
+
+  .md\:ml-px {
+    margin-left: 1px;
+  }
+
+  .md\:mx-px {
+    margin-left: 1px;
+    margin-right: 1px;
+  }
+
+  .md\:my-px {
+    margin-top: 1px;
+    margin-bottom: 1px;
+  }
+
+  .md\:m-px {
+    margin: 1px;
   }
 
   .md\:-mt-0 {
@@ -11841,36 +11841,6 @@ button,
     margin: 2rem;
   }
 
-  .lg\:mt-px {
-    margin-top: 1px;
-  }
-
-  .lg\:mr-px {
-    margin-right: 1px;
-  }
-
-  .lg\:mb-px {
-    margin-bottom: 1px;
-  }
-
-  .lg\:ml-px {
-    margin-left: 1px;
-  }
-
-  .lg\:mx-px {
-    margin-left: 1px;
-    margin-right: 1px;
-  }
-
-  .lg\:my-px {
-    margin-top: 1px;
-    margin-bottom: 1px;
-  }
-
-  .lg\:m-px {
-    margin: 1px;
-  }
-
   .lg\:mt-auto {
     margin-top: auto;
   }
@@ -11899,6 +11869,36 @@ button,
 
   .lg\:m-auto {
     margin: auto;
+  }
+
+  .lg\:mt-px {
+    margin-top: 1px;
+  }
+
+  .lg\:mr-px {
+    margin-right: 1px;
+  }
+
+  .lg\:mb-px {
+    margin-bottom: 1px;
+  }
+
+  .lg\:ml-px {
+    margin-left: 1px;
+  }
+
+  .lg\:mx-px {
+    margin-left: 1px;
+    margin-right: 1px;
+  }
+
+  .lg\:my-px {
+    margin-top: 1px;
+    margin-bottom: 1px;
+  }
+
+  .lg\:m-px {
+    margin: 1px;
   }
 
   .lg\:-mt-0 {
@@ -14802,36 +14802,6 @@ button,
     margin: 2rem;
   }
 
-  .xl\:mt-px {
-    margin-top: 1px;
-  }
-
-  .xl\:mr-px {
-    margin-right: 1px;
-  }
-
-  .xl\:mb-px {
-    margin-bottom: 1px;
-  }
-
-  .xl\:ml-px {
-    margin-left: 1px;
-  }
-
-  .xl\:mx-px {
-    margin-left: 1px;
-    margin-right: 1px;
-  }
-
-  .xl\:my-px {
-    margin-top: 1px;
-    margin-bottom: 1px;
-  }
-
-  .xl\:m-px {
-    margin: 1px;
-  }
-
   .xl\:mt-auto {
     margin-top: auto;
   }
@@ -14860,6 +14830,36 @@ button,
 
   .xl\:m-auto {
     margin: auto;
+  }
+
+  .xl\:mt-px {
+    margin-top: 1px;
+  }
+
+  .xl\:mr-px {
+    margin-right: 1px;
+  }
+
+  .xl\:mb-px {
+    margin-bottom: 1px;
+  }
+
+  .xl\:ml-px {
+    margin-left: 1px;
+  }
+
+  .xl\:mx-px {
+    margin-left: 1px;
+    margin-right: 1px;
+  }
+
+  .xl\:my-px {
+    margin-top: 1px;
+    margin-bottom: 1px;
+  }
+
+  .xl\:m-px {
+    margin: 1px;
   }
 
   .xl\:-mt-0 {

--- a/defaultConfig.js
+++ b/defaultConfig.js
@@ -644,6 +644,7 @@ module.exports = {
   */
 
   margin: {
+    'auto': 'auto',
     'px': '1px',
     '0': '0',
     '1': '0.25rem',

--- a/docs/source/docs/spacing.blade.md
+++ b/docs/source/docs/spacing.blade.md
@@ -49,6 +49,6 @@ For example, `.pt-2` would add `.5rem` of padding to the top of the element, `.m
         <div><code class="inline-block my-1 mr-1 px-2 py-1 font-mono border rounded">6</code> 1.5rem</div>
         <div><code class="inline-block my-1 mr-1 px-2 py-1 font-mono border rounded">8</code> 2rem</div>
         <div><code class="inline-block my-1 mr-1 px-1 py-1 font-mono border rounded">px</code> 1px</div>
-        <div><code class="inline-block my-1 mr-1 px-1 py-1 font-mono border rounded">auto</code> auto <span class="text-slate-light text-xs">(horizontal margins only)</span></div>
+        <div><code class="inline-block my-1 mr-1 px-1 py-1 font-mono border rounded">auto</code> auto <span class="text-slate-light text-xs">(margins only)</span></div>
     </div>
 </div>

--- a/src/generators/spacing.js
+++ b/src/generators/spacing.js
@@ -97,31 +97,6 @@ export default function({ padding, margin, negativeMargin }) {
   return _.flatten([
     definePadding(padding),
     defineMargin(margin),
-    defineClasses({
-      'mt-auto': {
-        'margin-top': 'auto',
-      },
-      'mr-auto': {
-        'margin-right': 'auto',
-      },
-      'mb-auto': {
-        'margin-bottom': 'auto',
-      },
-      'ml-auto': {
-        'margin-left': 'auto',
-      },
-      'mx-auto': {
-        'margin-left': 'auto',
-        'margin-right': 'auto',
-      },
-      'my-auto': {
-        'margin-top': 'auto',
-        'margin-bottom': 'auto',
-      },
-      'm-auto': {
-        margin: 'auto',
-      },
-    }),
     defineNegativeMargin(negativeMargin),
   ])
 }


### PR DESCRIPTION
This is step 2 of #82.

This removes the custom generated margin-auto utilities and simply adds `auto` to margins in the default config.

This is breaking change, and shouldn't be merged in until the next breaking release.