### PR TITLE
Allow plugins to register base styles

### DIFF
--- a/__tests__/processPlugins.test.js
+++ b/__tests__/processPlugins.test.js
@@ -254,6 +254,33 @@ test('plugins can create components with object syntax', () => {
     `)
 })
 
+test('plugins can add base styles with object syntax', () => {
+  const { base } = processPlugins(
+    [
+      function({ addBase }) {
+        addBase({
+          'img': {
+            maxWidth: '100%',
+          },
+          'button': {
+            fontFamily: 'inherit',
+          },
+        })
+      },
+    ],
+    makeConfig()
+  )
+
+  expect(css(base)).toMatchCss(`
+    img {
+      max-width: 100%
+    }
+    button {
+      font-family: inherit
+    }
+    `)
+})
+
 test('plugins can create components with raw PostCSS nodes', () => {
   const { components, utilities } = processPlugins(
     [

--- a/__tests__/processPlugins.test.js
+++ b/__tests__/processPlugins.test.js
@@ -281,6 +281,39 @@ test('plugins can add base styles with object syntax', () => {
     `)
 })
 
+test('plugins can add base styles with raw PostCSS nodes', () => {
+  const { base } = processPlugins(
+    [
+      function({ addBase }) {
+        addBase([
+          postcss.rule({ selector: 'img' }).append([
+            postcss.decl({
+              prop: 'max-width',
+              value: '100%',
+            }),
+          ]),
+          postcss.rule({ selector: 'button' }).append([
+            postcss.decl({
+              prop: 'font-family',
+              value: 'inherit',
+            }),
+          ]),
+        ])
+      },
+    ],
+    makeConfig()
+  )
+
+  expect(css(base)).toMatchCss(`
+    img {
+      max-width: 100%
+    }
+    button {
+      font-family: inherit
+    }
+    `)
+})
+
 test('plugins can create components with raw PostCSS nodes', () => {
   const { components, utilities } = processPlugins(
     [

--- a/src/lib/substituteTailwindAtRules.js
+++ b/src/lib/substituteTailwindAtRules.js
@@ -8,7 +8,10 @@ function updateSource(nodes, source) {
   })
 }
 
-export default function(config, { components: pluginComponents, utilities: pluginUtilities }) {
+export default function(
+  config,
+  { base: pluginBase, components: pluginComponents, utilities: pluginUtilities }
+) {
   return function(css) {
     css.walkAtRules('tailwind', atRule => {
       if (atRule.params === 'preflight') {
@@ -17,6 +20,11 @@ export default function(config, { components: pluginComponents, utilities: plugi
         )
 
         atRule.before(updateSource(preflightTree, atRule.source))
+        atRule.remove()
+      }
+
+      if (atRule.params === 'base') {
+        atRule.before(updateSource(pluginBase, atRule.source))
         atRule.remove()
       }
 

--- a/src/util/processPlugins.js
+++ b/src/util/processPlugins.js
@@ -16,6 +16,7 @@ function parseStyles(styles) {
 }
 
 export default function(plugins, config) {
+  const pluginBaseStyles = []
   const pluginComponents = []
   const pluginUtilities = []
   const pluginVariantGenerators = {}
@@ -63,6 +64,9 @@ export default function(plugins, config) {
 
         pluginComponents.push(...styles.nodes)
       },
+      addBase: (baseStyles) => {
+        pluginBaseStyles.push(...parseStyles(baseStyles))
+      },
       addVariant: (name, generator) => {
         pluginVariantGenerators[name] = generateVariantFunction(generator)
       },
@@ -70,6 +74,7 @@ export default function(plugins, config) {
   })
 
   return {
+    base: pluginBaseStyles,
     components: pluginComponents,
     utilities: pluginUtilities,
     variantGenerators: pluginVariantGenerators,


### PR DESCRIPTION
This PR makes it possible for plugins to add base styles using a new `addBase` helper. Those base styles are rendered at a new `@tailwind base` directive.

This sets the stage for converting our preflight styles into a core plugin, and removing `@tailwind preflight` in favor of `@tailwind base`.