### PR TITLE
Split flexbox plugin into multiple plugins

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -2851,16 +2851,16 @@ table {
   flex: none !important;
 }
 
+.flex-grow-0 {
+  flex-grow: 0 !important;
+}
+
 .flex-grow {
   flex-grow: 1 !important;
 }
 
 .flex-shrink {
   flex-shrink: 1 !important;
-}
-
-.flex-grow-0 {
-  flex-grow: 0 !important;
 }
 
 .flex-shrink-0 {
@@ -8536,16 +8536,16 @@ table {
     flex: none !important;
   }
 
+  .sm\:flex-grow-0 {
+    flex-grow: 0 !important;
+  }
+
   .sm\:flex-grow {
     flex-grow: 1 !important;
   }
 
   .sm\:flex-shrink {
     flex-shrink: 1 !important;
-  }
-
-  .sm\:flex-grow-0 {
-    flex-grow: 0 !important;
   }
 
   .sm\:flex-shrink-0 {
@@ -14206,16 +14206,16 @@ table {
     flex: none !important;
   }
 
+  .md\:flex-grow-0 {
+    flex-grow: 0 !important;
+  }
+
   .md\:flex-grow {
     flex-grow: 1 !important;
   }
 
   .md\:flex-shrink {
     flex-shrink: 1 !important;
-  }
-
-  .md\:flex-grow-0 {
-    flex-grow: 0 !important;
   }
 
   .md\:flex-shrink-0 {
@@ -19876,16 +19876,16 @@ table {
     flex: none !important;
   }
 
+  .lg\:flex-grow-0 {
+    flex-grow: 0 !important;
+  }
+
   .lg\:flex-grow {
     flex-grow: 1 !important;
   }
 
   .lg\:flex-shrink {
     flex-shrink: 1 !important;
-  }
-
-  .lg\:flex-grow-0 {
-    flex-grow: 0 !important;
   }
 
   .lg\:flex-shrink-0 {
@@ -25546,16 +25546,16 @@ table {
     flex: none !important;
   }
 
+  .xl\:flex-grow-0 {
+    flex-grow: 0 !important;
+  }
+
   .xl\:flex-grow {
     flex-grow: 1 !important;
   }
 
   .xl\:flex-shrink {
     flex-shrink: 1 !important;
-  }
-
-  .xl\:flex-grow-0 {
-    flex-grow: 0 !important;
   }
 
   .xl\:flex-shrink-0 {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -2703,6 +2703,14 @@ table {
   display: inline !important;
 }
 
+.flex {
+  display: flex !important;
+}
+
+.inline-flex {
+  display: inline-flex !important;
+}
+
 .table {
   display: table !important;
 }
@@ -2717,14 +2725,6 @@ table {
 
 .hidden {
   display: none !important;
-}
-
-.flex {
-  display: flex !important;
-}
-
-.inline-flex {
-  display: inline-flex !important;
 }
 
 .flex-row {
@@ -8388,6 +8388,14 @@ table {
     display: inline !important;
   }
 
+  .sm\:flex {
+    display: flex !important;
+  }
+
+  .sm\:inline-flex {
+    display: inline-flex !important;
+  }
+
   .sm\:table {
     display: table !important;
   }
@@ -8402,14 +8410,6 @@ table {
 
   .sm\:hidden {
     display: none !important;
-  }
-
-  .sm\:flex {
-    display: flex !important;
-  }
-
-  .sm\:inline-flex {
-    display: inline-flex !important;
   }
 
   .sm\:flex-row {
@@ -14058,6 +14058,14 @@ table {
     display: inline !important;
   }
 
+  .md\:flex {
+    display: flex !important;
+  }
+
+  .md\:inline-flex {
+    display: inline-flex !important;
+  }
+
   .md\:table {
     display: table !important;
   }
@@ -14072,14 +14080,6 @@ table {
 
   .md\:hidden {
     display: none !important;
-  }
-
-  .md\:flex {
-    display: flex !important;
-  }
-
-  .md\:inline-flex {
-    display: inline-flex !important;
   }
 
   .md\:flex-row {
@@ -19728,6 +19728,14 @@ table {
     display: inline !important;
   }
 
+  .lg\:flex {
+    display: flex !important;
+  }
+
+  .lg\:inline-flex {
+    display: inline-flex !important;
+  }
+
   .lg\:table {
     display: table !important;
   }
@@ -19742,14 +19750,6 @@ table {
 
   .lg\:hidden {
     display: none !important;
-  }
-
-  .lg\:flex {
-    display: flex !important;
-  }
-
-  .lg\:inline-flex {
-    display: inline-flex !important;
   }
 
   .lg\:flex-row {
@@ -25398,6 +25398,14 @@ table {
     display: inline !important;
   }
 
+  .xl\:flex {
+    display: flex !important;
+  }
+
+  .xl\:inline-flex {
+    display: inline-flex !important;
+  }
+
   .xl\:table {
     display: table !important;
   }
@@ -25412,14 +25420,6 @@ table {
 
   .xl\:hidden {
     display: none !important;
-  }
-
-  .xl\:flex {
-    display: flex !important;
-  }
-
-  .xl\:inline-flex {
-    display: inline-flex !important;
   }
 
   .xl\:flex-row {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -2859,12 +2859,12 @@ table {
   flex-grow: 1 !important;
 }
 
-.flex-shrink {
-  flex-shrink: 1 !important;
-}
-
 .flex-shrink-0 {
   flex-shrink: 0 !important;
+}
+
+.flex-shrink {
+  flex-shrink: 1 !important;
 }
 
 .float-right {
@@ -8544,12 +8544,12 @@ table {
     flex-grow: 1 !important;
   }
 
-  .sm\:flex-shrink {
-    flex-shrink: 1 !important;
-  }
-
   .sm\:flex-shrink-0 {
     flex-shrink: 0 !important;
+  }
+
+  .sm\:flex-shrink {
+    flex-shrink: 1 !important;
   }
 
   .sm\:float-right {
@@ -14214,12 +14214,12 @@ table {
     flex-grow: 1 !important;
   }
 
-  .md\:flex-shrink {
-    flex-shrink: 1 !important;
-  }
-
   .md\:flex-shrink-0 {
     flex-shrink: 0 !important;
+  }
+
+  .md\:flex-shrink {
+    flex-shrink: 1 !important;
   }
 
   .md\:float-right {
@@ -19884,12 +19884,12 @@ table {
     flex-grow: 1 !important;
   }
 
-  .lg\:flex-shrink {
-    flex-shrink: 1 !important;
-  }
-
   .lg\:flex-shrink-0 {
     flex-shrink: 0 !important;
+  }
+
+  .lg\:flex-shrink {
+    flex-shrink: 1 !important;
   }
 
   .lg\:float-right {
@@ -25554,12 +25554,12 @@ table {
     flex-grow: 1 !important;
   }
 
-  .xl\:flex-shrink {
-    flex-shrink: 1 !important;
-  }
-
   .xl\:flex-shrink-0 {
     flex-shrink: 0 !important;
+  }
+
+  .xl\:flex-shrink {
+    flex-shrink: 1 !important;
   }
 
   .xl\:float-right {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -2851,16 +2851,16 @@ table {
   flex: none;
 }
 
+.flex-grow-0 {
+  flex-grow: 0;
+}
+
 .flex-grow {
   flex-grow: 1;
 }
 
 .flex-shrink {
   flex-shrink: 1;
-}
-
-.flex-grow-0 {
-  flex-grow: 0;
 }
 
 .flex-shrink-0 {
@@ -8536,16 +8536,16 @@ table {
     flex: none;
   }
 
+  .sm\:flex-grow-0 {
+    flex-grow: 0;
+  }
+
   .sm\:flex-grow {
     flex-grow: 1;
   }
 
   .sm\:flex-shrink {
     flex-shrink: 1;
-  }
-
-  .sm\:flex-grow-0 {
-    flex-grow: 0;
   }
 
   .sm\:flex-shrink-0 {
@@ -14206,16 +14206,16 @@ table {
     flex: none;
   }
 
+  .md\:flex-grow-0 {
+    flex-grow: 0;
+  }
+
   .md\:flex-grow {
     flex-grow: 1;
   }
 
   .md\:flex-shrink {
     flex-shrink: 1;
-  }
-
-  .md\:flex-grow-0 {
-    flex-grow: 0;
   }
 
   .md\:flex-shrink-0 {
@@ -19876,16 +19876,16 @@ table {
     flex: none;
   }
 
+  .lg\:flex-grow-0 {
+    flex-grow: 0;
+  }
+
   .lg\:flex-grow {
     flex-grow: 1;
   }
 
   .lg\:flex-shrink {
     flex-shrink: 1;
-  }
-
-  .lg\:flex-grow-0 {
-    flex-grow: 0;
   }
 
   .lg\:flex-shrink-0 {
@@ -25546,16 +25546,16 @@ table {
     flex: none;
   }
 
+  .xl\:flex-grow-0 {
+    flex-grow: 0;
+  }
+
   .xl\:flex-grow {
     flex-grow: 1;
   }
 
   .xl\:flex-shrink {
     flex-shrink: 1;
-  }
-
-  .xl\:flex-grow-0 {
-    flex-grow: 0;
   }
 
   .xl\:flex-shrink-0 {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -2859,12 +2859,12 @@ table {
   flex-grow: 1;
 }
 
-.flex-shrink {
-  flex-shrink: 1;
-}
-
 .flex-shrink-0 {
   flex-shrink: 0;
+}
+
+.flex-shrink {
+  flex-shrink: 1;
 }
 
 .float-right {
@@ -8544,12 +8544,12 @@ table {
     flex-grow: 1;
   }
 
-  .sm\:flex-shrink {
-    flex-shrink: 1;
-  }
-
   .sm\:flex-shrink-0 {
     flex-shrink: 0;
+  }
+
+  .sm\:flex-shrink {
+    flex-shrink: 1;
   }
 
   .sm\:float-right {
@@ -14214,12 +14214,12 @@ table {
     flex-grow: 1;
   }
 
-  .md\:flex-shrink {
-    flex-shrink: 1;
-  }
-
   .md\:flex-shrink-0 {
     flex-shrink: 0;
+  }
+
+  .md\:flex-shrink {
+    flex-shrink: 1;
   }
 
   .md\:float-right {
@@ -19884,12 +19884,12 @@ table {
     flex-grow: 1;
   }
 
-  .lg\:flex-shrink {
-    flex-shrink: 1;
-  }
-
   .lg\:flex-shrink-0 {
     flex-shrink: 0;
+  }
+
+  .lg\:flex-shrink {
+    flex-shrink: 1;
   }
 
   .lg\:float-right {
@@ -25554,12 +25554,12 @@ table {
     flex-grow: 1;
   }
 
-  .xl\:flex-shrink {
-    flex-shrink: 1;
-  }
-
   .xl\:flex-shrink-0 {
     flex-shrink: 0;
+  }
+
+  .xl\:flex-shrink {
+    flex-shrink: 1;
   }
 
   .xl\:float-right {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -2703,6 +2703,14 @@ table {
   display: inline;
 }
 
+.flex {
+  display: flex;
+}
+
+.inline-flex {
+  display: inline-flex;
+}
+
 .table {
   display: table;
 }
@@ -2717,14 +2725,6 @@ table {
 
 .hidden {
   display: none;
-}
-
-.flex {
-  display: flex;
-}
-
-.inline-flex {
-  display: inline-flex;
 }
 
 .flex-row {
@@ -8388,6 +8388,14 @@ table {
     display: inline;
   }
 
+  .sm\:flex {
+    display: flex;
+  }
+
+  .sm\:inline-flex {
+    display: inline-flex;
+  }
+
   .sm\:table {
     display: table;
   }
@@ -8402,14 +8410,6 @@ table {
 
   .sm\:hidden {
     display: none;
-  }
-
-  .sm\:flex {
-    display: flex;
-  }
-
-  .sm\:inline-flex {
-    display: inline-flex;
   }
 
   .sm\:flex-row {
@@ -14058,6 +14058,14 @@ table {
     display: inline;
   }
 
+  .md\:flex {
+    display: flex;
+  }
+
+  .md\:inline-flex {
+    display: inline-flex;
+  }
+
   .md\:table {
     display: table;
   }
@@ -14072,14 +14080,6 @@ table {
 
   .md\:hidden {
     display: none;
-  }
-
-  .md\:flex {
-    display: flex;
-  }
-
-  .md\:inline-flex {
-    display: inline-flex;
   }
 
   .md\:flex-row {
@@ -19728,6 +19728,14 @@ table {
     display: inline;
   }
 
+  .lg\:flex {
+    display: flex;
+  }
+
+  .lg\:inline-flex {
+    display: inline-flex;
+  }
+
   .lg\:table {
     display: table;
   }
@@ -19742,14 +19750,6 @@ table {
 
   .lg\:hidden {
     display: none;
-  }
-
-  .lg\:flex {
-    display: flex;
-  }
-
-  .lg\:inline-flex {
-    display: inline-flex;
   }
 
   .lg\:flex-row {
@@ -25398,6 +25398,14 @@ table {
     display: inline;
   }
 
+  .xl\:flex {
+    display: flex;
+  }
+
+  .xl\:inline-flex {
+    display: inline-flex;
+  }
+
   .xl\:table {
     display: table;
   }
@@ -25412,14 +25420,6 @@ table {
 
   .xl\:hidden {
     display: none;
-  }
-
-  .xl\:flex {
-    display: flex;
-  }
-
-  .xl\:inline-flex {
-    display: inline-flex;
   }
 
   .xl\:flex-row {

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -25,6 +25,7 @@ module.exports = {
     alignSelf: ['responsive'],
     justifyContent: ['responsive'],
     alignContent: ['responsive'],
+    flex: ['responsive'],
     flexbox: ['responsive'],
     float: ['responsive'],
     fontFamily: ['responsive'],

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -22,6 +22,7 @@ module.exports = {
     flexDirection: ['responsive'],
     flexWrap: ['responsive'],
     alignItems: ['responsive'],
+    alignSelf: ['responsive'],
     flexbox: ['responsive'],
     float: ['responsive'],
     fontFamily: ['responsive'],

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -24,6 +24,7 @@ module.exports = {
     alignItems: ['responsive'],
     alignSelf: ['responsive'],
     justifyContent: ['responsive'],
+    alignContent: ['responsive'],
     flexbox: ['responsive'],
     float: ['responsive'],
     fontFamily: ['responsive'],

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -23,6 +23,7 @@ module.exports = {
     flexWrap: ['responsive'],
     alignItems: ['responsive'],
     alignSelf: ['responsive'],
+    justifyContent: ['responsive'],
     flexbox: ['responsive'],
     float: ['responsive'],
     fontFamily: ['responsive'],

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -26,6 +26,7 @@ module.exports = {
     justifyContent: ['responsive'],
     alignContent: ['responsive'],
     flex: ['responsive'],
+    flexGrow: ['responsive'],
     flexbox: ['responsive'],
     float: ['responsive'],
     fontFamily: ['responsive'],

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -21,6 +21,7 @@ module.exports = {
     display: ['responsive'],
     flexDirection: ['responsive'],
     flexWrap: ['responsive'],
+    alignItems: ['responsive'],
     flexbox: ['responsive'],
     float: ['responsive'],
     fontFamily: ['responsive'],

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -20,6 +20,7 @@ module.exports = {
     cursor: ['responsive'],
     display: ['responsive'],
     flexDirection: ['responsive'],
+    flexWrap: ['responsive'],
     flexbox: ['responsive'],
     float: ['responsive'],
     fontFamily: ['responsive'],

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -27,7 +27,7 @@ module.exports = {
     alignContent: ['responsive'],
     flex: ['responsive'],
     flexGrow: ['responsive'],
-    flexbox: ['responsive'],
+    flexShrink: ['responsive'],
     float: ['responsive'],
     fontFamily: ['responsive'],
     fontWeight: ['responsive', 'hover', 'focus'],

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -19,6 +19,7 @@ module.exports = {
     borderWidth: ['responsive'],
     cursor: ['responsive'],
     display: ['responsive'],
+    flexDirection: ['responsive'],
     flexbox: ['responsive'],
     float: ['responsive'],
     fontFamily: ['responsive'],

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -21,7 +21,7 @@ import justifyContent from './plugins/justifyContent'
 import alignContent from './plugins/alignContent'
 import flex from './plugins/flex'
 import flexGrow from './plugins/flexGrow'
-import flexbox from './plugins/flexbox'
+import flexShrink from './plugins/flexShrink'
 import float from './plugins/float'
 import fontFamily from './plugins/fontFamily'
 import fontWeight from './plugins/fontWeight'
@@ -103,7 +103,7 @@ export default function(config) {
     alignContent,
     flex,
     flexGrow,
-    flexbox,
+    flexShrink,
     float,
     fontFamily,
     fontWeight,

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -15,6 +15,7 @@ import cursor from './plugins/cursor'
 import display from './plugins/display'
 import flexDirection from './plugins/flexDirection'
 import flexWrap from './plugins/flexWrap'
+import alignItems from './plugins/alignItems'
 import flexbox from './plugins/flexbox'
 import float from './plugins/float'
 import fontFamily from './plugins/fontFamily'
@@ -91,6 +92,7 @@ export default function(config) {
     display,
     flexDirection,
     flexWrap,
+    alignItems,
     flexbox,
     float,
     fontFamily,

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -19,6 +19,7 @@ import alignItems from './plugins/alignItems'
 import alignSelf from './plugins/alignSelf'
 import justifyContent from './plugins/justifyContent'
 import alignContent from './plugins/alignContent'
+import flex from './plugins/flex'
 import flexbox from './plugins/flexbox'
 import float from './plugins/float'
 import fontFamily from './plugins/fontFamily'
@@ -99,6 +100,7 @@ export default function(config) {
     alignSelf,
     justifyContent,
     alignContent,
+    flex,
     flexbox,
     float,
     fontFamily,

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -20,6 +20,7 @@ import alignSelf from './plugins/alignSelf'
 import justifyContent from './plugins/justifyContent'
 import alignContent from './plugins/alignContent'
 import flex from './plugins/flex'
+import flexGrow from './plugins/flexGrow'
 import flexbox from './plugins/flexbox'
 import float from './plugins/float'
 import fontFamily from './plugins/fontFamily'
@@ -101,6 +102,7 @@ export default function(config) {
     justifyContent,
     alignContent,
     flex,
+    flexGrow,
     flexbox,
     float,
     fontFamily,

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -17,6 +17,7 @@ import flexDirection from './plugins/flexDirection'
 import flexWrap from './plugins/flexWrap'
 import alignItems from './plugins/alignItems'
 import alignSelf from './plugins/alignSelf'
+import justifyContent from './plugins/justifyContent'
 import flexbox from './plugins/flexbox'
 import float from './plugins/float'
 import fontFamily from './plugins/fontFamily'
@@ -95,6 +96,7 @@ export default function(config) {
     flexWrap,
     alignItems,
     alignSelf,
+    justifyContent,
     flexbox,
     float,
     fontFamily,

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -18,6 +18,7 @@ import flexWrap from './plugins/flexWrap'
 import alignItems from './plugins/alignItems'
 import alignSelf from './plugins/alignSelf'
 import justifyContent from './plugins/justifyContent'
+import alignContent from './plugins/alignContent'
 import flexbox from './plugins/flexbox'
 import float from './plugins/float'
 import fontFamily from './plugins/fontFamily'
@@ -97,6 +98,7 @@ export default function(config) {
     alignItems,
     alignSelf,
     justifyContent,
+    alignContent,
     flexbox,
     float,
     fontFamily,

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -16,6 +16,7 @@ import display from './plugins/display'
 import flexDirection from './plugins/flexDirection'
 import flexWrap from './plugins/flexWrap'
 import alignItems from './plugins/alignItems'
+import alignSelf from './plugins/alignSelf'
 import flexbox from './plugins/flexbox'
 import float from './plugins/float'
 import fontFamily from './plugins/fontFamily'
@@ -93,6 +94,7 @@ export default function(config) {
     flexDirection,
     flexWrap,
     alignItems,
+    alignSelf,
     flexbox,
     float,
     fontFamily,

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -13,6 +13,7 @@ import borderStyle from './plugins/borderStyle'
 import borderWidth from './plugins/borderWidth'
 import cursor from './plugins/cursor'
 import display from './plugins/display'
+import flexDirection from './plugins/flexDirection'
 import flexbox from './plugins/flexbox'
 import float from './plugins/float'
 import fontFamily from './plugins/fontFamily'
@@ -87,6 +88,7 @@ export default function(config) {
     borderWidth,
     cursor,
     display,
+    flexDirection,
     flexbox,
     float,
     fontFamily,

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -14,6 +14,7 @@ import borderWidth from './plugins/borderWidth'
 import cursor from './plugins/cursor'
 import display from './plugins/display'
 import flexDirection from './plugins/flexDirection'
+import flexWrap from './plugins/flexWrap'
 import flexbox from './plugins/flexbox'
 import float from './plugins/float'
 import fontFamily from './plugins/fontFamily'
@@ -89,6 +90,7 @@ export default function(config) {
     cursor,
     display,
     flexDirection,
+    flexWrap,
     flexbox,
     float,
     fontFamily,

--- a/src/plugins/alignContent.js
+++ b/src/plugins/alignContent.js
@@ -1,0 +1,24 @@
+export default function({ variants }) {
+  return function({ addUtilities }) {
+    addUtilities(
+      {
+        '.content-center': {
+          'align-content': 'center',
+        },
+        '.content-start': {
+          'align-content': 'flex-start',
+        },
+        '.content-end': {
+          'align-content': 'flex-end',
+        },
+        '.content-between': {
+          'align-content': 'space-between',
+        },
+        '.content-around': {
+          'align-content': 'space-around',
+        },
+      },
+      variants
+    )
+  }
+}

--- a/src/plugins/alignItems.js
+++ b/src/plugins/alignItems.js
@@ -1,0 +1,24 @@
+export default function({ variants }) {
+  return function({ addUtilities }) {
+    addUtilities(
+      {
+        '.items-start': {
+          'align-items': 'flex-start',
+        },
+        '.items-end': {
+          'align-items': 'flex-end',
+        },
+        '.items-center': {
+          'align-items': 'center',
+        },
+        '.items-baseline': {
+          'align-items': 'baseline',
+        },
+        '.items-stretch': {
+          'align-items': 'stretch',
+        },
+      },
+      variants
+    )
+  }
+}

--- a/src/plugins/alignSelf.js
+++ b/src/plugins/alignSelf.js
@@ -1,0 +1,24 @@
+export default function({ variants }) {
+  return function({ addUtilities }) {
+    addUtilities(
+      {
+        '.self-auto': {
+          'align-self': 'auto',
+        },
+        '.self-start': {
+          'align-self': 'flex-start',
+        },
+        '.self-end': {
+          'align-self': 'flex-end',
+        },
+        '.self-center': {
+          'align-self': 'center',
+        },
+        '.self-stretch': {
+          'align-self': 'stretch',
+        },
+      },
+      variants
+    )
+  }
+}

--- a/src/plugins/display.js
+++ b/src/plugins/display.js
@@ -11,6 +11,12 @@ export default function({ variants }) {
         '.inline': {
           display: 'inline',
         },
+        '.flex': {
+          display: 'flex',
+        },
+        '.inline-flex': {
+          display: 'inline-flex',
+        },
         '.table': {
           display: 'table',
         },

--- a/src/plugins/flex.js
+++ b/src/plugins/flex.js
@@ -1,0 +1,21 @@
+export default function({ variants }) {
+  return function({ addUtilities }) {
+    addUtilities(
+      {
+        '.flex-1': {
+          flex: '1 1 0%',
+        },
+        '.flex-auto': {
+          flex: '1 1 auto',
+        },
+        '.flex-initial': {
+          flex: '0 1 auto',
+        },
+        '.flex-none': {
+          flex: 'none',
+        },
+      },
+      variants
+    )
+  }
+}

--- a/src/plugins/flexDirection.js
+++ b/src/plugins/flexDirection.js
@@ -1,0 +1,21 @@
+export default function({ variants }) {
+  return function({ addUtilities }) {
+    addUtilities(
+      {
+        '.flex-row': {
+          'flex-direction': 'row',
+        },
+        '.flex-row-reverse': {
+          'flex-direction': 'row-reverse',
+        },
+        '.flex-col': {
+          'flex-direction': 'column',
+        },
+        '.flex-col-reverse': {
+          'flex-direction': 'column-reverse',
+        },
+      },
+      variants
+    )
+  }
+}

--- a/src/plugins/flexGrow.js
+++ b/src/plugins/flexGrow.js
@@ -2,11 +2,11 @@ export default function({ variants }) {
   return function({ addUtilities }) {
     addUtilities(
       {
-        '.flex-shrink': {
-          'flex-shrink': '1',
+        '.flex-grow-0': {
+          'flex-grow': '0',
         },
-        '.flex-shrink-0': {
-          'flex-shrink': '0',
+        '.flex-grow': {
+          'flex-grow': '1',
         },
       },
       variants

--- a/src/plugins/flexShrink.js
+++ b/src/plugins/flexShrink.js
@@ -2,11 +2,11 @@ export default function({ variants }) {
   return function({ addUtilities }) {
     addUtilities(
       {
-        '.flex-shrink': {
-          'flex-shrink': '1',
-        },
         '.flex-shrink-0': {
           'flex-shrink': '0',
+        },
+        '.flex-shrink': {
+          'flex-shrink': '1',
         },
       },
       variants

--- a/src/plugins/flexWrap.js
+++ b/src/plugins/flexWrap.js
@@ -1,0 +1,18 @@
+export default function({ variants }) {
+  return function({ addUtilities }) {
+    addUtilities(
+      {
+        '.flex-wrap': {
+          'flex-wrap': 'wrap',
+        },
+        '.flex-wrap-reverse': {
+          'flex-wrap': 'wrap-reverse',
+        },
+        '.flex-no-wrap': {
+          'flex-wrap': 'nowrap',
+        },
+      },
+      variants
+    )
+  }
+}

--- a/src/plugins/flexbox.js
+++ b/src/plugins/flexbox.js
@@ -2,21 +2,6 @@ export default function({ variants }) {
   return function({ addUtilities }) {
     addUtilities(
       {
-        '.content-center': {
-          'align-content': 'center',
-        },
-        '.content-start': {
-          'align-content': 'flex-start',
-        },
-        '.content-end': {
-          'align-content': 'flex-end',
-        },
-        '.content-between': {
-          'align-content': 'space-between',
-        },
-        '.content-around': {
-          'align-content': 'space-around',
-        },
         '.flex-1': {
           flex: '1 1 0%',
         },

--- a/src/plugins/flexbox.js
+++ b/src/plugins/flexbox.js
@@ -2,21 +2,6 @@ export default function({ variants }) {
   return function({ addUtilities }) {
     addUtilities(
       {
-        '.self-auto': {
-          'align-self': 'auto',
-        },
-        '.self-start': {
-          'align-self': 'flex-start',
-        },
-        '.self-end': {
-          'align-self': 'flex-end',
-        },
-        '.self-center': {
-          'align-self': 'center',
-        },
-        '.self-stretch': {
-          'align-self': 'stretch',
-        },
         '.justify-start': {
           'justify-content': 'flex-start',
         },

--- a/src/plugins/flexbox.js
+++ b/src/plugins/flexbox.js
@@ -2,15 +2,6 @@ export default function({ variants }) {
   return function({ addUtilities }) {
     addUtilities(
       {
-        '.flex-wrap': {
-          'flex-wrap': 'wrap',
-        },
-        '.flex-wrap-reverse': {
-          'flex-wrap': 'wrap-reverse',
-        },
-        '.flex-no-wrap': {
-          'flex-wrap': 'nowrap',
-        },
         '.items-start': {
           'align-items': 'flex-start',
         },

--- a/src/plugins/flexbox.js
+++ b/src/plugins/flexbox.js
@@ -2,12 +2,6 @@ export default function({ variants }) {
   return function({ addUtilities }) {
     addUtilities(
       {
-        '.flex': {
-          display: 'flex',
-        },
-        '.inline-flex': {
-          display: 'inline-flex',
-        },
         '.flex-row': {
           'flex-direction': 'row',
         },

--- a/src/plugins/flexbox.js
+++ b/src/plugins/flexbox.js
@@ -2,21 +2,6 @@ export default function({ variants }) {
   return function({ addUtilities }) {
     addUtilities(
       {
-        '.justify-start': {
-          'justify-content': 'flex-start',
-        },
-        '.justify-end': {
-          'justify-content': 'flex-end',
-        },
-        '.justify-center': {
-          'justify-content': 'center',
-        },
-        '.justify-between': {
-          'justify-content': 'space-between',
-        },
-        '.justify-around': {
-          'justify-content': 'space-around',
-        },
         '.content-center': {
           'align-content': 'center',
         },

--- a/src/plugins/flexbox.js
+++ b/src/plugins/flexbox.js
@@ -2,18 +2,6 @@ export default function({ variants }) {
   return function({ addUtilities }) {
     addUtilities(
       {
-        '.flex-1': {
-          flex: '1 1 0%',
-        },
-        '.flex-auto': {
-          flex: '1 1 auto',
-        },
-        '.flex-initial': {
-          flex: '0 1 auto',
-        },
-        '.flex-none': {
-          flex: 'none',
-        },
         '.flex-grow': {
           'flex-grow': '1',
         },

--- a/src/plugins/flexbox.js
+++ b/src/plugins/flexbox.js
@@ -2,21 +2,6 @@ export default function({ variants }) {
   return function({ addUtilities }) {
     addUtilities(
       {
-        '.items-start': {
-          'align-items': 'flex-start',
-        },
-        '.items-end': {
-          'align-items': 'flex-end',
-        },
-        '.items-center': {
-          'align-items': 'center',
-        },
-        '.items-baseline': {
-          'align-items': 'baseline',
-        },
-        '.items-stretch': {
-          'align-items': 'stretch',
-        },
         '.self-auto': {
           'align-self': 'auto',
         },

--- a/src/plugins/flexbox.js
+++ b/src/plugins/flexbox.js
@@ -2,18 +2,6 @@ export default function({ variants }) {
   return function({ addUtilities }) {
     addUtilities(
       {
-        '.flex-row': {
-          'flex-direction': 'row',
-        },
-        '.flex-row-reverse': {
-          'flex-direction': 'row-reverse',
-        },
-        '.flex-col': {
-          'flex-direction': 'column',
-        },
-        '.flex-col-reverse': {
-          'flex-direction': 'column-reverse',
-        },
         '.flex-wrap': {
           'flex-wrap': 'wrap',
         },

--- a/src/plugins/justifyContent.js
+++ b/src/plugins/justifyContent.js
@@ -1,0 +1,24 @@
+export default function({ variants }) {
+  return function({ addUtilities }) {
+    addUtilities(
+      {
+        '.justify-start': {
+          'justify-content': 'flex-start',
+        },
+        '.justify-end': {
+          'justify-content': 'flex-end',
+        },
+        '.justify-center': {
+          'justify-content': 'center',
+        },
+        '.justify-between': {
+          'justify-content': 'space-between',
+        },
+        '.justify-around': {
+          'justify-content': 'space-around',
+        },
+      },
+      variants
+    )
+  }
+}


### PR DESCRIPTION
This PR splits the `flexbox` core plugin into multiple plugins:

- `flexDirection`
- `flexWrap`
- `alignItems`
- `alignSelf`
- `justifyContent`
- `alignContent`
- `flex`
- `flexGrow`
- `flexShrink`

It also moves the `.flex` and `.inline-flex` utilities into the `display` module, which is where they really belong anyways.

The motivation for this change is two-fold:

- I am planning to make some of the flexbox utilities customizable, like flex-grow and flex-shrink and it would be nice to have `flexGrow` and `flexShrink` as top level keys in the theme instead of nested under a `flexbox` key
- Some of these properties also apply to CSS Grid, like `align-items` for example, and `order` if we add that in the future, so having them inside the `flexbox` plugin will be regrettable down the road

This is breaking change but only in the config file, so not a huge deal.