### PR TITLE
Should @apply omit the !important or not

### DIFF
--- a/__tests__/applyAtRule.test.js
+++ b/__tests__/applyAtRule.test.js
@@ -50,3 +50,12 @@ test('it fails if the class does not exist', () => {
     expect(error.reason).toEqual('No .a class found.')
   })
 })
+
+test('it ignores !important', () => {
+  const output = '.a { color: red !important; } .b { color: red; }'
+
+  return run('.a { color: red !important; } .b { @apply .a; }').then(result => {
+    expect(result.css).toEqual(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})


### PR DESCRIPTION
Hey there,

I am a huge fan of ```!important``` as you already noticed ;-)
In https://github.com/tailwindcss/tailwindcss/pull/99 there is an ongoing PR to add some !important functionality to tailwind.

I am **not** sure how to use it in combination with ```@apply```.

There are 3 Possibilities.

## 1. remove ```!important``` of declarations from ```@apply```


Input
```css
.a { color: red !important; }
.b { @apply .a; }
```

Output
```css
.a { color: red !important; }
.b { color: red; }
```

The ```!important``` is removed.
I can add it again if I do something like that.

Input
```css
.a { color: red !important; }
.b { @important { @apply .a; } }
```

Output
```css
.a { color: red !important; }
.b { color: red !important; }
```

## 2. keep ```!important``` of declarations from ```@apply```

Input
```css
.a { color: red !important; }
.b { @apply .a; }
```

Output
```css
.a { color: red !important; }
.b { color: red !important; }
```

I have no possibility to remove the ```!important``` easily of class ```.b```

## 3. keep ```!important``` of declarations from ```@apply``` but allow removing

Input
```css
.a { color: red !important; }
.b { @apply .a; }
```

Output
```css
.a { color: red !important; }
.b { color: red !important; }
```

Input
```css
.a { color: red !important; }
.b { @unimportant { @apply .a;} }
```

Output
```css
.a { color: red !important; }
.b { color: red; }
```

# Opinion

In my opinion utilities used in CSS directly should be important.
One should not be able to overwrite it easily (See [The Importantce of !important by csswizardry](https://csswizardry.com/2016/05/the-importance-of-important/)).

When used in objects, the Base-Objects should not be altered but be immutable.
Instead it should be modified through *modifiers*.
This is [The open/closed principle applied to CSS](https://csswizardry.com/2012/06/the-open-closed-principle-applied-to-css/).

*(For "modifier" see [BEM](https://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/), this links is just for documentation purpose when somebody less experienced stumbles upon this issue)*

If ```@apply``` copies ```!important``` the modifier cannot be modify the base-element easily.
So Option 2 fails here IMO leaving options 1 and 3 there.

Solution 1 has some "magic". I don't like magic.
But I like the solution more that Number 3 because it does not need any extra effort to write the correct CSS.

What do you think?

I added a failing test with my favor expectation.