### PR TITLE
add test harness for cli.js and stdout bugfix

### DIFF
--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -1,0 +1,21 @@
+import { spawnSync } from 'child_process'
+import fs from 'fs'
+import path from 'path'
+
+function runCli(task, options) {
+  return spawnSync('node', [`${path.join(process.cwd(), 'lib/cli.js')}`, `${task}`, ...options])
+}
+
+function pathToFixture(fixture) {
+  return path.resolve(`${__dirname}/fixtures/${fixture}`)
+}
+
+function readFixture(fixture) {
+  return fs.readFileSync(pathToFixture(fixture), 'utf8')
+}
+
+test('stdout only contains processed output', () => {
+  const expected = readFixture('tailwind-cli-output.css')
+  const result = runCli('build', [pathToFixture('tailwind-cli-input.css')])
+  expect(result.stdout.toString()).toEqual(expected)
+})

--- a/__tests__/fixtures/tailwind-cli-input.css
+++ b/__tests__/fixtures/tailwind-cli-input.css
@@ -1,0 +1,3 @@
+body {
+  color: green;
+}

--- a/__tests__/fixtures/tailwind-cli-output.css
+++ b/__tests__/fixtures/tailwind-cli-output.css
@@ -1,0 +1,3 @@
+body {
+  color: green;
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -20,7 +20,7 @@ function writeStrategy(options) {
 }
 
 function buildTailwind(inputFile, config, write) {
-  console.log('Building Tailwind!')
+  console.warn('Building Tailwind!')
 
   const input = fs.readFileSync(inputFile, 'utf8')
 
@@ -28,9 +28,9 @@ function buildTailwind(inputFile, config, write) {
     .process(input, { from: inputFile })
     .then(result => {
       write(result.css)
-      console.log('Finished building Tailwind!')
+      console.warn('Finished building Tailwind!')
     })
-    .catch(error => console.log(error))
+    .catch(error => console.error(error))
 }
 
 const packageJson = require(path.resolve(__dirname, '../package.json'))
@@ -48,7 +48,7 @@ program
     }
 
     if (fs.existsSync(destination)) {
-      console.log(`Destination ${destination} already exists, aborting.`)
+      console.error(`Destination ${destination} already exists, aborting.`)
       process.exit(1)
     }
 
@@ -58,7 +58,7 @@ program
       destination,
       output.replace("require('./plugins/container')", "require('tailwindcss/plugins/container')")
     )
-    console.log(`Generated Tailwind config: ${destination}`)
+    console.warn(`Generated Tailwind config: ${destination}`)
     process.exit()
   })
 


### PR DESCRIPTION
When used on the CLI, `lib/cli.js` was writing the output of log statements to `STDOUT`; this caused consumers of the CLI who wanted to pipe the processed output (css) to other unix utilities to end up with invalid CSS due to the log messages appearing at the start and end of the files

You can replicate this bug on the current master branch via `tailwindcss build someInput.css > someOutput.css`, at which point `someOutput.css` will contain 

```css
Building Tailwind!
[processed css]
Finished building Tailwind!
```

This PR fixes this by replacing `console.log` with `console.warn` and `console.error`, which both write output to `STDERR`. There is no functional change to the rest of the codebase or the logging output that a user will see; this change allows the `tailwindcss` CLI to act as a normal unix CLI tool would.

