### PR TITLE
Update navigation.blade.md

### DIFF
--- a/docs/source/docs/examples/navigation.blade.md
+++ b/docs/source/docs/examples/navigation.blade.md
@@ -38,7 +38,7 @@ description: null
       <svg class="h-3 w-3" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><title>Menu</title><path d="M0 3h20v2H0V3zm0 6h20v2H0V9zm0 6h20v2H0v-2z"/></svg>
     </button>
   </div>
-  <div class="w-full block flex-grow lg:flex lg:items-center lg:w-auto">
+  <div class="w-full block flex-grow lg:flex lg:items-center lg:w-auto sm:hidden">
     <div class="text-sm lg:flex-grow">
       <a href="#responsive-header" class="block mt-4 lg:inline-block lg:mt-0 text-teal-lighter hover:text-white mr-4">
         Docs


### PR DESCRIPTION
Add `sm:hidden` so the `a` links are hidden on small screens for a full responsive menu.

It was opened as an issue here: https://github.com/tailwindcss/discuss/issues/68

If you collapse the page, the menu items are not hidden. If this is by design then cool, but figured I would open this and see what yall thought.
