### PR TITLE
fix bug in purgecss extractor

### DIFF
--- a/docs/source/docs/controlling-file-size.blade.md
+++ b/docs/source/docs/controlling-file-size.blade.md
@@ -165,7 +165,7 @@ let PurgecssPlugin = require("purgecss-webpack-plugin");
 // https://github.com/FullHuman/purgecss#extractor
 class TailwindExtractor {
   static extract(content) {
-    return content.match(/[A-z0-9-:\/]+/g);
+    return content.match(/[A-z0-9-:\/]+/g) || [];
   }
 }
 


### PR DESCRIPTION
`content.match` will return `null` on files without any  matches (e.g. empty files). This causes purgecss to fail. Defaulting to an empty array when content.match is falsy fixes this