### PR TITLE
Add support for hardcore bloat mode with `modules: 'all'`

### DIFF
--- a/__tests__/mergeConfigWithDefaults.test.js
+++ b/__tests__/mergeConfigWithDefaults.test.js
@@ -53,6 +53,33 @@ test('user modules are merged with default modules', () => {
   })
 })
 
+test('setting modules to "all" creates all variants for all modules', () => {
+  const userConfig = {
+    modules: 'all',
+    options: {},
+  }
+
+  const defaultConfig = {
+    modules: {
+      flexbox: ['responsive'],
+      textAlign: ['hover'],
+      textColors: ['focus'],
+    },
+    options: {},
+  }
+
+  const result = mergeConfigWithDefaults(userConfig, defaultConfig)
+
+  expect(result).toEqual({
+    modules: {
+      flexbox: ['responsive', 'hover', 'focus', 'parent-hover'],
+      textAlign: ['responsive', 'hover', 'focus', 'parent-hover'],
+      textColors: ['responsive', 'hover', 'focus', 'parent-hover'],
+    },
+    options: {},
+  })
+})
+
 test('user options are merged with default options', () => {
   const userConfig = {
     modules: {},

--- a/src/util/mergeConfigWithDefaults.js
+++ b/src/util/mergeConfigWithDefaults.js
@@ -1,8 +1,16 @@
 import _ from 'lodash'
 
+function mergeModules(userModules, defaultModules) {
+  if (userModules === 'all') {
+    return _.mapValues(defaultModules, () => ['responsive', 'hover', 'focus', 'parent-hover'])
+  }
+
+  return _.defaults(userModules, defaultModules)
+}
+
 export default function(userConfig, defaultConfig) {
   _.defaults(userConfig, defaultConfig)
-  userConfig.modules = _.defaults(userConfig.modules, defaultConfig.modules)
+  userConfig.modules = mergeModules(userConfig.modules, defaultConfig.modules)
   userConfig.options = _.defaults(userConfig.options, defaultConfig.options)
   return userConfig
 }


### PR DESCRIPTION
Turns on every variant for every module :feelsgood:

```
{
  // ...
  modules: 'all',
}
```

This will generate an *enormous* CSS file ready to tackle any user interface problem ever imagined.