### PR TITLE
Use system font stack by default instead of sans-serif

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -422,6 +422,14 @@ ul {
  */
 
 /**
+ * Use the system font stack as a sane default.
+ */
+
+html {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+}
+
+/**
  * Allow adding a border to an element by just adding a border-width.
  *
  * By default, the way the browser specifies that an element should have no

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -422,6 +422,14 @@ ul {
  */
 
 /**
+ * Use the system font stack as a sane default.
+ */
+
+html {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+}
+
+/**
  * Allow adding a border to an element by just adding a border-width.
  *
  * By default, the way the browser specifies that an element should have no

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -70,6 +70,14 @@ ul {
  */
 
 /**
+ * Use the system font stack as a sane default.
+ */
+
+html {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+}
+
+/**
  * Allow adding a border to an element by just adding a border-width.
  *
  * By default, the way the browser specifies that an element should have no


### PR DESCRIPTION
Literally nobody wants to use `sans-serif` as their default font family. At least _some_ people want to use the system-ui font stack, so this is better.

Will consider collapsing this into our SUIT CSS base styles but in a separate PR.