### PR TITLE
Add support for passing a function as the prefix

### DIFF
--- a/__tests__/applyClassPrefix.test.js
+++ b/__tests__/applyClassPrefix.test.js
@@ -16,3 +16,27 @@ test('it prefixes classes with the provided prefix', () => {
   expect(result.css).toEqual(expected)
   expect(result.warnings().length).toBe(0)
 })
+
+test('it handles a function as the prefix', () => {
+  const input = postcss.parse(`
+    .foo { color: red; }
+    .apple, .pear { color: green; }
+  `)
+
+  const expected = `
+    .tw-foo { color: red; }
+    .apple, .pear { color: green; }
+  `
+
+  const prefixFunc = selector => {
+    if (selector === '.foo') {
+      return 'tw-'
+    }
+
+    return ''
+  }
+
+  const result = applyClassPrefix(input, prefixFunc).toResult()
+  expect(result.css).toEqual(expected)
+  expect(result.warnings().length).toBe(0)
+})

--- a/src/util/applyClassPrefix.js
+++ b/src/util/applyClassPrefix.js
@@ -1,6 +1,9 @@
 export default function(css, prefix) {
+  const prefixIsFunc = typeof prefix === 'function'
   css.walkRules(rule => {
-    rule.selectors = rule.selectors.map(selector => `.${prefix}${selector.slice(1)}`)
+    rule.selectors = rule.selectors.map(
+      selector => `.${prefixIsFunc ? prefix(selector) : prefix}${selector.slice(1)}`
+    )
   })
   return css
 }


### PR DESCRIPTION
This PR will add the ability to pass a function to the `prefix` option, as discussed in https://github.com/tailwindcss/tailwindcss/issues/330.

```javascript
{
  // ...
  options: {
    prefix: function (selector) {
      if (selector === '.foo') {
        return 'tw-'
      }

      return ''  
    },
    important: false,
    separator: ':',
  },
  // ...
}
```