### PR TITLE
Make headings inherit line-height in Preflight

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -486,6 +486,7 @@ h5,
 h6 {
   font-size: inherit;
   font-weight: inherit;
+  line-height: inherit;
 }
 
 .container {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -486,6 +486,7 @@ h5,
 h6 {
   font-size: inherit;
   font-weight: inherit;
+  line-height: inherit;
 }
 
 .container {

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -132,4 +132,5 @@ h5,
 h6 {
   font-size: inherit;
   font-weight: inherit;
+  line-height: inherit;
 }


### PR DESCRIPTION
If we're going to reset the font-size and font-weight for headings, we should reset the line-height too. We don't want headings to really look like headings in any way by default, any styling should be explicit and intentional to ensure you don't accidentally deviate from your own design system.