### PR TITLE
Revert trying to reset Chrome 62 default button styles

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -530,6 +530,18 @@ fieldset {
   border-color: #dae4e9;
 }
 
+/**
+ * Temporary reset for a change introduced in Chrome 62 but now reverted.
+ *
+ * We can remove this when the reversion is in a normal Chrome release.
+ */
+button,
+[type="button"],
+[type="reset"],
+[type="submit"] {
+  border-radius: 0;
+}
+
 textarea {
   resize: vertical;
 }

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -530,19 +530,6 @@ fieldset {
   border-color: #dae4e9;
 }
 
-/**
- * Temporary reset for a change introduced in Chrome 62 but now reverted.
- *
- * We can remove this when the reversion is in a normal Chrome release.
- */
-input[type="button" i],
-input[type="submit" i],
-input[type="reset" i],
-input[type="file" i]::-webkit-file-upload-button,
-button {
-  border-radius: 0;
-}
-
 textarea {
   resize: vertical;
 }

--- a/css/preflight.css
+++ b/css/preflight.css
@@ -530,6 +530,18 @@ fieldset {
   border-color: config('borderColors.default', currentColor);
 }
 
+/**
+ * Temporary reset for a change introduced in Chrome 62 but now reverted.
+ *
+ * We can remove this when the reversion is in a normal Chrome release.
+ */
+button,
+[type="button"],
+[type="reset"],
+[type="submit"] {
+  border-radius: 0;
+}
+
 textarea { resize: vertical; }
 
 img { max-width: 100%; }

--- a/css/preflight.css
+++ b/css/preflight.css
@@ -530,19 +530,6 @@ fieldset {
   border-color: config('borderColors.default', currentColor);
 }
 
-/**
- * Temporary reset for a change introduced in Chrome 62 but now reverted.
- *
- * We can remove this when the reversion is in a normal Chrome release.
- */
-input[type="button" i],
-input[type="submit" i],
-input[type="reset" i],
-input[type="file" i]::-webkit-file-upload-button,
-button {
-  border-radius: 0;
-}
-
 textarea { resize: vertical; }
 
 img { max-width: 100%; }


### PR DESCRIPTION
Resolves #215.

In Chrome 62, a user agent stylesheet change was made on macOS that gave all button-ish elements a 4px border radius. This is annoying.

Other discussions:

https://github.com/necolas/normalize.css/issues/706
https://github.com/primer/primer/pull/388
https://github.com/twbs/bootstrap/issues/24093

We tried to "fix" this by taking all of the selectors Chrome was targeting:

```css
input[type="button" i],
input[type="submit" i],
input[type="reset" i],
input[type="file" i]::-webkit-file-upload-button,
button {
    /* The color is similar to the border of OSX 10.12 buttons. */
    border-color: #d8d8d8 #d1d1d1 #bababa;
    border-radius: 4px;
    border-style: solid;
    border-width: 1px;
    /* Fixed padding provided by ThemeMac::ControlPadding() - 1px for broder */
    padding: 1px 7px 2px;
}
```

...and undoing the border reset.

The issue is some of these selectors have a higher specificity than a single class would, meaning for things like `<input type="button">`, our `rounded` utilities don't have any effect.

It turns out Chrome has now reverted this change:

https://bugs.chromium.org/p/chromium/issues/detail?id=752450#c13

...so it will stop being a problem in Chrome 63.

As such, we've opted to not attempt to "fix" this at all, because even though we could reset it for single selectors like `button`, we can't target `input[type="button"]` without breaking our own utilities.

Instead, it's recommended that users explicitly add `rounded-none` to buttons that should have square corners until Chrome 62 is no longer in widespread usage.

We may revisit "fixing" this in another patch release if we can think of an easy fix that doesn't introduce specificity issues, but reverting it for now so we can tag 0.2.1 and get our `rounded` utilities working again on `<input type="{button|reset|submit}">` elements.