### PR TITLE
Move spacing to its own variable in the default config

### DIFF
--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -129,6 +129,24 @@ let colors = {
   'pink-lightest': '#ffebef',
 }
 
+let spacing = {
+  'px': '1px',
+  '0': '0',
+  '1': '0.25rem',
+  '2': '0.5rem',
+  '3': '0.75rem',
+  '4': '1rem',
+  '5': '1.25rem',
+  '6': '1.5rem',
+  '8': '2rem',
+  '10': '2.5rem',
+  '12': '3rem',
+  '16': '4rem',
+  '20': '5rem',
+  '24': '6rem',
+  '32': '8rem',
+}
+
 module.exports = {
 
   /*
@@ -660,23 +678,7 @@ module.exports = {
   |
   */
 
-  padding: {
-    'px': '1px',
-    '0': '0',
-    '1': '0.25rem',
-    '2': '0.5rem',
-    '3': '0.75rem',
-    '4': '1rem',
-    '5': '1.25rem',
-    '6': '1.5rem',
-    '8': '2rem',
-    '10': '2.5rem',
-    '12': '3rem',
-    '16': '4rem',
-    '20': '5rem',
-    '24': '6rem',
-    '32': '8rem',
-  },
+  padding: spacing,
 
 
   /*
@@ -695,24 +697,7 @@ module.exports = {
   |
   */
 
-  margin: {
-    'auto': 'auto',
-    'px': '1px',
-    '0': '0',
-    '1': '0.25rem',
-    '2': '0.5rem',
-    '3': '0.75rem',
-    '4': '1rem',
-    '5': '1.25rem',
-    '6': '1.5rem',
-    '8': '2rem',
-    '10': '2.5rem',
-    '12': '3rem',
-    '16': '4rem',
-    '20': '5rem',
-    '24': '6rem',
-    '32': '8rem',
-  },
+  margin: global.Object.assign({ 'auto': 'auto' }, spacing),
 
 
   /*
@@ -731,23 +716,7 @@ module.exports = {
   |
   */
 
-  negativeMargin: {
-    'px': '1px',
-    '0': '0',
-    '1': '0.25rem',
-    '2': '0.5rem',
-    '3': '0.75rem',
-    '4': '1rem',
-    '5': '1.25rem',
-    '6': '1.5rem',
-    '8': '2rem',
-    '10': '2.5rem',
-    '12': '3rem',
-    '16': '4rem',
-    '20': '5rem',
-    '24': '6rem',
-    '32': '8rem',
-  },
+  negativeMargin: spacing,
 
 
   /*


### PR DESCRIPTION
I generally want the same values available for paddings, margins and negative margins. The defaults seem to be the same too, so I think it makes sense to do this.

- Pros: easier to add new spacing values
- Cons: none that I can think of