### PR TITLE
Attempt to fix iOS Safari's baked in border radius

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -518,6 +518,24 @@ textarea {
 }
 
 /**
+ * Reset the border radius on form elements to be consistent
+ * across browsers (iOS Safari rounds them by default), but
+ * ensure radio buttons stay rounded using a low specificity
+ * selector.
+ */
+
+input,
+button,
+select,
+textarea {
+  border-radius: 0;
+}
+
+[type="radio"] {
+  border-radius: 50%;
+}
+
+/**
  * Use the configured 'bold' weight for `strong` elements
  * by default, falling back to 'bolder' (as per normalize.css)
  * if there is no configured 'bold' weight.

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -518,6 +518,24 @@ textarea {
 }
 
 /**
+ * Reset the border radius on form elements to be consistent
+ * across browsers (iOS Safari rounds them by default), but
+ * ensure radio buttons stay rounded using a low specificity
+ * selector.
+ */
+
+input,
+button,
+select,
+textarea {
+  border-radius: 0;
+}
+
+[type="radio"] {
+  border-radius: 50%;
+}
+
+/**
  * Use the configured 'bold' weight for `strong` elements
  * by default, falling back to 'bolder' (as per normalize.css)
  * if there is no configured 'bold' weight.

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -164,6 +164,24 @@ textarea {
 }
 
 /**
+ * Reset the border radius on form elements to be consistent
+ * across browsers (iOS Safari rounds them by default), but
+ * ensure radio buttons stay rounded using a low specificity
+ * selector.
+ */
+
+input,
+button,
+select,
+textarea {
+  border-radius: 0;
+}
+
+[type="radio"] {
+  border-radius: 50%;
+}
+
+/**
  * Use the configured 'bold' weight for `strong` elements
  * by default, falling back to 'bolder' (as per normalize.css)
  * if there is no configured 'bold' weight.


### PR DESCRIPTION
On iOS, Safari adds a border radius to most form elements (inputs, text areas, etc.), whereas every other browser leaves the corners square by default.

This makes it easy to run into situations where you accidentally depend on the default behavior of say Chrome giving you square corners, and then you check your site on iOS Safari and notice everything is rounded.

This PR attempts to avoid this pitfall by ensuring all form elements have a border radius of 0 by default, then re-adds a circular border radius (taken from the iOS Safari user agent stylesheet) to radio buttons, because on iOS Safari those become square when you set border radius to 0.

I use a very low specificity selector (just `[type="radio"]`) to fix the radio buttons to make sure you can still override that stuff with classes if necessary.

I'm not fully convinced this is worth adding because it might create more trouble than it solves. If you have a lot of experience dealing with cross-browser form styling and can think of any negative consequences to this, please share. I'm especially curious about other mobile browsers.