### PR TITLE
Update overflow.js

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -7073,7 +7073,7 @@ button,
     -ms-overflow-style: -ms-scrollbar;
   }
 
-  .sm\.overflow-y-scroll {
+  .sm\:overflow-y-scroll {
     overflow-y: scroll;
     -ms-overflow-style: -ms-scrollbar;
   }
@@ -10959,7 +10959,7 @@ button,
     -ms-overflow-style: -ms-scrollbar;
   }
 
-  .md\.overflow-y-scroll {
+  .md\:overflow-y-scroll {
     overflow-y: scroll;
     -ms-overflow-style: -ms-scrollbar;
   }  
@@ -14845,7 +14845,7 @@ button,
     -ms-overflow-style: -ms-scrollbar;
   }
 
-  .lg\.overflow-y-scroll {
+  .lg\:overflow-y-scroll {
     overflow-y: scroll;
     -ms-overflow-style: -ms-scrollbar;
   }
@@ -18731,7 +18731,7 @@ button,
     -ms-overflow-style: -ms-scrollbar;
   }
 
-  .xl\.overflow-y-scroll {
+  .xl\:overflow-y-scroll {
     overflow-y: scroll;
     -ms-overflow-style: -ms-scrollbar;
   }  

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -7067,7 +7067,7 @@ button,
     overflow-y: auto;
     -ms-overflow-style: -ms-autohiding-scrollbar;
   }
-  
+ 
   .sm\:overflow-x-scroll {
     overflow-x: scroll;
     -ms-overflow-style: -ms-scrollbar;
@@ -10953,7 +10953,7 @@ button,
     overflow-y: auto;
     -ms-overflow-style: -ms-autohiding-scrollbar;
   }
-  
+ 
   .md\:overflow-x-scroll {
     overflow-x: scroll;
     -ms-overflow-style: -ms-scrollbar;
@@ -14839,7 +14839,7 @@ button,
     overflow-y: auto;
     -ms-overflow-style: -ms-autohiding-scrollbar;
   }
-  
+ 
   .lg\:overflow-x-scroll {
     overflow-x: scroll;
     -ms-overflow-style: -ms-scrollbar;
@@ -18725,7 +18725,7 @@ button,
     overflow-y: auto;
     -ms-overflow-style: -ms-autohiding-scrollbar;
   }
-  
+ 
   .xl\:overflow-x-scroll {
     overflow-x: scroll;
     -ms-overflow-style: -ms-scrollbar;

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -7058,14 +7058,24 @@ button,
     overflow: scroll;
   }
 
-  .sm\:overflow-x-scroll {
+  .sm\:overflow-x-auto {
     overflow-x: auto;
     -ms-overflow-style: -ms-autohiding-scrollbar;
   }
 
-  .sm\:overflow-y-scroll {
+  .sm\:overflow-y-auto {
     overflow-y: auto;
     -ms-overflow-style: -ms-autohiding-scrollbar;
+  }
+  
+  .sm\:overflow-x-scroll {
+    overflow-x: scroll;
+    -ms-overflow-style: -ms-scrollbar;
+  }
+
+  .sm\.overflow-y-scroll {
+    overflow-y: scroll;
+    -ms-overflow-style: -ms-scrollbar;
   }
 
   .sm\:scrolling-touch {
@@ -10934,15 +10944,25 @@ button,
     overflow: scroll;
   }
 
-  .md\:overflow-x-scroll {
+  .md\:overflow-x-auto {
     overflow-x: auto;
     -ms-overflow-style: -ms-autohiding-scrollbar;
   }
 
-  .md\:overflow-y-scroll {
+  .md\:overflow-y-auto {
     overflow-y: auto;
     -ms-overflow-style: -ms-autohiding-scrollbar;
   }
+  
+  .md\:overflow-x-scroll {
+    overflow-x: scroll;
+    -ms-overflow-style: -ms-scrollbar;
+  }
+
+  .md\.overflow-y-scroll {
+    overflow-y: scroll;
+    -ms-overflow-style: -ms-scrollbar;
+  }  
 
   .md\:scrolling-touch {
     -webkit-overflow-scrolling: touch;
@@ -14810,14 +14830,24 @@ button,
     overflow: scroll;
   }
 
-  .lg\:overflow-x-scroll {
+  .lg\:overflow-x-auto {
     overflow-x: auto;
     -ms-overflow-style: -ms-autohiding-scrollbar;
   }
 
-  .lg\:overflow-y-scroll {
+  .lg\:overflow-y-auto {
     overflow-y: auto;
     -ms-overflow-style: -ms-autohiding-scrollbar;
+  }
+  
+  .lg\:overflow-x-scroll {
+    overflow-x: scroll;
+    -ms-overflow-style: -ms-scrollbar;
+  }
+
+  .lg\.overflow-y-scroll {
+    overflow-y: scroll;
+    -ms-overflow-style: -ms-scrollbar;
   }
 
   .lg\:scrolling-touch {
@@ -18686,15 +18716,25 @@ button,
     overflow: scroll;
   }
 
-  .xl\:overflow-x-scroll {
+  .xl\:overflow-x-auto {
     overflow-x: auto;
     -ms-overflow-style: -ms-autohiding-scrollbar;
   }
 
-  .xl\:overflow-y-scroll {
+  .xl\:overflow-y-auto {
     overflow-y: auto;
     -ms-overflow-style: -ms-autohiding-scrollbar;
   }
+  
+  .xl\:overflow-x-scroll {
+    overflow-x: scroll;
+    -ms-overflow-style: -ms-scrollbar;
+  }
+
+  .xl\.overflow-y-scroll {
+    overflow-y: scroll;
+    -ms-overflow-style: -ms-scrollbar;
+  }  
 
   .xl\:scrolling-touch {
     -webkit-overflow-scrolling: touch;

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -7067,7 +7067,7 @@ button,
     overflow-y: auto;
     -ms-overflow-style: -ms-autohiding-scrollbar;
   }
- 
+
   .sm\:overflow-x-scroll {
     overflow-x: scroll;
     -ms-overflow-style: -ms-scrollbar;
@@ -10953,7 +10953,7 @@ button,
     overflow-y: auto;
     -ms-overflow-style: -ms-autohiding-scrollbar;
   }
- 
+
   .md\:overflow-x-scroll {
     overflow-x: scroll;
     -ms-overflow-style: -ms-scrollbar;
@@ -14839,7 +14839,7 @@ button,
     overflow-y: auto;
     -ms-overflow-style: -ms-autohiding-scrollbar;
   }
- 
+
   .lg\:overflow-x-scroll {
     overflow-x: scroll;
     -ms-overflow-style: -ms-scrollbar;
@@ -18725,7 +18725,7 @@ button,
     overflow-y: auto;
     -ms-overflow-style: -ms-autohiding-scrollbar;
   }
- 
+
   .xl\:overflow-x-scroll {
     overflow-x: scroll;
     -ms-overflow-style: -ms-scrollbar;

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3165,14 +3165,24 @@ button,
   overflow: scroll;
 }
 
-.overflow-x-scroll {
+.overflow-x-auto {
   overflow-x: auto;
   -ms-overflow-style: -ms-autohiding-scrollbar;
 }
 
-.overflow-y-scroll {
+.overflow-y-auto {
   overflow-y: auto;
   -ms-overflow-style: -ms-autohiding-scrollbar;
+}
+
+.overflow-x-scroll {
+  overflow-x: scroll;
+  -ms-overflow-style: -ms-scrollbar;
+}
+
+.overflow-y-scroll {
+  overflow-y: scroll;
+  -ms-overflow-style: -ms-scrollbar;
 }
 
 .scrolling-touch {

--- a/src/generators/overflow.js
+++ b/src/generators/overflow.js
@@ -6,13 +6,21 @@ export default function() {
     'overflow-hidden': { overflow: 'hidden' },
     'overflow-visible': { overflow: 'visible' },
     'overflow-scroll': { overflow: 'scroll' },
-    'overflow-x-scroll': {
+    'overflow-x-auto': {
       'overflow-x': 'auto',
       '-ms-overflow-style': '-ms-autohiding-scrollbar',
     },
-    'overflow-y-scroll': {
+    'overflow-y-auto': {
       'overflow-y': 'auto',
       '-ms-overflow-style': '-ms-autohiding-scrollbar',
+    },
+    'overflow-x-scroll': {
+       'overflow-x': 'scroll' ,
+      '-ms-overflow-style': '-ms-scrollbar',
+    },
+    'overflow-y-scroll': {
+       'overflow-y': 'scroll' ,
+      '-ms-overflow-style': '-ms-scrollbar',
     },
     'scrolling-touch': { '-webkit-overflow-scrolling': 'touch' },
     'scrolling-auto': { '-webkit-overflow-scrolling': 'auto' },


### PR DESCRIPTION
Currently there are a number of `overflow` rules - but the naming is inconsisent.

- You have `overflow-auto` - which applies `auto` rules.
- You have `overflow-scroll` - which applies `scroll` rules.
- but then you have `overflow-x-scroll` - which incorrectly `auto` rules instead of `scroll` rules.

This PR fixes the names and adds both options for `x` and `y` to have both `auto` and `scroll` options.