### PR TITLE
Support object syntax for theme colors

### DIFF
--- a/__tests__/plugins/backgroundColor.test.js
+++ b/__tests__/plugins/backgroundColor.test.js
@@ -1,0 +1,64 @@
+import _ from 'lodash'
+import escapeClassName from '../../src/util/escapeClassName'
+import plugin from '../../src/plugins/backgroundColor'
+
+test('colors can be a nested object', () => {
+  const addedUtilities = []
+
+  const config = {
+    theme: {
+      backgroundColor: {
+        purple: 'purple',
+        red: {
+          1: 'rgb(33,0,0)',
+          2: 'rgb(67,0,0)',
+          3: 'rgb(100,0,0)',
+        },
+        green: {
+          1: 'rgb(0,33,0)',
+          2: 'rgb(0,67,0)',
+          3: 'rgb(0,100,0)',
+        },
+        blue: {
+          1: 'rgb(0,0,33)',
+          2: 'rgb(0,0,67)',
+          3: 'rgb(0,0,100)',
+        },
+      },
+    },
+    variants: {
+      backgroundColor: ['responsive'],
+    },
+  }
+
+  const pluginApi = {
+    config: (key, defaultValue) => _.get(config, key, defaultValue),
+    e: escapeClassName,
+    addUtilities(utilities, variants) {
+      addedUtilities.push({
+        utilities,
+        variants,
+      })
+    },
+  }
+
+  plugin()(pluginApi)
+
+  expect(addedUtilities).toEqual([
+    {
+      utilities: {
+        '.bg-purple': { 'background-color': 'purple' },
+        '.bg-red-1': { 'background-color': 'rgb(33,0,0)' },
+        '.bg-red-2': { 'background-color': 'rgb(67,0,0)' },
+        '.bg-red-3': { 'background-color': 'rgb(100,0,0)' },
+        '.bg-green-1': { 'background-color': 'rgb(0,33,0)' },
+        '.bg-green-2': { 'background-color': 'rgb(0,67,0)' },
+        '.bg-green-3': { 'background-color': 'rgb(0,100,0)' },
+        '.bg-blue-1': { 'background-color': 'rgb(0,0,33)' },
+        '.bg-blue-2': { 'background-color': 'rgb(0,0,67)' },
+        '.bg-blue-3': { 'background-color': 'rgb(0,0,100)' },
+      },
+      variants: ['responsive'],
+    },
+  ])
+})

--- a/__tests__/plugins/borderColor.test.js
+++ b/__tests__/plugins/borderColor.test.js
@@ -1,13 +1,13 @@
 import _ from 'lodash'
 import escapeClassName from '../../src/util/escapeClassName'
-import plugin from '../../src/plugins/textColor'
+import plugin from '../../src/plugins/borderColor'
 
 test('colors can be a nested object', () => {
   const addedUtilities = []
 
   const config = {
     theme: {
-      textColor: {
+      borderColor: {
         purple: 'purple',
         red: {
           1: 'rgb(33,0,0)',
@@ -27,7 +27,7 @@ test('colors can be a nested object', () => {
       },
     },
     variants: {
-      textColor: ['responsive'],
+      borderColor: ['responsive'],
     },
   }
 
@@ -47,16 +47,16 @@ test('colors can be a nested object', () => {
   expect(addedUtilities).toEqual([
     {
       utilities: {
-        '.text-purple': { color: 'purple' },
-        '.text-red-1': { color: 'rgb(33,0,0)' },
-        '.text-red-2': { color: 'rgb(67,0,0)' },
-        '.text-red-3': { color: 'rgb(100,0,0)' },
-        '.text-green-1': { color: 'rgb(0,33,0)' },
-        '.text-green-2': { color: 'rgb(0,67,0)' },
-        '.text-green-3': { color: 'rgb(0,100,0)' },
-        '.text-blue-1': { color: 'rgb(0,0,33)' },
-        '.text-blue-2': { color: 'rgb(0,0,67)' },
-        '.text-blue-3': { color: 'rgb(0,0,100)' },
+        '.border-purple': { 'border-color': 'purple' },
+        '.border-red-1': { 'border-color': 'rgb(33,0,0)' },
+        '.border-red-2': { 'border-color': 'rgb(67,0,0)' },
+        '.border-red-3': { 'border-color': 'rgb(100,0,0)' },
+        '.border-green-1': { 'border-color': 'rgb(0,33,0)' },
+        '.border-green-2': { 'border-color': 'rgb(0,67,0)' },
+        '.border-green-3': { 'border-color': 'rgb(0,100,0)' },
+        '.border-blue-1': { 'border-color': 'rgb(0,0,33)' },
+        '.border-blue-2': { 'border-color': 'rgb(0,0,67)' },
+        '.border-blue-3': { 'border-color': 'rgb(0,0,100)' },
       },
       variants: ['responsive'],
     },

--- a/__tests__/plugins/textColor.test.js
+++ b/__tests__/plugins/textColor.test.js
@@ -1,0 +1,64 @@
+import _ from 'lodash'
+import escapeClassName from '../../src/util/escapeClassName'
+import plugin from '../../src/plugins/textColor'
+
+test('colors can be a nested object', () => {
+  const addedUtilities = []
+
+  const config = {
+    theme: {
+      textColor: {
+        purple: 'purple',
+        red: {
+          1: 'rgb(33,0,0)',
+          2: 'rgb(67,0,0)',
+          3: 'rgb(100,0,0)',
+        },
+        green: {
+          1: 'rgb(0,33,0)',
+          2: 'rgb(0,67,0)',
+          3: 'rgb(0,100,0)',
+        },
+        blue: {
+          1: 'rgb(0,0,33)',
+          2: 'rgb(0,0,67)',
+          3: 'rgb(0,0,100)',
+        },
+      },
+    },
+    variants: {
+      textColor: ['responsive'],
+    },
+  }
+
+  const pluginApi = {
+    config: (key, defaultValue) => _.get(config, key, defaultValue),
+    e: escapeClassName,
+    addUtilities(utilities, variants) {
+      addedUtilities.push({
+        utilities,
+        variants,
+      })
+    },
+  }
+
+  plugin()(pluginApi)
+
+  expect(addedUtilities).toEqual([
+    {
+      utilities: {
+        '.text-purple': { 'color': 'purple' },
+        '.text-red-1': { 'color': 'rgb(33,0,0)' },
+        '.text-red-2': { 'color': 'rgb(67,0,0)' },
+        '.text-red-3': { 'color': 'rgb(100,0,0)' },
+        '.text-green-1': { 'color': 'rgb(0,33,0)' },
+        '.text-green-2': { 'color': 'rgb(0,67,0)' },
+        '.text-green-3': { 'color': 'rgb(0,100,0)' },
+        '.text-blue-1': { 'color': 'rgb(0,0,33)' },
+        '.text-blue-2': { 'color': 'rgb(0,0,67)' },
+        '.text-blue-3': { 'color': 'rgb(0,0,100)' },
+      },
+      variants: ['responsive'],
+    },
+  ])
+})

--- a/src/plugins/backgroundColor.js
+++ b/src/plugins/backgroundColor.js
@@ -1,9 +1,22 @@
 import _ from 'lodash'
 
+function buildColorPalette(colors) {
+  const result = _(colors)
+    .flatMap((color, name) => {
+      return _.isObject(color)
+        ? _.map(color, (value, key) => [`${name}-${key}`, value])
+        : [[name, color]]
+    })
+    .fromPairs()
+    .value()
+
+  return result
+}
+
 export default function() {
   return function({ addUtilities, e, config }) {
     const utilities = _.fromPairs(
-      _.map(config('theme.backgroundColor'), (value, modifier) => {
+      _.map(buildColorPalette(config('theme.backgroundColor')), (value, modifier) => {
         return [
           `.${e(`bg-${modifier}`)}`,
           {

--- a/src/plugins/backgroundColor.js
+++ b/src/plugins/backgroundColor.js
@@ -1,22 +1,10 @@
 import _ from 'lodash'
-
-function buildColorPalette(colors) {
-  const result = _(colors)
-    .flatMap((color, name) => {
-      return _.isObject(color)
-        ? _.map(color, (value, key) => [`${name}-${key}`, value])
-        : [[name, color]]
-    })
-    .fromPairs()
-    .value()
-
-  return result
-}
+import flattenColorPalette from '../util/flattenColorPalette'
 
 export default function() {
   return function({ addUtilities, e, config }) {
     const utilities = _.fromPairs(
-      _.map(buildColorPalette(config('theme.backgroundColor')), (value, modifier) => {
+      _.map(flattenColorPalette(config('theme.backgroundColor')), (value, modifier) => {
         return [
           `.${e(`bg-${modifier}`)}`,
           {

--- a/src/plugins/borderColor.js
+++ b/src/plugins/borderColor.js
@@ -1,9 +1,12 @@
 import _ from 'lodash'
+import flattenColorPalette from '../util/flattenColorPalette'
 
 export default function() {
   return function({ addUtilities, e, config }) {
+    const colors = flattenColorPalette(config('theme.borderColor'))
+
     const utilities = _.fromPairs(
-      _.map(_.omit(config('theme.borderColor'), 'default'), (value, modifier) => {
+      _.map(_.omit(colors, 'default'), (value, modifier) => {
         return [
           `.${e(`border-${modifier}`)}`,
           {

--- a/src/plugins/textColor.js
+++ b/src/plugins/textColor.js
@@ -1,9 +1,10 @@
 import _ from 'lodash'
+import flattenColorPalette from '../util/flattenColorPalette'
 
 export default function() {
   return function({ addUtilities, e, config }) {
     const utilities = _.fromPairs(
-      _.map(config('theme.textColor'), (value, modifier) => {
+      _.map(flattenColorPalette(config('theme.textColor')), (value, modifier) => {
         return [
           `.${e(`text-${modifier}`)}`,
           {

--- a/src/util/flattenColorPalette.js
+++ b/src/util/flattenColorPalette.js
@@ -1,0 +1,14 @@
+import _ from 'lodash'
+
+export default function flattenColorPalette(colors) {
+  const result = _(colors)
+    .flatMap((color, name) => {
+      return _.isObject(color)
+        ? _.map(color, (value, key) => [`${name}-${key}`, value])
+        : [[name, color]]
+    })
+    .fromPairs()
+    .value()
+
+  return result
+}


### PR DESCRIPTION
This PR makes it possible to specify your colors using an object syntax like this:

```js
module.exports = {
    theme: {
      colors: {
        red: {
          1: 'rgb(33,0,0)',
          2: 'rgb(67,0,0)',
          3: 'rgb(100,0,0)',
        },
        green: {
          1: 'rgb(0,33,0)',
          2: 'rgb(0,67,0)',
          3: 'rgb(0,100,0)',
        },
        blue: {
          1: 'rgb(0,0,33)',
          2: 'rgb(0,0,67)',
          3: 'rgb(0,0,100)',
        },
      },
    },
},
```

I was hesitant to add this at first because I don't like introducing additional complexity into how the core plugins translate their configuration into actual CSS classes, and a flat key-value list is much simpler than a nested object like this in that regard.

My main motivation for adding this is that I want to make it really easy for people to "compose" custom color palettes out of a larger collection of colors we provide as part of Tailwind.

For example, imagine there was an official `@tailwindcss/colors` package that contained not only the colors Tailwind normally ships with, but a few dozen additional color palettes, like a lighter blue, a more navy blue, a warmer yellow or gold color, a set of warm greys, a very cool blue-ish grey, etc.

If this PR is merged, building your own site's color palette out of those predefined swatches would be really easy, and you could easily specify your own names for the actual colors:

```js
const colors = require('@tailwindcss/colors')

module.exports = {
    theme: {
      colors: {
        red: colors.red,
        grey: colors.blueGrey,
        yellow: colors.gold,
        green: colors.forestGreen,
        blue: colors.navyBlue,
      },
    },
},
```

This would hopefully help to  alleviate a really common problem people run into which is "how do I generate my own set of color shades from some base color I have?".

If Steve and I can put together a pretty comprehensive set of like 75-100 colors, all with 10 shades each, I feel like most people will be able to find the color they are looking for and won't need to figure out how to make all of the different shades themselves.

This PR doesn't contain any breaking changes, and still supports a simple key-value list just like it did before.