### PR TITLE
Reset heading styles in preflight

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -478,6 +478,16 @@ table {
   border-collapse: collapse;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: 100%;
+  font-weight: normal;
+}
+
 .container {
   width: 100%;
 }

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -484,8 +484,8 @@ h3,
 h4,
 h5,
 h6 {
-  font-size: 100%;
-  font-weight: normal;
+  font-size: inherit;
+  font-weight: inherit;
 }
 
 .container {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -478,6 +478,16 @@ table {
   border-collapse: collapse;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: 100%;
+  font-weight: normal;
+}
+
 .container {
   width: 100%;
 }

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -484,8 +484,8 @@ h3,
 h4,
 h5,
 h6 {
-  font-size: 100%;
-  font-weight: normal;
+  font-size: inherit;
+  font-weight: inherit;
 }
 
 .container {

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -130,6 +130,6 @@ h3,
 h4,
 h5,
 h6 {
-  font-size: 100%;
-  font-weight: normal;
+  font-size: inherit;
+  font-weight: inherit;
 }

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -123,3 +123,13 @@ button,
 table {
   border-collapse: collapse;
 }
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: 100%;
+  font-weight: normal;
+}


### PR DESCRIPTION
Set all headings to inherit the parent font size and reset the font-weight to normal. This prevents you from accidentally using browser default sizes in your designs and deviating from your design system.

This is a breaking change but if it breaks your site, it's actually just pointing out your own mistake 👍 
