### PR TITLE
Add support for custom container classes

### DIFF
--- a/__tests__/containerPlugin.test.js
+++ b/__tests__/containerPlugin.test.js
@@ -150,6 +150,32 @@ test('horizontal padding can be included by default', () => {
   `)
 })
 
+test('custom class names can be specified', () => {
+  const [components] = processPluginsWithValidConfig({
+    plugins: [
+      container({
+        className: 'my-container',
+      }),
+    ],
+  })
+
+  expect(css(components)).toMatchCss(`
+    .my-container { width: 100% }
+    @media (min-width: 576px) {
+      .my-container { max-width: 576px }
+    }
+    @media (min-width: 768px) {
+      .my-container { max-width: 768px }
+    }
+    @media (min-width: 992px) {
+      .my-container { max-width: 992px }
+    }
+    @media (min-width: 1200px) {
+      .my-container { max-width: 1200px }
+    }
+  `)
+})
+
 test('setting all options at once', () => {
   const [components] = processPluginsWithValidConfig({
     plugins: [
@@ -158,6 +184,7 @@ test('setting all options at once', () => {
           sm: '400px',
           lg: '500px',
         },
+        className: 'my-container',
         center: true,
         padding: '2rem',
       }),
@@ -165,7 +192,7 @@ test('setting all options at once', () => {
   })
 
   expect(css(components)).toMatchCss(`
-    .container {
+    .my-container {
       width: 100%;
       margin-right: auto;
       margin-left: auto;
@@ -173,10 +200,10 @@ test('setting all options at once', () => {
       padding-left: 2rem
     }
     @media (min-width: 400px) {
-      .container { max-width: 400px }
+      .my-container { max-width: 400px }
     }
     @media (min-width: 500px) {
-      .container { max-width: 500px }
+      .my-container { max-width: 500px }
     }
   `)
 })

--- a/src/plugins/container.js
+++ b/src/plugins/container.js
@@ -26,12 +26,14 @@ module.exports = function(options) {
   return function({ addComponents, config }) {
     const screens = _.get(options, 'screens', config('screens'))
 
+    const className = _.get(options, 'className', 'container')
+
     const minWidths = extractMinWidths(screens)
 
     const atRules = _.map(minWidths, minWidth => {
       return {
         [`@media (min-width: ${minWidth})`]: {
-          '.container': {
+          [`.${className}`]: {
             'max-width': minWidth,
           },
         },
@@ -40,7 +42,7 @@ module.exports = function(options) {
 
     addComponents([
       {
-        '.container': Object.assign(
+        [`.${className}`]: Object.assign(
           { width: '100%' },
           _.get(options, 'center', false) ? { marginRight: 'auto', marginLeft: 'auto' } : {},
           _.has(options, 'padding')


### PR DESCRIPTION
This will add support for custom class names on the container. Currently using this in a project to create a "wide" container modifier by doing this:

```
plugins: [
  require('tailwindcss/plugins/container')(),
  require('tailwindcss/plugins/container')({
    className: 'container--wide',
    screens: [
      '1500px',
    ],
  }),
],
```

This lets me use `class="container container--wide"` to add that extra breakpoint only in the places I need.

It will of course also let anyone specify a custom class name if the word `container` feels too... bounded.