### PR TITLE
Use global.Object.assign to allow Nuxt.js import

### DIFF
--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -399,7 +399,7 @@ module.exports = {
   |
   */
 
-  borderColors: Object.assign({ default: colors['grey-light'] }, colors),
+  borderColors: global.Object.assign({ default: colors['grey-light'] }, colors),
 
 
   /*


### PR DESCRIPTION
When using an `Object.assign` polyfill (e.g. when using Nuxt.js), it's not possible to import the TailwindCSS config in your frontend files/components. When using `global.Object.assign`, it works out without problems.

See https://twitter.com/adamwathan/status/968652732167995392 for full discussion.