### PR TITLE
Add new outline module

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3191,6 +3191,22 @@ button,
   opacity: 1;
 }
 
+.outline {
+  outline: 2px solid rgba(52, 144, 220, .5);
+}
+
+.outline-none {
+  outline: none;
+}
+
+.hover\:outline:hover {
+  outline: 2px solid rgba(52, 144, 220, .5);
+}
+
+.hover\:outline-none:hover {
+  outline: none;
+}
+
 .overflow-auto {
   overflow: auto;
 }
@@ -7096,6 +7112,22 @@ button,
     opacity: 1;
   }
 
+  .sm\:outline {
+    outline: 2px solid rgba(52, 144, 220, .5);
+  }
+
+  .sm\:outline-none {
+    outline: none;
+  }
+
+  .sm\:hover\:outline:hover {
+    outline: 2px solid rgba(52, 144, 220, .5);
+  }
+
+  .sm\:hover\:outline-none:hover {
+    outline: none;
+  }
+
   .sm\:overflow-auto {
     overflow: auto;
   }
@@ -10992,6 +11024,22 @@ button,
 
   .md\:opacity-100 {
     opacity: 1;
+  }
+
+  .md\:outline {
+    outline: 2px solid rgba(52, 144, 220, .5);
+  }
+
+  .md\:outline-none {
+    outline: none;
+  }
+
+  .md\:hover\:outline:hover {
+    outline: 2px solid rgba(52, 144, 220, .5);
+  }
+
+  .md\:hover\:outline-none:hover {
+    outline: none;
   }
 
   .md\:overflow-auto {
@@ -14892,6 +14940,22 @@ button,
     opacity: 1;
   }
 
+  .lg\:outline {
+    outline: 2px solid rgba(52, 144, 220, .5);
+  }
+
+  .lg\:outline-none {
+    outline: none;
+  }
+
+  .lg\:hover\:outline:hover {
+    outline: 2px solid rgba(52, 144, 220, .5);
+  }
+
+  .lg\:hover\:outline-none:hover {
+    outline: none;
+  }
+
   .lg\:overflow-auto {
     overflow: auto;
   }
@@ -18788,6 +18852,22 @@ button,
 
   .xl\:opacity-100 {
     opacity: 1;
+  }
+
+  .xl\:outline {
+    outline: 2px solid rgba(52, 144, 220, .5);
+  }
+
+  .xl\:outline-none {
+    outline: none;
+  }
+
+  .xl\:hover\:outline:hover {
+    outline: 2px solid rgba(52, 144, 220, .5);
+  }
+
+  .xl\:hover\:outline-none:hover {
+    outline: none;
   }
 
   .xl\:overflow-auto {

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -780,6 +780,28 @@ module.exports = {
 
   /*
   |-----------------------------------------------------------------------------
+  | Outline                                https://tailwindcss.com/docs/outline
+  |-----------------------------------------------------------------------------
+  |
+  | Here is where you define your outline utilities. By default we provide
+  | a reset and an example blue outline. You can, of course, modify these
+  | values as needed.
+  |
+  | If a `default` outline is provided, it will be made available as the
+  | non-suffixed `.outline` utility.
+  |
+  | Class name: .outline{-name?}
+  |
+  */
+
+  outline: {
+    default: `2px solid rgba(52,144,220,0.5)`,
+    'none': 'none',
+  },
+
+
+  /*
+  |-----------------------------------------------------------------------------
   | SVG fill                                   https://tailwindcss.com/docs/svg
   |-----------------------------------------------------------------------------
   |
@@ -862,6 +884,7 @@ module.exports = {
     minWidth: ['responsive'],
     negativeMargin: ['responsive'],
     opacity: ['responsive'],
+    outline: ['responsive', 'hover'],
     overflow: ['responsive'],
     padding: ['responsive'],
     pointerEvents: ['responsive'],

--- a/src/generators/outline.js
+++ b/src/generators/outline.js
@@ -1,0 +1,10 @@
+import _ from 'lodash'
+import defineClass from '../util/defineClass'
+
+export default function({ outline }) {
+  return _.map(outline, (value, modifier) => {
+    return defineClass(modifier === 'default' ? 'outline' : `outline-${modifier}`, {
+      outline: value,
+    })
+  })
+}

--- a/src/utilityModules.js
+++ b/src/utilityModules.js
@@ -24,6 +24,7 @@ import minHeight from './generators/minHeight'
 import minWidth from './generators/minWidth'
 import negativeMargin from './generators/negativeMargin'
 import opacity from './generators/opacity'
+import outline from './generators/outline'
 import overflow from './generators/overflow'
 import padding from './generators/padding'
 import pointerEvents from './generators/pointerEvents'
@@ -71,6 +72,7 @@ export default [
   { name: 'minWidth', generator: minWidth },
   { name: 'negativeMargin', generator: negativeMargin },
   { name: 'opacity', generator: opacity },
+  { name: 'outline', generator: outline },
   { name: 'overflow', generator: overflow },
   { name: 'padding', generator: padding },
   { name: 'pointerEvents', generator: pointerEvents },


### PR DESCRIPTION
This adds a new outline module, which can be configured in a very similar way to shadows.

```js
outline: {
  default: `2px solid rgba(52,144,220,0.5)`,
  'none': 'none',
},
```

However, now that I've built this, I sort of think shadows are a better choice regardless, read more about that here: https://github.com/tailwindcss/tailwindcss/issues/56#issuecomment-397363973

I'm thinking we simply create a hardcoded `outline-none` reset instead, and be done with it.