### PR TITLE
Adds a style field to point to the compiled css

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A utility-first CSS framework for rapidly building custom user interfaces.",
   "license": "MIT",
   "main": "lib/index.js",
+  "style": "dist/tailwind.css",
   "repository": "https://github.com/tailwindcss/tailwindcss.git",
   "bugs": "https://github.com/tailwindcss/tailwindcss/issues",
   "homepage": "https://tailwindcss.com",


### PR DESCRIPTION
To support [Sheetify](https://github.com/stackcss/sheetify) and use TailwindCSS within a [Choo](https://choo.io/) app for example, when wanting to consume stylesheets from an NPM package, Sheetify looks for the `.css` file specified in the package's `main` or `style` field (as described [here](https://github.com/stackcss/sheetify#use-npm-packages)).

Since Tailwind's `main` field isn't pointing to the stylesheet, adding the `style` field which does point to the compiled Tailwind stylesheet allows you to use it via
```javascript
var css = require('sheetify')
css('tailwindcss')

```