### PR TITLE
Update default breakpoints

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -482,9 +482,9 @@ table {
   width: 100%;
 }
 
-@media (min-width: 576px) {
+@media (min-width: 568px) {
   .container {
-    max-width: 576px;
+    max-width: 568px;
   }
 }
 
@@ -494,15 +494,15 @@ table {
   }
 }
 
-@media (min-width: 992px) {
+@media (min-width: 1024px) {
   .container {
-    max-width: 992px;
+    max-width: 1024px;
   }
 }
 
-@media (min-width: 1200px) {
+@media (min-width: 1280px) {
   .container {
-    max-width: 1200px;
+    max-width: 1280px;
   }
 }
 
@@ -6198,7 +6198,7 @@ table {
   color: #e3342f;
 }
 
-@media (min-width: 576px) {
+@media (min-width: 568px) {
   .sm\:list-reset {
     list-style: none !important;
     padding: 0 !important;
@@ -17538,7 +17538,7 @@ table {
   }
 }
 
-@media (min-width: 992px) {
+@media (min-width: 1024px) {
   .lg\:list-reset {
     list-style: none !important;
     padding: 0 !important;
@@ -23208,7 +23208,7 @@ table {
   }
 }
 
-@media (min-width: 1200px) {
+@media (min-width: 1280px) {
   .xl\:list-reset {
     list-style: none !important;
     padding: 0 !important;

--- a/__tests__/fixtures/tailwind-output-with-explicit-screen-utilities.css
+++ b/__tests__/fixtures/tailwind-output-with-explicit-screen-utilities.css
@@ -2,7 +2,7 @@
   color: red;
 }
 
-@media (min-width: 576px) {
+@media (min-width: 568px) {
   .sm\:example {
     color: red;
   }
@@ -14,13 +14,13 @@
   }
 }
 
-@media (min-width: 992px) {
+@media (min-width: 1024px) {
   .lg\:example {
     color: red;
   }
 }
 
-@media (min-width: 1200px) {
+@media (min-width: 1280px) {
   .xl\:example {
     color: red;
   }

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -482,9 +482,9 @@ table {
   width: 100%;
 }
 
-@media (min-width: 576px) {
+@media (min-width: 568px) {
   .container {
-    max-width: 576px;
+    max-width: 568px;
   }
 }
 
@@ -494,15 +494,15 @@ table {
   }
 }
 
-@media (min-width: 992px) {
+@media (min-width: 1024px) {
   .container {
-    max-width: 992px;
+    max-width: 1024px;
   }
 }
 
-@media (min-width: 1200px) {
+@media (min-width: 1280px) {
   .container {
-    max-width: 1200px;
+    max-width: 1280px;
   }
 }
 
@@ -6198,7 +6198,7 @@ table {
   color: #e3342f;
 }
 
-@media (min-width: 576px) {
+@media (min-width: 568px) {
   .sm\:list-reset {
     list-style: none;
     padding: 0;
@@ -17538,7 +17538,7 @@ table {
   }
 }
 
-@media (min-width: 992px) {
+@media (min-width: 1024px) {
   .lg\:list-reset {
     list-style: none;
     padding: 0;
@@ -23208,7 +23208,7 @@ table {
   }
 }
 
-@media (min-width: 1200px) {
+@media (min-width: 1280px) {
   .xl\:list-reset {
     list-style: none;
     padding: 0;

--- a/defaultTheme.js
+++ b/defaultTheme.js
@@ -103,10 +103,10 @@ module.exports = function() {
       '32': '8rem',
     },
     screens: {
-      sm: '576px',
+      sm: '568px',
       md: '768px',
-      lg: '992px',
-      xl: '1200px',
+      lg: '1024px',
+      xl: '1280px',
     },
     fontFamily: {
       sans: [


### PR DESCRIPTION
This PR changes the default breakpoints to the following values:

```diff
  screens: {
-   sm: '576px',
+   sm: '568px',

    md: '768px',

-   lg: '992px',
+   lg: '1024px',

-   xl: '1200px',
+   xl: '1280px',
  },
```

Prior to this, our breakpoints were taken from Bootstrap and as far as I can tell, the values chosen are fairly arbitrary. This PR changes each breakpoint to the nearest value that matches a common device resolution.

576 becomes 568, which is the height of an iPhone SE/iPod Touch. Prior to this change, using an iPhone SE in landscape mode would not trigger the `sm` breakpoint, but now it would. Feels like a nice improvement to me as I hate switching my phone to landscape in hopes of getting a slightly less stacked layout only to see that I'm still in the same breakpoint.

768 is unchanged, as it's a very common width for iPads.

992 becomes 1024, which is a common height for iPads, as well as the width of the 12.9" iPad Pro.

1200 becomes 1280, which is the width of a 13" MacBook Pro.

These changes aren't radical and won't affect existing sites that have their own `screens` config (and of course are still completely customizable), but at least there is some reasonable rationale for these values.