### PR TITLE
Return expectation promise in CLI test cases

### DIFF
--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -16,21 +16,21 @@ describe('cli', () => {
 
   describe('init', () => {
     it('creates a Tailwind config file', () => {
-      cli(['init']).then(() => {
+      return cli(['init']).then(() => {
         expect(utils.writeFile.mock.calls[0][0]).toEqual(constants.defaultConfigFile)
         expect(utils.writeFile.mock.calls[0][1]).toContain('defaultConfig')
       })
     })
 
     it('creates a Tailwind config file in a custom location', () => {
-      cli(['init', 'custom.js']).then(() => {
+      return cli(['init', 'custom.js']).then(() => {
         expect(utils.writeFile.mock.calls[0][0]).toEqual('custom.js')
         expect(utils.writeFile.mock.calls[0][1]).toContain('defaultConfig')
       })
     })
 
     it('creates a Tailwind config file without comments', () => {
-      cli(['init', '--no-comments']).then(() => {
+      return cli(['init', '--no-comments']).then(() => {
         expect(utils.writeFile.mock.calls[0][1]).not.toContain('/**')
         expect(utils.writeFile.mock.calls[0][1]).toContain('//')
       })
@@ -39,32 +39,32 @@ describe('cli', () => {
 
   describe('build', () => {
     it('compiles CSS file', () => {
-      cli(['build', inputCssPath]).then(() => {
+      return cli(['build', inputCssPath]).then(() => {
         expect(process.stdout.write.mock.calls[0][0]).toContain('.example')
       })
     })
 
     it('compiles CSS file using custom configuration', () => {
-      cli(['build', inputCssPath, '--config', customConfigPath]).then(() => {
+      return cli(['build', inputCssPath, '--config', customConfigPath]).then(() => {
         expect(process.stdout.write.mock.calls[0][0]).toContain('400px')
       })
     })
 
     it('creates compiled CSS file', () => {
-      cli(['build', inputCssPath, '--output', 'output.css']).then(() => {
+      return cli(['build', inputCssPath, '--output', 'output.css']).then(() => {
         expect(utils.writeFile.mock.calls[0][0]).toEqual('output.css')
         expect(utils.writeFile.mock.calls[0][1]).toContain('.example')
       })
     })
 
     it('compiles CSS file with autoprefixer', () => {
-      cli(['build', inputCssPath]).then(() => {
+      return cli(['build', inputCssPath]).then(() => {
         expect(process.stdout.write.mock.calls[0][0]).toContain('-ms-input-placeholder')
       })
     })
 
     it('compiles CSS file without autoprefixer', () => {
-      cli(['build', inputCssPath, '--no-autoprefixer']).then(() => {
+      return cli(['build', inputCssPath, '--no-autoprefixer']).then(() => {
         expect(process.stdout.write.mock.calls[0][0]).not.toContain('-ms-input-placeholder')
       })
     })


### PR DESCRIPTION
CLI test cases are all asynchronous but Jest doesn't actually know that because they aren't returning a promise. This fixes that to avoid false positive passing test cases.