### PR TITLE
docs: fix typo (hex code for green color)

### DIFF
--- a/docs/source/docs/adding-new-utilities.blade.md
+++ b/docs/source/docs/adding-new-utilities.blade.md
@@ -30,7 +30,7 @@ For example, given the following CSS:
 }
 
 .bg-green {
-  background-color: #0000ff;
+  background-color: #00ff00;
 }
 ```
 


### PR DESCRIPTION
`bg-green` should be `#0F0`, not `#00F` (which would be blue).