### PR TITLE
Allow modules: [...variants] syntax to bulk apply variants

### DIFF
--- a/__tests__/mergeConfigWithDefaults.test.js
+++ b/__tests__/mergeConfigWithDefaults.test.js
@@ -80,6 +80,33 @@ test('setting modules to "all" creates all variants for all modules', () => {
   })
 })
 
+test('setting modules to an array of variants applies those variants to all modules', () => {
+  const userConfig = {
+    modules: ['responsive', 'focus', 'hover', 'custom-variant'],
+    options: {},
+  }
+
+  const defaultConfig = {
+    modules: {
+      flexbox: ['responsive'],
+      textAlign: ['hover'],
+      textColors: ['focus'],
+    },
+    options: {},
+  }
+
+  const result = mergeConfigWithDefaults(userConfig, defaultConfig)
+
+  expect(result).toEqual({
+    modules: {
+      flexbox: ['responsive', 'focus', 'hover', 'custom-variant'],
+      textAlign: ['responsive', 'focus', 'hover', 'custom-variant'],
+      textColors: ['responsive', 'focus', 'hover', 'custom-variant'],
+    },
+    options: {},
+  })
+})
+
 test('user options are merged with default options', () => {
   const userConfig = {
     modules: {},

--- a/src/util/mergeConfigWithDefaults.js
+++ b/src/util/mergeConfigWithDefaults.js
@@ -1,6 +1,10 @@
 import _ from 'lodash'
 
 function mergeModules(userModules, defaultModules) {
+  if (_.isArray(userModules)) {
+    return _.mapValues(defaultModules, () => userModules)
+  }
+
   if (userModules === 'all') {
     return _.mapValues(defaultModules, () => [
       'responsive',


### PR DESCRIPTION
Now that you can add custom variants to Tailwind as well as control the order in which variants are generated, our simple `modules: 'all'` syntax for bulk enabling everything is a bit insufficient, as internally we have no way of knowing where your custom variants should exist in the precedence list.

This PR preserves the original `modules: 'all'` syntax for people who don't care about custom variants, but introduces a new shorthand syntax for people who do.

It allows you to provide an array of variant names, and have those automatically applied to all of Tailwind's default modules:

```js
modules.exports {
  // ...
  modules: ['responsive', 'hover', 'focus', 'custom-variant'],
  // ...
}
```

Long term it would be nice to have a way to do this that includes utilities provided by plugins as well, but for now this is an improvement.