### PR TITLE
Change the config.js to tailwind.js tht is recommended in step 3.

### DIFF
--- a/docs/source/docs/installation.blade.md
+++ b/docs/source/docs/installation.blade.md
@@ -110,7 +110,7 @@ To avoid specificity issues, we highly recommend structuring your main styleshee
 For simple projects or just giving Tailwind a spin, you can use the Tailwind CLI tool to process your CSS:
 
 <div class="bg-smoke-lighter font-mono text-sm p-4">
-  <div class="text-purple-dark">./node_modules/.bin/tailwind build <span class="text-blue-dark">styles.css</span> <span class="text-smoke-darker">[-c ./config.js] [-o ./output.css]</span></div>
+  <div class="text-purple-dark">./node_modules/.bin/tailwind build <span class="text-blue-dark">styles.css</span> <span class="text-smoke-darker">[-c ./tailwind.js] [-o ./output.css]</span></div>
 </div>
 
 #### Using Tailwind with PostCSS


### PR DESCRIPTION
In step 2 of installation you say: 

> We recommend creating a `tailwind.js` file in your project's root.

Then in Step 4: 

``` 
./node_modules/.bin/tailwind build styles.css [-c ./config.js] [-o ./output.css]
```

Why config.js and not tailwind.js that you recommended earlier? This PR I just tried to unify the docs. 😄 