### PR TITLE
Make container plugin a core plugin, configured in theme

### DIFF
--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -30,7 +30,6 @@ describe('cli', () => {
     it('creates a Tailwind config file without comments', () => {
       return cli(['init', '--no-comments']).then(() => {
         expect(utils.writeFile.mock.calls[0][1]).not.toContain('/**')
-        expect(utils.writeFile.mock.calls[0][1]).toContain('//')
       })
     })
   })

--- a/__tests__/containerPlugin.test.js
+++ b/__tests__/containerPlugin.test.js
@@ -41,6 +41,29 @@ test.only('options are not required', () => {
   `)
 })
 
+test.only('screens can be passed explicitly', () => {
+  const { components } = processPlugins(
+    [container()],
+    config({
+      theme: {
+        container: {
+          screens: ['400px', '500px'],
+        },
+      },
+    })
+  )
+
+  expect(css(components)).toMatchCss(`
+    .container { width: 100% }
+    @media (min-width: 400px) {
+      .container { max-width: 400px }
+    }
+    @media (min-width: 500px) {
+      .container { max-width: 500px }
+    }
+  `)
+})
+
 test.only('the container can be centered by default', () => {
   const { components } = processPlugins(
     [container()],
@@ -113,6 +136,7 @@ test.only('setting all options at once', () => {
     config({
       theme: {
         container: {
+          screens: ['400px', '500px'],
           center: true,
           padding: '2rem',
         },
@@ -128,17 +152,11 @@ test.only('setting all options at once', () => {
       padding-right: 2rem;
       padding-left: 2rem
     }
-    @media (min-width: 576px) {
-      .container { max-width: 576px }
+    @media (min-width: 400px) {
+      .container { max-width: 400px }
     }
-    @media (min-width: 768px) {
-      .container { max-width: 768px }
-    }
-    @media (min-width: 992px) {
-      .container { max-width: 992px }
-    }
-    @media (min-width: 1200px) {
-      .container { max-width: 1200px }
+    @media (min-width: 500px) {
+      .container { max-width: 500px }
     }
   `)
 })

--- a/__tests__/containerPlugin.test.js
+++ b/__tests__/containerPlugin.test.js
@@ -41,59 +41,16 @@ test.only('options are not required', () => {
   `)
 })
 
-test.only('screens can be specified explicitly', () => {
-  const { components } = processPlugins(
-    [
-      container({
-        screens: {
-          sm: '400px',
-          lg: '500px',
-        },
-      }),
-    ],
-    config()
-  )
-
-  expect(css(components)).toMatchCss(`
-    .container { width: 100% }
-    @media (min-width: 400px) {
-      .container { max-width: 400px }
-    }
-    @media (min-width: 500px) {
-      .container { max-width: 500px }
-    }
-  `)
-})
-
-test.only('screens can be an array', () => {
-  const { components } = processPlugins(
-    [
-      container({
-        screens: ['400px', '500px'],
-      }),
-    ],
-    config()
-  )
-
-  expect(css(components)).toMatchCss(`
-    .container { width: 100% }
-    @media (min-width: 400px) {
-      .container { max-width: 400px }
-    }
-    @media (min-width: 500px) {
-      .container { max-width: 500px }
-    }
-  `)
-})
-
 test.only('the container can be centered by default', () => {
   const { components } = processPlugins(
-    [
-      container({
-        center: true,
-      }),
-    ],
-    config()
+    [container()],
+    config({
+      theme: {
+        container: {
+          center: true,
+        },
+      },
+    })
   )
 
   expect(css(components)).toMatchCss(`
@@ -119,12 +76,14 @@ test.only('the container can be centered by default', () => {
 
 test.only('horizontal padding can be included by default', () => {
   const { components } = processPlugins(
-    [
-      container({
-        padding: '2rem',
-      }),
-    ],
-    config()
+    [container()],
+    config({
+      theme: {
+        container: {
+          padding: '2rem',
+        },
+      },
+    })
   )
 
   expect(css(components)).toMatchCss(`
@@ -150,17 +109,15 @@ test.only('horizontal padding can be included by default', () => {
 
 test.only('setting all options at once', () => {
   const { components } = processPlugins(
-    [
-      container({
-        screens: {
-          sm: '400px',
-          lg: '500px',
+    [container()],
+    config({
+      theme: {
+        container: {
+          center: true,
+          padding: '2rem',
         },
-        center: true,
-        padding: '2rem',
-      }),
-    ],
-    config()
+      },
+    })
   )
 
   expect(css(components)).toMatchCss(`
@@ -171,11 +128,17 @@ test.only('setting all options at once', () => {
       padding-right: 2rem;
       padding-left: 2rem
     }
-    @media (min-width: 400px) {
-      .container { max-width: 400px }
+    @media (min-width: 576px) {
+      .container { max-width: 576px }
     }
-    @media (min-width: 500px) {
-      .container { max-width: 500px }
+    @media (min-width: 768px) {
+      .container { max-width: 768px }
+    }
+    @media (min-width: 992px) {
+      .container { max-width: 992px }
+    }
+    @media (min-width: 1200px) {
+      .container { max-width: 1200px }
     }
   `)
 })

--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -69,12 +69,6 @@ module.exports = {
     width: ['responsive'],
     zIndex: ['responsive'],
   },
-  corePlugins: {
-  },
-  plugins: [
-    require('./plugins/container')({
-      // center: true,
-      // padding: '1rem',
-    }),
-  ],
+  corePlugins: {},
+  plugins: [],
 }

--- a/plugins/container.js
+++ b/plugins/container.js
@@ -1,1 +1,0 @@
-module.exports = require('../lib/plugins/container')

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1,4 +1,5 @@
 import preflight from './plugins/preflight'
+import container from './plugins/container'
 import appearance from './plugins/appearance'
 import backgroundAttachment from './plugins/backgroundAttachment'
 import backgroundColor from './plugins/backgroundColor'
@@ -67,6 +68,7 @@ import configurePlugins from './util/configurePlugins'
 export default function({ corePlugins: corePluginConfig }) {
   return configurePlugins(corePluginConfig, {
     preflight,
+    container,
     appearance,
     backgroundAttachment,
     backgroundColor,

--- a/src/plugins/container.js
+++ b/src/plugins/container.js
@@ -24,7 +24,7 @@ function extractMinWidths(breakpoints) {
 
 module.exports = function() {
   return function({ addComponents, config }) {
-    const minWidths = extractMinWidths(config('theme.screens'))
+    const minWidths = extractMinWidths(config('theme.container.screens', config('theme.screens')))
 
     const atRules = _.map(minWidths, minWidth => {
       return {

--- a/src/plugins/container.js
+++ b/src/plugins/container.js
@@ -22,11 +22,9 @@ function extractMinWidths(breakpoints) {
   })
 }
 
-module.exports = function(options) {
+module.exports = function() {
   return function({ addComponents, config }) {
-    const screens = _.get(options, 'screens', config('theme.screens'))
-
-    const minWidths = extractMinWidths(screens)
+    const minWidths = extractMinWidths(config('theme.screens'))
 
     const atRules = _.map(minWidths, minWidth => {
       return {
@@ -42,9 +40,14 @@ module.exports = function(options) {
       {
         '.container': Object.assign(
           { width: '100%' },
-          _.get(options, 'center', false) ? { marginRight: 'auto', marginLeft: 'auto' } : {},
-          _.has(options, 'padding')
-            ? { paddingRight: options.padding, paddingLeft: options.padding }
+          config('theme.container.center', false)
+            ? { marginRight: 'auto', marginLeft: 'auto' }
+            : {},
+          _.has(config('theme.container', {}), 'padding')
+            ? {
+                paddingRight: config('theme.container.padding'),
+                paddingLeft: config('theme.container.padding'),
+              }
             : {}
         ),
       },


### PR DESCRIPTION
In 0.x there was no real way to disable "modules" that weren't generating only utilities, because you disabled a module by setting it to `false` in the same place you would normally specify the variants, and variants don't make any sense for plugins that do anything other than generate utilities.

For this reason, we decided to turn the `container` module into what was essentially a first-class third-party plugin that was included and enabled by default in the `plugins` section of your config file.

In 1.x, core plugins are disabled using the new `corePlugins` key, so there's no longer a great reason for the container plugin to be treated like a third-party plugin, and it's actually kind of confusing.

**This PR makes the container plugin a true core plugin just like all of the utility plugins and Preflight.**

It is no longer present in the `plugins` section of your config by default:

```diff
  module.exports = {
    // ...
    plugins: [
-     require('./plugins/container')({
-       // center: true,
-       // padding: '1rem',
-     }),
    ],
  }
```

You disable it by setting it to `false` in your `corePlugins` config, like all other core plugins:

```js
module.exports = {
  corePlugins: {
    container: false
  }
}
```

...and for the reasons outlined in #696, you configure it in your `theme`, using the same options it used to take as direct arguments:

```js
module.exports = {
  theme: {
    container: {
      screens: ['400px', '500px'],
      center: true,
      padding: '1rem',
    }
  }
}
```

Every option is optional as it was before, with screens defaulting to your `theme.screens`, center defaulting to `false`, and padding defaulting to `0`.

This is a breaking change but very minor as it only impacts your config file.