### PR TITLE
Inherit background, text, and border colors from theme colors at merge level

### DIFF
--- a/__tests__/mergeConfigWithDefaults.test.js
+++ b/__tests__/mergeConfigWithDefaults.test.js
@@ -300,3 +300,166 @@ test('missing top level keys are pulled from the default config', () => {
     },
   })
 })
+
+test('user colors replace background, text, and border colors', () => {
+  const userConfig = {
+    theme: {
+      colors: {
+        red: 'red',
+        green: 'green',
+        blue: 'blue',
+      },
+    },
+  }
+
+  const defaultConfig = {
+    prefix: '-',
+    important: false,
+    separator: ':',
+    theme: {
+      colors: {
+        cyan: 'cyan',
+        magenta: 'magenta',
+        yellow: 'yellow',
+      },
+      backgroundColors: {
+        cyan: 'cyan',
+        magenta: 'magenta',
+        yellow: 'yellow',
+      },
+      textColors: {
+        cyan: 'cyan',
+        magenta: 'magenta',
+        yellow: 'yellow',
+      },
+      borderColors: {
+        cyan: 'cyan',
+        magenta: 'magenta',
+        yellow: 'yellow',
+      },
+    },
+    variants: {
+      backgroundColors: ['responsive'],
+      textColors: ['responsive'],
+      borderColors: ['responsive'],
+    },
+  }
+
+  const result = mergeConfigWithDefaults(userConfig, defaultConfig)
+
+  expect(result).toEqual({
+    prefix: '-',
+    important: false,
+    separator: ':',
+    theme: {
+      colors: {
+        red: 'red',
+        green: 'green',
+        blue: 'blue',
+      },
+      backgroundColors: {
+        red: 'red',
+        green: 'green',
+        blue: 'blue',
+      },
+      textColors: {
+        red: 'red',
+        green: 'green',
+        blue: 'blue',
+      },
+      borderColors: {
+        red: 'red',
+        green: 'green',
+        blue: 'blue',
+      },
+    },
+    variants: {
+      backgroundColors: ['responsive'],
+      textColors: ['responsive'],
+      borderColors: ['responsive'],
+    },
+  })
+})
+
+test('user background, text, and border colors replace user colors', () => {
+  const userConfig = {
+    theme: {
+      colors: {
+        red: 'red',
+        green: 'green',
+        blue: 'blue',
+      },
+      backgroundColors: {
+        cyan: 'cyan',
+      },
+      textColors: {
+        magenta: 'magenta',
+      },
+      borderColors: {
+        yellow: 'yellow',
+      },
+    },
+  }
+
+  const defaultConfig = {
+    prefix: '-',
+    important: false,
+    separator: ':',
+    theme: {
+      colors: {
+        cyan: 'cyan',
+        magenta: 'magenta',
+        yellow: 'yellow',
+      },
+      backgroundColors: {
+        cyan: 'cyan',
+        magenta: 'magenta',
+        yellow: 'yellow',
+      },
+      textColors: {
+        cyan: 'cyan',
+        magenta: 'magenta',
+        yellow: 'yellow',
+      },
+      borderColors: {
+        cyan: 'cyan',
+        magenta: 'magenta',
+        yellow: 'yellow',
+      },
+    },
+    variants: {
+      backgroundColors: ['responsive'],
+      textColors: ['responsive'],
+      borderColors: ['responsive'],
+    },
+  }
+
+  const result = mergeConfigWithDefaults(userConfig, defaultConfig)
+
+  expect(result).toEqual({
+    prefix: '-',
+    important: false,
+    separator: ':',
+    theme: {
+      colors: {
+        red: 'red',
+        green: 'green',
+        blue: 'blue',
+      },
+      backgroundColors: {
+        cyan: 'cyan',
+      },
+      textColors: {
+        magenta: 'magenta',
+      },
+      borderColors: {
+        yellow: 'yellow',
+      },
+    },
+    variants: {
+      backgroundColors: ['responsive'],
+      textColors: ['responsive'],
+      borderColors: ['responsive'],
+    },
+  })
+})

--- a/src/util/mergeConfigWithDefaults.js
+++ b/src/util/mergeConfigWithDefaults.js
@@ -3,7 +3,12 @@ import _ from 'lodash'
 export default function(userConfig, defaultConfig) {
   return _.defaults(
     {
-      theme: _.defaults(userConfig.theme, defaultConfig.theme),
+      theme: _.defaults(userConfig.theme, {
+        ...defaultConfig.theme,
+        backgroundColors: _.get(userConfig.theme, 'colors', defaultConfig.theme.backgroundColors),
+        textColors: _.get(userConfig.theme, 'colors', defaultConfig.theme.textColors),
+        borderColors: _.get(userConfig.theme, 'colors', defaultConfig.theme.borderColors),
+      }),
       variants: _.defaults(userConfig.variants, defaultConfig.variants),
     },
     userConfig,


### PR DESCRIPTION
This is an alternative to #639 which I think may be a better solution (or maybe not!)

Instead of each plugin internally knowing how to find the right values it should use from the theme, this PR pushes that logic to the existing configuration merging layer, so that there is always a "complete" config at the end of the day, instead of a config that is completely missing the backgroundColors, borderColors, and textColors keys.

Essentially this flattens/freezes any sort of inherited value at the merge layer, so that each plugin simply receives it's configuration directly.

There are pros and cons to both approaches annoyingly, but at least today I am convinced this is the better approach.

My main argument for it internally is that I foresee a future where one day I split out all of the "framework generation" code from Tailwind into another project, like maybe `tailwindcss/engine`, and that project is a PostCSS plugin that only deals with plugins and has no concept of a default theme or default styles.

If that project existed, I would want to be able to use the utility plugins from Tailwind  as plugins to the engine without there ever being weird errors about things like "key 'theme' not found" because the plugins are reaching up to the config looking for their values. If every plugin is configured explicitly from the outside in, they would all be straightforward to use in the engine context.

The only real con to this approach is that this merge layer could continue to grow and get more complicated if we introduce other "magic" shared keys for things like spacing or sizing. There is something admittedly nice about keeping all of the fallback/inheritance logic for a specific plugin localized within that plugin. Hard call.