### PR TITLE
[0.3] Add `pin-none` utility to reset positioning at higher breakpoints

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3413,6 +3413,13 @@ button,
   position: relative;
 }
 
+.pin-none {
+  top: auto;
+  right: auto;
+  bottom: auto;
+  left: auto;
+}
+
 .pin-t {
   top: 0;
 }
@@ -3444,8 +3451,6 @@ button,
   right: 0;
   bottom: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
 }
 
 .resize-none {
@@ -7252,6 +7257,13 @@ button,
     position: relative;
   }
 
+  .sm\:pin-none {
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
+  }
+
   .sm\:pin-t {
     top: 0;
   }
@@ -7283,8 +7295,6 @@ button,
     right: 0;
     bottom: 0;
     left: 0;
-    width: 100%;
-    height: 100%;
   }
 
   .sm\:resize-none {
@@ -11092,6 +11102,13 @@ button,
     position: relative;
   }
 
+  .md\:pin-none {
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
+  }
+
   .md\:pin-t {
     top: 0;
   }
@@ -11123,8 +11140,6 @@ button,
     right: 0;
     bottom: 0;
     left: 0;
-    width: 100%;
-    height: 100%;
   }
 
   .md\:resize-none {
@@ -14932,6 +14947,13 @@ button,
     position: relative;
   }
 
+  .lg\:pin-none {
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
+  }
+
   .lg\:pin-t {
     top: 0;
   }
@@ -14963,8 +14985,6 @@ button,
     right: 0;
     bottom: 0;
     left: 0;
-    width: 100%;
-    height: 100%;
   }
 
   .lg\:resize-none {
@@ -18772,6 +18792,13 @@ button,
     position: relative;
   }
 
+  .xl\:pin-none {
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
+  }
+
   .xl\:pin-t {
     top: 0;
   }
@@ -18803,8 +18830,6 @@ button,
     right: 0;
     bottom: 0;
     left: 0;
-    width: 100%;
-    height: 100%;
   }
 
   .xl\:resize-none {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3420,19 +3420,10 @@ button,
   left: auto;
 }
 
-.pin-t {
+.pin {
   top: 0;
-}
-
-.pin-r {
   right: 0;
-}
-
-.pin-b {
   bottom: 0;
-}
-
-.pin-l {
   left: 0;
 }
 
@@ -3446,10 +3437,19 @@ button,
   left: 0;
 }
 
-.pin {
+.pin-t {
   top: 0;
+}
+
+.pin-r {
   right: 0;
+}
+
+.pin-b {
   bottom: 0;
+}
+
+.pin-l {
   left: 0;
 }
 
@@ -7264,19 +7264,10 @@ button,
     left: auto;
   }
 
-  .sm\:pin-t {
+  .sm\:pin {
     top: 0;
-  }
-
-  .sm\:pin-r {
     right: 0;
-  }
-
-  .sm\:pin-b {
     bottom: 0;
-  }
-
-  .sm\:pin-l {
     left: 0;
   }
 
@@ -7290,10 +7281,19 @@ button,
     left: 0;
   }
 
-  .sm\:pin {
+  .sm\:pin-t {
     top: 0;
+  }
+
+  .sm\:pin-r {
     right: 0;
+  }
+
+  .sm\:pin-b {
     bottom: 0;
+  }
+
+  .sm\:pin-l {
     left: 0;
   }
 
@@ -11109,19 +11109,10 @@ button,
     left: auto;
   }
 
-  .md\:pin-t {
+  .md\:pin {
     top: 0;
-  }
-
-  .md\:pin-r {
     right: 0;
-  }
-
-  .md\:pin-b {
     bottom: 0;
-  }
-
-  .md\:pin-l {
     left: 0;
   }
 
@@ -11135,10 +11126,19 @@ button,
     left: 0;
   }
 
-  .md\:pin {
+  .md\:pin-t {
     top: 0;
+  }
+
+  .md\:pin-r {
     right: 0;
+  }
+
+  .md\:pin-b {
     bottom: 0;
+  }
+
+  .md\:pin-l {
     left: 0;
   }
 
@@ -14954,19 +14954,10 @@ button,
     left: auto;
   }
 
-  .lg\:pin-t {
+  .lg\:pin {
     top: 0;
-  }
-
-  .lg\:pin-r {
     right: 0;
-  }
-
-  .lg\:pin-b {
     bottom: 0;
-  }
-
-  .lg\:pin-l {
     left: 0;
   }
 
@@ -14980,10 +14971,19 @@ button,
     left: 0;
   }
 
-  .lg\:pin {
+  .lg\:pin-t {
     top: 0;
+  }
+
+  .lg\:pin-r {
     right: 0;
+  }
+
+  .lg\:pin-b {
     bottom: 0;
+  }
+
+  .lg\:pin-l {
     left: 0;
   }
 
@@ -18799,19 +18799,10 @@ button,
     left: auto;
   }
 
-  .xl\:pin-t {
+  .xl\:pin {
     top: 0;
-  }
-
-  .xl\:pin-r {
     right: 0;
-  }
-
-  .xl\:pin-b {
     bottom: 0;
-  }
-
-  .xl\:pin-l {
     left: 0;
   }
 
@@ -18825,10 +18816,19 @@ button,
     left: 0;
   }
 
-  .xl\:pin {
+  .xl\:pin-t {
     top: 0;
+  }
+
+  .xl\:pin-r {
     right: 0;
+  }
+
+  .xl\:pin-b {
     bottom: 0;
+  }
+
+  .xl\:pin-l {
     left: 0;
   }
 

--- a/src/generators/position.js
+++ b/src/generators/position.js
@@ -6,6 +6,12 @@ export default function() {
     fixed: { position: 'fixed' },
     absolute: { position: 'absolute' },
     relative: { position: 'relative' },
+    'pin-none': {
+      top: 'auto',
+      right: 'auto',
+      bottom: 'auto',
+      left: 'auto',
+    },
     'pin-t': { top: 0 },
     'pin-r': { right: 0 },
     'pin-b': { bottom: 0 },
@@ -17,8 +23,6 @@ export default function() {
       right: 0,
       bottom: 0,
       left: 0,
-      width: '100%',
-      height: '100%',
     },
   })
 }

--- a/src/generators/position.js
+++ b/src/generators/position.js
@@ -12,17 +12,17 @@ export default function() {
       bottom: 'auto',
       left: 'auto',
     },
-    'pin-t': { top: 0 },
-    'pin-r': { right: 0 },
-    'pin-b': { bottom: 0 },
-    'pin-l': { left: 0 },
-    'pin-y': { top: 0, bottom: 0 },
-    'pin-x': { right: 0, left: 0 },
     pin: {
       top: 0,
       right: 0,
       bottom: 0,
       left: 0,
     },
+    'pin-y': { top: 0, bottom: 0 },
+    'pin-x': { right: 0, left: 0 },
+    'pin-t': { top: 0 },
+    'pin-r': { right: 0 },
+    'pin-b': { bottom: 0 },
+    'pin-l': { left: 0 },
   })
 }


### PR DESCRIPTION
Resolves #234.

Also removes height/width declarations from `.pin` (they never should have been there 🙈) and sorts the pin utilities from most general to most specific.

This is probably *technically* a breaking change, I'm not sure I think it's serious enough to justify waiting for 0.3 though.