### PR TITLE
Make core plugins that depend on colors fall back to global color palette if not specified explicitly

### DIFF
--- a/__tests__/corePlugins/backgroundColors.test.js
+++ b/__tests__/corePlugins/backgroundColors.test.js
@@ -1,0 +1,82 @@
+import _ from 'lodash'
+import escapeClassName from '../../src/util/escapeClassName'
+import plugin from '../../src/plugins/backgroundColors'
+
+test('it generates background color utilities', () => {
+  const addedUtilities = []
+
+  const pluginApi = {
+    config: (path, defaultValue) => null,
+    e: escapeClassName,
+    addUtilities(utilities, variants) {
+      addedUtilities.push({
+        utilities,
+        variants,
+      })
+    },
+  }
+
+  plugin({
+    variants: ['responsive', 'hover', 'focus'],
+    values: {
+      red: '#e3342f',
+      green: '#38c172',
+      blue: '#3490dc',
+    },
+  })(pluginApi)
+
+  expect(addedUtilities).toEqual([
+    {
+      utilities: {
+        '.bg-red': { 'background-color': '#e3342f' },
+        '.bg-green': { 'background-color': '#38c172' },
+        '.bg-blue': { 'background-color': '#3490dc' },
+      },
+      variants: ['responsive', 'hover', 'focus'],
+    },
+  ])
+})
+
+test('it uses the theme color palette if no background colors are provided', () => {
+  const addedUtilities = []
+
+  const pluginApi = {
+    config: (path, defaultValue) =>
+      _.get(
+        {
+          theme: {
+            colors: {
+              orange: '#f6993f',
+              teal: '#4dc0b5',
+              indigo: '#6574cd',
+            },
+          },
+        },
+        path,
+        defaultValue
+      ),
+    e: escapeClassName,
+    addUtilities(utilities, variants) {
+      addedUtilities.push({
+        utilities,
+        variants,
+      })
+    },
+  }
+
+  plugin({
+    variants: ['responsive', 'hover', 'focus'],
+    values: undefined,
+  })(pluginApi)
+
+  expect(addedUtilities).toEqual([
+    {
+      utilities: {
+        '.bg-orange': { 'background-color': '#f6993f' },
+        '.bg-teal': { 'background-color': '#4dc0b5' },
+        '.bg-indigo': { 'background-color': '#6574cd' },
+      },
+      variants: ['responsive', 'hover', 'focus'],
+    },
+  ])
+})

--- a/__tests__/corePlugins/backgroundColors.test.js
+++ b/__tests__/corePlugins/backgroundColors.test.js
@@ -6,7 +6,7 @@ test('it generates background color utilities', () => {
   const addedUtilities = []
 
   const pluginApi = {
-    config: (path, defaultValue) => null,
+    config: () => null,
     e: escapeClassName,
     addUtilities(utilities, variants) {
       addedUtilities.push({

--- a/__tests__/corePlugins/borderColors.test.js
+++ b/__tests__/corePlugins/borderColors.test.js
@@ -7,43 +7,66 @@ test('it generates border color utilities', () => {
 
   const pluginApi = {
     e: escapeClassName,
-    addUtilities(utilities) {
-      addedUtilities.push(utilities)
+    addUtilities(utilities, variants) {
+      addedUtilities.push({
+        utilities: utilities,
+        variants: variants,
+      })
     },
   }
 
   plugin({
     variants: ['responsive', 'hover', 'focus'],
     values: {
-      'grey-dark': '#8795a1',
-      grey: '#b8c2cc',
-      'grey-light': '#dae1e7',
-      'red-dark': '#cc1f1a',
       red: '#e3342f',
-      'red-light': '#ef5753',
-      'green-dark': '#1f9d55',
       green: '#38c172',
-      'green-light': '#51d88a',
-      'blue-dark': '#2779bd',
       blue: '#3490dc',
-      'blue-light': '#6cb2eb',
+    },
+  })(pluginApi)
+
+  expect(addedUtilities).toEqual([
+  {
+    utilities: {
+      '.border-red': { 'border-color': '#e3342f' },
+      '.border-green': { 'border-color': '#38c172' },
+      '.border-blue': { 'border-color': '#3490dc' },
+    },
+    variants: ['responsive', 'hover', 'focus'],
+  },
+  ])
+})
+
+test('it ignores the default border color', () => {
+  const addedUtilities = []
+
+  const pluginApi = {
+    e: escapeClassName,
+    addUtilities(utilities, variants) {
+      addedUtilities.push({
+        utilities: utilities,
+        variants: variants,
+      })
+    },
+  }
+
+  plugin({
+    variants: ['responsive', 'hover', 'focus'],
+    values: {
+      red: '#e3342f',
+      green: '#38c172',
+      blue: '#3490dc',
+      default: '#dae1e7',
     },
   })(pluginApi)
 
   expect(addedUtilities).toEqual([
     {
-      '.border-grey-dark': { 'border-color': '#8795a1' },
-      '.border-grey': { 'border-color': '#b8c2cc' },
-      '.border-grey-light': { 'border-color': '#dae1e7' },
-      '.border-red-dark': { 'border-color': '#cc1f1a' },
-      '.border-red': { 'border-color': '#e3342f' },
-      '.border-red-light': { 'border-color': '#ef5753' },
-      '.border-green-dark': { 'border-color': '#1f9d55' },
-      '.border-green': { 'border-color': '#38c172' },
-      '.border-green-light': { 'border-color': '#51d88a' },
-      '.border-blue-dark': { 'border-color': '#2779bd' },
-      '.border-blue': { 'border-color': '#3490dc' },
-      '.border-blue-light': { 'border-color': '#6cb2eb' },
+      utilities: {
+        '.border-red': { 'border-color': '#e3342f' },
+        '.border-green': { 'border-color': '#38c172' },
+        '.border-blue': { 'border-color': '#3490dc' },
+      },
+      variants: ['responsive', 'hover', 'focus'],
     },
   ])
 })

--- a/__tests__/corePlugins/borderColors.test.js
+++ b/__tests__/corePlugins/borderColors.test.js
@@ -6,7 +6,7 @@ test('it generates border color utilities', () => {
   const addedUtilities = []
 
   const pluginApi = {
-    config: (path, defaultValue) => null,
+    config: () => null,
     e: escapeClassName,
     addUtilities(utilities, variants) {
       addedUtilities.push({
@@ -41,7 +41,7 @@ test('it ignores the default border color', () => {
   const addedUtilities = []
 
   const pluginApi = {
-    config: (path, defaultValue) => null,
+    config: () => null,
     e: escapeClassName,
     addUtilities(utilities, variants) {
       addedUtilities.push({

--- a/__tests__/corePlugins/borderColors.test.js
+++ b/__tests__/corePlugins/borderColors.test.js
@@ -6,6 +6,7 @@ test('it generates border color utilities', () => {
   const addedUtilities = []
 
   const pluginApi = {
+    config: (path, defaultValue) => null,
     e: escapeClassName,
     addUtilities(utilities, variants) {
       addedUtilities.push({
@@ -40,6 +41,7 @@ test('it ignores the default border color', () => {
   const addedUtilities = []
 
   const pluginApi = {
+    config: (path, defaultValue) => null,
     e: escapeClassName,
     addUtilities(utilities, variants) {
       addedUtilities.push({
@@ -65,6 +67,50 @@ test('it ignores the default border color', () => {
         '.border-red': { 'border-color': '#e3342f' },
         '.border-green': { 'border-color': '#38c172' },
         '.border-blue': { 'border-color': '#3490dc' },
+      },
+      variants: ['responsive', 'hover', 'focus'],
+    },
+  ])
+})
+
+test('it uses the theme color palette if no border colors are provided', () => {
+  const addedUtilities = []
+
+  const pluginApi = {
+    config: (path, defaultValue) =>
+      _.get(
+        {
+          theme: {
+            colors: {
+              orange: '#f6993f',
+              teal: '#4dc0b5',
+              indigo: '#6574cd',
+            },
+          },
+        },
+        path,
+        defaultValue
+      ),
+    e: escapeClassName,
+    addUtilities(utilities, variants) {
+      addedUtilities.push({
+        utilities,
+        variants,
+      })
+    },
+  }
+
+  plugin({
+    variants: ['responsive', 'hover', 'focus'],
+    values: undefined,
+  })(pluginApi)
+
+  expect(addedUtilities).toEqual([
+    {
+      utilities: {
+        '.border-orange': { 'border-color': '#f6993f' },
+        '.border-teal': { 'border-color': '#4dc0b5' },
+        '.border-indigo': { 'border-color': '#6574cd' },
       },
       variants: ['responsive', 'hover', 'focus'],
     },

--- a/__tests__/corePlugins/borderColors.test.js
+++ b/__tests__/corePlugins/borderColors.test.js
@@ -10,8 +10,8 @@ test('it generates border color utilities', () => {
     e: escapeClassName,
     addUtilities(utilities, variants) {
       addedUtilities.push({
-        utilities: utilities,
-        variants: variants,
+        utilities,
+        variants,
       })
     },
   }
@@ -26,14 +26,14 @@ test('it generates border color utilities', () => {
   })(pluginApi)
 
   expect(addedUtilities).toEqual([
-  {
-    utilities: {
-      '.border-red': { 'border-color': '#e3342f' },
-      '.border-green': { 'border-color': '#38c172' },
-      '.border-blue': { 'border-color': '#3490dc' },
+    {
+      utilities: {
+        '.border-red': { 'border-color': '#e3342f' },
+        '.border-green': { 'border-color': '#38c172' },
+        '.border-blue': { 'border-color': '#3490dc' },
+      },
+      variants: ['responsive', 'hover', 'focus'],
     },
-    variants: ['responsive', 'hover', 'focus'],
-  },
   ])
 })
 
@@ -45,8 +45,8 @@ test('it ignores the default border color', () => {
     e: escapeClassName,
     addUtilities(utilities, variants) {
       addedUtilities.push({
-        utilities: utilities,
-        variants: variants,
+        utilities,
+        variants,
       })
     },
   }

--- a/__tests__/corePlugins/borderColors.test.js
+++ b/__tests__/corePlugins/borderColors.test.js
@@ -1,0 +1,49 @@
+import _ from 'lodash'
+import escapeClassName from '../../src/util/escapeClassName'
+import plugin from '../../src/plugins/borderColors'
+
+test('it generates border color utilities', () => {
+  const addedUtilities = []
+
+  const pluginApi = {
+    e: escapeClassName,
+    addUtilities(utilities) {
+      addedUtilities.push(utilities)
+    },
+  }
+
+  plugin({
+    variants: ['responsive', 'hover', 'focus'],
+    values: {
+      'grey-dark': '#8795a1',
+      grey: '#b8c2cc',
+      'grey-light': '#dae1e7',
+      'red-dark': '#cc1f1a',
+      red: '#e3342f',
+      'red-light': '#ef5753',
+      'green-dark': '#1f9d55',
+      green: '#38c172',
+      'green-light': '#51d88a',
+      'blue-dark': '#2779bd',
+      blue: '#3490dc',
+      'blue-light': '#6cb2eb',
+    },
+  })(pluginApi)
+
+  expect(addedUtilities).toEqual([
+    {
+      '.border-grey-dark': { 'border-color': '#8795a1' },
+      '.border-grey': { 'border-color': '#b8c2cc' },
+      '.border-grey-light': { 'border-color': '#dae1e7' },
+      '.border-red-dark': { 'border-color': '#cc1f1a' },
+      '.border-red': { 'border-color': '#e3342f' },
+      '.border-red-light': { 'border-color': '#ef5753' },
+      '.border-green-dark': { 'border-color': '#1f9d55' },
+      '.border-green': { 'border-color': '#38c172' },
+      '.border-green-light': { 'border-color': '#51d88a' },
+      '.border-blue-dark': { 'border-color': '#2779bd' },
+      '.border-blue': { 'border-color': '#3490dc' },
+      '.border-blue-light': { 'border-color': '#6cb2eb' },
+    },
+  ])
+})

--- a/__tests__/corePlugins/textColors.test.js
+++ b/__tests__/corePlugins/textColors.test.js
@@ -1,0 +1,82 @@
+import _ from 'lodash'
+import escapeClassName from '../../src/util/escapeClassName'
+import plugin from '../../src/plugins/textColors'
+
+test('it generates text color utilities', () => {
+  const addedUtilities = []
+
+  const pluginApi = {
+    config: (path, defaultValue) => null,
+    e: escapeClassName,
+    addUtilities(utilities, variants) {
+      addedUtilities.push({
+        utilities,
+        variants,
+      })
+    },
+  }
+
+  plugin({
+    variants: ['responsive', 'hover', 'focus'],
+    values: {
+      red: '#e3342f',
+      green: '#38c172',
+      blue: '#3490dc',
+    },
+  })(pluginApi)
+
+  expect(addedUtilities).toEqual([
+    {
+      utilities: {
+        '.text-red': { 'color': '#e3342f' },
+        '.text-green': { 'color': '#38c172' },
+        '.text-blue': { 'color': '#3490dc' },
+      },
+      variants: ['responsive', 'hover', 'focus'],
+    },
+  ])
+})
+
+test('it uses the theme color palette if no text colors are provided', () => {
+  const addedUtilities = []
+
+  const pluginApi = {
+    config: (path, defaultValue) =>
+      _.get(
+        {
+          theme: {
+            colors: {
+              orange: '#f6993f',
+              teal: '#4dc0b5',
+              indigo: '#6574cd',
+            },
+          },
+        },
+        path,
+        defaultValue
+      ),
+    e: escapeClassName,
+    addUtilities(utilities, variants) {
+      addedUtilities.push({
+        utilities,
+        variants,
+      })
+    },
+  }
+
+  plugin({
+    variants: ['responsive', 'hover', 'focus'],
+    values: undefined,
+  })(pluginApi)
+
+  expect(addedUtilities).toEqual([
+    {
+      utilities: {
+        '.text-orange': { 'color': '#f6993f' },
+        '.text-teal': { 'color': '#4dc0b5' },
+        '.text-indigo': { 'color': '#6574cd' },
+      },
+      variants: ['responsive', 'hover', 'focus'],
+    },
+  ])
+})

--- a/__tests__/corePlugins/textColors.test.js
+++ b/__tests__/corePlugins/textColors.test.js
@@ -6,7 +6,7 @@ test('it generates text color utilities', () => {
   const addedUtilities = []
 
   const pluginApi = {
-    config: (path, defaultValue) => null,
+    config: () => null,
     e: escapeClassName,
     addUtilities(utilities, variants) {
       addedUtilities.push({
@@ -28,9 +28,9 @@ test('it generates text color utilities', () => {
   expect(addedUtilities).toEqual([
     {
       utilities: {
-        '.text-red': { 'color': '#e3342f' },
-        '.text-green': { 'color': '#38c172' },
-        '.text-blue': { 'color': '#3490dc' },
+        '.text-red': { color: '#e3342f' },
+        '.text-green': { color: '#38c172' },
+        '.text-blue': { color: '#3490dc' },
       },
       variants: ['responsive', 'hover', 'focus'],
     },
@@ -72,9 +72,9 @@ test('it uses the theme color palette if no text colors are provided', () => {
   expect(addedUtilities).toEqual([
     {
       utilities: {
-        '.text-orange': { 'color': '#f6993f' },
-        '.text-teal': { 'color': '#4dc0b5' },
-        '.text-indigo': { 'color': '#6574cd' },
+        '.text-orange': { color: '#f6993f' },
+        '.text-teal': { color: '#4dc0b5' },
+        '.text-indigo': { color: '#6574cd' },
       },
       variants: ['responsive', 'hover', 'focus'],
     },

--- a/src/plugins/backgroundColors.js
+++ b/src/plugins/backgroundColors.js
@@ -1,9 +1,10 @@
 import _ from 'lodash'
 
 export default function({ values, variants }) {
-  return function({ addUtilities, e }) {
+  return function({ addUtilities, e, config }) {
+    const backgroundColors = _.isUndefined(values) ? config('theme.colors') : values
     const utilities = _.fromPairs(
-      _.map(values, (value, modifier) => {
+      _.map(backgroundColors, (value, modifier) => {
         return [
           `.${e(`bg-${modifier}`)}`,
           {

--- a/src/plugins/borderColors.js
+++ b/src/plugins/borderColors.js
@@ -1,9 +1,10 @@
 import _ from 'lodash'
 
 export default function({ values, variants }) {
-  return function({ addUtilities, e }) {
+  return function({ addUtilities, e, config }) {
+    const borderColors = _.isUndefined(values) ? config('theme.colors') : values
     const utilities = _.fromPairs(
-      _.map(_.omit(values, 'default'), (value, modifier) => {
+      _.map(_.omit(borderColors, 'default'), (value, modifier) => {
         return [
           `.${e(`border-${modifier}`)}`,
           {

--- a/src/plugins/textColors.js
+++ b/src/plugins/textColors.js
@@ -1,9 +1,10 @@
 import _ from 'lodash'
 
 export default function({ values, variants }) {
-  return function({ addUtilities, e }) {
+  return function({ addUtilities, e, config }) {
+    const textColors = _.isUndefined(values) ? config('theme.colors') : values
     const utilities = _.fromPairs(
-      _.map(values, (value, modifier) => {
+      _.map(textColors, (value, modifier) => {
         return [
           `.${e(`text-${modifier}`)}`,
           {


### PR DESCRIPTION
**PRing this against `config-restructuring` to make the diff cleaner for now, but ultimately will be targeting the `next` branch once `config-restructuring` is merged.**

This PR makes it so that changes to the `colors` object in the `theme` section of your config file are automatically inherited by the `backgroundColors`, `borderColors`, and `textColors` core plugins.

This means that instead of having to do this:

```js
module.exports = {
  theme: {
    colors: {
      ...defaultTheme.colors,
      customColor: '#bada55',
    },
    backgroundColors: {
      ...defaultTheme.colors,
      customColor: '#bada55',
    },
    borderColors: {
      ...defaultTheme.colors,
      customColor: '#bada55',
    },
    textColors: {
      ...defaultTheme.colors,
      customColor: '#bada55',
    },
  },
}
```

...or this:

```js
const colors = {
  ...defaultTheme.colors,
  customColor: '#bada55',
}

module.exports = {
  theme: {
    colors: colors,
    backgroundColors: colors,
    borderColors: colors,
    textColors: colors,
  },
}
```

...you can just do this:

```js
module.exports = {
  theme: {
    colors: {
      ...defaultTheme.colors,
      customColor: '#bada55',
    },
  },
}
```

I still need to figure out a solution for the `borderColors.default` thing, because to make this PR work properly I also need to delete the `backgroundColors`, `borderColors`, and `textColors` sections from the default theme. Won't merge until I have that figured out.