### PR TITLE
Add option to disable autoprefixer in CLI

### DIFF
--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -56,5 +56,17 @@ describe('cli', () => {
         expect(utils.writeFile.mock.calls[0][1]).toContain('.example')
       })
     })
+
+    it('compiles CSS file with autoprefixer', () => {
+      cli(['build', inputCssPath]).then(() => {
+        expect(process.stdout.write.mock.calls[0][0]).toContain('-ms-input-placeholder')
+      })
+    })
+
+    it('compiles CSS file without autoprefixer', () => {
+      cli(['build', inputCssPath, '--no-autoprefixer']).then(() => {
+        expect(process.stdout.write.mock.calls[0][0]).not.toContain('-ms-input-placeholder')
+      })
+    })
   })
 })

--- a/src/cli/commands/build.js
+++ b/src/cli/commands/build.js
@@ -63,6 +63,7 @@ function stopWithHelp(...msgs) {
  * @param {string} inputFile
  * @param {string} configFile
  * @param {string} outputFile
+ * @param {boolean} autoprefix
  * @return {Promise}
  */
 function build(inputFile, configFile, outputFile, autoprefix) {
@@ -85,6 +86,7 @@ function build(inputFile, configFile, outputFile, autoprefix) {
  * @param {string} inputFile
  * @param {string} configFile
  * @param {string} outputFile
+ * @param {boolean} autoprefix
  * @return {Promise}
  */
 function buildToStdout(inputFile, configFile, outputFile, autoprefix) {
@@ -99,6 +101,7 @@ function buildToStdout(inputFile, configFile, outputFile, autoprefix) {
  * @param {string} inputFile
  * @param {string} configFile
  * @param {string} outputFile
+ * @param {boolean} autoprefix
  * @param {int[]} startTime
  * @return {Promise}
  */


### PR DESCRIPTION
There are a lot of situations where people are using `tailwind build` to avoid ejecting from things like create-react-app or whatever the hell Angular people use. Those tools already run autoprefixer though, so running it twice just slows things down for no reason.

This PR adds a `--no-autoprefixer` option to the `build` command so people can opt-out of it for better performance if they are already prefixing their CSS in a later step.

@MattStypa: Would appreciate your eyes on this if you have a minute 👍 