### PR TITLE
Use object spread to eliminate need for lodash.defaults

### DIFF
--- a/src/util/mergeConfigWithDefaults.js
+++ b/src/util/mergeConfigWithDefaults.js
@@ -1,12 +1,8 @@
-import _ from 'lodash'
-
 export default function(userConfig, defaultConfig) {
-  return _.defaults(
-    {
-      theme: _.defaults(userConfig.theme, defaultConfig.theme),
-      variants: _.defaults(userConfig.variants, defaultConfig.variants),
-    },
-    userConfig,
-    defaultConfig
-  )
+  return {
+    ...defaultConfig,
+    ...userConfig,
+    theme: { ...defaultConfig.theme, ...userConfig.theme },
+    variants: { ...defaultConfig.variants, ...userConfig.variants },
+  }
 }


### PR DESCRIPTION
I ran `yarn run jest mergeConfig`, and all the tests still pass. 👍 If you still prefer the lodash syntax, I won't be offended.