### PR TITLE
[0.5] Generate focus variants last and group-hover variants first

### DIFF
--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -69,9 +69,9 @@ test('it can generate group-hover variants', () => {
   })
 })
 
-test('it can generate hover and focus variants', () => {
+test('it can generate all variants', () => {
   const input = `
-    @variants hover, focus {
+    @variants hover, focus, group-hover {
       .banana { color: yellow; }
       .chocolate { color: brown; }
     }
@@ -80,10 +80,12 @@ test('it can generate hover and focus variants', () => {
   const output = `
       .banana { color: yellow; }
       .chocolate { color: brown; }
-      .focus\\:banana:focus { color: yellow; }
-      .focus\\:chocolate:focus { color: brown; }
+      .group:hover .group-hover\\:banana { color: yellow; }
+      .group:hover .group-hover\\:chocolate { color: brown; }
       .hover\\:banana:hover { color: yellow; }
       .hover\\:chocolate:hover { color: brown; }
+      .focus\\:banana:focus { color: yellow; }
+      .focus\\:chocolate:focus { color: brown; }
   `
 
   return run(input).then(result => {
@@ -104,10 +106,10 @@ test('it wraps the output in a responsive at-rule if responsive is included as a
     @responsive {
       .banana { color: yellow; }
       .chocolate { color: brown; }
-      .focus\\:banana:focus { color: yellow; }
-      .focus\\:chocolate:focus { color: brown; }
       .hover\\:banana:hover { color: yellow; }
       .hover\\:chocolate:hover { color: brown; }
+      .focus\\:banana:focus { color: yellow; }
+      .focus\\:chocolate:focus { color: brown; }
     }
   `
 

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -48,7 +48,7 @@ export default function(config) {
 
       atRule.before(atRule.clone().nodes)
 
-      _.forEach(['focus', 'hover', 'group-hover'], variant => {
+      _.forEach(['group-hover', 'hover', 'focus'], variant => {
         if (variants.includes(variant)) {
           variantGenerators[variant](atRule, unwrappedConfig)
         }


### PR DESCRIPTION
Resolves #392.

This PR changes the order in which [state variants](https://tailwindcss.com/docs/state-variants) are generated to be more intuitive.

Prior to this PR, variants were generated in this order:

1. Focus
2. Hover
3. Group Hover

That means if an element had both hover and focus styles applied to the same property, the hover styles would win if the element was hovered and focused simultaneously:

```html
<!-- This button will be green if hovered and focused -->
<button class="bg-blue focus:bg-red hover:bg-green">Click</button>
```

While this feels right for buttons, it feels wrong for inputs, where a focus style feels like it should take precedence over a hover style:

![weird-input-hover](https://user-images.githubusercontent.com/4323180/37296869-92df0a72-25f2-11e8-9ebe-fc05f33523c3.gif)

Choosing either option here has trade-offs, but I'm convinced that having focus styles trump hover styles is a better trade-off for two reasons:

1. Even though for non-input elements it feels more correct for hover to trump focus, it is very uncommon for focus and hover to both target the same property on those elements, so in practice it doesn't actually matter. I've *never* given a button a default background color, a focus background color, and a hover background color. Any focus styles I apply to buttons are usually changing the outline color or border.

2. The only elements where it is reasonably common to target the same property on both hover and focus are input elements, so since that situation actually happens, it makes sense to optimize for it.

This PR also moves `group-hover` to the beginning, giving it the lowest precedence whereas previously it had the highest precedence. That means that now, if a button is inside a div and has a group hover background color *and* a regular hover background color, hovering the button will apply the hover background instead of the group hover background.