### PR TITLE
Combine wrap-normal and break-normal, rename wrap-break to break-words

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -7161,16 +7161,13 @@ samp {
   white-space: pre-wrap !important;
 }
 
-.wrap-break {
-  overflow-wrap: break-word !important;
-}
-
-.wrap-normal {
-  overflow-wrap: normal !important;
-}
-
 .break-normal {
+  overflow-wrap: normal !important;
   word-break: normal !important;
+}
+
+.break-words {
+  overflow-wrap: break-word !important;
 }
 
 .break-all {
@@ -13905,16 +13902,13 @@ samp {
     white-space: pre-wrap !important;
   }
 
-  .sm\:wrap-break {
-    overflow-wrap: break-word !important;
-  }
-
-  .sm\:wrap-normal {
-    overflow-wrap: normal !important;
-  }
-
   .sm\:break-normal {
+    overflow-wrap: normal !important;
     word-break: normal !important;
+  }
+
+  .sm\:break-words {
+    overflow-wrap: break-word !important;
   }
 
   .sm\:break-all {
@@ -20650,16 +20644,13 @@ samp {
     white-space: pre-wrap !important;
   }
 
-  .md\:wrap-break {
-    overflow-wrap: break-word !important;
-  }
-
-  .md\:wrap-normal {
-    overflow-wrap: normal !important;
-  }
-
   .md\:break-normal {
+    overflow-wrap: normal !important;
     word-break: normal !important;
+  }
+
+  .md\:break-words {
+    overflow-wrap: break-word !important;
   }
 
   .md\:break-all {
@@ -27395,16 +27386,13 @@ samp {
     white-space: pre-wrap !important;
   }
 
-  .lg\:wrap-break {
-    overflow-wrap: break-word !important;
-  }
-
-  .lg\:wrap-normal {
-    overflow-wrap: normal !important;
-  }
-
   .lg\:break-normal {
+    overflow-wrap: normal !important;
     word-break: normal !important;
+  }
+
+  .lg\:break-words {
+    overflow-wrap: break-word !important;
   }
 
   .lg\:break-all {
@@ -34140,16 +34128,13 @@ samp {
     white-space: pre-wrap !important;
   }
 
-  .xl\:wrap-break {
-    overflow-wrap: break-word !important;
-  }
-
-  .xl\:wrap-normal {
-    overflow-wrap: normal !important;
-  }
-
   .xl\:break-normal {
+    overflow-wrap: normal !important;
     word-break: normal !important;
+  }
+
+  .xl\:break-words {
+    overflow-wrap: break-word !important;
   }
 
   .xl\:break-all {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -7161,16 +7161,13 @@ samp {
   white-space: pre-wrap;
 }
 
-.wrap-break {
-  overflow-wrap: break-word;
-}
-
-.wrap-normal {
-  overflow-wrap: normal;
-}
-
 .break-normal {
+  overflow-wrap: normal;
   word-break: normal;
+}
+
+.break-words {
+  overflow-wrap: break-word;
 }
 
 .break-all {
@@ -13905,16 +13902,13 @@ samp {
     white-space: pre-wrap;
   }
 
-  .sm\:wrap-break {
-    overflow-wrap: break-word;
-  }
-
-  .sm\:wrap-normal {
-    overflow-wrap: normal;
-  }
-
   .sm\:break-normal {
+    overflow-wrap: normal;
     word-break: normal;
+  }
+
+  .sm\:break-words {
+    overflow-wrap: break-word;
   }
 
   .sm\:break-all {
@@ -20650,16 +20644,13 @@ samp {
     white-space: pre-wrap;
   }
 
-  .md\:wrap-break {
-    overflow-wrap: break-word;
-  }
-
-  .md\:wrap-normal {
-    overflow-wrap: normal;
-  }
-
   .md\:break-normal {
+    overflow-wrap: normal;
     word-break: normal;
+  }
+
+  .md\:break-words {
+    overflow-wrap: break-word;
   }
 
   .md\:break-all {
@@ -27395,16 +27386,13 @@ samp {
     white-space: pre-wrap;
   }
 
-  .lg\:wrap-break {
-    overflow-wrap: break-word;
-  }
-
-  .lg\:wrap-normal {
-    overflow-wrap: normal;
-  }
-
   .lg\:break-normal {
+    overflow-wrap: normal;
     word-break: normal;
+  }
+
+  .lg\:break-words {
+    overflow-wrap: break-word;
   }
 
   .lg\:break-all {
@@ -34140,16 +34128,13 @@ samp {
     white-space: pre-wrap;
   }
 
-  .xl\:wrap-break {
-    overflow-wrap: break-word;
-  }
-
-  .xl\:wrap-normal {
-    overflow-wrap: normal;
-  }
-
   .xl\:break-normal {
+    overflow-wrap: normal;
     word-break: normal;
+  }
+
+  .xl\:break-words {
+    overflow-wrap: break-word;
   }
 
   .xl\:break-all {

--- a/src/plugins/whitespace.js
+++ b/src/plugins/whitespace.js
@@ -8,10 +8,11 @@ export default function() {
         '.whitespace-pre-line': { 'white-space': 'pre-line' },
         '.whitespace-pre-wrap': { 'white-space': 'pre-wrap' },
 
-        '.wrap-break': { 'overflow-wrap': 'break-word' },
-        '.wrap-normal': { 'overflow-wrap': 'normal' },
-
-        '.break-normal': { 'word-break': 'normal' },
+        '.break-normal': {
+          'overflow-wrap': 'normal',
+          'word-break': 'normal',
+        },
+        '.break-words': { 'overflow-wrap': 'break-word' },
         '.break-all': { 'word-break': 'break-all' },
 
         '.truncate': {


### PR DESCRIPTION
In #571 we added a `.break-all` utility and renamed `.break-words` to `.wrap-break` because we decided it made sense to have `.wrap-normal` and `.break-normal` as separate "reset" utilities, since they target different properties.

In practice I think this is wasting an opportunity to make things easier for the end user, so this PR tweaks things so that wrap-break is back to `.break-words`, and `.break-normal` now resets both word-break and overflow-wrap.

In my testing there are no situations where it ever makes sense to add `break-words` and `break-all` to the same element, because `break-all` always takes precedence, so we might as well treat these like they are manipulating the same property and provide a little normalization for the end user.

Here's a more readable diff:

```diff
- .wrap-normal {
-   overflow-wrap: normal;
- }
- .wrap-break {
-   overflow-wrap: break-word;
- }
- .break-normal {
-   word-break: normal;
- }
- .break-all {
-   word-break: break-all;
- }
+ .break-normal {
+   overflow-wrap: normal;
+   word-break: normal;
+ }
+ .break-words {
+   overflow-wrap: break-word;
+ }
+ .break-all {
+   word-break: break-all;
+ }
```