### PR TITLE
Support disabling all corePlugins with corePlugins: false

### DIFF
--- a/__tests__/configurePlugins.test.js
+++ b/__tests__/configurePlugins.test.js
@@ -16,3 +16,15 @@ test('setting a plugin to false removes it', () => {
 
   expect(configuredPlugins).toEqual(['fontSize', 'backgroundPosition'])
 })
+
+test('passing only false removes all plugins', () => {
+  const plugins = {
+    fontSize: () => 'fontSize',
+    display: () => 'display',
+    backgroundPosition: () => 'backgroundPosition',
+  }
+
+  const configuredPlugins = configurePlugins(false, plugins)
+
+  expect(configuredPlugins).toEqual([])
+})

--- a/src/util/configurePlugins.js
+++ b/src/util/configurePlugins.js
@@ -1,7 +1,7 @@
 export default function(pluginConfig, plugins) {
   return Object.keys(plugins)
     .filter(pluginName => {
-      return pluginConfig[pluginName] !== false
+      return pluginConfig !== false && pluginConfig[pluginName] !== false
     })
     .map(pluginName => {
       return plugins[pluginName]()


### PR DESCRIPTION
Closes #833.

This PR makes it possible to disable every core plugin by setting `corePlugins` to `false` in your config:

```js
module.exports = {
  corePlugins: false
}
```

Useful for testing, as well as for people who want to use Tailwind more like a CSS generating engine and want to provide all of their own plugins.