### PR TITLE
Fix 'backgrond' typo in installation docs.

### DIFF
--- a/docs/source/docs/installation.blade.md
+++ b/docs/source/docs/installation.blade.md
@@ -79,7 +79,7 @@ To avoid specificity issues, we highly recommend structuring your main styleshee
  *
  * Or if using a preprocessor..
  * 
- * @@import "utilities/backgrond-patterns";
+ * @@import "utilities/background-patterns";
  * @@import "utilities/skew-transforms";
  */
 ```


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/151829/32499572-ee0fb630-c3a0-11e7-8796-28a5ce25e04d.png)

Who doesn't love a single-character pull request? 😘 