### PR TITLE
Add "prefix" and "important" options to config

### DIFF
--- a/__tests__/applyClassPrefix.test.js
+++ b/__tests__/applyClassPrefix.test.js
@@ -1,0 +1,18 @@
+import postcss from 'postcss'
+import applyClassPrefix from '../src/util/applyClassPrefix'
+
+test('it prefixes classes with the provided prefix', () => {
+  const input = postcss.parse(`
+    .foo { color: red; }
+    .apple, .pear { color: green; }
+  `)
+
+  const expected = `
+    .tw-foo { color: red; }
+    .tw-apple, .tw-pear { color: green; }
+  `
+
+  const result = applyClassPrefix(input, 'tw-').toResult()
+  expect(result.css).toEqual(expected)
+  expect(result.warnings().length).toBe(0)
+})

--- a/src/lib/generateUtilities.js
+++ b/src/lib/generateUtilities.js
@@ -1,4 +1,6 @@
 import _ from 'lodash'
+import postcss from 'postcss'
+import applyClassPrefix from '../util/applyClassPrefix'
 import backgroundColors from '../generators/backgroundColors'
 import backgroundPositions from '../generators/backgroundPositions'
 import backgroundSize from '../generators/backgroundSize'
@@ -39,50 +41,61 @@ import zIndex from '../generators/zIndex'
 
 export default function(config) {
   return function(css) {
-    const options = config()
+    const unwrappedConfig = config()
 
     css.walkAtRules('tailwind', atRule => {
       if (atRule.params === 'utilities') {
-        const utilities = _.flatten([
-          lists(options),
-          forms(options),
-          textSizes(options),
-          textWeights(options),
-          textFonts(options),
-          textColors(options),
-          textLeading(options),
-          textTracking(options),
-          textAlign(options),
-          textWrap(options),
-          textStyle(options),
-          verticalAlign(options),
-          backgroundColors(options),
-          backgroundPositions(options),
-          backgroundSize(options),
-          borderStylesReset(options),
-          borderWidths(options),
-          borderColors(options),
-          borderStyles(options),
-          rounded(options),
-          display(options),
-          position(options),
-          overflow(options),
-          sizing(options),
-          spacing(options),
-          shadows(options),
-          flex(options),
-          floats(options),
-          visibility(options),
-          zIndex(options),
-          opacity(options),
-          userSelect(options),
-          pointerEvents(options),
-          resize(options),
-          cursor(options),
-        ])
+        const utilities = postcss.root({
+          nodes: _.flatten([
+            lists(unwrappedConfig),
+            forms(unwrappedConfig),
+            textSizes(unwrappedConfig),
+            textWeights(unwrappedConfig),
+            textFonts(unwrappedConfig),
+            textColors(unwrappedConfig),
+            textLeading(unwrappedConfig),
+            textTracking(unwrappedConfig),
+            textAlign(unwrappedConfig),
+            textWrap(unwrappedConfig),
+            textStyle(unwrappedConfig),
+            verticalAlign(unwrappedConfig),
+            backgroundColors(unwrappedConfig),
+            backgroundPositions(unwrappedConfig),
+            backgroundSize(unwrappedConfig),
+            borderStylesReset(unwrappedConfig),
+            borderWidths(unwrappedConfig),
+            borderColors(unwrappedConfig),
+            borderStyles(unwrappedConfig),
+            rounded(unwrappedConfig),
+            display(unwrappedConfig),
+            position(unwrappedConfig),
+            overflow(unwrappedConfig),
+            sizing(unwrappedConfig),
+            spacing(unwrappedConfig),
+            shadows(unwrappedConfig),
+            flex(unwrappedConfig),
+            floats(unwrappedConfig),
+            visibility(unwrappedConfig),
+            zIndex(unwrappedConfig),
+            opacity(unwrappedConfig),
+            userSelect(unwrappedConfig),
+            pointerEvents(unwrappedConfig),
+            resize(unwrappedConfig),
+            cursor(unwrappedConfig),
+          ]),
+        })
 
-        atRule.before(container(options))
-        atRule.before(responsive(utilities))
+        if (_.get(unwrappedConfig, 'options.important', false)) {
+          utilities.walkDecls(decl => (decl.important = true))
+        }
+
+        const tailwindClasses = postcss.root({
+          nodes: [...container(unwrappedConfig), responsive(utilities)],
+        })
+
+        applyClassPrefix(tailwindClasses, _.get(unwrappedConfig, 'options.prefix', ''))
+
+        atRule.before(tailwindClasses)
         atRule.remove()
       }
     })

--- a/src/util/applyClassPrefix.js
+++ b/src/util/applyClassPrefix.js
@@ -1,0 +1,6 @@
+export default function(css, prefix) {
+  css.walkRules(rule => {
+    rule.selectors = rule.selectors.map(selector => `.${prefix}${selector.slice(1)}`)
+  })
+  return css
+}

--- a/src/util/responsive.js
+++ b/src/util/responsive.js
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import postcss from 'postcss'
 import cloneNodes from './cloneNodes'
 
@@ -6,5 +7,5 @@ export default function responsive(rules) {
     .atRule({
       name: 'responsive',
     })
-    .append(cloneNodes(rules))
+    .append(cloneNodes(_.isArray(rules) ? rules : rules.nodes))
 }


### PR DESCRIPTION
*This replaces #183 which was based on `develop`; we've decided to merge against `master` instead.*

This could've been two separate PRs but it's really just the consolidation of #99 and #100 but moved into the config file instead of being made available as at-rules.

This PR adds support for a new `options` key in the config file, with two options so far:

```js
{
    // ...
    options: {
        prefix: 'tw-', // Defaults to ''
        important: true, // Default to false
    }
}
```

### Prefix

The prefix option causes all of Tailwind's utilities to be generated with the given prefix.

This is *(shockingly)* more complex than it sounds, so there's a few rules worth understanding.

1. The prefix is added to the beginning of the *utility name*, not the full *class name.*

    This means that if you set a prefix of `tw-`, you'll get utilities that look like this:

    ```less
    .tw-text-blue { ... }
    .hover:tw-text-blue { ... }
    .sm:tw-text-blue { ... }
    .md:tw-text-blue { ... }
    .lg:tw-text-blue { ... }
    .xl:tw-text-blue { ... }
    ```

    ...***not*** like this:

    ```less
    .tw-text-blue { ... }
    .tw-hover:text-blue { ... }
    .tw-sm:text-blue { ... }
    .tw-md:text-blue { ... }
    .tw-lg:text-blue { ... }
    .tw-xl:text-blue { ... }
    ```

    This may seem counter-intuitive at first, keep reading.

2. Your own classes that Tailwind touches with features like `@responsive` **do not** adopt this prefix.

    For example, this custom class wrapped in `@responsive`:

    ```less
    @responsive {
        .foo { color: blue }
    }
    ```

    ...will generate this code:

    ```less
    .foo { color: blue }
    @media (min-width: 576px) {
        .sm:foo { color: blue }
    }
    @media (min-width: 768px) {
        .md:foo { color: blue }
    }
    @media (min-width: 992px) {
        .lg:foo { color: blue }
    }
    @media (min-width: 1200px) {
        .xl:foo { color: blue }
    }
    ```

    ...***not*** this code:

    ```less
    .tw-foo { color: blue }
    @media (min-width: 576px) {
        .sm:tw-foo { color: blue }
    }
    @media (min-width: 768px) {
        .md:tw-foo { color: blue }
    }
    @media (min-width: 992px) {
        .lg:tw-foo { color: blue }
    }
    @media (min-width: 1200px) {
        .xl:tw-foo { color: blue }
    }
    ```

    This is the reason for putting the prefix at the beginning of the *utility* name, not the class name.

    If we put the prefix at the beginning of the full class, your own custom utilities would have no prefix, and the responsive prefixes would look different:

    ```html
    <div class="tw-text-blue custom-foo tw-md:text-red md:custom-bar">
        <!-- ... -->
    </div>
    ```

    This inconsistency was ugly enough that it felt like putting the prefix before just the utility portion was the right move, because the only other option was prefixing your own custom utilities too, and that didn't feel right either.

### Important

Important is simpler; it just makes all of Tailwind's utilities `!important`.

It doesn't make any of your own custom utilities that use Tailwind features important though; if you want that behavior, simply mark them as `!important` yourself:

```less
@responsive {
    .foo {
        color: blue !important;
    }
}
```

One important special case here is the `.container` class. Using the `important` option **does not** make the `.container` class important.

This is because that class isn't really a utility; it's more of a component. It already gets special treatment in the codebase in that it doesn't get responsive variations generated (`.md:container`, `.lg:container`, etc.).

Since it's more of a component, it makes sense that it's styles should be overridable if needed, even though I don't know why you'd ever do that.

### The End.

If you have opinions about all the prefix positioning crap I am open to hearing them, we argued about it for a while and this seemed like the best solution.