### PR TITLE
Add a way to have variant part be appended as suffix instead of only prefix 

### DIFF
--- a/__tests__/customConfig.test.js
+++ b/__tests__/customConfig.test.js
@@ -20,7 +20,7 @@ test('it uses the values from the custom config file', () => {
           color: blue;
         }
         @media (min-width: 400px) {
-          .mobile\\:foo {
+          .foo\\@mobile {
             color: blue;
           }
         }

--- a/__tests__/fixtures/customConfig.js
+++ b/__tests__/fixtures/customConfig.js
@@ -2,4 +2,8 @@ module.exports = {
   screens: {
     mobile: '400px',
   },
+  options: {
+    separator: '@',
+    variantsAsSuffix: true,
+  },
 }

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -920,6 +920,7 @@ module.exports = {
     prefix: '',
     important: false,
     separator: ':',
+    variantsAsSuffix: false,
   },
 
 }

--- a/src/lib/substituteResponsiveAtRules.js
+++ b/src/lib/substituteResponsiveAtRules.js
@@ -6,8 +6,10 @@ import buildClassVariant from '../util/buildClassVariant'
 
 export default function(config) {
   return function(css) {
-    const screens = config().screens
-    const separator = config().options.separator
+    const config_ = config()
+    const screens = config_.screens
+    const separator = config_.options.separator
+    const variantsAsSuffix = config_.options.variantsAsSuffix
     const responsiveRules = []
     let finalRules = []
 
@@ -28,7 +30,7 @@ export default function(config) {
         responsiveRules.map(rule => {
           const cloned = rule.clone()
           cloned.selectors = _.map(rule.selectors, selector =>
-            buildClassVariant(selector, screen, separator)
+            buildClassVariant(selector, screen, variantsAsSuffix, separator)
           )
           return cloned
         })

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -2,8 +2,8 @@ import _ from 'lodash'
 import postcss from 'postcss'
 import buildClassVariant from '../util/buildClassVariant'
 
-function buildPseudoClassVariant(selector, pseudoClass, separator) {
-  return `${buildClassVariant(selector, pseudoClass, separator)}:${pseudoClass}`
+function buildPseudoClassVariant(selector, pseudoClass, variantsAsSuffix, separator) {
+  return `${buildClassVariant(selector, pseudoClass, variantsAsSuffix, separator)}:${pseudoClass}`
 }
 
 function generatePseudoClassVariant(pseudoClass) {
@@ -11,7 +11,12 @@ function generatePseudoClassVariant(pseudoClass) {
     const cloned = container.clone()
 
     cloned.walkRules(rule => {
-      rule.selector = buildPseudoClassVariant(rule.selector, pseudoClass, config.options.separator)
+      rule.selector = buildPseudoClassVariant(
+        rule.selector,
+        pseudoClass,
+        config.options.variantsAsSuffix,
+        config.options.separator
+      )
     })
 
     container.before(cloned.nodes)
@@ -19,11 +24,16 @@ function generatePseudoClassVariant(pseudoClass) {
 }
 
 const variantGenerators = {
-  'group-hover': (container, { options: { separator } }) => {
+  'group-hover': (container, { options: { separator, variantsAsSuffix } }) => {
     const cloned = container.clone()
 
     cloned.walkRules(rule => {
-      rule.selector = `.group:hover ${buildClassVariant(rule.selector, 'group-hover', separator)}`
+      rule.selector = `.group:hover ${buildClassVariant(
+        rule.selector,
+        'group-hover',
+        variantsAsSuffix,
+        separator
+      )}`
     })
 
     container.before(cloned.nodes)

--- a/src/util/buildClassVariant.js
+++ b/src/util/buildClassVariant.js
@@ -1,5 +1,8 @@
 import escapeClassName from './escapeClassName'
 
-export default function buildClassVariant(className, variantName, separator) {
+export default function buildClassVariant(className, variantName, variantsAsSuffix, separator) {
+  if (variantsAsSuffix) {
+    return `${className}${escapeClassName(separator)}${variantName}`
+  }
   return `.${variantName}${escapeClassName(separator)}${className.slice(1)}`
 }


### PR DESCRIPTION
This pr adds prop variantsAsSuffix to config.options. which once set to true moves adds variant part as suffix instead of prefix.