### PR TITLE
Rename pin utilities to top/right/bottom/left/inset and make customizable

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -5667,43 +5667,43 @@ samp {
   position: sticky !important;
 }
 
-.pin-none {
+.inset-auto {
   top: auto !important;
   right: auto !important;
   bottom: auto !important;
   left: auto !important;
 }
 
-.pin {
+.inset-0 {
   top: 0 !important;
   right: 0 !important;
   bottom: 0 !important;
   left: 0 !important;
 }
 
-.pin-y {
+.inset-y-0 {
   top: 0 !important;
   bottom: 0 !important;
 }
 
-.pin-x {
+.inset-x-0 {
   right: 0 !important;
   left: 0 !important;
 }
 
-.pin-t {
+.top-0 {
   top: 0 !important;
 }
 
-.pin-r {
+.right-0 {
   right: 0 !important;
 }
 
-.pin-b {
+.bottom-0 {
   bottom: 0 !important;
 }
 
-.pin-l {
+.left-0 {
   left: 0 !important;
 }
 
@@ -12416,43 +12416,43 @@ samp {
     position: sticky !important;
   }
 
-  .sm\:pin-none {
+  .sm\:inset-auto {
     top: auto !important;
     right: auto !important;
     bottom: auto !important;
     left: auto !important;
   }
 
-  .sm\:pin {
+  .sm\:inset-0 {
     top: 0 !important;
     right: 0 !important;
     bottom: 0 !important;
     left: 0 !important;
   }
 
-  .sm\:pin-y {
+  .sm\:inset-y-0 {
     top: 0 !important;
     bottom: 0 !important;
   }
 
-  .sm\:pin-x {
+  .sm\:inset-x-0 {
     right: 0 !important;
     left: 0 !important;
   }
 
-  .sm\:pin-t {
+  .sm\:top-0 {
     top: 0 !important;
   }
 
-  .sm\:pin-r {
+  .sm\:right-0 {
     right: 0 !important;
   }
 
-  .sm\:pin-b {
+  .sm\:bottom-0 {
     bottom: 0 !important;
   }
 
-  .sm\:pin-l {
+  .sm\:left-0 {
     left: 0 !important;
   }
 
@@ -19158,43 +19158,43 @@ samp {
     position: sticky !important;
   }
 
-  .md\:pin-none {
+  .md\:inset-auto {
     top: auto !important;
     right: auto !important;
     bottom: auto !important;
     left: auto !important;
   }
 
-  .md\:pin {
+  .md\:inset-0 {
     top: 0 !important;
     right: 0 !important;
     bottom: 0 !important;
     left: 0 !important;
   }
 
-  .md\:pin-y {
+  .md\:inset-y-0 {
     top: 0 !important;
     bottom: 0 !important;
   }
 
-  .md\:pin-x {
+  .md\:inset-x-0 {
     right: 0 !important;
     left: 0 !important;
   }
 
-  .md\:pin-t {
+  .md\:top-0 {
     top: 0 !important;
   }
 
-  .md\:pin-r {
+  .md\:right-0 {
     right: 0 !important;
   }
 
-  .md\:pin-b {
+  .md\:bottom-0 {
     bottom: 0 !important;
   }
 
-  .md\:pin-l {
+  .md\:left-0 {
     left: 0 !important;
   }
 
@@ -25900,43 +25900,43 @@ samp {
     position: sticky !important;
   }
 
-  .lg\:pin-none {
+  .lg\:inset-auto {
     top: auto !important;
     right: auto !important;
     bottom: auto !important;
     left: auto !important;
   }
 
-  .lg\:pin {
+  .lg\:inset-0 {
     top: 0 !important;
     right: 0 !important;
     bottom: 0 !important;
     left: 0 !important;
   }
 
-  .lg\:pin-y {
+  .lg\:inset-y-0 {
     top: 0 !important;
     bottom: 0 !important;
   }
 
-  .lg\:pin-x {
+  .lg\:inset-x-0 {
     right: 0 !important;
     left: 0 !important;
   }
 
-  .lg\:pin-t {
+  .lg\:top-0 {
     top: 0 !important;
   }
 
-  .lg\:pin-r {
+  .lg\:right-0 {
     right: 0 !important;
   }
 
-  .lg\:pin-b {
+  .lg\:bottom-0 {
     bottom: 0 !important;
   }
 
-  .lg\:pin-l {
+  .lg\:left-0 {
     left: 0 !important;
   }
 
@@ -32642,43 +32642,43 @@ samp {
     position: sticky !important;
   }
 
-  .xl\:pin-none {
+  .xl\:inset-auto {
     top: auto !important;
     right: auto !important;
     bottom: auto !important;
     left: auto !important;
   }
 
-  .xl\:pin {
+  .xl\:inset-0 {
     top: 0 !important;
     right: 0 !important;
     bottom: 0 !important;
     left: 0 !important;
   }
 
-  .xl\:pin-y {
+  .xl\:inset-y-0 {
     top: 0 !important;
     bottom: 0 !important;
   }
 
-  .xl\:pin-x {
+  .xl\:inset-x-0 {
     right: 0 !important;
     left: 0 !important;
   }
 
-  .xl\:pin-t {
+  .xl\:top-0 {
     top: 0 !important;
   }
 
-  .xl\:pin-r {
+  .xl\:right-0 {
     right: 0 !important;
   }
 
-  .xl\:pin-b {
+  .xl\:bottom-0 {
     bottom: 0 !important;
   }
 
-  .xl\:pin-l {
+  .xl\:left-0 {
     left: 0 !important;
   }
 

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -5667,18 +5667,18 @@ samp {
   position: sticky !important;
 }
 
-.inset-auto {
-  top: auto !important;
-  right: auto !important;
-  bottom: auto !important;
-  left: auto !important;
-}
-
 .inset-0 {
   top: 0 !important;
   right: 0 !important;
   bottom: 0 !important;
   left: 0 !important;
+}
+
+.inset-auto {
+  top: auto !important;
+  right: auto !important;
+  bottom: auto !important;
+  left: auto !important;
 }
 
 .inset-y-0 {
@@ -5689,6 +5689,16 @@ samp {
 .inset-x-0 {
   right: 0 !important;
   left: 0 !important;
+}
+
+.inset-y-auto {
+  top: auto !important;
+  bottom: auto !important;
+}
+
+.inset-x-auto {
+  right: auto !important;
+  left: auto !important;
 }
 
 .top-0 {
@@ -5705,6 +5715,22 @@ samp {
 
 .left-0 {
   left: 0 !important;
+}
+
+.top-auto {
+  top: auto !important;
+}
+
+.right-auto {
+  right: auto !important;
+}
+
+.bottom-auto {
+  bottom: auto !important;
+}
+
+.left-auto {
+  left: auto !important;
 }
 
 .resize-none {
@@ -12416,18 +12442,18 @@ samp {
     position: sticky !important;
   }
 
-  .sm\:inset-auto {
-    top: auto !important;
-    right: auto !important;
-    bottom: auto !important;
-    left: auto !important;
-  }
-
   .sm\:inset-0 {
     top: 0 !important;
     right: 0 !important;
     bottom: 0 !important;
     left: 0 !important;
+  }
+
+  .sm\:inset-auto {
+    top: auto !important;
+    right: auto !important;
+    bottom: auto !important;
+    left: auto !important;
   }
 
   .sm\:inset-y-0 {
@@ -12438,6 +12464,16 @@ samp {
   .sm\:inset-x-0 {
     right: 0 !important;
     left: 0 !important;
+  }
+
+  .sm\:inset-y-auto {
+    top: auto !important;
+    bottom: auto !important;
+  }
+
+  .sm\:inset-x-auto {
+    right: auto !important;
+    left: auto !important;
   }
 
   .sm\:top-0 {
@@ -12454,6 +12490,22 @@ samp {
 
   .sm\:left-0 {
     left: 0 !important;
+  }
+
+  .sm\:top-auto {
+    top: auto !important;
+  }
+
+  .sm\:right-auto {
+    right: auto !important;
+  }
+
+  .sm\:bottom-auto {
+    bottom: auto !important;
+  }
+
+  .sm\:left-auto {
+    left: auto !important;
   }
 
   .sm\:resize-none {
@@ -19158,18 +19210,18 @@ samp {
     position: sticky !important;
   }
 
-  .md\:inset-auto {
-    top: auto !important;
-    right: auto !important;
-    bottom: auto !important;
-    left: auto !important;
-  }
-
   .md\:inset-0 {
     top: 0 !important;
     right: 0 !important;
     bottom: 0 !important;
     left: 0 !important;
+  }
+
+  .md\:inset-auto {
+    top: auto !important;
+    right: auto !important;
+    bottom: auto !important;
+    left: auto !important;
   }
 
   .md\:inset-y-0 {
@@ -19180,6 +19232,16 @@ samp {
   .md\:inset-x-0 {
     right: 0 !important;
     left: 0 !important;
+  }
+
+  .md\:inset-y-auto {
+    top: auto !important;
+    bottom: auto !important;
+  }
+
+  .md\:inset-x-auto {
+    right: auto !important;
+    left: auto !important;
   }
 
   .md\:top-0 {
@@ -19196,6 +19258,22 @@ samp {
 
   .md\:left-0 {
     left: 0 !important;
+  }
+
+  .md\:top-auto {
+    top: auto !important;
+  }
+
+  .md\:right-auto {
+    right: auto !important;
+  }
+
+  .md\:bottom-auto {
+    bottom: auto !important;
+  }
+
+  .md\:left-auto {
+    left: auto !important;
   }
 
   .md\:resize-none {
@@ -25900,18 +25978,18 @@ samp {
     position: sticky !important;
   }
 
-  .lg\:inset-auto {
-    top: auto !important;
-    right: auto !important;
-    bottom: auto !important;
-    left: auto !important;
-  }
-
   .lg\:inset-0 {
     top: 0 !important;
     right: 0 !important;
     bottom: 0 !important;
     left: 0 !important;
+  }
+
+  .lg\:inset-auto {
+    top: auto !important;
+    right: auto !important;
+    bottom: auto !important;
+    left: auto !important;
   }
 
   .lg\:inset-y-0 {
@@ -25922,6 +26000,16 @@ samp {
   .lg\:inset-x-0 {
     right: 0 !important;
     left: 0 !important;
+  }
+
+  .lg\:inset-y-auto {
+    top: auto !important;
+    bottom: auto !important;
+  }
+
+  .lg\:inset-x-auto {
+    right: auto !important;
+    left: auto !important;
   }
 
   .lg\:top-0 {
@@ -25938,6 +26026,22 @@ samp {
 
   .lg\:left-0 {
     left: 0 !important;
+  }
+
+  .lg\:top-auto {
+    top: auto !important;
+  }
+
+  .lg\:right-auto {
+    right: auto !important;
+  }
+
+  .lg\:bottom-auto {
+    bottom: auto !important;
+  }
+
+  .lg\:left-auto {
+    left: auto !important;
   }
 
   .lg\:resize-none {
@@ -32642,18 +32746,18 @@ samp {
     position: sticky !important;
   }
 
-  .xl\:inset-auto {
-    top: auto !important;
-    right: auto !important;
-    bottom: auto !important;
-    left: auto !important;
-  }
-
   .xl\:inset-0 {
     top: 0 !important;
     right: 0 !important;
     bottom: 0 !important;
     left: 0 !important;
+  }
+
+  .xl\:inset-auto {
+    top: auto !important;
+    right: auto !important;
+    bottom: auto !important;
+    left: auto !important;
   }
 
   .xl\:inset-y-0 {
@@ -32664,6 +32768,16 @@ samp {
   .xl\:inset-x-0 {
     right: 0 !important;
     left: 0 !important;
+  }
+
+  .xl\:inset-y-auto {
+    top: auto !important;
+    bottom: auto !important;
+  }
+
+  .xl\:inset-x-auto {
+    right: auto !important;
+    left: auto !important;
   }
 
   .xl\:top-0 {
@@ -32680,6 +32794,22 @@ samp {
 
   .xl\:left-0 {
     left: 0 !important;
+  }
+
+  .xl\:top-auto {
+    top: auto !important;
+  }
+
+  .xl\:right-auto {
+    right: auto !important;
+  }
+
+  .xl\:bottom-auto {
+    bottom: auto !important;
+  }
+
+  .xl\:left-auto {
+    left: auto !important;
   }
 
   .xl\:resize-none {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -5667,43 +5667,43 @@ samp {
   position: sticky;
 }
 
-.pin-none {
+.inset-auto {
   top: auto;
   right: auto;
   bottom: auto;
   left: auto;
 }
 
-.pin {
+.inset-0 {
   top: 0;
   right: 0;
   bottom: 0;
   left: 0;
 }
 
-.pin-y {
+.inset-y-0 {
   top: 0;
   bottom: 0;
 }
 
-.pin-x {
+.inset-x-0 {
   right: 0;
   left: 0;
 }
 
-.pin-t {
+.top-0 {
   top: 0;
 }
 
-.pin-r {
+.right-0 {
   right: 0;
 }
 
-.pin-b {
+.bottom-0 {
   bottom: 0;
 }
 
-.pin-l {
+.left-0 {
   left: 0;
 }
 
@@ -12416,43 +12416,43 @@ samp {
     position: sticky;
   }
 
-  .sm\:pin-none {
+  .sm\:inset-auto {
     top: auto;
     right: auto;
     bottom: auto;
     left: auto;
   }
 
-  .sm\:pin {
+  .sm\:inset-0 {
     top: 0;
     right: 0;
     bottom: 0;
     left: 0;
   }
 
-  .sm\:pin-y {
+  .sm\:inset-y-0 {
     top: 0;
     bottom: 0;
   }
 
-  .sm\:pin-x {
+  .sm\:inset-x-0 {
     right: 0;
     left: 0;
   }
 
-  .sm\:pin-t {
+  .sm\:top-0 {
     top: 0;
   }
 
-  .sm\:pin-r {
+  .sm\:right-0 {
     right: 0;
   }
 
-  .sm\:pin-b {
+  .sm\:bottom-0 {
     bottom: 0;
   }
 
-  .sm\:pin-l {
+  .sm\:left-0 {
     left: 0;
   }
 
@@ -19158,43 +19158,43 @@ samp {
     position: sticky;
   }
 
-  .md\:pin-none {
+  .md\:inset-auto {
     top: auto;
     right: auto;
     bottom: auto;
     left: auto;
   }
 
-  .md\:pin {
+  .md\:inset-0 {
     top: 0;
     right: 0;
     bottom: 0;
     left: 0;
   }
 
-  .md\:pin-y {
+  .md\:inset-y-0 {
     top: 0;
     bottom: 0;
   }
 
-  .md\:pin-x {
+  .md\:inset-x-0 {
     right: 0;
     left: 0;
   }
 
-  .md\:pin-t {
+  .md\:top-0 {
     top: 0;
   }
 
-  .md\:pin-r {
+  .md\:right-0 {
     right: 0;
   }
 
-  .md\:pin-b {
+  .md\:bottom-0 {
     bottom: 0;
   }
 
-  .md\:pin-l {
+  .md\:left-0 {
     left: 0;
   }
 
@@ -25900,43 +25900,43 @@ samp {
     position: sticky;
   }
 
-  .lg\:pin-none {
+  .lg\:inset-auto {
     top: auto;
     right: auto;
     bottom: auto;
     left: auto;
   }
 
-  .lg\:pin {
+  .lg\:inset-0 {
     top: 0;
     right: 0;
     bottom: 0;
     left: 0;
   }
 
-  .lg\:pin-y {
+  .lg\:inset-y-0 {
     top: 0;
     bottom: 0;
   }
 
-  .lg\:pin-x {
+  .lg\:inset-x-0 {
     right: 0;
     left: 0;
   }
 
-  .lg\:pin-t {
+  .lg\:top-0 {
     top: 0;
   }
 
-  .lg\:pin-r {
+  .lg\:right-0 {
     right: 0;
   }
 
-  .lg\:pin-b {
+  .lg\:bottom-0 {
     bottom: 0;
   }
 
-  .lg\:pin-l {
+  .lg\:left-0 {
     left: 0;
   }
 
@@ -32642,43 +32642,43 @@ samp {
     position: sticky;
   }
 
-  .xl\:pin-none {
+  .xl\:inset-auto {
     top: auto;
     right: auto;
     bottom: auto;
     left: auto;
   }
 
-  .xl\:pin {
+  .xl\:inset-0 {
     top: 0;
     right: 0;
     bottom: 0;
     left: 0;
   }
 
-  .xl\:pin-y {
+  .xl\:inset-y-0 {
     top: 0;
     bottom: 0;
   }
 
-  .xl\:pin-x {
+  .xl\:inset-x-0 {
     right: 0;
     left: 0;
   }
 
-  .xl\:pin-t {
+  .xl\:top-0 {
     top: 0;
   }
 
-  .xl\:pin-r {
+  .xl\:right-0 {
     right: 0;
   }
 
-  .xl\:pin-b {
+  .xl\:bottom-0 {
     bottom: 0;
   }
 
-  .xl\:pin-l {
+  .xl\:left-0 {
     left: 0;
   }
 

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -5667,18 +5667,18 @@ samp {
   position: sticky;
 }
 
-.inset-auto {
-  top: auto;
-  right: auto;
-  bottom: auto;
-  left: auto;
-}
-
 .inset-0 {
   top: 0;
   right: 0;
   bottom: 0;
   left: 0;
+}
+
+.inset-auto {
+  top: auto;
+  right: auto;
+  bottom: auto;
+  left: auto;
 }
 
 .inset-y-0 {
@@ -5689,6 +5689,16 @@ samp {
 .inset-x-0 {
   right: 0;
   left: 0;
+}
+
+.inset-y-auto {
+  top: auto;
+  bottom: auto;
+}
+
+.inset-x-auto {
+  right: auto;
+  left: auto;
 }
 
 .top-0 {
@@ -5705,6 +5715,22 @@ samp {
 
 .left-0 {
   left: 0;
+}
+
+.top-auto {
+  top: auto;
+}
+
+.right-auto {
+  right: auto;
+}
+
+.bottom-auto {
+  bottom: auto;
+}
+
+.left-auto {
+  left: auto;
 }
 
 .resize-none {
@@ -12416,18 +12442,18 @@ samp {
     position: sticky;
   }
 
-  .sm\:inset-auto {
-    top: auto;
-    right: auto;
-    bottom: auto;
-    left: auto;
-  }
-
   .sm\:inset-0 {
     top: 0;
     right: 0;
     bottom: 0;
     left: 0;
+  }
+
+  .sm\:inset-auto {
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
   }
 
   .sm\:inset-y-0 {
@@ -12438,6 +12464,16 @@ samp {
   .sm\:inset-x-0 {
     right: 0;
     left: 0;
+  }
+
+  .sm\:inset-y-auto {
+    top: auto;
+    bottom: auto;
+  }
+
+  .sm\:inset-x-auto {
+    right: auto;
+    left: auto;
   }
 
   .sm\:top-0 {
@@ -12454,6 +12490,22 @@ samp {
 
   .sm\:left-0 {
     left: 0;
+  }
+
+  .sm\:top-auto {
+    top: auto;
+  }
+
+  .sm\:right-auto {
+    right: auto;
+  }
+
+  .sm\:bottom-auto {
+    bottom: auto;
+  }
+
+  .sm\:left-auto {
+    left: auto;
   }
 
   .sm\:resize-none {
@@ -19158,18 +19210,18 @@ samp {
     position: sticky;
   }
 
-  .md\:inset-auto {
-    top: auto;
-    right: auto;
-    bottom: auto;
-    left: auto;
-  }
-
   .md\:inset-0 {
     top: 0;
     right: 0;
     bottom: 0;
     left: 0;
+  }
+
+  .md\:inset-auto {
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
   }
 
   .md\:inset-y-0 {
@@ -19180,6 +19232,16 @@ samp {
   .md\:inset-x-0 {
     right: 0;
     left: 0;
+  }
+
+  .md\:inset-y-auto {
+    top: auto;
+    bottom: auto;
+  }
+
+  .md\:inset-x-auto {
+    right: auto;
+    left: auto;
   }
 
   .md\:top-0 {
@@ -19196,6 +19258,22 @@ samp {
 
   .md\:left-0 {
     left: 0;
+  }
+
+  .md\:top-auto {
+    top: auto;
+  }
+
+  .md\:right-auto {
+    right: auto;
+  }
+
+  .md\:bottom-auto {
+    bottom: auto;
+  }
+
+  .md\:left-auto {
+    left: auto;
   }
 
   .md\:resize-none {
@@ -25900,18 +25978,18 @@ samp {
     position: sticky;
   }
 
-  .lg\:inset-auto {
-    top: auto;
-    right: auto;
-    bottom: auto;
-    left: auto;
-  }
-
   .lg\:inset-0 {
     top: 0;
     right: 0;
     bottom: 0;
     left: 0;
+  }
+
+  .lg\:inset-auto {
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
   }
 
   .lg\:inset-y-0 {
@@ -25922,6 +26000,16 @@ samp {
   .lg\:inset-x-0 {
     right: 0;
     left: 0;
+  }
+
+  .lg\:inset-y-auto {
+    top: auto;
+    bottom: auto;
+  }
+
+  .lg\:inset-x-auto {
+    right: auto;
+    left: auto;
   }
 
   .lg\:top-0 {
@@ -25938,6 +26026,22 @@ samp {
 
   .lg\:left-0 {
     left: 0;
+  }
+
+  .lg\:top-auto {
+    top: auto;
+  }
+
+  .lg\:right-auto {
+    right: auto;
+  }
+
+  .lg\:bottom-auto {
+    bottom: auto;
+  }
+
+  .lg\:left-auto {
+    left: auto;
   }
 
   .lg\:resize-none {
@@ -32642,18 +32746,18 @@ samp {
     position: sticky;
   }
 
-  .xl\:inset-auto {
-    top: auto;
-    right: auto;
-    bottom: auto;
-    left: auto;
-  }
-
   .xl\:inset-0 {
     top: 0;
     right: 0;
     bottom: 0;
     left: 0;
+  }
+
+  .xl\:inset-auto {
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
   }
 
   .xl\:inset-y-0 {
@@ -32664,6 +32768,16 @@ samp {
   .xl\:inset-x-0 {
     right: 0;
     left: 0;
+  }
+
+  .xl\:inset-y-auto {
+    top: auto;
+    bottom: auto;
+  }
+
+  .xl\:inset-x-auto {
+    right: auto;
+    left: auto;
   }
 
   .xl\:top-0 {
@@ -32680,6 +32794,22 @@ samp {
 
   .xl\:left-0 {
     left: 0;
+  }
+
+  .xl\:top-auto {
+    top: auto;
+  }
+
+  .xl\:right-auto {
+    right: auto;
+  }
+
+  .xl\:bottom-auto {
+    bottom: auto;
+  }
+
+  .xl\:left-auto {
+    left: auto;
   }
 
   .xl\:resize-none {

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -49,6 +49,7 @@ module.exports = {
     padding: ['responsive'],
     pointerEvents: ['responsive'],
     position: ['responsive'],
+    inset: ['responsive'],
     resize: ['responsive'],
     boxShadow: ['responsive', 'hover', 'focus'],
     fill: [],

--- a/defaultTheme.js
+++ b/defaultTheme.js
@@ -366,5 +366,9 @@ module.exports = function() {
       disc: 'disc',
       decimal: 'decimal',
     },
+    inset: {
+      '0': 0,
+      auto: 'auto',
+    },
   }
 }

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -42,6 +42,7 @@ import overflow from './plugins/overflow'
 import padding from './plugins/padding'
 import pointerEvents from './plugins/pointerEvents'
 import position from './plugins/position'
+import inset from './plugins/inset'
 import resize from './plugins/resize'
 import boxShadow from './plugins/boxShadow'
 import fill from './plugins/fill'
@@ -110,6 +111,7 @@ export default function({ corePlugins: corePluginConfig }) {
     padding,
     pointerEvents,
     position,
+    inset,
     resize,
     boxShadow,
     fill,

--- a/src/plugins/inset.js
+++ b/src/plugins/inset.js
@@ -2,24 +2,24 @@ export default function() {
   return function({ addUtilities, config }) {
     addUtilities(
       {
-        '.pin-none': {
+        '.inset-auto': {
           top: 'auto',
           right: 'auto',
           bottom: 'auto',
           left: 'auto',
         },
-        '.pin': {
+        '.inset-0': {
           top: 0,
           right: 0,
           bottom: 0,
           left: 0,
         },
-        '.pin-y': { top: 0, bottom: 0 },
-        '.pin-x': { right: 0, left: 0 },
-        '.pin-t': { top: 0 },
-        '.pin-r': { right: 0 },
-        '.pin-b': { bottom: 0 },
-        '.pin-l': { left: 0 },
+        '.inset-y-0': { top: 0, bottom: 0 },
+        '.inset-x-0': { right: 0, left: 0 },
+        '.top-0': { top: 0 },
+        '.right-0': { right: 0 },
+        '.bottom-0': { bottom: 0 },
+        '.left-0': { left: 0 },
       },
       config('variants.inset')
     )

--- a/src/plugins/inset.js
+++ b/src/plugins/inset.js
@@ -1,0 +1,27 @@
+export default function() {
+  return function({ addUtilities, config }) {
+    addUtilities(
+      {
+        '.pin-none': {
+          top: 'auto',
+          right: 'auto',
+          bottom: 'auto',
+          left: 'auto',
+        },
+        '.pin': {
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
+        },
+        '.pin-y': { top: 0, bottom: 0 },
+        '.pin-x': { right: 0, left: 0 },
+        '.pin-t': { top: 0 },
+        '.pin-r': { right: 0 },
+        '.pin-b': { bottom: 0 },
+        '.pin-l': { left: 0 },
+      },
+      config('variants.inset')
+    )
+  }
+}

--- a/src/plugins/inset.js
+++ b/src/plugins/inset.js
@@ -1,27 +1,32 @@
+import _ from 'lodash'
+
 export default function() {
-  return function({ addUtilities, config }) {
-    addUtilities(
-      {
-        '.inset-auto': {
-          top: 'auto',
-          right: 'auto',
-          bottom: 'auto',
-          left: 'auto',
+  return function({ addUtilities, e, config }) {
+    const generators = [
+      (size, modifier) => ({
+        [`.${e(`inset-${modifier}`)}`]: {
+          top: `${size}`,
+          right: `${size}`,
+          bottom: `${size}`,
+          left: `${size}`,
         },
-        '.inset-0': {
-          top: 0,
-          right: 0,
-          bottom: 0,
-          left: 0,
-        },
-        '.inset-y-0': { top: 0, bottom: 0 },
-        '.inset-x-0': { right: 0, left: 0 },
-        '.top-0': { top: 0 },
-        '.right-0': { right: 0 },
-        '.bottom-0': { bottom: 0 },
-        '.left-0': { left: 0 },
-      },
-      config('variants.inset')
-    )
+      }),
+      (size, modifier) => ({
+        [`.${e(`inset-y-${modifier}`)}`]: { top: `${size}`, bottom: `${size}` },
+        [`.${e(`inset-x-${modifier}`)}`]: { right: `${size}`, left: `${size}` },
+      }),
+      (size, modifier) => ({
+        [`.${e(`top-${modifier}`)}`]: { top: `${size}` },
+        [`.${e(`right-${modifier}`)}`]: { right: `${size}` },
+        [`.${e(`bottom-${modifier}`)}`]: { bottom: `${size}` },
+        [`.${e(`left-${modifier}`)}`]: { left: `${size}` },
+      }),
+    ]
+
+    const utilities = _.flatMap(generators, generator => {
+      return _.flatMap(config('theme.inset'), generator)
+    })
+
+    addUtilities(utilities, config('variants.inset'))
   }
 }

--- a/src/plugins/position.js
+++ b/src/plugins/position.js
@@ -7,24 +7,6 @@ export default function() {
         '.absolute': { position: 'absolute' },
         '.relative': { position: 'relative' },
         '.sticky': { position: 'sticky' },
-        '.pin-none': {
-          top: 'auto',
-          right: 'auto',
-          bottom: 'auto',
-          left: 'auto',
-        },
-        '.pin': {
-          top: 0,
-          right: 0,
-          bottom: 0,
-          left: 0,
-        },
-        '.pin-y': { top: 0, bottom: 0 },
-        '.pin-x': { right: 0, left: 0 },
-        '.pin-t': { top: 0 },
-        '.pin-r': { right: 0 },
-        '.pin-b': { bottom: 0 },
-        '.pin-l': { left: 0 },
       },
       config('variants.position')
     )


### PR DESCRIPTION
In Tailwind 0.x we took the fairly heavy handed approach of assuming that anything you could accomplish with `top: {value}` could also be accomplished with `top: 0; margin-top: {value}`. We did this mostly for file size concerns, and take to advantage of Tailwind's inherit composability so it wasn't necessary to duplicate the spacing scale to yet another category of utilities.

Because of that stance, we named the top/right/bottom/left classes `pin-{side}`, because the idea is that you were pinning the element to some edge of the container, since we only supported a zero value. This was also convenient because we wanted to be able to pin an element to all sides using a single class, and unlike margin/padding, CSS didn't have any sort of shorthand property for setting top/right/bottom/left all at once, so we had nowhere to draw naming inspiration from (or so we thought.) If we called `pin-t` `top-0` instead, what would we call `pin-x`?

Later I discovered that there is at least one very important use case for setting a `top` value other than zero, and that's when working with [sticky positioning](https://developer.mozilla.org/en-US/docs/Web/CSS/position#Sticky_positioning), one of the most useful new-ish features I've ever come across in CSS.

When I realized I needed stuff like `top-16` to get sticky positioned elements in the right place, I started to regret our `pin-t` approach. I also realized that people sometimes need things like `left: 100%` when you are trying to position an element _outside_ of its parent, like you might do with a complex nested dropdown.

People have suggested supporting classes like `pin-t-16` or `pin-l-full` in the past, but that feels like a bad name compared to `top-16` or `left-full`, so instead of living with that naming debt forever I think it's worth fixing it now for 1.0.

The question of course was what to name the shorthand `pin`, `pin-x`, and `pin-y` properties 🤔 Well it turns out, in the new-ish [CSS Logical Properties and Values](https://www.w3.org/TR/css-logical-1/#inset-properties) spec there is a new `inset` property, which is a shorthand for top/right/bottom/left! 🎉 

So this PR introduces the following class name changes:

| Old | New |
| --- | --- |
| `.pin-none`  | `.inset-auto`  |
| `.pin`  | `.inset-0`  |
| `.pin-y`  | `.inset-y-0`  |
| `.pin-x`  | `.inset-x-0`  |
| `.pin-t`  | `.top-0`  |
| `.pin-r`  | `.right-0`  |
| `.pin-b`  | `.bottom-0`  |
| `.pin-l`  | `.left-0`  |

It also adds the following new classes by default:

| Class |
| --- |
| `.inset-y-auto`  |
| `.inset-x-auto`  |
| `.top-auto`  |
| `.right-auto`  |
| `.bottom-auto`  |
| `.left-auto`  |

It also makes all of these values customizable using a new `inset` key in the theme config:

```js
module.exports = {
  theme: {
    inset: {
      '0': 0,
      auto: 'auto',
    },
  }
}
```

These classes now live in a new `inset` plugin instead of the `position` plugin, so their variants are also controlled separately:

```js
module.exports = {
  variants: {
    position: ['responsive'],
    inset: ['responsive'],
  }
}
```

This is an annoying BC break but I think it's worth it to not regret the `pin-{side}` naming convention for years to come.