### PR TITLE
Add snug and relaxed line-heights

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -3093,8 +3093,16 @@ table {
   line-height: 1.25 !important;
 }
 
+.leading-snug {
+  line-height: 1.375 !important;
+}
+
 .leading-normal {
   line-height: 1.5 !important;
+}
+
+.leading-relaxed {
+  line-height: 1.625 !important;
 }
 
 .leading-loose {
@@ -8750,8 +8758,16 @@ table {
     line-height: 1.25 !important;
   }
 
+  .sm\:leading-snug {
+    line-height: 1.375 !important;
+  }
+
   .sm\:leading-normal {
     line-height: 1.5 !important;
+  }
+
+  .sm\:leading-relaxed {
+    line-height: 1.625 !important;
   }
 
   .sm\:leading-loose {
@@ -14392,8 +14408,16 @@ table {
     line-height: 1.25 !important;
   }
 
+  .md\:leading-snug {
+    line-height: 1.375 !important;
+  }
+
   .md\:leading-normal {
     line-height: 1.5 !important;
+  }
+
+  .md\:leading-relaxed {
+    line-height: 1.625 !important;
   }
 
   .md\:leading-loose {
@@ -20034,8 +20058,16 @@ table {
     line-height: 1.25 !important;
   }
 
+  .lg\:leading-snug {
+    line-height: 1.375 !important;
+  }
+
   .lg\:leading-normal {
     line-height: 1.5 !important;
+  }
+
+  .lg\:leading-relaxed {
+    line-height: 1.625 !important;
   }
 
   .lg\:leading-loose {
@@ -25676,8 +25708,16 @@ table {
     line-height: 1.25 !important;
   }
 
+  .xl\:leading-snug {
+    line-height: 1.375 !important;
+  }
+
   .xl\:leading-normal {
     line-height: 1.5 !important;
+  }
+
+  .xl\:leading-relaxed {
+    line-height: 1.625 !important;
   }
 
   .xl\:leading-loose {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3093,8 +3093,16 @@ table {
   line-height: 1.25;
 }
 
+.leading-snug {
+  line-height: 1.375;
+}
+
 .leading-normal {
   line-height: 1.5;
+}
+
+.leading-relaxed {
+  line-height: 1.625;
 }
 
 .leading-loose {
@@ -8750,8 +8758,16 @@ table {
     line-height: 1.25;
   }
 
+  .sm\:leading-snug {
+    line-height: 1.375;
+  }
+
   .sm\:leading-normal {
     line-height: 1.5;
+  }
+
+  .sm\:leading-relaxed {
+    line-height: 1.625;
   }
 
   .sm\:leading-loose {
@@ -14392,8 +14408,16 @@ table {
     line-height: 1.25;
   }
 
+  .md\:leading-snug {
+    line-height: 1.375;
+  }
+
   .md\:leading-normal {
     line-height: 1.5;
+  }
+
+  .md\:leading-relaxed {
+    line-height: 1.625;
   }
 
   .md\:leading-loose {
@@ -20034,8 +20058,16 @@ table {
     line-height: 1.25;
   }
 
+  .lg\:leading-snug {
+    line-height: 1.375;
+  }
+
   .lg\:leading-normal {
     line-height: 1.5;
+  }
+
+  .lg\:leading-relaxed {
+    line-height: 1.625;
   }
 
   .lg\:leading-loose {
@@ -25676,8 +25708,16 @@ table {
     line-height: 1.25;
   }
 
+  .xl\:leading-snug {
+    line-height: 1.375;
+  }
+
   .xl\:leading-normal {
     line-height: 1.5;
+  }
+
+  .xl\:leading-relaxed {
+    line-height: 1.625;
   }
 
   .xl\:leading-loose {

--- a/defaultTheme.js
+++ b/defaultTheme.js
@@ -162,7 +162,9 @@ module.exports = function() {
     lineHeight: {
       none: 1,
       tight: 1.25,
+      snug: 1.375,
       normal: 1.5,
+      relaxed: 1.625,
       loose: 2,
     },
     letterSpacing: {


### PR DESCRIPTION
This PR adds two new line-height values:

```diff
  lineHeight: {
    none: 1,
    tight: 1.25,
+   snug: 1.375,
    normal: 1.5,
+   relaxed: 1.625,
    loose: 2,
  },
```

The `snug` value is useful for larger text that is still laid out in a paragraph-ish style, like the "Got creative ideas? ..." text on the Framer home page:

![image](https://user-images.githubusercontent.com/4323180/53135116-00de5900-3548-11e9-9391-f72d58e1facb.png)

The `relaxed` value is useful for smaller paragraph text, close to what sites like Medium use for long form writing:

![image](https://user-images.githubusercontent.com/4323180/53135473-51a28180-3549-11e9-9cc4-c8fa8d150e45.png)

None of the existing values have been renamed or changed so this isn't a breaking change 👍 
