### PR TITLE
Add .bg-center-bottom and .bg-center-top

### DIFF
--- a/src/generators/backgroundPosition.js
+++ b/src/generators/backgroundPosition.js
@@ -4,6 +4,8 @@ export default function() {
   return defineClasses({
     'bg-bottom': { 'background-position': 'bottom' },
     'bg-center': { 'background-position': 'center' },
+    'bg-center-bottom': { 'background-position': 'center bottom' },
+    'bg-center-top': { 'background-position': 'center top' },
     'bg-left': { 'background-position': 'left' },
     'bg-left-bottom': { 'background-position': 'left bottom' },
     'bg-left-top': { 'background-position': 'left top' },


### PR DESCRIPTION
I found that there was no way to center a background image at the top or bottom of the element using the available classes. It is possible to center it on the right and left borders, though.

Those two new classes should fix this