### PR TITLE
Add `@important` at-rule

### DIFF
--- a/__tests__/importantAtRule.test.js
+++ b/__tests__/importantAtRule.test.js
@@ -1,0 +1,29 @@
+import postcss from 'postcss'
+import plugin from '../src/lib/substituteImportantAtRules'
+
+function run(input, opts = () => {}) {
+  return postcss([plugin(opts)]).process(input)
+}
+
+test("it makes every property of every nested rule !important", () => {
+  const input = `
+    .foo { color: blue; }
+    @important {
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+    }
+    .bar { color: red; }
+  `
+
+  const output = `
+    .foo { color: blue; }
+    .banana { color: yellow !important; }
+    .chocolate { color: brown !important; }
+    .bar { color: red; }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toEqual(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import evaluateTailwindFunctions from './lib/evaluateTailwindFunctions'
 import generateUtilities from './lib/generateUtilities'
 import substituteHoverableAtRules from './lib/substituteHoverableAtRules'
 import substituteFocusableAtRules from './lib/substituteFocusableAtRules'
+import substituteImportantAtRules from './lib/substituteImportantAtRules'
 import substituteResponsiveAtRules from './lib/substituteResponsiveAtRules'
 import substituteScreenAtRules from './lib/substituteScreenAtRules'
 import substituteClassApplyAtRules from './lib/substituteClassApplyAtRules'
@@ -37,6 +38,7 @@ const plugin = postcss.plugin('tailwind', (config) => {
     generateUtilities(lazyConfig),
     substituteHoverableAtRules(lazyConfig),
     substituteFocusableAtRules(lazyConfig),
+    substituteImportantAtRules(lazyConfig),
     substituteResponsiveAtRules(lazyConfig),
     substituteScreenAtRules(lazyConfig),
     substituteClassApplyAtRules(lazyConfig),

--- a/src/lib/substituteImportantAtRules.js
+++ b/src/lib/substituteImportantAtRules.js
@@ -1,0 +1,15 @@
+import _ from 'lodash'
+import postcss from 'postcss'
+import cloneNodes from '../util/cloneNodes'
+
+export default function(config) {
+  return function (css) {
+    const options = config()
+
+    css.walkAtRules('important', atRule => {
+      atRule.walkDecls(decl => decl.important = true)
+      atRule.before(cloneNodes(atRule.nodes))
+      atRule.remove()
+    })
+  }
+}


### PR DESCRIPTION
Wrapping a set of rules with this at-rule will make every single property in those classes !important.

I don't intend to use this in core, but it's really useful for folks who want to use Tailwind on top of an existing base of CSS where the non-important versions of our utilities might not be enough to defeat the specificity of their existing styles.

Using this at-rule, someone could import Tailwind into their codebase like this:

```
@important {
  @tailwind utilities;
}
```

...and then all of their Tailwind utilities would be !important, making it easy to use them to override their existing CSS.

This at-rule is processed *after* generating utilities but *before* generating responsive variants, so if you make your utilities important, the responsive utilities will automatically be important too.

@psren you'll probably be interested in this one :) I still want to merge your PR for the `screen-utilities` marker because I think it's useful either way, but want to talk over naming with other folks on the team first.