### PR TITLE
Allow users to customize default variant placement

### DIFF
--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -218,6 +218,33 @@ test('variants are generated in the order specified', () => {
   })
 })
 
+test('the default variant can be generated in a specified position', () => {
+  const input = `
+    @variants focus, active, default, hover {
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+    }
+  `
+
+  const output = `
+      .focus\\:banana:focus { color: yellow; }
+      .focus\\:chocolate:focus { color: brown; }
+      .active\\:banana:active { color: yellow; }
+      .active\\:chocolate:active { color: brown; }
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+      .hover\\:banana:hover { color: yellow; }
+      .hover\\:chocolate:hover { color: brown; }
+  `
+
+  return run(input, {
+    ...config,
+  }).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('plugin variants can modify rules using the raw PostCSS API', () => {
   const input = `
     @variants important {

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -10,7 +10,12 @@ function generatePseudoClassVariant(pseudoClass) {
   })
 }
 
+function ensureIncludesDefault(variants) {
+  return variants.includes('default') ? variants : ['default', ...variants]
+}
+
 const defaultVariantGenerators = {
+  default: generateVariantFunction(() => {}),
   'group-hover': generateVariantFunction(({ modifySelectors, separator }) => {
     return modifySelectors(({ className }) => {
       return `.group:hover .group-hover${separator}${className}`
@@ -38,9 +43,7 @@ export default function(config, { variantGenerators: pluginVariantGenerators }) 
         responsiveParent.append(atRule)
       }
 
-      atRule.before(atRule.clone().nodes)
-
-      _.forEach(_.without(variants, 'responsive'), variant => {
+      _.forEach(_.without(ensureIncludesDefault(variants), 'responsive'), variant => {
         variantGenerators[variant](atRule, config)
       })
 


### PR DESCRIPTION
This PR makes it possible for users to customize where the `default` (unaltered) variant for a utility is placed in the final CSS relative to other variants generated for that utility.

This is done by explicitly specifying `default` in the variant list if you want the default variant to be placed anywhere other than first in the list.

For example, this CSS:

```css
@variants focus, default, hover {
  .order-2 {
    order: 2
  }
}
```

...will generate this output:

```css
.focus\:order-2:focus {
  order: 2
}

.order-2 {
  order: 2
}

.hover\:order-2:hover {
  order: 2
}
```

If the `default` variant is not specified in the list, the default variant will be invisibly prepended to the variants list, ensuring that the default variant is always rendered first.

This feature is useful in situations where you want to create a custom variant that should still be overridable by a default variant when necessary, like outlined by @benface here:

https://github.com/tailwindcss/tailwindcss/issues/496#issuecomment-399441184