### PR TITLE
Fix for border-style in preflight

### DIFF
--- a/css/preflight.css
+++ b/css/preflight.css
@@ -482,3 +482,13 @@ button,
 table {
   border-collapse: collapse;
 }
+
+/**
+ * Resolves issue with putting border-style solid on the wildcard selector
+ *
+ * https://github.com/tailwindcss/tailwindcss/issues/564
+ */
+
+* {
+  border-style: inherit;
+}


### PR DESCRIPTION
Resolves specific issue with Google Maps as tracked here: https://github.com/tailwindcss/tailwindcss/issues/564

Adds the following to preflight.css:

```css
* {
border-style: inherit;
}
```

Which prevents some weird bugs when you're trying to make CSS triangles via border-width and using absolute positioning.

This will cause API breaking changes to how classes like `@apply border;` work however (you'll have to manually set the border-style).