### PR TITLE
Support creating new variants through plugins (WIP)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,10 @@
   },
   "parserOptions": {
     "ecmaVersion": 6,
-    "sourceType": "module"
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true
+    }
   },
   "extends": ["eslint-config-postcss", "prettier"],
   "plugins": ["prettier"],

--- a/__tests__/applyAtRule.test.js
+++ b/__tests__/applyAtRule.test.js
@@ -1,7 +1,7 @@
 import postcss from 'postcss'
 import plugin from '../src/lib/substituteClassApplyAtRules'
 
-function run(input, opts = () => {}) {
+function run(input, opts = {}) {
   return postcss([plugin(opts)]).process(input, { from: undefined })
 }
 

--- a/__tests__/configFunction.test.js
+++ b/__tests__/configFunction.test.js
@@ -2,7 +2,7 @@ import postcss from 'postcss'
 import plugin from '../src/lib/evaluateTailwindFunctions'
 
 function run(input, opts = {}) {
-  return postcss([plugin(() => opts)]).process(input, { from: undefined })
+  return postcss([plugin(opts)]).process(input, { from: undefined })
 }
 
 test('it looks up values in the config using dot notation', () => {

--- a/__tests__/containerPlugin.test.js
+++ b/__tests__/containerPlugin.test.js
@@ -26,7 +26,7 @@ function processPluginsWithValidConfig(config) {
 }
 
 test('options are not required', () => {
-  const [components] = processPluginsWithValidConfig({
+  const { components } = processPluginsWithValidConfig({
     plugins: [container()],
   })
 
@@ -48,7 +48,7 @@ test('options are not required', () => {
 })
 
 test('screens can be specified explicitly', () => {
-  const [components] = processPluginsWithValidConfig({
+  const { components } = processPluginsWithValidConfig({
     plugins: [
       container({
         screens: {
@@ -71,7 +71,7 @@ test('screens can be specified explicitly', () => {
 })
 
 test('screens can be an array', () => {
-  const [components] = processPluginsWithValidConfig({
+  const { components } = processPluginsWithValidConfig({
     plugins: [
       container({
         screens: ['400px', '500px'],
@@ -91,7 +91,7 @@ test('screens can be an array', () => {
 })
 
 test('the container can be centered by default', () => {
-  const [components] = processPluginsWithValidConfig({
+  const { components } = processPluginsWithValidConfig({
     plugins: [
       container({
         center: true,
@@ -121,7 +121,7 @@ test('the container can be centered by default', () => {
 })
 
 test('horizontal padding can be included by default', () => {
-  const [components] = processPluginsWithValidConfig({
+  const { components } = processPluginsWithValidConfig({
     plugins: [
       container({
         padding: '2rem',
@@ -151,7 +151,7 @@ test('horizontal padding can be included by default', () => {
 })
 
 test('setting all options at once', () => {
-  const [components] = processPluginsWithValidConfig({
+  const { components } = processPluginsWithValidConfig({
     plugins: [
       container({
         screens: {

--- a/__tests__/processPlugins.test.js
+++ b/__tests__/processPlugins.test.js
@@ -19,7 +19,7 @@ function processPluginsWithValidConfig(config) {
 }
 
 test('plugins can create utilities with object syntax', () => {
-  const [components, utilities] = processPluginsWithValidConfig({
+  const { components, utilities } = processPluginsWithValidConfig({
     plugins: [
       function({ addUtilities }) {
         addUtilities({
@@ -54,7 +54,7 @@ test('plugins can create utilities with object syntax', () => {
 })
 
 test('plugins can create utilities with arrays of objects', () => {
-  const [components, utilities] = processPluginsWithValidConfig({
+  const { components, utilities } = processPluginsWithValidConfig({
     plugins: [
       function({ addUtilities }) {
         addUtilities([
@@ -95,7 +95,7 @@ test('plugins can create utilities with arrays of objects', () => {
 })
 
 test('plugins can create utilities with raw PostCSS nodes', () => {
-  const [components, utilities] = processPluginsWithValidConfig({
+  const { components, utilities } = processPluginsWithValidConfig({
     plugins: [
       function({ addUtilities }) {
         addUtilities([
@@ -139,7 +139,7 @@ test('plugins can create utilities with raw PostCSS nodes', () => {
 })
 
 test('plugins can create utilities with mixed object styles and PostCSS nodes', () => {
-  const [components, utilities] = processPluginsWithValidConfig({
+  const { components, utilities } = processPluginsWithValidConfig({
     plugins: [
       function({ addUtilities }) {
         addUtilities([
@@ -182,7 +182,7 @@ test('plugins can create utilities with mixed object styles and PostCSS nodes', 
 })
 
 test('plugins can create utilities with variants', () => {
-  const [components, utilities] = processPluginsWithValidConfig({
+  const { components, utilities } = processPluginsWithValidConfig({
     plugins: [
       function({ addUtilities }) {
         addUtilities(
@@ -220,7 +220,7 @@ test('plugins can create utilities with variants', () => {
 })
 
 test('plugins can create components with object syntax', () => {
-  const [components, utilities] = processPluginsWithValidConfig({
+  const { components, utilities } = processPluginsWithValidConfig({
     plugins: [
       function({ addComponents }) {
         addComponents({
@@ -253,7 +253,7 @@ test('plugins can create components with object syntax', () => {
 })
 
 test('plugins can create components with raw PostCSS nodes', () => {
-  const [components, utilities] = processPluginsWithValidConfig({
+  const { components, utilities } = processPluginsWithValidConfig({
     plugins: [
       function({ addComponents }) {
         addComponents([
@@ -301,7 +301,7 @@ test('plugins can create components with raw PostCSS nodes', () => {
 })
 
 test('plugins can create components with mixed object styles and raw PostCSS nodes', () => {
-  const [components, utilities] = processPluginsWithValidConfig({
+  const { components, utilities } = processPluginsWithValidConfig({
     plugins: [
       function({ addComponents }) {
         addComponents([
@@ -348,7 +348,7 @@ test('plugins can create components with mixed object styles and raw PostCSS nod
 })
 
 test('plugins can create components with media queries with object syntax', () => {
-  const [components, utilities] = processPluginsWithValidConfig({
+  const { components, utilities } = processPluginsWithValidConfig({
     plugins: [
       function({ addComponents }) {
         addComponents({
@@ -399,7 +399,7 @@ test('plugins can create components with media queries with object syntax', () =
 })
 
 test('media queries can be defined multiple times using objects-in-array syntax', () => {
-  const [components, utilities] = processPluginsWithValidConfig({
+  const { components, utilities } = processPluginsWithValidConfig({
     plugins: [
       function({ addComponents }) {
         addComponents([
@@ -452,7 +452,7 @@ test('media queries can be defined multiple times using objects-in-array syntax'
 })
 
 test('plugins can create nested rules', () => {
-  const [components, utilities] = processPluginsWithValidConfig({
+  const { components, utilities } = processPluginsWithValidConfig({
     plugins: [
       function({ addComponents }) {
         addComponents({
@@ -519,7 +519,7 @@ test('plugins can create rules with escaped selectors', () => {
     ],
   }
 
-  const [components, utilities] = processPluginsWithValidConfig(config)
+  const { components, utilities } = processPluginsWithValidConfig(config)
 
   expect(components.length).toBe(0)
   expect(css(utilities)).toMatchCss(`
@@ -532,7 +532,7 @@ test('plugins can create rules with escaped selectors', () => {
 })
 
 test('plugins can access the current config', () => {
-  const [components, utilities] = processPluginsWithValidConfig({
+  const { components, utilities } = processPluginsWithValidConfig({
     screens: {
       sm: '576px',
       md: '768px',
@@ -593,7 +593,7 @@ test('plugins can access the current config', () => {
 })
 
 test('plugins can provide fallbacks to keys missing from the config', () => {
-  const [components, utilities] = processPluginsWithValidConfig({
+  const { components, utilities } = processPluginsWithValidConfig({
     borderRadius: {
       '1': '1px',
       '2': '2px',
@@ -620,7 +620,7 @@ test('plugins can provide fallbacks to keys missing from the config', () => {
 })
 
 test('variants are optional when adding utilities', () => {
-  const [, utilities] = processPluginsWithValidConfig({
+  const { utilities } = processPluginsWithValidConfig({
     plugins: [
       function({ addUtilities }) {
         addUtilities({
@@ -642,7 +642,7 @@ test('variants are optional when adding utilities', () => {
 })
 
 test('plugins can add multiple sets of utilities and components', () => {
-  const [components, utilities] = processPluginsWithValidConfig({
+  const { components, utilities } = processPluginsWithValidConfig({
     plugins: [
       function({ addUtilities, addComponents }) {
         addComponents({
@@ -699,7 +699,7 @@ test('plugins can add multiple sets of utilities and components', () => {
 })
 
 test('plugins respect prefix and important options by default when adding utilities', () => {
-  const [, utilities] = processPluginsWithValidConfig({
+  const { utilities } = processPluginsWithValidConfig({
     plugins: [
       function({ addUtilities }) {
         addUtilities({
@@ -725,7 +725,7 @@ test('plugins respect prefix and important options by default when adding utilit
 })
 
 test("component declarations respect the 'prefix' option by default", () => {
-  const [components] = processPluginsWithValidConfig({
+  const { components } = processPluginsWithValidConfig({
     plugins: [
       function({ addComponents }) {
         addComponents({
@@ -748,7 +748,7 @@ test("component declarations respect the 'prefix' option by default", () => {
 })
 
 test("component declarations can optionally ignore 'prefix' option", () => {
-  const [components] = processPluginsWithValidConfig({
+  const { components } = processPluginsWithValidConfig({
     plugins: [
       function({ addComponents }) {
         addComponents(
@@ -774,7 +774,7 @@ test("component declarations can optionally ignore 'prefix' option", () => {
 })
 
 test("component declarations are not affected by the 'important' option", () => {
-  const [components] = processPluginsWithValidConfig({
+  const { components } = processPluginsWithValidConfig({
     plugins: [
       function({ addComponents }) {
         addComponents({
@@ -797,7 +797,7 @@ test("component declarations are not affected by the 'important' option", () => 
 })
 
 test("plugins can apply the user's chosen prefix to components manually", () => {
-  const [components] = processPluginsWithValidConfig({
+  const { components } = processPluginsWithValidConfig({
     plugins: [
       function({ addComponents, prefix }) {
         addComponents(
@@ -823,7 +823,7 @@ test("plugins can apply the user's chosen prefix to components manually", () => 
 })
 
 test('prefix can optionally be ignored for utilities', () => {
-  const [, utilities] = processPluginsWithValidConfig({
+  const { utilities } = processPluginsWithValidConfig({
     plugins: [
       function({ addUtilities }) {
         addUtilities(
@@ -854,7 +854,7 @@ test('prefix can optionally be ignored for utilities', () => {
 })
 
 test('important can optionally be ignored for utilities', () => {
-  const [, utilities] = processPluginsWithValidConfig({
+  const { utilities } = processPluginsWithValidConfig({
     plugins: [
       function({ addUtilities }) {
         addUtilities(
@@ -885,7 +885,7 @@ test('important can optionally be ignored for utilities', () => {
 })
 
 test('variants can still be specified when ignoring prefix and important options', () => {
-  const [, utilities] = processPluginsWithValidConfig({
+  const { utilities } = processPluginsWithValidConfig({
     plugins: [
       function({ addUtilities }) {
         addUtilities(
@@ -909,7 +909,7 @@ test('variants can still be specified when ignoring prefix and important options
   })
 
   expect(css(utilities)).toMatchCss(`
-    @variants responsive, hover, focus{
+    @variants responsive, hover, focus {
       .rotate-90 {
         transform: rotate(90deg)
       }
@@ -918,7 +918,7 @@ test('variants can still be specified when ignoring prefix and important options
 })
 
 test('prefix will prefix all classes in a selector', () => {
-  const [components] = processPluginsWithValidConfig({
+  const { components } = processPluginsWithValidConfig({
     plugins: [
       function({ addComponents, prefix }) {
         addComponents(

--- a/__tests__/responsiveAtRule.test.js
+++ b/__tests__/responsiveAtRule.test.js
@@ -2,7 +2,7 @@ import postcss from 'postcss'
 import plugin from '../src/lib/substituteResponsiveAtRules'
 import config from '../defaultConfig.stub.js'
 
-function run(input, opts = () => config) {
+function run(input, opts = config) {
   return postcss([plugin(opts)]).process(input, { from: undefined })
 }
 
@@ -31,7 +31,7 @@ test('it can generate responsive variants', () => {
       }
   `
 
-  return run(input, () => ({
+  return run(input, {
     screens: {
       sm: '500px',
       md: '750px',
@@ -40,7 +40,7 @@ test('it can generate responsive variants', () => {
     options: {
       separator: ':',
     },
-  })).then(result => {
+  }).then(result => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -71,7 +71,7 @@ test('it can generate responsive variants with a custom separator', () => {
       }
   `
 
-  return run(input, () => ({
+  return run(input, {
     screens: {
       sm: '500px',
       md: '750px',
@@ -80,7 +80,7 @@ test('it can generate responsive variants with a custom separator', () => {
     options: {
       separator: '__',
     },
-  })).then(result => {
+  }).then(result => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -117,7 +117,7 @@ test('responsive variants are grouped', () => {
       }
   `
 
-  return run(input, () => ({
+  return run(input, {
     screens: {
       sm: '500px',
       md: '750px',
@@ -126,7 +126,7 @@ test('responsive variants are grouped', () => {
     options: {
       separator: ':',
     },
-  })).then(result => {
+  }).then(result => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -152,7 +152,7 @@ test('screen prefix is only applied to the last class in a selector', () => {
       }
   `
 
-  return run(input, () => ({
+  return run(input, {
     screens: {
       sm: '500px',
       md: '750px',
@@ -161,7 +161,7 @@ test('screen prefix is only applied to the last class in a selector', () => {
     options: {
       separator: ':',
     },
-  })).then(result => {
+  }).then(result => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -187,7 +187,7 @@ test('responsive variants are generated for all selectors in a rule', () => {
       }
   `
 
-  return run(input, () => ({
+  return run(input, {
     screens: {
       sm: '500px',
       md: '750px',
@@ -196,7 +196,7 @@ test('responsive variants are generated for all selectors in a rule', () => {
     options: {
       separator: ':',
     },
-  })).then(result => {
+  }).then(result => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -209,7 +209,7 @@ test('selectors with no classes cannot be made responsive', () => {
     }
   `
   expect.assertions(1)
-  return run(input, () => ({
+  return run(input, {
     screens: {
       sm: '500px',
       md: '750px',
@@ -218,7 +218,7 @@ test('selectors with no classes cannot be made responsive', () => {
     options: {
       separator: ':',
     },
-  })).catch(e => {
+  }).catch(e => {
     expect(e).toMatchObject({ name: 'CssSyntaxError' })
   })
 })
@@ -230,7 +230,7 @@ test('all selectors in a rule must contain classes', () => {
     }
   `
   expect.assertions(1)
-  return run(input, () => ({
+  return run(input, {
     screens: {
       sm: '500px',
       md: '750px',
@@ -239,7 +239,7 @@ test('all selectors in a rule must contain classes', () => {
     options: {
       separator: ':',
     },
-  })).catch(e => {
+  }).catch(e => {
     expect(e).toMatchObject({ name: 'CssSyntaxError' })
   })
 })

--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -2,7 +2,7 @@ import postcss from 'postcss'
 import plugin from '../src/lib/substituteVariantsAtRules'
 import config from '../defaultConfig.stub.js'
 
-function run(input, opts = () => config) {
+function run(input, opts = config) {
   return postcss([plugin(opts)]).process(input, { from: undefined })
 }
 
@@ -182,7 +182,7 @@ test('plugin variants work', () => {
       .first-child\\:chocolate:first-child { color: brown; }
   `
 
-  return run(input, () => ({
+  return run(input, {
     ...config,
     plugins: [
       ...config.plugins,
@@ -192,7 +192,7 @@ test('plugin variants work', () => {
         })
       },
     ],
-  })).then(result => {
+  }).then(result => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })

--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -166,3 +166,34 @@ test('variants are generated in the order specified', () => {
     expect(result.warnings().length).toBe(0)
   })
 })
+
+test('plugin variants work', () => {
+  const input = `
+    @variants first-child {
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+    }
+  `
+
+  const output = `
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+      .first-child\\:banana:first-child { color: yellow; }
+      .first-child\\:chocolate:first-child { color: brown; }
+  `
+
+  return run(input, () => ({
+    ...config,
+    plugins: [
+      ...config.plugins,
+      function({ addVariant }) {
+        addVariant('first-child', ({ className, separator }) => {
+          return `.first-child${separator}${className}:first-child`
+        })
+      },
+    ],
+  })).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})

--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -1,9 +1,10 @@
 import postcss from 'postcss'
 import plugin from '../src/lib/substituteVariantsAtRules'
 import config from '../defaultConfig.stub.js'
+import processPlugins from '../src/util/processPlugins'
 
 function run(input, opts = config) {
-  return postcss([plugin(opts)]).process(input, { from: undefined })
+  return postcss([plugin(opts, processPlugins(opts))]).process(input, { from: undefined })
 }
 
 test('it can generate hover variants', () => {

--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -92,7 +92,7 @@ test('it can generate group-hover variants', () => {
 
 test('it can generate hover, active and focus variants', () => {
   const input = `
-    @variants hover, active, group-hover, focus {
+    @variants group-hover, hover, focus, active {
       .banana { color: yellow; }
       .chocolate { color: brown; }
     }
@@ -134,6 +134,31 @@ test('it wraps the output in a responsive at-rule if responsive is included as a
       .focus\\:banana:focus { color: yellow; }
       .focus\\:chocolate:focus { color: brown; }
     }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('variants are generated in the order specified', () => {
+  const input = `
+    @variants focus, active, hover {
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+    }
+  `
+
+  const output = `
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+      .focus\\:banana:focus { color: yellow; }
+      .focus\\:chocolate:focus { color: brown; }
+      .active\\:banana:active { color: yellow; }
+      .active\\:chocolate:active { color: brown; }
+      .hover\\:banana:hover { color: yellow; }
+      .hover\\:chocolate:hover { color: brown; }
   `
 
   return run(input).then(result => {

--- a/src/index.js
+++ b/src/index.js
@@ -5,14 +5,9 @@ import postcss from 'postcss'
 import perfectionist from 'perfectionist'
 
 import registerConfigAsDependency from './lib/registerConfigAsDependency'
-import substituteTailwindAtRules from './lib/substituteTailwindAtRules'
-import evaluateTailwindFunctions from './lib/evaluateTailwindFunctions'
-import substituteVariantsAtRules from './lib/substituteVariantsAtRules'
-import substituteResponsiveAtRules from './lib/substituteResponsiveAtRules'
-import substituteScreenAtRules from './lib/substituteScreenAtRules'
-import substituteClassApplyAtRules from './lib/substituteClassApplyAtRules'
-
+import processTailwindFeatures from './processTailwindFeatures'
 import mergeConfigWithDefaults from './util/mergeConfigWithDefaults'
+
 
 const plugin = postcss.plugin('tailwind', config => {
   const plugins = []
@@ -36,26 +31,19 @@ const plugin = postcss.plugin('tailwind', config => {
     )
   }
 
-  return postcss(
+  return postcss([
     ...plugins,
-    ...[
-      substituteTailwindAtRules(lazyConfig),
-      evaluateTailwindFunctions(lazyConfig),
-      substituteVariantsAtRules(lazyConfig),
-      substituteResponsiveAtRules(lazyConfig),
-      substituteScreenAtRules(lazyConfig),
-      substituteClassApplyAtRules(lazyConfig),
-      perfectionist({
-        cascade: true,
-        colorShorthand: true,
-        indentSize: 2,
-        maxSelectorLength: 1,
-        maxValueLength: false,
-        trimLeadingZero: true,
-        trimTrailingZeros: true,
-      }),
-    ]
-  )
+    processTailwindFeatures(lazyConfig),
+    perfectionist({
+      cascade: true,
+      colorShorthand: true,
+      indentSize: 2,
+      maxSelectorLength: 1,
+      maxValueLength: false,
+      trimLeadingZero: true,
+      trimTrailingZeros: true,
+    }),
+  ])
 })
 
 plugin.defaultConfig = function() {

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,6 @@ import registerConfigAsDependency from './lib/registerConfigAsDependency'
 import processTailwindFeatures from './processTailwindFeatures'
 import mergeConfigWithDefaults from './util/mergeConfigWithDefaults'
 
-
 const plugin = postcss.plugin('tailwind', config => {
   const plugins = []
 

--- a/src/lib/evaluateTailwindFunctions.js
+++ b/src/lib/evaluateTailwindFunctions.js
@@ -5,7 +5,7 @@ export default function(config) {
   return functions({
     functions: {
       config: (path, defaultValue) => {
-        return _.get(config(), _.trim(path, `'"`), defaultValue)
+        return _.get(config, _.trim(path, `'"`), defaultValue)
       },
     },
   })

--- a/src/lib/substituteResponsiveAtRules.js
+++ b/src/lib/substituteResponsiveAtRules.js
@@ -6,8 +6,8 @@ import buildSelectorVariant from '../util/buildSelectorVariant'
 
 export default function(config) {
   return function(css) {
-    const screens = config().screens
-    const separator = config().options.separator
+    const screens = config.screens
+    const separator = config.options.separator
     const responsiveRules = []
     let finalRules = []
 

--- a/src/lib/substituteScreenAtRules.js
+++ b/src/lib/substituteScreenAtRules.js
@@ -3,17 +3,15 @@ import buildMediaQuery from '../util/buildMediaQuery'
 
 export default function(config) {
   return function(css) {
-    const options = config()
-
     css.walkAtRules('screen', atRule => {
       const screen = atRule.params
 
-      if (!_.has(options.screens, screen)) {
+      if (!_.has(config.screens, screen)) {
         throw atRule.error(`No \`${screen}\` screen found.`)
       }
 
       atRule.name = 'media'
-      atRule.params = buildMediaQuery(options.screens[screen])
+      atRule.params = buildMediaQuery(config.screens[screen])
     })
   }
 }

--- a/src/lib/substituteTailwindAtRules.js
+++ b/src/lib/substituteTailwindAtRules.js
@@ -7,10 +7,8 @@ import processPlugins from '../util/processPlugins'
 
 export default function(config) {
   return function(css) {
-    const unwrappedConfig = config()
-
     const { components: pluginComponents, utilities: pluginUtilities } = processPlugins(
-      unwrappedConfig
+      config
     )
 
     css.walkAtRules('tailwind', atRule => {
@@ -37,9 +35,9 @@ export default function(config) {
       }
 
       if (atRule.params === 'utilities') {
-        const utilities = generateModules(utilityModules, unwrappedConfig.modules, unwrappedConfig)
+        const utilities = generateModules(utilityModules, config.modules, config)
 
-        if (unwrappedConfig.options.important) {
+        if (config.options.important) {
           utilities.walkDecls(decl => (decl.important = true))
         }
 
@@ -51,7 +49,7 @@ export default function(config) {
           nodes: pluginUtilities,
         })
 
-        prefixTree(tailwindUtilityTree, unwrappedConfig.options.prefix)
+        prefixTree(tailwindUtilityTree, config.options.prefix)
 
         tailwindUtilityTree.walk(node => (node.source = atRule.source))
         pluginUtilityTree.walk(node => (node.source = atRule.source))

--- a/src/lib/substituteTailwindAtRules.js
+++ b/src/lib/substituteTailwindAtRules.js
@@ -9,7 +9,9 @@ export default function(config) {
   return function(css) {
     const unwrappedConfig = config()
 
-    const [pluginComponents, pluginUtilities] = processPlugins(unwrappedConfig)
+    const { components: pluginComponents, utilities: pluginUtilities } = processPlugins(
+      unwrappedConfig
+    )
 
     css.walkAtRules('tailwind', atRule => {
       if (atRule.params === 'preflight') {

--- a/src/lib/substituteTailwindAtRules.js
+++ b/src/lib/substituteTailwindAtRules.js
@@ -3,14 +3,9 @@ import postcss from 'postcss'
 import utilityModules from '../utilityModules'
 import prefixTree from '../util/prefixTree'
 import generateModules from '../util/generateModules'
-import processPlugins from '../util/processPlugins'
 
-export default function(config) {
+export default function(config, { components: pluginComponents, utilities: pluginUtilities }) {
   return function(css) {
-    const { components: pluginComponents, utilities: pluginUtilities } = processPlugins(
-      config
-    )
-
     css.walkAtRules('tailwind', atRule => {
       if (atRule.params === 'preflight') {
         const preflightTree = postcss.parse(

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -42,7 +42,7 @@ export default function(config) {
     const unwrappedConfig = config()
 
     css.walkAtRules('variants', atRule => {
-      const variants = postcss.list.comma(atRule.params)
+      const variants = postcss.list.comma(atRule.params).filter(variant => variant !== '')
 
       if (variants.includes('responsive')) {
         const responsiveParent = postcss.atRule({ name: 'responsive' })
@@ -52,10 +52,8 @@ export default function(config) {
 
       atRule.before(atRule.clone().nodes)
 
-      _.forEach(['group-hover', 'hover', 'focus', 'active'], variant => {
-        if (variants.includes(variant)) {
-          variantGenerators[variant](atRule, unwrappedConfig)
-        }
+      _.forEach(_.without(variants, 'responsive'), variant => {
+        variantGenerators[variant](atRule, unwrappedConfig)
       })
 
       atRule.remove()

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -2,7 +2,6 @@ import _ from 'lodash'
 import postcss from 'postcss'
 import buildSelectorVariant from '../util/buildSelectorVariant'
 import generateVariantFunction from '../util/generateVariantFunction'
-import processPlugins from '../util/processPlugins'
 
 function generatePseudoClassVariant(pseudoClass) {
   return generateVariantFunction(({ className, separator }) => {
@@ -29,11 +28,11 @@ const defaultVariantGenerators = {
   active: generatePseudoClassVariant('active'),
 }
 
-export default function(config) {
+export default function(config, { variantGenerators: pluginVariantGenerators }) {
   return function(css) {
     const variantGenerators = {
       ...defaultVariantGenerators,
-      ...processPlugins(config).variantGenerators,
+      ...pluginVariantGenerators,
     }
 
     css.walkAtRules('variants', atRule => {

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -31,10 +31,9 @@ const defaultVariantGenerators = {
 
 export default function(config) {
   return function(css) {
-    const unwrappedConfig = config()
     const variantGenerators = {
       ...defaultVariantGenerators,
-      ...processPlugins(unwrappedConfig).variantGenerators,
+      ...processPlugins(config).variantGenerators,
     }
 
     css.walkAtRules('variants', atRule => {
@@ -49,7 +48,7 @@ export default function(config) {
       atRule.before(atRule.clone().nodes)
 
       _.forEach(_.without(variants, 'responsive'), variant => {
-        variantGenerators[variant](atRule, unwrappedConfig)
+        variantGenerators[variant](atRule, config)
       })
 
       atRule.remove()

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -1,6 +1,7 @@
 import _ from 'lodash'
 import postcss from 'postcss'
 import buildSelectorVariant from '../util/buildSelectorVariant'
+import processPlugins from '../util/processPlugins'
 
 function buildPseudoClassVariant(selector, pseudoClass, separator) {
   return `${buildSelectorVariant(selector, pseudoClass, separator)}:${pseudoClass}`
@@ -18,7 +19,7 @@ function generatePseudoClassVariant(pseudoClass) {
   }
 }
 
-const variantGenerators = {
+const defaultVariantGenerators = {
   'group-hover': (container, { options: { separator } }) => {
     const cloned = container.clone()
 
@@ -40,6 +41,10 @@ const variantGenerators = {
 export default function(config) {
   return function(css) {
     const unwrappedConfig = config()
+    const variantGenerators = {
+      ...defaultVariantGenerators,
+      ...processPlugins(unwrappedConfig).variantGenerators,
+    }
 
     css.walkAtRules('variants', atRule => {
       const variants = postcss.list.comma(atRule.params).filter(variant => variant !== '')

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -1,28 +1,21 @@
 import _ from 'lodash'
 import postcss from 'postcss'
-import buildSelectorVariant from '../util/buildSelectorVariant'
 import generateVariantFunction from '../util/generateVariantFunction'
 
 function generatePseudoClassVariant(pseudoClass) {
-  return generateVariantFunction(({ className, separator }) => {
-    return `.${pseudoClass}${separator}${className}:${pseudoClass}`
+  return generateVariantFunction(({ modifySelectors, separator }) => {
+    return modifySelectors(({ className }) => {
+      return `.${pseudoClass}${separator}${className}:${pseudoClass}`
+    })
   })
 }
 
 const defaultVariantGenerators = {
-  'group-hover': (container, { options: { separator } }) => {
-    const cloned = container.clone()
-
-    cloned.walkRules(rule => {
-      rule.selector = `.group:hover ${buildSelectorVariant(
-        rule.selector,
-        'group-hover',
-        separator
-      )}`
+  'group-hover': generateVariantFunction(({ modifySelectors, separator }) => {
+    return modifySelectors(({ className }) => {
+      return `.group:hover .group-hover${separator}${className}`
     })
-
-    container.before(cloned.nodes)
-  },
+  }),
   hover: generatePseudoClassVariant('hover'),
   focus: generatePseudoClassVariant('focus'),
   active: generatePseudoClassVariant('active'),

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -1,22 +1,13 @@
 import _ from 'lodash'
 import postcss from 'postcss'
 import buildSelectorVariant from '../util/buildSelectorVariant'
+import generateVariantFunction from '../util/generateVariantFunction'
 import processPlugins from '../util/processPlugins'
 
-function buildPseudoClassVariant(selector, pseudoClass, separator) {
-  return `${buildSelectorVariant(selector, pseudoClass, separator)}:${pseudoClass}`
-}
-
 function generatePseudoClassVariant(pseudoClass) {
-  return (container, config) => {
-    const cloned = container.clone()
-
-    cloned.walkRules(rule => {
-      rule.selector = buildPseudoClassVariant(rule.selector, pseudoClass, config.options.separator)
-    })
-
-    container.before(cloned.nodes)
-  }
+  return generateVariantFunction(({ className, separator }) => {
+    return `.${pseudoClass}${separator}${className}:${pseudoClass}`
+  })
 }
 
 const defaultVariantGenerators = {

--- a/src/processTailwindFeatures.js
+++ b/src/processTailwindFeatures.js
@@ -1,23 +1,21 @@
-import path from 'path'
-
-import _ from 'lodash'
 import postcss from 'postcss'
 
-import registerConfigAsDependency from './lib/registerConfigAsDependency'
 import substituteTailwindAtRules from './lib/substituteTailwindAtRules'
 import evaluateTailwindFunctions from './lib/evaluateTailwindFunctions'
 import substituteVariantsAtRules from './lib/substituteVariantsAtRules'
 import substituteResponsiveAtRules from './lib/substituteResponsiveAtRules'
 import substituteScreenAtRules from './lib/substituteScreenAtRules'
 import substituteClassApplyAtRules from './lib/substituteClassApplyAtRules'
+import processPlugins from './util/processPlugins'
 
 export default function(lazyConfig) {
   const config = lazyConfig()
+  const plugins = processPlugins(config)
 
   return postcss([
-    substituteTailwindAtRules(config),
+    substituteTailwindAtRules(config, plugins),
     evaluateTailwindFunctions(config),
-    substituteVariantsAtRules(config),
+    substituteVariantsAtRules(config, plugins),
     substituteResponsiveAtRules(config),
     substituteScreenAtRules(config),
     substituteClassApplyAtRules(config),

--- a/src/processTailwindFeatures.js
+++ b/src/processTailwindFeatures.js
@@ -1,0 +1,25 @@
+import path from 'path'
+
+import _ from 'lodash'
+import postcss from 'postcss'
+
+import registerConfigAsDependency from './lib/registerConfigAsDependency'
+import substituteTailwindAtRules from './lib/substituteTailwindAtRules'
+import evaluateTailwindFunctions from './lib/evaluateTailwindFunctions'
+import substituteVariantsAtRules from './lib/substituteVariantsAtRules'
+import substituteResponsiveAtRules from './lib/substituteResponsiveAtRules'
+import substituteScreenAtRules from './lib/substituteScreenAtRules'
+import substituteClassApplyAtRules from './lib/substituteClassApplyAtRules'
+
+export default function(lazyConfig) {
+  const config = lazyConfig()
+
+  return postcss([
+    substituteTailwindAtRules(config),
+    evaluateTailwindFunctions(config),
+    substituteVariantsAtRules(config),
+    substituteResponsiveAtRules(config),
+    substituteScreenAtRules(config),
+    substituteClassApplyAtRules(config),
+  ])
+}

--- a/src/util/generateVariantFunction.js
+++ b/src/util/generateVariantFunction.js
@@ -1,0 +1,16 @@
+import escapeClassName from './escapeClassName'
+
+export default function generateVariantFunction(generator) {
+  return (container, config) => {
+    const cloned = container.clone()
+
+    cloned.walkRules(rule => {
+      rule.selector = generator({
+        className: rule.selector.slice(1),
+        separator: escapeClassName(config.options.separator),
+      })
+    })
+
+    container.before(cloned.nodes)
+  }
+}

--- a/src/util/processPlugins.js
+++ b/src/util/processPlugins.js
@@ -17,6 +17,7 @@ function parseStyles(styles) {
 export default function(config) {
   const pluginComponents = []
   const pluginUtilities = []
+  const pluginVariantGenerators = {}
 
   config.plugins.forEach(plugin => {
     plugin({
@@ -62,5 +63,9 @@ export default function(config) {
     })
   })
 
-  return [pluginComponents, pluginUtilities]
+  return {
+    components: pluginComponents,
+    utilities: pluginUtilities,
+    variantGenerators: pluginVariantGenerators,
+  }
 }

--- a/src/util/processPlugins.js
+++ b/src/util/processPlugins.js
@@ -14,6 +14,21 @@ function parseStyles(styles) {
   return _.flatMap(styles, style => (style instanceof Node ? style : parseObjectStyles(style)))
 }
 
+function generateVariantFunction(generator) {
+  return (container, config) => {
+    const cloned = container.clone()
+
+    cloned.walkRules(rule => {
+      rule.selector = generator({
+        className: rule.selector.slice(1),
+        separator: escapeClassName(config.options.separator),
+      })
+    })
+
+    container.before(cloned.nodes)
+  }
+}
+
 export default function(config) {
   const pluginComponents = []
   const pluginUtilities = []
@@ -59,6 +74,9 @@ export default function(config) {
         })
 
         pluginComponents.push(...styles.nodes)
+      },
+      addVariant: (name, generator) => {
+        pluginVariantGenerators[name] = generateVariantFunction(generator)
       },
     })
   })

--- a/src/util/processPlugins.js
+++ b/src/util/processPlugins.js
@@ -2,6 +2,7 @@ import _ from 'lodash'
 import postcss from 'postcss'
 import Node from 'postcss/lib/node'
 import escapeClassName from '../util/escapeClassName'
+import generateVariantFunction from '../util/generateVariantFunction'
 import parseObjectStyles from '../util/parseObjectStyles'
 import prefixSelector from '../util/prefixSelector'
 import wrapWithVariants from '../util/wrapWithVariants'
@@ -12,21 +13,6 @@ function parseStyles(styles) {
   }
 
   return _.flatMap(styles, style => (style instanceof Node ? style : parseObjectStyles(style)))
-}
-
-function generateVariantFunction(generator) {
-  return (container, config) => {
-    const cloned = container.clone()
-
-    cloned.walkRules(rule => {
-      rule.selector = generator({
-        className: rule.selector.slice(1),
-        separator: escapeClassName(config.options.separator),
-      })
-    })
-
-    container.before(cloned.nodes)
-  }
 }
 
 export default function(config) {


### PR DESCRIPTION
Implementation for #496.

Right now this PR adds support for basic variant plugins that just alter the selector, like our bundled variants.

It lets you write a plugin like this to create a `first-child` variant:

```js
{
  // ...
  plugins: [
    // ...
    function({ addVariant }) {
      addVariant('first-child', ({ className, separator }) => {
        return `.first-child${separator}${className}:first-child`
      })
    }
  ]
}
```

It also changes how the order variants are generated in is determined, by pushing that control to the user instead of using a hard-coded order. Now the order of your variants in your `modules` config is the order we use to generate the variants, so if you list `['hover, 'focus']`, hover will be generated first, but if you list `['focus', 'hover']` then focus will be generated first. This puts the user in control of which rule takes precedence.

Next up:

- Support variant generators that modify properties, not just selectors
- Support variant generators that need to wrap rules in an at-rule (like a `supports-grid` variant)
- Allow variant generator plugin authors to control how responsive versions of their variants are generated (right now we just prefix the last class in the selector)