### PR TITLE
Add sourcemaps for replaced preflight styles

### DIFF
--- a/src/lib/substituteTailwindAtRules.js
+++ b/src/lib/substituteTailwindAtRules.js
@@ -13,9 +13,13 @@ export default function(config) {
 
     css.walkAtRules('tailwind', atRule => {
       if (atRule.params === 'preflight') {
-        atRule.before(
-          postcss.parse(fs.readFileSync(`${__dirname}/../../css/preflight.css`, 'utf8'))
+        const preflightTree = postcss.parse(
+          fs.readFileSync(`${__dirname}/../../css/preflight.css`, 'utf8')
         )
+
+        preflightTree.walk(node => (node.source = atRule.source))
+
+        atRule.before(preflightTree)
         atRule.remove()
       }
 


### PR DESCRIPTION
When replacing `@tailwind preflight` with the actual styles, we weren't updating all of the nodes in the preflight styles to point to the at-rule they are replacing.

This PR updates the source for each node so that when looking at your sourcemaps you can see that styles like `* { box-sizing: border-box }` originated from the `@tailwind preflight;` rule in your source CSS.

Fixes #441.