### PR TITLE
Add first class support for extending the default theme

### DIFF
--- a/__tests__/resolveConfig.test.js
+++ b/__tests__/resolveConfig.test.js
@@ -442,7 +442,7 @@ test('theme values in the extend section extend the existing theme', () => {
         backgroundColors: {
           customBackground: '#bada55',
         },
-      }
+      },
     },
   }
 
@@ -520,7 +520,7 @@ test('theme values in the extend section extend the user theme', () => {
         height: {
           customHeight: '500vh',
         },
-      }
+      },
     },
   }
 
@@ -536,7 +536,7 @@ test('theme values in the extend section extend the user theme', () => {
       },
       height: {
         '0': 0,
-        'full': '100%',
+        full: '100%',
       },
       width: {
         '0': 0,
@@ -604,7 +604,7 @@ test('theme values in the extend section can extend values that are depended on 
         backgroundColors: {
           customBackground: '#bada55',
         },
-      }
+      },
     },
   }
 

--- a/__tests__/resolveConfig.test.js
+++ b/__tests__/resolveConfig.test.js
@@ -655,3 +655,73 @@ test('theme values in the extend section can extend values that are depended on 
     },
   })
 })
+
+test('theme values in the extend section are not deeply merged', () => {
+  const userConfig = {
+    theme: {
+      extend: {
+        fonts: {
+          sans: [
+            'Comic Sans',
+          ],
+        }
+      },
+    },
+  }
+
+  const defaultConfig = {
+    prefix: '-',
+    important: false,
+    separator: ':',
+    theme: {
+      fonts: {
+        sans: [
+          'system-ui',
+          'Helvetica Neue',
+          'sans-serif',
+        ],
+        serif: [
+          'Constantia',
+          'Georgia',
+          'serif',
+        ],
+        mono: [
+          'Menlo',
+          'Courier New',
+          'monospace',
+        ],
+      },
+    },
+    variants: {
+      fonts: ['responsive'],
+    },
+  }
+
+  const result = resolveConfig([userConfig, defaultConfig])
+
+  expect(result).toEqual({
+    prefix: '-',
+    important: false,
+    separator: ':',
+    theme: {
+      fonts: {
+        sans: [
+          'Comic Sans',
+        ],
+        serif: [
+          'Constantia',
+          'Georgia',
+          'serif',
+        ],
+        mono: [
+          'Menlo',
+          'Courier New',
+          'monospace',
+        ],
+      },
+    },
+    variants: {
+      fonts: ['responsive'],
+    },
+  })
+})

--- a/__tests__/resolveConfig.test.js
+++ b/__tests__/resolveConfig.test.js
@@ -430,3 +430,228 @@ test('functions in the user theme section are lazily evaluated', () => {
     },
   })
 })
+
+test('theme values in the extend section extend the existing theme', () => {
+  const userConfig = {
+    theme: {
+      extend: {
+        opacity: {
+          '25': '25',
+          '75': '.75',
+        },
+        backgroundColors: {
+          customBackground: '#bada55',
+        },
+      }
+    },
+  }
+
+  const defaultConfig = {
+    prefix: '-',
+    important: false,
+    separator: ':',
+    theme: {
+      colors: {
+        cyan: 'cyan',
+        magenta: 'magenta',
+        yellow: 'yellow',
+      },
+      opacity: {
+        '0': '0',
+        '50': '.5',
+        '100': '1',
+      },
+      backgroundColors: ({ colors }) => colors,
+    },
+    variants: {
+      backgroundColors: ['responsive', 'hover', 'focus'],
+      opacity: ['responsive', 'hover', 'focus'],
+    },
+  }
+
+  const result = resolveConfig([userConfig, defaultConfig])
+
+  expect(result).toEqual({
+    prefix: '-',
+    important: false,
+    separator: ':',
+    theme: {
+      colors: {
+        cyan: 'cyan',
+        magenta: 'magenta',
+        yellow: 'yellow',
+      },
+      opacity: {
+        '0': '0',
+        '50': '.5',
+        '100': '1',
+        '25': '25',
+        '75': '.75',
+      },
+      backgroundColors: {
+        cyan: 'cyan',
+        magenta: 'magenta',
+        yellow: 'yellow',
+        customBackground: '#bada55',
+      },
+    },
+    variants: {
+      backgroundColors: ['responsive', 'hover', 'focus'],
+      opacity: ['responsive', 'hover', 'focus'],
+    },
+  })
+})
+
+test('theme values in the extend section extend the user theme', () => {
+  const userConfig = {
+    theme: {
+      opacity: {
+        '0': '0',
+        '20': '.2',
+        '40': '.4',
+      },
+      height: theme => theme.width,
+      extend: {
+        opacity: {
+          '60': '.6',
+          '80': '.8',
+          '100': '1',
+        },
+        height: {
+          customHeight: '500vh',
+        },
+      }
+    },
+  }
+
+  const defaultConfig = {
+    prefix: '-',
+    important: false,
+    separator: ':',
+    theme: {
+      opacity: {
+        '0': '0',
+        '50': '.5',
+        '100': '1',
+      },
+      height: {
+        '0': 0,
+        'full': '100%',
+      },
+      width: {
+        '0': 0,
+        '1': '.25rem',
+        '2': '.5rem',
+        '3': '.75rem',
+        '4': '1rem',
+      },
+    },
+    variants: {
+      opacity: ['responsive', 'hover', 'focus'],
+      height: ['responsive'],
+      width: ['responsive'],
+    },
+  }
+
+  const result = resolveConfig([userConfig, defaultConfig])
+
+  expect(result).toEqual({
+    prefix: '-',
+    important: false,
+    separator: ':',
+    theme: {
+      opacity: {
+        '0': '0',
+        '20': '.2',
+        '40': '.4',
+        '60': '.6',
+        '80': '.8',
+        '100': '1',
+      },
+      height: {
+        '0': 0,
+        '1': '.25rem',
+        '2': '.5rem',
+        '3': '.75rem',
+        '4': '1rem',
+        customHeight: '500vh',
+      },
+      width: {
+        '0': 0,
+        '1': '.25rem',
+        '2': '.5rem',
+        '3': '.75rem',
+        '4': '1rem',
+      },
+    },
+    variants: {
+      opacity: ['responsive', 'hover', 'focus'],
+      height: ['responsive'],
+      width: ['responsive'],
+    },
+  })
+})
+
+test('theme values in the extend section can extend values that are depended on lazily', () => {
+  const userConfig = {
+    theme: {
+      extend: {
+        colors: {
+          red: 'red',
+          green: 'green',
+          blue: 'blue',
+        },
+        backgroundColors: {
+          customBackground: '#bada55',
+        },
+      }
+    },
+  }
+
+  const defaultConfig = {
+    prefix: '-',
+    important: false,
+    separator: ':',
+    theme: {
+      colors: {
+        cyan: 'cyan',
+        magenta: 'magenta',
+        yellow: 'yellow',
+      },
+      backgroundColors: ({ colors }) => colors,
+    },
+    variants: {
+      backgroundColors: ['responsive', 'hover', 'focus'],
+    },
+  }
+
+  const result = resolveConfig([userConfig, defaultConfig])
+
+  expect(result).toEqual({
+    prefix: '-',
+    important: false,
+    separator: ':',
+    theme: {
+      colors: {
+        cyan: 'cyan',
+        magenta: 'magenta',
+        yellow: 'yellow',
+        red: 'red',
+        green: 'green',
+        blue: 'blue',
+      },
+      backgroundColors: {
+        cyan: 'cyan',
+        magenta: 'magenta',
+        yellow: 'yellow',
+        red: 'red',
+        green: 'green',
+        blue: 'blue',
+        customBackground: '#bada55',
+      },
+    },
+    variants: {
+      backgroundColors: ['responsive', 'hover', 'focus'],
+    },
+  })
+})

--- a/__tests__/resolveConfig.test.js
+++ b/__tests__/resolveConfig.test.js
@@ -661,10 +661,8 @@ test('theme values in the extend section are not deeply merged', () => {
     theme: {
       extend: {
         fonts: {
-          sans: [
-            'Comic Sans',
-          ],
-        }
+          sans: ['Comic Sans'],
+        },
       },
     },
   }
@@ -675,21 +673,9 @@ test('theme values in the extend section are not deeply merged', () => {
     separator: ':',
     theme: {
       fonts: {
-        sans: [
-          'system-ui',
-          'Helvetica Neue',
-          'sans-serif',
-        ],
-        serif: [
-          'Constantia',
-          'Georgia',
-          'serif',
-        ],
-        mono: [
-          'Menlo',
-          'Courier New',
-          'monospace',
-        ],
+        sans: ['system-ui', 'Helvetica Neue', 'sans-serif'],
+        serif: ['Constantia', 'Georgia', 'serif'],
+        mono: ['Menlo', 'Courier New', 'monospace'],
       },
     },
     variants: {
@@ -705,19 +691,9 @@ test('theme values in the extend section are not deeply merged', () => {
     separator: ':',
     theme: {
       fonts: {
-        sans: [
-          'Comic Sans',
-        ],
-        serif: [
-          'Constantia',
-          'Georgia',
-          'serif',
-        ],
-        mono: [
-          'Menlo',
-          'Courier New',
-          'monospace',
-        ],
+        sans: ['Comic Sans'],
+        serif: ['Constantia', 'Georgia', 'serif'],
+        mono: ['Menlo', 'Courier New', 'monospace'],
       },
     },
     variants: {

--- a/src/util/resolveConfig.js
+++ b/src/util/resolveConfig.js
@@ -12,13 +12,8 @@ function resolveFunctionKeys(object) {
   }, {})
 }
 
-function without(object, key) {
-  /* eslint-disable no-unused-vars */
-  return (({ [key]: _, ...rest }) => rest)(object)
-}
-
-function mergeExtensions(theme) {
-  return mergeWith({}, without(theme, 'extend'), theme.extend, (_, extensions, key) => {
+function mergeExtensions({ extend, ...theme }) {
+  return mergeWith({}, theme, extend, (_, extensions, key) => {
     return isFunction(theme[key])
       ? mergedTheme => ({
           ...theme[key](mergedTheme),

--- a/src/util/resolveConfig.js
+++ b/src/util/resolveConfig.js
@@ -1,19 +1,41 @@
-import _ from 'lodash'
+import mergeWith from 'lodash/mergeWith'
+import isFunction from 'lodash/isFunction'
+import defaults from 'lodash/defaults'
+import map from 'lodash/map'
+import get from 'lodash/get'
 
 function resolveFunctionKeys(object) {
   return Object.keys(object).reduce((resolved, key) => {
     return {
       ...resolved,
-      [key]: _.isFunction(object[key]) ? object[key](object) : object[key],
+      [key]: isFunction(object[key]) ? object[key](object) : object[key],
     }
   }, {})
 }
 
+function without(object, key) {
+  return (({[key]: _, ...rest }) => rest)(object)
+}
+
+function mergeExtensions(theme) {
+  return mergeWith({}, without(theme, 'extend'), theme.extend, (_, value, key) => {
+    return isFunction(theme[key])
+      ? mergedTheme => ({
+          ...theme[key](mergedTheme),
+          ...get(theme.extend, key, {})
+        })
+      : {
+          ...theme[key],
+          ...get(theme.extend, key, {}),
+        }
+  })
+}
+
 export default function(configs) {
-  return _.defaults(
+  return defaults(
     {
-      theme: resolveFunctionKeys(_.defaults(..._.map(configs, 'theme'))),
-      variants: _.defaults(..._.map(configs, 'variants')),
+      theme: resolveFunctionKeys(mergeExtensions(defaults(...map(configs, 'theme')))),
+      variants: defaults(...map(configs, 'variants')),
     },
     ...configs
   )

--- a/src/util/resolveConfig.js
+++ b/src/util/resolveConfig.js
@@ -13,7 +13,8 @@ function resolveFunctionKeys(object) {
 }
 
 function without(object, key) {
-  return (({[key]: _, ...rest }) => rest)(object)
+  /* eslint-disable no-unused-vars */
+  return (({ [key]: _, ...rest }) => rest)(object)
 }
 
 function mergeExtensions(theme) {
@@ -21,7 +22,7 @@ function mergeExtensions(theme) {
     return isFunction(theme[key])
       ? mergedTheme => ({
           ...theme[key](mergedTheme),
-          ...extensions
+          ...extensions,
         })
       : {
           ...theme[key],

--- a/src/util/resolveConfig.js
+++ b/src/util/resolveConfig.js
@@ -2,7 +2,6 @@ import mergeWith from 'lodash/mergeWith'
 import isFunction from 'lodash/isFunction'
 import defaults from 'lodash/defaults'
 import map from 'lodash/map'
-import get from 'lodash/get'
 
 function resolveFunctionKeys(object) {
   return Object.keys(object).reduce((resolved, key) => {
@@ -18,15 +17,15 @@ function without(object, key) {
 }
 
 function mergeExtensions(theme) {
-  return mergeWith({}, without(theme, 'extend'), theme.extend, (_, value, key) => {
+  return mergeWith({}, without(theme, 'extend'), theme.extend, (_, extensions, key) => {
     return isFunction(theme[key])
       ? mergedTheme => ({
           ...theme[key](mergedTheme),
-          ...get(theme.extend, key, {})
+          ...extensions
         })
       : {
           ...theme[key],
-          ...get(theme.extend, key, {}),
+          ...extensions,
         }
   })
 }


### PR DESCRIPTION
One of the changes we are making for 1.0 is to start encouraging people to only replace/extend what they need to change in the config file, rather than scaffolding every single value and giving the user complete ownership by default.

A challenge with this approach is that it's not quite as simple to just add a few new values to your config (or more aptly your `theme` in 1.0 terms).

Previously all of the default values would already be present, and you could just tack on any extra ones you wanted to add:

```diff
  // 0.x config format

  module.exports = {
    // ...
    borderWidths: {
      default: '1px',
      '0': '0',
      '2': '2px',
      '4': '4px',
      '8': '8px',
+     '10': '10px',
+     '12': '12px',
    },
  }
```

But with the approach we are recommending for 1.0, there would be no `borderWidths` key in your theme by default, and to add the two new values you'd also have to re-add the existing values.

```diff
  // 1.x config format

  module.exports = {
    // ...
    theme: {
+     borderWidths: {
+       default: '1px',
+       '0': '0',
+       '2': '2px',
+       '4': '4px',
+       '8': '8px',
+       '10': '10px',
+       '12': '12px',
+     },
    }
  }
```

My original thinking for working around this was just adding a new export (something like `tailwindcss/defaultTheme`) that users could import and spread into their theme to extend things, for example:

```diff
+ const defaultTheme = require('tailwindcss/defaultTheme')

  module.exports = {
    // ...
    theme: {
+     borderWidths: {
+       ...defaultTheme.borderWidths,
+       '10': '10px',
+       '12': '12px',
+     },
    }
  }
```

...but I realized this would break down in combination with the theme-values-as-closures support added in #645 (you can't spread in an object that hasn't even been fully evaluated yet).

So instead, the best idea I could come up with is a new `extend` key inside the theme section that will properly handle all of this stuff for you.

It looks like this:

```diff
  module.exports = {
    // ...
    theme: {
+     extend: {
+       borderWidths: {
+         '10': '10px',
+         '12': '12px',
+       },
+     }
    }
  }
```

By handling this in a first-class way we can intelligently handle the closure situations to give you intuitive results that make perfect sense but would be almost impossible to implement ergonomically in userland.

For example, this config file adds a few custom colors to the overall color palette, *and* adds a new background color, with the background colors still inheriting their base values from the user-extended color palette:

```js
module.exports = {
  theme: {
    extend: {
      colors: {
        cyan: 'cyan',
        magenta: 'magenta',
      },
      backgroundColors: {
        customBackground: '#bada55',
      },
    },
  },
}
```

The result here would be that you'd get all of the default background color utilities (`bg-blue`, `bg-blue-light`, etc.), as well as `bg-cyan` and `bg-magenta` from the extended color palette, and `bg-customBackground` for the color added only to `backgroundColors`. Doing this in user-land with the `defaultTheme` export and trying to spread stuff in yourself is not really even possible without extracting some variables to avoid duplication.

With this PR, a user theme would end up being broken into two sections: complete replacements, and extensions.

I expect in the real world it would usually look something like this:

```js
module.exports = {
  theme: {

    // Completely replaced values:
    colors: {
      // User's custom color palette
    },
    fonts: {
      // User's custom font stack
    },

    // Values that extend the defaults with a few extras:
    extend: {
      shadows: {
        xl: '0 25px 40px 0 rgba(0,0,0,0.11), 0 10px 20px 0 rgba(0,0,0,0.05)',
      },
      opacity: {
        '60': '.6',
      }
    },
  },
}
```