### PR TITLE
Doc Add group-hover to supported variants

### DIFF
--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -803,7 +803,7 @@ module.exports = {
   | Here is where you control which modules are generated and what variants are
   | generated for each of those modules.
   |
-  | Currently supported variants: 'responsive', 'hover', 'focus'
+  | Currently supported variants: 'responsive', 'hover', 'focus', 'group-hover'
   |
   | To disable a module completely, use `false` instead of an array.
   |


### PR DESCRIPTION
Add the group-hover option to supported variants in defaultConfig.

Based on #336 
