### PR TITLE
[0.3] Add parent-hover variant

### DIFF
--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -50,6 +50,27 @@ test('it can generate focus variants', () => {
   })
 })
 
+test('it can generate parent-hover variants', () => {
+  const input = `
+    @variants parent-hover {
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+    }
+  `
+
+  const output = `
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+      .parent:hover .parent-hover${separator}banana { color: yellow; }
+      .parent:hover .parent-hover${separator}chocolate { color: brown; }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('it can generate hover and focus variants', () => {
   const input = `
     @variants hover, focus {

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -803,7 +803,7 @@ module.exports = {
     resize: ['responsive'],
     shadows: ['responsive'],
     textAlign: ['responsive'],
-    textColors: ['responsive', 'hover'],
+    textColors: ['responsive', 'hover', 'parent-hover'],
     textSizes: ['responsive'],
     textStyle: ['responsive', 'hover'],
     tracking: ['responsive'],

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -803,7 +803,7 @@ module.exports = {
     resize: ['responsive'],
     shadows: ['responsive'],
     textAlign: ['responsive'],
-    textColors: ['responsive', 'hover', 'parent-hover'],
+    textColors: ['responsive', 'hover'],
     textSizes: ['responsive'],
     textStyle: ['responsive', 'hover'],
     tracking: ['responsive'],

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -24,6 +24,7 @@ const variantGenerators = {
     const cloned = container.clone()
 
     cloned.walkRules(rule => {
+      // prettier-ignore
       rule.selector = `.parent:hover .parent-hover${config.options.separator}${rule.selector.slice(1)}`
     })
 

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -24,7 +24,7 @@ const variantGenerators = {
     const cloned = container.clone()
 
     cloned.walkRules(rule => {
-      rule.selectors = [...rule.selectors, `.parent:hover .parent-hover${config.options.separator}${rule.selector.slice(1)}`]
+      rule.selector = `.parent:hover .parent-hover${config.options.separator}${rule.selector.slice(1)}`
     })
 
     container.before(cloned.nodes)

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -20,6 +20,15 @@ const variantGenerators = {
 
     container.before(cloned.nodes)
   },
+  'parent-hover': (container, config) => {
+    const cloned = container.clone()
+
+    cloned.walkRules(rule => {
+      rule.selectors = [...rule.selectors, `.parent:hover .parent-hover${config.options.separator}${rule.selector.slice(1)}`]
+    })
+
+    container.before(cloned.nodes)
+  },
 }
 
 export default function(config) {
@@ -37,7 +46,7 @@ export default function(config) {
 
       atRule.before(atRule.clone().nodes)
 
-      _.forEach(['focus', 'hover'], variant => {
+      _.forEach(['focus', 'hover', 'parent-hover'], variant => {
         if (variants.includes(variant)) {
           variantGenerators[variant](atRule, unwrappedConfig)
         }


### PR DESCRIPTION
This PR adds a new `parent-hover` variant that lets you style a child element when a marked parent element is hovered.

This adds support for the functionality mentioned in #199.

Here's an example fiddle:

https://jsfiddle.net/pgdzpryv/11/

I don't think we will ever enable this by default for any module, but now that we have the ability to enable/disable modules and variants in the upcoming 0.3 release, I think it's fine to add this functionality to core as an opt-in thing. Folks using PurgeCSS will probably feel most comfortable taking advantage of this, as it definitely will add a lot of extra classes, especially using the large default color palette.