### PR TITLE
Properly handle deeply nested at-rules inside of `@responsive`

### DIFF
--- a/__tests__/responsiveAtRule.test.js
+++ b/__tests__/responsiveAtRule.test.js
@@ -6,114 +6,6 @@ function run(input, opts = config) {
   return postcss([plugin(opts)]).process(input, { from: undefined })
 }
 
-test('it can generate responsive variants for nested at rules', () => {
-  const input = `
-    @responsive {
-      .banana { color: yellow; }
-      .chocolate { color: brown; }
-
-      @supports(display: grid) {
-        .grid\\:banana { color: blue; }
-        .grid\\:chocolate { color: green; }
-      }
-    }
-  `
-
-  const output = `
-    .banana {
-      color: yellow;
-    }
-
-    .chocolate {
-      color: brown;
-    }
-
-    @supports(display: grid) {
-      .grid\\:banana {
-        color: blue;
-      }
-
-      .grid\\:chocolate {
-        color: green;
-      }
-    }
-
-    @media (min-width: 500px) {
-      .sm\\:banana {
-        color: yellow;
-      }
-
-      .sm\\:chocolate {
-        color: brown;
-      }
-
-      @supports(display: grid) {
-        .sm\\:grid\\:banana {
-          color: blue;
-        }
-
-        .sm\\:grid\\:chocolate {
-          color: green;
-        }
-      }
-    }
-
-    @media (min-width: 750px) {
-      .md\\:banana {
-        color: yellow;
-      }
-
-      .md\\:chocolate {
-        color: brown;
-      }
-
-      @supports(display: grid) {
-        .md\\:grid\\:banana {
-          color: blue;
-        }
-
-        .md\\:grid\\:chocolate {
-          color: green;
-        }
-      }
-    }
-
-    @media (min-width: 1000px) {
-      .lg\\:banana {
-        color: yellow;
-      }
-
-      .lg\\:chocolate {
-        color: brown;
-      }
-
-      @supports(display: grid) {
-        .lg\\:grid\\:banana {
-          color: blue;
-        }
-
-        .lg\\:grid\\:chocolate {
-          color: green;
-        }
-      }
-    }
-  `
-
-  return run(input, {
-    screens: {
-      sm: '500px',
-      md: '750px',
-      lg: '1000px',
-    },
-    options: {
-      separator: ':',
-    },
-  }).then(result => {
-    expect(result.css).toMatchCss(output)
-    expect(result.warnings().length).toBe(0)
-  })
-})
-
 test('it can generate responsive variants', () => {
   const input = `
     @responsive {
@@ -269,6 +161,136 @@ test('responsive variants are grouped', () => {
     screens: {
       sm: '500px',
       md: '750px',
+      lg: '1000px',
+    },
+    options: {
+      separator: ':',
+    },
+  }).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it can generate responsive variants for nested at-rules', () => {
+  const input = `
+    @responsive {
+      .banana { color: yellow; }
+
+      @supports(display: grid) {
+        .grid\\:banana { color: blue; }
+      }
+    }
+  `
+
+  const output = `
+    .banana {
+      color: yellow;
+    }
+
+    @supports(display: grid) {
+      .grid\\:banana {
+        color: blue;
+      }
+    }
+
+    @media (min-width: 500px) {
+      .sm\\:banana {
+        color: yellow;
+      }
+
+      @supports(display: grid) {
+        .sm\\:grid\\:banana {
+          color: blue;
+        }
+      }
+    }
+
+    @media (min-width: 1000px) {
+      .lg\\:banana {
+        color: yellow;
+      }
+
+      @supports(display: grid) {
+        .lg\\:grid\\:banana {
+          color: blue;
+        }
+      }
+    }
+  `
+
+  return run(input, {
+    screens: {
+      sm: '500px',
+      lg: '1000px',
+    },
+    options: {
+      separator: ':',
+    },
+  }).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test.only('it can generate responsive variants for deeply nested at-rules', () => {
+  const input = `
+    @responsive {
+      .banana { color: yellow; }
+
+      @supports(display: grid) {
+        @supports(display: flex) {
+          .flex-grid\\:banana { color: blue; }
+        }
+      }
+    }
+  `
+
+  const output = `
+    .banana {
+      color: yellow;
+    }
+
+    @supports(display: grid) {
+      @supports(display: flex) {
+        .flex-grid\\:banana {
+          color: blue;
+        }
+      }
+    }
+
+    @media (min-width: 500px) {
+      .sm\\:banana {
+        color: yellow;
+      }
+
+      @supports(display: grid) {
+        @supports(display: flex) {
+          .sm\\:flex-grid\\:banana {
+            color: blue;
+          }
+        }
+      }
+    }
+
+    @media (min-width: 1000px) {
+      .lg\\:banana {
+        color: yellow;
+      }
+
+      @supports(display: grid) {
+        @supports(display: flex) {
+          .lg\\:flex-grid\\:banana {
+            color: blue;
+          }
+        }
+      }
+    }
+  `
+
+  return run(input, {
+    screens: {
+      sm: '500px',
       lg: '1000px',
     },
     options: {

--- a/__tests__/responsiveAtRule.test.js
+++ b/__tests__/responsiveAtRule.test.js
@@ -233,7 +233,7 @@ test('it can generate responsive variants for nested at-rules', () => {
   })
 })
 
-test.only('it can generate responsive variants for deeply nested at-rules', () => {
+test('it can generate responsive variants for deeply nested at-rules', () => {
   const input = `
     @responsive {
       .banana { color: yellow; }


### PR DESCRIPTION
#642 pointed out a bug in our `@responsive` handling that didn't account for child rules being at-rules.

That PR fixed the case of nested at-rules being a single level deep which was better than what we were doing, but there was still a bug if at-rules were nested deeper than one level.

This PR solves that issue and simplifies the code path dramatically by using a PostCSS root instance to hold all of the responsive rules, and manipulates all of the selectors using `walkRules` to recursively alter every rule instead of trying to determine the depth ourselves and handling regular rules differently than at-rules.