### PR TITLE
[0.3] Add resizable to allow resizing both axes

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3460,6 +3460,10 @@ button,
   resize: horizontal;
 }
 
+.resize {
+  resize: both;
+}
+
 .shadow {
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.10);
 }
@@ -7297,6 +7301,10 @@ button,
 
   .sm\:resize-x {
     resize: horizontal;
+  }
+
+  .sm\:resize {
+    resize: both;
   }
 
   .sm\:shadow {
@@ -11139,6 +11147,10 @@ button,
     resize: horizontal;
   }
 
+  .md\:resize {
+    resize: both;
+  }
+
   .md\:shadow {
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.10);
   }
@@ -14979,6 +14991,10 @@ button,
     resize: horizontal;
   }
 
+  .lg\:resize {
+    resize: both;
+  }
+
   .lg\:shadow {
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.10);
   }
@@ -18817,6 +18833,10 @@ button,
 
   .xl\:resize-x {
     resize: horizontal;
+  }
+
+  .xl\:resize {
+    resize: both;
   }
 
   .xl\:shadow {

--- a/docs/source/docs/resize.blade.md
+++ b/docs/source/docs/resize.blade.md
@@ -22,7 +22,7 @@ features:
     [
       '.resize',
       'resize: both;',
-      "Make an element resizable in both axes.",
+      "Make an element resizable along both axes.",
     ],
     [
       '.resize-y',

--- a/docs/source/docs/resize.blade.md
+++ b/docs/source/docs/resize.blade.md
@@ -1,7 +1,7 @@
 ---
 extends: _layouts.documentation
 title: "Resize"
-description: "Utilities for controlling the how a textarea can be resized."
+description: "Utilities for controlling the how an element can be resized."
 features:
   responsive: true
   customizable: false
@@ -17,17 +17,22 @@ features:
     [
       '.resize-none',
       'resize: none;',
-      "Make a textarea not resizable.",
+      "Make a element not resizable.",
+    ],
+    [
+      '.resize',
+      'resize: both;',
+      "Make a element resizable in both axes.",
     ],
     [
       '.resize-y',
       'resize: vertical;',
-      "Make a textarea resizable vertically.",
+      "Make a element resizable vertically.",
     ],
     [
       '.resize-x',
       'resize: horizontal;',
-      "Make a textarea resizable horizontally.",
+      "Make a element resizable horizontally.",
     ],
   ]
 ])

--- a/docs/source/docs/resize.blade.md
+++ b/docs/source/docs/resize.blade.md
@@ -17,22 +17,22 @@ features:
     [
       '.resize-none',
       'resize: none;',
-      "Make a element not resizable.",
+      "Make an element not resizable.",
     ],
     [
       '.resize',
       'resize: both;',
-      "Make a element resizable in both axes.",
+      "Make an element resizable in both axes.",
     ],
     [
       '.resize-y',
       'resize: vertical;',
-      "Make a element resizable vertically.",
+      "Make an element resizable vertically.",
     ],
     [
       '.resize-x',
       'resize: horizontal;',
-      "Make a element resizable horizontally.",
+      "Make an element resizable horizontally.",
     ],
   ]
 ])

--- a/docs/source/docs/resize.blade.md
+++ b/docs/source/docs/resize.blade.md
@@ -1,7 +1,7 @@
 ---
 extends: _layouts.documentation
 title: "Resize"
-description: "Utilities for controlling the how an element can be resized."
+description: "Utilities for controlling how an element can be resized."
 features:
   responsive: true
   customizable: false

--- a/src/generators/resize.js
+++ b/src/generators/resize.js
@@ -5,5 +5,6 @@ export default function() {
     'resize-none': { resize: 'none' },
     'resize-y': { resize: 'vertical' },
     'resize-x': { resize: 'horizontal' },
+    resize: { resize: 'both' },
   })
 }


### PR DESCRIPTION
The current resizing utility only allows one of the axes at the same time. Also, docs refer to 'textarea', but any element can be resized.