### PR TITLE
Revert #629

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -463,6 +463,11 @@ textarea {
   resize: vertical;
 }
 
+img {
+  max-width: 100%;
+  height: auto;
+}
+
 input::placeholder,
 textarea::placeholder {
   color: inherit;

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -463,6 +463,11 @@ textarea {
   resize: vertical;
 }
 
+img {
+  max-width: 100%;
+  height: auto;
+}
+
 input::placeholder,
 textarea::placeholder {
   color: inherit;

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -109,6 +109,11 @@ textarea {
   resize: vertical;
 }
 
+img {
+  max-width: 100%;
+  height: auto;
+}
+
 input::placeholder,
 textarea::placeholder {
   color: inherit;


### PR DESCRIPTION
This PR reverts a change in #629 that removed the following styles from Preflight:

```css
img {
  max-width: 100%;
  height: auto;
}
```

That PR was trying to fix an issue where the `height: auto` declaration was overriding the `height` attribute on an image in situations like this:

```html
<img src="..." width="250" height="1000">
```

...but I personally think this default is really useful, and would rather recommend people work around this issue using inline styles if it ever actually affects them:

```html
<img src="..." style="width: 250px; height: 1000px">
```