### PR TITLE
Leverage built-in escape handling in postcss-selector-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "autoprefixer": "^9.4.5",
     "bytes": "^3.0.0",
     "chalk": "^2.4.1",
-    "css.escape": "^1.5.1",
+    "cssesc": "^3.0.0",
     "fs-extra": "^4.0.2",
     "lodash": "^4.17.11",
     "node-emoji": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "autoprefixer": "^9.4.5",
     "bytes": "^3.0.0",
     "chalk": "^2.4.1",
-    "cssesc": "^3.0.0",
     "fs-extra": "^4.0.2",
     "lodash": "^4.17.11",
     "node-emoji": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "postcss-functions": "^3.0.0",
     "postcss-js": "^2.0.0",
     "postcss-nested": "^4.1.1",
-    "postcss-selector-parser": "^5.0.0",
+    "postcss-selector-parser": "^6.0.0",
     "pretty-hrtime": "^1.0.3",
     "strip-comments": "^1.0.2"
   },

--- a/src/util/buildSelectorVariant.js
+++ b/src/util/buildSelectorVariant.js
@@ -1,7 +1,5 @@
-import escapeClassName from './escapeClassName'
 import parser from 'postcss-selector-parser'
 import tap from 'lodash/tap'
-import get from 'lodash/get'
 
 export default function buildSelectorVariant(selector, variantName, separator, onError = () => {}) {
   return parser(selectors => {
@@ -11,12 +9,7 @@ export default function buildSelectorVariant(selector, variantName, separator, o
         return
       }
 
-      const baseClass = get(classSelector, 'raws.value', classSelector.value)
-
-      classSelector.setPropertyAndEscape(
-        'value',
-        `${variantName}${escapeClassName(separator)}${baseClass}`
-      )
+      classSelector.value = `${variantName}${separator}${classSelector.value}`
     })
   }).processSync(selector)
 }

--- a/src/util/escapeClassName.js
+++ b/src/util/escapeClassName.js
@@ -1,5 +1,8 @@
-import cssesc from 'cssesc'
+import parser from 'postcss-selector-parser'
+import get from 'lodash/get'
 
 export default function escapeClassName(className) {
-  return cssesc(className, { isIdentifier: true })
+  const node = parser.className()
+  node.value = className
+  return get(node, 'raws.value', node.value)
 }

--- a/src/util/escapeClassName.js
+++ b/src/util/escapeClassName.js
@@ -1,5 +1,5 @@
-import escape from 'css.escape'
+import cssesc from 'cssesc'
 
 export default function escapeClassName(className) {
-  return escape(className)
+  return cssesc(className, { isIdentifier: true })
 }

--- a/src/util/prefixSelector.js
+++ b/src/util/prefixSelector.js
@@ -1,14 +1,14 @@
 import parser from 'postcss-selector-parser'
-import get from 'lodash/get'
+import tap from 'lodash/tap'
 
 export default function(prefix, selector) {
   const getPrefix = typeof prefix === 'function' ? prefix : () => prefix
 
   return parser(selectors => {
     selectors.walkClasses(classSelector => {
-      const baseClass = get(classSelector, 'raws.value', classSelector.value)
-
-      classSelector.setPropertyAndEscape('value', `${getPrefix('.' + baseClass)}${baseClass}`)
+      tap(classSelector.value, baseClass => {
+        classSelector.value = `${getPrefix('.' + baseClass)}${baseClass}`
+      })
     })
   }).processSync(selector)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1481,11 +1481,6 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-css.escape@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
-  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
-
 cssesc@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-2.0.0.tgz#3b13bd1bb1cb36e1bcb5a4dcd27f54c5dcb35703"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1491,6 +1491,11 @@ cssesc@^2.0.0:
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-2.0.0.tgz#3b13bd1bb1cb36e1bcb5a4dcd27f54c5dcb35703"
   integrity sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==
 
+cssesc@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
+  integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
@@ -4031,12 +4036,21 @@ postcss-scss@^0.3.0:
   dependencies:
     postcss "^5.2.4"
 
-postcss-selector-parser@^5.0.0, postcss-selector-parser@^5.0.0-rc.4:
+postcss-selector-parser@^5.0.0-rc.4:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz#249044356697b33b64f1a8f7c80922dddee7195c"
   integrity sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==
   dependencies:
     cssesc "^2.0.0"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+
+postcss-selector-parser@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.0.tgz#5cf920dae70589adf1aba7ec72e39cc882e5cf40"
+  integrity sha512-E4EHwWgh5NIh/F44hYfQHR1jwejCza1ktpeWTetDtc71hxdDmWPjfSs28/58DBDIKxz5Dxlw8oW6am2ph/OCkg==
+  dependencies:
+    cssesc "^3.0.0"
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 


### PR DESCRIPTION
Removes our dependency on `css.escape` and ensures we always rely on postcss-selector-parser's built-in escape handling for any situations where we need to escape anything to avoid subtle inconsistencies.