### PR TITLE
Match apply rules against a lookup table instead of searching

### DIFF
--- a/__tests__/applyAtRule.test.js
+++ b/__tests__/applyAtRule.test.js
@@ -80,6 +80,22 @@ test('it fails if the class does not exist', () => {
   })
 })
 
+test('applying classes that are defined in a media query is not supported', () => {
+  const input = `
+    @media (min-width: 300px) {
+      .a { color: blue; }
+    }
+
+    .b {
+      @apply .a;
+    }
+  `
+  expect.assertions(1)
+  return run(input).catch(e => {
+    expect(e).toMatchObject({ name: 'CssSyntaxError' })
+  })
+})
+
 test('applying classes that are ever used in a media query is not supported', () => {
   const input = `
     .a {


### PR DESCRIPTION
Previously, every `@apply` call would traverse the entire CSS tree looking for a matching class. This is dumb since the CSS tree doesn't change (except for the contents of classes using `@apply`).

This PR changes this to build a lookup table at the beginning of the whole process so classes can be picked out by index instead of searching. This makes everything a *lot* faster (10,000 `@apply` rules dropped from 158s to 8s on my machine.)

The one risk here is if anyone was previously using multi-level `@apply` calls, like:

```css
.foo {
  color: red;
}

.bar {
  @apply .foo;
}

.baz {
  @apply .bar;
}
```

Previously this would work (by coincidence, because these rules happened to be in the right order for it to work), but now it won't. This has never been "supported" so I'm not too worried about it, but we can certainly make the failure around this more explicit in a future change.