### PR TITLE
Process tailwind features together

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ const plugin = postcss.plugin('tailwind', config => {
     plugins.push(registerConfigAsDependency(path.resolve(config)))
   }
 
-  const lazyConfig = () => {
+  const getConfig = () => {
     if (_.isUndefined(config)) {
       return require('../defaultConfig')()
     }
@@ -32,7 +32,7 @@ const plugin = postcss.plugin('tailwind', config => {
 
   return postcss([
     ...plugins,
-    processTailwindFeatures(lazyConfig),
+    processTailwindFeatures(getConfig),
     perfectionist({
       cascade: true,
       colorShorthand: true,

--- a/src/processTailwindFeatures.js
+++ b/src/processTailwindFeatures.js
@@ -11,9 +11,9 @@ import substituteClassApplyAtRules from './lib/substituteClassApplyAtRules'
 import generateUtilities from './util/generateUtilities'
 import processPlugins from './util/processPlugins'
 
-export default function(lazyConfig) {
+export default function(getConfig) {
   return function(css) {
-    const config = lazyConfig()
+    const config = getConfig()
     const processedPlugins = processPlugins(config)
     const utilities = generateUtilities(config, processedPlugins.utilities)
 

--- a/src/processTailwindFeatures.js
+++ b/src/processTailwindFeatures.js
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import postcss from 'postcss'
 
 import substituteTailwindAtRules from './lib/substituteTailwindAtRules'
@@ -23,6 +24,6 @@ export default function(lazyConfig) {
       substituteResponsiveAtRules(config),
       substituteScreenAtRules(config),
       substituteClassApplyAtRules(config, utilities),
-    ]).process(css, { from: css.source.input.file })
+    ]).process(css, { from: _.get(css, 'source.input.file') })
   }
 }

--- a/src/processTailwindFeatures.js
+++ b/src/processTailwindFeatures.js
@@ -11,16 +11,18 @@ import generateUtilities from './util/generateUtilities'
 import processPlugins from './util/processPlugins'
 
 export default function(lazyConfig) {
-  const config = lazyConfig()
-  const processedPlugins = processPlugins(config)
-  const utilities = generateUtilities(config, processedPlugins.utilities)
+  return function(css) {
+    const config = lazyConfig()
+    const processedPlugins = processPlugins(config)
+    const utilities = generateUtilities(config, processedPlugins.utilities)
 
-  return postcss([
-    substituteTailwindAtRules(config, processedPlugins, utilities),
-    evaluateTailwindFunctions(config),
-    substituteVariantsAtRules(config, processedPlugins),
-    substituteResponsiveAtRules(config),
-    substituteScreenAtRules(config),
-    substituteClassApplyAtRules(config, utilities),
-  ])
+    return postcss([
+      substituteTailwindAtRules(config, processedPlugins, utilities),
+      evaluateTailwindFunctions(config),
+      substituteVariantsAtRules(config, processedPlugins),
+      substituteResponsiveAtRules(config),
+      substituteScreenAtRules(config),
+      substituteClassApplyAtRules(config, utilities),
+    ]).process(css, { from: css.source.input.file })
+  }
 }


### PR DESCRIPTION
Resolves #519.

The way Webpack runs PostCSS stuff is a little hard to fully understand — some stuff seems to run only once, some stuff runs every time a build happens, etc.

As part of a refactoring in an earlier commit, I tried to extract all of Tailwind's processing to it's own plugin so I could stop passing around `lazyConfig` everywhere and still have changes to `tailwind.js` be respected on watch, but apparently I wasn't properly testing that it was still working because I broke it 🙃 

After some googling and trial and error, I figured out I can wrap all of these plugins in another plugin that runs all of the plugins synchronously, and this will cause Webpack to properly respect changes to the config file. Fingers crossed there are no unwanted side effects here, but I think we'll have to just throw it into the wild to know for sure.