### PR TITLE
Revert sm screen from 568px back to 576px

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -482,9 +482,9 @@ table {
   width: 100%;
 }
 
-@media (min-width: 568px) {
+@media (min-width: 576px) {
   .container {
-    max-width: 568px;
+    max-width: 576px;
   }
 }
 
@@ -6598,7 +6598,7 @@ table {
   color: #e3342f;
 }
 
-@media (min-width: 568px) {
+@media (min-width: 576px) {
   .sm\:list-reset {
     list-style: none !important;
     padding: 0 !important;

--- a/__tests__/fixtures/tailwind-output-with-explicit-screen-utilities.css
+++ b/__tests__/fixtures/tailwind-output-with-explicit-screen-utilities.css
@@ -2,7 +2,7 @@
   color: red;
 }
 
-@media (min-width: 568px) {
+@media (min-width: 576px) {
   .sm\:example {
     color: red;
   }

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -482,9 +482,9 @@ table {
   width: 100%;
 }
 
-@media (min-width: 568px) {
+@media (min-width: 576px) {
   .container {
-    max-width: 568px;
+    max-width: 576px;
   }
 }
 
@@ -6598,7 +6598,7 @@ table {
   color: #e3342f;
 }
 
-@media (min-width: 568px) {
+@media (min-width: 576px) {
   .sm\:list-reset {
     list-style: none;
     padding: 0;

--- a/defaultTheme.js
+++ b/defaultTheme.js
@@ -107,7 +107,7 @@ module.exports = function() {
       '64': '16rem',
     },
     screens: {
-      sm: '568px',
+      sm: '576px',
       md: '768px',
       lg: '1024px',
       xl: '1280px',


### PR DESCRIPTION
Keeping it at 576px means every default screen size has a matching maxWidth helper, without having to introduce new `max-w-screen-*` utilities on top of the regular maxWidth scale. The motivation for 568px was because that's the height of an iPhone SE, but (very sadly) I doubt we will see devices of that size ever again, so since most (almost all?) people use larger mobile devices, it's actually probably better that this breakpoint is wider because you get to use a little more of the available screen real estate. The iPhone 6/7/8 for example has a height of 667px, so with a 576px breakpoint, we're still wasting 91px, and with 568px we were wasting 99px.

The only thing that sucks is that even though this change means there is always a matching maxWidth for every default breakpoint, there is no logical mapping between them. The sm breakpoint is is max-w-xl for example, and the lg breakpoint is max-w-5xl. There's no way to make max-w-sm match the sm breakpoint and max-w-md match the md breakpoint because there's a maxWidth value that sits in between those two screen sizes, and I'd have no idea what to name it.

We could introduce aliases, so `max-w-xl` would also be defined as `max-w-screen-sm`, but that would be the first time we've ever done anything like that in the framework.

Really not sure what to do here.
