### PR TITLE
Fix wrong properties's description

### DIFF
--- a/docs/source/docs/background-color.blade.md
+++ b/docs/source/docs/background-color.blade.md
@@ -24,7 +24,7 @@ features:
       @foreach ($page->config['colors'] as $name => $value)
       <tr>
         <td class="p-2 border-t {{ $loop->first ? 'border-smoke' : 'border-smoke-light' }} font-mono text-xs text-purple-dark">.bg-{{ $name }}</td>
-        <td class="p-2 border-t {{ $loop->first ? 'border-smoke' : 'border-smoke-light' }} font-mono text-xs text-blue-dark">color: {{ $value }};</td>
+        <td class="p-2 border-t {{ $loop->first ? 'border-smoke' : 'border-smoke-light' }} font-mono text-xs text-blue-dark">background-color: {{ $value }};</td>
         <td class="p-2 border-t {{ $loop->first ? 'border-smoke' : 'border-smoke-light' }} text-sm text-grey-darker">Set the background color of an element to {{ implode(' ', array_reverse(explode('-', $name))) }}.</td>
       </tr>
       @endforeach

--- a/docs/source/docs/background-size.blade.md
+++ b/docs/source/docs/background-size.blade.md
@@ -28,12 +28,12 @@ features:
     <tbody class="align-baseline">
       <tr>
         <td class="p-2 border-t border-smoke font-mono text-xs text-purple-dark">.bg-cover</td>
-        <td class="p-2 border-t border-smoke font-mono text-xs text-blue-dark">background-position: cover;</td>
+        <td class="p-2 border-t border-smoke font-mono text-xs text-blue-dark">background-size: cover;</td>
         <td class="p-2 border-t border-smoke text-sm text-grey-darker">Scale the image until it fills the background layer.</td>
       </tr>
       <tr>
         <td class="p-2 border-t border-smoke-light font-mono text-xs text-purple-dark">.bg-contain</td>
-        <td class="p-2 border-t border-smoke-light font-mono text-xs text-blue-dark">background-position: contain;</td>
+        <td class="p-2 border-t border-smoke-light font-mono text-xs text-blue-dark">background-size: contain;</td>
         <td class="p-2 border-t border-smoke-light text-sm text-grey-darker">Scale the image to the outer edges without cropping or stretching.</td>
       </tr>
     </tbody>

--- a/docs/source/docs/border-color.blade.md
+++ b/docs/source/docs/border-color.blade.md
@@ -24,7 +24,7 @@ features:
       @foreach ($page->config['colors'] as $name => $value)
         <tr>
           <td class="p-2 border-t {{ $loop->first ? 'border-smoke' : 'border-smoke-light' }} font-mono text-xs text-purple-dark">.border-{{ $name }}</td>
-          <td class="p-2 border-t {{ $loop->first ? 'border-smoke' : 'border-smoke-light' }} font-mono text-xs text-blue-dark">color: {{ $value }};</td>
+          <td class="p-2 border-t {{ $loop->first ? 'border-smoke' : 'border-smoke-light' }} font-mono text-xs text-blue-dark">border-color: {{ $value }};</td>
           <td class="p-2 border-t {{ $loop->first ? 'border-smoke' : 'border-smoke-light' }} text-sm text-grey-darker">Set the border color of an element to {{ implode(' ', array_reverse(explode('-', $name))) }}.</td>
         </tr>
       @endforeach

--- a/docs/source/docs/flexbox-align-items.blade.md
+++ b/docs/source/docs/flexbox-align-items.blade.md
@@ -46,7 +46,7 @@ features:
       </tr>
       <tr>
         <td class="p-2 border-t border-smoke-light font-mono text-xs text-purple-dark">.items-baseline</td>
-        <td class="p-2 border-t border-smoke-light font-mono text-xs text-blue-dark">align-items: space-between;</td>
+        <td class="p-2 border-t border-smoke-light font-mono text-xs text-blue-dark">align-items: baseline;</td>
         <td class="p-2 border-t border-smoke-light text-sm text-grey-darker">Align the baselines of each item.</td>
       </tr>
     </tbody>


### PR DESCRIPTION
Hey.

There are a few mistakes/typos I've found in the docs. What I found for now:

1. flexbox's `align-items` property where the `.items-baseline` class's property description is `align-items: space-between`:
![image](https://user-images.githubusercontent.com/8510486/32650863-f7be1438-c607-11e7-89ec-939829e3e330.png)
2. background's `background-color` property where the `.bg-*` colors classes's description is using the `color` defenition:
![image](https://user-images.githubusercontent.com/8510486/32655923-74a07968-c618-11e7-8071-aa7c95fe1205.png)
3. background's `background-size` property where the `.bg-cover` and `.bg-contain` classes's description is using the `background-position` defenition:
![image](https://user-images.githubusercontent.com/8510486/32655838-09bc2b88-c618-11e7-8a99-5daabc55b8f7.png) 
4. border's `border-color` property where the `border-{color}` classes's description is using the `color` defenition:
![image](https://user-images.githubusercontent.com/8510486/32656152-5159708a-c619-11e7-83f6-07397a7d8f94.png)


This PR simply fixes that.