### PR TITLE
Prevent @apply from adding !important.

### DIFF
--- a/__tests__/applyAtRule.test.js
+++ b/__tests__/applyAtRule.test.js
@@ -14,6 +14,15 @@ test("it copies a class's declarations into itself", () => {
   })
 })
 
+test("it removes important from applied classes", () => {
+  const output = '.a { color: red !important; } .b { color: red; }'
+
+  return run('.a { color: red !important; } .b { @apply .a; }').then(result => {
+    expect(result.css).toEqual(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('it fails if the class does not exist', () => {
   return run('.b { @apply .a; }').catch(e => {
     expect(e).toMatchObject({ name: 'CssSyntaxError' })

--- a/__tests__/applyAtRule.test.js
+++ b/__tests__/applyAtRule.test.js
@@ -14,7 +14,7 @@ test("it copies a class's declarations into itself", () => {
   })
 })
 
-test("it removes important from applied classes", () => {
+test('it removes important from applied classes', () => {
   const output = '.a { color: red !important; } .b { color: red; }'
 
   return run('.a { color: red !important; } .b { @apply .a; }').then(result => {

--- a/src/lib/substituteClassApplyAtRules.js
+++ b/src/lib/substituteClassApplyAtRules.js
@@ -58,6 +58,10 @@ export default function() {
           })
         })
 
+        decls.forEach((decl) => {
+          decl.important = false
+        })
+
         atRule.before(decls)
 
         atRule.params = customProperties.join(' ')

--- a/src/lib/substituteClassApplyAtRules.js
+++ b/src/lib/substituteClassApplyAtRules.js
@@ -58,7 +58,7 @@ export default function() {
           })
         })
 
-        decls.forEach((decl) => {
+        decls.forEach(decl => {
           decl.important = false
         })
 


### PR DESCRIPTION
This PR addresses #299 and prevents `@apply` from adding `!important` to the output when you have using `{options: {important: true}}`.