### PR TITLE
Load tailwind.config.js automatically if present

### DIFF
--- a/__tests__/customConfig.test.js
+++ b/__tests__/customConfig.test.js
@@ -1,16 +1,17 @@
 import fs from 'fs'
 import path from 'path'
+import rimraf from 'rimraf'
 import postcss from 'postcss'
 import tailwind from '../src/index'
 
 function inTempDirectory(callback) {
   return new Promise(resolve => {
+    rimraf.sync('./__tmp')
     fs.mkdirSync(path.resolve('./__tmp'))
     process.chdir(path.resolve('./__tmp'))
     callback().then(() => {
       process.chdir(path.resolve('../'))
-      fs.rmdirSync(path.resolve('./__tmp'))
-      resolve()
+      rimraf('./__tmp', resolve)
     })
   })
 }
@@ -113,7 +114,6 @@ test('tailwind.config.js is picked up by default', () => {
             }
           }
         `)
-        fs.unlinkSync(path.resolve('./tailwind.config.js'))
       })
   })
 })

--- a/__tests__/customConfig.test.js
+++ b/__tests__/customConfig.test.js
@@ -1,6 +1,19 @@
+import fs from 'fs'
 import path from 'path'
 import postcss from 'postcss'
 import tailwind from '../src/index'
+
+function inTempDirectory(callback) {
+  return new Promise(resolve => {
+    fs.mkdirSync(path.resolve('./__tmp'))
+    process.chdir(path.resolve('./__tmp'))
+    callback().then(() => {
+      process.chdir(path.resolve('../'))
+      fs.rmdirSync(path.resolve('./__tmp'))
+      resolve()
+    })
+  })
+}
 
 test('it uses the values from the custom config file', () => {
   return postcss([tailwind(path.resolve(`${__dirname}/fixtures/custom-config.js`))])
@@ -25,7 +38,6 @@ test('it uses the values from the custom config file', () => {
           }
         }
       `
-
       expect(result.css).toMatchCss(expected)
     })
 })
@@ -64,4 +76,44 @@ test('custom config can be passed as an object', () => {
 
       expect(result.css).toMatchCss(expected)
     })
+})
+
+test('tailwind.config.js is picked up by default', () => {
+  return inTempDirectory(() => {
+    fs.writeFileSync(
+      path.resolve('./tailwind.config.js'),
+      `module.exports = {
+        theme: {
+          screens: {
+            mobile: '400px',
+          },
+        },
+      }`
+    )
+
+    return postcss([tailwind])
+      .process(
+        `
+          @responsive {
+            .foo {
+              color: blue;
+            }
+          }
+        `,
+        { from: undefined }
+      )
+      .then(result => {
+        expect(result.css).toMatchCss(`
+          .foo {
+            color: blue;
+          }
+          @media (min-width: 400px) {
+            .mobile\\:foo {
+              color: blue;
+            }
+          }
+        `)
+        fs.unlinkSync(path.resolve('./tailwind.config.js'))
+      })
+  })
 })

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-prettier": "^2.3.1",
     "jest": "^23.6.0",
     "prettier": "^1.7.4",
-    "rimraf": "^2.6.1"
+    "rimraf": "^2.6.3"
   },
   "dependencies": {
     "autoprefixer": "^9.4.5",

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ const plugin = postcss.plugin('tailwind', config => {
 
   return postcss([
     ...plugins,
-    processTailwindFeatures(getConfigFunction(resolvedConfigPath ? resolvedConfigPath : config)),
+    processTailwindFeatures(getConfigFunction(resolvedConfigPath || config)),
     perfectionist({
       cascade: true,
       colorShorthand: true,

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import path from 'path'
+import fs from 'fs'
 
 import _ from 'lodash'
 import postcss from 'postcss'
@@ -8,31 +9,50 @@ import registerConfigAsDependency from './lib/registerConfigAsDependency'
 import processTailwindFeatures from './processTailwindFeatures'
 import resolveConfig from './util/resolveConfig'
 
-const plugin = postcss.plugin('tailwind', config => {
-  const plugins = []
-
-  if (!_.isUndefined(config) && !_.isObject(config)) {
-    plugins.push(registerConfigAsDependency(path.resolve(config)))
+function resolveConfigPath(filePath) {
+  if (_.isObject(filePath)) {
+    return undefined
   }
 
-  const getConfig = () => {
-    if (_.isUndefined(config)) {
-      return resolveConfig([require('../defaultConfig')()])
-    }
+  if (!_.isUndefined(filePath)) {
+    return path.resolve(filePath)
+  }
 
-    if (!_.isObject(config)) {
-      delete require.cache[require.resolve(path.resolve(config))]
-    }
+  try {
+    const defaultConfigPath = path.resolve('./tailwind.config.js')
+    fs.accessSync(defaultConfigPath)
+    return defaultConfigPath
+  } catch (err) {
+    return undefined
+  }
+}
 
-    return resolveConfig([
-      _.isObject(config) ? config : require(path.resolve(config)),
-      require('../defaultConfig')(),
-    ])
+const getConfigFunction = config => () => {
+  if (_.isUndefined(config) && !_.isObject(config)) {
+    return resolveConfig([require('../defaultConfig')()])
+  }
+
+  if (!_.isObject(config)) {
+    delete require.cache[require.resolve(config)]
+  }
+
+  return resolveConfig([
+    _.isObject(config) ? config : require(config),
+    require('../defaultConfig')(),
+  ])
+}
+
+const plugin = postcss.plugin('tailwind', config => {
+  const plugins = []
+  const resolvedConfigPath = resolveConfigPath(config)
+
+  if (!_.isUndefined(resolvedConfigPath)) {
+    plugins.push(registerConfigAsDependency(resolvedConfigPath))
   }
 
   return postcss([
     ...plugins,
-    processTailwindFeatures(getConfig),
+    processTailwindFeatures(getConfigFunction(resolvedConfigPath ? resolvedConfigPath : config)),
     perfectionist({
       cascade: true,
       colorShorthand: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2208,6 +2208,18 @@ glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 globals@^11.0.1:
   version "11.5.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.5.0.tgz#6bc840de6771173b191f13d3a9c94d441ee92642"
@@ -4436,6 +4448,13 @@ rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1:
   integrity sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==
   dependencies:
     glob "^7.0.5"
+
+rimraf@^2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
 
 rsvp@^3.3.3:
   version "3.6.2"


### PR DESCRIPTION
This PR makes Tailwind automatically load a `tailwind.config.js` file (the new name we will be recommending in v1.0) as your config file if it's present in your project root.

This means you don't need to even invoke Tailwind as a function in your `postcss.config.js` file since PostCSS will handle that automatically, leaves things looking a bit cleaner:

```diff
  module.exports = {
    plugins: [
-     require('tailwindcss')('./tailwind.config.js'),
+     require('tailwindcss'),
      require('autoprefixer')
    ]
  }
```

You can of course still pass a path to your config file if you want to keep it somewhere else 👍 

```js
module.exports = {
  plugins: [
    require('tailwindcss')('./path/to/some/other/tailwind.config.js'),
    require('autoprefixer')
  ]
}
```