### PR TITLE
Allow plugins to register new config variables

### DIFF
--- a/src/lib/evaluateTailwindFunctions.js
+++ b/src/lib/evaluateTailwindFunctions.js
@@ -1,11 +1,12 @@
 import _ from 'lodash'
 import functions from 'postcss-functions'
 
-export default function(config) {
+export default function(config, pluginConfigValues) {
   return functions({
     functions: {
       config: (path, defaultValue) => {
-        return _.get(config, _.trim(path, `'"`), defaultValue)
+        const trimmedPath = _.trim(path, `'"`)
+        return _.get(config, trimmedPath, _.get(pluginConfigValues, trimmedPath, defaultValue))
       },
     },
   })

--- a/src/processTailwindFeatures.js
+++ b/src/processTailwindFeatures.js
@@ -18,7 +18,7 @@ export default function(getConfig) {
 
     return postcss([
       substituteTailwindAtRules(config, processedPlugins),
-      evaluateTailwindFunctions(config),
+      evaluateTailwindFunctions(config, processedPlugins.configValues),
       substituteVariantsAtRules(config, processedPlugins),
       substituteResponsiveAtRules(config),
       substituteScreenAtRules(config),

--- a/src/util/processPlugins.js
+++ b/src/util/processPlugins.js
@@ -19,6 +19,7 @@ export default function(plugins, config) {
   const pluginComponents = []
   const pluginUtilities = []
   const pluginVariantGenerators = {}
+  const pluginConfigValues = {}
 
   plugins.forEach(plugin => {
     plugin({
@@ -64,6 +65,9 @@ export default function(plugins, config) {
       addVariant: (name, generator) => {
         pluginVariantGenerators[name] = generateVariantFunction(generator)
       },
+      addConfig: (namespace, value) => {
+        pluginConfigValues[namespace] = value
+      },
     })
   })
 
@@ -71,5 +75,6 @@ export default function(plugins, config) {
     components: pluginComponents,
     utilities: pluginUtilities,
     variantGenerators: pluginVariantGenerators,
+    configValues: pluginConfigValues,
   }
 }


### PR DESCRIPTION
This PR adds a new `addConfig` function to the plugin API and makes it possible for plugins to expose variables to the `config()` helper function that we make available in the user's CSS.

PRing this to a `next` branch as it exists purely to support a future feature, and some things about this addition will likely change before all of this lands in a tagged release.