### PR TITLE
Add `@silent` at-rule

### DIFF
--- a/__tests__/fixtures/tailwind-input.css
+++ b/__tests__/fixtures/tailwind-input.css
@@ -5,6 +5,13 @@
 @responsive {
     .example {
         @apply .font-bold;
+        @apply .delete-me;
         color: config('colors.red');
+    }
+}
+
+@silent {
+    .delete-me {
+        background-color: blue;
     }
 }

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3547,6 +3547,7 @@ button,
 
 .example {
   font-weight: 700;
+  background-color: blue;
   color: #e3342f;
 }
 
@@ -6511,6 +6512,7 @@ button,
 
   .sm\:example {
     font-weight: 700;
+    background-color: blue;
     color: #e3342f;
   }
 }
@@ -9476,6 +9478,7 @@ button,
 
   .md\:example {
     font-weight: 700;
+    background-color: blue;
     color: #e3342f;
   }
 }
@@ -12441,6 +12444,7 @@ button,
 
   .lg\:example {
     font-weight: 700;
+    background-color: blue;
     color: #e3342f;
   }
 }
@@ -15406,6 +15410,7 @@ button,
 
   .xl\:example {
     font-weight: 700;
+    background-color: blue;
     color: #e3342f;
   }
 }

--- a/__tests__/silentAtRule.test.js
+++ b/__tests__/silentAtRule.test.js
@@ -47,7 +47,9 @@ it('throws an error if @silent is used anywhere but the root of the tree', () =>
   `)
 
   expect.assertions(1)
-  return postcss([tailwind()]).process(input).catch(e => {
-    expect(e).toMatchObject({ name: 'CssSyntaxError' })
-  })
+  return postcss([tailwind()])
+    .process(input)
+    .catch(e => {
+      expect(e).toMatchObject({ name: 'CssSyntaxError' })
+    })
 })

--- a/__tests__/silentAtRule.test.js
+++ b/__tests__/silentAtRule.test.js
@@ -31,3 +31,23 @@ it('removes silenced rules while still making them available to @apply', () => {
       expect(result.css).toBe(expected)
     })
 })
+
+it('throws an error if @silent is used anywhere but the root of the tree', () => {
+  const input = _.trim(`
+@media (min-width: 100px) {
+  @silent {
+    .foo {
+      color: red;
+    }
+  }
+  .bar {
+    @apply .foo;
+  }
+}
+  `)
+
+  expect.assertions(1)
+  return postcss([tailwind()]).process(input).catch(e => {
+    expect(e).toMatchObject({ name: 'CssSyntaxError' })
+  })
+})

--- a/__tests__/silentAtRule.test.js
+++ b/__tests__/silentAtRule.test.js
@@ -1,0 +1,33 @@
+import _ from 'lodash'
+import postcss from 'postcss'
+import tailwind from '../src/index'
+
+it('removes silenced rules while still making them available to @apply', () => {
+  const input = _.trim(`
+@silent {
+  @responsive {
+    .foo {
+      color: red;
+    }
+  }
+  @tailwind screens;
+}
+
+
+.bar {
+  @apply .foo;
+}
+  `)
+
+  const expected = _.trim(`
+.bar {
+  color: red;
+}
+  `)
+
+  return postcss([tailwind()])
+    .process(input)
+    .then(result => {
+      expect(result.css).toBe(expected)
+    })
+})

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import substituteFocusableAtRules from './lib/substituteFocusableAtRules'
 import substituteResponsiveAtRules from './lib/substituteResponsiveAtRules'
 import substituteScreenAtRules from './lib/substituteScreenAtRules'
 import substituteClassApplyAtRules from './lib/substituteClassApplyAtRules'
+import substituteSilentAtRules from './lib/substituteSilentAtRules'
 
 const plugin = postcss.plugin('tailwind', config => {
   const plugins = []
@@ -41,6 +42,7 @@ const plugin = postcss.plugin('tailwind', config => {
       substituteResponsiveAtRules(lazyConfig),
       substituteScreenAtRules(lazyConfig),
       substituteClassApplyAtRules(lazyConfig),
+      substituteSilentAtRules(lazyConfig),
       stylefmt,
     ]
   )

--- a/src/lib/substituteSilentAtRules.js
+++ b/src/lib/substituteSilentAtRules.js
@@ -1,0 +1,7 @@
+export default function() {
+  return function(css) {
+    css.walkAtRules('silent', atRule => {
+      atRule.remove()
+    })
+  }
+}

--- a/src/lib/substituteSilentAtRules.js
+++ b/src/lib/substituteSilentAtRules.js
@@ -1,6 +1,10 @@
 export default function() {
   return function(css) {
     css.walkAtRules('silent', atRule => {
+      if (atRule.parent.type !== 'root') {
+        throw atRule.error(`@silent at-rules cannot be nested.`)
+      }
+
       atRule.remove()
     })
   }

--- a/src/util/findMixin.js
+++ b/src/util/findMixin.js
@@ -1,10 +1,18 @@
 import _ from 'lodash'
 
+function ruleIsValidMixin(rule) {
+  if (rule.parent.type === 'root') {
+    return true
+  }
+
+  return rule.parent.type === 'atrule' && ['silent'].includes(rule.parent.name)
+}
+
 export default function findMixin(css, mixin, onError) {
   const matches = []
 
   css.walkRules(rule => {
-    if (rule.selectors.includes(mixin) && rule.parent.type === 'root') {
+    if (rule.selectors.includes(mixin) && ruleIsValidMixin(rule)) {
       matches.push(rule)
     }
   })


### PR DESCRIPTION
I'm not convinced I want to merge this but opening for discussion.

This PR adds support for this syntax:

```
@silent {
    .foo {
        color: blue;
    }
}

.bar {
    @apply .foo;
}
```

...which would generate:

```
.bar {
    color: blue;
}
```

This lets you do things like this:

```
@silent {
    @tailwind utilities;

    /* Necessary to make sure responsive variations are silenced. */
    @tailwind screens;
}

.btn {
    @apply .bg-blue;
    @apply .text-white;
    @apply .font-semibold;
    @apply .px-4 py-2;
}
```

The goal is to try and resolve situations like #150, where people want to use `@apply` to reference utility classes inside of scoped style blocks like in a Vue component.

If anyone in that situation wants to pull this branch down and give it a shot, I'd be interested in knowing your feedback.