### PR TITLE
Add 100% position offsets.

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3539,6 +3539,22 @@ button,
   left: 0;
 }
 
+.pin-t-full {
+  top: 100%;
+}
+
+.pin-r-full {
+  right: 100%;
+}
+
+.pin-b-full {
+  bottom: 100%;
+}
+
+.pin-l-full {
+  left: 100%;
+}
+
 .resize-none {
   resize: none;
 }
@@ -7444,6 +7460,22 @@ button,
     left: 0;
   }
 
+  .sm\:pin-t-full {
+    top: 100%;
+  }
+
+  .sm\:pin-r-full {
+    right: 100%;
+  }
+
+  .sm\:pin-b-full {
+    bottom: 100%;
+  }
+
+  .sm\:pin-l-full {
+    left: 100%;
+  }
+
   .sm\:resize-none {
     resize: none;
   }
@@ -11340,6 +11372,22 @@ button,
 
   .md\:pin-l {
     left: 0;
+  }
+
+  .md\:pin-t-full {
+    top: 100%;
+  }
+
+  .md\:pin-r-full {
+    right: 100%;
+  }
+
+  .md\:pin-b-full {
+    bottom: 100%;
+  }
+
+  .md\:pin-l-full {
+    left: 100%;
   }
 
   .md\:resize-none {
@@ -15240,6 +15288,22 @@ button,
     left: 0;
   }
 
+  .lg\:pin-t-full {
+    top: 100%;
+  }
+
+  .lg\:pin-r-full {
+    right: 100%;
+  }
+
+  .lg\:pin-b-full {
+    bottom: 100%;
+  }
+
+  .lg\:pin-l-full {
+    left: 100%;
+  }
+
   .lg\:resize-none {
     resize: none;
   }
@@ -19136,6 +19200,22 @@ button,
 
   .xl\:pin-l {
     left: 0;
+  }
+
+  .xl\:pin-t-full {
+    top: 100%;
+  }
+
+  .xl\:pin-r-full {
+    right: 100%;
+  }
+
+  .xl\:pin-b-full {
+    bottom: 100%;
+  }
+
+  .xl\:pin-l-full {
+    left: 100%;
   }
 
   .xl\:resize-none {

--- a/src/generators/position.js
+++ b/src/generators/position.js
@@ -25,5 +25,9 @@ export default function() {
     'pin-r': { right: 0 },
     'pin-b': { bottom: 0 },
     'pin-l': { left: 0 },
+    'pin-t-full': { top: '100%' },
+    'pin-r-full': { right: '100%' },
+    'pin-b-full': { bottom: '100%' },
+    'pin-l-full': { left: '100%' },
   })
 }


### PR DESCRIPTION
As mentioned [over here](https://github.com/tailwindcss/tailwindcss/pull/348#issuecomment-381018331), I often use all offset directions at `100%`. For example, to hang something off the right-hand side of the right edge of an element with `left: 100%`. The [pull request I linked to](https://github.com/tailwindcss/tailwindcss/pull/348#issuecomment-381018331) also shows a cool use of this helper. 

Regarding the naming, I went with `full` rather than `100`, as it seems like it is used elsewhere. For example, how `100%` is treated for `width`.

First time contributing here. No offence taken if this PR is rejected!