### PR TITLE
Change text on primary button on landing

### DIFF
--- a/docs/source/index.blade.php
+++ b/docs/source/index.blade.php
@@ -28,7 +28,7 @@
       </div>
       <h2 class="mt-12 font-light text-3xl sm:text-4xl text-center">A Utility-First CSS Framework<br class="hidden sm:inline-block"> for Rapid UI Development</h2>
       <div class="mt-12 sm:flex sm:justify-center">
-        <a class="mt-6 sm:mt-0 mx-auto sm:mx-2 max-w-xs rounded-full text-center leading-none font-semibold block px-12 py-3 border-2 border-tailwind-teal bg-tailwind-teal text-white hover:border-tailwind-teal-light hover:bg-tailwind-teal-light hover:bg-tailwind-teal-light" href="/docs/what-is-tailwind">Get Started</a>
+        <a class="mt-6 sm:mt-0 mx-auto sm:mx-2 max-w-xs rounded-full text-center leading-none font-semibold block px-12 py-3 border-2 border-tailwind-teal bg-tailwind-teal text-white hover:border-tailwind-teal-light hover:bg-tailwind-teal-light hover:bg-tailwind-teal-light" href="/docs/what-is-tailwind">Learn More</a>
         <a class="mt-6 sm:mt-0 mx-auto sm:mx-2 max-w-xs rounded-full text-center leading-none font-semibold block px-12 py-3 border-2 border-tailwind-teal text-tailwind-teal hover:text-white hover:border-tailwind-teal-light hover:bg-tailwind-teal-light hover:bg-tailwind-teal-light" href="https://github.com/tailwindcss/tailwindcss">GitHub</a>
       </div>
     </div>


### PR DESCRIPTION
The current text is "Get Started".

This sounds like something I'd click _after_ I'd read all about the framework, was sold on the ideas, and was ready to, you know, start.

Given that the button sends folks to "What is Tailwind?", I think something like "Learn More" is more congruent.

New text in place:

<img width="556" alt="screen shot 2017-12-07 at 10 26 33 am" src="https://user-images.githubusercontent.com/46677/33722860-1c49dcce-db39-11e7-86dc-6257f84d4692.png">

