### PR TITLE
[WIP] Background gradients

### DIFF
--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -773,6 +773,7 @@ module.exports = {
     modules: {
       appearance: ['responsive'],
       backgroundColors: ['responsive', 'hover'],
+      backgroundGradients: ['responsive'],
       backgroundPosition: ['responsive'],
       backgroundSize: ['responsive'],
       borderColors: ['responsive', 'hover'],

--- a/src/generators/backgroundGradients.js
+++ b/src/generators/backgroundGradients.js
@@ -1,0 +1,23 @@
+import _ from 'lodash'
+import defineClasses from '../util/defineClasses'
+
+export default function({ backgroundColors }) {
+  return _.compact(
+    _.flatMap(backgroundColors, (startColor, startClassName) => {
+      return _.flatMap(backgroundColors, (endColor, endClassName) => {
+        if (startClassName === endClassName) {
+          return false
+        }
+
+        return defineClasses({
+          [`bg-gradient-y-${startClassName}-to-${endClassName}`]: {
+            'background-color': `linear-gradient(${startColor}, ${endColor})`,
+          },
+          [`bg-gradient-x-${startClassName}-to-${endClassName}`]: {
+            'background-color': `linear-gradient(to right, ${startColor}, ${endColor})`,
+          },
+        })
+      })
+    })
+  )
+}

--- a/src/utilityModules.js
+++ b/src/utilityModules.js
@@ -1,6 +1,7 @@
 import lists from './generators/lists'
 import appearance from './generators/appearance'
 import backgroundColors from './generators/backgroundColors'
+import backgroundGradients from './generators/backgroundGradients'
 import backgroundPosition from './generators/backgroundPosition'
 import backgroundSize from './generators/backgroundSize'
 import borderColors from './generators/borderColors'
@@ -44,6 +45,7 @@ export default [
   { name: 'lists', generator: lists },
   { name: 'appearance', generator: appearance },
   { name: 'backgroundColors', generator: backgroundColors },
+  { name: 'backgroundGradients', generator: backgroundGradients },
   { name: 'backgroundPosition', generator: backgroundPosition },
   { name: 'backgroundSize', generator: backgroundSize },
   { name: 'borderColors', generator: borderColors },


### PR DESCRIPTION
Previous discussion: https://github.com/tailwindcss/discuss/issues/73

Proposed syntax: `bg-gradient-[x|y]-$color1-to-$color2`

I wanted to spike out this feature and quickly realized that making gradients of every color combination was going to generate a lot of CSS (several thousand new rules; realistically <10 would ever be used in a given project). The tests were taking forever to run (presumably due to the much larger fixtures) so it seemed like a good place to stop and reflect on the approach.

A few options I considered:

* Generate combinations of the "primary" colors (`red-to-blue`, not `red-to-red-darker`)
* Generate gradients within the same primary color (`red-to-red-dark`, `red-to-red-light`, etc but not `red-to-blue`, `red-to-green`)
* Generate gradients for adjacent colors on the wheel (`yellow-to-orange`, `yellow-to-green`, etc but not `pink-to-green` or `blue-to-orange`)
* Maybe some special cases that also blend every color to `white`, `black`, `transparent`

Any thoughts? Maybe there is some other configuration approach that could be taken.

(Test and docs are obviously missing)

