### PR TITLE
Add .pin-none to the docs

### DIFF
--- a/docs/source/docs/positioning.blade.md
+++ b/docs/source/docs/positioning.blade.md
@@ -66,6 +66,11 @@ features:
       "top: 0;\nright: 0;\nbottom: 0;\nleft: 0;",
       "Anchor absolutely positioned element to all the edges of the nearest positioned parent.",
     ],
+    [
+      '.pin-none',
+      "top: auto;\nright: auto;\nbottom: auto;\nleft: auto;",
+      "Reset absolutely positioned element to all the edges from a given breakpoint onwards.",
+    ],
   ]
 ])
 


### PR DESCRIPTION
This PR only mentions `.pin-none` in the docs to make it visible for people who might need it.