### PR TITLE
Use configured monospace font for monospace elements

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -527,6 +527,20 @@ strong {
   font-weight: 700;
 }
 
+/**
+ * Use the configured 'mono' font family for elements that
+ * are expected to be rendered with a monospace font, falling
+ * back to the system monospace stack if there is no configured
+ * 'mono' font family.
+ */
+
+pre,
+code,
+kbd,
+samp {
+  font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
 .container {
   width: 100%;
 }

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -527,6 +527,20 @@ strong {
   font-weight: 700;
 }
 
+/**
+ * Use the configured 'mono' font family for elements that
+ * are expected to be rendered with a monospace font, falling
+ * back to the system monospace stack if there is no configured
+ * 'mono' font family.
+ */
+
+pre,
+code,
+kbd,
+samp {
+  font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
 .container {
   width: 100%;
 }

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -172,3 +172,17 @@ textarea {
 strong {
   font-weight: theme('fontWeight.bold', bolder);
 }
+
+/**
+ * Use the configured 'mono' font family for elements that
+ * are expected to be rendered with a monospace font, falling
+ * back to the system monospace stack if there is no configured
+ * 'mono' font family.
+ */
+
+pre,
+code,
+kbd,
+samp {
+  font-family: theme('fontFamily.mono', SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
+}


### PR DESCRIPTION
Use the configured 'mono' font family for elements that are expected to be rendered with a monospace font, falling back to the system monospace stack if there is no configured 'mono' font family.

This helps to avoid the common mistake of using an element like `code` but forgetting to apply the `font-mono` class and accidentally introducing a new font family into your design.