### PR TITLE
Rename leading-* to lh-* and use numeric scale

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -3085,20 +3085,20 @@ table {
   height: 100vh !important;
 }
 
-.leading-none {
+.lh-1 {
   line-height: 1 !important;
 }
 
-.leading-tight {
+.lh-2 {
+  line-height: 2 !important;
+}
+
+.lh-1\.25 {
   line-height: 1.25 !important;
 }
 
-.leading-normal {
+.lh-1\.5 {
   line-height: 1.5 !important;
-}
-
-.leading-loose {
-  line-height: 2 !important;
 }
 
 .m-0 {
@@ -8686,20 +8686,20 @@ table {
     height: 100vh !important;
   }
 
-  .sm\:leading-none {
+  .sm\:lh-1 {
     line-height: 1 !important;
   }
 
-  .sm\:leading-tight {
+  .sm\:lh-2 {
+    line-height: 2 !important;
+  }
+
+  .sm\:lh-1\.25 {
     line-height: 1.25 !important;
   }
 
-  .sm\:leading-normal {
+  .sm\:lh-1\.5 {
     line-height: 1.5 !important;
-  }
-
-  .sm\:leading-loose {
-    line-height: 2 !important;
   }
 
   .sm\:m-0 {
@@ -14272,20 +14272,20 @@ table {
     height: 100vh !important;
   }
 
-  .md\:leading-none {
+  .md\:lh-1 {
     line-height: 1 !important;
   }
 
-  .md\:leading-tight {
+  .md\:lh-2 {
+    line-height: 2 !important;
+  }
+
+  .md\:lh-1\.25 {
     line-height: 1.25 !important;
   }
 
-  .md\:leading-normal {
+  .md\:lh-1\.5 {
     line-height: 1.5 !important;
-  }
-
-  .md\:leading-loose {
-    line-height: 2 !important;
   }
 
   .md\:m-0 {
@@ -19858,20 +19858,20 @@ table {
     height: 100vh !important;
   }
 
-  .lg\:leading-none {
+  .lg\:lh-1 {
     line-height: 1 !important;
   }
 
-  .lg\:leading-tight {
+  .lg\:lh-2 {
+    line-height: 2 !important;
+  }
+
+  .lg\:lh-1\.25 {
     line-height: 1.25 !important;
   }
 
-  .lg\:leading-normal {
+  .lg\:lh-1\.5 {
     line-height: 1.5 !important;
-  }
-
-  .lg\:leading-loose {
-    line-height: 2 !important;
   }
 
   .lg\:m-0 {
@@ -25444,20 +25444,20 @@ table {
     height: 100vh !important;
   }
 
-  .xl\:leading-none {
+  .xl\:lh-1 {
     line-height: 1 !important;
   }
 
-  .xl\:leading-tight {
+  .xl\:lh-2 {
+    line-height: 2 !important;
+  }
+
+  .xl\:lh-1\.25 {
     line-height: 1.25 !important;
   }
 
-  .xl\:leading-normal {
+  .xl\:lh-1\.5 {
     line-height: 1.5 !important;
-  }
-
-  .xl\:leading-loose {
-    line-height: 2 !important;
   }
 
   .xl\:m-0 {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3085,20 +3085,20 @@ table {
   height: 100vh;
 }
 
-.leading-none {
+.lh-1 {
   line-height: 1;
 }
 
-.leading-tight {
+.lh-2 {
+  line-height: 2;
+}
+
+.lh-1\.25 {
   line-height: 1.25;
 }
 
-.leading-normal {
+.lh-1\.5 {
   line-height: 1.5;
-}
-
-.leading-loose {
-  line-height: 2;
 }
 
 .m-0 {
@@ -8686,20 +8686,20 @@ table {
     height: 100vh;
   }
 
-  .sm\:leading-none {
+  .sm\:lh-1 {
     line-height: 1;
   }
 
-  .sm\:leading-tight {
+  .sm\:lh-2 {
+    line-height: 2;
+  }
+
+  .sm\:lh-1\.25 {
     line-height: 1.25;
   }
 
-  .sm\:leading-normal {
+  .sm\:lh-1\.5 {
     line-height: 1.5;
-  }
-
-  .sm\:leading-loose {
-    line-height: 2;
   }
 
   .sm\:m-0 {
@@ -14272,20 +14272,20 @@ table {
     height: 100vh;
   }
 
-  .md\:leading-none {
+  .md\:lh-1 {
     line-height: 1;
   }
 
-  .md\:leading-tight {
+  .md\:lh-2 {
+    line-height: 2;
+  }
+
+  .md\:lh-1\.25 {
     line-height: 1.25;
   }
 
-  .md\:leading-normal {
+  .md\:lh-1\.5 {
     line-height: 1.5;
-  }
-
-  .md\:leading-loose {
-    line-height: 2;
   }
 
   .md\:m-0 {
@@ -19858,20 +19858,20 @@ table {
     height: 100vh;
   }
 
-  .lg\:leading-none {
+  .lg\:lh-1 {
     line-height: 1;
   }
 
-  .lg\:leading-tight {
+  .lg\:lh-2 {
+    line-height: 2;
+  }
+
+  .lg\:lh-1\.25 {
     line-height: 1.25;
   }
 
-  .lg\:leading-normal {
+  .lg\:lh-1\.5 {
     line-height: 1.5;
-  }
-
-  .lg\:leading-loose {
-    line-height: 2;
   }
 
   .lg\:m-0 {
@@ -25444,20 +25444,20 @@ table {
     height: 100vh;
   }
 
-  .xl\:leading-none {
+  .xl\:lh-1 {
     line-height: 1;
   }
 
-  .xl\:leading-tight {
+  .xl\:lh-2 {
+    line-height: 2;
+  }
+
+  .xl\:lh-1\.25 {
     line-height: 1.25;
   }
 
-  .xl\:leading-normal {
+  .xl\:lh-1\.5 {
     line-height: 1.5;
-  }
-
-  .xl\:leading-loose {
-    line-height: 2;
   }
 
   .xl\:m-0 {

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -24,7 +24,7 @@ module.exports = {
     fontFamily: ['responsive'],
     fontWeight: ['responsive', 'hover', 'focus'],
     height: ['responsive'],
-    leading: ['responsive'],
+    lineHeight: ['responsive'],
     listStyle: ['responsive'],
     margin: ['responsive'],
     maxHeight: ['responsive'],

--- a/defaultTheme.js
+++ b/defaultTheme.js
@@ -159,11 +159,11 @@ module.exports = function() {
       extrabold: 800,
       black: 900,
     },
-    leading: {
-      none: 1,
-      tight: 1.25,
-      normal: 1.5,
-      loose: 2,
+    lineHeight: {
+      '1': 1,
+      '1.25': 1.25,
+      '1.5': 1.5,
+      '2': 2,
     },
     tracking: {
       tight: '-0.05em',

--- a/plugins/leading.js
+++ b/plugins/leading.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/leading').default

--- a/plugins/lineHeight.js
+++ b/plugins/lineHeight.js
@@ -1,0 +1,1 @@
+module.exports = require('../lib/plugins/lineHeight').default

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -18,7 +18,7 @@ import float from './plugins/float'
 import fontFamily from './plugins/fontFamily'
 import fontWeight from './plugins/fontWeight'
 import height from './plugins/height'
-import leading from './plugins/leading'
+import lineHeight from './plugins/lineHeight'
 import margin from './plugins/margin'
 import maxHeight from './plugins/maxHeight'
 import maxWidth from './plugins/maxWidth'
@@ -92,7 +92,7 @@ export default function(config) {
     fontFamily,
     fontWeight,
     height,
-    leading,
+    lineHeight,
     margin,
     maxHeight,
     maxWidth,

--- a/src/plugins/lineHeight.js
+++ b/src/plugins/lineHeight.js
@@ -5,7 +5,7 @@ export default function({ values, variants }) {
     const utilities = _.fromPairs(
       _.map(values, (value, modifier) => {
         return [
-          `.${e(`leading-${modifier}`)}`,
+          `.${e(`lh-${modifier}`)}`,
           {
             'line-height': value,
           },


### PR DESCRIPTION
This PR changes the name of our line-height classes from `leading-*` to `lh-*`.

| Old Class  | New Class |
| ------------- | ------------- |
| `leading-none`  | `lh-1`  |
| `leading-tight`  | `lh-1.25`  |
| `leading-normal`  | `lh-1.5`  |
| `leading-loose`  | `lh-2`  |

### Changing the class prefix

The primary motivation for this is to make the naming mirror the CSS property more closely, as leading is an unfamiliar term to many. I considered `line-height-*` and `line-h-*` as well, but based on a [Twitter poll](https://twitter.com/adamwathan/status/1096472738850426880) I ran, people preferred the `lh-*` abbreviation (and so do I).

I noticed GitHub uses this prefix in [Primer](https://styleguide.github.com/primer/utilities/typography/#line-height-styles) which also made me feel more comfortable with it, since in general they tend to use more verbose names than Tailwind.

### Switching to a numeric scale

One of the most annoying things about `leading-normal` to me is that on almost every project I work on, I set the default line-height to `leading-tight` right on the `<body>` tag. So my "normal" line-height is `tight`, and `leading-normal` isn't normal at all. I could change the value of `leading-normal` to be `1.25` on those projects, but then what name should I use for `1.5`?

On top of that, it's hard to introduce new values in the existing descriptive scale. Switching to a literal numeric scale makes that trivial.

In general, I don't think the descriptive scale is a useful abstraction in this case. Users can always add descriptive value if they like, like `lh-copy`, `lh-heading`, etc. but I think starting with literal values serves people better by default with no real downside.

### Changing the core plugin name

This PR also changes the core plugin name from `leading` to `lineHeight`, so line-height values would be customized by editing the `lineHeight` key in the theme section of your config, and variants would be customized by editing the `lineHeight` key in the variants section of your config. This is in line with #656 and along with the class name change, and makes these settings more easily guessable.