### PR TITLE
[0.5] Rename `.roman` to `.not-italic`

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -4205,7 +4205,7 @@ button,
   font-style: italic;
 }
 
-.roman {
+.not-italic {
   font-style: normal;
 }
 
@@ -4251,7 +4251,7 @@ button,
   font-style: italic;
 }
 
-.hover\:roman:hover {
+.hover\:not-italic:hover {
   font-style: normal;
 }
 
@@ -8084,7 +8084,7 @@ button,
     font-style: italic;
   }
 
-  .sm\:roman {
+  .sm\:not-italic {
     font-style: normal;
   }
 
@@ -8130,7 +8130,7 @@ button,
     font-style: italic;
   }
 
-  .sm\:hover\:roman:hover {
+  .sm\:hover\:not-italic:hover {
     font-style: normal;
   }
 
@@ -11964,7 +11964,7 @@ button,
     font-style: italic;
   }
 
-  .md\:roman {
+  .md\:not-italic {
     font-style: normal;
   }
 
@@ -12010,7 +12010,7 @@ button,
     font-style: italic;
   }
 
-  .md\:hover\:roman:hover {
+  .md\:hover\:not-italic:hover {
     font-style: normal;
   }
 
@@ -15844,7 +15844,7 @@ button,
     font-style: italic;
   }
 
-  .lg\:roman {
+  .lg\:not-italic {
     font-style: normal;
   }
 
@@ -15890,7 +15890,7 @@ button,
     font-style: italic;
   }
 
-  .lg\:hover\:roman:hover {
+  .lg\:hover\:not-italic:hover {
     font-style: normal;
   }
 
@@ -19724,7 +19724,7 @@ button,
     font-style: italic;
   }
 
-  .xl\:roman {
+  .xl\:not-italic {
     font-style: normal;
   }
 
@@ -19770,7 +19770,7 @@ button,
     font-style: italic;
   }
 
-  .xl\:hover\:roman:hover {
+  .xl\:hover\:not-italic:hover {
     font-style: normal;
   }
 

--- a/src/generators/textStyle.js
+++ b/src/generators/textStyle.js
@@ -3,7 +3,7 @@ import defineClasses from '../util/defineClasses'
 export default function() {
   return defineClasses({
     italic: { 'font-style': 'italic' },
-    roman: { 'font-style': 'normal' },
+    'not-italic': { 'font-style': 'normal' },
 
     uppercase: { 'text-transform': 'uppercase' },
     lowercase: { 'text-transform': 'lowercase' },


### PR DESCRIPTION
Resolves #413.

Prior to this PR, the `.roman` class was used to "un-italicize" text responsively:

```html
<p class="italic md:roman">Lorem ipsum</p>
```

We struggled with naming this class originally and didn't like `not-italic` for some reason. Circling back like 5 months later I think it's a fine name and a lot less confusing.

Breaking change so slated for 0.5.