### PR TITLE
Allow users to override a core plugin's configuration

### DIFF
--- a/__tests__/configurePlugins.test.js
+++ b/__tests__/configurePlugins.test.js
@@ -2,19 +2,19 @@ import configurePlugins from '../src/util/configurePlugins'
 
 test('setting a plugin to false removes it', () => {
   const plugins = {
-    fontSize: (options) => {
+    fontSize: options => {
       return {
         plugin: 'fontSize',
         options,
       }
     },
-    display: (options) => {
+    display: options => {
       return {
         plugin: 'display',
         options,
       }
     },
-    backgroundPosition: (options) => {
+    backgroundPosition: options => {
       return {
         plugin: 'backgroundPosition',
         options,
@@ -36,19 +36,19 @@ test('setting a plugin to false removes it', () => {
 
 test('setting a plugin to an object configures that plugin', () => {
   const plugins = {
-    fontSize: (options) => {
+    fontSize: options => {
       return {
         plugin: 'fontSize',
         options,
       }
     },
-    display: (options) => {
+    display: options => {
       return {
         plugin: 'display',
         options,
       }
     },
-    backgroundPosition: (options) => {
+    backgroundPosition: options => {
       return {
         plugin: 'backgroundPosition',
         options,
@@ -57,13 +57,22 @@ test('setting a plugin to an object configures that plugin', () => {
   }
 
   const configuredPlugins = configurePlugins(plugins, {
-    fontSize: { variants: ['responsive', 'hover'], values: { '12': '12px', '14': '14px', '16': '16px', } },
+    fontSize: {
+      variants: ['responsive', 'hover'],
+      values: { '12': '12px', '14': '14px', '16': '16px' },
+    },
     display: { variants: ['responsive'] },
     backgroundPosition: {},
   })
 
   expect(configuredPlugins).toEqual([
-    { plugin: 'fontSize', options: { variants: ['responsive', 'hover'], values: { '12': '12px', '14': '14px', '16': '16px', } } },
+    {
+      plugin: 'fontSize',
+      options: {
+        variants: ['responsive', 'hover'],
+        values: { '12': '12px', '14': '14px', '16': '16px' },
+      },
+    },
     { plugin: 'display', options: { variants: ['responsive'] } },
     { plugin: 'backgroundPosition', options: {} },
   ])

--- a/__tests__/configurePlugins.test.js
+++ b/__tests__/configurePlugins.test.js
@@ -77,3 +77,48 @@ test('setting a plugin to an object configures that plugin', () => {
     { plugin: 'backgroundPosition', options: {} },
   ])
 })
+
+test('plugins are configured with their default configuration if no custom config is provided', () => {
+  const plugins = {
+    fontSize: options => {
+      return {
+        plugin: 'fontSize',
+        options,
+      }
+    },
+    display: options => {
+      return {
+        plugin: 'display',
+        options,
+      }
+    },
+    backgroundPosition: options => {
+      return {
+        plugin: 'backgroundPosition',
+        options,
+      }
+    },
+  }
+
+  const configuredPlugins = configurePlugins(plugins, {
+    fontSize: {
+      variants: ['responsive', 'hover'],
+      values: { '12': '12px', '14': '14px', '16': '16px' },
+    },
+    backgroundPosition: {},
+  }, {
+    display: { variants: ['responsive'] },
+  })
+
+  expect(configuredPlugins).toEqual([
+    {
+      plugin: 'fontSize',
+      options: {
+        variants: ['responsive', 'hover'],
+        values: { '12': '12px', '14': '14px', '16': '16px' },
+      },
+    },
+    { plugin: 'display', options: { variants: ['responsive'] } },
+    { plugin: 'backgroundPosition', options: {} },
+  ])
+})

--- a/__tests__/configurePlugins.test.js
+++ b/__tests__/configurePlugins.test.js
@@ -122,3 +122,52 @@ test('plugins are configured with their default configuration if no custom confi
     { plugin: 'backgroundPosition', options: {} },
   ])
 })
+
+test('custom plugin configuration overrides default plugin configuration', () => {
+  const plugins = {
+    fontSize: options => {
+      return {
+        plugin: 'fontSize',
+        options,
+      }
+    },
+    display: options => {
+      return {
+        plugin: 'display',
+        options,
+      }
+    },
+    backgroundPosition: options => {
+      return {
+        plugin: 'backgroundPosition',
+        options,
+      }
+    },
+  }
+
+  const configuredPlugins = configurePlugins(plugins, {
+    fontSize: {
+      variants: ['responsive', 'hover'],
+      values: { '12': '12px', '14': '14px', '16': '16px' },
+    },
+    display: { variants: ['responsive'] },
+    backgroundPosition: {},
+  }, {
+    fontSize: {
+      variants: ['focus', 'active'],
+      values: { 'sm': '.75rem', 'md': '1rem', 'lg': '1.5rem' },
+    },
+  })
+
+  expect(configuredPlugins).toEqual([
+    {
+      plugin: 'fontSize',
+      options: {
+        variants: ['responsive', 'hover'],
+        values: { '12': '12px', '14': '14px', '16': '16px' },
+      },
+    },
+    { plugin: 'display', options: { variants: ['responsive'] } },
+    { plugin: 'backgroundPosition', options: {} },
+  ])
+})

--- a/__tests__/configurePlugins.test.js
+++ b/__tests__/configurePlugins.test.js
@@ -33,3 +33,38 @@ test('setting a plugin to false removes it', () => {
     { plugin: 'backgroundPosition', options: {} },
   ])
 })
+
+test('setting a plugin to an object configures that plugin', () => {
+  const plugins = {
+    fontSize: (options) => {
+      return {
+        plugin: 'fontSize',
+        options,
+      }
+    },
+    display: (options) => {
+      return {
+        plugin: 'display',
+        options,
+      }
+    },
+    backgroundPosition: (options) => {
+      return {
+        plugin: 'backgroundPosition',
+        options,
+      }
+    },
+  }
+
+  const configuredPlugins = configurePlugins(plugins, {
+    fontSize: { variants: ['responsive', 'hover'], values: { '12': '12px', '14': '14px', '16': '16px', } },
+    display: { variants: ['responsive'] },
+    backgroundPosition: {},
+  })
+
+  expect(configuredPlugins).toEqual([
+    { plugin: 'fontSize', options: { variants: ['responsive', 'hover'], values: { '12': '12px', '14': '14px', '16': '16px', } } },
+    { plugin: 'display', options: { variants: ['responsive'] } },
+    { plugin: 'backgroundPosition', options: {} },
+  ])
+})

--- a/__tests__/configurePlugins.test.js
+++ b/__tests__/configurePlugins.test.js
@@ -1,0 +1,35 @@
+import configurePlugins from '../src/util/configurePlugins'
+
+test('setting a plugin to false removes it', () => {
+  const plugins = {
+    fontSize: (options) => {
+      return {
+        plugin: 'fontSize',
+        options,
+      }
+    },
+    display: (options) => {
+      return {
+        plugin: 'display',
+        options,
+      }
+    },
+    backgroundPosition: (options) => {
+      return {
+        plugin: 'backgroundPosition',
+        options,
+      }
+    },
+  }
+
+  const configuredPlugins = configurePlugins(plugins, {
+    fontSize: {},
+    display: false,
+    backgroundPosition: {},
+  })
+
+  expect(configuredPlugins).toEqual([
+    { plugin: 'fontSize', options: {} },
+    { plugin: 'backgroundPosition', options: {} },
+  ])
+})

--- a/__tests__/configurePlugins.test.js
+++ b/__tests__/configurePlugins.test.js
@@ -100,15 +100,19 @@ test('plugins are configured with their default configuration if no custom confi
     },
   }
 
-  const configuredPlugins = configurePlugins(plugins, {
-    fontSize: {
-      variants: ['responsive', 'hover'],
-      values: { '12': '12px', '14': '14px', '16': '16px' },
+  const configuredPlugins = configurePlugins(
+    plugins,
+    {
+      fontSize: {
+        variants: ['responsive', 'hover'],
+        values: { '12': '12px', '14': '14px', '16': '16px' },
+      },
+      backgroundPosition: {},
     },
-    backgroundPosition: {},
-  }, {
-    display: { variants: ['responsive'] },
-  })
+    {
+      display: { variants: ['responsive'] },
+    }
+  )
 
   expect(configuredPlugins).toEqual([
     {
@@ -145,19 +149,23 @@ test('custom plugin configuration overrides default plugin configuration', () =>
     },
   }
 
-  const configuredPlugins = configurePlugins(plugins, {
-    fontSize: {
-      variants: ['responsive', 'hover'],
-      values: { '12': '12px', '14': '14px', '16': '16px' },
+  const configuredPlugins = configurePlugins(
+    plugins,
+    {
+      fontSize: {
+        variants: ['responsive', 'hover'],
+        values: { '12': '12px', '14': '14px', '16': '16px' },
+      },
+      display: { variants: ['responsive'] },
+      backgroundPosition: {},
     },
-    display: { variants: ['responsive'] },
-    backgroundPosition: {},
-  }, {
-    fontSize: {
-      variants: ['focus', 'active'],
-      values: { 'sm': '.75rem', 'md': '1rem', 'lg': '1.5rem' },
-    },
-  })
+    {
+      fontSize: {
+        variants: ['focus', 'active'],
+        values: { sm: '.75rem', md: '1rem', lg: '1.5rem' },
+      },
+    }
+  )
 
   expect(configuredPlugins).toEqual([
     {

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -53,14 +53,15 @@ import _ from 'lodash'
 import configurePlugins from './util/configurePlugins'
 
 function loadPlugins({ theme, variants, corePlugins }, plugins) {
-  const defaultCorePluginConfig = _.fromPairs(Object.keys(plugins)
-    .map(plugin => [
+  const defaultCorePluginConfig = _.fromPairs(
+    Object.keys(plugins).map(plugin => [
       plugin,
       {
         values: theme[plugin],
         variants: variants[plugin],
-      }
-    ]))
+      },
+    ])
+  )
 
   return configurePlugins(plugins, corePlugins, defaultCorePluginConfig)
 }

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -49,15 +49,20 @@ import whitespace from './plugins/whitespace'
 import width from './plugins/width'
 import zIndex from './plugins/zIndex'
 
+import _ from 'lodash'
+import configurePlugins from './util/configurePlugins'
+
 function loadPlugins({ theme, variants, corePlugins }, plugins) {
-  return Object.keys(plugins)
-    .filter(plugin => corePlugins[plugin] !== false)
-    .map(plugin =>
-      plugins[plugin]({
+  const defaultCorePluginConfig = _.fromPairs(Object.keys(plugins)
+    .map(plugin => [
+      plugin,
+      {
         values: theme[plugin],
         variants: variants[plugin],
-      })
-    )
+      }
+    ]))
+
+  return configurePlugins(plugins, corePlugins, defaultCorePluginConfig)
 }
 
 export default function(config) {

--- a/src/util/configurePlugins.js
+++ b/src/util/configurePlugins.js
@@ -1,7 +1,9 @@
 export default function(plugins, pluginConfig) {
-  return Object.keys(plugins).filter(pluginName => {
-    return pluginConfig[pluginName] !== false
-  }).map(pluginName => {
-    return plugins[pluginName](pluginConfig[pluginName])
-  })
+  return Object.keys(plugins)
+    .filter(pluginName => {
+      return pluginConfig[pluginName] !== false
+    })
+    .map(pluginName => {
+      return plugins[pluginName](pluginConfig[pluginName])
+    })
 }

--- a/src/util/configurePlugins.js
+++ b/src/util/configurePlugins.js
@@ -1,9 +1,11 @@
-export default function(plugins, pluginConfig) {
+import _ from 'lodash'
+
+export default function(plugins, pluginConfig, defaultPluginConfig = {}) {
   return Object.keys(plugins)
     .filter(pluginName => {
       return pluginConfig[pluginName] !== false
     })
     .map(pluginName => {
-      return plugins[pluginName](pluginConfig[pluginName])
+      return plugins[pluginName](_.get(pluginConfig, pluginName, defaultPluginConfig[pluginName]))
     })
 }

--- a/src/util/configurePlugins.js
+++ b/src/util/configurePlugins.js
@@ -1,0 +1,7 @@
+export default function(plugins, pluginConfig) {
+  return Object.keys(plugins).filter(pluginName => {
+    return pluginConfig[pluginName] !== false
+  }).map(pluginName => {
+    return plugins[pluginName](pluginConfig[pluginName])
+  })
+}


### PR DESCRIPTION
This PR makes it possible for users to completely override a core plugin's configuration by providing a configuration object in the `corePlugins` section of the config file.

```js
module.exports = {
  // ...
  corePlugins: {
    fontSize: {
      variants: ['responsive'],
      values: {
        sm: '0.875rem',
        md: '1rem',
        lg: '2rem',
      }
    }
  }
}

```

This configuration overrides any configuration that would be derived from the `theme` and `variants` sections.

Right now this isn't really useful but it's part of the vision outlined in #637. It's at least necessary to be able to set a core plugin to `false` to disable it, and it's very possible that in the future some core plugins expose additional advanced configuration that is only accessible through `corePlugins` for users who want to do something very custom (like change a class name) and deviate from the Tailwind's defaults significantly.