### PR TITLE
Support unquoted lists as default theme function values

### DIFF
--- a/__tests__/themeFunction.test.js
+++ b/__tests__/themeFunction.test.js
@@ -88,3 +88,24 @@ test('quotes are preserved around default values', () => {
     expect(result.warnings().length).toBe(0)
   })
 })
+
+test('an unquoted list is valid as a default value', () => {
+  const input = `
+    .heading { font-family: theme('fonts.sans', Helvetica, Arial, sans-serif); }
+  `
+
+  const output = `
+    .heading { font-family: Helvetica, Arial, sans-serif; }
+  `
+
+  return run(input, {
+    theme: {
+      fonts: {
+        serif: 'Constantia',
+      },
+    },
+  }).then(result => {
+    expect(result.css).toEqual(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})

--- a/src/lib/evaluateTailwindFunctions.js
+++ b/src/lib/evaluateTailwindFunctions.js
@@ -4,8 +4,8 @@ import functions from 'postcss-functions'
 export default function(config) {
   return functions({
     functions: {
-      theme: (path, defaultValue) => {
-        return _.get(config.theme, _.trim(path, `'"`), defaultValue)
+      theme: (path, ...defaultValue) => {
+        return _.get(config.theme, _.trim(path, `'"`), defaultValue.join(', '))
       },
     },
   })


### PR DESCRIPTION
This PR makes it possible to provide an unquoted, comma separated list of values as the default value in the `theme` function.

This is useful when you want to fallback to a CSS-style list, like you might see in a font stack:

```css
html {
  font-family: Helvetica, Arial, sans-serif;
}
```

Usage looks like this:

```css
html {
  font-family: theme('fontFamily.sans', Helvetica, Arial, sans-serif);
}
```