### PR TITLE
Bake in vendor prefixes for `appearance-none` utility

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -644,7 +644,9 @@ button,
 }
 
 .appearance-none {
-  appearance: none;
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
 }
 
 .bg-fixed {
@@ -4527,7 +4529,9 @@ button,
   }
 
   .sm\:appearance-none {
-    appearance: none;
+    -webkit-appearance: none;
+       -moz-appearance: none;
+            appearance: none;
   }
 
   .sm\:bg-fixed {
@@ -8403,7 +8407,9 @@ button,
   }
 
   .md\:appearance-none {
-    appearance: none;
+    -webkit-appearance: none;
+       -moz-appearance: none;
+            appearance: none;
   }
 
   .md\:bg-fixed {
@@ -12279,7 +12285,9 @@ button,
   }
 
   .lg\:appearance-none {
-    appearance: none;
+    -webkit-appearance: none;
+       -moz-appearance: none;
+            appearance: none;
   }
 
   .lg\:bg-fixed {
@@ -16155,7 +16163,9 @@ button,
   }
 
   .xl\:appearance-none {
-    appearance: none;
+    -webkit-appearance: none;
+       -moz-appearance: none;
+            appearance: none;
   }
 
   .xl\:bg-fixed {

--- a/src/generators/appearance.js
+++ b/src/generators/appearance.js
@@ -2,6 +2,10 @@ import defineClasses from '../util/defineClasses'
 
 export default function() {
   return defineClasses({
-    'appearance-none': { appearance: 'none' },
+    'appearance-none': {
+      '-webkit-appearance': 'none',
+      '-moz-appearance': 'none',
+      appearance: 'none',
+    },
   })
 }


### PR DESCRIPTION
Have had a few situations come up now where people were wondering why `appearance-none` wasn't working and it was because they weren't adding vendor prefixes in their build process.

I'm opening this PR to try and decide if it makes sense to bake those prefixes in for at least this class, since `appearance: none` is supported by literally *no* browsers without a prefix.

Does this seem like a reasonable solution? Would it be better to add autoprefixer as a dependency of Tailwind to at least run it against our own generated code, respecting the the user's browserslist config if they have one? Should we just add some documentation to the installation page that recommends autoprefixer? Maybe even a new documentation page that addresses how Tailwind approaches browser support?

So many ways to solve this problem 🤔 