### PR TITLE
Leave defaultConfig commented out

### DIFF
--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -37,7 +37,6 @@ export function run(cliParams, cliOptions) {
 
     let stub = utils
       .readFile(constants.configStubFile)
-      .replace('// let defaultConfig', 'let defaultConfig')
       .replace("require('./plugins/container')", "require('tailwindcss/plugins/container')")
 
     noComments && (stub = utils.stripBlockComments(stub))


### PR DESCRIPTION
The _defaultConfig_ variable is currently unused in the config file. As a part of **eslint:recommended**, this is disallowed. It would make more sense to leave it commented out, as it exists in the stub, rather than uncommenting it during the cli init process.

For me, personally, I end up making new vue apps relatively often for mockups, which does use **estlint:recommended**. For most of these projects, I only end up with a couple of changes to the config file and I haven't felt a need to reach for that _defaultConfig_ variable.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
