### PR TITLE
Account for function values in theme function

### DIFF
--- a/__tests__/resolveConfig.test.js
+++ b/__tests__/resolveConfig.test.js
@@ -758,6 +758,66 @@ test('the theme function can use a default value if the key is missing', () => {
   })
 })
 
+test('the theme function can resolve function values', () => {
+  const userConfig = {
+    theme: {
+      backgroundColor: theme => ({
+        orange: 'orange',
+        ...theme('colors'),
+      }),
+      borderColor: theme => theme('backgroundColor'),
+    },
+  }
+
+  const defaultConfig = {
+    prefix: '-',
+    important: false,
+    separator: ':',
+    theme: {
+      colors: {
+        red: 'red',
+        green: 'green',
+        blue: 'blue',
+      },
+    },
+    variants: {
+      backgroundColor: ['responsive', 'hover', 'focus'],
+      borderColor: ['responsive', 'hover', 'focus'],
+    },
+  }
+
+  const result = resolveConfig([userConfig, defaultConfig])
+
+  expect(result).toEqual({
+    prefix: '-',
+    important: false,
+    separator: ':',
+    theme: {
+      colors: {
+        red: 'red',
+        green: 'green',
+        blue: 'blue',
+      },
+      backgroundColor: {
+        orange: 'orange',
+        red: 'red',
+        green: 'green',
+        blue: 'blue',
+      },
+      borderColor: {
+        orange: 'orange',
+        red: 'red',
+        green: 'green',
+        blue: 'blue',
+      },
+    },
+    variants: {
+      backgroundColor: ['responsive', 'hover', 'focus'],
+      borderColor: ['responsive', 'hover', 'focus'],
+    },
+  })
+})
+
 test('theme values in the extend section are lazily evaluated', () => {
   const userConfig = {
     theme: {

--- a/src/util/resolveConfig.js
+++ b/src/util/resolveConfig.js
@@ -25,7 +25,10 @@ function mergeExtensions({ extend, ...theme }) {
 }
 
 function resolveFunctionKeys(object) {
-  const resolveObjectPath = (key, defaultValue) => get(object, key, defaultValue)
+  const resolveObjectPath = (key, defaultValue) => {
+    const val = get(object, key, defaultValue)
+    return isFunction(val) ? val(resolveObjectPath) : val
+  }
 
   return Object.keys(object).reduce((resolved, key) => {
     return {


### PR DESCRIPTION
This PR fixes an issue where function values are not resolved when using the `theme` function inside your config.

For example:

```js
module.exports = {
  theme: {
    backgroundColor: theme => theme('colors'),
    borderColor: theme => theme('backgroundColor'),
  }
}
```

This would not resolve correctly because the `theme` function was not accounting for function values, in this case the `backgroundColor` value