### PR TITLE
Add cursor-default utility

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3533,6 +3533,10 @@ button,
   cursor: auto;
 }
 
+.cursor-default {
+  cursor: default;
+}
+
 .cursor-pointer {
   cursor: pointer;
 }
@@ -6491,6 +6495,10 @@ button,
 
   .sm\:cursor-auto {
     cursor: auto;
+  }
+
+  .sm\:cursor-default {
+    cursor: default;
   }
 
   .sm\:cursor-pointer {
@@ -9454,6 +9462,10 @@ button,
     cursor: auto;
   }
 
+  .md\:cursor-default {
+    cursor: default;
+  }
+
   .md\:cursor-pointer {
     cursor: pointer;
   }
@@ -12415,6 +12427,10 @@ button,
     cursor: auto;
   }
 
+  .lg\:cursor-default {
+    cursor: default;
+  }
+
   .lg\:cursor-pointer {
     cursor: pointer;
   }
@@ -15374,6 +15390,10 @@ button,
 
   .xl\:cursor-auto {
     cursor: auto;
+  }
+
+  .xl\:cursor-default {
+    cursor: default;
   }
 
   .xl\:cursor-pointer {

--- a/src/generators/cursor.js
+++ b/src/generators/cursor.js
@@ -3,6 +3,7 @@ import defineClasses from '../util/defineClasses'
 export default function() {
   return defineClasses({
     'cursor-auto': { cursor: 'auto' },
+    'cursor-default': { cursor: 'default' },
     'cursor-pointer': { cursor: 'pointer' },
     'cursor-not-allowed': { cursor: 'not-allowed' },
   })


### PR DESCRIPTION
Resolves #159; turns out `select-none` doesn't reliably trigger default cursor on all browsers so this ends up being pretty useful.