### PR TITLE
[0.7] Add object-fit & object-position utilities

### DIFF
--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -887,6 +887,7 @@ module.exports = {
     minWidth: ['responsive'],
     negativeMargin: ['responsive'],
     objectFit: false,
+    objectPosition: false,
     opacity: ['responsive'],
     outline: ['focus'],
     overflow: ['responsive'],

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -886,6 +886,7 @@ module.exports = {
     minHeight: ['responsive'],
     minWidth: ['responsive'],
     negativeMargin: ['responsive'],
+    objectFit: false,
     opacity: ['responsive'],
     outline: ['focus'],
     overflow: ['responsive'],

--- a/src/generators/objectFit.js
+++ b/src/generators/objectFit.js
@@ -1,0 +1,11 @@
+import defineClasses from '../util/defineClasses'
+
+export default function() {
+  return defineClasses({
+    'object-contain': { 'object-fit': 'contain' },
+    'object-cover': { 'object-fit': 'cover' },
+    'object-fill': { 'object-fit': 'fill' },
+    'object-none': { 'object-fit': 'none' },
+    'object-scale-down': { 'object-fit': 'scale-down' },
+  })
+}

--- a/src/generators/objectPosition.js
+++ b/src/generators/objectPosition.js
@@ -1,0 +1,15 @@
+import defineClasses from '../util/defineClasses'
+
+export default function() {
+  return defineClasses({
+    'object-bottom': { 'object-position': 'bottom' },
+    'object-center': { 'object-position': 'center' },
+    'object-left': { 'object-position': 'left' },
+    'object-left-bottom': { 'object-position': 'left bottom' },
+    'object-left-top': { 'object-position': 'left top' },
+    'object-right': { 'object-position': 'right' },
+    'object-right-bottom': { 'object-position': 'right bottom' },
+    'object-right-top': { 'object-position': 'right top' },
+    'object-top': { 'object-position': 'top' },
+  })
+}

--- a/src/utilityModules.js
+++ b/src/utilityModules.js
@@ -24,6 +24,7 @@ import maxWidth from './generators/maxWidth'
 import minHeight from './generators/minHeight'
 import minWidth from './generators/minWidth'
 import negativeMargin from './generators/negativeMargin'
+import objectFit from './generators/objectFit'
 import opacity from './generators/opacity'
 import outline from './generators/outline'
 import overflow from './generators/overflow'
@@ -73,6 +74,7 @@ export default [
   { name: 'minHeight', generator: minHeight },
   { name: 'minWidth', generator: minWidth },
   { name: 'negativeMargin', generator: negativeMargin },
+  { name: 'objectFit', generator: objectFit },
   { name: 'opacity', generator: opacity },
   { name: 'outline', generator: outline },
   { name: 'overflow', generator: overflow },

--- a/src/utilityModules.js
+++ b/src/utilityModules.js
@@ -25,6 +25,7 @@ import minHeight from './generators/minHeight'
 import minWidth from './generators/minWidth'
 import negativeMargin from './generators/negativeMargin'
 import objectFit from './generators/objectFit'
+import objectPosition from './generators/objectPosition'
 import opacity from './generators/opacity'
 import outline from './generators/outline'
 import overflow from './generators/overflow'
@@ -75,6 +76,7 @@ export default [
   { name: 'minWidth', generator: minWidth },
   { name: 'negativeMargin', generator: negativeMargin },
   { name: 'objectFit', generator: objectFit },
+  { name: 'objectPosition', generator: objectPosition },
   { name: 'opacity', generator: opacity },
   { name: 'outline', generator: outline },
   { name: 'overflow', generator: overflow },


### PR DESCRIPTION
Replacement for #347

- Added `object-fit` utilities
- Added `object-position` utilities (inspired by `background-position`, since [they can have the same values)](https://drafts.csswg.org/css-images-3/#the-object-position)

Closes #317