### PR TITLE
Add new word-break utilities

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -6019,12 +6019,20 @@ table {
   white-space: pre-wrap !important;
 }
 
-.break-words {
-  word-wrap: break-word !important;
+.wrap-break {
+  overflow-wrap: break-word !important;
+}
+
+.wrap-normal {
+  overflow-wrap: normal !important;
 }
 
 .break-normal {
-  word-wrap: normal !important;
+  word-break: normal !important;
+}
+
+.break-all {
+  word-break: break-all !important;
 }
 
 .truncate {
@@ -11680,12 +11688,20 @@ table {
     white-space: pre-wrap !important;
   }
 
-  .sm\:break-words {
-    word-wrap: break-word !important;
+  .sm\:wrap-break {
+    overflow-wrap: break-word !important;
+  }
+
+  .sm\:wrap-normal {
+    overflow-wrap: normal !important;
   }
 
   .sm\:break-normal {
-    word-wrap: normal !important;
+    word-break: normal !important;
+  }
+
+  .sm\:break-all {
+    word-break: break-all !important;
   }
 
   .sm\:truncate {
@@ -17342,12 +17358,20 @@ table {
     white-space: pre-wrap !important;
   }
 
-  .md\:break-words {
-    word-wrap: break-word !important;
+  .md\:wrap-break {
+    overflow-wrap: break-word !important;
+  }
+
+  .md\:wrap-normal {
+    overflow-wrap: normal !important;
   }
 
   .md\:break-normal {
-    word-wrap: normal !important;
+    word-break: normal !important;
+  }
+
+  .md\:break-all {
+    word-break: break-all !important;
   }
 
   .md\:truncate {
@@ -23004,12 +23028,20 @@ table {
     white-space: pre-wrap !important;
   }
 
-  .lg\:break-words {
-    word-wrap: break-word !important;
+  .lg\:wrap-break {
+    overflow-wrap: break-word !important;
+  }
+
+  .lg\:wrap-normal {
+    overflow-wrap: normal !important;
   }
 
   .lg\:break-normal {
-    word-wrap: normal !important;
+    word-break: normal !important;
+  }
+
+  .lg\:break-all {
+    word-break: break-all !important;
   }
 
   .lg\:truncate {
@@ -28666,12 +28698,20 @@ table {
     white-space: pre-wrap !important;
   }
 
-  .xl\:break-words {
-    word-wrap: break-word !important;
+  .xl\:wrap-break {
+    overflow-wrap: break-word !important;
+  }
+
+  .xl\:wrap-normal {
+    overflow-wrap: normal !important;
   }
 
   .xl\:break-normal {
-    word-wrap: normal !important;
+    word-break: normal !important;
+  }
+
+  .xl\:break-all {
+    word-break: break-all !important;
   }
 
   .xl\:truncate {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -6019,12 +6019,20 @@ table {
   white-space: pre-wrap;
 }
 
-.break-words {
-  word-wrap: break-word;
+.wrap-break {
+  overflow-wrap: break-word;
+}
+
+.wrap-normal {
+  overflow-wrap: normal;
 }
 
 .break-normal {
-  word-wrap: normal;
+  word-break: normal;
+}
+
+.break-all {
+  word-break: break-all;
 }
 
 .truncate {
@@ -11680,12 +11688,20 @@ table {
     white-space: pre-wrap;
   }
 
-  .sm\:break-words {
-    word-wrap: break-word;
+  .sm\:wrap-break {
+    overflow-wrap: break-word;
+  }
+
+  .sm\:wrap-normal {
+    overflow-wrap: normal;
   }
 
   .sm\:break-normal {
-    word-wrap: normal;
+    word-break: normal;
+  }
+
+  .sm\:break-all {
+    word-break: break-all;
   }
 
   .sm\:truncate {
@@ -17342,12 +17358,20 @@ table {
     white-space: pre-wrap;
   }
 
-  .md\:break-words {
-    word-wrap: break-word;
+  .md\:wrap-break {
+    overflow-wrap: break-word;
+  }
+
+  .md\:wrap-normal {
+    overflow-wrap: normal;
   }
 
   .md\:break-normal {
-    word-wrap: normal;
+    word-break: normal;
+  }
+
+  .md\:break-all {
+    word-break: break-all;
   }
 
   .md\:truncate {
@@ -23004,12 +23028,20 @@ table {
     white-space: pre-wrap;
   }
 
-  .lg\:break-words {
-    word-wrap: break-word;
+  .lg\:wrap-break {
+    overflow-wrap: break-word;
+  }
+
+  .lg\:wrap-normal {
+    overflow-wrap: normal;
   }
 
   .lg\:break-normal {
-    word-wrap: normal;
+    word-break: normal;
+  }
+
+  .lg\:break-all {
+    word-break: break-all;
   }
 
   .lg\:truncate {
@@ -28666,12 +28698,20 @@ table {
     white-space: pre-wrap;
   }
 
-  .xl\:break-words {
-    word-wrap: break-word;
+  .xl\:wrap-break {
+    overflow-wrap: break-word;
+  }
+
+  .xl\:wrap-normal {
+    overflow-wrap: normal;
   }
 
   .xl\:break-normal {
-    word-wrap: normal;
+    word-break: normal;
+  }
+
+  .xl\:break-all {
+    word-break: break-all;
   }
 
   .xl\:truncate {

--- a/src/plugins/whitespace.js
+++ b/src/plugins/whitespace.js
@@ -8,8 +8,11 @@ export default function({ variants }) {
         '.whitespace-pre-line': { 'white-space': 'pre-line' },
         '.whitespace-pre-wrap': { 'white-space': 'pre-wrap' },
 
-        '.break-words': { 'word-wrap': 'break-word' },
-        '.break-normal': { 'word-wrap': 'normal' },
+        '.wrap-break': { 'overflow-wrap': 'break-word' },
+        '.wrap-normal': { 'overflow-wrap': 'normal' },
+
+        '.break-normal': { 'word-break': 'normal' },
+        '.break-all': { 'word-break': 'break-all' },
 
         '.truncate': {
           overflow: 'hidden',


### PR DESCRIPTION
This PR introduces a **BREAKING CHANGE** for 1.0:
- Changes `word-wrap` to `overflow-wrap` to better match the [spec](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap)
- Renames `.break-words` to `.wrap-break`
- Renames `.break-normal` to `.wrap-normal`
- Adds `.break-normal` and  `.break-all` to set and element's `word-break` properties

Closes #411. Closes #571.