### PR TITLE
Support configuring a single list of variants to apply to all relevant plugins

### DIFF
--- a/__tests__/plugins/backgroundColor.test.js
+++ b/__tests__/plugins/backgroundColor.test.js
@@ -40,6 +40,13 @@ test('colors can be a nested object', () => {
   const pluginApi = {
     config: (key, defaultValue) => _.get(config, key, defaultValue),
     e: escapeClassName,
+    variants: (path, defaultValue) => {
+      if (_.isArray(config.variants)) {
+        return config.variants
+      }
+
+      return _.get(config.variants, path, defaultValue)
+    },
     addUtilities(utilities, variants) {
       addedUtilities.push({
         utilities,

--- a/__tests__/plugins/borderColor.test.js
+++ b/__tests__/plugins/borderColor.test.js
@@ -40,6 +40,13 @@ test('colors can be a nested object', () => {
   const pluginApi = {
     config: (key, defaultValue) => _.get(config, key, defaultValue),
     e: escapeClassName,
+    variants: (path, defaultValue) => {
+      if (_.isArray(config.variants)) {
+        return config.variants
+      }
+
+      return _.get(config.variants, path, defaultValue)
+    },
     addUtilities(utilities, variants) {
       addedUtilities.push({
         utilities,

--- a/__tests__/plugins/fill.test.js
+++ b/__tests__/plugins/fill.test.js
@@ -40,6 +40,13 @@ test('colors can be a nested object', () => {
   const pluginApi = {
     config: (key, defaultValue) => _.get(config, key, defaultValue),
     e: escapeClassName,
+    variants: (path, defaultValue) => {
+      if (_.isArray(config.variants)) {
+        return config.variants
+      }
+
+      return _.get(config.variants, path, defaultValue)
+    },
     addUtilities(utilities, variants) {
       addedUtilities.push({
         utilities,

--- a/__tests__/plugins/stroke.test.js
+++ b/__tests__/plugins/stroke.test.js
@@ -40,6 +40,13 @@ test('colors can be a nested object', () => {
   const pluginApi = {
     config: (key, defaultValue) => _.get(config, key, defaultValue),
     e: escapeClassName,
+    variants: (path, defaultValue) => {
+      if (_.isArray(config.variants)) {
+        return config.variants
+      }
+
+      return _.get(config.variants, path, defaultValue)
+    },
     addUtilities(utilities, variants) {
       addedUtilities.push({
         utilities,

--- a/__tests__/plugins/textColor.test.js
+++ b/__tests__/plugins/textColor.test.js
@@ -40,6 +40,13 @@ test('colors can be a nested object', () => {
   const pluginApi = {
     config: (key, defaultValue) => _.get(config, key, defaultValue),
     e: escapeClassName,
+    variants: (path, defaultValue) => {
+      if (_.isArray(config.variants)) {
+        return config.variants
+      }
+
+      return _.get(config.variants, path, defaultValue)
+    },
     addUtilities(utilities, variants) {
       addedUtilities.push({
         utilities,

--- a/__tests__/processPlugins.test.js
+++ b/__tests__/processPlugins.test.js
@@ -657,6 +657,91 @@ test('plugins can access the current config', () => {
     `)
 })
 
+test('plugins can access the variants config directly', () => {
+  const { components, utilities } = processPlugins(
+    [
+      function({ addUtilities, variants }) {
+        addUtilities(
+          {
+            '.object-fill': {
+              'object-fit': 'fill',
+            },
+            '.object-contain': {
+              'object-fit': 'contain',
+            },
+            '.object-cover': {
+              'object-fit': 'cover',
+            },
+          },
+          variants('objectFit')
+        )
+      },
+    ],
+    makeConfig({
+      variants: {
+        objectFit: ['responsive', 'focus', 'hover'],
+      },
+    })
+  )
+
+  expect(components.length).toBe(0)
+  expect(css(utilities)).toMatchCss(`
+    @variants responsive, focus, hover {
+      .object-fill {
+        object-fit: fill
+      }
+      .object-contain {
+        object-fit: contain
+      }
+      .object-cover {
+        object-fit: cover
+      }
+    }
+    `)
+})
+
+test('plugins apply all global variants when variants are configured globally', () => {
+  const { components, utilities } = processPlugins(
+    [
+      function({ addUtilities, variants }) {
+        addUtilities(
+          {
+            '.object-fill': {
+              'object-fit': 'fill',
+            },
+          },
+          variants('objectFit')
+        )
+        addUtilities(
+          {
+            '.rotate-90deg': {
+              transform: 'rotate(90deg)',
+            },
+          },
+          variants('rotate')
+        )
+      },
+    ],
+    makeConfig({
+      variants: ['responsive', 'focus', 'hover'],
+    })
+  )
+
+  expect(components.length).toBe(0)
+  expect(css(utilities)).toMatchCss(`
+    @variants responsive, focus, hover {
+      .object-fill {
+        object-fit: fill
+      }
+    }
+    @variants responsive, focus, hover {
+      .rotate-90deg {
+        transform: rotate(90deg)
+      }
+    }
+    `)
+})
+
 test('plugins can provide fallbacks to keys missing from the config', () => {
   const { components, utilities } = processPlugins(
     [

--- a/src/plugins/alignContent.js
+++ b/src/plugins/alignContent.js
@@ -1,5 +1,5 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.content-center': {
@@ -18,7 +18,7 @@ export default function() {
           'align-content': 'space-around',
         },
       },
-      config('variants.alignContent')
+      variants('alignContent')
     )
   }
 }

--- a/src/plugins/alignItems.js
+++ b/src/plugins/alignItems.js
@@ -1,5 +1,5 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.items-start': {
@@ -18,7 +18,7 @@ export default function() {
           'align-items': 'stretch',
         },
       },
-      config('variants.alignItems')
+      variants('alignItems')
     )
   }
 }

--- a/src/plugins/alignSelf.js
+++ b/src/plugins/alignSelf.js
@@ -1,5 +1,5 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.self-auto': {
@@ -18,7 +18,7 @@ export default function() {
           'align-self': 'stretch',
         },
       },
-      config('variants.alignSelf')
+      variants('alignSelf')
     )
   }
 }

--- a/src/plugins/appearance.js
+++ b/src/plugins/appearance.js
@@ -1,10 +1,10 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.appearance-none': { appearance: 'none' },
       },
-      config('variants.appearance')
+      variants('appearance')
     )
   }
 }

--- a/src/plugins/backgroundAttachment.js
+++ b/src/plugins/backgroundAttachment.js
@@ -1,12 +1,12 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.bg-fixed': { 'background-attachment': 'fixed' },
         '.bg-local': { 'background-attachment': 'local' },
         '.bg-scroll': { 'background-attachment': 'scroll' },
       },
-      config('variants.backgroundAttachment')
+      variants('backgroundAttachment')
     )
   }
 }

--- a/src/plugins/backgroundColor.js
+++ b/src/plugins/backgroundColor.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import flattenColorPalette from '../util/flattenColorPalette'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const utilities = _.fromPairs(
       _.map(flattenColorPalette(config('theme.backgroundColor')), (value, modifier) => {
         return [
@@ -14,6 +14,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.backgroundColor'))
+    addUtilities(utilities, variants('backgroundColor'))
   }
 }

--- a/src/plugins/backgroundPosition.js
+++ b/src/plugins/backgroundPosition.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const utilities = _.fromPairs(
       _.map(config('theme.backgroundPosition'), (value, modifier) => {
         return [
@@ -13,6 +13,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.backgroundPosition'))
+    addUtilities(utilities, variants('backgroundPosition'))
   }
 }

--- a/src/plugins/backgroundRepeat.js
+++ b/src/plugins/backgroundRepeat.js
@@ -1,5 +1,5 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.bg-repeat': { 'background-repeat': 'repeat' },
@@ -7,7 +7,7 @@ export default function() {
         '.bg-repeat-x': { 'background-repeat': 'repeat-x' },
         '.bg-repeat-y': { 'background-repeat': 'repeat-y' },
       },
-      config('variants.backgroundRepeat')
+      variants('backgroundRepeat')
     )
   }
 }

--- a/src/plugins/backgroundSize.js
+++ b/src/plugins/backgroundSize.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const utilities = _.fromPairs(
       _.map(config('theme.backgroundSize'), (value, modifier) => {
         return [
@@ -13,6 +13,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.backgroundSize'))
+    addUtilities(utilities, variants('backgroundSize'))
   }
 }

--- a/src/plugins/borderCollapse.js
+++ b/src/plugins/borderCollapse.js
@@ -1,11 +1,11 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.border-collapse': { 'border-collapse': 'collapse' },
         '.border-separate': { 'border-collapse': 'separate' },
       },
-      config('variants.borderCollapse')
+      variants('borderCollapse')
     )
   }
 }

--- a/src/plugins/borderColor.js
+++ b/src/plugins/borderColor.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import flattenColorPalette from '../util/flattenColorPalette'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const colors = flattenColorPalette(config('theme.borderColor'))
 
     const utilities = _.fromPairs(
@@ -16,6 +16,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.borderColor'))
+    addUtilities(utilities, variants('borderColor'))
   }
 }

--- a/src/plugins/borderRadius.js
+++ b/src/plugins/borderRadius.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const generators = [
       (value, modifier) => ({
         [`.${e(`rounded${modifier}`)}`]: { borderRadius: `${value}` },
@@ -38,6 +38,6 @@ export default function() {
       })
     })
 
-    addUtilities(utilities, config('variants.borderRadius'))
+    addUtilities(utilities, variants('borderRadius'))
   }
 }

--- a/src/plugins/borderStyle.js
+++ b/src/plugins/borderStyle.js
@@ -1,5 +1,5 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.border-solid': {
@@ -15,7 +15,7 @@ export default function() {
           'border-style': 'none',
         },
       },
-      config('variants.borderStyle')
+      variants('borderStyle')
     )
   }
 }

--- a/src/plugins/borderWidth.js
+++ b/src/plugins/borderWidth.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const generators = [
       (value, modifier) => ({
         [`.${e(`border${modifier}`)}`]: { borderWidth: `${value}` },
@@ -20,6 +20,6 @@ export default function() {
       })
     })
 
-    addUtilities(utilities, config('variants.borderWidth'))
+    addUtilities(utilities, variants('borderWidth'))
   }
 }

--- a/src/plugins/boxShadow.js
+++ b/src/plugins/boxShadow.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const utilities = _.fromPairs(
       _.map(config('theme.boxShadow'), (value, modifier) => {
         const className = modifier === 'default' ? 'shadow' : `shadow-${modifier}`
@@ -14,6 +14,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.boxShadow'))
+    addUtilities(utilities, variants('boxShadow'))
   }
 }

--- a/src/plugins/cursor.js
+++ b/src/plugins/cursor.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const utilities = _.fromPairs(
       _.map(config('theme.cursor'), (value, modifier) => {
         return [
@@ -13,6 +13,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.cursor'))
+    addUtilities(utilities, variants('cursor'))
   }
 }

--- a/src/plugins/display.js
+++ b/src/plugins/display.js
@@ -1,5 +1,5 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.block': {
@@ -30,7 +30,7 @@ export default function() {
           display: 'none',
         },
       },
-      config('variants.display')
+      variants('display')
     )
   }
 }

--- a/src/plugins/fill.js
+++ b/src/plugins/fill.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import flattenColorPalette from '../util/flattenColorPalette'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const utilities = _.fromPairs(
       _.map(flattenColorPalette(config('theme.fill')), (value, modifier) => {
         return [
@@ -14,6 +14,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.fill'))
+    addUtilities(utilities, variants('fill'))
   }
 }

--- a/src/plugins/flex.js
+++ b/src/plugins/flex.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const utilities = _.fromPairs(
       _.map(config('theme.flex'), (value, modifier) => {
         return [
@@ -13,6 +13,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.flex'))
+    addUtilities(utilities, variants('flex'))
   }
 }

--- a/src/plugins/flexDirection.js
+++ b/src/plugins/flexDirection.js
@@ -1,5 +1,5 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.flex-row': {
@@ -15,7 +15,7 @@ export default function() {
           'flex-direction': 'column-reverse',
         },
       },
-      config('variants.flexDirection')
+      variants('flexDirection')
     )
   }
 }

--- a/src/plugins/flexGrow.js
+++ b/src/plugins/flexGrow.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     addUtilities(
       _.fromPairs(
         _.map(config('theme.flexGrow'), (value, modifier) => {
@@ -14,7 +14,7 @@ export default function() {
           ]
         })
       ),
-      config('variants.flexGrow')
+      variants('flexGrow')
     )
   }
 }

--- a/src/plugins/flexShrink.js
+++ b/src/plugins/flexShrink.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     addUtilities(
       _.fromPairs(
         _.map(config('theme.flexShrink'), (value, modifier) => {
@@ -14,7 +14,7 @@ export default function() {
           ]
         })
       ),
-      config('variants.flexShrink')
+      variants('flexShrink')
     )
   }
 }

--- a/src/plugins/flexWrap.js
+++ b/src/plugins/flexWrap.js
@@ -1,5 +1,5 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.flex-wrap': {
@@ -12,7 +12,7 @@ export default function() {
           'flex-wrap': 'nowrap',
         },
       },
-      config('variants.flexWrap')
+      variants('flexWrap')
     )
   }
 }

--- a/src/plugins/float.js
+++ b/src/plugins/float.js
@@ -1,5 +1,5 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.float-right': { float: 'right' },
@@ -11,7 +11,7 @@ export default function() {
           clear: 'both',
         },
       },
-      config('variants.float')
+      variants('float')
     )
   }
 }

--- a/src/plugins/fontFamily.js
+++ b/src/plugins/fontFamily.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const utilities = _.fromPairs(
       _.map(config('theme.fontFamily'), (value, modifier) => {
         return [
@@ -13,6 +13,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.fontFamily'))
+    addUtilities(utilities, variants('fontFamily'))
   }
 }

--- a/src/plugins/fontSize.js
+++ b/src/plugins/fontSize.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const utilities = _.fromPairs(
       _.map(config('theme.fontSize'), (value, modifier) => {
         return [
@@ -13,6 +13,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.fontSize'))
+    addUtilities(utilities, variants('fontSize'))
   }
 }

--- a/src/plugins/fontSmoothing.js
+++ b/src/plugins/fontSmoothing.js
@@ -1,5 +1,5 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.antialiased': {
@@ -11,7 +11,7 @@ export default function() {
           '-moz-osx-font-smoothing': 'auto',
         },
       },
-      config('variants.fontSmoothing')
+      variants('fontSmoothing')
     )
   }
 }

--- a/src/plugins/fontStyle.js
+++ b/src/plugins/fontStyle.js
@@ -1,11 +1,11 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.italic': { 'font-style': 'italic' },
         '.not-italic': { 'font-style': 'normal' },
       },
-      config('variants.fontStyle')
+      variants('fontStyle')
     )
   }
 }

--- a/src/plugins/fontWeight.js
+++ b/src/plugins/fontWeight.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const utilities = _.fromPairs(
       _.map(config('theme.fontWeight'), (value, modifier) => {
         return [
@@ -13,6 +13,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.fontWeight'))
+    addUtilities(utilities, variants('fontWeight'))
   }
 }

--- a/src/plugins/height.js
+++ b/src/plugins/height.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const utilities = _.fromPairs(
       _.map(config('theme.height'), (value, modifier) => {
         return [
@@ -13,6 +13,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.height'))
+    addUtilities(utilities, variants('height'))
   }
 }

--- a/src/plugins/inset.js
+++ b/src/plugins/inset.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const generators = [
       (size, modifier) => ({
         [`.${e(`inset-${modifier}`)}`]: {
@@ -27,6 +27,6 @@ export default function() {
       return _.flatMap(config('theme.inset'), generator)
     })
 
-    addUtilities(utilities, config('variants.inset'))
+    addUtilities(utilities, variants('inset'))
   }
 }

--- a/src/plugins/justifyContent.js
+++ b/src/plugins/justifyContent.js
@@ -1,5 +1,5 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.justify-start': {
@@ -18,7 +18,7 @@ export default function() {
           'justify-content': 'space-around',
         },
       },
-      config('variants.justifyContent')
+      variants('justifyContent')
     )
   }
 }

--- a/src/plugins/letterSpacing.js
+++ b/src/plugins/letterSpacing.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, config, e }) {
+  return function({ addUtilities, config, variants, e }) {
     const utilities = _.fromPairs(
       _.map(config('theme.letterSpacing'), (value, modifier) => {
         return [
@@ -13,6 +13,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.letterSpacing'))
+    addUtilities(utilities, variants('letterSpacing'))
   }
 }

--- a/src/plugins/lineHeight.js
+++ b/src/plugins/lineHeight.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const utilities = _.fromPairs(
       _.map(config('theme.lineHeight'), (value, modifier) => {
         return [
@@ -13,6 +13,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.lineHeight'))
+    addUtilities(utilities, variants('lineHeight'))
   }
 }

--- a/src/plugins/listStylePosition.js
+++ b/src/plugins/listStylePosition.js
@@ -1,11 +1,11 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.list-inside': { 'list-style-position': 'inside' },
         '.list-outside': { 'list-style-position': 'outside' },
       },
-      config('variants.listStylePosition')
+      variants('listStylePosition')
     )
   }
 }

--- a/src/plugins/listStyleType.js
+++ b/src/plugins/listStyleType.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const utilities = _.fromPairs(
       _.map(config('theme.listStyleType'), (value, modifier) => {
         return [
@@ -13,6 +13,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.listStyleType'))
+    addUtilities(utilities, variants('listStyleType'))
   }
 }

--- a/src/plugins/margin.js
+++ b/src/plugins/margin.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const generators = [
       (size, modifier) => ({
         [`.${e(`m-${modifier}`)}`]: { margin: `${size}` },
@@ -22,6 +22,6 @@ export default function() {
       return _.flatMap(config('theme.margin'), generator)
     })
 
-    addUtilities(utilities, config('variants.margin'))
+    addUtilities(utilities, variants('margin'))
   }
 }

--- a/src/plugins/maxHeight.js
+++ b/src/plugins/maxHeight.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const utilities = _.fromPairs(
       _.map(config('theme.maxHeight'), (value, modifier) => {
         return [
@@ -13,6 +13,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.maxHeight'))
+    addUtilities(utilities, variants('maxHeight'))
   }
 }

--- a/src/plugins/maxWidth.js
+++ b/src/plugins/maxWidth.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const utilities = _.fromPairs(
       _.map(config('theme.maxWidth'), (value, modifier) => {
         return [
@@ -13,6 +13,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.maxWidth'))
+    addUtilities(utilities, variants('maxWidth'))
   }
 }

--- a/src/plugins/minHeight.js
+++ b/src/plugins/minHeight.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const utilities = _.fromPairs(
       _.map(config('theme.minHeight'), (value, modifier) => {
         return [
@@ -13,6 +13,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.minHeight'))
+    addUtilities(utilities, variants('minHeight'))
   }
 }

--- a/src/plugins/minWidth.js
+++ b/src/plugins/minWidth.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const utilities = _.fromPairs(
       _.map(config('theme.minWidth'), (value, modifier) => {
         return [
@@ -13,6 +13,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.minWidth'))
+    addUtilities(utilities, variants('minWidth'))
   }
 }

--- a/src/plugins/negativeMargin.js
+++ b/src/plugins/negativeMargin.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const generators = [
       (size, modifier) => ({
         [`.${e(`-m-${modifier}`)}`]: { margin: `${size}` },
@@ -24,6 +24,6 @@ export default function() {
       })
     })
 
-    addUtilities(utilities, config('variants.negativeMargin'))
+    addUtilities(utilities, variants('negativeMargin'))
   }
 }

--- a/src/plugins/objectFit.js
+++ b/src/plugins/objectFit.js
@@ -1,5 +1,5 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.object-contain': { 'object-fit': 'contain' },
@@ -8,7 +8,7 @@ export default function() {
         '.object-none': { 'object-fit': 'none' },
         '.object-scale-down': { 'object-fit': 'scale-down' },
       },
-      config('variants.objectFit')
+      variants('objectFit')
     )
   }
 }

--- a/src/plugins/objectPosition.js
+++ b/src/plugins/objectPosition.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const utilities = _.fromPairs(
       _.map(config('theme.objectPosition'), (value, modifier) => {
         return [
@@ -13,6 +13,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.objectPosition'))
+    addUtilities(utilities, variants('objectPosition'))
   }
 }

--- a/src/plugins/opacity.js
+++ b/src/plugins/opacity.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const utilities = _.fromPairs(
       _.map(config('theme.opacity'), (value, modifier) => {
         return [
@@ -13,6 +13,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.opacity'))
+    addUtilities(utilities, variants('opacity'))
   }
 }

--- a/src/plugins/outline.js
+++ b/src/plugins/outline.js
@@ -1,10 +1,10 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.outline-none': { outline: '0' },
       },
-      config('variants.outline')
+      variants('outline')
     )
   }
 }

--- a/src/plugins/overflow.js
+++ b/src/plugins/overflow.js
@@ -1,5 +1,5 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.overflow-auto': { overflow: 'auto' },
@@ -17,7 +17,7 @@ export default function() {
         '.scrolling-touch': { '-webkit-overflow-scrolling': 'touch' },
         '.scrolling-auto': { '-webkit-overflow-scrolling': 'auto' },
       },
-      config('variants.overflow')
+      variants('overflow')
     )
   }
 }

--- a/src/plugins/padding.js
+++ b/src/plugins/padding.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const generators = [
       (size, modifier) => ({
         [`.${e(`p-${modifier}`)}`]: { padding: `${size}` },
@@ -22,6 +22,6 @@ export default function() {
       return _.flatMap(config('theme.padding'), generator)
     })
 
-    addUtilities(utilities, config('variants.padding'))
+    addUtilities(utilities, variants('padding'))
   }
 }

--- a/src/plugins/pointerEvents.js
+++ b/src/plugins/pointerEvents.js
@@ -1,11 +1,11 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.pointer-events-none': { 'pointer-events': 'none' },
         '.pointer-events-auto': { 'pointer-events': 'auto' },
       },
-      config('variants.pointerEvents')
+      variants('pointerEvents')
     )
   }
 }

--- a/src/plugins/position.js
+++ b/src/plugins/position.js
@@ -1,5 +1,5 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.static': { position: 'static' },
@@ -8,7 +8,7 @@ export default function() {
         '.relative': { position: 'relative' },
         '.sticky': { position: 'sticky' },
       },
-      config('variants.position')
+      variants('position')
     )
   }
 }

--- a/src/plugins/resize.js
+++ b/src/plugins/resize.js
@@ -1,5 +1,5 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.resize-none': { resize: 'none' },
@@ -7,7 +7,7 @@ export default function() {
         '.resize-x': { resize: 'horizontal' },
         '.resize': { resize: 'both' },
       },
-      config('variants.resize')
+      variants('resize')
     )
   }
 }

--- a/src/plugins/stroke.js
+++ b/src/plugins/stroke.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import flattenColorPalette from '../util/flattenColorPalette'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const utilities = _.fromPairs(
       _.map(flattenColorPalette(config('theme.stroke')), (value, modifier) => {
         return [
@@ -14,6 +14,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.stroke'))
+    addUtilities(utilities, variants('stroke'))
   }
 }

--- a/src/plugins/tableLayout.js
+++ b/src/plugins/tableLayout.js
@@ -1,11 +1,11 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.table-auto': { 'table-layout': 'auto' },
         '.table-fixed': { 'table-layout': 'fixed' },
       },
-      config('variants.tableLayout')
+      variants('tableLayout')
     )
   }
 }

--- a/src/plugins/textAlign.js
+++ b/src/plugins/textAlign.js
@@ -1,5 +1,5 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.text-left': { 'text-align': 'left' },
@@ -7,7 +7,7 @@ export default function() {
         '.text-right': { 'text-align': 'right' },
         '.text-justify': { 'text-align': 'justify' },
       },
-      config('variants.textAlign')
+      variants('textAlign')
     )
   }
 }

--- a/src/plugins/textColor.js
+++ b/src/plugins/textColor.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import flattenColorPalette from '../util/flattenColorPalette'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const utilities = _.fromPairs(
       _.map(flattenColorPalette(config('theme.textColor')), (value, modifier) => {
         return [
@@ -14,6 +14,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.textColor'))
+    addUtilities(utilities, variants('textColor'))
   }
 }

--- a/src/plugins/textDecoration.js
+++ b/src/plugins/textDecoration.js
@@ -1,12 +1,12 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.underline': { 'text-decoration': 'underline' },
         '.line-through': { 'text-decoration': 'line-through' },
         '.no-underline': { 'text-decoration': 'none' },
       },
-      config('variants.textDecoration')
+      variants('textDecoration')
     )
   }
 }

--- a/src/plugins/textTransform.js
+++ b/src/plugins/textTransform.js
@@ -1,5 +1,5 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.uppercase': { 'text-transform': 'uppercase' },
@@ -7,7 +7,7 @@ export default function() {
         '.capitalize': { 'text-transform': 'capitalize' },
         '.normal-case': { 'text-transform': 'none' },
       },
-      config('variants.textTransform')
+      variants('textTransform')
     )
   }
 }

--- a/src/plugins/userSelect.js
+++ b/src/plugins/userSelect.js
@@ -1,11 +1,11 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.select-none': { 'user-select': 'none' },
         '.select-text': { 'user-select': 'text' },
       },
-      config('variants.userSelect')
+      variants('userSelect')
     )
   }
 }

--- a/src/plugins/verticalAlign.js
+++ b/src/plugins/verticalAlign.js
@@ -1,5 +1,5 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.align-baseline': { 'vertical-align': 'baseline' },
@@ -9,7 +9,7 @@ export default function() {
         '.align-text-top': { 'vertical-align': 'text-top' },
         '.align-text-bottom': { 'vertical-align': 'text-bottom' },
       },
-      config('variants.verticalAlign')
+      variants('verticalAlign')
     )
   }
 }

--- a/src/plugins/visibility.js
+++ b/src/plugins/visibility.js
@@ -1,11 +1,11 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.visible': { visibility: 'visible' },
         '.invisible': { visibility: 'hidden' },
       },
-      config('variants.visibility')
+      variants('visibility')
     )
   }
 }

--- a/src/plugins/whitespace.js
+++ b/src/plugins/whitespace.js
@@ -1,5 +1,5 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.whitespace-normal': { 'white-space': 'normal' },
@@ -8,7 +8,7 @@ export default function() {
         '.whitespace-pre-line': { 'white-space': 'pre-line' },
         '.whitespace-pre-wrap': { 'white-space': 'pre-wrap' },
       },
-      config('variants.whitespace')
+      variants('whitespace')
     )
   }
 }

--- a/src/plugins/width.js
+++ b/src/plugins/width.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, e, config }) {
+  return function({ addUtilities, e, config, variants }) {
     const utilities = _.fromPairs(
       _.map(config('theme.width'), (value, modifier) => {
         return [
@@ -13,6 +13,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.width'))
+    addUtilities(utilities, variants('width'))
   }
 }

--- a/src/plugins/wordBreak.js
+++ b/src/plugins/wordBreak.js
@@ -1,5 +1,5 @@
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, variants }) {
     addUtilities(
       {
         '.break-normal': {
@@ -15,7 +15,7 @@ export default function() {
           'white-space': 'nowrap',
         },
       },
-      config('variants.wordBreak')
+      variants('wordBreak')
     )
   }
 }

--- a/src/plugins/zIndex.js
+++ b/src/plugins/zIndex.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, config }) {
+  return function({ addUtilities, config, variants }) {
     const utilities = _.fromPairs(
       _.map(config('theme.zIndex'), (value, modifier) => {
         return [
@@ -13,6 +13,6 @@ export default function() {
       })
     )
 
-    addUtilities(utilities, config('variants.zIndex'))
+    addUtilities(utilities, variants('zIndex'))
   }
 }

--- a/src/util/processPlugins.js
+++ b/src/util/processPlugins.js
@@ -29,6 +29,13 @@ export default function(plugins, config) {
     plugin({
       postcss,
       config: (path, defaultValue) => _.get(config, path, defaultValue),
+      variants: (path, defaultValue) => {
+        if (_.isArray(config.variants)) {
+          return config.variants
+        }
+
+        return _.get(config.variants, path, defaultValue)
+      },
       e: escapeClassName,
       prefix: applyConfiguredPrefix,
       addUtilities: (utilities, options) => {


### PR DESCRIPTION
Closes #851.

This PR makes it possible for users to specify a global variants configuration that should be applied to all utilities by assigning an array of variants directly to the `variants` property in their `tailwind.config.js` file:

```js
module.exports  = {
  variants: ['responsive', 'group-hover', 'hover', 'focus']
}
```

This is useful for Purgecss users who just want everything available and don't want to micro-optimize at the individual plugin level.

No breaking changes here technically but plugin authors would be encouraged to update their plugins to use the new `variants` function made available through the plugin API to look up the variants for their plugin instead of using the `config` function.

```diff
- function({ addUtilities, config }) {
+ function({ addUtilities, variants }) {
    addUtilities(
      {
        '.content-center': {
          'align-content': 'center',
        },
      },
-     config('variants.alignContent')
+     variants('alignContent')
    )
  }
```

This will ensure that your plugin respects the users global variants configuration if they choose to use this feature.