### PR TITLE
Add configurable naming support for classes

### DIFF
--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -874,4 +874,321 @@ module.exports = {
     separator: ':',
   },
 
+  naming: {
+    backgroundColors: {
+      base: 'bg',
+      modifierPrefix: '-'
+    },
+    backgroundPositions: {
+      base: 'bg-',
+      sides: {
+        top: 'top',
+        right: 'right',
+        rightTop: 'right-top',
+        rightBottom: 'right-bottom',
+        bottom: 'bottom',
+        left: 'left',
+        leftTop: 'left-top',
+        leftBottom: 'left-bottom',
+        left: 'left',
+        center: 'center'
+      }
+    },
+    backgroundAttachment: {
+      fixed: 'bg-fixed',
+      local: 'bg-local',
+      scroll: 'bg-scroll'
+    },
+    backgroundRepeat: {
+      repeat: 'bg-repeat',
+      noRepeat: 'bg-no-repeat',
+      repeatX: 'bg-repeat-x',
+      repeatY: 'bg-repeat-y'
+    },
+    backgroundSize: {
+      contain: 'bg-contain',
+      cover: 'bg-cover',
+    },
+    borderColors: {
+      base: 'border',
+      modifierPrefix: '-'
+    },
+    borderStyle: {
+      solid: 'border-solid',
+      dashed: 'border-dashed',
+      dotted: 'border-dotted',
+      none: 'border-none'
+    },
+    borderWidths: {
+      base: 'border',
+      withSides: 'border-',
+      modifierPrefix: '-',
+      sides: {
+        top: 't',
+        right: 'r',
+        bottom: 'b',
+        left: 'l'
+      }
+    },
+    container: {
+      base: 'container'
+    },
+    cursor: {
+      auto: 'cursor-auto',
+      default: 'cursor-default',
+      pointer: 'cursor-pointer',
+      notAllowed: 'cursor-not-allowed',
+    },
+    display: {
+      block: 'block',
+      inlineBlock: 'inline-block',
+      inline: 'inline',
+      table: 'table',
+      tableRow: 'table-row',
+      tableCell: 'table-cell',
+      hidden: 'hidden'
+    },
+    flex: {
+      flex: 'flex',
+      inlineFlex: 'inline-flex',
+      flexRow: 'flex-row',
+      flexRowReverse: 'flex-row-reverse',
+      flexCol: 'flex-col',
+      flexColReverse: 'flex-col-reverse',
+      flexWrap: 'flex-wrap',
+      flexWrapReverse: 'flex-wrap-reverse',
+      flexNoWrap: 'flex-no-wrap',
+      itemsStart: 'items-start',
+      itemsEnd: 'items-end',
+      itemsCenter: 'items-center',
+      itemsBaseline: 'items-baseline',
+      itemsStretch: 'items-stretch',
+      selfAuto: 'self-auto',
+      selfStart: 'self-start',
+      selfEnd: 'self-end',
+      selfCenter: 'self-center',
+      selfStretch: 'self-stretch',
+      justifyStart: 'justify-start',
+      justifyEnd: 'justify-end',
+      justifyCenter: 'justify-center',
+      justifyBetween: 'justify-between',
+      justifyAround: 'justify-around',
+      contentCenter: 'content-center',
+      contentStart: 'content-start',
+      contentEnd: 'content-end',
+      contentBetween: 'content-between',
+      contentAround: 'content-around',
+      flex1: 'flex-1',
+      flexAuto: 'flex-auto',
+      flexInitial: 'flex-initial',
+      flexNone: 'flex-none',
+      flexGrow: 'flex-grow',
+      flexShrink: 'flex-shrink',
+      flexNoGrow: 'flex-no-grow',
+      flexNoShrink: 'flex-no-shrink'
+    },
+    floats: {
+      floatRight: 'float-right',
+      floatLeft: 'float-left',
+      floatNone: 'float-none',
+      clearfix: 'clearfix'
+    },
+    forms: {
+      appearanceNone: 'appearance-none'
+    },
+    lists: {
+      listReset: 'list-reset'
+    },
+    opacity: {
+      base: 'opacity',
+      modifierPrefix: '-'
+    },
+    overflow: {
+      base: 'overflow-',
+      auto: 'auto',
+      hidden: 'hidden',
+      visible: 'visible',
+      scroll: 'scroll',
+      xScroll: 'x-scroll',
+      yScroll: 'y-scroll',
+      scrollingTouch: 'scrolling-touch',
+      scrollingAuto: 'scrolling-auto',
+    },
+    pointerEvents: {
+      pointerAuto: 'pointer-events-auto',
+      pointerNone: 'pointer-events-none',
+    },
+    position: {
+      static: 'static',
+      fixed: 'fixed',
+      absolute: 'absolute',
+      relative: 'relative',
+      pin: 'pin',
+      pinNone: 'pin-none',
+      pinT: 'pin-t',
+      pinR: 'pin-r',
+      pinB: 'pin-b',
+      pinL: 'pin-l',
+      pinX: 'pin-x',
+      pinY: 'pin-y'
+    },
+    resize: {
+      resize: 'resize',
+      resizeNone: 'resize-none',
+      resizeX: 'resize-x',
+      resizeY: 'resize-y'
+    },
+    svgFill: {
+      base: 'fill',
+      modifierPrefix: '-'
+    },
+    svgStroke: {
+      base: 'stroke',
+      modifierPrefix: '-'
+    },
+    rounded: {
+      base: 'rounded',
+      withSides: 'rounded-',
+      modifierPrefix: '-',
+      sidesSeparator: '',
+      sides: {
+        top: 't',
+        right: 'r',
+        bottom: 'b',
+        left: 'l'
+      }
+    },
+    shadow: {
+      base: 'shadow',
+      modifierPrefix: '-'
+    },
+    height: {
+      base: 'h',
+      modifierPrefix: '-'
+    },
+    maxHeight: {
+      base: 'max-h',
+      modifierPrefix: '-'
+    },
+    minHeight: {
+      base: 'min-h',
+      modifierPrefix: '-'
+    },
+    width: {
+      base: 'w',
+      modifierPrefix: '-'
+    },
+    maxWidth: {
+      base: 'max-w',
+      modifierPrefix: '-'
+    },
+    minWidth: {
+      base: 'min-w',
+      modifierPrefix: '-'
+    },
+    margin: {
+      base: 'm',
+      modifierPrefix: '-',
+      y: 'y',
+      x: 'x',
+      t: 't',
+      r: 'r',
+      b: 'b',
+      l: 'l'
+    },
+    negativeMargin: {
+      base: '-m',
+      modifierPrefix: '-',
+      y: 'y',
+      x: 'x',
+      t: 't',
+      r: 'r',
+      b: 'b',
+      l: 'l'
+    },
+    padding: {
+      base: 'p',
+      modifierPrefix: '-',
+      y: 'y',
+      x: 'x',
+      t: 't',
+      r: 'r',
+      b: 'b',
+      l: 'l'
+    },
+    textAlign: {
+      left: 'text-left',
+      center: 'text-center',
+      right: 'text-right',
+      justify: 'text-justify'
+    },
+    textColors: {
+      base: 'text',
+      modifierPrefix: '-'
+    },
+    fonts: {
+      base: 'font',
+      modifierPrefix: '-'
+    },
+    leading: {
+      base: 'leading',
+      modifierPrefix: '-'
+    },
+    textSizes: {
+      base: 'text',
+      modifierPrefix: '-'
+    },
+    textStyle: {
+      italic: 'italic',
+      roman: 'roman',
+      uppercase: 'uppercase',
+      lowercase: 'lowercase',
+      capitalize: 'capitalize',
+      normalCase: 'normal-case',
+      underline: 'underline',
+      lineThrough: 'line-through',
+      noUnderline: 'no-underline',
+      antialiased: 'antialiased',
+      subpixelAntialiased: 'subpixel-antialiased'
+    },
+    textTracking: {
+      base: 'tracking',
+      modifierPrefix: '-'
+    },
+    fontWeights: {
+      base: 'font',
+      modifierPrefix: '-'
+    },
+    textWrap: {
+      whitespaceNormal: 'whitespace-normal',
+      whitespaceNoWrap: 'whitespace-no-wrap',
+      whitespacePre: 'whitespace-pre',
+      whitespacePreLine: 'whitespace-pre-line',
+      whitespacePreWrap: 'whitespace-pre-wrap',
+      breakWords: 'break-words',
+      breakNormal: 'break-normal',
+      truncate: 'truncate'
+    },
+    userSelect: {
+      selectNone: 'select-none',
+      selectText: 'select-text'
+    },
+    verticalAlign: {
+      alignBaseline: 'align-baseline',
+      alignTop: 'align-top',
+      alignMiddle: 'align-middle',
+      alignBottom: 'align-bottom',
+      alignTextTop: 'align-text-top',
+      alignTextBottom: 'align-text-bottom'
+    },
+    visibility: {
+      visible: 'visible',
+      invisible: 'invisible'
+    },
+    zIndex: {
+      base: 'z',
+      modifierPrefix: '-'
+    }
+  }
+
 }

--- a/src/generators/appearance.js
+++ b/src/generators/appearance.js
@@ -1,7 +1,7 @@
 import defineClasses from '../util/defineClasses'
 
-export default function() {
+export default function({ naming: { forms: ns } }) {
   return defineClasses({
-    'appearance-none': { appearance: 'none' },
+    [ns.appearanceNone]: { appearance: 'none' },
   })
 }

--- a/src/generators/backgroundAttachment.js
+++ b/src/generators/backgroundAttachment.js
@@ -1,9 +1,9 @@
 import defineClasses from '../util/defineClasses'
 
-export default function() {
+export default function({ naming: { backgroundAttachment: ns } }) {
   return defineClasses({
-    'bg-fixed': { 'background-attachment': 'fixed' },
-    'bg-local': { 'background-attachment': 'local' },
-    'bg-scroll': { 'background-attachment': 'scroll' },
+    [ns.fixed]: { 'background-attachment': 'fixed' },
+    [ns.local]: { 'background-attachment': 'local' },
+    [ns.scroll]: { 'background-attachment': 'scroll' },
   })
 }

--- a/src/generators/backgroundColors.js
+++ b/src/generators/backgroundColors.js
@@ -1,9 +1,9 @@
 import _ from 'lodash'
 import defineClass from '../util/defineClass'
 
-export default function({ backgroundColors }) {
+export default function({ backgroundColors, naming: { backgroundColors: ns } }) {
   return _.map(backgroundColors, (color, className) => {
-    return defineClass(`bg-${className}`, {
+    return defineClass(`${ns.base}${ns.modifierPrefix}${className}`, {
       'background-color': color,
     })
   })

--- a/src/generators/backgroundPosition.js
+++ b/src/generators/backgroundPosition.js
@@ -1,15 +1,15 @@
 import defineClasses from '../util/defineClasses'
 
-export default function() {
+export default function({ naming: { backgroundPositions: ns } }) {
   return defineClasses({
-    'bg-bottom': { 'background-position': 'bottom' },
-    'bg-center': { 'background-position': 'center' },
-    'bg-left': { 'background-position': 'left' },
-    'bg-left-bottom': { 'background-position': 'left bottom' },
-    'bg-left-top': { 'background-position': 'left top' },
-    'bg-right': { 'background-position': 'right' },
-    'bg-right-bottom': { 'background-position': 'right bottom' },
-    'bg-right-top': { 'background-position': 'right top' },
-    'bg-top': { 'background-position': 'top' },
+    [`${ns.base}${ns.sides.bottom}`]: { 'background-position': 'bottom' },
+    [`${ns.base}${ns.sides.center}`]: { 'background-position': 'center' },
+    [`${ns.base}${ns.sides.left}`]: { 'background-position': 'left' },
+    [`${ns.base}${ns.sides.leftBottom}`]: { 'background-position': 'left bottom' },
+    [`${ns.base}${ns.sides.leftTop}`]: { 'background-position': 'left top' },
+    [`${ns.base}${ns.sides.right}`]: { 'background-position': 'right' },
+    [`${ns.base}${ns.sides.rightBottom}`]: { 'background-position': 'right bottom' },
+    [`${ns.base}${ns.sides.rightTop}`]: { 'background-position': 'right top' },
+    [`${ns.base}${ns.sides.top}`]: { 'background-position': 'top' },
   })
 }

--- a/src/generators/backgroundRepeat.js
+++ b/src/generators/backgroundRepeat.js
@@ -1,10 +1,10 @@
 import defineClasses from '../util/defineClasses'
 
-export default function() {
+export default function({ naming: { backgroundRepeat: ns } }) {
   return defineClasses({
-    'bg-repeat': { 'background-repeat': 'repeat' },
-    'bg-no-repeat': { 'background-repeat': 'no-repeat' },
-    'bg-repeat-x': { 'background-repeat': 'repeat-x' },
-    'bg-repeat-y': { 'background-repeat': 'repeat-y' },
+    [ns.repeat]: { 'background-repeat': 'repeat' },
+    [ns.noRepeat]: { 'background-repeat': 'no-repeat' },
+    [ns.repeatX]: { 'background-repeat': 'repeat-x' },
+    [ns.repeatY]: { 'background-repeat': 'repeat-y' },
   })
 }

--- a/src/generators/backgroundSize.js
+++ b/src/generators/backgroundSize.js
@@ -1,11 +1,11 @@
 import defineClasses from '../util/defineClasses'
 
-export default function() {
+export default function({ naming: { backgroundSize: ns } }) {
   return defineClasses({
-    'bg-cover': {
+    [ns.cover]: {
       'background-size': 'cover',
     },
-    'bg-contain': {
+    [ns.contain]: {
       'background-size': 'contain',
     },
   })

--- a/src/generators/borderColors.js
+++ b/src/generators/borderColors.js
@@ -1,9 +1,9 @@
 import _ from 'lodash'
 import defineClass from '../util/defineClass'
 
-export default function({ borderColors }) {
+export default function({ borderColors, naming: { borderColors: ns } }) {
   return _.map(_.omit(borderColors, 'default'), (color, className) => {
-    return defineClass(`border-${className}`, {
+    return defineClass(`${ns.base}${ns.modifierPrefix}${className}`, {
       'border-color': color,
     })
   })

--- a/src/generators/borderRadius.js
+++ b/src/generators/borderRadius.js
@@ -1,45 +1,45 @@
 import _ from 'lodash'
 import defineClasses from '../util/defineClasses'
 
-function defineBorderRadiusUtilities(borderRadiuses) {
+function defineBorderRadiusUtilities(borderRadiuses, ns) {
   const generators = [
     (radius, modifier) =>
       defineClasses({
-        [`rounded${modifier}`]: {
+        [`${ns.base}${modifier}`]: {
           'border-radius': `${radius}`,
         },
       }),
     (radius, modifier) =>
       defineClasses({
-        [`rounded-t${modifier}`]: {
+        [`${ns.withSides}${ns.sides.top}${modifier}`]: {
           'border-top-left-radius': `${radius}`,
           'border-top-right-radius': `${radius}`,
         },
-        [`rounded-r${modifier}`]: {
+        [`${ns.withSides}${ns.sides.right}${modifier}`]: {
           'border-top-right-radius': `${radius}`,
           'border-bottom-right-radius': `${radius}`,
         },
-        [`rounded-b${modifier}`]: {
+        [`${ns.withSides}${ns.sides.bottom}${modifier}`]: {
           'border-bottom-right-radius': `${radius}`,
           'border-bottom-left-radius': `${radius}`,
         },
-        [`rounded-l${modifier}`]: {
+        [`${ns.withSides}${ns.sides.left}${modifier}`]: {
           'border-top-left-radius': `${radius}`,
           'border-bottom-left-radius': `${radius}`,
         },
       }),
     (radius, modifier) =>
       defineClasses({
-        [`rounded-tl${modifier}`]: {
+        [`${ns.withSides}${ns.sides.top}${ns.sidesSeparator}${ns.sides.left}${modifier}`]: {
           'border-top-left-radius': `${radius}`,
         },
-        [`rounded-tr${modifier}`]: {
+        [`${ns.withSides}${ns.sides.top}${ns.sidesSeparator}${ns.sides.right}${modifier}`]: {
           'border-top-right-radius': `${radius}`,
         },
-        [`rounded-br${modifier}`]: {
+        [`${ns.withSides}${ns.sides.bottom}${ns.sidesSeparator}${ns.sides.right}${modifier}`]: {
           'border-bottom-right-radius': `${radius}`,
         },
-        [`rounded-bl${modifier}`]: {
+        [`${ns.withSides}${ns.sides.bottom}${ns.sidesSeparator}${ns.sides.left}${modifier}`]: {
           'border-bottom-left-radius': `${radius}`,
         },
       }),
@@ -47,11 +47,11 @@ function defineBorderRadiusUtilities(borderRadiuses) {
 
   return _.flatMap(generators, generator => {
     return _.flatMap(borderRadiuses, (radius, modifier) => {
-      return generator(radius, modifier === 'default' ? '' : `-${modifier}`)
+      return generator(radius, modifier === 'default' ? '' : `${ns.modifierPrefix}${modifier}`)
     })
   })
 }
 
-module.exports = function({ borderRadius }) {
-  return defineBorderRadiusUtilities(borderRadius)
+module.exports = function({ borderRadius, naming: { rounded: ns } }) {
+  return defineBorderRadiusUtilities(borderRadius, ns)
 }

--- a/src/generators/borderStyle.js
+++ b/src/generators/borderStyle.js
@@ -1,17 +1,17 @@
 import defineClasses from '../util/defineClasses'
 
-export default function() {
+export default function({ naming: { borderStyle: ns } }) {
   return defineClasses({
-    'border-solid': {
+    [ns.solid]: {
       'border-style': 'solid',
     },
-    'border-dashed': {
+    [ns.dashed]: {
       'border-style': 'dashed',
     },
-    'border-dotted': {
+    [ns.dotted]: {
       'border-style': 'dotted',
     },
-    'border-none': {
+    [ns.none]: {
       'border-style': 'none',
     },
   })

--- a/src/generators/borderWidths.js
+++ b/src/generators/borderWidths.js
@@ -1,26 +1,26 @@
 import _ from 'lodash'
 import defineClasses from '../util/defineClasses'
 
-function defineBorderWidthUtilities(borderWidths) {
+function defineBorderWidthUtilities(borderWidths, ns) {
   const generators = [
     (width, modifier) =>
       defineClasses({
-        [`border${modifier}`]: {
+        [`${ns.base}${modifier}`]: {
           'border-width': `${width}`,
         },
       }),
     (width, modifier) =>
       defineClasses({
-        [`border-t${modifier}`]: {
+        [`${ns.withSides}${ns.sides.top}${modifier}`]: {
           'border-top-width': `${width}`,
         },
-        [`border-r${modifier}`]: {
+        [`${ns.withSides}${ns.sides.right}${modifier}`]: {
           'border-right-width': `${width}`,
         },
-        [`border-b${modifier}`]: {
+        [`${ns.withSides}${ns.sides.bottom}${modifier}`]: {
           'border-bottom-width': `${width}`,
         },
-        [`border-l${modifier}`]: {
+        [`${ns.withSides}${ns.sides.left}${modifier}`]: {
           'border-left-width': `${width}`,
         },
       }),
@@ -28,11 +28,11 @@ function defineBorderWidthUtilities(borderWidths) {
 
   return _.flatMap(generators, generator => {
     return _.flatMap(borderWidths, (width, modifier) => {
-      return generator(width, modifier === 'default' ? '' : `-${modifier}`)
+      return generator(width, modifier === 'default' ? '' : `${ns.modifierPrefix}${modifier}`)
     })
   })
 }
 
-module.exports = function({ borderWidths }) {
-  return defineBorderWidthUtilities(borderWidths)
+module.exports = function({ borderWidths, naming: { borderWidths: ns } }) {
+  return defineBorderWidthUtilities(borderWidths, ns)
 }

--- a/src/generators/container.js
+++ b/src/generators/container.js
@@ -24,7 +24,7 @@ function extractMinWidths(breakpoints) {
   })
 }
 
-export default function({ screens }) {
+export default function({ screens, naming: { container: ns } }) {
   const minWidths = extractMinWidths(screens)
 
   const atRules = _.map(minWidths, minWidth => {
@@ -33,7 +33,7 @@ export default function({ screens }) {
       params: `(min-width: ${minWidth})`,
     })
     atRule.append(
-      defineClass('container', {
+      defineClass(ns.base, {
         'max-width': minWidth,
       })
     )
@@ -41,7 +41,7 @@ export default function({ screens }) {
   })
 
   return [
-    defineClass('container', {
+    defineClass(ns.base, {
       width: '100%',
     }),
     ...atRules,

--- a/src/generators/cursor.js
+++ b/src/generators/cursor.js
@@ -1,10 +1,10 @@
 import defineClasses from '../util/defineClasses'
 
-export default function() {
+export default function({ naming: { cursor: ns } }) {
   return defineClasses({
-    'cursor-auto': { cursor: 'auto' },
-    'cursor-default': { cursor: 'default' },
-    'cursor-pointer': { cursor: 'pointer' },
-    'cursor-not-allowed': { cursor: 'not-allowed' },
+    [ns.auto]: { cursor: 'auto' },
+    [ns.default]: { cursor: 'default' },
+    [ns.pointer]: { cursor: 'pointer' },
+    [ns.notAllowed]: { cursor: 'not-allowed' },
   })
 }

--- a/src/generators/display.js
+++ b/src/generators/display.js
@@ -1,26 +1,26 @@
 import defineClasses from '../util/defineClasses'
 
-export default function() {
+export default function({ naming: { display: ns } }) {
   return defineClasses({
-    block: {
+    [ns.block]: {
       display: 'block',
     },
-    'inline-block': {
+    [ns.inlineBlock]: {
       display: 'inline-block',
     },
-    inline: {
+    [ns.inline]: {
       display: 'inline',
     },
-    table: {
+    [ns.table]: {
       display: 'table',
     },
-    'table-row': {
+    [ns.tableRow]: {
       display: 'table-row',
     },
-    'table-cell': {
+    [ns.tableCell]: {
       display: 'table-cell',
     },
-    hidden: {
+    [ns.hidden]: {
       display: 'none',
     },
   })

--- a/src/generators/flexbox.js
+++ b/src/generators/flexbox.js
@@ -1,116 +1,116 @@
 import defineClasses from '../util/defineClasses'
 
-export default function() {
+export default function({ naming: { flex: ns } }) {
   return defineClasses({
-    flex: {
+    [ns.flex]: {
       display: 'flex',
     },
-    'inline-flex': {
+    [ns.inlineFlex]: {
       display: 'inline-flex',
     },
-    'flex-row': {
+    [ns.flexRow]: {
       'flex-direction': 'row',
     },
-    'flex-row-reverse': {
+    [ns.flexRowReverse]: {
       'flex-direction': 'row-reverse',
     },
-    'flex-col': {
+    [ns.flexCol]: {
       'flex-direction': 'column',
     },
-    'flex-col-reverse': {
+    [ns.flexColReverse]: {
       'flex-direction': 'column-reverse',
     },
-    'flex-wrap': {
+    [ns.flexWrap]: {
       'flex-wrap': 'wrap',
     },
-    'flex-wrap-reverse': {
+    [ns.flexWrapReverse]: {
       'flex-wrap': 'wrap-reverse',
     },
-    'flex-no-wrap': {
+    [ns.flexNoWrap]: {
       'flex-wrap': 'nowrap',
     },
-    'items-start': {
+    [ns.itemsStart]: {
       'align-items': 'flex-start',
     },
-    'items-end': {
+    [ns.itemsEnd]: {
       'align-items': 'flex-end',
     },
-    'items-center': {
+    [ns.itemsCenter]: {
       'align-items': 'center',
     },
-    'items-baseline': {
+    [ns.itemsBaseline]: {
       'align-items': 'baseline',
     },
-    'items-stretch': {
+    [ns.itemsStretch]: {
       'align-items': 'stretch',
     },
-    'self-auto': {
+    [ns.selfAuto]: {
       'align-self': 'auto',
     },
-    'self-start': {
+    [ns.selfStart]: {
       'align-self': 'flex-start',
     },
-    'self-end': {
+    [ns.selfEnd]: {
       'align-self': 'flex-end',
     },
-    'self-center': {
+    [ns.selfCenter]: {
       'align-self': 'center',
     },
-    'self-stretch': {
+    [ns.selfStretch]: {
       'align-self': 'stretch',
     },
-    'justify-start': {
+    [ns.justifyStart]: {
       'justify-content': 'flex-start',
     },
-    'justify-end': {
+    [ns.justifyEnd]: {
       'justify-content': 'flex-end',
     },
-    'justify-center': {
+    [ns.justifyCenter]: {
       'justify-content': 'center',
     },
-    'justify-between': {
+    [ns.justifyBetween]: {
       'justify-content': 'space-between',
     },
-    'justify-around': {
+    [ns.justifyAround]: {
       'justify-content': 'space-around',
     },
-    'content-center': {
+    [ns.contentCenter]: {
       'align-content': 'center',
     },
-    'content-start': {
+    [ns.contentStart]: {
       'align-content': 'flex-start',
     },
-    'content-end': {
+    [ns.contentEnd]: {
       'align-content': 'flex-end',
     },
-    'content-between': {
+    [ns.contentBetween]: {
       'align-content': 'space-between',
     },
-    'content-around': {
+    [ns.contentAround]: {
       'align-content': 'space-around',
     },
-    'flex-1': {
+    [ns.flex1]: {
       flex: '1',
     },
-    'flex-auto': {
+    [ns.flexAuto]: {
       flex: 'auto',
     },
-    'flex-initial': {
+    [ns.flexInitial]: {
       flex: 'initial',
     },
-    'flex-none': {
+    [ns.flexNone]: {
       flex: 'none',
     },
-    'flex-grow': {
+    [ns.flexGrow]: {
       'flex-grow': '1',
     },
-    'flex-shrink': {
+    [ns.flexShrink]: {
       'flex-shrink': '1',
     },
-    'flex-no-grow': {
+    [ns.flexNoGrow]: {
       'flex-grow': '0',
     },
-    'flex-no-shrink': {
+    [ns.flexNoShrink]: {
       'flex-shrink': '0',
     },
   })

--- a/src/generators/float.js
+++ b/src/generators/float.js
@@ -2,15 +2,15 @@ import _ from 'lodash'
 import postcss from 'postcss'
 import defineClasses from '../util/defineClasses'
 
-export default function() {
+export default function({ naming: { floats: ns } }) {
   return _.concat(
     defineClasses({
-      'float-right': { float: 'right' },
-      'float-left': { float: 'left' },
-      'float-none': { float: 'none' },
+      [ns.floatRight]: { float: 'right' },
+      [ns.floatLeft]: { float: 'left' },
+      [ns.floatNone]: { float: 'none' },
     }),
     postcss.parse(`
-      .clearfix:after {
+      .${ns.clearfix}:after {
         content: "";
         display: table;
         clear: both;

--- a/src/generators/fontWeights.js
+++ b/src/generators/fontWeights.js
@@ -1,9 +1,9 @@
 import _ from 'lodash'
 import defineClass from '../util/defineClass'
 
-export default function({ fontWeights }) {
+export default function({ fontWeights, naming: { fontWeights: ns } }) {
   return _.map(fontWeights, (weight, modifier) => {
-    return defineClass(`font-${modifier}`, {
+    return defineClass(`${ns.base}${ns.modifierPrefix}${modifier}`, {
       'font-weight': `${weight}`,
     })
   })

--- a/src/generators/fonts.js
+++ b/src/generators/fonts.js
@@ -1,13 +1,13 @@
 import _ from 'lodash'
 import defineClass from '../util/defineClass'
 
-export default function({ fonts }) {
+export default function({ fonts, naming: { fonts: ns } }) {
   return _.map(fonts, (families, font) => {
     if (_.isArray(families)) {
       families = families.join(', ')
     }
 
-    return defineClass(`font-${font}`, {
+    return defineClass(`${ns.base}${ns.modifierPrefix}${font}`, {
       'font-family': `${families}`,
     })
   })

--- a/src/generators/height.js
+++ b/src/generators/height.js
@@ -1,14 +1,14 @@
 import _ from 'lodash'
 import defineClass from '../util/defineClass'
 
-function defineHeights(heights) {
+function defineHeights(heights, ns) {
   return _.map(heights, (size, modifer) => {
-    return defineClass(`h-${modifer}`, {
+    return defineClass(`${ns.base}${ns.modifierPrefix}${modifer}`, {
       height: `${size}`,
     })
   })
 }
 
 export default function(config) {
-  return _.flatten([defineHeights(config.height)])
+  return _.flatten([defineHeights(config.height, config.naming.height)])
 }

--- a/src/generators/leading.js
+++ b/src/generators/leading.js
@@ -1,9 +1,9 @@
 import _ from 'lodash'
 import defineClass from '../util/defineClass'
 
-export default function({ leading }) {
+export default function({ leading, naming: { leading: ns } }) {
   return _.map(leading, (value, modifier) => {
-    return defineClass(`leading-${modifier}`, {
+    return defineClass(`${ns.base}${ns.modifierPrefix}${modifier}`, {
       'line-height': `${value}`,
     })
   })

--- a/src/generators/lists.js
+++ b/src/generators/lists.js
@@ -1,8 +1,8 @@
 import defineClasses from '../util/defineClasses'
 
-export default function() {
+export default function({ naming: { lists: ns } }) {
   return defineClasses({
-    'list-reset': {
+    [ns.listReset]: {
       'list-style': 'none',
       padding: '0',
     },

--- a/src/generators/margin.js
+++ b/src/generators/margin.js
@@ -1,23 +1,29 @@
 import _ from 'lodash'
 import defineClasses from '../util/defineClasses'
 
-function defineMargin(margin) {
+function defineMargin(margin, ns) {
   const generators = [
     (size, modifier) =>
       defineClasses({
-        [`m-${modifier}`]: { margin: `${size}` },
+        [`${ns.base}${ns.modifierPrefix}${modifier}`]: { margin: `${size}` },
       }),
     (size, modifier) =>
       defineClasses({
-        [`my-${modifier}`]: { 'margin-top': `${size}`, 'margin-bottom': `${size}` },
-        [`mx-${modifier}`]: { 'margin-left': `${size}`, 'margin-right': `${size}` },
+        [`${ns.base}${ns.y}${ns.modifierPrefix}${modifier}`]: {
+          'margin-top': `${size}`,
+          'margin-bottom': `${size}`,
+        },
+        [`${ns.base}${ns.x}${ns.modifierPrefix}${modifier}`]: {
+          'margin-left': `${size}`,
+          'margin-right': `${size}`,
+        },
       }),
     (size, modifier) =>
       defineClasses({
-        [`mt-${modifier}`]: { 'margin-top': `${size}` },
-        [`mr-${modifier}`]: { 'margin-right': `${size}` },
-        [`mb-${modifier}`]: { 'margin-bottom': `${size}` },
-        [`ml-${modifier}`]: { 'margin-left': `${size}` },
+        [`${ns.base}${ns.t}${ns.modifierPrefix}${modifier}`]: { 'margin-top': `${size}` },
+        [`${ns.base}${ns.r}${ns.modifierPrefix}${modifier}`]: { 'margin-right': `${size}` },
+        [`${ns.base}${ns.b}${ns.modifierPrefix}${modifier}`]: { 'margin-bottom': `${size}` },
+        [`${ns.base}${ns.l}${ns.modifierPrefix}${modifier}`]: { 'margin-left': `${size}` },
       }),
   ]
 
@@ -26,6 +32,6 @@ function defineMargin(margin) {
   })
 }
 
-export default function({ margin }) {
-  return _.flatten([defineMargin(margin)])
+export default function({ margin, naming: { margin: ns } }) {
+  return _.flatten([defineMargin(margin, ns)])
 }

--- a/src/generators/maxHeight.js
+++ b/src/generators/maxHeight.js
@@ -1,14 +1,14 @@
 import _ from 'lodash'
 import defineClass from '../util/defineClass'
 
-function defineMaxHeights(heights) {
+function defineMaxHeights(heights, ns) {
   return _.map(heights, (size, modifer) => {
-    return defineClass(`max-h-${modifer}`, {
+    return defineClass(`${ns.base}${ns.modifierPrefix}${modifer}`, {
       'max-height': `${size}`,
     })
   })
 }
 
 export default function(config) {
-  return _.flatten([defineMaxHeights(config.maxHeight)])
+  return _.flatten([defineMaxHeights(config.maxHeight, config.naming.maxHeight)])
 }

--- a/src/generators/maxWidth.js
+++ b/src/generators/maxWidth.js
@@ -1,14 +1,14 @@
 import _ from 'lodash'
 import defineClass from '../util/defineClass'
 
-function defineMaxWidths(widths) {
+function defineMaxWidths(widths, ns) {
   return _.map(widths, (size, modifer) => {
-    return defineClass(`max-w-${modifer}`, {
+    return defineClass(`${ns.base}${ns.modifierPrefix}${modifer}`, {
       'max-width': `${size}`,
     })
   })
 }
 
 export default function(config) {
-  return _.flatten([defineMaxWidths(config.maxWidth)])
+  return _.flatten([defineMaxWidths(config.maxWidth, config.naming.maxWidth)])
 }

--- a/src/generators/minHeight.js
+++ b/src/generators/minHeight.js
@@ -1,14 +1,14 @@
 import _ from 'lodash'
 import defineClass from '../util/defineClass'
 
-function defineMinHeights(heights) {
+function defineMinHeights(heights, ns) {
   return _.map(heights, (size, modifer) => {
-    return defineClass(`min-h-${modifer}`, {
+    return defineClass(`${ns.base}${ns.modifierPrefix}${modifer}`, {
       'min-height': `${size}`,
     })
   })
 }
 
 export default function(config) {
-  return _.flatten([defineMinHeights(config.minHeight)])
+  return _.flatten([defineMinHeights(config.minHeight, config.naming.minHeight)])
 }

--- a/src/generators/minWidth.js
+++ b/src/generators/minWidth.js
@@ -1,14 +1,14 @@
 import _ from 'lodash'
 import defineClass from '../util/defineClass'
 
-function defineMinWidths(widths) {
+function defineMinWidths(widths, ns) {
   return _.map(widths, (size, modifer) => {
-    return defineClass(`min-w-${modifer}`, {
+    return defineClass(`${ns.base}${ns.modifierPrefix}${modifer}`, {
       'min-width': `${size}`,
     })
   })
 }
 
 export default function(config) {
-  return _.flatten([defineMinWidths(config.minWidth)])
+  return _.flatten([defineMinWidths(config.minWidth, config.naming.minWidth)])
 }

--- a/src/generators/negativeMargin.js
+++ b/src/generators/negativeMargin.js
@@ -1,23 +1,29 @@
 import _ from 'lodash'
 import defineClasses from '../util/defineClasses'
 
-function defineNegativeMargin(negativeMargin) {
+function defineNegativeMargin(negativeMargin, ns) {
   const generators = [
     (size, modifier) =>
       defineClasses({
-        [`-m-${modifier}`]: { margin: `${size}` },
+        [`${ns.base}${ns.modifierPrefix}${modifier}`]: { margin: `${size}` },
       }),
     (size, modifier) =>
       defineClasses({
-        [`-my-${modifier}`]: { 'margin-top': `${size}`, 'margin-bottom': `${size}` },
-        [`-mx-${modifier}`]: { 'margin-left': `${size}`, 'margin-right': `${size}` },
+        [`${ns.base}${ns.y}${ns.modifierPrefix}${modifier}`]: {
+          'margin-top': `${size}`,
+          'margin-bottom': `${size}`,
+        },
+        [`${ns.base}${ns.x}${ns.modifierPrefix}${modifier}`]: {
+          'margin-left': `${size}`,
+          'margin-right': `${size}`,
+        },
       }),
     (size, modifier) =>
       defineClasses({
-        [`-mt-${modifier}`]: { 'margin-top': `${size}` },
-        [`-mr-${modifier}`]: { 'margin-right': `${size}` },
-        [`-mb-${modifier}`]: { 'margin-bottom': `${size}` },
-        [`-ml-${modifier}`]: { 'margin-left': `${size}` },
+        [`${ns.base}${ns.t}${ns.modifierPrefix}${modifier}`]: { 'margin-top': `${size}` },
+        [`${ns.base}${ns.r}${ns.modifierPrefix}${modifier}`]: { 'margin-right': `${size}` },
+        [`${ns.base}${ns.b}${ns.modifierPrefix}${modifier}`]: { 'margin-bottom': `${size}` },
+        [`${ns.base}${ns.l}${ns.modifierPrefix}${modifier}`]: { 'margin-left': `${size}` },
       }),
   ]
 
@@ -28,6 +34,6 @@ function defineNegativeMargin(negativeMargin) {
   })
 }
 
-export default function({ negativeMargin }) {
-  return _.flatten([defineNegativeMargin(negativeMargin)])
+export default function({ negativeMargin, naming: { negativeMargin: ns } }) {
+  return _.flatten([defineNegativeMargin(negativeMargin, ns)])
 }

--- a/src/generators/opacity.js
+++ b/src/generators/opacity.js
@@ -1,9 +1,9 @@
 import _ from 'lodash'
 import defineClass from '../util/defineClass'
 
-export default function({ opacity }) {
+export default function({ opacity, naming: { opacity: ns } }) {
   return _.map(opacity, (value, modifier) => {
-    return defineClass(`opacity-${modifier}`, {
+    return defineClass(`${ns.base}${ns.modifierPrefix}${modifier}`, {
       opacity: value,
     })
   })

--- a/src/generators/overflow.js
+++ b/src/generators/overflow.js
@@ -1,20 +1,20 @@
 import defineClasses from '../util/defineClasses'
 
-export default function() {
+export default function({ naming: { overflow: ns } }) {
   return defineClasses({
-    'overflow-auto': { overflow: 'auto' },
-    'overflow-hidden': { overflow: 'hidden' },
-    'overflow-visible': { overflow: 'visible' },
-    'overflow-scroll': { overflow: 'scroll' },
-    'overflow-x-scroll': {
+    [`${ns.base}${ns.auto}`]: { overflow: 'auto' },
+    [`${ns.base}${ns.hidden}`]: { overflow: 'hidden' },
+    [`${ns.base}${ns.visible}`]: { overflow: 'visible' },
+    [`${ns.base}${ns.scroll}`]: { overflow: 'scroll' },
+    [`${ns.base}${ns.xScroll}`]: {
       'overflow-x': 'auto',
       '-ms-overflow-style': '-ms-autohiding-scrollbar',
     },
-    'overflow-y-scroll': {
+    [`${ns.base}${ns.yScroll}`]: {
       'overflow-y': 'auto',
       '-ms-overflow-style': '-ms-autohiding-scrollbar',
     },
-    'scrolling-touch': { '-webkit-overflow-scrolling': 'touch' },
-    'scrolling-auto': { '-webkit-overflow-scrolling': 'auto' },
+    [`${ns.scrollingTouch}`]: { '-webkit-overflow-scrolling': 'touch' },
+    [`${ns.scrollingAuto}`]: { '-webkit-overflow-scrolling': 'auto' },
   })
 }

--- a/src/generators/padding.js
+++ b/src/generators/padding.js
@@ -1,23 +1,29 @@
 import _ from 'lodash'
 import defineClasses from '../util/defineClasses'
 
-function definePadding(padding) {
+function definePadding(padding, ns) {
   const generators = [
     (size, modifier) =>
       defineClasses({
-        [`p-${modifier}`]: { padding: `${size}` },
+        [`${ns.base}${ns.modifierPrefix}${modifier}`]: { padding: `${size}` },
       }),
     (size, modifier) =>
       defineClasses({
-        [`py-${modifier}`]: { 'padding-top': `${size}`, 'padding-bottom': `${size}` },
-        [`px-${modifier}`]: { 'padding-left': `${size}`, 'padding-right': `${size}` },
+        [`${ns.base}${ns.y}${ns.modifierPrefix}${modifier}`]: {
+          'padding-top': `${size}`,
+          'padding-bottom': `${size}`,
+        },
+        [`${ns.base}${ns.x}${ns.modifierPrefix}${modifier}`]: {
+          'padding-left': `${size}`,
+          'padding-right': `${size}`,
+        },
       }),
     (size, modifier) =>
       defineClasses({
-        [`pt-${modifier}`]: { 'padding-top': `${size}` },
-        [`pr-${modifier}`]: { 'padding-right': `${size}` },
-        [`pb-${modifier}`]: { 'padding-bottom': `${size}` },
-        [`pl-${modifier}`]: { 'padding-left': `${size}` },
+        [`${ns.base}${ns.t}${ns.modifierPrefix}${modifier}`]: { 'padding-top': `${size}` },
+        [`${ns.base}${ns.r}${ns.modifierPrefix}${modifier}`]: { 'padding-right': `${size}` },
+        [`${ns.base}${ns.b}${ns.modifierPrefix}${modifier}`]: { 'padding-bottom': `${size}` },
+        [`${ns.base}${ns.l}${ns.modifierPrefix}${modifier}`]: { 'padding-left': `${size}` },
       }),
   ]
 
@@ -26,6 +32,6 @@ function definePadding(padding) {
   })
 }
 
-export default function({ padding }) {
-  return _.flatten([definePadding(padding)])
+export default function({ padding, naming: { padding: ns } }) {
+  return _.flatten([definePadding(padding, ns)])
 }

--- a/src/generators/pointerEvents.js
+++ b/src/generators/pointerEvents.js
@@ -1,8 +1,8 @@
 import defineClasses from '../util/defineClasses'
 
-export default function() {
+export default function({ naming: { pointerEvents: ns } }) {
   return defineClasses({
-    'pointer-events-none': { 'pointer-events': 'none' },
-    'pointer-events-auto': { 'pointer-events': 'auto' },
+    [ns.pointerNone]: { 'pointer-events': 'none' },
+    [ns.pointerAuto]: { 'pointer-events': 'auto' },
   })
 }

--- a/src/generators/position.js
+++ b/src/generators/position.js
@@ -1,28 +1,28 @@
 import defineClasses from '../util/defineClasses'
 
-export default function() {
+export default function({ naming: { position: ns } }) {
   return defineClasses({
-    static: { position: 'static' },
-    fixed: { position: 'fixed' },
-    absolute: { position: 'absolute' },
-    relative: { position: 'relative' },
-    'pin-none': {
+    [ns.static]: { position: 'static' },
+    [ns.fixed]: { position: 'fixed' },
+    [ns.absolute]: { position: 'absolute' },
+    [ns.relative]: { position: 'relative' },
+    [ns.pinNone]: {
       top: 'auto',
       right: 'auto',
       bottom: 'auto',
       left: 'auto',
     },
-    pin: {
+    [ns.pin]: {
       top: 0,
       right: 0,
       bottom: 0,
       left: 0,
     },
-    'pin-y': { top: 0, bottom: 0 },
-    'pin-x': { right: 0, left: 0 },
-    'pin-t': { top: 0 },
-    'pin-r': { right: 0 },
-    'pin-b': { bottom: 0 },
-    'pin-l': { left: 0 },
+    [ns.pinY]: { top: 0, bottom: 0 },
+    [ns.pinX]: { right: 0, left: 0 },
+    [ns.pinT]: { top: 0 },
+    [ns.pinR]: { right: 0 },
+    [ns.pinB]: { bottom: 0 },
+    [ns.pinL]: { left: 0 },
   })
 }

--- a/src/generators/resize.js
+++ b/src/generators/resize.js
@@ -1,10 +1,10 @@
 import defineClasses from '../util/defineClasses'
 
-export default function() {
+export default function({ naming: { resize: ns } }) {
   return defineClasses({
-    'resize-none': { resize: 'none' },
-    'resize-y': { resize: 'vertical' },
-    'resize-x': { resize: 'horizontal' },
-    resize: { resize: 'both' },
+    [ns.resizeNone]: { resize: 'none' },
+    [ns.resizeY]: { resize: 'vertical' },
+    [ns.resizeX]: { resize: 'horizontal' },
+    [ns.resize]: { resize: 'both' },
   })
 }

--- a/src/generators/shadows.js
+++ b/src/generators/shadows.js
@@ -1,10 +1,13 @@
 import _ from 'lodash'
 import defineClass from '../util/defineClass'
 
-export default function({ shadows }) {
+export default function({ shadows, naming: { shadow: ns } }) {
   return _.map(shadows, (shadow, modifier) => {
-    return defineClass(modifier === 'default' ? 'shadow' : `shadow-${modifier}`, {
-      'box-shadow': shadow,
-    })
+    return defineClass(
+      modifier === 'default' ? ns.base : `${ns.base}${ns.modifierPrefix}${modifier}`,
+      {
+        'box-shadow': shadow,
+      }
+    )
   })
 }

--- a/src/generators/svgFill.js
+++ b/src/generators/svgFill.js
@@ -1,9 +1,9 @@
 import _ from 'lodash'
 import defineClass from '../util/defineClass'
 
-export default function({ svgFill }) {
+export default function({ svgFill, naming: { svgFill: ns } }) {
   return _.map(svgFill, (color, modifier) => {
-    return defineClass(`fill-${modifier}`, {
+    return defineClass(`${ns.base}${ns.modifierPrefix}${modifier}`, {
       fill: color,
     })
   })

--- a/src/generators/svgStroke.js
+++ b/src/generators/svgStroke.js
@@ -1,9 +1,9 @@
 import _ from 'lodash'
 import defineClass from '../util/defineClass'
 
-export default function({ svgStroke }) {
+export default function({ svgStroke, naming: { svgStroke: ns } }) {
   return _.map(svgStroke, (color, modifier) => {
-    return defineClass(`stroke-${modifier}`, {
+    return defineClass(`${ns.base}${ns.modifierPrefix}${modifier}`, {
       stroke: color,
     })
   })

--- a/src/generators/textAlign.js
+++ b/src/generators/textAlign.js
@@ -1,10 +1,10 @@
 import defineClasses from '../util/defineClasses'
 
-export default function() {
+export default function({ naming: { textAlign: ns } }) {
   return defineClasses({
-    'text-left': { 'text-align': 'left' },
-    'text-center': { 'text-align': 'center' },
-    'text-right': { 'text-align': 'right' },
-    'text-justify': { 'text-align': 'justify' },
+    [ns.left]: { 'text-align': 'left' },
+    [ns.center]: { 'text-align': 'center' },
+    [ns.right]: { 'text-align': 'right' },
+    [ns.justify]: { 'text-align': 'justify' },
   })
 }

--- a/src/generators/textColors.js
+++ b/src/generators/textColors.js
@@ -1,9 +1,9 @@
 import _ from 'lodash'
 import defineClass from '../util/defineClass'
 
-export default function({ textColors }) {
+export default function({ textColors, naming: { textColors: ns } }) {
   return _.map(textColors, (color, modifier) => {
-    return defineClass(`text-${modifier}`, {
+    return defineClass(`${ns.base}${ns.modifierPrefix}${modifier}`, {
       color,
     })
   })

--- a/src/generators/textSizes.js
+++ b/src/generators/textSizes.js
@@ -1,9 +1,9 @@
 import _ from 'lodash'
 import defineClass from '../util/defineClass'
 
-export default function({ textSizes }) {
+export default function({ textSizes, naming: { textSizes: ns } }) {
   return _.map(textSizes, (size, modifier) => {
-    return defineClass(`text-${modifier}`, {
+    return defineClass(`${ns.base}${ns.modifierPrefix}${modifier}`, {
       'font-size': `${size}`,
     })
   })

--- a/src/generators/textStyle.js
+++ b/src/generators/textStyle.js
@@ -1,24 +1,24 @@
 import defineClasses from '../util/defineClasses'
 
-export default function() {
+export default function({ naming: { textStyle: ns } }) {
   return defineClasses({
-    italic: { 'font-style': 'italic' },
-    roman: { 'font-style': 'normal' },
+    [ns.italic]: { 'font-style': 'italic' },
+    [ns.roman]: { 'font-style': 'normal' },
 
-    uppercase: { 'text-transform': 'uppercase' },
-    lowercase: { 'text-transform': 'lowercase' },
-    capitalize: { 'text-transform': 'capitalize' },
-    'normal-case': { 'text-transform': 'none' },
+    [ns.uppercase]: { 'text-transform': 'uppercase' },
+    [ns.lowercase]: { 'text-transform': 'lowercase' },
+    [ns.capitalize]: { 'text-transform': 'capitalize' },
+    [ns.normalCase]: { 'text-transform': 'none' },
 
-    underline: { 'text-decoration': 'underline' },
-    'line-through': { 'text-decoration': 'line-through' },
-    'no-underline': { 'text-decoration': 'none' },
+    [ns.underline]: { 'text-decoration': 'underline' },
+    [ns.lineThrough]: { 'text-decoration': 'line-through' },
+    [ns.noUnderline]: { 'text-decoration': 'none' },
 
-    antialiased: {
+    [ns.antialiased]: {
       '-webkit-font-smoothing': 'antialiased',
       '-moz-osx-font-smoothing': 'grayscale',
     },
-    'subpixel-antialiased': {
+    [ns.subpixelAntialiased]: {
       '-webkit-font-smoothing': 'auto',
       '-moz-osx-font-smoothing': 'auto',
     },

--- a/src/generators/tracking.js
+++ b/src/generators/tracking.js
@@ -1,9 +1,9 @@
 import _ from 'lodash'
 import defineClass from '../util/defineClass'
 
-export default function({ tracking }) {
+export default function({ tracking, naming: { textTracking: ns } }) {
   return _.map(tracking, (value, modifier) => {
-    return defineClass(`tracking-${modifier}`, {
+    return defineClass(`${ns.base}${ns.modifierPrefix}${modifier}`, {
       'letter-spacing': `${value}`,
     })
   })

--- a/src/generators/userSelect.js
+++ b/src/generators/userSelect.js
@@ -1,8 +1,8 @@
 import defineClasses from '../util/defineClasses'
 
-export default function() {
+export default function({ naming: { userSelect: ns } }) {
   return defineClasses({
-    'select-none': { 'user-select': 'none' },
-    'select-text': { 'user-select': 'text' },
+    [ns.selectNone]: { 'user-select': 'none' },
+    [ns.selectText]: { 'user-select': 'text' },
   })
 }

--- a/src/generators/verticalAlign.js
+++ b/src/generators/verticalAlign.js
@@ -1,12 +1,12 @@
 import defineClasses from '../util/defineClasses'
 
-export default function() {
+export default function({ naming: { verticalAlign: ns } }) {
   return defineClasses({
-    'align-baseline': { 'vertical-align': 'baseline' },
-    'align-top': { 'vertical-align': 'top' },
-    'align-middle': { 'vertical-align': 'middle' },
-    'align-bottom': { 'vertical-align': 'bottom' },
-    'align-text-top': { 'vertical-align': 'text-top' },
-    'align-text-bottom': { 'vertical-align': 'text-bottom' },
+    [ns.alignBaseline]: { 'vertical-align': 'baseline' },
+    [ns.alignTop]: { 'vertical-align': 'top' },
+    [ns.alignMiddle]: { 'vertical-align': 'middle' },
+    [ns.alignBottom]: { 'vertical-align': 'bottom' },
+    [ns.alignTextTop]: { 'vertical-align': 'text-top' },
+    [ns.alignTextBottom]: { 'vertical-align': 'text-bottom' },
   })
 }

--- a/src/generators/visibility.js
+++ b/src/generators/visibility.js
@@ -1,8 +1,8 @@
 import defineClasses from '../util/defineClasses'
 
-export default function() {
+export default function({ naming: { visibility: ns } }) {
   return defineClasses({
-    visible: { visibility: 'visible' },
-    invisible: { visibility: 'hidden' },
+    [ns.visible]: { visibility: 'visible' },
+    [ns.invisible]: { visibility: 'hidden' },
   })
 }

--- a/src/generators/whitespace.js
+++ b/src/generators/whitespace.js
@@ -1,17 +1,17 @@
 import defineClasses from '../util/defineClasses'
 
-export default function() {
+export default function({ naming: { textWrap: ns } }) {
   return defineClasses({
-    'whitespace-normal': { 'white-space': 'normal' },
-    'whitespace-no-wrap': { 'white-space': 'nowrap' },
-    'whitespace-pre': { 'white-space': 'pre' },
-    'whitespace-pre-line': { 'white-space': 'pre-line' },
-    'whitespace-pre-wrap': { 'white-space': 'pre-wrap' },
+    [ns.whitespaceNormal]: { 'white-space': 'normal' },
+    [ns.whitespaceNoWrap]: { 'white-space': 'nowrap' },
+    [ns.whitespacePre]: { 'white-space': 'pre' },
+    [ns.whitespacePreLine]: { 'white-space': 'pre-line' },
+    [ns.whitespacePreWrap]: { 'white-space': 'pre-wrap' },
 
-    'break-words': { 'word-wrap': 'break-word' },
-    'break-normal': { 'word-wrap': 'normal' },
+    [ns.breakWords]: { 'word-wrap': 'break-word' },
+    [ns.breakNormal]: { 'word-wrap': 'normal' },
 
-    truncate: {
+    [ns.truncate]: {
       overflow: 'hidden',
       'text-overflow': 'ellipsis',
       'white-space': 'nowrap',

--- a/src/generators/width.js
+++ b/src/generators/width.js
@@ -1,14 +1,14 @@
 import _ from 'lodash'
 import defineClass from '../util/defineClass'
 
-function defineWidths(widths) {
+function defineWidths(widths, ns) {
   return _.map(widths, (size, modifer) => {
-    return defineClass(`w-${modifer}`, {
+    return defineClass(`${ns.base}${ns.modifierPrefix}${modifer}`, {
       width: `${size}`,
     })
   })
 }
 
 export default function(config) {
-  return _.flatten([defineWidths(config.width)])
+  return _.flatten([defineWidths(config.width, config.naming.width)])
 }

--- a/src/generators/zIndex.js
+++ b/src/generators/zIndex.js
@@ -1,9 +1,9 @@
 import _ from 'lodash'
 import defineClass from '../util/defineClass'
 
-export default function({ zIndex }) {
+export default function({ zIndex, naming: { zIndex: ns } }) {
   return _.map(zIndex, (value, modifier) => {
-    return defineClass(`z-${modifier}`, {
+    return defineClass(`${ns.base}${ns.modifierPrefix}${modifier}`, {
       'z-index': value,
     })
   })


### PR DESCRIPTION
By using a dictionary for css names, different flavours of terse/verbose classes can be generated.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
