### PR TITLE
[0.3] Remove preflight SVG reset

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -555,11 +555,6 @@ img {
   max-width: 100%;
 }
 
-svg {
-  fill: none;
-  stroke: none;
-}
-
 button,
 input,
 optgroup,

--- a/css/preflight.css
+++ b/css/preflight.css
@@ -551,11 +551,6 @@ textarea { resize: vertical; }
 
 img { max-width: 100%; }
 
-svg {
-  fill: none;
-  stroke: none;
-}
-
 button, input, optgroup, select, textarea { font-family: inherit; }
 
 input::placeholder, textarea::placeholder {


### PR DESCRIPTION
Has more downsides than upsides. Setting the fill to none by default will override the fill set on the actual SVG tag, and every browser defaults to a black fill anyways so SVG author who are creating stroke-only SVGs are all already going to be aware of this and accounting for it by setting `fill="none"` directly on their SVG assets.