### PR TITLE
Add more detail to `@apply` errors

### DIFF
--- a/src/lib/substituteClassApplyAtRules.js
+++ b/src/lib/substituteClassApplyAtRules.js
@@ -24,7 +24,7 @@ function findMixin(css, mixin, onError) {
 
   if (_.isEmpty(matches)) {
     // prettier-ignore
-    onError(`\`@apply\` cannot be used with ${mixin} because ${mixin} either does not exist, or it's actual definition includes a pseudo-class like :hover, :active, etc.`)
+    onError(`\`@apply\` cannot be used with \`${mixin}\` because \`${mixin}\` either cannot be found, or it's actual definition includes a pseudo-selector like :hover, :active, etc. If you're sure that \`${mixin}\` exists, make sure that any \`@import\` statements are being properly processed *before* Tailwind CSS sees your CSS, as \`@apply\` can only be used for classes in the same CSS tree.`)
   }
 
   if (matches.length > 1) {


### PR DESCRIPTION
Keep getting questions from people asking why `@apply` doesn't work for them and it inevitably ends up being because they are trying to use it across files and don't have their `@import` statements being inlined properly.