### PR TITLE
Make link styling opt-in instead of opt-out

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -500,6 +500,16 @@ h6 {
 }
 
 /**
+ * Reset links to optimize for opt-in styling instead of
+ * opt-out.
+ */
+
+a {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+/**
  * Reset form element properties that are easy to forget to
  * style explicitly so you don't inadvertently introduce
  * styles that deviate from your design system. These styles

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -500,6 +500,16 @@ h6 {
 }
 
 /**
+ * Reset links to optimize for opt-in styling instead of
+ * opt-out.
+ */
+
+a {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+/**
  * Reset form element properties that are easy to forget to
  * style explicitly so you don't inadvertently introduce
  * styles that deviate from your design system. These styles

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -146,6 +146,16 @@ h6 {
 }
 
 /**
+ * Reset links to optimize for opt-in styling instead of
+ * opt-out.
+ */
+
+a {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+/**
  * Reset form element properties that are easy to forget to
  * style explicitly so you don't inadvertently introduce
  * styles that deviate from your design system. These styles


### PR DESCRIPTION
This is an opinionated and breaking change, but I am personally sick of adding `no-underline` to 95% of links on the projects I work on. Asking people to add `underline` when they want an underline seems like the better trade-off to me.

Similarly, I literally never want the default browser blue, so `inherit` seems like a much more useful default.