### PR TITLE
[0.3] Remove margins on lists by default

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -508,6 +508,11 @@ fieldset {
   padding: 0;
 }
 
+ol,
+ul {
+  margin: 0;
+}
+
 /**
  * Suppress the focus outline on elements that cannot be accessed via keyboard.
  * This prevents an unwanted focus outline from appearing around elements that
@@ -603,7 +608,6 @@ button,
 
 .list-reset {
   list-style: none;
-  margin: 0;
   padding: 0;
 }
 
@@ -4447,7 +4451,6 @@ button,
 @media (min-width: 576px) {
   .sm\:list-reset {
     list-style: none;
-    margin: 0;
     padding: 0;
   }
 
@@ -8292,7 +8295,6 @@ button,
 @media (min-width: 768px) {
   .md\:list-reset {
     list-style: none;
-    margin: 0;
     padding: 0;
   }
 
@@ -12137,7 +12139,6 @@ button,
 @media (min-width: 992px) {
   .lg\:list-reset {
     list-style: none;
-    margin: 0;
     padding: 0;
   }
 
@@ -15982,7 +15983,6 @@ button,
 @media (min-width: 1200px) {
   .xl\:list-reset {
     list-style: none;
-    margin: 0;
     padding: 0;
   }
 

--- a/css/preflight.css
+++ b/css/preflight.css
@@ -508,6 +508,11 @@ fieldset {
   padding: 0;
 }
 
+ol,
+ul {
+  margin: 0;
+}
+
 /**
  * Suppress the focus outline on elements that cannot be accessed via keyboard.
  * This prevents an unwanted focus outline from appearing around elements that

--- a/docs/source/docs/lists.blade.md
+++ b/docs/source/docs/lists.blade.md
@@ -15,7 +15,7 @@ features:
   'rows' => [
     [
       '.list-reset',
-      "list-style: none;\nmargin: 0;\npadding: 0;",
+      "list-style: none;\npadding: 0;",
       "Disable default browser styling for lists and list items.",
     ],
   ]

--- a/src/generators/lists.js
+++ b/src/generators/lists.js
@@ -4,7 +4,6 @@ export default function() {
   return defineClasses({
     'list-reset': {
       'list-style': 'none',
-      margin: '0',
       padding: '0',
     },
   })


### PR DESCRIPTION
Currently margins are removed in the `list-reset` class.

We remove margins by default on [all kinds of other elements](https://github.com/tailwindcss/tailwindcss/blob/master/css/preflight.css#L476-L489), so it seems reasonable to me to remove them by default on lists too, leaving `list-reset` to only handle removing the list style and the left padding.

Without this, lists will have some non-standard margin on the top and bottom by default that uses a value from outside of Tailwind's spacing config, which seems like an unnecessary inconsistency.

I'm also considering changing `list-reset` to `list-style-none` and putting the onus on the user to remove the padding, but also happy to make that a separate PR, and still not entirely convinced on it anyways.