### PR TITLE
Feature: Generator for scroll snap

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -4791,6 +4791,30 @@ table {
   box-shadow: none;
 }
 
+.snap-x {
+  scroll-snap-type: x mandatory;
+}
+
+.snap-y {
+  scroll-snap-type: y mandatory;
+}
+
+.snap-xy {
+  scoll-snap-type: both mandatory;
+}
+
+.snap-start {
+  scroll-snap-align: start;
+}
+
+.snap-end {
+  scroll-snap-align: end;
+}
+
+.snap-center {
+  scroll-snap-align: center;
+}
+
 .fill-current {
   fill: currentColor;
 }

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -10392,6 +10392,30 @@ table {
     box-shadow: none;
   }
 
+  .sm\:snap-x {
+    scroll-snap-type: x mandatory;
+  }
+
+  .sm\:snap-y {
+    scroll-snap-type: y mandatory;
+  }
+
+  .sm\:snap-xy {
+    scoll-snap-type: both mandatory;
+  }
+
+  .sm\:snap-start {
+    scroll-snap-align: start;
+  }
+
+  .sm\:snap-end {
+    scroll-snap-align: end;
+  }
+
+  .sm\:snap-center {
+    scroll-snap-align: center;
+  }
+
   .sm\:table-auto {
     table-layout: auto;
   }
@@ -15960,6 +15984,30 @@ table {
 
   .md\:focus\:shadow-none:focus {
     box-shadow: none;
+  }
+
+  .md\:snap-x {
+    scroll-snap-type: x mandatory;
+  }
+
+  .md\:snap-y {
+    scroll-snap-type: y mandatory;
+  }
+
+  .md\:snap-xy {
+    scoll-snap-type: both mandatory;
+  }
+
+  .md\:snap-start {
+    scroll-snap-align: start;
+  }
+
+  .md\:snap-end {
+    scroll-snap-align: end;
+  }
+
+  .md\:snap-center {
+    scroll-snap-align: center;
   }
 
   .md\:table-auto {
@@ -21532,6 +21580,30 @@ table {
     box-shadow: none;
   }
 
+  .lg\:snap-x {
+    scroll-snap-type: x mandatory;
+  }
+
+  .lg\:snap-y {
+    scroll-snap-type: y mandatory;
+  }
+
+  .lg\:snap-xy {
+    scoll-snap-type: both mandatory;
+  }
+
+  .lg\:snap-start {
+    scroll-snap-align: start;
+  }
+
+  .lg\:snap-end {
+    scroll-snap-align: end;
+  }
+
+  .lg\:snap-center {
+    scroll-snap-align: center;
+  }
+
   .lg\:table-auto {
     table-layout: auto;
   }
@@ -27100,6 +27172,30 @@ table {
 
   .xl\:focus\:shadow-none:focus {
     box-shadow: none;
+  }
+
+  .xl\:snap-x {
+    scroll-snap-type: x mandatory;
+  }
+
+  .xl\:snap-y {
+    scroll-snap-type: y mandatory;
+  }
+
+  .xl\:snap-xy {
+    scoll-snap-type: both mandatory;
+  }
+
+  .xl\:snap-start {
+    scroll-snap-align: start;
+  }
+
+  .xl\:snap-end {
+    scroll-snap-align: end;
+  }
+
+  .xl\:snap-center {
+    scroll-snap-align: center;
   }
 
   .xl\:table-auto {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -4800,7 +4800,7 @@ table {
 }
 
 .snap-xy {
-  scoll-snap-type: both mandatory;
+  scroll-snap-type: both mandatory;
 }
 
 .snap-start {
@@ -10401,7 +10401,7 @@ table {
   }
 
   .sm\:snap-xy {
-    scoll-snap-type: both mandatory;
+    scroll-snap-type: both mandatory;
   }
 
   .sm\:snap-start {
@@ -15995,7 +15995,7 @@ table {
   }
 
   .md\:snap-xy {
-    scoll-snap-type: both mandatory;
+    scroll-snap-type: both mandatory;
   }
 
   .md\:snap-start {
@@ -21589,7 +21589,7 @@ table {
   }
 
   .lg\:snap-xy {
-    scoll-snap-type: both mandatory;
+    scroll-snap-type: both mandatory;
   }
 
   .lg\:snap-start {
@@ -27183,7 +27183,7 @@ table {
   }
 
   .xl\:snap-xy {
-    scoll-snap-type: both mandatory;
+    scroll-snap-type: both mandatory;
   }
 
   .xl\:snap-start {

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -895,6 +895,7 @@ module.exports = {
     position: ['responsive'],
     resize: ['responsive'],
     shadows: ['responsive', 'hover', 'focus'],
+    snap: ['responsive'],
     svgFill: [],
     svgStroke: [],
     tableLayout: ['responsive'],

--- a/src/generators/snap.js
+++ b/src/generators/snap.js
@@ -1,0 +1,12 @@
+import defineClasses from '../util/defineClasses'
+
+export default function() {
+  return defineClasses({
+    'snap-x': { 'scroll-snap-type': 'x mandatory' },
+    'snap-y': { 'scroll-snap-type': 'y mandatory' },
+    'snap-xy': { 'scroll-snap-type': 'both mandatory' },
+    'snap-start': { 'scroll-snap-align': 'start' },
+    'snap-end': { 'scroll-snap-align': 'end' },
+    'snap-center': { 'scroll-snap-align': 'center' },
+  })
+}

--- a/src/utilityModules.js
+++ b/src/utilityModules.js
@@ -32,6 +32,7 @@ import pointerEvents from './generators/pointerEvents'
 import position from './generators/position'
 import resize from './generators/resize'
 import shadows from './generators/shadows'
+import snap from './generators/snap'
 import svgFill from './generators/svgFill'
 import svgStroke from './generators/svgStroke'
 import tableLayout from './generators/tableLayout'
@@ -82,6 +83,7 @@ export default [
   { name: 'position', generator: position },
   { name: 'resize', generator: resize },
   { name: 'shadows', generator: shadows },
+  { name: 'snap', generator: snap },
   { name: 'svgFill', generator: svgFill },
   { name: 'svgStroke', generator: svgStroke },
   { name: 'tableLayout', generator: tableLayout },


### PR DESCRIPTION
Adds a generator for controlling snappy scrolling as described by:

https://css-tricks.com/introducing-css-scroll-snap-points/
https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-type

Note that this is an experimental feature that will not work in all browsers.