### PR TITLE
Remove placeholder opacity

### DIFF
--- a/css/preflight.css
+++ b/css/preflight.css
@@ -583,7 +583,6 @@ button, input, optgroup, select, textarea { font-family: inherit; }
 
 input::placeholder, textarea::placeholder {
     color: inherit;
-    opacity: .5;
 }
 
 button, [role=button] {


### PR DESCRIPTION
In most cases this opacity default automatically makes placeholder text not pass ADA compliancy (its way to light). I think it would be better to leave it up to the developer to style it on their app. 

The alternative is for me to override this back to 1 in my global file but I thought others might want this too.

Thoughts on this change?