### PR TITLE
Simplify repository configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "style": "dist/tailwind.css",
-  "repository": "https://github.com/tailwindcss/tailwindcss.git",
-  "bugs": "https://github.com/tailwindcss/tailwindcss/issues",
+  "repository": "tailwindcss/tailwindcss",
   "homepage": "https://tailwindcss.com",
   "bin": {
     "tailwind": "lib/cli.js"


### PR DESCRIPTION
This pull request simplifies the `package.json` configuration.

**Repository:**
npm uses GitHub as the default provider for the [repository configuration](https://docs.npmjs.com/files/package.json#repository) which makes it possible to specify only the vendor/organisation and package name.

**Bugs:**
npm is smart enough to automagically send the user to the repository's issues list using the npm bugs command.