### PR TITLE
Clean else

### DIFF
--- a/jest/customMatchers.js
+++ b/jest/customMatchers.js
@@ -11,11 +11,11 @@ expect.extend({
         message: () => `expected ${received} not to match CSS ${argument}`,
         pass: true,
       }
-    } else {
-      return {
-        message: () => `expected ${received} to match CSS ${argument}`,
-        pass: false,
-      }
+    }
+
+    return {
+      message: () => `expected ${received} to match CSS ${argument}`,
+      pass: false,
     }
   },
 })


### PR DESCRIPTION
I've removed the `else` when we have already returned something :put_litter_in_its_place: