### PR TITLE
Use configured bold for strong tags

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -506,6 +506,16 @@ textarea {
   color: inherit;
 }
 
+/**
+ * Use the configured 'bold' weight for `strong` elements
+ * by default, falling back to 'bolder' (as per normalize.css)
+ * if there is no configured 'bold' weight.
+ */
+
+strong {
+  font-weight: 700;
+}
+
 .container {
   width: 100%;
 }

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -506,6 +506,16 @@ textarea {
   color: inherit;
 }
 
+/**
+ * Use the configured 'bold' weight for `strong` elements
+ * by default, falling back to 'bolder' (as per normalize.css)
+ * if there is no configured 'bold' weight.
+ */
+
+strong {
+  font-weight: 700;
+}
+
 .container {
   width: 100%;
 }

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -151,3 +151,13 @@ textarea {
   line-height: inherit;
   color: inherit;
 }
+
+/**
+ * Use the configured 'bold' weight for `strong` elements
+ * by default, falling back to 'bolder' (as per normalize.css)
+ * if there is no configured 'bold' weight.
+ */
+
+strong {
+  font-weight: theme('fontWeight.bold', bolder);
+}


### PR DESCRIPTION
Use the configured 'bold' weight for `strong` elements by default, falling back to 'bolder' (as per normalize.css) if there is no configured 'bold' weight.

This isn't perfect as there's no guarantee the user wants to use `bolder` for `strong` tags if they've changed the name of their font-weight classes, but it's one of those "slightly better than what we had before, and definitely not in any way worse" improvements that there's no reason not to make.