### PR TITLE
[0.2] Rework `rounded` utilities to `radius`, add ability to target corners

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -2116,6 +2116,26 @@ button,
   border-radius: 0;
 }
 
+.radius-t-none {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.radius-r-none {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.radius-b-none {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.radius-l-none {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
 .radius-tr-none {
   border-top-right-radius: 0;
 }
@@ -2134,6 +2154,26 @@ button,
 
 .radius-sm {
   border-radius: .125rem;
+}
+
+.radius-t-sm {
+  border-top-left-radius: .125rem;
+  border-top-right-radius: .125rem;
+}
+
+.radius-r-sm {
+  border-top-right-radius: .125rem;
+  border-bottom-right-radius: .125rem;
+}
+
+.radius-b-sm {
+  border-bottom-right-radius: .125rem;
+  border-bottom-left-radius: .125rem;
+}
+
+.radius-l-sm {
+  border-top-left-radius: .125rem;
+  border-bottom-left-radius: .125rem;
 }
 
 .radius-tr-sm {
@@ -2156,6 +2196,26 @@ button,
   border-radius: .25rem;
 }
 
+.radius-t-md {
+  border-top-left-radius: .25rem;
+  border-top-right-radius: .25rem;
+}
+
+.radius-r-md {
+  border-top-right-radius: .25rem;
+  border-bottom-right-radius: .25rem;
+}
+
+.radius-b-md {
+  border-bottom-right-radius: .25rem;
+  border-bottom-left-radius: .25rem;
+}
+
+.radius-l-md {
+  border-top-left-radius: .25rem;
+  border-bottom-left-radius: .25rem;
+}
+
 .radius-tr-md {
   border-top-right-radius: .25rem;
 }
@@ -2176,6 +2236,26 @@ button,
   border-radius: .5rem;
 }
 
+.radius-t-lg {
+  border-top-left-radius: .5rem;
+  border-top-right-radius: .5rem;
+}
+
+.radius-r-lg {
+  border-top-right-radius: .5rem;
+  border-bottom-right-radius: .5rem;
+}
+
+.radius-b-lg {
+  border-bottom-right-radius: .5rem;
+  border-bottom-left-radius: .5rem;
+}
+
+.radius-l-lg {
+  border-top-left-radius: .5rem;
+  border-bottom-left-radius: .5rem;
+}
+
 .radius-tr-lg {
   border-top-right-radius: .5rem;
 }
@@ -2194,6 +2274,26 @@ button,
 
 .radius-full {
   border-radius: 9999px;
+}
+
+.radius-t-full {
+  border-top-left-radius: 9999px;
+  border-top-right-radius: 9999px;
+}
+
+.radius-r-full {
+  border-top-right-radius: 9999px;
+  border-bottom-right-radius: 9999px;
+}
+
+.radius-b-full {
+  border-bottom-right-radius: 9999px;
+  border-bottom-left-radius: 9999px;
+}
+
+.radius-l-full {
+  border-top-left-radius: 9999px;
+  border-bottom-left-radius: 9999px;
 }
 
 .radius-tr-full {
@@ -5136,6 +5236,26 @@ button,
     border-radius: 0;
   }
 
+  .sm\:radius-t-none {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+
+  .sm\:radius-r-none {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .sm\:radius-b-none {
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  .sm\:radius-l-none {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
   .sm\:radius-tr-none {
     border-top-right-radius: 0;
   }
@@ -5154,6 +5274,26 @@ button,
 
   .sm\:radius-sm {
     border-radius: .125rem;
+  }
+
+  .sm\:radius-t-sm {
+    border-top-left-radius: .125rem;
+    border-top-right-radius: .125rem;
+  }
+
+  .sm\:radius-r-sm {
+    border-top-right-radius: .125rem;
+    border-bottom-right-radius: .125rem;
+  }
+
+  .sm\:radius-b-sm {
+    border-bottom-right-radius: .125rem;
+    border-bottom-left-radius: .125rem;
+  }
+
+  .sm\:radius-l-sm {
+    border-top-left-radius: .125rem;
+    border-bottom-left-radius: .125rem;
   }
 
   .sm\:radius-tr-sm {
@@ -5176,6 +5316,26 @@ button,
     border-radius: .25rem;
   }
 
+  .sm\:radius-t-md {
+    border-top-left-radius: .25rem;
+    border-top-right-radius: .25rem;
+  }
+
+  .sm\:radius-r-md {
+    border-top-right-radius: .25rem;
+    border-bottom-right-radius: .25rem;
+  }
+
+  .sm\:radius-b-md {
+    border-bottom-right-radius: .25rem;
+    border-bottom-left-radius: .25rem;
+  }
+
+  .sm\:radius-l-md {
+    border-top-left-radius: .25rem;
+    border-bottom-left-radius: .25rem;
+  }
+
   .sm\:radius-tr-md {
     border-top-right-radius: .25rem;
   }
@@ -5196,6 +5356,26 @@ button,
     border-radius: .5rem;
   }
 
+  .sm\:radius-t-lg {
+    border-top-left-radius: .5rem;
+    border-top-right-radius: .5rem;
+  }
+
+  .sm\:radius-r-lg {
+    border-top-right-radius: .5rem;
+    border-bottom-right-radius: .5rem;
+  }
+
+  .sm\:radius-b-lg {
+    border-bottom-right-radius: .5rem;
+    border-bottom-left-radius: .5rem;
+  }
+
+  .sm\:radius-l-lg {
+    border-top-left-radius: .5rem;
+    border-bottom-left-radius: .5rem;
+  }
+
   .sm\:radius-tr-lg {
     border-top-right-radius: .5rem;
   }
@@ -5214,6 +5394,26 @@ button,
 
   .sm\:radius-full {
     border-radius: 9999px;
+  }
+
+  .sm\:radius-t-full {
+    border-top-left-radius: 9999px;
+    border-top-right-radius: 9999px;
+  }
+
+  .sm\:radius-r-full {
+    border-top-right-radius: 9999px;
+    border-bottom-right-radius: 9999px;
+  }
+
+  .sm\:radius-b-full {
+    border-bottom-right-radius: 9999px;
+    border-bottom-left-radius: 9999px;
+  }
+
+  .sm\:radius-l-full {
+    border-top-left-radius: 9999px;
+    border-bottom-left-radius: 9999px;
   }
 
   .sm\:radius-tr-full {
@@ -8157,6 +8357,26 @@ button,
     border-radius: 0;
   }
 
+  .md\:radius-t-none {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+
+  .md\:radius-r-none {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .md\:radius-b-none {
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  .md\:radius-l-none {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
   .md\:radius-tr-none {
     border-top-right-radius: 0;
   }
@@ -8175,6 +8395,26 @@ button,
 
   .md\:radius-sm {
     border-radius: .125rem;
+  }
+
+  .md\:radius-t-sm {
+    border-top-left-radius: .125rem;
+    border-top-right-radius: .125rem;
+  }
+
+  .md\:radius-r-sm {
+    border-top-right-radius: .125rem;
+    border-bottom-right-radius: .125rem;
+  }
+
+  .md\:radius-b-sm {
+    border-bottom-right-radius: .125rem;
+    border-bottom-left-radius: .125rem;
+  }
+
+  .md\:radius-l-sm {
+    border-top-left-radius: .125rem;
+    border-bottom-left-radius: .125rem;
   }
 
   .md\:radius-tr-sm {
@@ -8197,6 +8437,26 @@ button,
     border-radius: .25rem;
   }
 
+  .md\:radius-t-md {
+    border-top-left-radius: .25rem;
+    border-top-right-radius: .25rem;
+  }
+
+  .md\:radius-r-md {
+    border-top-right-radius: .25rem;
+    border-bottom-right-radius: .25rem;
+  }
+
+  .md\:radius-b-md {
+    border-bottom-right-radius: .25rem;
+    border-bottom-left-radius: .25rem;
+  }
+
+  .md\:radius-l-md {
+    border-top-left-radius: .25rem;
+    border-bottom-left-radius: .25rem;
+  }
+
   .md\:radius-tr-md {
     border-top-right-radius: .25rem;
   }
@@ -8217,6 +8477,26 @@ button,
     border-radius: .5rem;
   }
 
+  .md\:radius-t-lg {
+    border-top-left-radius: .5rem;
+    border-top-right-radius: .5rem;
+  }
+
+  .md\:radius-r-lg {
+    border-top-right-radius: .5rem;
+    border-bottom-right-radius: .5rem;
+  }
+
+  .md\:radius-b-lg {
+    border-bottom-right-radius: .5rem;
+    border-bottom-left-radius: .5rem;
+  }
+
+  .md\:radius-l-lg {
+    border-top-left-radius: .5rem;
+    border-bottom-left-radius: .5rem;
+  }
+
   .md\:radius-tr-lg {
     border-top-right-radius: .5rem;
   }
@@ -8235,6 +8515,26 @@ button,
 
   .md\:radius-full {
     border-radius: 9999px;
+  }
+
+  .md\:radius-t-full {
+    border-top-left-radius: 9999px;
+    border-top-right-radius: 9999px;
+  }
+
+  .md\:radius-r-full {
+    border-top-right-radius: 9999px;
+    border-bottom-right-radius: 9999px;
+  }
+
+  .md\:radius-b-full {
+    border-bottom-right-radius: 9999px;
+    border-bottom-left-radius: 9999px;
+  }
+
+  .md\:radius-l-full {
+    border-top-left-radius: 9999px;
+    border-bottom-left-radius: 9999px;
   }
 
   .md\:radius-tr-full {
@@ -11178,6 +11478,26 @@ button,
     border-radius: 0;
   }
 
+  .lg\:radius-t-none {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+
+  .lg\:radius-r-none {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .lg\:radius-b-none {
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  .lg\:radius-l-none {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
   .lg\:radius-tr-none {
     border-top-right-radius: 0;
   }
@@ -11196,6 +11516,26 @@ button,
 
   .lg\:radius-sm {
     border-radius: .125rem;
+  }
+
+  .lg\:radius-t-sm {
+    border-top-left-radius: .125rem;
+    border-top-right-radius: .125rem;
+  }
+
+  .lg\:radius-r-sm {
+    border-top-right-radius: .125rem;
+    border-bottom-right-radius: .125rem;
+  }
+
+  .lg\:radius-b-sm {
+    border-bottom-right-radius: .125rem;
+    border-bottom-left-radius: .125rem;
+  }
+
+  .lg\:radius-l-sm {
+    border-top-left-radius: .125rem;
+    border-bottom-left-radius: .125rem;
   }
 
   .lg\:radius-tr-sm {
@@ -11218,6 +11558,26 @@ button,
     border-radius: .25rem;
   }
 
+  .lg\:radius-t-md {
+    border-top-left-radius: .25rem;
+    border-top-right-radius: .25rem;
+  }
+
+  .lg\:radius-r-md {
+    border-top-right-radius: .25rem;
+    border-bottom-right-radius: .25rem;
+  }
+
+  .lg\:radius-b-md {
+    border-bottom-right-radius: .25rem;
+    border-bottom-left-radius: .25rem;
+  }
+
+  .lg\:radius-l-md {
+    border-top-left-radius: .25rem;
+    border-bottom-left-radius: .25rem;
+  }
+
   .lg\:radius-tr-md {
     border-top-right-radius: .25rem;
   }
@@ -11238,6 +11598,26 @@ button,
     border-radius: .5rem;
   }
 
+  .lg\:radius-t-lg {
+    border-top-left-radius: .5rem;
+    border-top-right-radius: .5rem;
+  }
+
+  .lg\:radius-r-lg {
+    border-top-right-radius: .5rem;
+    border-bottom-right-radius: .5rem;
+  }
+
+  .lg\:radius-b-lg {
+    border-bottom-right-radius: .5rem;
+    border-bottom-left-radius: .5rem;
+  }
+
+  .lg\:radius-l-lg {
+    border-top-left-radius: .5rem;
+    border-bottom-left-radius: .5rem;
+  }
+
   .lg\:radius-tr-lg {
     border-top-right-radius: .5rem;
   }
@@ -11256,6 +11636,26 @@ button,
 
   .lg\:radius-full {
     border-radius: 9999px;
+  }
+
+  .lg\:radius-t-full {
+    border-top-left-radius: 9999px;
+    border-top-right-radius: 9999px;
+  }
+
+  .lg\:radius-r-full {
+    border-top-right-radius: 9999px;
+    border-bottom-right-radius: 9999px;
+  }
+
+  .lg\:radius-b-full {
+    border-bottom-right-radius: 9999px;
+    border-bottom-left-radius: 9999px;
+  }
+
+  .lg\:radius-l-full {
+    border-top-left-radius: 9999px;
+    border-bottom-left-radius: 9999px;
   }
 
   .lg\:radius-tr-full {
@@ -14199,6 +14599,26 @@ button,
     border-radius: 0;
   }
 
+  .xl\:radius-t-none {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+
+  .xl\:radius-r-none {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .xl\:radius-b-none {
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  .xl\:radius-l-none {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
   .xl\:radius-tr-none {
     border-top-right-radius: 0;
   }
@@ -14217,6 +14637,26 @@ button,
 
   .xl\:radius-sm {
     border-radius: .125rem;
+  }
+
+  .xl\:radius-t-sm {
+    border-top-left-radius: .125rem;
+    border-top-right-radius: .125rem;
+  }
+
+  .xl\:radius-r-sm {
+    border-top-right-radius: .125rem;
+    border-bottom-right-radius: .125rem;
+  }
+
+  .xl\:radius-b-sm {
+    border-bottom-right-radius: .125rem;
+    border-bottom-left-radius: .125rem;
+  }
+
+  .xl\:radius-l-sm {
+    border-top-left-radius: .125rem;
+    border-bottom-left-radius: .125rem;
   }
 
   .xl\:radius-tr-sm {
@@ -14239,6 +14679,26 @@ button,
     border-radius: .25rem;
   }
 
+  .xl\:radius-t-md {
+    border-top-left-radius: .25rem;
+    border-top-right-radius: .25rem;
+  }
+
+  .xl\:radius-r-md {
+    border-top-right-radius: .25rem;
+    border-bottom-right-radius: .25rem;
+  }
+
+  .xl\:radius-b-md {
+    border-bottom-right-radius: .25rem;
+    border-bottom-left-radius: .25rem;
+  }
+
+  .xl\:radius-l-md {
+    border-top-left-radius: .25rem;
+    border-bottom-left-radius: .25rem;
+  }
+
   .xl\:radius-tr-md {
     border-top-right-radius: .25rem;
   }
@@ -14259,6 +14719,26 @@ button,
     border-radius: .5rem;
   }
 
+  .xl\:radius-t-lg {
+    border-top-left-radius: .5rem;
+    border-top-right-radius: .5rem;
+  }
+
+  .xl\:radius-r-lg {
+    border-top-right-radius: .5rem;
+    border-bottom-right-radius: .5rem;
+  }
+
+  .xl\:radius-b-lg {
+    border-bottom-right-radius: .5rem;
+    border-bottom-left-radius: .5rem;
+  }
+
+  .xl\:radius-l-lg {
+    border-top-left-radius: .5rem;
+    border-bottom-left-radius: .5rem;
+  }
+
   .xl\:radius-tr-lg {
     border-top-right-radius: .5rem;
   }
@@ -14277,6 +14757,26 @@ button,
 
   .xl\:radius-full {
     border-radius: 9999px;
+  }
+
+  .xl\:radius-t-full {
+    border-top-left-radius: 9999px;
+    border-top-right-radius: 9999px;
+  }
+
+  .xl\:radius-r-full {
+    border-top-right-radius: 9999px;
+    border-bottom-right-radius: 9999px;
+  }
+
+  .xl\:radius-b-full {
+    border-bottom-right-radius: 9999px;
+    border-bottom-left-radius: 9999px;
+  }
+
+  .xl\:radius-l-full {
+    border-top-left-radius: 9999px;
+    border-bottom-left-radius: 9999px;
   }
 
   .xl\:radius-tr-full {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -2112,124 +2112,104 @@ button,
   border-style: none;
 }
 
-.rounded {
-  border-radius: .25rem;
-}
-
-.rounded-t {
-  border-top-right-radius: .25rem;
-  border-top-left-radius: .25rem;
-}
-
-.rounded-r {
-  border-top-right-radius: .25rem;
-  border-bottom-right-radius: .25rem;
-}
-
-.rounded-b {
-  border-bottom-right-radius: .25rem;
-  border-bottom-left-radius: .25rem;
-}
-
-.rounded-l {
-  border-top-left-radius: .25rem;
-  border-bottom-left-radius: .25rem;
-}
-
-.rounded-sm {
-  border-radius: .125rem;
-}
-
-.rounded-t-sm {
-  border-top-right-radius: .125rem;
-  border-top-left-radius: .125rem;
-}
-
-.rounded-r-sm {
-  border-top-right-radius: .125rem;
-  border-bottom-right-radius: .125rem;
-}
-
-.rounded-b-sm {
-  border-bottom-right-radius: .125rem;
-  border-bottom-left-radius: .125rem;
-}
-
-.rounded-l-sm {
-  border-top-left-radius: .125rem;
-  border-bottom-left-radius: .125rem;
-}
-
-.rounded-lg {
-  border-radius: .5rem;
-}
-
-.rounded-t-lg {
-  border-top-right-radius: .5rem;
-  border-top-left-radius: .5rem;
-}
-
-.rounded-r-lg {
-  border-top-right-radius: .5rem;
-  border-bottom-right-radius: .5rem;
-}
-
-.rounded-b-lg {
-  border-bottom-right-radius: .5rem;
-  border-bottom-left-radius: .5rem;
-}
-
-.rounded-l-lg {
-  border-top-left-radius: .5rem;
-  border-bottom-left-radius: .5rem;
-}
-
-.rounded-full {
-  border-radius: 9999px;
-}
-
-.rounded-t-full {
-  border-top-right-radius: 9999px;
-  border-top-left-radius: 9999px;
-}
-
-.rounded-r-full {
-  border-top-right-radius: 9999px;
-  border-bottom-right-radius: 9999px;
-}
-
-.rounded-b-full {
-  border-bottom-right-radius: 9999px;
-  border-bottom-left-radius: 9999px;
-}
-
-.rounded-l-full {
-  border-top-left-radius: 9999px;
-  border-bottom-left-radius: 9999px;
-}
-
-.rounded-none {
+.radius-none {
   border-radius: 0;
 }
 
-.rounded-t-none {
+.radius-tr-none {
   border-top-right-radius: 0;
-  border-top-left-radius: 0;
 }
 
-.rounded-r-none {
-  border-top-right-radius: 0;
+.radius-br-none {
   border-bottom-right-radius: 0;
 }
 
-.rounded-b-none {
-  border-bottom-right-radius: 0;
+.radius-bl-none {
   border-bottom-left-radius: 0;
 }
 
-.rounded-l-none {
+.radius-tl-none {
   border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
+}
+
+.radius-sm {
+  border-radius: .125rem;
+}
+
+.radius-tr-sm {
+  border-top-right-radius: .125rem;
+}
+
+.radius-br-sm {
+  border-bottom-right-radius: .125rem;
+}
+
+.radius-bl-sm {
+  border-bottom-left-radius: .125rem;
+}
+
+.radius-tl-sm {
+  border-top-left-radius: .125rem;
+}
+
+.radius-md {
+  border-radius: .25rem;
+}
+
+.radius-tr-md {
+  border-top-right-radius: .25rem;
+}
+
+.radius-br-md {
+  border-bottom-right-radius: .25rem;
+}
+
+.radius-bl-md {
+  border-bottom-left-radius: .25rem;
+}
+
+.radius-tl-md {
+  border-top-left-radius: .25rem;
+}
+
+.radius-lg {
+  border-radius: .5rem;
+}
+
+.radius-tr-lg {
+  border-top-right-radius: .5rem;
+}
+
+.radius-br-lg {
+  border-bottom-right-radius: .5rem;
+}
+
+.radius-bl-lg {
+  border-bottom-left-radius: .5rem;
+}
+
+.radius-tl-lg {
+  border-top-left-radius: .5rem;
+}
+
+.radius-full {
+  border-radius: 9999px;
+}
+
+.radius-tr-full {
+  border-top-right-radius: 9999px;
+}
+
+.radius-br-full {
+  border-bottom-right-radius: 9999px;
+}
+
+.radius-bl-full {
+  border-bottom-left-radius: 9999px;
+}
+
+.radius-tl-full {
+  border-top-left-radius: 9999px;
 }
 
 .block {
@@ -5152,124 +5132,104 @@ button,
     border-style: none;
   }
 
-  .sm\:rounded {
-    border-radius: .25rem;
-  }
-
-  .sm\:rounded-t {
-    border-top-right-radius: .25rem;
-    border-top-left-radius: .25rem;
-  }
-
-  .sm\:rounded-r {
-    border-top-right-radius: .25rem;
-    border-bottom-right-radius: .25rem;
-  }
-
-  .sm\:rounded-b {
-    border-bottom-right-radius: .25rem;
-    border-bottom-left-radius: .25rem;
-  }
-
-  .sm\:rounded-l {
-    border-top-left-radius: .25rem;
-    border-bottom-left-radius: .25rem;
-  }
-
-  .sm\:rounded-sm {
-    border-radius: .125rem;
-  }
-
-  .sm\:rounded-t-sm {
-    border-top-right-radius: .125rem;
-    border-top-left-radius: .125rem;
-  }
-
-  .sm\:rounded-r-sm {
-    border-top-right-radius: .125rem;
-    border-bottom-right-radius: .125rem;
-  }
-
-  .sm\:rounded-b-sm {
-    border-bottom-right-radius: .125rem;
-    border-bottom-left-radius: .125rem;
-  }
-
-  .sm\:rounded-l-sm {
-    border-top-left-radius: .125rem;
-    border-bottom-left-radius: .125rem;
-  }
-
-  .sm\:rounded-lg {
-    border-radius: .5rem;
-  }
-
-  .sm\:rounded-t-lg {
-    border-top-right-radius: .5rem;
-    border-top-left-radius: .5rem;
-  }
-
-  .sm\:rounded-r-lg {
-    border-top-right-radius: .5rem;
-    border-bottom-right-radius: .5rem;
-  }
-
-  .sm\:rounded-b-lg {
-    border-bottom-right-radius: .5rem;
-    border-bottom-left-radius: .5rem;
-  }
-
-  .sm\:rounded-l-lg {
-    border-top-left-radius: .5rem;
-    border-bottom-left-radius: .5rem;
-  }
-
-  .sm\:rounded-full {
-    border-radius: 9999px;
-  }
-
-  .sm\:rounded-t-full {
-    border-top-right-radius: 9999px;
-    border-top-left-radius: 9999px;
-  }
-
-  .sm\:rounded-r-full {
-    border-top-right-radius: 9999px;
-    border-bottom-right-radius: 9999px;
-  }
-
-  .sm\:rounded-b-full {
-    border-bottom-right-radius: 9999px;
-    border-bottom-left-radius: 9999px;
-  }
-
-  .sm\:rounded-l-full {
-    border-top-left-radius: 9999px;
-    border-bottom-left-radius: 9999px;
-  }
-
-  .sm\:rounded-none {
+  .sm\:radius-none {
     border-radius: 0;
   }
 
-  .sm\:rounded-t-none {
+  .sm\:radius-tr-none {
     border-top-right-radius: 0;
-    border-top-left-radius: 0;
   }
 
-  .sm\:rounded-r-none {
-    border-top-right-radius: 0;
+  .sm\:radius-br-none {
     border-bottom-right-radius: 0;
   }
 
-  .sm\:rounded-b-none {
-    border-bottom-right-radius: 0;
+  .sm\:radius-bl-none {
     border-bottom-left-radius: 0;
   }
 
-  .sm\:rounded-l-none {
+  .sm\:radius-tl-none {
     border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
+  }
+
+  .sm\:radius-sm {
+    border-radius: .125rem;
+  }
+
+  .sm\:radius-tr-sm {
+    border-top-right-radius: .125rem;
+  }
+
+  .sm\:radius-br-sm {
+    border-bottom-right-radius: .125rem;
+  }
+
+  .sm\:radius-bl-sm {
+    border-bottom-left-radius: .125rem;
+  }
+
+  .sm\:radius-tl-sm {
+    border-top-left-radius: .125rem;
+  }
+
+  .sm\:radius-md {
+    border-radius: .25rem;
+  }
+
+  .sm\:radius-tr-md {
+    border-top-right-radius: .25rem;
+  }
+
+  .sm\:radius-br-md {
+    border-bottom-right-radius: .25rem;
+  }
+
+  .sm\:radius-bl-md {
+    border-bottom-left-radius: .25rem;
+  }
+
+  .sm\:radius-tl-md {
+    border-top-left-radius: .25rem;
+  }
+
+  .sm\:radius-lg {
+    border-radius: .5rem;
+  }
+
+  .sm\:radius-tr-lg {
+    border-top-right-radius: .5rem;
+  }
+
+  .sm\:radius-br-lg {
+    border-bottom-right-radius: .5rem;
+  }
+
+  .sm\:radius-bl-lg {
+    border-bottom-left-radius: .5rem;
+  }
+
+  .sm\:radius-tl-lg {
+    border-top-left-radius: .5rem;
+  }
+
+  .sm\:radius-full {
+    border-radius: 9999px;
+  }
+
+  .sm\:radius-tr-full {
+    border-top-right-radius: 9999px;
+  }
+
+  .sm\:radius-br-full {
+    border-bottom-right-radius: 9999px;
+  }
+
+  .sm\:radius-bl-full {
+    border-bottom-left-radius: 9999px;
+  }
+
+  .sm\:radius-tl-full {
+    border-top-left-radius: 9999px;
   }
 
   .sm\:block {
@@ -8193,124 +8153,104 @@ button,
     border-style: none;
   }
 
-  .md\:rounded {
-    border-radius: .25rem;
-  }
-
-  .md\:rounded-t {
-    border-top-right-radius: .25rem;
-    border-top-left-radius: .25rem;
-  }
-
-  .md\:rounded-r {
-    border-top-right-radius: .25rem;
-    border-bottom-right-radius: .25rem;
-  }
-
-  .md\:rounded-b {
-    border-bottom-right-radius: .25rem;
-    border-bottom-left-radius: .25rem;
-  }
-
-  .md\:rounded-l {
-    border-top-left-radius: .25rem;
-    border-bottom-left-radius: .25rem;
-  }
-
-  .md\:rounded-sm {
-    border-radius: .125rem;
-  }
-
-  .md\:rounded-t-sm {
-    border-top-right-radius: .125rem;
-    border-top-left-radius: .125rem;
-  }
-
-  .md\:rounded-r-sm {
-    border-top-right-radius: .125rem;
-    border-bottom-right-radius: .125rem;
-  }
-
-  .md\:rounded-b-sm {
-    border-bottom-right-radius: .125rem;
-    border-bottom-left-radius: .125rem;
-  }
-
-  .md\:rounded-l-sm {
-    border-top-left-radius: .125rem;
-    border-bottom-left-radius: .125rem;
-  }
-
-  .md\:rounded-lg {
-    border-radius: .5rem;
-  }
-
-  .md\:rounded-t-lg {
-    border-top-right-radius: .5rem;
-    border-top-left-radius: .5rem;
-  }
-
-  .md\:rounded-r-lg {
-    border-top-right-radius: .5rem;
-    border-bottom-right-radius: .5rem;
-  }
-
-  .md\:rounded-b-lg {
-    border-bottom-right-radius: .5rem;
-    border-bottom-left-radius: .5rem;
-  }
-
-  .md\:rounded-l-lg {
-    border-top-left-radius: .5rem;
-    border-bottom-left-radius: .5rem;
-  }
-
-  .md\:rounded-full {
-    border-radius: 9999px;
-  }
-
-  .md\:rounded-t-full {
-    border-top-right-radius: 9999px;
-    border-top-left-radius: 9999px;
-  }
-
-  .md\:rounded-r-full {
-    border-top-right-radius: 9999px;
-    border-bottom-right-radius: 9999px;
-  }
-
-  .md\:rounded-b-full {
-    border-bottom-right-radius: 9999px;
-    border-bottom-left-radius: 9999px;
-  }
-
-  .md\:rounded-l-full {
-    border-top-left-radius: 9999px;
-    border-bottom-left-radius: 9999px;
-  }
-
-  .md\:rounded-none {
+  .md\:radius-none {
     border-radius: 0;
   }
 
-  .md\:rounded-t-none {
+  .md\:radius-tr-none {
     border-top-right-radius: 0;
-    border-top-left-radius: 0;
   }
 
-  .md\:rounded-r-none {
-    border-top-right-radius: 0;
+  .md\:radius-br-none {
     border-bottom-right-radius: 0;
   }
 
-  .md\:rounded-b-none {
-    border-bottom-right-radius: 0;
+  .md\:radius-bl-none {
     border-bottom-left-radius: 0;
   }
 
-  .md\:rounded-l-none {
+  .md\:radius-tl-none {
     border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
+  }
+
+  .md\:radius-sm {
+    border-radius: .125rem;
+  }
+
+  .md\:radius-tr-sm {
+    border-top-right-radius: .125rem;
+  }
+
+  .md\:radius-br-sm {
+    border-bottom-right-radius: .125rem;
+  }
+
+  .md\:radius-bl-sm {
+    border-bottom-left-radius: .125rem;
+  }
+
+  .md\:radius-tl-sm {
+    border-top-left-radius: .125rem;
+  }
+
+  .md\:radius-md {
+    border-radius: .25rem;
+  }
+
+  .md\:radius-tr-md {
+    border-top-right-radius: .25rem;
+  }
+
+  .md\:radius-br-md {
+    border-bottom-right-radius: .25rem;
+  }
+
+  .md\:radius-bl-md {
+    border-bottom-left-radius: .25rem;
+  }
+
+  .md\:radius-tl-md {
+    border-top-left-radius: .25rem;
+  }
+
+  .md\:radius-lg {
+    border-radius: .5rem;
+  }
+
+  .md\:radius-tr-lg {
+    border-top-right-radius: .5rem;
+  }
+
+  .md\:radius-br-lg {
+    border-bottom-right-radius: .5rem;
+  }
+
+  .md\:radius-bl-lg {
+    border-bottom-left-radius: .5rem;
+  }
+
+  .md\:radius-tl-lg {
+    border-top-left-radius: .5rem;
+  }
+
+  .md\:radius-full {
+    border-radius: 9999px;
+  }
+
+  .md\:radius-tr-full {
+    border-top-right-radius: 9999px;
+  }
+
+  .md\:radius-br-full {
+    border-bottom-right-radius: 9999px;
+  }
+
+  .md\:radius-bl-full {
+    border-bottom-left-radius: 9999px;
+  }
+
+  .md\:radius-tl-full {
+    border-top-left-radius: 9999px;
   }
 
   .md\:block {
@@ -11234,124 +11174,104 @@ button,
     border-style: none;
   }
 
-  .lg\:rounded {
-    border-radius: .25rem;
-  }
-
-  .lg\:rounded-t {
-    border-top-right-radius: .25rem;
-    border-top-left-radius: .25rem;
-  }
-
-  .lg\:rounded-r {
-    border-top-right-radius: .25rem;
-    border-bottom-right-radius: .25rem;
-  }
-
-  .lg\:rounded-b {
-    border-bottom-right-radius: .25rem;
-    border-bottom-left-radius: .25rem;
-  }
-
-  .lg\:rounded-l {
-    border-top-left-radius: .25rem;
-    border-bottom-left-radius: .25rem;
-  }
-
-  .lg\:rounded-sm {
-    border-radius: .125rem;
-  }
-
-  .lg\:rounded-t-sm {
-    border-top-right-radius: .125rem;
-    border-top-left-radius: .125rem;
-  }
-
-  .lg\:rounded-r-sm {
-    border-top-right-radius: .125rem;
-    border-bottom-right-radius: .125rem;
-  }
-
-  .lg\:rounded-b-sm {
-    border-bottom-right-radius: .125rem;
-    border-bottom-left-radius: .125rem;
-  }
-
-  .lg\:rounded-l-sm {
-    border-top-left-radius: .125rem;
-    border-bottom-left-radius: .125rem;
-  }
-
-  .lg\:rounded-lg {
-    border-radius: .5rem;
-  }
-
-  .lg\:rounded-t-lg {
-    border-top-right-radius: .5rem;
-    border-top-left-radius: .5rem;
-  }
-
-  .lg\:rounded-r-lg {
-    border-top-right-radius: .5rem;
-    border-bottom-right-radius: .5rem;
-  }
-
-  .lg\:rounded-b-lg {
-    border-bottom-right-radius: .5rem;
-    border-bottom-left-radius: .5rem;
-  }
-
-  .lg\:rounded-l-lg {
-    border-top-left-radius: .5rem;
-    border-bottom-left-radius: .5rem;
-  }
-
-  .lg\:rounded-full {
-    border-radius: 9999px;
-  }
-
-  .lg\:rounded-t-full {
-    border-top-right-radius: 9999px;
-    border-top-left-radius: 9999px;
-  }
-
-  .lg\:rounded-r-full {
-    border-top-right-radius: 9999px;
-    border-bottom-right-radius: 9999px;
-  }
-
-  .lg\:rounded-b-full {
-    border-bottom-right-radius: 9999px;
-    border-bottom-left-radius: 9999px;
-  }
-
-  .lg\:rounded-l-full {
-    border-top-left-radius: 9999px;
-    border-bottom-left-radius: 9999px;
-  }
-
-  .lg\:rounded-none {
+  .lg\:radius-none {
     border-radius: 0;
   }
 
-  .lg\:rounded-t-none {
+  .lg\:radius-tr-none {
     border-top-right-radius: 0;
-    border-top-left-radius: 0;
   }
 
-  .lg\:rounded-r-none {
-    border-top-right-radius: 0;
+  .lg\:radius-br-none {
     border-bottom-right-radius: 0;
   }
 
-  .lg\:rounded-b-none {
-    border-bottom-right-radius: 0;
+  .lg\:radius-bl-none {
     border-bottom-left-radius: 0;
   }
 
-  .lg\:rounded-l-none {
+  .lg\:radius-tl-none {
     border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
+  }
+
+  .lg\:radius-sm {
+    border-radius: .125rem;
+  }
+
+  .lg\:radius-tr-sm {
+    border-top-right-radius: .125rem;
+  }
+
+  .lg\:radius-br-sm {
+    border-bottom-right-radius: .125rem;
+  }
+
+  .lg\:radius-bl-sm {
+    border-bottom-left-radius: .125rem;
+  }
+
+  .lg\:radius-tl-sm {
+    border-top-left-radius: .125rem;
+  }
+
+  .lg\:radius-md {
+    border-radius: .25rem;
+  }
+
+  .lg\:radius-tr-md {
+    border-top-right-radius: .25rem;
+  }
+
+  .lg\:radius-br-md {
+    border-bottom-right-radius: .25rem;
+  }
+
+  .lg\:radius-bl-md {
+    border-bottom-left-radius: .25rem;
+  }
+
+  .lg\:radius-tl-md {
+    border-top-left-radius: .25rem;
+  }
+
+  .lg\:radius-lg {
+    border-radius: .5rem;
+  }
+
+  .lg\:radius-tr-lg {
+    border-top-right-radius: .5rem;
+  }
+
+  .lg\:radius-br-lg {
+    border-bottom-right-radius: .5rem;
+  }
+
+  .lg\:radius-bl-lg {
+    border-bottom-left-radius: .5rem;
+  }
+
+  .lg\:radius-tl-lg {
+    border-top-left-radius: .5rem;
+  }
+
+  .lg\:radius-full {
+    border-radius: 9999px;
+  }
+
+  .lg\:radius-tr-full {
+    border-top-right-radius: 9999px;
+  }
+
+  .lg\:radius-br-full {
+    border-bottom-right-radius: 9999px;
+  }
+
+  .lg\:radius-bl-full {
+    border-bottom-left-radius: 9999px;
+  }
+
+  .lg\:radius-tl-full {
+    border-top-left-radius: 9999px;
   }
 
   .lg\:block {
@@ -14275,124 +14195,104 @@ button,
     border-style: none;
   }
 
-  .xl\:rounded {
-    border-radius: .25rem;
-  }
-
-  .xl\:rounded-t {
-    border-top-right-radius: .25rem;
-    border-top-left-radius: .25rem;
-  }
-
-  .xl\:rounded-r {
-    border-top-right-radius: .25rem;
-    border-bottom-right-radius: .25rem;
-  }
-
-  .xl\:rounded-b {
-    border-bottom-right-radius: .25rem;
-    border-bottom-left-radius: .25rem;
-  }
-
-  .xl\:rounded-l {
-    border-top-left-radius: .25rem;
-    border-bottom-left-radius: .25rem;
-  }
-
-  .xl\:rounded-sm {
-    border-radius: .125rem;
-  }
-
-  .xl\:rounded-t-sm {
-    border-top-right-radius: .125rem;
-    border-top-left-radius: .125rem;
-  }
-
-  .xl\:rounded-r-sm {
-    border-top-right-radius: .125rem;
-    border-bottom-right-radius: .125rem;
-  }
-
-  .xl\:rounded-b-sm {
-    border-bottom-right-radius: .125rem;
-    border-bottom-left-radius: .125rem;
-  }
-
-  .xl\:rounded-l-sm {
-    border-top-left-radius: .125rem;
-    border-bottom-left-radius: .125rem;
-  }
-
-  .xl\:rounded-lg {
-    border-radius: .5rem;
-  }
-
-  .xl\:rounded-t-lg {
-    border-top-right-radius: .5rem;
-    border-top-left-radius: .5rem;
-  }
-
-  .xl\:rounded-r-lg {
-    border-top-right-radius: .5rem;
-    border-bottom-right-radius: .5rem;
-  }
-
-  .xl\:rounded-b-lg {
-    border-bottom-right-radius: .5rem;
-    border-bottom-left-radius: .5rem;
-  }
-
-  .xl\:rounded-l-lg {
-    border-top-left-radius: .5rem;
-    border-bottom-left-radius: .5rem;
-  }
-
-  .xl\:rounded-full {
-    border-radius: 9999px;
-  }
-
-  .xl\:rounded-t-full {
-    border-top-right-radius: 9999px;
-    border-top-left-radius: 9999px;
-  }
-
-  .xl\:rounded-r-full {
-    border-top-right-radius: 9999px;
-    border-bottom-right-radius: 9999px;
-  }
-
-  .xl\:rounded-b-full {
-    border-bottom-right-radius: 9999px;
-    border-bottom-left-radius: 9999px;
-  }
-
-  .xl\:rounded-l-full {
-    border-top-left-radius: 9999px;
-    border-bottom-left-radius: 9999px;
-  }
-
-  .xl\:rounded-none {
+  .xl\:radius-none {
     border-radius: 0;
   }
 
-  .xl\:rounded-t-none {
+  .xl\:radius-tr-none {
     border-top-right-radius: 0;
-    border-top-left-radius: 0;
   }
 
-  .xl\:rounded-r-none {
-    border-top-right-radius: 0;
+  .xl\:radius-br-none {
     border-bottom-right-radius: 0;
   }
 
-  .xl\:rounded-b-none {
-    border-bottom-right-radius: 0;
+  .xl\:radius-bl-none {
     border-bottom-left-radius: 0;
   }
 
-  .xl\:rounded-l-none {
+  .xl\:radius-tl-none {
     border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
+  }
+
+  .xl\:radius-sm {
+    border-radius: .125rem;
+  }
+
+  .xl\:radius-tr-sm {
+    border-top-right-radius: .125rem;
+  }
+
+  .xl\:radius-br-sm {
+    border-bottom-right-radius: .125rem;
+  }
+
+  .xl\:radius-bl-sm {
+    border-bottom-left-radius: .125rem;
+  }
+
+  .xl\:radius-tl-sm {
+    border-top-left-radius: .125rem;
+  }
+
+  .xl\:radius-md {
+    border-radius: .25rem;
+  }
+
+  .xl\:radius-tr-md {
+    border-top-right-radius: .25rem;
+  }
+
+  .xl\:radius-br-md {
+    border-bottom-right-radius: .25rem;
+  }
+
+  .xl\:radius-bl-md {
+    border-bottom-left-radius: .25rem;
+  }
+
+  .xl\:radius-tl-md {
+    border-top-left-radius: .25rem;
+  }
+
+  .xl\:radius-lg {
+    border-radius: .5rem;
+  }
+
+  .xl\:radius-tr-lg {
+    border-top-right-radius: .5rem;
+  }
+
+  .xl\:radius-br-lg {
+    border-bottom-right-radius: .5rem;
+  }
+
+  .xl\:radius-bl-lg {
+    border-bottom-left-radius: .5rem;
+  }
+
+  .xl\:radius-tl-lg {
+    border-top-left-radius: .5rem;
+  }
+
+  .xl\:radius-full {
+    border-radius: 9999px;
+  }
+
+  .xl\:radius-tr-full {
+    border-top-right-radius: 9999px;
+  }
+
+  .xl\:radius-br-full {
+    border-bottom-right-radius: 9999px;
+  }
+
+  .xl\:radius-bl-full {
+    border-bottom-left-radius: 9999px;
+  }
+
+  .xl\:radius-tl-full {
+    border-top-left-radius: 9999px;
   }
 
   .xl\:block {

--- a/defaultConfig.js
+++ b/defaultConfig.js
@@ -410,16 +410,16 @@ module.exports = {
   | is provided, it will be made available as the non-suffixed `.rounded`
   | utility.
   |
-  | Class name: .rounded{-radius?}
+  | Class name: .radius-{size}
   |
   */
 
   borderRadius: {
-    default: '.25rem',
+    'none': '0',
     'sm': '.125rem',
+    'md': '.25rem',
     'lg': '.5rem',
     'full': '9999px',
-    'none': '0',
   },
 
 

--- a/src/generators/rounded.js
+++ b/src/generators/rounded.js
@@ -2,27 +2,21 @@ import _ from 'lodash'
 import defineClasses from '../util/defineClasses'
 
 function sizedBorder(radius, modifier) {
-  modifier = modifier === 'default' ? '' : `-${modifier}`
-
   return defineClasses({
-    [`rounded${modifier}`]: {
+    [`radius-${modifier}`]: {
       'border-radius': `${radius}`,
     },
-    [`rounded-t${modifier}`]: {
+    [`radius-tr-${modifier}`]: {
       'border-top-right-radius': `${radius}`,
-      'border-top-left-radius': `${radius}`,
     },
-    [`rounded-r${modifier}`]: {
-      'border-top-right-radius': `${radius}`,
+    [`radius-br-${modifier}`]: {
       'border-bottom-right-radius': `${radius}`,
     },
-    [`rounded-b${modifier}`]: {
-      'border-bottom-right-radius': `${radius}`,
+    [`radius-bl-${modifier}`]: {
       'border-bottom-left-radius': `${radius}`,
     },
-    [`rounded-l${modifier}`]: {
+    [`radius-tl-${modifier}`]: {
       'border-top-left-radius': `${radius}`,
-      'border-bottom-left-radius': `${radius}`,
     },
   })
 }

--- a/src/generators/rounded.js
+++ b/src/generators/rounded.js
@@ -6,6 +6,22 @@ function sizedBorder(radius, modifier) {
     [`radius-${modifier}`]: {
       'border-radius': `${radius}`,
     },
+    [`radius-t-${modifier}`]: {
+      'border-top-left-radius': `${radius}`,
+      'border-top-right-radius': `${radius}`,
+    },
+    [`radius-r-${modifier}`]: {
+      'border-top-right-radius': `${radius}`,
+      'border-bottom-right-radius': `${radius}`,
+    },
+    [`radius-b-${modifier}`]: {
+      'border-bottom-right-radius': `${radius}`,
+      'border-bottom-left-radius': `${radius}`,
+    },
+    [`radius-l-${modifier}`]: {
+      'border-top-left-radius': `${radius}`,
+      'border-bottom-left-radius': `${radius}`,
+    },
     [`radius-tr-${modifier}`]: {
       'border-top-right-radius': `${radius}`,
     },


### PR DESCRIPTION
*This PR is targeting the branch #188 is based on and should be merged against that branch first if we think this is a good idea.*

This PR changes the name of the `rounded` utility to `radius`, removes the default no-modifier `rounded` utility altogether, and removes the ability to round the sides of an element (`rounded-t-sm`), adding the ability to round specific corners instead (`radius-tl-sm radius-tr-sm`).

## Changing `rounded` to `radius`

The name `rounded` is a bit unusual compared to our other utilities. On its own it's kind of nice, "this element is rounded", but when combined with modifiers it starts to feel awkward:

```
<div class="rounded-lg"></div>
```

In particular, `rounded-none` felt really odd.

Other utilities use a more active/declarative tense which feels a little more natural with modifiers. For example, we use `tracking-wide` not `tracked-wide`, and `shadow-md` not `shadowed-md`.

Switching to just `round` felt wrong because "round" sounds like you're making something a circle, not just rounding it slightly.

Switching to `radius-md` feels more consistent with `tracking-wide` and `shadow-md`, where it's like we're saying "The radius of this element is medium sized."

`radius-none` also feels miles better than `rounded-none`.

It's also closer to the CSS property name which, although not a primary goal when we choose names, always ends up being a plus if we like a name better for other justifiable reasons and it *also* happens to be closer to the CSS property name.

### Downsides

1. This is a big breaking change, but that's why we're still 0.x so while unfortunate, this would be the time to do it.
2. We lose the no-modifier `rounded` utility in favor of `radius-md`. I considered keeping a default `radius` utility, but it feels weird, like `tracking` would feel without a modifier.

## Targeting corners ~~instead of~~ in addition to sides

Currently we support rounding the *sides* of an element, like so:

```
<div class="radius-t-lg"></div>
```

...which would round the top-left and top-right corners.

As part of reworking some of this border radius stuff, this PR ~~replaces the ability to target sides with~~ adds the ability to target *corners*.

So the above code ~~would~~ could be rewritten like:

```
<div class="radius-tl-lg radius-tr-lg"></div>
```

Motivations for this:

1. Currently it's very unintuitive to round a single corner. You have to round the entire element, then disable rounding on the two opposing sides. This is how you round just the bottom left corner for example:

    ```
    <div class="radius-lg radius-t-none radius-r-none"></div>
    ```

    This is really weird. ~~Switching to~~ Supporting corners ~~instead of~~ in addition to sides lets you be very explicit and direct about what you are trying to do:

    ```
    <div class="radius-bl-lg"></div>
    ```

2. ~~The existing radius side utilities have two declarations each; one for each corner they are targeting:~~

    ```
    .rounded-t {
        border-top-left-radius: .25rem;
        border-top-right-radius: .25rem;
    }
    ```

    ~~This is the reason for issue 1. We are trading fine grained control for a bit of convenience, and nowadays I think I'm convinced that it's better to make this a simpler and more direct abstraction on top of the individual CSS properties.~~

    Forget this point :)

### Downsides

1. Again big breaking change.
2. The `tl`, `tr`, `bl`, `br` abbreviations are going to take some getting used to; I think they are pretty unintuitive but don't have a better alternative.
3. ~~You now need two classes to round both corners on one side of an element:~~

    ```
    <div class="radius-tl-lg radius-tr-lg"></div>
    ```

   ~~This is without a doubt harder to read and grok than:~~

    ```
    <div class="radius-t-lg"></div>
    ```

    ~~It's only worse when combined with a bunch of other utilities too.~~

    No longer relevant; keeping both.

### ~~Q: Should we support targeting both sides *and* corners?~~

~~Part of me really wants to support targeting corners as well as sides, since it's much more common to style two adjacent corners than one individual corner.~~

~~The issue is it adds 100 more classes to the output, and 20 new classes every time you add a new radius size. This results in about ~1kb of extra file size (minified and gzipped) for the default configuration, which is not insignificant since the whole file is about ~29kb to begin with.~~

~~It would also be the only time in the framework that we provide "shortcut" classes like that for things you could already do with existing classes.~~ Actually we already do this sort of thing for `pl` and `pr` with `px`, and in a few other places 🤔 

So my questions are:

1. Is it worth keeping the side helpers for convenience, despite the extra file size? Is adding two classes with the new `tr`-style abbreviations so ugly that it's worth it?
2. Should we just keep it to sides and forget targeting corners since that's not terribly common, and instead suggest that people create their own utilities for that if they ever need to do it?

I should've made this two separate PRs and discussions but it's too late now 🙊 