### PR TITLE
Add height: auto; to img tag in preflight

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -589,6 +589,7 @@ textarea {
 
 img {
   max-width: 100%;
+  height: auto;
 }
 
 button,

--- a/css/preflight.css
+++ b/css/preflight.css
@@ -577,7 +577,7 @@ button,
 
 textarea { resize: vertical; }
 
-img { max-width: 100%; }
+img { max-width: 100%; height: auto; }
 
 button, input, optgroup, select, textarea { font-family: inherit; }
 


### PR DESCRIPTION
Right now it's just set to max-width: 100%, and without the height: auto browsers can behave differently. 