### PR TITLE
Enable object fit/position plugins by default

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -4099,6 +4099,62 @@ table {
   margin-left: -1px !important;
 }
 
+.object-contain {
+  object-fit: contain !important;
+}
+
+.object-cover {
+  object-fit: cover !important;
+}
+
+.object-fill {
+  object-fit: fill !important;
+}
+
+.object-none {
+  object-fit: none !important;
+}
+
+.object-scale-down {
+  object-fit: scale-down !important;
+}
+
+.object-bottom {
+  object-position: bottom !important;
+}
+
+.object-center {
+  object-position: center !important;
+}
+
+.object-left {
+  object-position: left !important;
+}
+
+.object-left-bottom {
+  object-position: left bottom !important;
+}
+
+.object-left-top {
+  object-position: left top !important;
+}
+
+.object-right {
+  object-position: right !important;
+}
+
+.object-right-bottom {
+  object-position: right bottom !important;
+}
+
+.object-right-top {
+  object-position: right top !important;
+}
+
+.object-top {
+  object-position: top !important;
+}
+
 .opacity-0 {
   opacity: 0 !important;
 }
@@ -9700,6 +9756,62 @@ table {
     margin-left: -1px !important;
   }
 
+  .sm\:object-contain {
+    object-fit: contain !important;
+  }
+
+  .sm\:object-cover {
+    object-fit: cover !important;
+  }
+
+  .sm\:object-fill {
+    object-fit: fill !important;
+  }
+
+  .sm\:object-none {
+    object-fit: none !important;
+  }
+
+  .sm\:object-scale-down {
+    object-fit: scale-down !important;
+  }
+
+  .sm\:object-bottom {
+    object-position: bottom !important;
+  }
+
+  .sm\:object-center {
+    object-position: center !important;
+  }
+
+  .sm\:object-left {
+    object-position: left !important;
+  }
+
+  .sm\:object-left-bottom {
+    object-position: left bottom !important;
+  }
+
+  .sm\:object-left-top {
+    object-position: left top !important;
+  }
+
+  .sm\:object-right {
+    object-position: right !important;
+  }
+
+  .sm\:object-right-bottom {
+    object-position: right bottom !important;
+  }
+
+  .sm\:object-right-top {
+    object-position: right top !important;
+  }
+
+  .sm\:object-top {
+    object-position: top !important;
+  }
+
   .sm\:opacity-0 {
     opacity: 0 !important;
   }
@@ -15284,6 +15396,62 @@ table {
 
   .md\:-ml-px {
     margin-left: -1px !important;
+  }
+
+  .md\:object-contain {
+    object-fit: contain !important;
+  }
+
+  .md\:object-cover {
+    object-fit: cover !important;
+  }
+
+  .md\:object-fill {
+    object-fit: fill !important;
+  }
+
+  .md\:object-none {
+    object-fit: none !important;
+  }
+
+  .md\:object-scale-down {
+    object-fit: scale-down !important;
+  }
+
+  .md\:object-bottom {
+    object-position: bottom !important;
+  }
+
+  .md\:object-center {
+    object-position: center !important;
+  }
+
+  .md\:object-left {
+    object-position: left !important;
+  }
+
+  .md\:object-left-bottom {
+    object-position: left bottom !important;
+  }
+
+  .md\:object-left-top {
+    object-position: left top !important;
+  }
+
+  .md\:object-right {
+    object-position: right !important;
+  }
+
+  .md\:object-right-bottom {
+    object-position: right bottom !important;
+  }
+
+  .md\:object-right-top {
+    object-position: right top !important;
+  }
+
+  .md\:object-top {
+    object-position: top !important;
   }
 
   .md\:opacity-0 {
@@ -20872,6 +21040,62 @@ table {
     margin-left: -1px !important;
   }
 
+  .lg\:object-contain {
+    object-fit: contain !important;
+  }
+
+  .lg\:object-cover {
+    object-fit: cover !important;
+  }
+
+  .lg\:object-fill {
+    object-fit: fill !important;
+  }
+
+  .lg\:object-none {
+    object-fit: none !important;
+  }
+
+  .lg\:object-scale-down {
+    object-fit: scale-down !important;
+  }
+
+  .lg\:object-bottom {
+    object-position: bottom !important;
+  }
+
+  .lg\:object-center {
+    object-position: center !important;
+  }
+
+  .lg\:object-left {
+    object-position: left !important;
+  }
+
+  .lg\:object-left-bottom {
+    object-position: left bottom !important;
+  }
+
+  .lg\:object-left-top {
+    object-position: left top !important;
+  }
+
+  .lg\:object-right {
+    object-position: right !important;
+  }
+
+  .lg\:object-right-bottom {
+    object-position: right bottom !important;
+  }
+
+  .lg\:object-right-top {
+    object-position: right top !important;
+  }
+
+  .lg\:object-top {
+    object-position: top !important;
+  }
+
   .lg\:opacity-0 {
     opacity: 0 !important;
   }
@@ -26456,6 +26680,62 @@ table {
 
   .xl\:-ml-px {
     margin-left: -1px !important;
+  }
+
+  .xl\:object-contain {
+    object-fit: contain !important;
+  }
+
+  .xl\:object-cover {
+    object-fit: cover !important;
+  }
+
+  .xl\:object-fill {
+    object-fit: fill !important;
+  }
+
+  .xl\:object-none {
+    object-fit: none !important;
+  }
+
+  .xl\:object-scale-down {
+    object-fit: scale-down !important;
+  }
+
+  .xl\:object-bottom {
+    object-position: bottom !important;
+  }
+
+  .xl\:object-center {
+    object-position: center !important;
+  }
+
+  .xl\:object-left {
+    object-position: left !important;
+  }
+
+  .xl\:object-left-bottom {
+    object-position: left bottom !important;
+  }
+
+  .xl\:object-left-top {
+    object-position: left top !important;
+  }
+
+  .xl\:object-right {
+    object-position: right !important;
+  }
+
+  .xl\:object-right-bottom {
+    object-position: right bottom !important;
+  }
+
+  .xl\:object-right-top {
+    object-position: right top !important;
+  }
+
+  .xl\:object-top {
+    object-position: top !important;
   }
 
   .xl\:opacity-0 {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -4099,6 +4099,62 @@ table {
   margin-left: -1px;
 }
 
+.object-contain {
+  object-fit: contain;
+}
+
+.object-cover {
+  object-fit: cover;
+}
+
+.object-fill {
+  object-fit: fill;
+}
+
+.object-none {
+  object-fit: none;
+}
+
+.object-scale-down {
+  object-fit: scale-down;
+}
+
+.object-bottom {
+  object-position: bottom;
+}
+
+.object-center {
+  object-position: center;
+}
+
+.object-left {
+  object-position: left;
+}
+
+.object-left-bottom {
+  object-position: left bottom;
+}
+
+.object-left-top {
+  object-position: left top;
+}
+
+.object-right {
+  object-position: right;
+}
+
+.object-right-bottom {
+  object-position: right bottom;
+}
+
+.object-right-top {
+  object-position: right top;
+}
+
+.object-top {
+  object-position: top;
+}
+
 .opacity-0 {
   opacity: 0;
 }
@@ -9700,6 +9756,62 @@ table {
     margin-left: -1px;
   }
 
+  .sm\:object-contain {
+    object-fit: contain;
+  }
+
+  .sm\:object-cover {
+    object-fit: cover;
+  }
+
+  .sm\:object-fill {
+    object-fit: fill;
+  }
+
+  .sm\:object-none {
+    object-fit: none;
+  }
+
+  .sm\:object-scale-down {
+    object-fit: scale-down;
+  }
+
+  .sm\:object-bottom {
+    object-position: bottom;
+  }
+
+  .sm\:object-center {
+    object-position: center;
+  }
+
+  .sm\:object-left {
+    object-position: left;
+  }
+
+  .sm\:object-left-bottom {
+    object-position: left bottom;
+  }
+
+  .sm\:object-left-top {
+    object-position: left top;
+  }
+
+  .sm\:object-right {
+    object-position: right;
+  }
+
+  .sm\:object-right-bottom {
+    object-position: right bottom;
+  }
+
+  .sm\:object-right-top {
+    object-position: right top;
+  }
+
+  .sm\:object-top {
+    object-position: top;
+  }
+
   .sm\:opacity-0 {
     opacity: 0;
   }
@@ -15284,6 +15396,62 @@ table {
 
   .md\:-ml-px {
     margin-left: -1px;
+  }
+
+  .md\:object-contain {
+    object-fit: contain;
+  }
+
+  .md\:object-cover {
+    object-fit: cover;
+  }
+
+  .md\:object-fill {
+    object-fit: fill;
+  }
+
+  .md\:object-none {
+    object-fit: none;
+  }
+
+  .md\:object-scale-down {
+    object-fit: scale-down;
+  }
+
+  .md\:object-bottom {
+    object-position: bottom;
+  }
+
+  .md\:object-center {
+    object-position: center;
+  }
+
+  .md\:object-left {
+    object-position: left;
+  }
+
+  .md\:object-left-bottom {
+    object-position: left bottom;
+  }
+
+  .md\:object-left-top {
+    object-position: left top;
+  }
+
+  .md\:object-right {
+    object-position: right;
+  }
+
+  .md\:object-right-bottom {
+    object-position: right bottom;
+  }
+
+  .md\:object-right-top {
+    object-position: right top;
+  }
+
+  .md\:object-top {
+    object-position: top;
   }
 
   .md\:opacity-0 {
@@ -20872,6 +21040,62 @@ table {
     margin-left: -1px;
   }
 
+  .lg\:object-contain {
+    object-fit: contain;
+  }
+
+  .lg\:object-cover {
+    object-fit: cover;
+  }
+
+  .lg\:object-fill {
+    object-fit: fill;
+  }
+
+  .lg\:object-none {
+    object-fit: none;
+  }
+
+  .lg\:object-scale-down {
+    object-fit: scale-down;
+  }
+
+  .lg\:object-bottom {
+    object-position: bottom;
+  }
+
+  .lg\:object-center {
+    object-position: center;
+  }
+
+  .lg\:object-left {
+    object-position: left;
+  }
+
+  .lg\:object-left-bottom {
+    object-position: left bottom;
+  }
+
+  .lg\:object-left-top {
+    object-position: left top;
+  }
+
+  .lg\:object-right {
+    object-position: right;
+  }
+
+  .lg\:object-right-bottom {
+    object-position: right bottom;
+  }
+
+  .lg\:object-right-top {
+    object-position: right top;
+  }
+
+  .lg\:object-top {
+    object-position: top;
+  }
+
   .lg\:opacity-0 {
     opacity: 0;
   }
@@ -26456,6 +26680,62 @@ table {
 
   .xl\:-ml-px {
     margin-left: -1px;
+  }
+
+  .xl\:object-contain {
+    object-fit: contain;
+  }
+
+  .xl\:object-cover {
+    object-fit: cover;
+  }
+
+  .xl\:object-fill {
+    object-fit: fill;
+  }
+
+  .xl\:object-none {
+    object-fit: none;
+  }
+
+  .xl\:object-scale-down {
+    object-fit: scale-down;
+  }
+
+  .xl\:object-bottom {
+    object-position: bottom;
+  }
+
+  .xl\:object-center {
+    object-position: center;
+  }
+
+  .xl\:object-left {
+    object-position: left;
+  }
+
+  .xl\:object-left-bottom {
+    object-position: left bottom;
+  }
+
+  .xl\:object-left-top {
+    object-position: left top;
+  }
+
+  .xl\:object-right {
+    object-position: right;
+  }
+
+  .xl\:object-right-bottom {
+    object-position: right bottom;
+  }
+
+  .xl\:object-right-top {
+    object-position: right top;
+  }
+
+  .xl\:object-top {
+    object-position: top;
   }
 
   .xl\:opacity-0 {

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -32,8 +32,8 @@ module.exports = {
     minHeight: ['responsive'],
     minWidth: ['responsive'],
     negativeMargin: ['responsive'],
-    objectFit: [],
-    objectPosition: [],
+    objectFit: ['responsive'],
+    objectPosition: ['responsive'],
     opacity: ['responsive'],
     outline: ['focus'],
     overflow: ['responsive'],
@@ -61,8 +61,6 @@ module.exports = {
     zIndex: ['responsive'],
   },
   corePlugins: {
-    objectFit: false,
-    objectPosition: false,
   },
   plugins: [
     require('./plugins/container')({


### PR DESCRIPTION
In 0.x both of these plugins are disabled by default due to a lack of IE 11 support, but I think I'm comfortable enabling them for 1.0 in spite of that (as well as the small increase in file size.)

In the future I want to explore using [caniuse-api](https://github.com/Nyalab/caniuse-api) to automatically disable/enable certain features based on your required browser support in your `browserlist` config 👍 

(since I am loosening my attitude on not including features that don't have IE 11 support you might also see some CSS Grid stuff shortly after 1.0 👀 )