### PR TITLE
Add the word "flexbox" to all flexbox doc pages

### DIFF
--- a/docs/source/docs/flexbox-align-content.blade.md
+++ b/docs/source/docs/flexbox-align-content.blade.md
@@ -1,7 +1,7 @@
 ---
 extends: _layouts.documentation
 title: "Align Content"
-description: "Utilities for controlling how lines are positioned in multi-line flex containers."
+description: "Utilities for controlling how lines are positioned in multi-line flexbox containers."
 features:
   responsive: true
   customizable: false

--- a/docs/source/docs/flexbox-align-items.blade.md
+++ b/docs/source/docs/flexbox-align-items.blade.md
@@ -1,7 +1,7 @@
 ---
 extends: _layouts.documentation
 title: "Align Items"
-description: "Utilities for controlling how flex items are positioned along a container's cross axis."
+description: "Utilities for controlling how flexbox items are positioned along a container's cross axis."
 features:
   responsive: true
   customizable: false

--- a/docs/source/docs/flexbox-align-self.blade.md
+++ b/docs/source/docs/flexbox-align-self.blade.md
@@ -1,7 +1,7 @@
 ---
 extends: _layouts.documentation
 title: "Align Self"
-description: "Utilities for controlling how an individual flex item is positioned along its container's cross axis."
+description: "Utilities for controlling how an individual flexbox item is positioned along its container's cross axis."
 features:
   responsive: true
   customizable: false

--- a/docs/source/docs/flexbox-direction.blade.md
+++ b/docs/source/docs/flexbox-direction.blade.md
@@ -1,7 +1,7 @@
 ---
 extends: _layouts.documentation
 title: "Flex Direction"
-description: "Utilities for controlling the direction of flex items."
+description: "Utilities for controlling the direction of flexbox items."
 features:
   responsive: true
   customizable: false

--- a/docs/source/docs/flexbox-display.blade.md
+++ b/docs/source/docs/flexbox-display.blade.md
@@ -1,7 +1,7 @@
 ---
 extends: _layouts.documentation
 title: "Flex Display"
-description: "Utilities for creating flex containers."
+description: "Utilities for creating flexbox containers."
 features:
   responsive: true
   customizable: false

--- a/docs/source/docs/flexbox-flex-grow-shrink.blade.md
+++ b/docs/source/docs/flexbox-flex-grow-shrink.blade.md
@@ -1,7 +1,7 @@
 ---
 extends: _layouts.documentation
 title: "Flex, Grow, &amp; Shrink"
-description: "Utilities for controlling how flex items grow and shrink."
+description: "Utilities for controlling how flexbox items grow and shrink."
 features:
   responsive: true
   customizable: false

--- a/docs/source/docs/flexbox-justify-content.blade.md
+++ b/docs/source/docs/flexbox-justify-content.blade.md
@@ -1,7 +1,7 @@
 ---
 extends: _layouts.documentation
 title: "Justify Content"
-description: "Utilities for controlling flex items are positioned along a container's main axis."
+description: "Utilities for controlling flexbox items are positioned along a container's main axis."
 features:
   responsive: true
   customizable: false

--- a/docs/source/docs/flexbox-wrapping.blade.md
+++ b/docs/source/docs/flexbox-wrapping.blade.md
@@ -1,7 +1,7 @@
 ---
 extends: _layouts.documentation
 title: "Flex Wrapping"
-description: "Utilities for controlling how flex items wrap."
+description: "Utilities for controlling how flexbox items wrap."
 features:
   responsive: true
   customizable: false


### PR DESCRIPTION
Right now when you search for "flexbox" in the Tailwind docs you don't see any of the flexbox pages, since they don't actually say "flexbox" anywhere.

This PR simply changes "flex" to "flexbox" in the description of each page, which will fix this. I thought the description might be the best place to add this because the snippet shown in the search will likely end up being very useful.