### PR TITLE
Add inherit to the color palette

### DIFF
--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -45,6 +45,7 @@ View the full documentation at https://tailwindcss.com.
 
 var colors = {
   'transparent': 'transparent',
+  'inherit': 'inherit',
 
   'black': '#222b2f',
   'grey-darkest': '#364349',


### PR DESCRIPTION
This PR adds the possibility to do something like `text-inherit` or `bg-inherit`.

An example use case would be for keeping links the same color than the rest of the text.

:octocat: 