### PR TITLE
Don't export core plugins

### DIFF
--- a/plugins/appearance.js
+++ b/plugins/appearance.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/appearance').default

--- a/plugins/backgroundAttachment.js
+++ b/plugins/backgroundAttachment.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/backgroundAttachment').default

--- a/plugins/backgroundColor.js
+++ b/plugins/backgroundColor.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/backgroundColor').default

--- a/plugins/backgroundPosition.js
+++ b/plugins/backgroundPosition.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/backgroundPosition').default

--- a/plugins/backgroundRepeat.js
+++ b/plugins/backgroundRepeat.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/backgroundRepeat').default

--- a/plugins/backgroundSize.js
+++ b/plugins/backgroundSize.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/backgroundSize').default

--- a/plugins/borderCollapse.js
+++ b/plugins/borderCollapse.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/borderCollapse').default

--- a/plugins/borderColor.js
+++ b/plugins/borderColor.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/borderColor').default

--- a/plugins/borderRadius.js
+++ b/plugins/borderRadius.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/borderRadius').default

--- a/plugins/borderStyle.js
+++ b/plugins/borderStyle.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/borderStyle').default

--- a/plugins/borderWidth.js
+++ b/plugins/borderWidth.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/borderWidth').default

--- a/plugins/boxShadow.js
+++ b/plugins/boxShadow.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/boxShadow').default

--- a/plugins/cursor.js
+++ b/plugins/cursor.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/cursor').default

--- a/plugins/display.js
+++ b/plugins/display.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/display').default

--- a/plugins/fill.js
+++ b/plugins/fill.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/fill').default

--- a/plugins/flexbox.js
+++ b/plugins/flexbox.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/flexbox').default

--- a/plugins/float.js
+++ b/plugins/float.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/float').default

--- a/plugins/fontFamily.js
+++ b/plugins/fontFamily.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/fontFamily').default

--- a/plugins/fontSize.js
+++ b/plugins/fontSize.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/fontSize').default

--- a/plugins/fontSmoothing.js
+++ b/plugins/fontSmoothing.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/fontSmoothing').default

--- a/plugins/fontStyle.js
+++ b/plugins/fontStyle.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/fontStyle').default

--- a/plugins/fontWeight.js
+++ b/plugins/fontWeight.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/fontWeight').default

--- a/plugins/height.js
+++ b/plugins/height.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/height').default

--- a/plugins/letterSpacing.js
+++ b/plugins/letterSpacing.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/letterSpacing').default

--- a/plugins/lineHeight.js
+++ b/plugins/lineHeight.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/lineHeight').default

--- a/plugins/listStyle.js
+++ b/plugins/listStyle.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/listStyle').default

--- a/plugins/margin.js
+++ b/plugins/margin.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/margin').default

--- a/plugins/maxHeight.js
+++ b/plugins/maxHeight.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/maxHeight').default

--- a/plugins/maxWidth.js
+++ b/plugins/maxWidth.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/maxWidth').default

--- a/plugins/minHeight.js
+++ b/plugins/minHeight.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/minHeight').default

--- a/plugins/minWidth.js
+++ b/plugins/minWidth.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/minWidth').default

--- a/plugins/negativeMargin.js
+++ b/plugins/negativeMargin.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/negativeMargin').default

--- a/plugins/objectFit.js
+++ b/plugins/objectFit.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/objectFit').default

--- a/plugins/objectPosition.js
+++ b/plugins/objectPosition.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/objectPosition').default

--- a/plugins/opacity.js
+++ b/plugins/opacity.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/opacity').default

--- a/plugins/outline.js
+++ b/plugins/outline.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/outline').default

--- a/plugins/overflow.js
+++ b/plugins/overflow.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/overflow').default

--- a/plugins/padding.js
+++ b/plugins/padding.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/padding').default

--- a/plugins/pointerEvents.js
+++ b/plugins/pointerEvents.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/pointerEvents').default

--- a/plugins/position.js
+++ b/plugins/position.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/position').default

--- a/plugins/preflight.js
+++ b/plugins/preflight.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/preflight').default

--- a/plugins/resize.js
+++ b/plugins/resize.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/resize').default

--- a/plugins/stroke.js
+++ b/plugins/stroke.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/stroke').default

--- a/plugins/tableLayout.js
+++ b/plugins/tableLayout.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/tableLayout').default

--- a/plugins/textAlign.js
+++ b/plugins/textAlign.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/textAlign').default

--- a/plugins/textColor.js
+++ b/plugins/textColor.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/textColor').default

--- a/plugins/textDecoration.js
+++ b/plugins/textDecoration.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/textDecoration').default

--- a/plugins/textTransform.js
+++ b/plugins/textTransform.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/textTransform').default

--- a/plugins/userSelect.js
+++ b/plugins/userSelect.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/userSelect').default

--- a/plugins/verticalAlign.js
+++ b/plugins/verticalAlign.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/verticalAlign').default

--- a/plugins/visibility.js
+++ b/plugins/visibility.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/visibility').default

--- a/plugins/whitespace.js
+++ b/plugins/whitespace.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/whitespace').default

--- a/plugins/width.js
+++ b/plugins/width.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/width').default

--- a/plugins/zIndex.js
+++ b/plugins/zIndex.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/zIndex').default


### PR DESCRIPTION
Originally I thought this would be useful in case someone disabled a core plugin and wanted to use it as if it were a third-party plugin so that they could override configuration, but none of those configuration options even exist, so YAGNI. Can always do this later if it would actually be useful, right now it's a huge pain in the ass.