### PR TITLE
[0.3] Remove redundant default option fallbacks

### DIFF
--- a/__tests__/defaultConfig.test.js
+++ b/__tests__/defaultConfig.test.js
@@ -1,0 +1,5 @@
+import config from '../defaultConfig.js'
+
+test('the default config matches the stub', () => {
+  expect(config()).toEqual(require('../defaultConfig.stub.js'))
+})

--- a/__tests__/importsConfig.test.js
+++ b/__tests__/importsConfig.test.js
@@ -1,7 +1,0 @@
-import tailwind from '../src/index'
-import config from '../defaultConfig.js'
-
-test('it can accept a config file', () => {
-  tailwind('./defaultConfig.js')
-  expect(require('../defaultConfig.stub.js')).toEqual(config())
-})

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -818,11 +818,11 @@ module.exports = {
 
   /*
   |-----------------------------------------------------------------------------
-  | Options                  https://tailwindcss.com/docs/configuration#options
+  | Advanced Options         https://tailwindcss.com/docs/configuration#options
   |-----------------------------------------------------------------------------
   |
-  | Here is where you can set your Tailwind configuration options. For more
-  | details about these options, visit the configuration options documentation.
+  | Here is where you can tweak advanced configuration options. We recommend
+  | leaving these options alone unless you absolutely need to change them.
   |
   */
 

--- a/src/lib/substituteTailwindUtilitiesAtRules.js
+++ b/src/lib/substituteTailwindUtilitiesAtRules.js
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import postcss from 'postcss'
 import applyClassPrefix from '../util/applyClassPrefix'
 import generateModules from '../util/generateModules'
@@ -16,7 +15,7 @@ export default function(config) {
 
       const utilities = generateModules(utilityModules, unwrappedConfig.modules, unwrappedConfig)
 
-      if (_.get(unwrappedConfig, 'options.important', false)) {
+      if (unwrappedConfig.options.important) {
         utilities.walkDecls(decl => (decl.important = true))
       }
 
@@ -24,7 +23,7 @@ export default function(config) {
         nodes: [...container(unwrappedConfig), ...utilities.nodes],
       })
 
-      applyClassPrefix(tailwindClasses, _.get(unwrappedConfig, 'options.prefix', ''))
+      applyClassPrefix(tailwindClasses, unwrappedConfig.options.prefix)
 
       atRule.before(tailwindClasses)
       atRule.remove()


### PR DESCRIPTION
Right now when trying to determine the `important` and `prefix` values in the config, we fall back using lodash to hardcoded defaults directly in the plugin code.

These fallbacks are unnecessary since the default options are merged with the user's options way earlier in the processing chain.

This PR removes those redundant fallbacks, and also adds some messaging around these options being "advanced", and that they aren't intended to really be tweaked just for fun. We had considered not including this section in the generated default config at all for that reason, but doing that introduces unnecessary complexity right now, and also makes these options less discoverable for the people who may actually need them.