### PR TITLE
Remove default list margin

### DIFF
--- a/css/preflight.css
+++ b/css/preflight.css
@@ -508,6 +508,11 @@ fieldset {
   padding: 0;
 }
 
+ol,
+ul {
+  margin: 0;
+}
+
 /**
  * Suppress the focus outline on elements that cannot be accessed via keyboard.
  * This prevents an unwanted focus outline from appearing around elements that


### PR DESCRIPTION
This PR is a follow-up to #224. I really think it makes sense to remove the margin on `ul` and `ol` because we do it for headings and paragraphs. Like Adam said in that issue, it's the left padding that is hard to re-create, not the margin.