### PR TITLE
Make stylesheets load in parallel

### DIFF
--- a/docs/source/_layouts/master.blade.php
+++ b/docs/source/_layouts/master.blade.php
@@ -12,11 +12,9 @@
   <title>{{ $page->title ? $page->title . ' - Tailwind CSS' : 'Tailwind CSS - A Utility-First CSS Framework for Rapid UI Development' }}</title>
   <meta name="theme-color" content="#ffffff">
   @yield('meta')
-  <style>
-    @import url("https://use.typekit.net/iqy1okj.css");
-  </style>
+  <link rel="stylesheet" href="https://use.typekit.net/iqy1okj.css">
   <link rel="stylesheet" href="{{ mix('/css/main.css') }}">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css">
   <script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
   <script src="{{ mix('/js/nav.js') }}"></script>
 </head>


### PR DESCRIPTION
Optimized loading of Typekit css, switched from `@import` to `<link>`

Using only `link` tags results in parallel loading in all browsers (and is supposed to be faster).

[Source](http://www.stevesouders.com/blog/2009/04/09/dont-use-import/)

Looks like it's also the default from Typekit.

[Typekit Blog](https://blog.typekit.com/2017/08/30/css-font-loading/)