### PR TITLE
 Update font docs to include note about wrapping fonts in quotes 

### DIFF
--- a/docs/source/docs/fonts.blade.md
+++ b/docs/source/docs/fonts.blade.md
@@ -40,5 +40,36 @@ features:
     ],
     'variants' => [
         'responsive',
-    ],
+    ]
 ])
+
+### Note
+
+Some fonts, such as fonts with an integer in their name, are required to be wrapped in quotes. 
+
+For example:
+```js
+// ...
+
+module.exports = {
+  // ...
+    fonts: {
+      sans: [
+        'Exo 2',   // Replace this...
+        '"Exo 2"', // With this...
+        '-apple-system',
+        'BlinkMacSystemFont',
+        'Segoe UI',
+        'Roboto',
+        'Oxygen',
+        'Ubuntu',
+        'Cantarell',
+        'Fira Sans',
+        'Droid Sans',
+        'Helvetica Neue',
+        'sans-serif'
+      ],
+    // ...
+  }
+}
+```

--- a/docs/source/docs/fonts.blade.md
+++ b/docs/source/docs/fonts.blade.md
@@ -40,7 +40,7 @@ features:
     ],
     'variants' => [
         'responsive',
-    ]
+    ],
 ])
 
 ### Note

--- a/docs/source/docs/fonts.blade.md
+++ b/docs/source/docs/fonts.blade.md
@@ -45,9 +45,9 @@ features:
 
 ### Note
 
-Some fonts, such as fonts with an integer in their name, are required to be wrapped in quotes. 
+Some font names are required to be wrapped in quotes, such as fonts with an integer in their name. 
 
-For example:
+For example, in the fonts section of your config file:
 ```js
 // ...
 


### PR DESCRIPTION
I updated the font docs to include a note and example about wrapping certain font names in quotes.