### PR TITLE
Make flex-grow/shrink customizable

### DIFF
--- a/defaultTheme.js
+++ b/defaultTheme.js
@@ -314,5 +314,13 @@ module.exports = function() {
     stroke: {
       current: 'currentColor',
     },
+    flexGrow: {
+      '0': 0,
+      default: 1,
+    },
+    flexShrink: {
+      '0': 0,
+      default: 1,
+    },
   }
 }

--- a/src/plugins/flexGrow.js
+++ b/src/plugins/flexGrow.js
@@ -1,14 +1,19 @@
-export default function({ variants }) {
-  return function({ addUtilities }) {
+import _ from 'lodash'
+
+export default function({ values, variants }) {
+  return function({ addUtilities, e }) {
     addUtilities(
-      {
-        '.flex-grow-0': {
-          'flex-grow': '0',
-        },
-        '.flex-grow': {
-          'flex-grow': '1',
-        },
-      },
+      _.fromPairs(
+        _.map(values, (value, modifier) => {
+          const className = modifier === 'default' ? 'flex-grow' : `flex-grow-${modifier}`
+          return [
+            `.${e(className)}`,
+            {
+              'flex-grow': value,
+            },
+          ]
+        })
+      ),
       variants
     )
   }

--- a/src/plugins/flexShrink.js
+++ b/src/plugins/flexShrink.js
@@ -1,14 +1,19 @@
-export default function({ variants }) {
-  return function({ addUtilities }) {
+import _ from 'lodash'
+
+export default function({ values, variants }) {
+  return function({ addUtilities, e }) {
     addUtilities(
-      {
-        '.flex-shrink-0': {
-          'flex-shrink': '0',
-        },
-        '.flex-shrink': {
-          'flex-shrink': '1',
-        },
-      },
+      _.fromPairs(
+        _.map(values, (value, modifier) => {
+          const className = modifier === 'default' ? 'flex-shrink' : `flex-shrink-${modifier}`
+          return [
+            `.${e(className)}`,
+            {
+              'flex-shrink': value,
+            },
+          ]
+        })
+      ),
       variants
     )
   }


### PR DESCRIPTION
This PR makes the `flex-grow-*` and `flex-shrink-*` classes customizable, in case you ever need values beyond 1 and 0.