### PR TITLE
Add `cursor: move` property.

### DIFF
--- a/src/generators/cursor.js
+++ b/src/generators/cursor.js
@@ -5,6 +5,7 @@ export default function() {
     'cursor-auto': { cursor: 'auto' },
     'cursor-default': { cursor: 'default' },
     'cursor-pointer': { cursor: 'pointer' },
+    'cursor-move': { cursor: 'move' },
     'cursor-not-allowed': { cursor: 'not-allowed' },
   })
 }


### PR DESCRIPTION
Just a quick addition to the cursor generator to add `move` as an option? I am building a custom fieldtype that uses sorting for our Laravel CMS ;-)