### PR TITLE
Revert #745, always default to bolder for strong tags

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -530,16 +530,6 @@ textarea {
 }
 
 /**
- * Use the configured 'bold' weight for `strong` elements
- * by default, falling back to 'bolder' (as per normalize.css)
- * if there is no configured 'bold' weight.
- */
-
-strong {
-  font-weight: 700;
-}
-
-/**
  * Use the configured 'mono' font family for elements that
  * are expected to be rendered with a monospace font, falling
  * back to the system monospace stack if there is no configured

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -530,16 +530,6 @@ textarea {
 }
 
 /**
- * Use the configured 'bold' weight for `strong` elements
- * by default, falling back to 'bolder' (as per normalize.css)
- * if there is no configured 'bold' weight.
- */
-
-strong {
-  font-weight: 700;
-}
-
-/**
  * Use the configured 'mono' font family for elements that
  * are expected to be rendered with a monospace font, falling
  * back to the system monospace stack if there is no configured

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -176,16 +176,6 @@ textarea {
 }
 
 /**
- * Use the configured 'bold' weight for `strong` elements
- * by default, falling back to 'bolder' (as per normalize.css)
- * if there is no configured 'bold' weight.
- */
-
-strong {
-  font-weight: theme('fontWeight.bold', bolder);
-}
-
-/**
  * Use the configured 'mono' font family for elements that
  * are expected to be rendered with a monospace font, falling
  * back to the system monospace stack if there is no configured


### PR DESCRIPTION
I didn't realize that `bolder` in CSS was actually [relative to the parent font-weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#Meaning_of_relative_weights), so hard-coding this to a specific value by default is probably not correct even if it does increase the odds of the end-user sticking to their own design system.

Since I don't have a perfect solution for this I think it's better to take no stance at all and just let normalize do it's regular thing.