### PR TITLE
Split wordBreak plugin from whitespace plugin

### DIFF
--- a/defaultConfig.stub.js
+++ b/defaultConfig.stub.js
@@ -67,6 +67,7 @@ module.exports = {
     verticalAlign: ['responsive'],
     visibility: ['responsive'],
     whitespace: ['responsive'],
+    wordBreak: ['responsive'],
     width: ['responsive'],
     zIndex: ['responsive'],
   },

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -61,6 +61,7 @@ import userSelect from './plugins/userSelect'
 import verticalAlign from './plugins/verticalAlign'
 import visibility from './plugins/visibility'
 import whitespace from './plugins/whitespace'
+import wordBreak from './plugins/wordBreak'
 import width from './plugins/width'
 import zIndex from './plugins/zIndex'
 
@@ -131,6 +132,7 @@ export default function({ corePlugins: corePluginConfig }) {
     verticalAlign,
     visibility,
     whitespace,
+    wordBreak,
     width,
     zIndex,
   })

--- a/src/plugins/whitespace.js
+++ b/src/plugins/whitespace.js
@@ -7,19 +7,6 @@ export default function() {
         '.whitespace-pre': { 'white-space': 'pre' },
         '.whitespace-pre-line': { 'white-space': 'pre-line' },
         '.whitespace-pre-wrap': { 'white-space': 'pre-wrap' },
-
-        '.break-normal': {
-          'overflow-wrap': 'normal',
-          'word-break': 'normal',
-        },
-        '.break-words': { 'overflow-wrap': 'break-word' },
-        '.break-all': { 'word-break': 'break-all' },
-
-        '.truncate': {
-          overflow: 'hidden',
-          'text-overflow': 'ellipsis',
-          'white-space': 'nowrap',
-        },
       },
       config('variants.whitespace')
     )

--- a/src/plugins/wordBreak.js
+++ b/src/plugins/wordBreak.js
@@ -1,0 +1,21 @@
+export default function() {
+  return function({ addUtilities, config }) {
+    addUtilities(
+      {
+        '.break-normal': {
+          'overflow-wrap': 'normal',
+          'word-break': 'normal',
+        },
+        '.break-words': { 'overflow-wrap': 'break-word' },
+        '.break-all': { 'word-break': 'break-all' },
+
+        '.truncate': {
+          overflow: 'hidden',
+          'text-overflow': 'ellipsis',
+          'white-space': 'nowrap',
+        },
+      },
+      config('variants.wordBreak')
+    )
+  }
+}


### PR DESCRIPTION
This PR splits `word-break`-related utilities out of the whitespace plugin and into a new `wordBreak` plugin to be consistent with how we split the flexbox and textStyles plugins.