### PR TITLE
[0.5] Move cursor utility options to config instead of hard-coding

### DIFF
--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -818,6 +818,27 @@ module.exports = {
 
   /*
   |-----------------------------------------------------------------------------
+  | Cursor                                  https://tailwindcss.com/docs/cursor
+  |-----------------------------------------------------------------------------
+  |
+  | Here is where you define your cursor utility values. By default we provide
+  | a sensible set of values that are commonly needed in most applications, but
+  | feel free to add any you need that are not included.
+  |
+  | Class name: .cursor-{name}
+  |
+  */
+
+  cursor: {
+    'auto': 'auto',
+    'default': 'default',
+    'pointer': 'pointer',
+    'not-allowed': 'not-allowed',
+  },
+
+
+  /*
+  |-----------------------------------------------------------------------------
   | Modules                  https://tailwindcss.com/docs/configuration#modules
   |-----------------------------------------------------------------------------
   |

--- a/src/generators/cursor.js
+++ b/src/generators/cursor.js
@@ -1,10 +1,10 @@
-import defineClasses from '../util/defineClasses'
+import _ from 'lodash'
+import defineClass from '../util/defineClass'
 
-export default function() {
-  return defineClasses({
-    'cursor-auto': { cursor: 'auto' },
-    'cursor-default': { cursor: 'default' },
-    'cursor-pointer': { cursor: 'pointer' },
-    'cursor-not-allowed': { cursor: 'not-allowed' },
+export default function({ cursor }) {
+  return _.map(cursor, (value, modifier) => {
+    return defineClass(`cursor-${modifier}`, {
+      cursor: value,
+    })
   })
 }


### PR DESCRIPTION
Several folks have asked for additional cursor options to be added to the framework, but there's like 40 different options and supporting all of them by default is no good.

This PR adds a new `cursor` config key where users can specify which cursors they want available in their app.

I'm not totally sold on merging this yet but opening it in case I decide it's a good idea. Part of me still would rather just merge the two open PRs since they are for fairly common values and tell people to create their own utilities if they need any of the more obscure cursor options.