### PR TITLE
Added .cursor-wait class

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -2183,6 +2183,10 @@ button,
   cursor: not-allowed;
 }
 
+.cursor-wait {
+  cursor: wait;
+}
+
 .block {
   display: block;
 }
@@ -6066,6 +6070,10 @@ button,
     cursor: not-allowed;
   }
 
+  .sm\:cursor-wait {
+    cursor: wait;
+  }
+
   .sm\:block {
     display: block;
   }
@@ -9940,6 +9948,10 @@ button,
 
   .md\:cursor-not-allowed {
     cursor: not-allowed;
+  }
+
+  .md\:cursor-wait {
+    cursor: wait;
   }
 
   .md\:block {
@@ -13818,6 +13830,10 @@ button,
     cursor: not-allowed;
   }
 
+  .lg\:cursor-wait {
+    cursor: wait;
+  }
+
   .lg\:block {
     display: block;
   }
@@ -17692,6 +17708,10 @@ button,
 
   .xl\:cursor-not-allowed {
     cursor: not-allowed;
+  }
+
+  .xl\:cursor-wait {
+    cursor: wait;
   }
 
   .xl\:block {

--- a/docs/source/docs/cursor.blade.md
+++ b/docs/source/docs/cursor.blade.md
@@ -28,6 +28,11 @@ features:
       'cursor: not-allowed;',
       "Set the mouse cursor to indicate that the action will not be executed.",
     ],
+    [
+      '.cursor-wait',
+      'cursor: wait;',
+      "Set the mouse cursor to indicate that an action is being executed.",
+    ],
   ]
 ])
 

--- a/src/generators/cursor.js
+++ b/src/generators/cursor.js
@@ -6,5 +6,6 @@ export default function() {
     'cursor-default': { cursor: 'default' },
     'cursor-pointer': { cursor: 'pointer' },
     'cursor-not-allowed': { cursor: 'not-allowed' },
+    'cursor-wait': { cursor: 'wait' },
   })
 }


### PR DESCRIPTION
The `cursor: wait` property turns the mouse cursor into a system specifiy "hourglass" that indicates to the user that an action is in progress.

I thought this is a missing feature that is often used in applications.