### PR TITLE
Add classes for flex-basis

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -2986,12 +2986,20 @@ table {
   flex-shrink: 1;
 }
 
+.flex-basis-auto {
+  flex-basis: auto;
+}
+
 .flex-no-grow {
   flex-grow: 0;
 }
 
 .flex-no-shrink {
   flex-shrink: 0;
+}
+
+.flex-no-basis {
+  flex-basis: 0;
 }
 
 .float-right {
@@ -8571,12 +8579,20 @@ table {
     flex-shrink: 1;
   }
 
+  .sm\:flex-basis-auto {
+    flex-basis: auto;
+  }
+
   .sm\:flex-no-grow {
     flex-grow: 0;
   }
 
   .sm\:flex-no-shrink {
     flex-shrink: 0;
+  }
+
+  .sm\:flex-no-basis {
+    flex-basis: 0;
   }
 
   .sm\:float-right {
@@ -14141,12 +14157,20 @@ table {
     flex-shrink: 1;
   }
 
+  .md\:flex-basis-auto {
+    flex-basis: auto;
+  }
+
   .md\:flex-no-grow {
     flex-grow: 0;
   }
 
   .md\:flex-no-shrink {
     flex-shrink: 0;
+  }
+
+  .md\:flex-no-basis {
+    flex-basis: 0;
   }
 
   .md\:float-right {
@@ -19711,12 +19735,20 @@ table {
     flex-shrink: 1;
   }
 
+  .lg\:flex-basis-auto {
+    flex-basis: auto;
+  }
+
   .lg\:flex-no-grow {
     flex-grow: 0;
   }
 
   .lg\:flex-no-shrink {
     flex-shrink: 0;
+  }
+
+  .lg\:flex-no-basis {
+    flex-basis: 0;
   }
 
   .lg\:float-right {
@@ -25281,12 +25313,20 @@ table {
     flex-shrink: 1;
   }
 
+  .xl\:flex-basis-auto {
+    flex-basis: auto;
+  }
+
   .xl\:flex-no-grow {
     flex-grow: 0;
   }
 
   .xl\:flex-no-shrink {
     flex-shrink: 0;
+  }
+
+  .xl\:flex-no-basis {
+    flex-basis: 0;
   }
 
   .xl\:float-right {

--- a/src/generators/flexbox.js
+++ b/src/generators/flexbox.js
@@ -107,11 +107,17 @@ export default function() {
     'flex-shrink': {
       'flex-shrink': '1',
     },
+    'flex-basis-auto': {
+      'flex-basis': 'auto',
+    },
     'flex-no-grow': {
       'flex-grow': '0',
     },
     'flex-no-shrink': {
       'flex-shrink': '0',
+    },
+    'flex-no-basis': {
+      'flex-basis': '0',
     },
   })
 }


### PR DESCRIPTION
Hi
This PR adds `flex-no-basis` and `flex-basis-auto` classes.
I'm using it all the time so thought it would be nice to have this built-in.

I'm mostly using it for making equal size columns without being explicit about widths.

For example, instead
```
<div class="flex">
    <div class="w-1/2">...</div>
    <div class="w-1/2">...</div>
</div>
```

I like to write
```
<div class="flex">
    <div class="flex-grow flex-no-basis">...</div>
    <div class="flex-grow flex-no-basis">...</div>
</div>
```