### PR TITLE
Add overflow hidden classes for each axis

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3223,6 +3223,14 @@ button,
   overflow-y: hidden;
 }
 
+.overflow-x-visible {
+  overflow-x: visible;
+}
+
+.overflow-y-visible {
+  overflow-y: visible;
+}
+
 .overflow-x-scroll {
   overflow-x: scroll;
 }
@@ -7136,6 +7144,14 @@ button,
     overflow-y: hidden;
   }
 
+  .sm\:overflow-x-visible {
+    overflow-x: visible;
+  }
+
+  .sm\:overflow-y-visible {
+    overflow-y: visible;
+  }
+
   .sm\:overflow-x-scroll {
     overflow-x: scroll;
   }
@@ -11040,6 +11056,14 @@ button,
 
   .md\:overflow-y-hidden {
     overflow-y: hidden;
+  }
+
+  .md\:overflow-x-visible {
+    overflow-x: visible;
+  }
+
+  .md\:overflow-y-visible {
+    overflow-y: visible;
   }
 
   .md\:overflow-x-scroll {
@@ -14948,6 +14972,14 @@ button,
     overflow-y: hidden;
   }
 
+  .lg\:overflow-x-visible {
+    overflow-x: visible;
+  }
+
+  .lg\:overflow-y-visible {
+    overflow-y: visible;
+  }
+
   .lg\:overflow-x-scroll {
     overflow-x: scroll;
   }
@@ -18852,6 +18884,14 @@ button,
 
   .xl\:overflow-y-hidden {
     overflow-y: hidden;
+  }
+
+  .xl\:overflow-x-visible {
+    overflow-x: visible;
+  }
+
+  .xl\:overflow-y-visible {
+    overflow-y: visible;
   }
 
   .xl\:overflow-x-scroll {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3215,6 +3215,14 @@ button,
   overflow-y: auto;
 }
 
+.overflow-x-hidden {
+  overflow-x: hidden;
+}
+
+.overflow-y-hidden {
+  overflow-y: hidden;
+}
+
 .overflow-x-scroll {
   overflow-x: scroll;
 }
@@ -7120,6 +7128,14 @@ button,
     overflow-y: auto;
   }
 
+  .sm\:overflow-x-hidden {
+    overflow-x: hidden;
+  }
+
+  .sm\:overflow-y-hidden {
+    overflow-y: hidden;
+  }
+
   .sm\:overflow-x-scroll {
     overflow-x: scroll;
   }
@@ -11016,6 +11032,14 @@ button,
 
   .md\:overflow-y-auto {
     overflow-y: auto;
+  }
+
+  .md\:overflow-x-hidden {
+    overflow-x: hidden;
+  }
+
+  .md\:overflow-y-hidden {
+    overflow-y: hidden;
   }
 
   .md\:overflow-x-scroll {
@@ -14916,6 +14940,14 @@ button,
     overflow-y: auto;
   }
 
+  .lg\:overflow-x-hidden {
+    overflow-x: hidden;
+  }
+
+  .lg\:overflow-y-hidden {
+    overflow-y: hidden;
+  }
+
   .lg\:overflow-x-scroll {
     overflow-x: scroll;
   }
@@ -18812,6 +18844,14 @@ button,
 
   .xl\:overflow-y-auto {
     overflow-y: auto;
+  }
+
+  .xl\:overflow-x-hidden {
+    overflow-x: hidden;
+  }
+
+  .xl\:overflow-y-hidden {
+    overflow-y: hidden;
   }
 
   .xl\:overflow-x-scroll {

--- a/src/generators/overflow.js
+++ b/src/generators/overflow.js
@@ -10,6 +10,8 @@ export default function() {
     'overflow-y-auto': { 'overflow-y': 'auto' },
     'overflow-x-hidden': { 'overflow-x': 'hidden' },
     'overflow-y-hidden': { 'overflow-y': 'hidden' },
+    'overflow-x-visible': { 'overflow-x': 'visible' },
+    'overflow-y-visible': { 'overflow-y': 'visible' },
     'overflow-x-scroll': { 'overflow-x': 'scroll' },
     'overflow-y-scroll': { 'overflow-y': 'scroll' },
     'scrolling-touch': { '-webkit-overflow-scrolling': 'touch' },

--- a/src/generators/overflow.js
+++ b/src/generators/overflow.js
@@ -8,6 +8,8 @@ export default function() {
     'overflow-scroll': { overflow: 'scroll' },
     'overflow-x-auto': { 'overflow-x': 'auto' },
     'overflow-y-auto': { 'overflow-y': 'auto' },
+    'overflow-x-hidden': { 'overflow-x': 'hidden' },
+    'overflow-y-hidden': { 'overflow-y': 'hidden' },
     'overflow-x-scroll': { 'overflow-x': 'scroll' },
     'overflow-y-scroll': { 'overflow-y': 'scroll' },
     'scrolling-touch': { '-webkit-overflow-scrolling': 'touch' },


### PR DESCRIPTION
This PR adds classes to set `overflow: hidden` for each axis independently. Added a the generated CSS to the tests.

Let me know if you want me to do anything else in order to merge this.

Closes #439.