### PR TITLE
Don't reset borders for specific elements, fix Chrome 62 border radius debacle

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -528,6 +528,18 @@ fieldset {
   border-width: 0;
   border-style: solid;
   border-color: #dae4e9;
+}
+
+/**
+ * Temporary reset for a change introduced in Chrome 62 but now reverted.
+ *
+ * We can remove this when the reversion is in a normal Chrome release.
+ */
+input[type="button" i],
+input[type="submit" i],
+input[type="reset" i],
+input[type="file" i]::-webkit-file-upload-button,
+button {
   border-radius: 0;
 }
 

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -490,7 +490,6 @@ pre {
 
 button {
   background: transparent;
-  border: 0;
   padding: 0;
 }
 
@@ -505,13 +504,8 @@ button:focus {
 }
 
 fieldset {
-  border: 0;
   margin: 0;
   padding: 0;
-}
-
-iframe {
-  border: 0;
 }
 
 /**
@@ -534,6 +528,7 @@ iframe {
   border-width: 0;
   border-style: solid;
   border-color: #dae4e9;
+  border-radius: 0;
 }
 
 textarea {

--- a/css/preflight.css
+++ b/css/preflight.css
@@ -528,6 +528,18 @@ fieldset {
   border-width: 0;
   border-style: solid;
   border-color: config('borderColors.default', currentColor);
+}
+
+/**
+ * Temporary reset for a change introduced in Chrome 62 but now reverted.
+ *
+ * We can remove this when the reversion is in a normal Chrome release.
+ */
+input[type="button" i],
+input[type="submit" i],
+input[type="reset" i],
+input[type="file" i]::-webkit-file-upload-button,
+button {
   border-radius: 0;
 }
 

--- a/css/preflight.css
+++ b/css/preflight.css
@@ -490,7 +490,6 @@ pre {
 
 button {
   background: transparent;
-  border: 0;
   padding: 0;
 }
 
@@ -505,13 +504,8 @@ button:focus {
 }
 
 fieldset {
-  border: 0;
   margin: 0;
   padding: 0;
-}
-
-iframe {
-  border: 0;
 }
 
 /**
@@ -534,6 +528,7 @@ iframe {
   border-width: 0;
   border-style: solid;
   border-color: config('borderColors.default', currentColor);
+  border-radius: 0;
 }
 
 textarea { resize: vertical; }


### PR DESCRIPTION
Setting `border: 0` on a handful of elements breaks our universal border style reset, since the unviersal selector has no specificity and is defeated by element selectors. Turns out those old resets don't matter anyways since our universal reset does the same job.

This also resets the border radius of buttons and button-like things to 0 because Chrome 62 recently shipped some new default styles for buttons on macOS. This has been reverted upstream in Chrome, but I think it makes sense to keep this in our own reset until Chrome 62 is no longer in active use.