### PR TITLE
Fix property reference syntax

### DIFF
--- a/docs/source/docs/flexbox-align-items.blade.md
+++ b/docs/source/docs/flexbox-align-items.blade.md
@@ -13,7 +13,7 @@ features:
   'rows' => [
     [
       '.items-stretch',
-      'align-items: flex-stretch;',
+      'align-items: stretch;',
       "Stretch items to fill the cross axis.",
     ],
     [


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
https://tailwindcss.com/docs/flexbox-align-items
`align-items: flex-stretch;` -> `align-items: stretch;`