### PR TITLE
Add `round` and `space` background-repeat utilities

### DIFF
--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -1460,6 +1460,14 @@ table {
   background-repeat: repeat-y;
 }
 
+.bg-repeat-round {
+  background-repeat: round;
+}
+
+.bg-repeat-space {
+  background-repeat: space;
+}
+
 .bg-auto {
   background-size: auto;
 }
@@ -7053,6 +7061,14 @@ table {
     background-repeat: repeat-y;
   }
 
+  .sm\:bg-repeat-round {
+    background-repeat: round;
+  }
+
+  .sm\:bg-repeat-space {
+    background-repeat: space;
+  }
+
   .sm\:bg-auto {
     background-size: auto;
   }
@@ -12621,6 +12637,14 @@ table {
 
   .md\:bg-repeat-y {
     background-repeat: repeat-y;
+  }
+
+  .md\:bg-repeat-round {
+    background-repeat: round;
+  }
+
+  .md\:bg-repeat-space {
+    background-repeat: space;
   }
 
   .md\:bg-auto {
@@ -18193,6 +18217,14 @@ table {
     background-repeat: repeat-y;
   }
 
+  .lg\:bg-repeat-round {
+    background-repeat: round;
+  }
+
+  .lg\:bg-repeat-space {
+    background-repeat: space;
+  }
+
   .lg\:bg-auto {
     background-size: auto;
   }
@@ -23761,6 +23793,14 @@ table {
 
   .xl\:bg-repeat-y {
     background-repeat: repeat-y;
+  }
+
+  .xl\:bg-repeat-round {
+    background-repeat: round;
+  }
+
+  .xl\:bg-repeat-space {
+    background-repeat: space;
   }
 
   .xl\:bg-auto {

--- a/src/generators/backgroundRepeat.js
+++ b/src/generators/backgroundRepeat.js
@@ -6,5 +6,7 @@ export default function() {
     'bg-no-repeat': { 'background-repeat': 'no-repeat' },
     'bg-repeat-x': { 'background-repeat': 'repeat-x' },
     'bg-repeat-y': { 'background-repeat': 'repeat-y' },
+    'bg-repeat-round': { 'background-repeat': 'round' },
+    'bg-repeat-space': { 'background-repeat': 'space' },
   })
 }


### PR DESCRIPTION
This PR adds two utilities: `bg-repeat-round` and `bg-repeat-space`. These values are [well supported](https://caniuse.com/#feat=background-repeat-round-space) so I think it makes sense to include them in the core.