### PR TITLE
Fix path issues in CLI

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -8,19 +8,6 @@ import postcss from 'postcss'
 import process from 'process'
 import program from 'commander'
 
-function loadConfig(configPath) {
-  if (configPath === undefined) {
-    return undefined
-  }
-
-  if (!fs.existsSync(path.resolve(configPath))) {
-    console.error(`Config file [${configPath}] does not exist.`)
-    process.exit(1)
-  }
-
-  return require(path.resolve(configPath))
-}
-
 function writeStrategy(options) {
   if (options.output === undefined) {
     return output => {
@@ -46,7 +33,7 @@ function buildTailwind(inputFile, config, write) {
     .catch(error => console.log(error))
 }
 
-const packageJson = require(path.resolve(__dirname, '/../package.json'))
+const packageJson = require(path.resolve(__dirname, '../package.json'))
 
 program.version(packageJson.version).usage('<command> [<args>]')
 
@@ -65,7 +52,7 @@ program
       process.exit(1)
     }
 
-    const output = fs.readFileSync(path.resolve(__dirname, '/../defaultConfig.js'), 'utf8')
+    const output = fs.readFileSync(path.resolve(__dirname, '../defaultConfig.js'), 'utf8')
     fs.outputFileSync(destination, output.replace('// var defaultConfig', 'var defaultConfig'))
     process.exit()
   })
@@ -83,7 +70,7 @@ program
       process.exit(1)
     }
 
-    buildTailwind(inputFile, loadConfig(options.config), writeStrategy(options)).then(() => {
+    buildTailwind(inputFile, options.config, writeStrategy(options)).then(() => {
       process.exit()
     })
   })


### PR DESCRIPTION
Resolves #147.

When enforcing our lint rules, a subtle bug was introduced where paths were being resolved to the root of the file system instead of relative to where the CLI source file was located.

This is because of the leading slash in the second argument to `path.resolve`:

```
path.resolve(__dirname, '/../package.json')
```

Originally this was written as:

```
path.resolve(__dirname + '/../package.json')
```

...which worked fine, but failed ESLint. Swapping the `+` for a `,` caused `path.resolve` to treat the second path as absolute and resolve to just that path on it's own.

This change gets rid of the leading slash so the path is properly resolved as relative to `__dirname`.

This change also stops the CLI from loading the user's config file before passing it in for processing. Previously we supported passing a config object rather than just a path, but when removing that option, we made the mistake of not updating the CLI tool to pass a path instead of an object.