### PR TITLE
Add success message after tailwind init command

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -54,6 +54,7 @@ program
 
     const output = fs.readFileSync(path.resolve(__dirname, '../defaultConfig.js'), 'utf8')
     fs.outputFileSync(destination, output.replace('// var defaultConfig', 'var defaultConfig'))
+    console.log(`Generated Tailwind config: ${destination}`)
     process.exit()
   })
 


### PR DESCRIPTION
This provides a little feedback after running the `tailwind init` command, letting users know that it actually worked, and where to find their config file.

```
tailwind init
Generated Tailwind config: /Users/jonathan/Sites/tailwindcss/tailwind.js
```

Closes #175