### PR TITLE
Rename roman to not-italic

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -5737,7 +5737,7 @@ table {
   font-style: italic !important;
 }
 
-.roman {
+.not-italic {
   font-style: normal !important;
 }
 
@@ -5745,7 +5745,7 @@ table {
   font-style: italic !important;
 }
 
-.hover\:roman:hover {
+.hover\:not-italic:hover {
   font-style: normal !important;
 }
 
@@ -5753,7 +5753,7 @@ table {
   font-style: italic !important;
 }
 
-.focus\:roman:focus {
+.focus\:not-italic:focus {
   font-style: normal !important;
 }
 
@@ -11322,7 +11322,7 @@ table {
     font-style: italic !important;
   }
 
-  .sm\:roman {
+  .sm\:not-italic {
     font-style: normal !important;
   }
 
@@ -11330,7 +11330,7 @@ table {
     font-style: italic !important;
   }
 
-  .sm\:hover\:roman:hover {
+  .sm\:hover\:not-italic:hover {
     font-style: normal !important;
   }
 
@@ -11338,7 +11338,7 @@ table {
     font-style: italic !important;
   }
 
-  .sm\:focus\:roman:focus {
+  .sm\:focus\:not-italic:focus {
     font-style: normal !important;
   }
 
@@ -16908,7 +16908,7 @@ table {
     font-style: italic !important;
   }
 
-  .md\:roman {
+  .md\:not-italic {
     font-style: normal !important;
   }
 
@@ -16916,7 +16916,7 @@ table {
     font-style: italic !important;
   }
 
-  .md\:hover\:roman:hover {
+  .md\:hover\:not-italic:hover {
     font-style: normal !important;
   }
 
@@ -16924,7 +16924,7 @@ table {
     font-style: italic !important;
   }
 
-  .md\:focus\:roman:focus {
+  .md\:focus\:not-italic:focus {
     font-style: normal !important;
   }
 
@@ -22494,7 +22494,7 @@ table {
     font-style: italic !important;
   }
 
-  .lg\:roman {
+  .lg\:not-italic {
     font-style: normal !important;
   }
 
@@ -22502,7 +22502,7 @@ table {
     font-style: italic !important;
   }
 
-  .lg\:hover\:roman:hover {
+  .lg\:hover\:not-italic:hover {
     font-style: normal !important;
   }
 
@@ -22510,7 +22510,7 @@ table {
     font-style: italic !important;
   }
 
-  .lg\:focus\:roman:focus {
+  .lg\:focus\:not-italic:focus {
     font-style: normal !important;
   }
 
@@ -28080,7 +28080,7 @@ table {
     font-style: italic !important;
   }
 
-  .xl\:roman {
+  .xl\:not-italic {
     font-style: normal !important;
   }
 
@@ -28088,7 +28088,7 @@ table {
     font-style: italic !important;
   }
 
-  .xl\:hover\:roman:hover {
+  .xl\:hover\:not-italic:hover {
     font-style: normal !important;
   }
 
@@ -28096,7 +28096,7 @@ table {
     font-style: italic !important;
   }
 
-  .xl\:focus\:roman:focus {
+  .xl\:focus\:not-italic:focus {
     font-style: normal !important;
   }
 

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -5737,7 +5737,7 @@ table {
   font-style: italic;
 }
 
-.roman {
+.not-italic {
   font-style: normal;
 }
 
@@ -5745,7 +5745,7 @@ table {
   font-style: italic;
 }
 
-.hover\:roman:hover {
+.hover\:not-italic:hover {
   font-style: normal;
 }
 
@@ -5753,7 +5753,7 @@ table {
   font-style: italic;
 }
 
-.focus\:roman:focus {
+.focus\:not-italic:focus {
   font-style: normal;
 }
 
@@ -11322,7 +11322,7 @@ table {
     font-style: italic;
   }
 
-  .sm\:roman {
+  .sm\:not-italic {
     font-style: normal;
   }
 
@@ -11330,7 +11330,7 @@ table {
     font-style: italic;
   }
 
-  .sm\:hover\:roman:hover {
+  .sm\:hover\:not-italic:hover {
     font-style: normal;
   }
 
@@ -11338,7 +11338,7 @@ table {
     font-style: italic;
   }
 
-  .sm\:focus\:roman:focus {
+  .sm\:focus\:not-italic:focus {
     font-style: normal;
   }
 
@@ -16908,7 +16908,7 @@ table {
     font-style: italic;
   }
 
-  .md\:roman {
+  .md\:not-italic {
     font-style: normal;
   }
 
@@ -16916,7 +16916,7 @@ table {
     font-style: italic;
   }
 
-  .md\:hover\:roman:hover {
+  .md\:hover\:not-italic:hover {
     font-style: normal;
   }
 
@@ -16924,7 +16924,7 @@ table {
     font-style: italic;
   }
 
-  .md\:focus\:roman:focus {
+  .md\:focus\:not-italic:focus {
     font-style: normal;
   }
 
@@ -22494,7 +22494,7 @@ table {
     font-style: italic;
   }
 
-  .lg\:roman {
+  .lg\:not-italic {
     font-style: normal;
   }
 
@@ -22502,7 +22502,7 @@ table {
     font-style: italic;
   }
 
-  .lg\:hover\:roman:hover {
+  .lg\:hover\:not-italic:hover {
     font-style: normal;
   }
 
@@ -22510,7 +22510,7 @@ table {
     font-style: italic;
   }
 
-  .lg\:focus\:roman:focus {
+  .lg\:focus\:not-italic:focus {
     font-style: normal;
   }
 
@@ -28080,7 +28080,7 @@ table {
     font-style: italic;
   }
 
-  .xl\:roman {
+  .xl\:not-italic {
     font-style: normal;
   }
 
@@ -28088,7 +28088,7 @@ table {
     font-style: italic;
   }
 
-  .xl\:hover\:roman:hover {
+  .xl\:hover\:not-italic:hover {
     font-style: normal;
   }
 
@@ -28096,7 +28096,7 @@ table {
     font-style: italic;
   }
 
-  .xl\:focus\:roman:focus {
+  .xl\:focus\:not-italic:focus {
     font-style: normal;
   }
 

--- a/src/plugins/fontStyle.js
+++ b/src/plugins/fontStyle.js
@@ -3,7 +3,7 @@ export default function({ variants }) {
     addUtilities(
       {
         '.italic': { 'font-style': 'italic' },
-        '.roman': { 'font-style': 'normal' },
+        '.not-italic': { 'font-style': 'normal' },
       },
       variants
     )


### PR DESCRIPTION
I made this same change way back in [v0.5.0](https://github.com/tailwindcss/tailwindcss/releases?after=v0.6.2#roman-renamed-to-not-italic) but had to revert it due to a bug in [postcss-selector-not](https://github.com/postcss/postcss-selector-not/issues/10) that made it impossible for people to use Tailwind with that plugin becuase of classes like `sm:not-italic` being interpreted as containing a `:not` pseudo-selector.

That has since been fixed, and [postcss-preset-env](https://github.com/csstools/postcss-preset-env) (the library most people would be transitively depending on postcss-selector-not from) has been tagged to use the fixed version, so I think (especially for 1.0) that it is safe to finally make this change.