### PR TITLE
Rename tracking-* to letters-*

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -5871,15 +5871,15 @@ table {
   -moz-osx-font-smoothing: auto !important;
 }
 
-.tracking-tight {
+.letters-tight {
   letter-spacing: -0.05em !important;
 }
 
-.tracking-normal {
+.letters-normal {
   letter-spacing: 0 !important;
 }
 
-.tracking-wide {
+.letters-wide {
   letter-spacing: .05em !important;
 }
 
@@ -11456,15 +11456,15 @@ table {
     -moz-osx-font-smoothing: auto !important;
   }
 
-  .sm\:tracking-tight {
+  .sm\:letters-tight {
     letter-spacing: -0.05em !important;
   }
 
-  .sm\:tracking-normal {
+  .sm\:letters-normal {
     letter-spacing: 0 !important;
   }
 
-  .sm\:tracking-wide {
+  .sm\:letters-wide {
     letter-spacing: .05em !important;
   }
 
@@ -17042,15 +17042,15 @@ table {
     -moz-osx-font-smoothing: auto !important;
   }
 
-  .md\:tracking-tight {
+  .md\:letters-tight {
     letter-spacing: -0.05em !important;
   }
 
-  .md\:tracking-normal {
+  .md\:letters-normal {
     letter-spacing: 0 !important;
   }
 
-  .md\:tracking-wide {
+  .md\:letters-wide {
     letter-spacing: .05em !important;
   }
 
@@ -22628,15 +22628,15 @@ table {
     -moz-osx-font-smoothing: auto !important;
   }
 
-  .lg\:tracking-tight {
+  .lg\:letters-tight {
     letter-spacing: -0.05em !important;
   }
 
-  .lg\:tracking-normal {
+  .lg\:letters-normal {
     letter-spacing: 0 !important;
   }
 
-  .lg\:tracking-wide {
+  .lg\:letters-wide {
     letter-spacing: .05em !important;
   }
 
@@ -28214,15 +28214,15 @@ table {
     -moz-osx-font-smoothing: auto !important;
   }
 
-  .xl\:tracking-tight {
+  .xl\:letters-tight {
     letter-spacing: -0.05em !important;
   }
 
-  .xl\:tracking-normal {
+  .xl\:letters-normal {
     letter-spacing: 0 !important;
   }
 
-  .xl\:tracking-wide {
+  .xl\:letters-wide {
     letter-spacing: .05em !important;
   }
 

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -5871,15 +5871,15 @@ table {
   -moz-osx-font-smoothing: auto;
 }
 
-.tracking-tight {
+.letters-tight {
   letter-spacing: -0.05em;
 }
 
-.tracking-normal {
+.letters-normal {
   letter-spacing: 0;
 }
 
-.tracking-wide {
+.letters-wide {
   letter-spacing: .05em;
 }
 
@@ -11456,15 +11456,15 @@ table {
     -moz-osx-font-smoothing: auto;
   }
 
-  .sm\:tracking-tight {
+  .sm\:letters-tight {
     letter-spacing: -0.05em;
   }
 
-  .sm\:tracking-normal {
+  .sm\:letters-normal {
     letter-spacing: 0;
   }
 
-  .sm\:tracking-wide {
+  .sm\:letters-wide {
     letter-spacing: .05em;
   }
 
@@ -17042,15 +17042,15 @@ table {
     -moz-osx-font-smoothing: auto;
   }
 
-  .md\:tracking-tight {
+  .md\:letters-tight {
     letter-spacing: -0.05em;
   }
 
-  .md\:tracking-normal {
+  .md\:letters-normal {
     letter-spacing: 0;
   }
 
-  .md\:tracking-wide {
+  .md\:letters-wide {
     letter-spacing: .05em;
   }
 
@@ -22628,15 +22628,15 @@ table {
     -moz-osx-font-smoothing: auto;
   }
 
-  .lg\:tracking-tight {
+  .lg\:letters-tight {
     letter-spacing: -0.05em;
   }
 
-  .lg\:tracking-normal {
+  .lg\:letters-normal {
     letter-spacing: 0;
   }
 
-  .lg\:tracking-wide {
+  .lg\:letters-wide {
     letter-spacing: .05em;
   }
 
@@ -28214,15 +28214,15 @@ table {
     -moz-osx-font-smoothing: auto;
   }
 
-  .xl\:tracking-tight {
+  .xl\:letters-tight {
     letter-spacing: -0.05em;
   }
 
-  .xl\:tracking-normal {
+  .xl\:letters-normal {
     letter-spacing: 0;
   }
 
-  .xl\:tracking-wide {
+  .xl\:letters-wide {
     letter-spacing: .05em;
   }
 

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -52,7 +52,7 @@ module.exports = {
     textTransform: ['responsive', 'hover', 'focus'],
     textDecoration: ['responsive', 'hover', 'focus'],
     fontSmoothing: ['responsive', 'hover', 'focus'],
-    tracking: ['responsive'],
+    letterSpacing: ['responsive'],
     userSelect: ['responsive'],
     verticalAlign: ['responsive'],
     visibility: ['responsive'],

--- a/defaultTheme.js
+++ b/defaultTheme.js
@@ -165,7 +165,7 @@ module.exports = function() {
       normal: 1.5,
       loose: 2,
     },
-    tracking: {
+    letterSpacing: {
       tight: '-0.05em',
       normal: '0',
       wide: '0.05em',

--- a/plugins/letterSpacing.js
+++ b/plugins/letterSpacing.js
@@ -1,0 +1,1 @@
+module.exports = require('../lib/plugins/letterSpacing').default

--- a/plugins/tracking.js
+++ b/plugins/tracking.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/tracking').default

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -45,7 +45,7 @@ import fontStyle from './plugins/fontStyle'
 import textTransform from './plugins/textTransform'
 import textDecoration from './plugins/textDecoration'
 import fontSmoothing from './plugins/fontSmoothing'
-import tracking from './plugins/tracking'
+import letterSpacing from './plugins/letterSpacing'
 import userSelect from './plugins/userSelect'
 import verticalAlign from './plugins/verticalAlign'
 import visibility from './plugins/visibility'
@@ -119,7 +119,7 @@ export default function(config) {
     textTransform,
     textDecoration,
     fontSmoothing,
-    tracking,
+    letterSpacing,
     userSelect,
     verticalAlign,
     visibility,

--- a/src/plugins/letterSpacing.js
+++ b/src/plugins/letterSpacing.js
@@ -5,7 +5,7 @@ export default function({ values, variants }) {
     const utilities = _.fromPairs(
       _.map(values, (value, modifier) => {
         return [
-          `.tracking-${modifier}`,
+          `.letters-${modifier}`,
           {
             'letter-spacing': value,
           },


### PR DESCRIPTION
This PR changes the name of our letter-spacing classes from `tracking-*` to `letters-*`.

| Old Class  | New Class |
| ------------- | ------------- |
| `tracking-tight`  | `letters-tight`  |
| `tracking-normal`  | `letters-normal`  |
| `tracking-wide`  | `letters-wide`  |

The motivation for this is the same as in #664. "Tracking" is not as well known in the web development world as "letter spacing" and since the CSS property is `letter-spacing` anyways I think it makes sense to stay closer to that.

I considered `letter-spacing-*` and `ls-*` as potential names as well, but `letter-spacing-*` is too long and `ls-*` is a bit too cryptic, as unlike line-height it's not quite as commonly used and `ls-*` could also mean `list-style`.

I considered also switching to a numeric scale, but because of the negative values it's awkward (`letters--1` or `-letters-1`). Using descriptive names like `tight` and `wide` is better in my opinion, and if necessary could be expanded with `tightest`, `tighter`, `wider`, and `widest`, which should be plenty of options.

This PR also changes the core plugin name from `tracking` to `letterSpacing`, so letter-spacing values would be customized by editing the `letterSpacing` key in the theme section of your config, and variants would be customized by editing the `letterSpacing` key in the variants section of your config. This is in line with #656 and along with the class name change, and makes these settings more easily guessable.