### PR TITLE
Support for active state variant

### DIFF
--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -101,12 +101,12 @@ test('it can generate hover, active and focus variants', () => {
   const output = `
       .banana { color: yellow; }
       .chocolate { color: brown; }
+      .focus\\:banana:focus { color: yellow; }
+      .focus\\:chocolate:focus { color: brown; }
       .hover\\:banana:hover { color: yellow; }
       .hover\\:chocolate:hover { color: brown; }
       .active\\:banana:active { color: yellow; }
       .active\\:chocolate:active { color: brown; }
-      .focus\\:banana:focus { color: yellow; }
-      .focus\\:chocolate:focus { color: brown; }
   `
 
   return run(input).then(result => {
@@ -127,10 +127,10 @@ test('it wraps the output in a responsive at-rule if responsive is included as a
     @responsive {
       .banana { color: yellow; }
       .chocolate { color: brown; }
-      .hover\\:banana:hover { color: yellow; }
-      .hover\\:chocolate:hover { color: brown; }
       .focus\\:banana:focus { color: yellow; }
       .focus\\:chocolate:focus { color: brown; }
+      .hover\\:banana:hover { color: yellow; }
+      .hover\\:chocolate:hover { color: brown; }
     }
   `
 

--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -101,12 +101,12 @@ test('it can generate hover, active and focus variants', () => {
   const output = `
       .banana { color: yellow; }
       .chocolate { color: brown; }
-      .focus\\:banana:focus { color: yellow; }
-      .focus\\:chocolate:focus { color: brown; }
-      .active\\:banana:active { color: yellow; }
-      .active\\:chocolate:active { color: brown; }
       .hover\\:banana:hover { color: yellow; }
       .hover\\:chocolate:hover { color: brown; }
+      .active\\:banana:active { color: yellow; }
+      .active\\:chocolate:active { color: brown; }
+      .focus\\:banana:focus { color: yellow; }
+      .focus\\:chocolate:focus { color: brown; }
   `
 
   return run(input).then(result => {
@@ -127,10 +127,10 @@ test('it wraps the output in a responsive at-rule if responsive is included as a
     @responsive {
       .banana { color: yellow; }
       .chocolate { color: brown; }
-      .focus\\:banana:focus { color: yellow; }
-      .focus\\:chocolate:focus { color: brown; }
       .hover\\:banana:hover { color: yellow; }
       .hover\\:chocolate:hover { color: brown; }
+      .focus\\:banana:focus { color: yellow; }
+      .focus\\:chocolate:focus { color: brown; }
     }
   `
 

--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -27,6 +27,27 @@ test('it can generate hover variants', () => {
   })
 })
 
+test('it can generate active variants', () => {
+  const input = `
+    @variants active {
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+    }
+  `
+
+  const output = `
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+      .active\\:banana:active { color: yellow; }
+      .active\\:chocolate:active { color: brown; }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('it can generate focus variants', () => {
   const input = `
     @variants focus {
@@ -69,9 +90,9 @@ test('it can generate group-hover variants', () => {
   })
 })
 
-test('it can generate hover and focus variants', () => {
+test('it can generate hover, active and focus variants', () => {
   const input = `
-    @variants hover, focus {
+    @variants hover, active, focus {
       .banana { color: yellow; }
       .chocolate { color: brown; }
     }
@@ -80,10 +101,12 @@ test('it can generate hover and focus variants', () => {
   const output = `
       .banana { color: yellow; }
       .chocolate { color: brown; }
-      .focus\\:banana:focus { color: yellow; }
-      .focus\\:chocolate:focus { color: brown; }
       .hover\\:banana:hover { color: yellow; }
       .hover\\:chocolate:hover { color: brown; }
+      .active\\:banana:active { color: yellow; }
+      .active\\:chocolate:active { color: brown; }
+      .focus\\:banana:focus { color: yellow; }
+      .focus\\:chocolate:focus { color: brown; }
   `
 
   return run(input).then(result => {
@@ -104,10 +127,10 @@ test('it wraps the output in a responsive at-rule if responsive is included as a
     @responsive {
       .banana { color: yellow; }
       .chocolate { color: brown; }
-      .focus\\:banana:focus { color: yellow; }
-      .focus\\:chocolate:focus { color: brown; }
       .hover\\:banana:hover { color: yellow; }
       .hover\\:chocolate:hover { color: brown; }
+      .focus\\:banana:focus { color: yellow; }
+      .focus\\:chocolate:focus { color: brown; }
     }
   `
 

--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -101,12 +101,12 @@ test('it can generate hover, active and focus variants', () => {
   const output = `
       .banana { color: yellow; }
       .chocolate { color: brown; }
-      .hover\\:banana:hover { color: yellow; }
-      .hover\\:chocolate:hover { color: brown; }
-      .active\\:banana:active { color: yellow; }
-      .active\\:chocolate:active { color: brown; }
       .focus\\:banana:focus { color: yellow; }
       .focus\\:chocolate:focus { color: brown; }
+      .active\\:banana:active { color: yellow; }
+      .active\\:chocolate:active { color: brown; }
+      .hover\\:banana:hover { color: yellow; }
+      .hover\\:chocolate:hover { color: brown; }
   `
 
   return run(input).then(result => {
@@ -127,10 +127,10 @@ test('it wraps the output in a responsive at-rule if responsive is included as a
     @responsive {
       .banana { color: yellow; }
       .chocolate { color: brown; }
-      .hover\\:banana:hover { color: yellow; }
-      .hover\\:chocolate:hover { color: brown; }
       .focus\\:banana:focus { color: yellow; }
       .focus\\:chocolate:focus { color: brown; }
+      .hover\\:banana:hover { color: yellow; }
+      .hover\\:chocolate:hover { color: brown; }
     }
   `
 

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -804,7 +804,8 @@ module.exports = {
   | Here is where you control which modules are generated and what variants are
   | generated for each of those modules.
   |
-  | Currently supported variants: 'responsive', 'hover', 'focus', 'group-hover'
+  | Currently supported variants: 'responsive', 'hover', 'active', focus', 
+  | 'group-hover'
   |
   | To disable a module completely, use `false` instead of an array.
   |

--- a/docs/source/_assets/less/main.less
+++ b/docs/source/_assets/less/main.less
@@ -24,6 +24,18 @@ ul {
 
 @tailwind utilities;
 
+.active\:bg-blue:active {
+  @apply .bg-blue;
+}
+
+.active\:text-white:active {
+  @apply .text-white;
+}
+
+.active\:border-transparent:active {
+  @apply .border-transparent;
+}
+
 .focus\:bg-grey-dark:focus {
   @apply .bg-grey-dark;
 }

--- a/docs/source/_partials/feature-badges.blade.php
+++ b/docs/source/_partials/feature-badges.blade.php
@@ -48,6 +48,22 @@
     </span>
     @endif
 
+    @if ($active)
+    <a href="#hover" class="mb-2 inline-flex items-center rounded-full border border-grey-light bg-grey-lightest text-xs font-semibold pl-1 pt-1 pb-1 pr-2 leading-none mr-2">
+      <span class="inline-flex rounded-full bg-green-light text-white mr-1">
+        <svg class="fill-current h-4 w-4" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M5.8 9.4c-.33-.442-.958-.53-1.4-.2-.442.33-.53.958-.2 1.4l3 4c.38.508 1.134.537 1.553.06l7-8c.363-.417.32-1.05-.094-1.413-.417-.363-1.05-.32-1.413.094L8.06 12.414 5.8 9.4z"/></svg>
+      </span>
+      <span>Active</span>
+    </a>
+    @else
+    <span class="mb-2 inline-flex items-center rounded-full border border-grey-light bg-grey-lightest text-xs font-semibold pl-1 pt-1 pb-1 pr-2 leading-none opacity-50 mr-2">
+      <span class="inline-flex rounded-full bg-grey text-white mr-1">
+        <svg class="fill-current h-4 w-4" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M10 8.586L6.707 5.293c-.39-.39-1.024-.39-1.414 0-.39.39-.39 1.024 0 1.414L8.586 10l-3.293 3.293c-.39.39-.39 1.024 0 1.414.39.39 1.024.39 1.414 0L10 11.414l3.293 3.293c.39.39 1.024.39 1.414 0 .39-.39.39-1.024 0-1.414L11.414 10l3.293-3.293c.39-.39.39-1.024 0-1.414-.39-.39-1.024-.39-1.414 0L10 8.586z"/></svg>
+      </span>
+      <span>Active</span>
+    </span>
+    @endif
+
     @if ($focus)
     <span class="mb-2 inline-flex items-center rounded-full border border-grey-light bg-grey-lightest text-xs font-semibold pl-1 pt-1 pb-1 pr-2 leading-none mr-2">
       <span class="inline-flex rounded-full bg-green-light text-white mr-1">

--- a/docs/source/_partials/variants-and-disabling.blade.php
+++ b/docs/source/_partials/variants-and-disabling.blade.php
@@ -9,8 +9,8 @@
     $extraVariants = collect([
         'responsive',
         'hover',
-        'active',
         'focus',
+        'active',
         'group-hover',
     ])->diff($variants)
     ->take(3 - count($variants))
@@ -28,7 +28,7 @@
 @component('_partials.customized-config', ['key' => 'modules'])
   // ...
 - {{ $utility['property'] }}: [{{$currentVariants}}],
-+ {{ $utility['property'] }}: ['responsive', 'hover', 'active', 'focus'],
++ {{ $utility['property'] }}: ['responsive', 'hover', 'focus'],
 @endcomponent
 
 @isset($extraMessage)

--- a/docs/source/_partials/variants-and-disabling.blade.php
+++ b/docs/source/_partials/variants-and-disabling.blade.php
@@ -9,6 +9,7 @@
     $extraVariants = collect([
         'responsive',
         'hover',
+        'active',
         'focus',
         'group-hover',
     ])->diff($variants)
@@ -16,7 +17,7 @@
     ->implode(' and ');
 @endphp
 
-<h3>Responsive, Hover, and Focus Variants</h3>
+<h3>Responsive, Hover, Active and Focus Variants</h3>
 
 <p>By default, {{ $whichVariants }} variants are generated for {{ $utility['name'] }} utilities.</p>
 
@@ -27,7 +28,7 @@
 @component('_partials.customized-config', ['key' => 'modules'])
   // ...
 - {{ $utility['property'] }}: [{{$currentVariants}}],
-+ {{ $utility['property'] }}: ['responsive', 'hover', 'focus'],
++ {{ $utility['property'] }}: ['responsive', 'hover', 'active', 'focus'],
 @endcomponent
 
 @isset($extraMessage)

--- a/docs/source/docs/background-attachment.blade.md
+++ b/docs/source/docs/background-attachment.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/background-color.blade.md
+++ b/docs/source/docs/background-color.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: true
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/background-position.blade.md
+++ b/docs/source/docs/background-position.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/background-repeat.blade.md
+++ b/docs/source/docs/background-repeat.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/background-size.blade.md
+++ b/docs/source/docs/background-size.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/border-color.blade.md
+++ b/docs/source/docs/border-color.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: true
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/border-radius.blade.md
+++ b/docs/source/docs/border-radius.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/border-style.blade.md
+++ b/docs/source/docs/border-style.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/border-width.blade.md
+++ b/docs/source/docs/border-width.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/configuration.blade.md
+++ b/docs/source/docs/configuration.blade.md
@@ -162,6 +162,7 @@ The available state variants are:
 
 - `responsive`, for generating breakpoint-specific versions of those utilities
 - `hover`, for generating versions of those utilities that only take effect on hover
+- `active`, for generating versions of those utilities that only take effect on active
 - `focus`, for generating versions of those utilities that only take effect on focus
 - `group-hover`, for generating versions of those utilities that only take effect when a marked parent element is hovered
 

--- a/docs/source/docs/cursor.blade.md
+++ b/docs/source/docs/cursor.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/display.blade.md
+++ b/docs/source/docs/display.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/flexbox-align-content.blade.md
+++ b/docs/source/docs/flexbox-align-content.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/flexbox-align-items.blade.md
+++ b/docs/source/docs/flexbox-align-items.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/flexbox-align-self.blade.md
+++ b/docs/source/docs/flexbox-align-self.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/flexbox-direction.blade.md
+++ b/docs/source/docs/flexbox-direction.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/flexbox-display.blade.md
+++ b/docs/source/docs/flexbox-display.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/flexbox-flex-grow-shrink.blade.md
+++ b/docs/source/docs/flexbox-flex-grow-shrink.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/flexbox-justify-content.blade.md
+++ b/docs/source/docs/flexbox-justify-content.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/flexbox-wrapping.blade.md
+++ b/docs/source/docs/flexbox-wrapping.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/floats.blade.md
+++ b/docs/source/docs/floats.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/font-weight.blade.md
+++ b/docs/source/docs/font-weight.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: true
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/fonts.blade.md
+++ b/docs/source/docs/fonts.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/forms.blade.md
+++ b/docs/source/docs/forms.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/height.blade.md
+++ b/docs/source/docs/height.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/letter-spacing.blade.md
+++ b/docs/source/docs/letter-spacing.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/line-height.blade.md
+++ b/docs/source/docs/line-height.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/lists.blade.md
+++ b/docs/source/docs/lists.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/max-height.blade.md
+++ b/docs/source/docs/max-height.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/max-width.blade.md
+++ b/docs/source/docs/max-width.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/min-height.blade.md
+++ b/docs/source/docs/min-height.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/min-width.blade.md
+++ b/docs/source/docs/min-width.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/opacity.blade.md
+++ b/docs/source/docs/opacity.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/overflow.blade.md
+++ b/docs/source/docs/overflow.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/pointer-events.blade.md
+++ b/docs/source/docs/pointer-events.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/positioning.blade.md
+++ b/docs/source/docs/positioning.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/resize.blade.md
+++ b/docs/source/docs/resize.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/shadows.blade.md
+++ b/docs/source/docs/shadows.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/spacing.blade.md
+++ b/docs/source/docs/spacing.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/state-variants.blade.md
+++ b/docs/source/docs/state-variants.blade.md
@@ -1,10 +1,10 @@
 ---
 extends: _layouts.documentation
 title: "State Variants"
-description: "Using utilities to style elements on hover, focus, and more."
+description: "Using utilities to style elements on hover, active, focus, and more."
 ---
 
-Similar to our [responsive prefixes](/docs/responsive-design), Tailwind makes it easy to style elements on hover, focus, and more using *state* prefixes.
+Similar to our [responsive prefixes](/docs/responsive-design), Tailwind makes it easy to style elements on hover, active, focus, and more using *state* prefixes.
 
 ## Hover
 
@@ -30,6 +30,35 @@ Add the `hover:` prefix to only apply a utility on hover.
     </div>
     <div>
       <p class="mb-2"><strong>By default, hover variants are only generated for background color, border color, font weight, text color, and text style utilities.</strong></p>
+      <p>You can customize this in the <a href="/docs/configuration#modules" class="underline">modules section</a> of your configuration file.</p>
+    </div>
+  </div>
+</div>
+
+## Active
+
+Add the `active:` prefix to only apply a utility on active.
+
+@component('_partials.code-sample', ['lang' => 'html', 'class' => 'text-center'])
+<button class="bg-transparent active:bg-blue text-blue-dark font-semibold active:text-white py-2 px-4 border border-blue active:border-transparent rounded">
+  Click me
+</button>
+
+
+@slot('code')
+<button class="bg-transparent active:bg-blue text-blue-dark active:text-white...">
+  Click me
+</button>
+@endslot
+@endcomponent
+
+<div class="bg-blue-light text-white font-semibold px-4 py-3 mb-4 -mt-2">
+  <div class="flex">
+    <div class="py-1">
+      <svg class="fill-current h-6 w-6 text-white opacity-75 mr-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M10 20C4.477 20 0 15.523 0 10S4.477 0 10 0s10 4.477 10 10-4.477 10-10 10zm0-2c4.418 0 8-3.582 8-8s-3.582-8-8-8-8 3.582-8 8 3.582 8 8 8zm-.5-5h1c.276 0 .5.224.5.5v1c0 .276-.224.5-.5.5h-1c-.276 0-.5-.224-.5-.5v-1c0-.276.224-.5.5-.5zm0-8h1c.276 0 .5.224.5.5V8l-.5 3-1 .5L9 8V5.5c0-.276.224-.5.5-.5z"/></svg>
+    </div>
+    <div>
+      <p class="mb-2"><strong>By default, active variants are not generated for any utilities.</strong></p>
       <p>You can customize this in the <a href="/docs/configuration#modules" class="underline">modules section</a> of your configuration file.</p>
     </div>
   </div>

--- a/docs/source/docs/state-variants.blade.md
+++ b/docs/source/docs/state-variants.blade.md
@@ -1,10 +1,10 @@
 ---
 extends: _layouts.documentation
 title: "State Variants"
-description: "Using utilities to style elements on hover, active, focus, and more."
+description: "Using utilities to style elements on hover, focus, and more."
 ---
 
-Similar to our [responsive prefixes](/docs/responsive-design), Tailwind makes it easy to style elements on hover, active, focus, and more using *state* prefixes.
+Similar to our [responsive prefixes](/docs/responsive-design), Tailwind makes it easy to style elements on hover, focus, and more using *state* prefixes.
 
 ## Hover
 

--- a/docs/source/docs/text-alignment.blade.md
+++ b/docs/source/docs/text-alignment.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/text-color.blade.md
+++ b/docs/source/docs/text-color.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: true
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/text-sizing.blade.md
+++ b/docs/source/docs/text-sizing.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/text-style.blade.md
+++ b/docs/source/docs/text-style.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: true
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/user-select.blade.md
+++ b/docs/source/docs/user-select.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/vertical-alignment.blade.md
+++ b/docs/source/docs/vertical-alignment.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/visibility.blade.md
+++ b/docs/source/docs/visibility.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: false
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/whitespace-and-wrapping.blade.md
+++ b/docs/source/docs/whitespace-and-wrapping.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/width.blade.md
+++ b/docs/source/docs/width.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: false
+  active: false
   focus: false
 ---
 

--- a/docs/source/docs/z-index.blade.md
+++ b/docs/source/docs/z-index.blade.md
@@ -6,6 +6,7 @@ features:
   responsive: true
   customizable: true
   hover: false
+  active: false
   focus: false
 ---
 

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -61,7 +61,7 @@ export default function(config) {
 
       atRule.before(atRule.clone().nodes)
 
-      _.forEach(['hover', 'active', 'focus', 'group-hover'], variant => {
+      _.forEach(['focus', 'hover', 'active', 'group-hover'], variant => {
         if (variants.includes(variant)) {
           variantGenerators[variant](atRule, unwrappedConfig)
         }

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -61,7 +61,7 @@ export default function(config) {
 
       atRule.before(atRule.clone().nodes)
 
-      _.forEach(['focus', 'active', 'hover', 'group-hover'], variant => {
+      _.forEach(['hover', 'active', 'focus', 'group-hover'], variant => {
         if (variants.includes(variant)) {
           variantGenerators[variant](atRule, unwrappedConfig)
         }

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -16,7 +16,11 @@ const variantGenerators = {
     const cloned = container.clone()
 
     cloned.walkRules(rule => {
-      rule.selector = `${buildClassVariant(rule.selector, 'active', config.options.separator)}:active`
+      rule.selector = `${buildClassVariant(
+        rule.selector,
+        'active',
+        config.options.separator
+      )}:active`
     })
 
     container.before(cloned.nodes)

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -61,7 +61,7 @@ export default function(config) {
 
       atRule.before(atRule.clone().nodes)
 
-      _.forEach(['hover', 'active', 'focus', 'group-hover'], variant => {
+      _.forEach(['focus', 'active', 'hover', 'group-hover'], variant => {
         if (variants.includes(variant)) {
           variantGenerators[variant](atRule, unwrappedConfig)
         }

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -12,6 +12,15 @@ const variantGenerators = {
 
     container.before(cloned.nodes)
   },
+  active: (container, config) => {
+    const cloned = container.clone()
+
+    cloned.walkRules(rule => {
+      rule.selector = `${buildClassVariant(rule.selector, 'active', config.options.separator)}:active`
+    })
+
+    container.before(cloned.nodes)
+  },
   focus: (container, config) => {
     const cloned = container.clone()
 
@@ -48,7 +57,7 @@ export default function(config) {
 
       atRule.before(atRule.clone().nodes)
 
-      _.forEach(['focus', 'hover', 'group-hover'], variant => {
+      _.forEach(['hover', 'active', 'focus', 'group-hover'], variant => {
         if (variants.includes(variant)) {
           variantGenerators[variant](atRule, unwrappedConfig)
         }


### PR DESCRIPTION
This is just a small addition to the state variant family. `active` state can come in handy while defining how buttons should behave when clicked, and I guess in a lot of other situations.

**The thing is: we already support `hover` and `focus`, right? Why not `active`?**

This pull request includes basic support, documentation and ad-hoc tests. It only needs to get merged to be up and running.

*A little sidenote: I changed the order in which state variants get generated, and their tests accordingly (now `hover` gets outputted before `focus`, and `active` sits between the two). That's to keep the same order throughout the codebase.*