### PR TITLE
Make form elements inherit more font properties

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -489,9 +489,11 @@ h6 {
 }
 
 /**
- * Inherit color, font-weight, and line-height from the parent
+ * Reset form elements to inherit their styles from the parent
  * so that form elements don't inadvertently have any styles
- * that deviate from your design system.
+ * that deviate from your design system. These styles
+ * supplement a partial reset that is already applied by
+ * normalize.css.
  */
 
 button,
@@ -499,9 +501,17 @@ input,
 optgroup,
 select,
 textarea {
+  padding: 0;
+  border-radius: 0;
+  background-color: transparent;
   color: inherit;
   font-weight: inherit;
   line-height: inherit;
+  font-style: inherit;
+  font-variant: inherit;
+  text-align: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
 }
 
 .container {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -488,6 +488,22 @@ h6 {
   font-weight: inherit;
 }
 
+/**
+ * Inherit color, font-weight, and line-height from the parent
+ * so that form elements don't inadvertently have any styles
+ * that deviate from your design system.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+}
+
 .container {
   width: 100%;
 }

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -504,7 +504,6 @@ textarea {
   padding: 0;
   line-height: inherit;
   color: inherit;
-  background-color: transparent;
 }
 
 .container {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -489,9 +489,9 @@ h6 {
 }
 
 /**
- * Reset form elements to inherit their styles from the parent
- * so that form elements don't inadvertently have any styles
- * that deviate from your design system. These styles
+ * Reset form element properties that are easy to forget to
+ * style explicitly so you don't inadvertently introduce
+ * styles that deviate from your design system. These styles
  * supplement a partial reset that is already applied by
  * normalize.css.
  */
@@ -502,16 +502,9 @@ optgroup,
 select,
 textarea {
   padding: 0;
-  border-radius: 0;
-  background-color: transparent;
-  color: inherit;
-  font-weight: inherit;
   line-height: inherit;
-  font-style: inherit;
-  font-variant: inherit;
-  text-align: inherit;
-  text-transform: inherit;
-  letter-spacing: inherit;
+  color: inherit;
+  background-color: transparent;
 }
 
 .container {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -489,9 +489,11 @@ h6 {
 }
 
 /**
- * Inherit color, font-weight, and line-height from the parent
+ * Reset form elements to inherit their styles from the parent
  * so that form elements don't inadvertently have any styles
- * that deviate from your design system.
+ * that deviate from your design system. These styles
+ * supplement a partial reset that is already applied by
+ * normalize.css.
  */
 
 button,
@@ -499,9 +501,17 @@ input,
 optgroup,
 select,
 textarea {
+  padding: 0;
+  border-radius: 0;
+  background-color: transparent;
   color: inherit;
   font-weight: inherit;
   line-height: inherit;
+  font-style: inherit;
+  font-variant: inherit;
+  text-align: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
 }
 
 .container {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -488,6 +488,22 @@ h6 {
   font-weight: inherit;
 }
 
+/**
+ * Inherit color, font-weight, and line-height from the parent
+ * so that form elements don't inadvertently have any styles
+ * that deviate from your design system.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+}
+
 .container {
   width: 100%;
 }

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -504,7 +504,6 @@ textarea {
   padding: 0;
   line-height: inherit;
   color: inherit;
-  background-color: transparent;
 }
 
 .container {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -489,9 +489,9 @@ h6 {
 }
 
 /**
- * Reset form elements to inherit their styles from the parent
- * so that form elements don't inadvertently have any styles
- * that deviate from your design system. These styles
+ * Reset form element properties that are easy to forget to
+ * style explicitly so you don't inadvertently introduce
+ * styles that deviate from your design system. These styles
  * supplement a partial reset that is already applied by
  * normalize.css.
  */
@@ -502,16 +502,9 @@ optgroup,
 select,
 textarea {
   padding: 0;
-  border-radius: 0;
-  background-color: transparent;
-  color: inherit;
-  font-weight: inherit;
   line-height: inherit;
-  font-style: inherit;
-  font-variant: inherit;
-  text-align: inherit;
-  text-transform: inherit;
-  letter-spacing: inherit;
+  color: inherit;
+  background-color: transparent;
 }
 
 .container {

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -133,3 +133,18 @@ h6 {
   font-size: inherit;
   font-weight: inherit;
 }
+
+/**
+ * Inherit color, font-weight, and line-height from the parent
+ * so that form elements don't inadvertently have any styles
+ * that deviate from your design system.
+ */
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+}

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -135,16 +135,27 @@ h6 {
 }
 
 /**
- * Inherit color, font-weight, and line-height from the parent
+ * Reset form elements to inherit their styles from the parent
  * so that form elements don't inadvertently have any styles
- * that deviate from your design system.
+ * that deviate from your design system. These styles
+ * supplement a partial reset that is already applied by
+ * normalize.css.
  */
+
 button,
 input,
 optgroup,
 select,
 textarea {
+  padding: 0;
+  border-radius: 0;
+  background-color: transparent;
   color: inherit;
   font-weight: inherit;
   line-height: inherit;
+  font-style: inherit;
+  font-variant: inherit;
+  text-align: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
 }

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -135,9 +135,9 @@ h6 {
 }
 
 /**
- * Reset form elements to inherit their styles from the parent
- * so that form elements don't inadvertently have any styles
- * that deviate from your design system. These styles
+ * Reset form element properties that are easy to forget to
+ * style explicitly so you don't inadvertently introduce
+ * styles that deviate from your design system. These styles
  * supplement a partial reset that is already applied by
  * normalize.css.
  */
@@ -148,14 +148,7 @@ optgroup,
 select,
 textarea {
   padding: 0;
-  border-radius: 0;
-  background-color: transparent;
-  color: inherit;
-  font-weight: inherit;
   line-height: inherit;
-  font-style: inherit;
-  font-variant: inherit;
-  text-align: inherit;
-  text-transform: inherit;
-  letter-spacing: inherit;
+  color: inherit;
+  background-color: transparent;
 }

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -150,5 +150,4 @@ textarea {
   padding: 0;
   line-height: inherit;
   color: inherit;
-  background-color: transparent;
 }


### PR DESCRIPTION
By default, browsers apply a bunch of default font-related properties to form elements that take precedence over styles defined on the parent element.

Since Tailwind encourages you to implement designs using a constrained system, this can be a bit of a pain point and lead to accidentally leaving in user agent styles that aren't part of your design system, like the text in inputs being full-on black, or buttons having a slightly different line-height than normal text.

Normalize.css (which we use as the base for our Preflight styles) [corrects](https://github.com/necolas/normalize.css/blob/master/normalize.css#L155-L169) a lot of these inconsistencies:

```css
/**
 * 1. Change the font styles in all browsers.
 * 2. Remove the margin in Firefox and Safari.
 */

button,
input,
optgroup,
select,
textarea {
  font-family: inherit; /* 1 */
  font-size: 100%; /* 1 */
  line-height: 1.15; /* 1 */
  margin: 0; /* 2 */
}
```

...but doesn't touch color or font-weight, as that would be a bit too opinionated for what Normalize is trying to do.

This PR makes all form elements inherit `color`, `font-weight`, and `line-height` so that it's much harder to accidentally introduce styles that deviate from your design system.

That way if you don't override any of those values on a form element with a utility, at least the default value will be something specified in your system (assuming you have added some base styles to the `html` or `body` tag).

Put another way, this PR tries to make sure that a form element with a given list of utilities applied to it looks exactly the same as a `span` would look with the same utilities.