### PR TITLE
Setup Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: php
+php:
+  - '7.1'
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - $HOME/.cache/yarn
+
+script:
+  - yarn
+  - yarn run test
+  - cd $TRAVIS_BUILD_DIR/docs && composer self-update
+  - cd $TRAVIS_BUILD_DIR/docs && composer install --prefer-dist --no-interaction
+  - cd $TRAVIS_BUILD_DIR/docs && yarn
+  - cd $TRAVIS_BUILD_DIR/docs && yarn run dev

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -6,3 +6,4 @@
 /source/js/
 /source/mix-manifest.json
 /tailwind.json
+/_tmp

--- a/docs/webpack.mix.js
+++ b/docs/webpack.mix.js
@@ -13,7 +13,11 @@ const env = argv.e || argv.env || 'local'
 const plugins = [
     new OnBuild(() => {
         command.get('./vendor/bin/jigsaw build ' + env, (error, stdout, stderr) => {
-            console.log(error ? stderr : stdout)
+            if (error) {
+                console.log(stderr)
+                process.exit(1)
+            }
+            console.log(stdout)
         })
     }),
     new Watch({


### PR DESCRIPTION
Codeship is awesome but they don't have public build logs, so when someone submits a PR that fails, they can't look at the build and see what went wrong.

This PR sets everything up for us to use Travis, and also builds the documentation as part of the build to make sure that we don't accidentally merge anything that breaks the docs site.