### PR TITLE
Preserve units for zero value properties

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ const plugin = postcss.plugin('tailwind', config => {
       maxValueLength: false,
       trimLeadingZero: true,
       trimTrailingZeros: true,
+      zeroLengthNoUnit: false,
     }),
   ])
 })


### PR DESCRIPTION
Fixes #532.

This PR configures [perfectionist](https://github.com/ben-eb/perfectionist) to not remove units from zero value properties (like trimming `0px` to `0`).

Tailwind already doesn't use units by default for the zero values of its own utilities so this was providing no benefit there, and had an unfortunate side effect of removing units from user-written CSS where the user might have added the units intentionally.

This was too opinionated for us to be doing and wasn't intentional, so removing as a bug fix.

If someone wants this behavior it's easy to add Perfectionist to their own build chain with that option enabled.