### PR TITLE
Add small-caps to Style & Decoration

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -1158,6 +1158,16 @@ button,
   text-transform: capitalize;
 }
 
+.all-small-caps,
+.hover\:all-small-caps:hover {
+  font-variant: all-small-caps;
+}
+
+.small-caps,
+.hover\:small-caps:hover {
+  font-variant: small-caps;
+}
+
 .normal-case,
 .hover\:normal-case:hover {
   text-transform: none;
@@ -4120,6 +4130,16 @@ button,
   .sm\:capitalize,
   .sm\:hover\:capitalize:hover {
     text-transform: capitalize;
+  }
+
+  .sm\:all-small-caps,
+  .sm\:hover\:all-small-caps:hover {
+    font-variant: all-small-caps;
+  }
+
+  .sm\:small-caps,
+  .sm\:hover\:small-caps:hover {
+    font-variant: small-caps;
   }
 
   .sm\:normal-case,
@@ -7087,6 +7107,16 @@ button,
     text-transform: capitalize;
   }
 
+  .md\:all-small-caps,
+  .md\:hover\:all-small-caps:hover {
+    font-variant: all-small-caps;
+  }
+
+  .md\:small-caps,
+  .md\:hover\:small-caps:hover {
+    font-variant: small-caps;
+  }
+
   .md\:normal-case,
   .md\:hover\:normal-case:hover {
     text-transform: none;
@@ -10052,6 +10082,16 @@ button,
     text-transform: capitalize;
   }
 
+  .lg\:all-small-caps,
+  .lg\:hover\:all-small-caps:hover {
+    font-variant: all-small-caps;
+  }
+
+  .lg\:small-caps,
+  .lg\:hover\:small-caps:hover {
+    font-variant: small-caps;
+  }
+
   .lg\:normal-case,
   .lg\:hover\:normal-case:hover {
     text-transform: none;
@@ -13015,6 +13055,16 @@ button,
   .xl\:capitalize,
   .xl\:hover\:capitalize:hover {
     text-transform: capitalize;
+  }
+
+  .xl\:all-small-caps,
+  .xl\:hover\:all-small-caps:hover {
+    font-variant: all-small-caps;
+  }
+
+  .xl\:small-caps,
+  .xl\:hover\:small-caps:hover {
+    font-variant: small-caps;
   }
 
   .xl\:normal-case,

--- a/docs/source/docs/text-style.blade.md
+++ b/docs/source/docs/text-style.blade.md
@@ -51,6 +51,16 @@ features:
         <td class="p-2 border-t border-smoke-light font-mono text-xs text-blue-dark">text-transform: capitalize;</td>
         <td class="p-2 border-t border-smoke-light text-sm text-grey-darker">Capitalizes the text within an element.</td>
       </tr>
+			<tr>
+				<td class="p-2 border-t border-smoke-light font-mono text-xs text-purple-dark">.small-caps</td>
+				<td class="p-2 border-t border-smoke-light font-mono text-xs text-blue-dark">font-variant: small-caps;</td>
+				<td class="p-2 border-t border-smoke-light text-sm text-grey-darker">Uses small capital glyphs for the text within an element.</td>
+			</tr>
+			<tr>
+				<td class="p-2 border-t border-smoke-light font-mono text-xs text-purple-dark">.small-caps-all</td>
+				<td class="p-2 border-t border-smoke-light font-mono text-xs text-blue-dark">font-variant: small-caps-all;</td>
+				<td class="p-2 border-t border-smoke-light text-sm text-grey-darker">Uses small capital glyphs for uppercase and lowercase letters within an element.</td>
+			</tr>
       <tr>
         <td class="p-2 border-t border-smoke-light font-mono text-xs text-purple-dark">.normal-case</td>
         <td class="p-2 border-t border-smoke-light font-mono text-xs text-blue-dark">text-transform: none;</td>

--- a/src/generators/textStyle.js
+++ b/src/generators/textStyle.js
@@ -10,6 +10,8 @@ export default function() {
       uppercase: { 'text-transform': 'uppercase' },
       lowercase: { 'text-transform': 'lowercase' },
       capitalize: { 'text-transform': 'capitalize' },
+      'all-small-caps': { 'font-variant': 'all-small-caps' },
+      'small-caps': { 'font-variant': 'small-caps' },
       'normal-case': { 'text-transform': 'none' },
 
       underline: { 'text-decoration': 'underline' },


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
Hi !
I realize just now I haven't created an issue to first discuss this PR, but I would consider it still a "fun experience" to see that PR refused. Anyway, here's my suggestion for adding small-caps and all-small-caps to the Style & Decoration section.

Thanks for your great work guys !

Xavier