### PR TITLE
Feature/add facebook meta tags

### DIFF
--- a/docs/source/_layouts/documentation.blade.php
+++ b/docs/source/_layouts/documentation.blade.php
@@ -7,6 +7,11 @@
 <meta name="twitter:description" content="{{ $page->description ? $page->description : 'Documentation for the Tailwind CSS framework.' }}">
 <meta name="twitter:image" content="https://tailwindcss.com/img/tailwind-square.png">
 <meta name="twitter:creator" content="@tailwindcss">
+<meta property="og:url"                content="https://tailwindcss.com/" />
+<meta property="og:type"               content="article" />
+<meta property="og:title"              content="Tailwind CSS" />
+<meta property="og:description"        content="A Utility-First CSS Framework for Rapid UI Development" />
+<meta property="og:image"              content="https://tailwindcss.com/img/twitter-card.png" />
 @endsection
 
 @section('body')

--- a/docs/source/_layouts/documentation.blade.php
+++ b/docs/source/_layouts/documentation.blade.php
@@ -7,11 +7,11 @@
 <meta name="twitter:description" content="{{ $page->description ? $page->description : 'Documentation for the Tailwind CSS framework.' }}">
 <meta name="twitter:image" content="https://tailwindcss.com/img/tailwind-square.png">
 <meta name="twitter:creator" content="@tailwindcss">
-<meta property="og:url"                content="https://tailwindcss.com/" />
-<meta property="og:type"               content="article" />
-<meta property="og:title"              content="Tailwind CSS" />
-<meta property="og:description"        content="A Utility-First CSS Framework for Rapid UI Development" />
-<meta property="og:image"              content="https://tailwindcss.com/img/twitter-card.png" />
+<meta property="og:url" content="https://tailwindcss.com/" />
+<meta property="og:type" content="article" />
+<meta property="og:title" content="Tailwind CSS" />
+<meta property="og:description" content="A Utility-First CSS Framework for Rapid UI Development" />
+<meta property="og:image" content="https://tailwindcss.com/img/twitter-card.png" />
 @endsection
 
 @section('body')

--- a/docs/source/_layouts/documentation.blade.php
+++ b/docs/source/_layouts/documentation.blade.php
@@ -9,8 +9,8 @@
 <meta name="twitter:creator" content="@tailwindcss">
 <meta property="og:url" content="https://tailwindcss.com/" />
 <meta property="og:type" content="article" />
-<meta property="og:title" content="Tailwind CSS" />
-<meta property="og:description" content="A Utility-First CSS Framework for Rapid UI Development" />
+<meta property="og:title" content="{{ $page->title ? $page->title . ' - Tailwind CSS' : 'Tailwind CSS - A Utility-First CSS Framework for Rapid UI Development' }}" />
+<meta property="og:description" content="{{ $page->description ? $page->description : 'Documentation for the Tailwind CSS framework.' }}" />
 <meta property="og:image" content="https://tailwindcss.com/img/twitter-card.png" />
 @endsection
 


### PR DESCRIPTION
Hey Adam,

like requested on Twitter here is the PR :-)

This PR adds the Facebook Open Graph Meta Tags to the site. This way the right content will be shown when the site is shared on Facebook. I have used the given Twitter Card image. Please change it if you want to use another image.

Greets