### PR TITLE
Add `disabled` variant 

### DIFF
--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -30,6 +30,27 @@ test('it can generate hover variants', () => {
   })
 })
 
+test('it can generate disabled variants', () => {
+  const input = `
+    @variants disabled {
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+    }
+  `
+
+  const output = `
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+      .disabled\\:banana:disabled { color: yellow; }
+      .disabled\\:chocolate:disabled { color: brown; }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('it can generate active variants', () => {
   const input = `
     @variants active {

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -25,6 +25,7 @@ const defaultVariantGenerators = {
   'focus-within': generatePseudoClassVariant('focus-within'),
   focus: generatePseudoClassVariant('focus'),
   active: generatePseudoClassVariant('active'),
+  disabled: generatePseudoClassVariant('disabled'),
 }
 
 export default function(config, { variantGenerators: pluginVariantGenerators }) {


### PR DESCRIPTION
This commit adds a `disabled` variant to the Tailwind core. Not sure if/where this would be used by default.

This will allow devs to add styling for disabled elements the same way we use other variants like `hover` and `focus`.

```html
<button class="bg-blue disabled:bg-grey-lighter">Disabled</button>
```

I noticed @adamwathan listed this small feature in #692. Maybe this solves that.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
