### PR TITLE
Rework list utilities

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -569,9 +569,8 @@ samp {
   }
 }
 
-.list-reset {
-  list-style: none !important;
-  padding: 0 !important;
+.list-none {
+  list-style-type: none !important;
 }
 
 .appearance-none {
@@ -6602,9 +6601,8 @@ samp {
 }
 
 @media (min-width: 640px) {
-  .sm\:list-reset {
-    list-style: none !important;
-    padding: 0 !important;
+  .sm\:list-none {
+    list-style-type: none !important;
   }
 
   .sm\:appearance-none {
@@ -12612,9 +12610,8 @@ samp {
 }
 
 @media (min-width: 768px) {
-  .md\:list-reset {
-    list-style: none !important;
-    padding: 0 !important;
+  .md\:list-none {
+    list-style-type: none !important;
   }
 
   .md\:appearance-none {
@@ -18622,9 +18619,8 @@ samp {
 }
 
 @media (min-width: 1024px) {
-  .lg\:list-reset {
-    list-style: none !important;
-    padding: 0 !important;
+  .lg\:list-none {
+    list-style-type: none !important;
   }
 
   .lg\:appearance-none {
@@ -24632,9 +24628,8 @@ samp {
 }
 
 @media (min-width: 1280px) {
-  .xl\:list-reset {
-    list-style: none !important;
-    padding: 0 !important;
+  .xl\:list-none {
+    list-style-type: none !important;
   }
 
   .xl\:appearance-none {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -569,18 +569,6 @@ samp {
   }
 }
 
-.list-none {
-  list-style-type: none !important;
-}
-
-.list-disc {
-  list-style-type: disc !important;
-}
-
-.list-decimal {
-  list-style-type: decimal !important;
-}
-
 .appearance-none {
   appearance: none !important;
 }
@@ -3185,6 +3173,26 @@ samp {
 
 .leading-loose {
   line-height: 2 !important;
+}
+
+.list-inside {
+  list-style-position: inside !important;
+}
+
+.list-outside {
+  list-style-position: outside !important;
+}
+
+.list-none {
+  list-style-type: none !important;
+}
+
+.list-disc {
+  list-style-type: disc !important;
+}
+
+.list-decimal {
+  list-style-type: decimal !important;
 }
 
 .m-0 {
@@ -6609,18 +6617,6 @@ samp {
 }
 
 @media (min-width: 640px) {
-  .sm\:list-none {
-    list-style-type: none !important;
-  }
-
-  .sm\:list-disc {
-    list-style-type: disc !important;
-  }
-
-  .sm\:list-decimal {
-    list-style-type: decimal !important;
-  }
-
   .sm\:appearance-none {
     appearance: none !important;
   }
@@ -9217,6 +9213,26 @@ samp {
 
   .sm\:leading-loose {
     line-height: 2 !important;
+  }
+
+  .sm\:list-inside {
+    list-style-position: inside !important;
+  }
+
+  .sm\:list-outside {
+    list-style-position: outside !important;
+  }
+
+  .sm\:list-none {
+    list-style-type: none !important;
+  }
+
+  .sm\:list-disc {
+    list-style-type: disc !important;
+  }
+
+  .sm\:list-decimal {
+    list-style-type: decimal !important;
   }
 
   .sm\:m-0 {
@@ -12626,18 +12642,6 @@ samp {
 }
 
 @media (min-width: 768px) {
-  .md\:list-none {
-    list-style-type: none !important;
-  }
-
-  .md\:list-disc {
-    list-style-type: disc !important;
-  }
-
-  .md\:list-decimal {
-    list-style-type: decimal !important;
-  }
-
   .md\:appearance-none {
     appearance: none !important;
   }
@@ -15234,6 +15238,26 @@ samp {
 
   .md\:leading-loose {
     line-height: 2 !important;
+  }
+
+  .md\:list-inside {
+    list-style-position: inside !important;
+  }
+
+  .md\:list-outside {
+    list-style-position: outside !important;
+  }
+
+  .md\:list-none {
+    list-style-type: none !important;
+  }
+
+  .md\:list-disc {
+    list-style-type: disc !important;
+  }
+
+  .md\:list-decimal {
+    list-style-type: decimal !important;
   }
 
   .md\:m-0 {
@@ -18643,18 +18667,6 @@ samp {
 }
 
 @media (min-width: 1024px) {
-  .lg\:list-none {
-    list-style-type: none !important;
-  }
-
-  .lg\:list-disc {
-    list-style-type: disc !important;
-  }
-
-  .lg\:list-decimal {
-    list-style-type: decimal !important;
-  }
-
   .lg\:appearance-none {
     appearance: none !important;
   }
@@ -21251,6 +21263,26 @@ samp {
 
   .lg\:leading-loose {
     line-height: 2 !important;
+  }
+
+  .lg\:list-inside {
+    list-style-position: inside !important;
+  }
+
+  .lg\:list-outside {
+    list-style-position: outside !important;
+  }
+
+  .lg\:list-none {
+    list-style-type: none !important;
+  }
+
+  .lg\:list-disc {
+    list-style-type: disc !important;
+  }
+
+  .lg\:list-decimal {
+    list-style-type: decimal !important;
   }
 
   .lg\:m-0 {
@@ -24660,18 +24692,6 @@ samp {
 }
 
 @media (min-width: 1280px) {
-  .xl\:list-none {
-    list-style-type: none !important;
-  }
-
-  .xl\:list-disc {
-    list-style-type: disc !important;
-  }
-
-  .xl\:list-decimal {
-    list-style-type: decimal !important;
-  }
-
   .xl\:appearance-none {
     appearance: none !important;
   }
@@ -27268,6 +27288,26 @@ samp {
 
   .xl\:leading-loose {
     line-height: 2 !important;
+  }
+
+  .xl\:list-inside {
+    list-style-position: inside !important;
+  }
+
+  .xl\:list-outside {
+    list-style-position: outside !important;
+  }
+
+  .xl\:list-none {
+    list-style-type: none !important;
+  }
+
+  .xl\:list-disc {
+    list-style-type: disc !important;
+  }
+
+  .xl\:list-decimal {
+    list-style-type: decimal !important;
   }
 
   .xl\:m-0 {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -573,6 +573,14 @@ samp {
   list-style-type: none !important;
 }
 
+.list-disc {
+  list-style-type: disc !important;
+}
+
+.list-decimal {
+  list-style-type: decimal !important;
+}
+
 .appearance-none {
   appearance: none !important;
 }
@@ -6605,6 +6613,14 @@ samp {
     list-style-type: none !important;
   }
 
+  .sm\:list-disc {
+    list-style-type: disc !important;
+  }
+
+  .sm\:list-decimal {
+    list-style-type: decimal !important;
+  }
+
   .sm\:appearance-none {
     appearance: none !important;
   }
@@ -12612,6 +12628,14 @@ samp {
 @media (min-width: 768px) {
   .md\:list-none {
     list-style-type: none !important;
+  }
+
+  .md\:list-disc {
+    list-style-type: disc !important;
+  }
+
+  .md\:list-decimal {
+    list-style-type: decimal !important;
   }
 
   .md\:appearance-none {
@@ -18623,6 +18647,14 @@ samp {
     list-style-type: none !important;
   }
 
+  .lg\:list-disc {
+    list-style-type: disc !important;
+  }
+
+  .lg\:list-decimal {
+    list-style-type: decimal !important;
+  }
+
   .lg\:appearance-none {
     appearance: none !important;
   }
@@ -24630,6 +24662,14 @@ samp {
 @media (min-width: 1280px) {
   .xl\:list-none {
     list-style-type: none !important;
+  }
+
+  .xl\:list-disc {
+    list-style-type: disc !important;
+  }
+
+  .xl\:list-decimal {
+    list-style-type: decimal !important;
   }
 
   .xl\:appearance-none {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -414,7 +414,9 @@ fieldset {
 
 ol,
 ul {
+  list-style: none;
   margin: 0;
+  padding: 0;
 }
 
 /**

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -569,18 +569,6 @@ samp {
   }
 }
 
-.list-none {
-  list-style-type: none;
-}
-
-.list-disc {
-  list-style-type: disc;
-}
-
-.list-decimal {
-  list-style-type: decimal;
-}
-
 .appearance-none {
   appearance: none;
 }
@@ -3185,6 +3173,26 @@ samp {
 
 .leading-loose {
   line-height: 2;
+}
+
+.list-inside {
+  list-style-position: inside;
+}
+
+.list-outside {
+  list-style-position: outside;
+}
+
+.list-none {
+  list-style-type: none;
+}
+
+.list-disc {
+  list-style-type: disc;
+}
+
+.list-decimal {
+  list-style-type: decimal;
 }
 
 .m-0 {
@@ -6609,18 +6617,6 @@ samp {
 }
 
 @media (min-width: 640px) {
-  .sm\:list-none {
-    list-style-type: none;
-  }
-
-  .sm\:list-disc {
-    list-style-type: disc;
-  }
-
-  .sm\:list-decimal {
-    list-style-type: decimal;
-  }
-
   .sm\:appearance-none {
     appearance: none;
   }
@@ -9217,6 +9213,26 @@ samp {
 
   .sm\:leading-loose {
     line-height: 2;
+  }
+
+  .sm\:list-inside {
+    list-style-position: inside;
+  }
+
+  .sm\:list-outside {
+    list-style-position: outside;
+  }
+
+  .sm\:list-none {
+    list-style-type: none;
+  }
+
+  .sm\:list-disc {
+    list-style-type: disc;
+  }
+
+  .sm\:list-decimal {
+    list-style-type: decimal;
   }
 
   .sm\:m-0 {
@@ -12626,18 +12642,6 @@ samp {
 }
 
 @media (min-width: 768px) {
-  .md\:list-none {
-    list-style-type: none;
-  }
-
-  .md\:list-disc {
-    list-style-type: disc;
-  }
-
-  .md\:list-decimal {
-    list-style-type: decimal;
-  }
-
   .md\:appearance-none {
     appearance: none;
   }
@@ -15234,6 +15238,26 @@ samp {
 
   .md\:leading-loose {
     line-height: 2;
+  }
+
+  .md\:list-inside {
+    list-style-position: inside;
+  }
+
+  .md\:list-outside {
+    list-style-position: outside;
+  }
+
+  .md\:list-none {
+    list-style-type: none;
+  }
+
+  .md\:list-disc {
+    list-style-type: disc;
+  }
+
+  .md\:list-decimal {
+    list-style-type: decimal;
   }
 
   .md\:m-0 {
@@ -18643,18 +18667,6 @@ samp {
 }
 
 @media (min-width: 1024px) {
-  .lg\:list-none {
-    list-style-type: none;
-  }
-
-  .lg\:list-disc {
-    list-style-type: disc;
-  }
-
-  .lg\:list-decimal {
-    list-style-type: decimal;
-  }
-
   .lg\:appearance-none {
     appearance: none;
   }
@@ -21251,6 +21263,26 @@ samp {
 
   .lg\:leading-loose {
     line-height: 2;
+  }
+
+  .lg\:list-inside {
+    list-style-position: inside;
+  }
+
+  .lg\:list-outside {
+    list-style-position: outside;
+  }
+
+  .lg\:list-none {
+    list-style-type: none;
+  }
+
+  .lg\:list-disc {
+    list-style-type: disc;
+  }
+
+  .lg\:list-decimal {
+    list-style-type: decimal;
   }
 
   .lg\:m-0 {
@@ -24660,18 +24692,6 @@ samp {
 }
 
 @media (min-width: 1280px) {
-  .xl\:list-none {
-    list-style-type: none;
-  }
-
-  .xl\:list-disc {
-    list-style-type: disc;
-  }
-
-  .xl\:list-decimal {
-    list-style-type: decimal;
-  }
-
   .xl\:appearance-none {
     appearance: none;
   }
@@ -27268,6 +27288,26 @@ samp {
 
   .xl\:leading-loose {
     line-height: 2;
+  }
+
+  .xl\:list-inside {
+    list-style-position: inside;
+  }
+
+  .xl\:list-outside {
+    list-style-position: outside;
+  }
+
+  .xl\:list-none {
+    list-style-type: none;
+  }
+
+  .xl\:list-disc {
+    list-style-type: disc;
+  }
+
+  .xl\:list-decimal {
+    list-style-type: decimal;
   }
 
   .xl\:m-0 {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -569,9 +569,8 @@ samp {
   }
 }
 
-.list-reset {
-  list-style: none;
-  padding: 0;
+.list-none {
+  list-style-type: none;
 }
 
 .appearance-none {
@@ -6602,9 +6601,8 @@ samp {
 }
 
 @media (min-width: 640px) {
-  .sm\:list-reset {
-    list-style: none;
-    padding: 0;
+  .sm\:list-none {
+    list-style-type: none;
   }
 
   .sm\:appearance-none {
@@ -12612,9 +12610,8 @@ samp {
 }
 
 @media (min-width: 768px) {
-  .md\:list-reset {
-    list-style: none;
-    padding: 0;
+  .md\:list-none {
+    list-style-type: none;
   }
 
   .md\:appearance-none {
@@ -18622,9 +18619,8 @@ samp {
 }
 
 @media (min-width: 1024px) {
-  .lg\:list-reset {
-    list-style: none;
-    padding: 0;
+  .lg\:list-none {
+    list-style-type: none;
   }
 
   .lg\:appearance-none {
@@ -24632,9 +24628,8 @@ samp {
 }
 
 @media (min-width: 1280px) {
-  .xl\:list-reset {
-    list-style: none;
-    padding: 0;
+  .xl\:list-none {
+    list-style-type: none;
   }
 
   .xl\:appearance-none {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -573,6 +573,14 @@ samp {
   list-style-type: none;
 }
 
+.list-disc {
+  list-style-type: disc;
+}
+
+.list-decimal {
+  list-style-type: decimal;
+}
+
 .appearance-none {
   appearance: none;
 }
@@ -6605,6 +6613,14 @@ samp {
     list-style-type: none;
   }
 
+  .sm\:list-disc {
+    list-style-type: disc;
+  }
+
+  .sm\:list-decimal {
+    list-style-type: decimal;
+  }
+
   .sm\:appearance-none {
     appearance: none;
   }
@@ -12612,6 +12628,14 @@ samp {
 @media (min-width: 768px) {
   .md\:list-none {
     list-style-type: none;
+  }
+
+  .md\:list-disc {
+    list-style-type: disc;
+  }
+
+  .md\:list-decimal {
+    list-style-type: decimal;
   }
 
   .md\:appearance-none {
@@ -18623,6 +18647,14 @@ samp {
     list-style-type: none;
   }
 
+  .lg\:list-disc {
+    list-style-type: disc;
+  }
+
+  .lg\:list-decimal {
+    list-style-type: decimal;
+  }
+
   .lg\:appearance-none {
     appearance: none;
   }
@@ -24630,6 +24662,14 @@ samp {
 @media (min-width: 1280px) {
   .xl\:list-none {
     list-style-type: none;
+  }
+
+  .xl\:list-disc {
+    list-style-type: disc;
+  }
+
+  .xl\:list-decimal {
+    list-style-type: decimal;
   }
 
   .xl\:appearance-none {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -414,7 +414,9 @@ fieldset {
 
 ol,
 ul {
+  list-style: none;
   margin: 0;
+  padding: 0;
 }
 
 /**

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -33,6 +33,7 @@ module.exports = {
     fontWeight: ['responsive', 'hover', 'focus'],
     height: ['responsive'],
     lineHeight: ['responsive'],
+    listStylePosition: ['responsive'],
     listStyleType: ['responsive'],
     margin: ['responsive'],
     maxHeight: ['responsive'],

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -33,7 +33,7 @@ module.exports = {
     fontWeight: ['responsive', 'hover', 'focus'],
     height: ['responsive'],
     lineHeight: ['responsive'],
-    listStyle: ['responsive'],
+    listStyleType: ['responsive'],
     margin: ['responsive'],
     maxHeight: ['responsive'],
     maxWidth: ['responsive'],

--- a/defaultTheme.js
+++ b/defaultTheme.js
@@ -331,6 +331,8 @@ module.exports = function() {
     },
     listStyleType: {
       none: 'none',
+      disc: 'disc',
+      decimal: 'decimal',
     },
   }
 }

--- a/defaultTheme.js
+++ b/defaultTheme.js
@@ -329,5 +329,8 @@ module.exports = function() {
       '0': 0,
       default: 1,
     },
+    listStyleType: {
+      none: 'none',
+    },
   }
 }

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1,5 +1,4 @@
 import preflight from './plugins/preflight'
-import listStyleType from './plugins/listStyleType'
 import appearance from './plugins/appearance'
 import backgroundAttachment from './plugins/backgroundAttachment'
 import backgroundColor from './plugins/backgroundColor'
@@ -27,6 +26,8 @@ import fontFamily from './plugins/fontFamily'
 import fontWeight from './plugins/fontWeight'
 import height from './plugins/height'
 import lineHeight from './plugins/lineHeight'
+import listStylePosition from './plugins/listStylePosition'
+import listStyleType from './plugins/listStyleType'
 import margin from './plugins/margin'
 import maxHeight from './plugins/maxHeight'
 import maxWidth from './plugins/maxWidth'
@@ -66,7 +67,6 @@ import configurePlugins from './util/configurePlugins'
 export default function({ corePlugins: corePluginConfig }) {
   return configurePlugins(corePluginConfig, {
     preflight,
-    listStyleType,
     appearance,
     backgroundAttachment,
     backgroundColor,
@@ -94,6 +94,8 @@ export default function({ corePlugins: corePluginConfig }) {
     fontWeight,
     height,
     lineHeight,
+    listStylePosition,
+    listStyleType,
     margin,
     maxHeight,
     maxWidth,

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1,5 +1,5 @@
 import preflight from './plugins/preflight'
-import listStyle from './plugins/listStyle'
+import listStyleType from './plugins/listStyleType'
 import appearance from './plugins/appearance'
 import backgroundAttachment from './plugins/backgroundAttachment'
 import backgroundColor from './plugins/backgroundColor'
@@ -66,7 +66,7 @@ import configurePlugins from './util/configurePlugins'
 export default function({ corePlugins: corePluginConfig }) {
   return configurePlugins(corePluginConfig, {
     preflight,
-    listStyle,
+    listStyleType,
     appearance,
     backgroundAttachment,
     backgroundColor,

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -62,7 +62,9 @@ fieldset {
 
 ol,
 ul {
+  list-style: none;
   margin: 0;
+  padding: 0;
 }
 
 /**

--- a/src/plugins/listStylePosition.js
+++ b/src/plugins/listStylePosition.js
@@ -1,0 +1,11 @@
+export default function() {
+  return function({ addUtilities, config }) {
+    addUtilities(
+      {
+        '.list-inside': { 'list-style-position': 'inside' },
+        '.list-outside': { 'list-style-position': 'outside' },
+      },
+      config('variants.listStylePosition')
+    )
+  }
+}

--- a/src/plugins/listStyleType.js
+++ b/src/plugins/listStyleType.js
@@ -2,12 +2,11 @@ export default function() {
   return function({ addUtilities, config }) {
     addUtilities(
       {
-        '.list-reset': {
-          'list-style': 'none',
-          padding: '0',
+        '.list-none': {
+          'list-style-type': 'none',
         },
       },
-      config('variants.listStyle')
+      config('variants.listStyleType')
     )
   }
 }

--- a/src/plugins/listStyleType.js
+++ b/src/plugins/listStyleType.js
@@ -1,12 +1,18 @@
+import _ from 'lodash'
+
 export default function() {
-  return function({ addUtilities, config }) {
-    addUtilities(
-      {
-        '.list-none': {
-          'list-style-type': 'none',
-        },
-      },
-      config('variants.listStyleType')
+  return function({ addUtilities, e, config }) {
+    const utilities = _.fromPairs(
+      _.map(config('theme.listStyleType'), (value, modifier) => {
+        return [
+          `.${e(`list-${modifier}`)}`,
+          {
+            'list-style-type': value,
+          },
+        ]
+      })
     )
+
+    addUtilities(utilities, config('variants.listStyleType'))
   }
 }


### PR DESCRIPTION
This PR removes the `list-reset` utility in favor of a new `list-none` utility that only sets the `list-style-type`, and makes it possible to add more list-style-type utilities by customizing your configuration file.

It also adds `list-inside` and `list-outside` utilities for setting `list-style-position`.

This is a potentially annoying breaking change, because previously `list-reset` also set `padding: 0`, and `list-none` doesn't do that.

That means that to upgrade you have two options:

1. Replace any instances of `list-reset` with `list-none p-0`.
2. Redefine `list-reset` in your own CSS:

    ```css
    .list-reset {
      list-style: none;
      padding: 0;
    }
    ```

The motivation for this is mostly about simplicity and consistency in the framework API. `list-reset` is sort of an odd class because it sets two unrelated properties, and nothing else in Tailwind (except `truncate`, which I'm also thinking hard about) does that. It meant we had to be careful to always define `list-reset` before our padding utilities for them to be composable, which isn't a huge deal, but was always a weird rule to have to remember when working on Tailwind itself.

I'm a bit conflicted on removing `list-reset` because I do think it's convenient, and I worry I am over-optimizing for keeping the framework itself simple. If people really, really want to keep it and don't want to have to write `list-none p-0` instead, I could probably be convinced the shoulder the complexity. Another alternative is just removing list styles by default in general, and making them opt-in instead, so you'd never have to write `list-reset` but sometimes you'd have to write `list-disc pl-4` or similar to get a normal looking list.