### PR TITLE
[Added] Adds the global display keywords initial and inherit

### DIFF
--- a/src/generators/display.js
+++ b/src/generators/display.js
@@ -23,5 +23,11 @@ export default function() {
     hidden: {
       display: 'none',
     },
+    initial: {
+      display: 'initial',
+    },
+    inherit: {
+      display: 'inherit',
+    },
   })
 }


### PR DESCRIPTION
This PR extends the display properties to include the global values `inherit` and `initial`.

Using these global values can be very useful as it allows you to revert a previously applied display property without having to explicitly define the box rendering method again. Sometimes it is not always immediately obvious what the initial display state was, so restoring the initial or inherited value removes guesswork.

Take `class='hidden md:block'` for example. I have to determine that the element had the property of a block in the first-place, otherwise I've broken my layout. By contrast `.md:initial` would disable the `.hidden` in any context.

Another good example might be be `<img class="hidden" />`. Is it a block, and inline-block or an inline element? I'd have to know that to correctly disable `.none` currently, where `.initial` will simply return it to whatever the browser thinks it should be.
