### PR TITLE
Add "outline-none" and "shadow-outline" utilities

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3192,7 +3192,7 @@ button,
 }
 
 .no-outline {
-  outline: none;
+  outline: 0;
 }
 
 .overflow-auto {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3575,6 +3575,10 @@ button,
   box-shadow: inset 0 2px 4px 0 rgba(0, 0, 0, .06);
 }
 
+.shadow-outline {
+  box-shadow: 2px solid rgba(52, 144, 220, .5);
+}
+
 .shadow-none {
   box-shadow: none;
 }
@@ -7480,6 +7484,10 @@ button,
     box-shadow: inset 0 2px 4px 0 rgba(0, 0, 0, .06);
   }
 
+  .sm\:shadow-outline {
+    box-shadow: 2px solid rgba(52, 144, 220, .5);
+  }
+
   .sm\:shadow-none {
     box-shadow: none;
   }
@@ -11376,6 +11384,10 @@ button,
 
   .md\:shadow-inner {
     box-shadow: inset 0 2px 4px 0 rgba(0, 0, 0, .06);
+  }
+
+  .md\:shadow-outline {
+    box-shadow: 2px solid rgba(52, 144, 220, .5);
   }
 
   .md\:shadow-none {
@@ -15276,6 +15288,10 @@ button,
     box-shadow: inset 0 2px 4px 0 rgba(0, 0, 0, .06);
   }
 
+  .lg\:shadow-outline {
+    box-shadow: 2px solid rgba(52, 144, 220, .5);
+  }
+
   .lg\:shadow-none {
     box-shadow: none;
   }
@@ -19172,6 +19188,10 @@ button,
 
   .xl\:shadow-inner {
     box-shadow: inset 0 2px 4px 0 rgba(0, 0, 0, .06);
+  }
+
+  .xl\:shadow-outline {
+    box-shadow: 2px solid rgba(52, 144, 220, .5);
   }
 
   .xl\:shadow-none {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3195,6 +3195,10 @@ button,
   outline: 0;
 }
 
+.focus\:outline-none:focus {
+  outline: 0;
+}
+
 .overflow-auto {
   overflow: auto;
 }

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3191,6 +3191,10 @@ button,
   opacity: 1;
 }
 
+.no-outline {
+  outline: none;
+}
+
 .overflow-auto {
   overflow: auto;
 }

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3583,6 +3583,30 @@ button,
   box-shadow: none;
 }
 
+.focus\:shadow:focus {
+  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, .1);
+}
+
+.focus\:shadow-md:focus {
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, .12), 0 2px 4px 0 rgba(0, 0, 0, .08);
+}
+
+.focus\:shadow-lg:focus {
+  box-shadow: 0 15px 30px 0 rgba(0, 0, 0, .11), 0 5px 15px 0 rgba(0, 0, 0, .08);
+}
+
+.focus\:shadow-inner:focus {
+  box-shadow: inset 0 2px 4px 0 rgba(0, 0, 0, .06);
+}
+
+.focus\:shadow-outline:focus {
+  box-shadow: 2px solid rgba(52, 144, 220, .5);
+}
+
+.focus\:shadow-none:focus {
+  box-shadow: none;
+}
+
 .fill-current {
   fill: currentColor;
 }
@@ -7492,6 +7516,30 @@ button,
     box-shadow: none;
   }
 
+  .sm\:focus\:shadow:focus {
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, .1);
+  }
+
+  .sm\:focus\:shadow-md:focus {
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, .12), 0 2px 4px 0 rgba(0, 0, 0, .08);
+  }
+
+  .sm\:focus\:shadow-lg:focus {
+    box-shadow: 0 15px 30px 0 rgba(0, 0, 0, .11), 0 5px 15px 0 rgba(0, 0, 0, .08);
+  }
+
+  .sm\:focus\:shadow-inner:focus {
+    box-shadow: inset 0 2px 4px 0 rgba(0, 0, 0, .06);
+  }
+
+  .sm\:focus\:shadow-outline:focus {
+    box-shadow: 2px solid rgba(52, 144, 220, .5);
+  }
+
+  .sm\:focus\:shadow-none:focus {
+    box-shadow: none;
+  }
+
   .sm\:text-left {
     text-align: left;
   }
@@ -11391,6 +11439,30 @@ button,
   }
 
   .md\:shadow-none {
+    box-shadow: none;
+  }
+
+  .md\:focus\:shadow:focus {
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, .1);
+  }
+
+  .md\:focus\:shadow-md:focus {
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, .12), 0 2px 4px 0 rgba(0, 0, 0, .08);
+  }
+
+  .md\:focus\:shadow-lg:focus {
+    box-shadow: 0 15px 30px 0 rgba(0, 0, 0, .11), 0 5px 15px 0 rgba(0, 0, 0, .08);
+  }
+
+  .md\:focus\:shadow-inner:focus {
+    box-shadow: inset 0 2px 4px 0 rgba(0, 0, 0, .06);
+  }
+
+  .md\:focus\:shadow-outline:focus {
+    box-shadow: 2px solid rgba(52, 144, 220, .5);
+  }
+
+  .md\:focus\:shadow-none:focus {
     box-shadow: none;
   }
 
@@ -15296,6 +15368,30 @@ button,
     box-shadow: none;
   }
 
+  .lg\:focus\:shadow:focus {
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, .1);
+  }
+
+  .lg\:focus\:shadow-md:focus {
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, .12), 0 2px 4px 0 rgba(0, 0, 0, .08);
+  }
+
+  .lg\:focus\:shadow-lg:focus {
+    box-shadow: 0 15px 30px 0 rgba(0, 0, 0, .11), 0 5px 15px 0 rgba(0, 0, 0, .08);
+  }
+
+  .lg\:focus\:shadow-inner:focus {
+    box-shadow: inset 0 2px 4px 0 rgba(0, 0, 0, .06);
+  }
+
+  .lg\:focus\:shadow-outline:focus {
+    box-shadow: 2px solid rgba(52, 144, 220, .5);
+  }
+
+  .lg\:focus\:shadow-none:focus {
+    box-shadow: none;
+  }
+
   .lg\:text-left {
     text-align: left;
   }
@@ -19195,6 +19291,30 @@ button,
   }
 
   .xl\:shadow-none {
+    box-shadow: none;
+  }
+
+  .xl\:focus\:shadow:focus {
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, .1);
+  }
+
+  .xl\:focus\:shadow-md:focus {
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, .12), 0 2px 4px 0 rgba(0, 0, 0, .08);
+  }
+
+  .xl\:focus\:shadow-lg:focus {
+    box-shadow: 0 15px 30px 0 rgba(0, 0, 0, .11), 0 5px 15px 0 rgba(0, 0, 0, .08);
+  }
+
+  .xl\:focus\:shadow-inner:focus {
+    box-shadow: inset 0 2px 4px 0 rgba(0, 0, 0, .06);
+  }
+
+  .xl\:focus\:shadow-outline:focus {
+    box-shadow: 2px solid rgba(52, 144, 220, .5);
+  }
+
+  .xl\:focus\:shadow-none:focus {
     box-shadow: none;
   }
 

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3191,7 +3191,7 @@ button,
   opacity: 1;
 }
 
-.no-outline {
+.outline-none {
   outline: 0;
 }
 

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -519,16 +519,6 @@ ul {
 }
 
 /**
- * Suppress the focus outline on elements that cannot be accessed via keyboard.
- * This prevents an unwanted focus outline from appearing around elements that
- * might still respond to pointer events.
- */
-
-[tabindex="-1"]:focus {
-  outline: none !important;
-}
-
-/**
  * Tailwind custom reset styles
  */
 

--- a/css/preflight.css
+++ b/css/preflight.css
@@ -514,16 +514,6 @@ ul {
 }
 
 /**
- * Suppress the focus outline on elements that cannot be accessed via keyboard.
- * This prevents an unwanted focus outline from appearing around elements that
- * might still respond to pointer events.
- */
-
-[tabindex="-1"]:focus {
-  outline: none !important;
-}
-
-/**
  * Tailwind custom reset styles
  */
 

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -728,6 +728,7 @@ module.exports = {
     'md': '0 4px 8px 0 rgba(0,0,0,0.12), 0 2px 4px 0 rgba(0,0,0,0.08)',
     'lg': '0 15px 30px 0 rgba(0,0,0,0.11), 0 5px 15px 0 rgba(0,0,0,0.08)',
     'inner': 'inset 0 2px 4px 0 rgba(0,0,0,0.06)',
+    'outline': '2px solid rgba(52,144,220,0.5)',
     'none': 'none',
   },
 

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -862,6 +862,7 @@ module.exports = {
     minWidth: ['responsive'],
     negativeMargin: ['responsive'],
     opacity: ['responsive'],
+    outline: [],
     overflow: ['responsive'],
     padding: ['responsive'],
     pointerEvents: ['responsive'],

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -869,7 +869,7 @@ module.exports = {
     pointerEvents: ['responsive'],
     position: ['responsive'],
     resize: ['responsive'],
-    shadows: ['responsive'],
+    shadows: ['responsive', 'focus'],
     svgFill: [],
     svgStroke: [],
     textAlign: ['responsive'],

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -863,7 +863,7 @@ module.exports = {
     minWidth: ['responsive'],
     negativeMargin: ['responsive'],
     opacity: ['responsive'],
-    outline: [],
+    outline: ['focus'],
     overflow: ['responsive'],
     padding: ['responsive'],
     pointerEvents: ['responsive'],

--- a/src/generators/outline.js
+++ b/src/generators/outline.js
@@ -1,0 +1,7 @@
+import defineClasses from '../util/defineClasses'
+
+export default function() {
+  return defineClasses({
+    'no-outline': { outline: 'none' },
+  })
+}

--- a/src/generators/outline.js
+++ b/src/generators/outline.js
@@ -2,6 +2,6 @@ import defineClasses from '../util/defineClasses'
 
 export default function() {
   return defineClasses({
-    'no-outline': { outline: '0' },
+    'outline-none': { outline: '0' },
   })
 }

--- a/src/generators/outline.js
+++ b/src/generators/outline.js
@@ -2,6 +2,6 @@ import defineClasses from '../util/defineClasses'
 
 export default function() {
   return defineClasses({
-    'no-outline': { outline: 'none' },
+    'no-outline': { outline: '0' },
   })
 }

--- a/src/utilityModules.js
+++ b/src/utilityModules.js
@@ -24,6 +24,7 @@ import minHeight from './generators/minHeight'
 import minWidth from './generators/minWidth'
 import negativeMargin from './generators/negativeMargin'
 import opacity from './generators/opacity'
+import outline from './generators/outline'
 import overflow from './generators/overflow'
 import padding from './generators/padding'
 import pointerEvents from './generators/pointerEvents'
@@ -71,6 +72,7 @@ export default [
   { name: 'minWidth', generator: minWidth },
   { name: 'negativeMargin', generator: negativeMargin },
   { name: 'opacity', generator: opacity },
+  { name: 'outline', generator: outline },
   { name: 'overflow', generator: overflow },
   { name: 'padding', generator: padding },
   { name: 'pointerEvents', generator: pointerEvents },


### PR DESCRIPTION
This is an alternative to #490, and implements what I suggested in https://github.com/tailwindcss/tailwindcss/issues/56#issuecomment-397363973.

1. This adds new outline module, which includes a single `outline-none` utility.
2. This adds a new default shadow utility, called `shadow-outline`. Since box-shadows are more useful than outlines in CSS (mostly because they respect border-radius), it makes more sense to use them than real CSS outlines.
3. This enables the `focus` variant for shadows and outlines by default.
4. This removes the default `tabindex="-1"` outline style from Preflight.

Closes #56
Closes #385
Closes #427