### PR TITLE
Change sm screen to 640px

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -545,9 +545,9 @@ samp {
   width: 100%;
 }
 
-@media (min-width: 568px) {
+@media (min-width: 640px) {
   .container {
-    max-width: 568px;
+    max-width: 640px;
   }
 }
 
@@ -6601,7 +6601,7 @@ samp {
   color: #e3342f;
 }
 
-@media (min-width: 568px) {
+@media (min-width: 640px) {
   .sm\:list-reset {
     list-style: none !important;
     padding: 0 !important;

--- a/__tests__/fixtures/tailwind-output-with-explicit-screen-utilities.css
+++ b/__tests__/fixtures/tailwind-output-with-explicit-screen-utilities.css
@@ -2,7 +2,7 @@
   color: red;
 }
 
-@media (min-width: 568px) {
+@media (min-width: 640px) {
   .sm\:example {
     color: red;
   }

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -545,9 +545,9 @@ samp {
   width: 100%;
 }
 
-@media (min-width: 568px) {
+@media (min-width: 640px) {
   .container {
-    max-width: 568px;
+    max-width: 640px;
   }
 }
 
@@ -6601,7 +6601,7 @@ samp {
   color: #e3342f;
 }
 
-@media (min-width: 568px) {
+@media (min-width: 640px) {
   .sm\:list-reset {
     list-style: none;
     padding: 0;

--- a/defaultTheme.js
+++ b/defaultTheme.js
@@ -107,7 +107,7 @@ module.exports = function() {
       '64': '16rem',
     },
     screens: {
-      sm: '568px',
+      sm: '640px',
       md: '768px',
       lg: '1024px',
       xl: '1280px',


### PR DESCRIPTION
Previously we switched the `sm` breakpoint from 576px (borrowed from Bootstrap) to 568px (to match the landscape viewport of an iPhone SE.)

The iPhone SE is no longer manufactured and no other smartphone maker makes a phone with a viewport size that low, so I think it makes more sense to use a larger size for `sm` than it does to try and optimize for a screen size that will eventually no longer really be used.

By changing the `sm` breakpoint from 568 to 640, you only have to worry about making your design work in the 640-768 range instead of the 568-768 range. This is really helpful if you have some sort of side-by-side layout that would work great at say 620px, but looks bad below that size.

Using 568px as the `sm` breakpoint, you would be forced to compromise on the design and serve a more stacked layout to devices all the way up to 768px, just because your original layout broke down right at the bottom end of the range.

At first it might sound wasteful to have to use the same layout for any viewport in the 0-640px range for similar reasons, but in practice the next viewport size you are likely to encounter under 640px is 480px, and the iPhone SE in portrait mode is 320px, so you're only really designing for the 320px-480px range in practice.

640px was chosen because it was the second smallest landscape viewport size I could find in [this article](https://mediag.com/blog/popular-screen-resolutions-designing-for-all/) (it's the size of the Galaxy S7). It also happens to be 128px away from 768px, which is exactly half the 256px gap between 768 and 1024, so that's at least a little satisfying :)