### PR TITLE
Accept config as a JS object

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ import mergeConfigWithDefaults from './util/mergeConfigWithDefaults'
 const plugin = postcss.plugin('tailwind', config => {
   const plugins = []
 
-  if (!_.isUndefined(config)) {
+  if (!_.isUndefined(config) && !_.isObject(config)) {
     plugins.push(registerConfigAsDependency(path.resolve(config)))
   }
 
@@ -26,8 +26,14 @@ const plugin = postcss.plugin('tailwind', config => {
       return require('../defaultConfig')()
     }
 
-    delete require.cache[require.resolve(path.resolve(config))]
-    return mergeConfigWithDefaults(require(path.resolve(config)), require('../defaultConfig')())
+    if (!_.isObject(config)) {
+      delete require.cache[require.resolve(path.resolve(config))]
+    }
+
+    return mergeConfigWithDefaults(
+      _.isObject(config) ? config : require(path.resolve(config)),
+      require('../defaultConfig')()
+    )
   }
 
   return postcss(


### PR DESCRIPTION
Replaces #457 

This feature was previously discussed here: https://github.com/tailwindcss/discuss/issues/37

I needed this for a custom gulp build script where the user is able to override parts of the Tailwind config using a JSON file, so the final config is built dynamically rather than contained in a single file. I am not sure if I implemented it properly, as I didn't take the time to go deep in the codebase, but this worked for me and all the tests passed. I'm sorry if I missed anything; if so please let me know. Also I imagine it would be a good idea to add a test for this feature.