### PR TITLE
Add default cursor option

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3509,6 +3509,10 @@ button,
   cursor: auto;
 }
 
+.cursor-default {
+  cursor: default;
+}
+
 .cursor-pointer {
   cursor: pointer;
 }
@@ -6450,6 +6454,10 @@ button,
 
   .sm\:cursor-auto {
     cursor: auto;
+  }
+
+  .sm\:cursor-default {
+    cursor: default;
   }
 
   .sm\:cursor-pointer {
@@ -9396,6 +9404,10 @@ button,
     cursor: auto;
   }
 
+  .md\:cursor-default {
+    cursor: default;
+  }
+
   .md\:cursor-pointer {
     cursor: pointer;
   }
@@ -12340,6 +12352,10 @@ button,
     cursor: auto;
   }
 
+  .lg\:cursor-default {
+    cursor: default;
+  }
+
   .lg\:cursor-pointer {
     cursor: pointer;
   }
@@ -15282,6 +15298,10 @@ button,
 
   .xl\:cursor-auto {
     cursor: auto;
+  }
+
+  .xl\:cursor-default {
+    cursor: default;
   }
 
   .xl\:cursor-pointer {

--- a/src/generators/cursor.js
+++ b/src/generators/cursor.js
@@ -3,6 +3,7 @@ import defineClasses from '../util/defineClasses'
 export default function() {
   return defineClasses({
     'cursor-auto': { 'cursor': 'auto' },
+    'cursor-default': { 'cursor': 'default' },
     'cursor-pointer': { 'cursor': 'pointer' },
     'cursor-not-allowed': { 'cursor': 'not-allowed' },
   })


### PR DESCRIPTION
It is somewhat cumbersome to undo `cursor-pointer` class and cannot be done with tailwind itself at the time of this PR. For example imagine a navigation where all `li` tags need to show as links but the currently active one. Consider below.
```
li {
    @apply .cursor-pointer;

    &.active {
        cursor: default; // no tailwind option
    }
}
```

Yes, one could do it with more complex selectors (see below), but it's much simpler to have the extra option available when needed (see even below - after the change).
```
li {
    &:not(.active) {
        @apply .cursor-pointer;
    }
}
```

After-PR option:
```
li {
    @apply .cursor-pointer;

    &.active {
        @apply .cursor-default;
    }
}
```
