### PR TITLE
Modernize codebase

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,18 +9,6 @@
   "extends": ["eslint-config-postcss", "prettier"],
   "plugins": ["prettier"],
   "rules": {
-    "prettier/prettier": [
-      "error",
-      {
-        "semi": false,
-        "singleQuote": true,
-        "printWidth": 100,
-        "tabWidth": 2,
-        "useTabs": false,
-        "trailingComma": "es5",
-        "bracketSpacing": true,
-        "parser": "flow"
-      }
-    ]
+    "prettier/prettier": "error"
   }
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.huskyrc
+++ b/.huskyrc
@@ -1,0 +1,5 @@
+{
+    "hooks": {
+        "pre-commit": "pretty-quick --staged"
+    }
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+/__tests__/fixtures
+/dist
+/lib
+/src/plugins/css/preflight.css

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "endOfLine": "lf",
+  "printWidth": 100,
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "8"
-  - "10"
+  - '8'
+  - '10'
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
     <a href="https://github.com/tailwindcss/tailwindcss/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/tailwindcss.svg" alt="License"></a>
 </p>
 
-------
+---
 
 ## Documentation
 

--- a/__tests__/applyAtRule.test.js
+++ b/__tests__/applyAtRule.test.js
@@ -12,11 +12,10 @@ const { utilities: defaultUtilities } = processPlugins(
   resolvedDefaultConfig
 )
 
-function run(input, config = resolvedDefaultConfig, utilities = defaultUtilities) {
-  return postcss([substituteClassApplyAtRules(config, utilities)]).process(input, {
+const run = (input, config = resolvedDefaultConfig, utilities = defaultUtilities) =>
+  postcss([substituteClassApplyAtRules(config, utilities)]).process(input, {
     from: undefined,
   })
-}
 
 test("it copies a class's declarations into itself", () => {
   const output = '.a { color: red; } .b { color: red; }'
@@ -104,11 +103,10 @@ test('cssnext custom property sets are preserved', () => {
   })
 })
 
-test('it fails if the class does not exist', () => {
-  return run('.b { @apply .a; }').catch(e => {
+test('it fails if the class does not exist', () =>
+  run('.b { @apply .a; }').catch(e => {
     expect(e).toMatchObject({ name: 'CssSyntaxError' })
-  })
-})
+  }))
 
 test('applying classes that are defined in a media query is not supported', () => {
   const input = `
@@ -231,9 +229,7 @@ test('you can apply utility classes without using the given prefix when using a 
   const config = resolveConfig([
     {
       ...defaultConfig,
-      prefix: () => {
-        return 'tw-'
-      },
+      prefix: () => 'tw-',
     },
   ])
 

--- a/__tests__/cli.compile.test.js
+++ b/__tests__/cli.compile.test.js
@@ -10,10 +10,9 @@ describe('cli compile', () => {
   const outputFile = 'output.css'
   const plugins = [tailwind(), autoprefixer]
 
-  it('compiles CSS file', () => {
-    return compile({ inputFile, outputFile, plugins }).then(result => {
+  test('compiles CSS file', () =>
+    compile({ inputFile, outputFile, plugins }).then(result => {
       expect(result.css).toContain('.example')
       expect(result.css).toContain('-ms-input-placeholder')
-    })
-  })
+    }))
 })

--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -17,62 +17,54 @@ describe('cli', () => {
   })
 
   describe('init', () => {
-    it('creates a Tailwind config file', () => {
-      return runInTempDirectory(() => {
-        return cli(['init']).then(() => {
+    test('creates a Tailwind config file', () =>
+      runInTempDirectory(() =>
+        cli(['init']).then(() => {
           expect(utils.readFile(constants.defaultConfigFile)).toEqual(simpleConfigFixture)
         })
-      })
-    })
+      ))
 
-    it('creates a full Tailwind config file', () => {
-      return runInTempDirectory(() => {
-        return cli(['init', '--full']).then(() => {
+    test('creates a full Tailwind config file', () =>
+      runInTempDirectory(() =>
+        cli(['init', '--full']).then(() => {
           expect(utils.readFile(constants.defaultConfigFile)).toEqual(defaultConfigFixture)
         })
-      })
-    })
+      ))
 
-    it('creates a Tailwind config file in a custom location', () => {
-      return runInTempDirectory(() => {
-        return cli(['init', 'custom.js']).then(() => {
+    test('creates a Tailwind config file in a custom location', () =>
+      runInTempDirectory(() =>
+        cli(['init', 'custom.js']).then(() => {
           expect(utils.exists('custom.js')).toEqual(true)
         })
-      })
-    })
+      ))
   })
 
   describe('build', () => {
-    it('compiles CSS file', () => {
-      return cli(['build', inputCssPath]).then(() => {
+    test('compiles CSS file', () =>
+      cli(['build', inputCssPath]).then(() => {
         expect(process.stdout.write.mock.calls[0][0]).toContain('.example')
-      })
-    })
+      }))
 
-    it('compiles CSS file using custom configuration', () => {
-      return cli(['build', inputCssPath, '--config', customConfigPath]).then(() => {
+    test('compiles CSS file using custom configuration', () =>
+      cli(['build', inputCssPath, '--config', customConfigPath]).then(() => {
         expect(process.stdout.write.mock.calls[0][0]).toContain('400px')
-      })
-    })
+      }))
 
-    it('creates compiled CSS file', () => {
-      return runInTempDirectory(() => {
-        return cli(['build', inputCssPath, '--output', 'output.css']).then(() => {
+    test('creates compiled CSS file', () =>
+      runInTempDirectory(() =>
+        cli(['build', inputCssPath, '--output', 'output.css']).then(() => {
           expect(utils.readFile('output.css')).toContain('.example')
         })
-      })
-    })
+      ))
 
-    it('compiles CSS file with autoprefixer', () => {
-      return cli(['build', inputCssPath]).then(() => {
+    test('compiles CSS file with autoprefixer', () =>
+      cli(['build', inputCssPath]).then(() => {
         expect(process.stdout.write.mock.calls[0][0]).toContain('-ms-input-placeholder')
-      })
-    })
+      }))
 
-    it('compiles CSS file without autoprefixer', () => {
-      return cli(['build', inputCssPath, '--no-autoprefixer']).then(() => {
+    test('compiles CSS file without autoprefixer', () =>
+      cli(['build', inputCssPath, '--no-autoprefixer']).then(() => {
         expect(process.stdout.write.mock.calls[0][0]).not.toContain('-ms-input-placeholder')
-      })
-    })
+      }))
   })
 })

--- a/__tests__/cli.utils.test.js
+++ b/__tests__/cli.utils.test.js
@@ -2,7 +2,7 @@ import * as utils from '../src/cli/utils'
 
 describe('cli utils', () => {
   describe('parseCliParams', () => {
-    it('parses CLI parameters', () => {
+    test('parses CLI parameters', () => {
       const result = utils.parseCliParams(['a', 'b', '-c', 'd'])
 
       expect(result).toEqual(['a', 'b'])
@@ -10,13 +10,13 @@ describe('cli utils', () => {
   })
 
   describe('parseCliOptions', () => {
-    it('parses CLI options', () => {
+    test('parses CLI options', () => {
       const result = utils.parseCliOptions(['a', '-b', 'c'], { test: ['b'] })
 
       expect(result).toEqual({ test: ['c'] })
     })
 
-    it('parses multiple types of options', () => {
+    test('parses multiple types of options', () => {
       const result = utils.parseCliOptions(['a', '-b', 'c', '--test', 'd', '-test', 'e'], {
         test: ['test', 'b'],
       })
@@ -24,31 +24,31 @@ describe('cli utils', () => {
       expect(result).toEqual({ test: ['c', 'd', 'e'] })
     })
 
-    it('ignores unknown options', () => {
+    test('ignores unknown options', () => {
       const result = utils.parseCliOptions(['a', '-b', 'c'], {})
 
       expect(result).toEqual({})
     })
 
-    it('maps options', () => {
+    test('maps options', () => {
       const result = utils.parseCliOptions(['a', '-b', 'c', '-d', 'e'], { test: ['b', 'd'] })
 
       expect(result).toEqual({ test: ['c', 'e'] })
     })
 
-    it('parses undefined options', () => {
+    test('parses undefined options', () => {
       const result = utils.parseCliOptions(['a'], { test: ['b'] })
 
       expect(result).toEqual({ test: undefined })
     })
 
-    it('parses flags', () => {
+    test('parses flags', () => {
       const result = utils.parseCliOptions(['a', '-b'], { test: ['b'] })
 
       expect(result).toEqual({ test: [] })
     })
 
-    it('accepts multiple values per option', () => {
+    test('accepts multiple values per option', () => {
       const result = utils.parseCliOptions(['a', '-b', 'c', 'd', '-e', 'f', '-g', 'h'], {
         test: ['b', 'g'],
       })
@@ -58,13 +58,13 @@ describe('cli utils', () => {
   })
 
   describe('getSimplePath', () => {
-    it('strips leading ./', () => {
+    test('strips leading ./', () => {
       const result = utils.getSimplePath('./test')
 
       expect(result).toEqual('test')
     })
 
-    it('returns unchanged path if it does not begin with ./', () => {
+    test('returns unchanged path if it does not begin with ./', () => {
       const result = utils.getSimplePath('../test')
 
       expect(result).toEqual('../test')

--- a/__tests__/containerPlugin.test.js
+++ b/__tests__/containerPlugin.test.js
@@ -3,12 +3,10 @@ import postcss from 'postcss'
 import processPlugins from '../src/util/processPlugins'
 import container from '../src/plugins/container'
 
-function css(nodes) {
-  return postcss.root({ nodes }).toString()
-}
+const css = nodes => postcss.root({ nodes }).toString()
 
-function config(overrides) {
-  return _.defaultsDeep(overrides, {
+const config = overrides =>
+  _.defaultsDeep(overrides, {
     theme: {
       screens: {
         sm: '576px',
@@ -19,7 +17,6 @@ function config(overrides) {
     },
     prefix: '',
   })
-}
 
 test.only('options are not required', () => {
   const { components } = processPlugins([container()], config())

--- a/__tests__/customConfig.test.js
+++ b/__tests__/customConfig.test.js
@@ -5,8 +5,8 @@ import tailwind from '../src/index'
 import { defaultConfigFile } from '../src/constants'
 import inTempDirectory from '../jest/runInTempDirectory'
 
-test('it uses the values from the custom config file', () => {
-  return postcss([tailwind(path.resolve(`${__dirname}/fixtures/custom-config.js`))])
+test('it uses the values from the custom config file', () =>
+  postcss([tailwind(path.resolve(`${__dirname}/fixtures/custom-config.js`))])
     .process(
       `
         @responsive {
@@ -29,11 +29,10 @@ test('it uses the values from the custom config file', () => {
         }
       `
       expect(result.css).toMatchCss(expected)
-    })
-})
+    }))
 
-test('custom config can be passed as an object', () => {
-  return postcss([
+test('custom config can be passed as an object', () =>
+  postcss([
     tailwind({
       theme: {
         screens: {
@@ -65,11 +64,10 @@ test('custom config can be passed as an object', () => {
       `
 
       expect(result.css).toMatchCss(expected)
-    })
-})
+    }))
 
-test('tailwind.config.js is picked up by default', () => {
-  return inTempDirectory(() => {
+test('tailwind.config.js is picked up by default', () =>
+  inTempDirectory(() => {
     fs.writeFileSync(
       path.resolve(defaultConfigFile),
       `module.exports = {
@@ -104,5 +102,4 @@ test('tailwind.config.js is picked up by default', () => {
           }
         `)
       })
-  })
-})
+  }))

--- a/__tests__/fixtures/tailwind-input-with-explicit-screen-utilities.css
+++ b/__tests__/fixtures/tailwind-input-with-explicit-screen-utilities.css
@@ -1,11 +1,11 @@
 @responsive {
-    .example {
-        color: red;
-    }
+  .example {
+    color: red;
+  }
 }
 
 @tailwind screens;
 
 .john {
-    content: "wick";
+  content: 'wick';
 }

--- a/__tests__/fixtures/tailwind-input.css
+++ b/__tests__/fixtures/tailwind-input.css
@@ -6,7 +6,7 @@
 
 @responsive {
   .example {
-    @apply .font-bold;
+    @apply font-bold;
     color: theme('colors.red.500');
   }
 }

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -481,7 +481,7 @@ textarea::placeholder {
 }
 
 button,
-[role="button"] {
+[role='button'] {
   cursor: pointer;
 }
 

--- a/__tests__/fixtures/tailwind-output-with-explicit-screen-utilities.css
+++ b/__tests__/fixtures/tailwind-output-with-explicit-screen-utilities.css
@@ -27,5 +27,5 @@
 }
 
 .john {
-  content: "wick";
+  content: 'wick';
 }

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -481,7 +481,7 @@ textarea::placeholder {
 }
 
 button,
-[role="button"] {
+[role='button'] {
   cursor: pointer;
 }
 

--- a/__tests__/parseObjectStyles.test.js
+++ b/__tests__/parseObjectStyles.test.js
@@ -1,9 +1,7 @@
 import parseObjectStyles from '../src/util/parseObjectStyles'
 import postcss from 'postcss'
 
-function css(nodes) {
-  return postcss.root({ nodes }).toString()
-}
+const css = nodes => postcss.root({ nodes }).toString()
 
 test('it parses simple single class definitions', () => {
   const result = parseObjectStyles({

--- a/__tests__/prefixSelector.test.js
+++ b/__tests__/prefixSelector.test.js
@@ -5,9 +5,7 @@ test('it prefixes classes with the provided prefix', () => {
 })
 
 test('it handles a function as the prefix', () => {
-  const prefixFunc = selector => {
-    return selector === '.foo' ? 'tw-' : ''
-  }
+  const prefixFunc = selector => (selector === '.foo' ? 'tw-' : '')
 
   expect(prefix(prefixFunc, '.foo')).toEqual('.tw-foo')
   expect(prefix(prefixFunc, '.bar')).toEqual('.bar')

--- a/__tests__/processPlugins.test.js
+++ b/__tests__/processPlugins.test.js
@@ -2,22 +2,19 @@ import _ from 'lodash'
 import _postcss from 'postcss'
 import processPlugins from '../src/util/processPlugins'
 
-function css(nodes) {
-  return _postcss.root({ nodes }).toString()
-}
+const css = nodes => _postcss.root({ nodes }).toString()
 
-function makeConfig(overrides) {
-  return _.defaultsDeep(overrides, {
+const makeConfig = overrides =>
+  _.defaultsDeep(overrides, {
     prefix: '',
     important: false,
     separator: ':',
   })
-}
 
 test('plugins can create utilities with object syntax', () => {
   const { components, utilities } = processPlugins(
     [
-      function({ addUtilities }) {
+      ({ addUtilities }) => {
         addUtilities({
           '.object-fill': {
             'object-fit': 'fill',
@@ -53,7 +50,7 @@ test('plugins can create utilities with object syntax', () => {
 test('plugins can create utilities with arrays of objects', () => {
   const { components, utilities } = processPlugins(
     [
-      function({ addUtilities }) {
+      ({ addUtilities }) => {
         addUtilities([
           {
             '.object-fill': {
@@ -95,7 +92,7 @@ test('plugins can create utilities with arrays of objects', () => {
 test('plugins can create utilities with raw PostCSS nodes', () => {
   const { components, utilities } = processPlugins(
     [
-      function({ addUtilities, postcss }) {
+      ({ addUtilities, postcss }) => {
         addUtilities([
           postcss.rule({ selector: '.object-fill' }).append([
             postcss.decl({
@@ -140,7 +137,7 @@ test('plugins can create utilities with raw PostCSS nodes', () => {
 test('plugins can create utilities with mixed object styles and PostCSS nodes', () => {
   const { components, utilities } = processPlugins(
     [
-      function({ addUtilities, postcss }) {
+      ({ addUtilities, postcss }) => {
         addUtilities([
           {
             '.object-fill': {
@@ -184,7 +181,7 @@ test('plugins can create utilities with mixed object styles and PostCSS nodes', 
 test('plugins can create utilities with variants', () => {
   const { components, utilities } = processPlugins(
     [
-      function({ addUtilities }) {
+      ({ addUtilities }) => {
         addUtilities(
           {
             '.object-fill': {
@@ -223,7 +220,7 @@ test('plugins can create utilities with variants', () => {
 test('plugins can create components with object syntax', () => {
   const { components, utilities } = processPlugins(
     [
-      function({ addComponents }) {
+      ({ addComponents }) => {
         addComponents({
           '.btn-blue': {
             backgroundColor: 'blue',
@@ -257,7 +254,7 @@ test('plugins can create components with object syntax', () => {
 test('plugins can add base styles with object syntax', () => {
   const { base } = processPlugins(
     [
-      function({ addBase }) {
+      ({ addBase }) => {
         addBase({
           img: {
             maxWidth: '100%',
@@ -284,7 +281,7 @@ test('plugins can add base styles with object syntax', () => {
 test('plugins can add base styles with raw PostCSS nodes', () => {
   const { base } = processPlugins(
     [
-      function({ addBase, postcss }) {
+      ({ addBase, postcss }) => {
         addBase([
           postcss.rule({ selector: 'img' }).append([
             postcss.decl({
@@ -317,7 +314,7 @@ test('plugins can add base styles with raw PostCSS nodes', () => {
 test('plugins can create components with raw PostCSS nodes', () => {
   const { components, utilities } = processPlugins(
     [
-      function({ addComponents, postcss }) {
+      ({ addComponents, postcss }) => {
         addComponents([
           postcss.rule({ selector: '.btn-blue' }).append([
             postcss.decl({
@@ -366,7 +363,7 @@ test('plugins can create components with raw PostCSS nodes', () => {
 test('plugins can create components with mixed object styles and raw PostCSS nodes', () => {
   const { components, utilities } = processPlugins(
     [
-      function({ addComponents, postcss }) {
+      ({ addComponents, postcss }) => {
         addComponents([
           postcss.rule({ selector: '.btn-blue' }).append([
             postcss.decl({
@@ -414,7 +411,7 @@ test('plugins can create components with mixed object styles and raw PostCSS nod
 test('plugins can create components with media queries with object syntax', () => {
   const { components, utilities } = processPlugins(
     [
-      function({ addComponents }) {
+      ({ addComponents }) => {
         addComponents({
           '.container': {
             width: '100%',
@@ -466,7 +463,7 @@ test('plugins can create components with media queries with object syntax', () =
 test('media queries can be defined multiple times using objects-in-array syntax', () => {
   const { components, utilities } = processPlugins(
     [
-      function({ addComponents }) {
+      ({ addComponents }) => {
         addComponents([
           {
             '.container': {
@@ -520,7 +517,7 @@ test('media queries can be defined multiple times using objects-in-array syntax'
 test('plugins can create nested rules', () => {
   const { components, utilities } = processPlugins(
     [
-      function({ addComponents }) {
+      ({ addComponents }) => {
         addComponents({
           '.btn-blue': {
             backgroundColor: 'blue',
@@ -576,7 +573,7 @@ test('plugins can create nested rules', () => {
 test('plugins can create rules with escaped selectors', () => {
   const { components, utilities } = processPlugins(
     [
-      function({ e, addUtilities }) {
+      ({ e, addUtilities }) => {
         addUtilities({
           [`.${e('top-1/4')}`]: {
             top: '25%',
@@ -600,7 +597,7 @@ test('plugins can create rules with escaped selectors', () => {
 test('plugins can access the current config', () => {
   const { components, utilities } = processPlugins(
     [
-      function({ addComponents, config }) {
+      ({ addComponents, config }) => {
         const containerClasses = [
           {
             '.container': {
@@ -660,7 +657,7 @@ test('plugins can access the current config', () => {
 test('plugins can access the variants config directly', () => {
   const { components, utilities } = processPlugins(
     [
-      function({ addUtilities, variants }) {
+      ({ addUtilities, variants }) => {
         addUtilities(
           {
             '.object-fill': {
@@ -703,7 +700,7 @@ test('plugins can access the variants config directly', () => {
 test('plugins apply all global variants when variants are configured globally', () => {
   const { components, utilities } = processPlugins(
     [
-      function({ addUtilities, variants }) {
+      ({ addUtilities, variants }) => {
         addUtilities(
           {
             '.object-fill': {
@@ -745,7 +742,7 @@ test('plugins apply all global variants when variants are configured globally', 
 test('plugins can provide fallbacks to keys missing from the config', () => {
   const { components, utilities } = processPlugins(
     [
-      function({ addComponents, config }) {
+      ({ addComponents, config }) => {
         addComponents({
           '.btn': {
             borderRadius: config('borderRadius.default', '.25rem'),
@@ -774,7 +771,7 @@ test('plugins can provide fallbacks to keys missing from the config', () => {
 test('variants are optional when adding utilities', () => {
   const { utilities } = processPlugins(
     [
-      function({ addUtilities }) {
+      ({ addUtilities }) => {
         addUtilities({
           '.border-collapse': {
             'border-collapse': 'collapse',
@@ -796,7 +793,7 @@ test('variants are optional when adding utilities', () => {
 test('plugins can add multiple sets of utilities and components', () => {
   const { components, utilities } = processPlugins(
     [
-      function({ addUtilities, addComponents }) {
+      ({ addUtilities, addComponents }) => {
         addComponents({
           '.card': {
             padding: '1rem',
@@ -854,7 +851,7 @@ test('plugins can add multiple sets of utilities and components', () => {
 test('plugins respect prefix and important options by default when adding utilities', () => {
   const { utilities } = processPlugins(
     [
-      function({ addUtilities }) {
+      ({ addUtilities }) => {
         addUtilities({
           '.rotate-90': {
             transform: 'rotate(90deg)',
@@ -880,7 +877,7 @@ test('plugins respect prefix and important options by default when adding utilit
 test("component declarations respect the 'prefix' option by default", () => {
   const { components } = processPlugins(
     [
-      function({ addComponents }) {
+      ({ addComponents }) => {
         addComponents({
           '.btn-blue': {
             backgroundColor: 'blue',
@@ -903,7 +900,7 @@ test("component declarations respect the 'prefix' option by default", () => {
 test('all selectors in a rule are prefixed', () => {
   const { utilities, components } = processPlugins(
     [
-      function({ addUtilities, addComponents }) {
+      ({ addUtilities, addComponents }) => {
         addUtilities({
           '.rotate-90, .rotate-1\\/4': {
             transform: 'rotate(90deg)',
@@ -939,7 +936,7 @@ test('all selectors in a rule are prefixed', () => {
 test("component declarations can optionally ignore 'prefix' option", () => {
   const { components } = processPlugins(
     [
-      function({ addComponents }) {
+      ({ addComponents }) => {
         addComponents(
           {
             '.btn-blue': {
@@ -965,7 +962,7 @@ test("component declarations can optionally ignore 'prefix' option", () => {
 test("component declarations are not affected by the 'important' option", () => {
   const { components } = processPlugins(
     [
-      function({ addComponents }) {
+      ({ addComponents }) => {
         addComponents({
           '.btn-blue': {
             backgroundColor: 'blue',
@@ -988,7 +985,7 @@ test("component declarations are not affected by the 'important' option", () => 
 test("plugins can apply the user's chosen prefix to components manually", () => {
   const { components } = processPlugins(
     [
-      function({ addComponents, prefix }) {
+      ({ addComponents, prefix }) => {
         addComponents(
           {
             [prefix('.btn-blue')]: {
@@ -1014,7 +1011,7 @@ test("plugins can apply the user's chosen prefix to components manually", () => 
 test('prefix can optionally be ignored for utilities', () => {
   const { utilities } = processPlugins(
     [
-      function({ addUtilities }) {
+      ({ addUtilities }) => {
         addUtilities(
           {
             '.rotate-90': {
@@ -1045,7 +1042,7 @@ test('prefix can optionally be ignored for utilities', () => {
 test('important can optionally be ignored for utilities', () => {
   const { utilities } = processPlugins(
     [
-      function({ addUtilities }) {
+      ({ addUtilities }) => {
         addUtilities(
           {
             '.rotate-90': {
@@ -1076,7 +1073,7 @@ test('important can optionally be ignored for utilities', () => {
 test('variants can still be specified when ignoring prefix and important options', () => {
   const { utilities } = processPlugins(
     [
-      function({ addUtilities }) {
+      ({ addUtilities }) => {
         addUtilities(
           {
             '.rotate-90': {
@@ -1109,7 +1106,7 @@ test('variants can still be specified when ignoring prefix and important options
 test('prefix will prefix all classes in a selector', () => {
   const { components } = processPlugins(
     [
-      function({ addComponents, prefix }) {
+      ({ addComponents, prefix }) => {
         addComponents(
           {
             [prefix('.btn-blue .w-1\\/4 > h1.text-xl + a .bar')]: {

--- a/__tests__/responsiveAtRule.test.js
+++ b/__tests__/responsiveAtRule.test.js
@@ -2,9 +2,7 @@ import postcss from 'postcss'
 import plugin from '../src/lib/substituteResponsiveAtRules'
 import config from '../stubs/defaultConfig.stub.js'
 
-function run(input, opts = config) {
-  return postcss([plugin(opts)]).process(input, { from: undefined })
-}
+const run = (input, opts = config) => postcss([plugin(opts)]).process(input, { from: undefined })
 
 test('it can generate responsive variants', () => {
   const input = `

--- a/__tests__/sanity.test.js
+++ b/__tests__/sanity.test.js
@@ -4,7 +4,7 @@ import postcss from 'postcss'
 import tailwind from '../src/index'
 import config from '../stubs/defaultConfig.stub.js'
 
-it('generates the right CSS', () => {
+test('generates the right CSS', () => {
   const inputPath = path.resolve(`${__dirname}/fixtures/tailwind-input.css`)
   const input = fs.readFileSync(inputPath, 'utf8')
 
@@ -20,7 +20,7 @@ it('generates the right CSS', () => {
     })
 })
 
-it('generates the right CSS when "important" is enabled', () => {
+test('generates the right CSS when "important" is enabled', () => {
   const inputPath = path.resolve(`${__dirname}/fixtures/tailwind-input.css`)
   const input = fs.readFileSync(inputPath, 'utf8')
 
@@ -36,15 +36,14 @@ it('generates the right CSS when "important" is enabled', () => {
     })
 })
 
-it('does not add any CSS if no Tailwind features are used', () => {
-  return postcss([tailwind()])
+test('does not add any CSS if no Tailwind features are used', () =>
+  postcss([tailwind()])
     .process('.foo { color: blue; }', { from: undefined })
     .then(result => {
       expect(result.css).toMatchCss('.foo { color: blue; }')
-    })
-})
+    }))
 
-it('generates the right CSS with implicit screen utilities', () => {
+test('generates the right CSS with implicit screen utilities', () => {
   const inputPath = path.resolve(
     `${__dirname}/fixtures/tailwind-input-with-explicit-screen-utilities.css`
   )

--- a/__tests__/screenAtRule.test.js
+++ b/__tests__/screenAtRule.test.js
@@ -2,9 +2,7 @@ import postcss from 'postcss'
 import plugin from '../src/lib/substituteScreenAtRules'
 import config from '../stubs/defaultConfig.stub.js'
 
-function run(input, opts = config) {
-  return postcss([plugin(opts)]).process(input, { from: undefined })
-}
+const run = (input, opts = config) => postcss([plugin(opts)]).process(input, { from: undefined })
 
 test('it can generate media queries from configured screen sizes', () => {
   const input = `

--- a/__tests__/themeFunction.test.js
+++ b/__tests__/themeFunction.test.js
@@ -1,9 +1,7 @@
 import postcss from 'postcss'
 import plugin from '../src/lib/evaluateTailwindFunctions'
 
-function run(input, opts = {}) {
-  return postcss([plugin(opts)]).process(input, { from: undefined })
-}
+const run = (input, opts = {}) => postcss([plugin(opts)]).process(input, { from: undefined })
 
 test('it looks up values in the theme using dot notation', () => {
   const input = `

--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -3,11 +3,10 @@ import plugin from '../src/lib/substituteVariantsAtRules'
 import processPlugins from '../src/util/processPlugins'
 import config from '../stubs/defaultConfig.stub.js'
 
-function run(input, opts = config) {
-  return postcss([plugin(opts, processPlugins(opts.plugins, opts))]).process(input, {
+const run = (input, opts = config) =>
+  postcss([plugin(opts, processPlugins(opts.plugins, opts))]).process(input, {
     from: undefined,
   })
-}
 
 test('it can generate hover variants', () => {
   const input = `
@@ -264,7 +263,7 @@ test('plugin variants can modify rules using the raw PostCSS API', () => {
     ...config,
     plugins: [
       ...config.plugins,
-      function({ addVariant }) {
+      ({ addVariant }) => {
         addVariant('important', ({ container }) => {
           container.walkRules(rule => {
             rule.selector = `.\\!${rule.selector.slice(1)}`
@@ -300,11 +299,11 @@ test('plugin variants can modify selectors with a simplified API', () => {
     ...config,
     plugins: [
       ...config.plugins,
-      function({ addVariant, e }) {
+      ({ addVariant, e }) => {
         addVariant('first-child', ({ modifySelectors, separator }) => {
-          modifySelectors(({ className }) => {
-            return `.${e(`first-child${separator}${className}`)}:first-child`
-          })
+          modifySelectors(
+            ({ className }) => `.${e(`first-child${separator}${className}`)}:first-child`
+          )
         })
       },
     ],
@@ -333,11 +332,11 @@ test('plugin variants that use modify selectors need to manually escape the clas
     ...config,
     plugins: [
       ...config.plugins,
-      function({ addVariant, e }) {
+      ({ addVariant, e }) => {
         addVariant('first-child', ({ modifySelectors, separator }) => {
-          modifySelectors(({ className }) => {
-            return `.${e(`first-child${separator}${className}`)}:first-child`
-          })
+          modifySelectors(
+            ({ className }) => `.${e(`first-child${separator}${className}`)}:first-child`
+          )
         })
       },
     ],
@@ -368,7 +367,7 @@ test('plugin variants can wrap rules in another at-rule using the raw PostCSS AP
     ...config,
     plugins: [
       ...config.plugins,
-      function({ addVariant, e }) {
+      ({ addVariant, e }) => {
         addVariant('supports-grid', ({ container, separator }) => {
           const supportsRule = postcss.atRule({ name: 'supports', params: '(display: grid)' })
           supportsRule.nodes = container.nodes

--- a/jest/customMatchers.js
+++ b/jest/customMatchers.js
@@ -2,20 +2,18 @@ expect.extend({
   // Compare two CSS strings with all whitespace removed
   // This is probably naive but it's fast and works well enough.
   toMatchCss(received, argument) {
-    function stripped(str) {
-      return str.replace(/\s/g, '')
-    }
+    const stripped = str => str.replace(/\s/g, '')
 
     if (stripped(received) === stripped(argument)) {
       return {
         message: () => `expected ${received} not to match CSS ${argument}`,
         pass: true,
       }
-    } else {
-      return {
-        message: () => `expected ${received} to match CSS ${argument}`,
-        pass: false,
-      }
+    }
+
+    return {
+      message: () => `expected ${received} to match CSS ${argument}`,
+      pass: false,
     }
   },
 })

--- a/jest/runInTempDirectory.js
+++ b/jest/runInTempDirectory.js
@@ -1,12 +1,11 @@
 import fs from 'fs'
 import path from 'path'
-
 import rimraf from 'rimraf'
 
 const tmpPath = path.resolve(__dirname, '../__tmp')
 
-export default function(callback) {
-  return new Promise(resolve => {
+export default callback =>
+  new Promise(resolve => {
     const currentPath = process.cwd()
 
     rimraf.sync(tmpPath)
@@ -18,4 +17,3 @@ export default function(callback) {
       rimraf(tmpPath, resolve)
     })
   })
-}

--- a/package.json
+++ b/package.json
@@ -34,8 +34,10 @@
     "eslint-config-postcss": "^2.0.2",
     "eslint-config-prettier": "^4.1.0",
     "eslint-plugin-prettier": "^3.0.1",
+    "husky": "^1.3.1",
     "jest": "^24.3.1",
-    "prettier": "^1.7.4",
+    "prettier": "1.17.0",
+    "pretty-quick": "^1.10.0",
     "rimraf": "^2.6.3"
   },
   "dependencies": {

--- a/src/build.js
+++ b/src/build.js
@@ -1,14 +1,16 @@
+import CleanCSS from 'clean-css'
 import fs from 'fs'
 import postcss from 'postcss'
 import tailwind from '..'
-import CleanCSS from 'clean-css'
 
-function buildDistFile(filename) {
-  return new Promise((resolve, reject) => {
+const buildDistFile = filename =>
+  new Promise((resolve, reject) => {
     console.log(`Processing ./${filename}.css...`)
 
     fs.readFile(`./${filename}.css`, (err, css) => {
-      if (err) throw err
+      if (err) {
+        throw err
+      }
 
       return postcss([tailwind(), require('autoprefixer')])
         .process(css, {
@@ -21,6 +23,7 @@ function buildDistFile(filename) {
           if (result.map) {
             fs.writeFileSync(`./dist/${filename}.css.map`, result.map)
           }
+
           return result
         })
         .then(result => {
@@ -34,7 +37,6 @@ function buildDistFile(filename) {
         })
     })
   })
-}
 
 console.info('Building Tailwind!')
 

--- a/src/cli/colors.js
+++ b/src/cli/colors.js
@@ -5,42 +5,32 @@ import chalk from 'chalk'
  *
  * @param {...string} msgs
  */
-export function bold(...msgs) {
-  return chalk.bold(...msgs)
-}
+export const bold = (...msgs) => chalk.bold(...msgs)
 
 /**
  * Applies colors to inform
  *
  * @param {...string} msgs
  */
-export function info(...msgs) {
-  return chalk.bold.cyan(...msgs)
-}
+export const info = (...msgs) => chalk.bold.cyan(...msgs)
 
 /**
  * Applies colors to signify error
  *
  * @param {...string} msgs
  */
-export function error(...msgs) {
-  return chalk.bold.red(...msgs)
-}
+export const error = (...msgs) => chalk.bold.red(...msgs)
 
 /**
  * Applies colors to represent a command
  *
  * @param {...string} msgs
  */
-export function command(...msgs) {
-  return chalk.bold.magenta(...msgs)
-}
+export const command = (...msgs) => chalk.bold.magenta(...msgs)
 
 /**
  * Applies colors to represent a file
  *
  * @param {...string} msgs
  */
-export function file(...msgs) {
-  return chalk.bold.magenta(...msgs)
-}
+export const file = (...msgs) => chalk.bold.magenta(...msgs)

--- a/src/cli/commands/build.js
+++ b/src/cli/commands/build.js
@@ -39,7 +39,7 @@ export const optionMap = {
  *
  * @param {...string} [msgs]
  */
-function stop(...msgs) {
+const stop = (...msgs) => {
   utils.header()
   utils.error(...msgs)
   utils.die()
@@ -50,7 +50,7 @@ function stop(...msgs) {
  *
  * @param {...string} [msgs]
  */
-function stopWithHelp(...msgs) {
+const stopWithHelp = (...msgs) => {
   utils.header()
   utils.error(...msgs)
   commands.help.forCommand(commands.build)
@@ -63,9 +63,8 @@ function stopWithHelp(...msgs) {
  * @param {CompileOptions} compileOptions
  * @return {Promise}
  */
-function buildToStdout(compileOptions) {
-  return compile(compileOptions).then(result => process.stdout.write(result.css))
-}
+const buildToStdout = compileOptions =>
+  compile(compileOptions).then(result => process.stdout.write(result.css))
 
 /**
  * Compiles CSS file and writes it to a file.
@@ -74,7 +73,7 @@ function buildToStdout(compileOptions) {
  * @param {int[]} startTime
  * @return {Promise}
  */
-function buildToFile(compileOptions, startTime) {
+const buildToFile = (compileOptions, startTime) => {
   const inputFileSimplePath = utils.getSimplePath(compileOptions.inputFile)
   const outputFileSimplePath = utils.getSimplePath(compileOptions.outputFile)
 
@@ -102,8 +101,8 @@ function buildToFile(compileOptions, startTime) {
  * @param {object} cliOptions
  * @return {Promise}
  */
-export function run(cliParams, cliOptions) {
-  return new Promise((resolve, reject) => {
+export const run = (cliParams, cliOptions) =>
+  new Promise((resolve, reject) => {
     const startTime = process.hrtime()
     const inputFile = cliParams[0]
     const configFile = cliOptions.config && cliOptions.config[0]
@@ -131,4 +130,3 @@ export function run(cliParams, cliOptions) {
 
     buildPromise.then(resolve).catch(reject)
   })
-}

--- a/src/cli/commands/help.js
+++ b/src/cli/commands/help.js
@@ -13,7 +13,7 @@ const PADDING_SIZE = 3
 /**
  * Prints general help.
  */
-export function forApp() {
+export const forApp = () => {
   const pad = Math.max(...map(commands, 'usage.length')) + PADDING_SIZE
 
   utils.log()
@@ -31,7 +31,7 @@ export function forApp() {
  *
  * @param {object} command
  */
-export function forCommand(command) {
+export const forCommand = command => {
   utils.log()
   utils.log('Usage:')
   utils.log('  ', colors.bold(constants.cli, command.usage))
@@ -55,7 +55,7 @@ export function forCommand(command) {
  *
  * @param {string} commandName
  */
-export function invalidCommand(commandName) {
+export const invalidCommand = commandName => {
   utils.error('Invalid command:', colors.command(commandName))
   forApp()
   utils.die()
@@ -67,8 +67,8 @@ export function invalidCommand(commandName) {
  * @param {string[]} cliParams
  * @return {Promise}
  */
-export function run(cliParams) {
-  return new Promise(resolve => {
+export const run = cliParams =>
+  new Promise(resolve => {
     utils.header()
 
     const commandName = cliParams[0]
@@ -82,4 +82,3 @@ export function run(cliParams) {
 
     resolve()
   })
-}

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -26,8 +26,8 @@ export const optionMap = {
  * @param {object} cliOptions
  * @return {Promise}
  */
-export function run(cliParams, cliOptions) {
-  return new Promise(resolve => {
+export const run = (cliParams, cliOptions) =>
+  new Promise(resolve => {
     utils.header()
 
     const full = cliOptions.full
@@ -47,4 +47,3 @@ export function run(cliParams, cliOptions) {
 
     resolve()
   })
-}

--- a/src/cli/compile.js
+++ b/src/cli/compile.js
@@ -23,7 +23,7 @@ const defaultOptions = {
  * @param {CompileOptions} options
  * @return {Promise}
  */
-export default function compile(options = {}) {
+export default (options = {}) => {
   const config = { ...defaultOptions, ...options }
   const css = utils.readFile(config.inputFile)
 

--- a/src/cli/main.js
+++ b/src/cli/main.js
@@ -7,8 +7,8 @@ import * as utils from './utils'
  * @param {string[]} cliArgs
  * @return {Promise}
  */
-export default function run(cliArgs) {
-  return new Promise((resolve, reject) => {
+export default cliArgs =>
+  new Promise((resolve, reject) => {
     const params = utils.parseCliParams(cliArgs)
     const command = commands[params[0]]
     const options = command ? utils.parseCliOptions(cliArgs, command.optionMap) : {}
@@ -19,4 +19,3 @@ export default function run(cliArgs) {
 
     commandPromise.then(resolve).catch(reject)
   })
-}

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -11,7 +11,7 @@ import packageJson from '../../package.json'
  * @param {string[]} cliArgs
  * @return {string[]}
  */
-export function parseCliParams(cliArgs) {
+export const parseCliParams = cliArgs => {
   const firstOptionIndex = cliArgs.findIndex(cliArg => cliArg.startsWith('-'))
 
   return firstOptionIndex > -1 ? cliArgs.slice(0, firstOptionIndex) : cliArgs
@@ -24,7 +24,7 @@ export function parseCliParams(cliArgs) {
  * @param {object} [optionMap]
  * @return {object}
  */
-export function parseCliOptions(cliArgs, optionMap = {}) {
+export const parseCliOptions = (cliArgs, optionMap = {}) => {
   let options = {}
   let currentOption = []
 
@@ -49,14 +49,14 @@ export function parseCliOptions(cliArgs, optionMap = {}) {
  *
  * @param {...string} [msgs]
  */
-export function log(...msgs) {
+export const log = (...msgs) => {
   console.log('  ', ...msgs)
 }
 
 /**
  * Prints application header to console.
  */
-export function header() {
+export const header = () => {
   log()
   log(colors.bold(packageJson.name), colors.info(packageJson.version))
 }
@@ -64,7 +64,7 @@ export function header() {
 /**
  * Prints application footer to console.
  */
-export function footer() {
+export const footer = () => {
   log()
 }
 
@@ -73,7 +73,7 @@ export function footer() {
  *
  * @param {...string} [msgs]
  */
-export function error(...msgs) {
+export const error = (...msgs) => {
   log()
   console.error('  ', emoji.no, colors.error(msgs.join(' ')))
 }
@@ -83,7 +83,7 @@ export function error(...msgs) {
  *
  * @param {...string} [msgs]
  */
-export function die(...msgs) {
+export const die = (...msgs) => {
   msgs.length && error(...msgs)
   footer()
   process.exit(1) // eslint-disable-line
@@ -95,9 +95,7 @@ export function die(...msgs) {
  * @param {string} path
  * @return {boolean}
  */
-export function exists(path) {
-  return existsSync(path)
-}
+export const exists = path => existsSync(path)
 
 /**
  * Copies file source to destination.
@@ -105,7 +103,7 @@ export function exists(path) {
  * @param {string} source
  * @param {string} destination
  */
-export function copyFile(source, destination) {
+export const copyFile = (source, destination) => {
   copyFileSync(source, destination)
 }
 
@@ -115,9 +113,7 @@ export function copyFile(source, destination) {
  * @param {string} path
  * @return {string}
  */
-export function readFile(path) {
-  return readFileSync(path, 'utf-8')
-}
+export const readFile = path => readFileSync(path, 'utf-8')
 
 /**
  * Writes content to file.
@@ -126,7 +122,7 @@ export function readFile(path) {
  * @param {string} content
  * @return {string}
  */
-export function writeFile(path, content) {
+export const writeFile = (path, content) => {
   ensureFileSync(path)
 
   return outputFileSync(path, content)
@@ -138,6 +134,4 @@ export function writeFile(path, content) {
  * @param {string} path
  * @return {string}
  */
-export function getSimplePath(path) {
-  return startsWith(path, './') ? path.slice(2) : path
-}
+export const getSimplePath = path => (startsWith(path, './') ? path.slice(2) : path)

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -67,8 +67,8 @@ import zIndex from './plugins/zIndex'
 
 import configurePlugins from './util/configurePlugins'
 
-export default function({ corePlugins: corePluginConfig }) {
-  return configurePlugins(corePluginConfig, {
+export default ({ corePlugins: corePluginConfig }) =>
+  configurePlugins(corePluginConfig, {
     preflight,
     container,
     appearance,
@@ -136,4 +136,3 @@ export default function({ corePlugins: corePluginConfig }) {
     width,
     zIndex,
   })
-}

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ import { defaultConfigFile } from './constants'
 
 import defaultConfig from '../stubs/defaultConfig.stub.js'
 
-function resolveConfigPath(filePath) {
+const resolveConfigPath = filePath => {
   if (_.isObject(filePath)) {
     return undefined
   }

--- a/src/lib/evaluateTailwindFunctions.js
+++ b/src/lib/evaluateTailwindFunctions.js
@@ -1,14 +1,12 @@
 import _ from 'lodash'
 import functions from 'postcss-functions'
 
-export default function(config) {
-  return functions({
+export default config =>
+  functions({
     functions: {
-      theme: (path, ...defaultValue) => {
-        return _.thru(_.get(config.theme, _.trim(path, `'"`), defaultValue), value => {
-          return _.isArray(value) ? value.join(', ') : value
-        })
-      },
+      theme: (path, ...defaultValue) =>
+        _.thru(_.get(config.theme, _.trim(path, `'"`), defaultValue), value =>
+          _.isArray(value) ? value.join(', ') : value
+        ),
     },
   })
-}

--- a/src/lib/formatCSS.js
+++ b/src/lib/formatCSS.js
@@ -9,7 +9,7 @@ function indentRecursive(node, indent = 0) {
     })
 }
 
-export default function formatNodes(root) {
+export default root => {
   indentRecursive(root)
   root.first.raws.before = ''
 }

--- a/src/lib/registerConfigAsDependency.js
+++ b/src/lib/registerConfigAsDependency.js
@@ -1,11 +1,11 @@
 import fs from 'fs'
 
-export default function(configFile) {
+export default configFile => {
   if (!fs.existsSync(configFile)) {
     throw new Error(`Specified Tailwind config file "${configFile}" doesn't exist.`)
   }
 
-  return function(css, opts) {
+  return (css, opts) => {
     opts.messages.push({
       type: 'dependency',
       file: configFile,

--- a/src/lib/substituteClassApplyAtRules.js
+++ b/src/lib/substituteClassApplyAtRules.js
@@ -3,7 +3,7 @@ import postcss from 'postcss'
 import escapeClassName from '../util/escapeClassName'
 import prefixSelector from '../util/prefixSelector'
 
-function buildClassTable(css) {
+const buildClassTable = css => {
   const classTable = {}
 
   css.walkRules(rule => {
@@ -16,7 +16,7 @@ function buildClassTable(css) {
   return classTable
 }
 
-function buildShadowTable(generatedUtilities) {
+const buildShadowTable = generatedUtilities => {
   const utilities = postcss.root()
 
   postcss.root({ nodes: generatedUtilities }).walkAtRules('variants', atRule => {
@@ -26,11 +26,9 @@ function buildShadowTable(generatedUtilities) {
   return buildClassTable(utilities)
 }
 
-function normalizeClassName(className) {
-  return `.${escapeClassName(_.trimStart(className, '.'))}`
-}
+const normalizeClassName = className => `.${escapeClassName(_.trimStart(className, '.'))}`
 
-function findClass(classToApply, classTable, onError) {
+const findClass = (classToApply, classTable, onError) => {
   const matches = _.get(classTable, classToApply, [])
 
   if (_.isEmpty(matches)) {
@@ -52,62 +50,58 @@ function findClass(classToApply, classTable, onError) {
   return match.clone().nodes
 }
 
-export default function(config, generatedUtilities) {
-  return function(css) {
-    const classLookup = buildClassTable(css)
-    const shadowLookup = buildShadowTable(generatedUtilities)
+export default (config, generatedUtilities) => css => {
+  const classLookup = buildClassTable(css)
+  const shadowLookup = buildShadowTable(generatedUtilities)
 
-    css.walkRules(rule => {
-      rule.walkAtRules('apply', atRule => {
-        const classesAndProperties = postcss.list.space(atRule.params)
+  css.walkRules(rule => {
+    rule.walkAtRules('apply', atRule => {
+      const classesAndProperties = postcss.list.space(atRule.params)
 
-        /*
-         * Don't wreck CSSNext-style @apply rules:
-         * http://cssnext.io/features/#custom-properties-set-apply
-         *
-         * These are deprecated in CSSNext but still playing it safe for now.
-         * We might consider renaming this at-rule.
-         */
-        const [customProperties, classes] = _.partition(classesAndProperties, classOrProperty => {
-          return _.startsWith(classOrProperty, '--')
+      /*
+       * Don't wreck CSSNext-style @apply rules:
+       * http://cssnext.io/features/#custom-properties-set-apply
+       *
+       * These are deprecated in CSSNext but still playing it safe for now.
+       * We might consider renaming this at-rule.
+       */
+      const [customProperties, classes] = _.partition(classesAndProperties, classOrProperty =>
+        _.startsWith(classOrProperty, '--')
+      )
+
+      const decls = _(classes)
+        .reject(cssClass => cssClass === '!important')
+        .flatMap(cssClass => {
+          const classToApply = normalizeClassName(cssClass)
+          const onError = message => atRule.error(message)
+
+          return _.reduce(
+            [
+              () => findClass(classToApply, classLookup, onError),
+              () => findClass(classToApply, shadowLookup, onError),
+              () => findClass(prefixSelector(config.prefix, classToApply), shadowLookup, onError),
+              () => {
+                // prettier-ignore
+                throw onError(`\`@apply\` cannot be used with \`${classToApply}\` because \`${classToApply}\` either cannot be found, or its actual definition includes a pseudo-selector like :hover, :active, etc. If you're sure that \`${classToApply}\` exists, make sure that any \`@import\` statements are being properly processed *before* Tailwind CSS sees your CSS, as \`@apply\` can only be used for classes in the same CSS tree.`)
+              },
+            ],
+            (classDecls, candidate) => (!_.isEmpty(classDecls) ? classDecls : candidate()),
+            []
+          )
         })
+        .value()
 
-        const decls = _(classes)
-          .reject(cssClass => cssClass === '!important')
-          .flatMap(cssClass => {
-            const classToApply = normalizeClassName(cssClass)
-            const onError = message => {
-              return atRule.error(message)
-            }
-
-            return _.reduce(
-              [
-                () => findClass(classToApply, classLookup, onError),
-                () => findClass(classToApply, shadowLookup, onError),
-                () => findClass(prefixSelector(config.prefix, classToApply), shadowLookup, onError),
-                () => {
-                  // prettier-ignore
-                  throw onError(`\`@apply\` cannot be used with \`${classToApply}\` because \`${classToApply}\` either cannot be found, or its actual definition includes a pseudo-selector like :hover, :active, etc. If you're sure that \`${classToApply}\` exists, make sure that any \`@import\` statements are being properly processed *before* Tailwind CSS sees your CSS, as \`@apply\` can only be used for classes in the same CSS tree.`)
-                },
-              ],
-              (classDecls, candidate) => (!_.isEmpty(classDecls) ? classDecls : candidate()),
-              []
-            )
-          })
-          .value()
-
-        _.tap(_.last(classesAndProperties) === '!important', important => {
-          decls.forEach(decl => (decl.important = important))
-        })
-
-        atRule.before(decls)
-
-        atRule.params = customProperties.join(' ')
-
-        if (_.isEmpty(customProperties)) {
-          atRule.remove()
-        }
+      _.tap(_.last(classesAndProperties) === '!important', important => {
+        decls.forEach(decl => (decl.important = important))
       })
+
+      atRule.before(decls)
+
+      atRule.params = customProperties.join(' ')
+
+      if (_.isEmpty(customProperties)) {
+        atRule.remove()
+      }
     })
-  }
+  })
 }

--- a/src/lib/substituteResponsiveAtRules.js
+++ b/src/lib/substituteResponsiveAtRules.js
@@ -4,61 +4,58 @@ import cloneNodes from '../util/cloneNodes'
 import buildMediaQuery from '../util/buildMediaQuery'
 import buildSelectorVariant from '../util/buildSelectorVariant'
 
-export default function(config) {
-  return function(css) {
-    const {
-      theme: { screens },
-      separator,
-    } = config
-    const responsiveRules = postcss.root()
-    const finalRules = []
+export default config => css => {
+  const {
+    theme: { screens },
+    separator,
+  } = config
+  const responsiveRules = postcss.root()
+  const finalRules = []
 
-    css.walkAtRules('responsive', atRule => {
-      const nodes = atRule.nodes
-      responsiveRules.append(...cloneNodes(nodes))
-      atRule.before(nodes)
-      atRule.remove()
+  css.walkAtRules('responsive', atRule => {
+    const nodes = atRule.nodes
+    responsiveRules.append(...cloneNodes(nodes))
+    atRule.before(nodes)
+    atRule.remove()
+  })
+
+  _.keys(screens).forEach(screen => {
+    const mediaQuery = postcss.atRule({
+      name: 'media',
+      params: buildMediaQuery(screens[screen]),
     })
 
-    _.keys(screens).forEach(screen => {
-      const mediaQuery = postcss.atRule({
-        name: 'media',
-        params: buildMediaQuery(screens[screen]),
-      })
-
-      mediaQuery.append(
-        _.tap(responsiveRules.clone(), clonedRoot => {
-          clonedRoot.walkRules(rule => {
-            rule.selectors = _.map(rule.selectors, selector =>
-              buildSelectorVariant(selector, screen, separator, message => {
-                throw rule.error(message)
-              })
-            )
-          })
+    mediaQuery.append(
+      _.tap(responsiveRules.clone(), clonedRoot => {
+        clonedRoot.walkRules(rule => {
+          rule.selectors = _.map(rule.selectors, selector =>
+            buildSelectorVariant(selector, screen, separator, message => {
+              throw rule.error(message)
+            })
+          )
         })
-      )
+      })
+    )
 
-      finalRules.push(mediaQuery)
-    })
+    finalRules.push(mediaQuery)
+  })
 
-    const hasScreenRules = finalRules.some(i => i.nodes.length !== 0)
+  const hasScreenRules = finalRules.some(i => i.nodes.length !== 0)
 
-    if (!hasScreenRules) {
-      return
+  if (!hasScreenRules) {
+    return
+  }
+
+  let includesScreensExplicitly = false
+
+  css.walkAtRules('tailwind', atRule => {
+    if (atRule.params === 'screens') {
+      atRule.replaceWith(finalRules)
+      includesScreensExplicitly = true
     }
+  })
 
-    let includesScreensExplicitly = false
-
-    css.walkAtRules('tailwind', atRule => {
-      if (atRule.params === 'screens') {
-        atRule.replaceWith(finalRules)
-        includesScreensExplicitly = true
-      }
-    })
-
-    if (!includesScreensExplicitly) {
-      css.append(finalRules)
-      return
-    }
+  if (!includesScreensExplicitly) {
+    css.append(finalRules)
   }
 }

--- a/src/lib/substituteScreenAtRules.js
+++ b/src/lib/substituteScreenAtRules.js
@@ -1,17 +1,15 @@
 import _ from 'lodash'
 import buildMediaQuery from '../util/buildMediaQuery'
 
-export default function({ theme }) {
-  return function(css) {
-    css.walkAtRules('screen', atRule => {
-      const screen = atRule.params
+export default ({ theme }) => css => {
+  css.walkAtRules('screen', atRule => {
+    const screen = atRule.params
 
-      if (!_.has(theme.screens, screen)) {
-        throw atRule.error(`No \`${screen}\` screen found.`)
-      }
+    if (!_.has(theme.screens, screen)) {
+      throw atRule.error(`No \`${screen}\` screen found.`)
+    }
 
-      atRule.name = 'media'
-      atRule.params = buildMediaQuery(theme.screens[screen])
-    })
-  }
+    atRule.name = 'media'
+    atRule.params = buildMediaQuery(theme.screens[screen])
+  })
 }

--- a/src/lib/substituteTailwindAtRules.js
+++ b/src/lib/substituteTailwindAtRules.js
@@ -7,26 +7,24 @@ function updateSource(nodes, source) {
   })
 }
 
-export default function(
+export default (
   config,
   { base: pluginBase, components: pluginComponents, utilities: pluginUtilities }
-) {
-  return function(css) {
-    css.walkAtRules('tailwind', atRule => {
-      if (atRule.params === 'base') {
-        atRule.before(updateSource(pluginBase, atRule.source))
-        atRule.remove()
-      }
+) => css => {
+  css.walkAtRules('tailwind', atRule => {
+    if (atRule.params === 'base') {
+      atRule.before(updateSource(pluginBase, atRule.source))
+      atRule.remove()
+    }
 
-      if (atRule.params === 'components') {
-        atRule.before(updateSource(pluginComponents, atRule.source))
-        atRule.remove()
-      }
+    if (atRule.params === 'components') {
+      atRule.before(updateSource(pluginComponents, atRule.source))
+      atRule.remove()
+    }
 
-      if (atRule.params === 'utilities') {
-        atRule.before(updateSource(pluginUtilities, atRule.source))
-        atRule.remove()
-      }
-    })
-  }
+    if (atRule.params === 'utilities') {
+      atRule.before(updateSource(pluginUtilities, atRule.source))
+      atRule.remove()
+    }
+  })
 }

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -3,52 +3,46 @@ import postcss from 'postcss'
 import generateVariantFunction from '../util/generateVariantFunction'
 import e from '../util/escapeClassName'
 
-function generatePseudoClassVariant(pseudoClass) {
-  return generateVariantFunction(({ modifySelectors, separator }) => {
-    return modifySelectors(({ className }) => {
-      return `.${e(`${pseudoClass}${separator}${className}`)}:${pseudoClass}`
-    })
-  })
-}
+const generatePseudoClassVariant = pseudoClass =>
+  generateVariantFunction(({ modifySelectors, separator }) =>
+    modifySelectors(
+      ({ className }) => `.${e(`${pseudoClass}${separator}${className}`)}:${pseudoClass}`
+    )
+  )
 
-function ensureIncludesDefault(variants) {
-  return variants.includes('default') ? variants : ['default', ...variants]
-}
+const ensureIncludesDefault = variants =>
+  variants.includes('default') ? variants : ['default', ...variants]
 
 const defaultVariantGenerators = {
   default: generateVariantFunction(() => {}),
-  'group-hover': generateVariantFunction(({ modifySelectors, separator }) => {
-    return modifySelectors(({ className }) => {
-      return `.group:hover .${e(`group-hover${separator}${className}`)}`
-    })
-  }),
+  'group-hover': generateVariantFunction(({ modifySelectors, separator }) =>
+    modifySelectors(({ className }) => `.group:hover .${e(`group-hover${separator}${className}`)}`)
+  ),
   hover: generatePseudoClassVariant('hover'),
   'focus-within': generatePseudoClassVariant('focus-within'),
   focus: generatePseudoClassVariant('focus'),
   active: generatePseudoClassVariant('active'),
 }
 
-export default function(config, { variantGenerators: pluginVariantGenerators }) {
-  return function(css) {
-    const variantGenerators = {
-      ...defaultVariantGenerators,
-      ...pluginVariantGenerators,
+export default (config, { variantGenerators: pluginVariantGenerators }) => css => {
+  const variantGenerators = {
+    ...defaultVariantGenerators,
+    ...pluginVariantGenerators,
+  }
+
+  css.walkAtRules('variants', atRule => {
+    const variants = postcss.list.comma(atRule.params).filter(variant => variant !== '')
+
+    if (variants.includes('responsive')) {
+      const responsiveParent = postcss.atRule({ name: 'responsive' })
+      atRule.before(responsiveParent)
+      responsiveParent.append(atRule)
     }
 
-    css.walkAtRules('variants', atRule => {
-      const variants = postcss.list.comma(atRule.params).filter(variant => variant !== '')
-
-      if (variants.includes('responsive')) {
-        const responsiveParent = postcss.atRule({ name: 'responsive' })
-        atRule.before(responsiveParent)
-        responsiveParent.append(atRule)
-      }
-
-      _.forEach(_.without(ensureIncludesDefault(variants), 'responsive'), variant => {
-        variantGenerators[variant](atRule, config)
-      })
-
-      atRule.remove()
+    _.forEach(_.without(ensureIncludesDefault(variants), 'responsive'), variant => {
+      variantGenerators[variant](atRule, config)
     })
-  }
+
+    atRule.remove()
+  })
 }

--- a/src/plugins/alignContent.js
+++ b/src/plugins/alignContent.js
@@ -1,24 +1,22 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.content-center': {
-          'align-content': 'center',
-        },
-        '.content-start': {
-          'align-content': 'flex-start',
-        },
-        '.content-end': {
-          'align-content': 'flex-end',
-        },
-        '.content-between': {
-          'align-content': 'space-between',
-        },
-        '.content-around': {
-          'align-content': 'space-around',
-        },
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.content-center': {
+        'align-content': 'center',
       },
-      variants('alignContent')
-    )
-  }
+      '.content-start': {
+        'align-content': 'flex-start',
+      },
+      '.content-end': {
+        'align-content': 'flex-end',
+      },
+      '.content-between': {
+        'align-content': 'space-between',
+      },
+      '.content-around': {
+        'align-content': 'space-around',
+      },
+    },
+    variants('alignContent')
+  )
 }

--- a/src/plugins/alignItems.js
+++ b/src/plugins/alignItems.js
@@ -1,24 +1,22 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.items-start': {
-          'align-items': 'flex-start',
-        },
-        '.items-end': {
-          'align-items': 'flex-end',
-        },
-        '.items-center': {
-          'align-items': 'center',
-        },
-        '.items-baseline': {
-          'align-items': 'baseline',
-        },
-        '.items-stretch': {
-          'align-items': 'stretch',
-        },
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.items-start': {
+        'align-items': 'flex-start',
       },
-      variants('alignItems')
-    )
-  }
+      '.items-end': {
+        'align-items': 'flex-end',
+      },
+      '.items-center': {
+        'align-items': 'center',
+      },
+      '.items-baseline': {
+        'align-items': 'baseline',
+      },
+      '.items-stretch': {
+        'align-items': 'stretch',
+      },
+    },
+    variants('alignItems')
+  )
 }

--- a/src/plugins/alignSelf.js
+++ b/src/plugins/alignSelf.js
@@ -1,24 +1,22 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.self-auto': {
-          'align-self': 'auto',
-        },
-        '.self-start': {
-          'align-self': 'flex-start',
-        },
-        '.self-end': {
-          'align-self': 'flex-end',
-        },
-        '.self-center': {
-          'align-self': 'center',
-        },
-        '.self-stretch': {
-          'align-self': 'stretch',
-        },
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.self-auto': {
+        'align-self': 'auto',
       },
-      variants('alignSelf')
-    )
-  }
+      '.self-start': {
+        'align-self': 'flex-start',
+      },
+      '.self-end': {
+        'align-self': 'flex-end',
+      },
+      '.self-center': {
+        'align-self': 'center',
+      },
+      '.self-stretch': {
+        'align-self': 'stretch',
+      },
+    },
+    variants('alignSelf')
+  )
 }

--- a/src/plugins/appearance.js
+++ b/src/plugins/appearance.js
@@ -1,10 +1,8 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.appearance-none': { appearance: 'none' },
-      },
-      variants('appearance')
-    )
-  }
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.appearance-none': { appearance: 'none' },
+    },
+    variants('appearance')
+  )
 }

--- a/src/plugins/backgroundAttachment.js
+++ b/src/plugins/backgroundAttachment.js
@@ -1,12 +1,10 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.bg-fixed': { 'background-attachment': 'fixed' },
-        '.bg-local': { 'background-attachment': 'local' },
-        '.bg-scroll': { 'background-attachment': 'scroll' },
-      },
-      variants('backgroundAttachment')
-    )
-  }
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.bg-fixed': { 'background-attachment': 'fixed' },
+      '.bg-local': { 'background-attachment': 'local' },
+      '.bg-scroll': { 'background-attachment': 'scroll' },
+    },
+    variants('backgroundAttachment')
+  )
 }

--- a/src/plugins/backgroundColor.js
+++ b/src/plugins/backgroundColor.js
@@ -1,19 +1,15 @@
 import _ from 'lodash'
 import flattenColorPalette from '../util/flattenColorPalette'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(flattenColorPalette(theme('backgroundColor')), (value, modifier) => {
-        return [
-          `.${e(`bg-${modifier}`)}`,
-          {
-            'background-color': value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(flattenColorPalette(theme('backgroundColor')), (value, modifier) => [
+      `.${e(`bg-${modifier}`)}`,
+      {
+        'background-color': value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('backgroundColor'))
-  }
+  addUtilities(utilities, variants('backgroundColor'))
 }

--- a/src/plugins/backgroundPosition.js
+++ b/src/plugins/backgroundPosition.js
@@ -1,18 +1,14 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('backgroundPosition'), (value, modifier) => {
-        return [
-          `.${e(`bg-${modifier}`)}`,
-          {
-            'background-position': value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(theme('backgroundPosition'), (value, modifier) => [
+      `.${e(`bg-${modifier}`)}`,
+      {
+        'background-position': value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('backgroundPosition'))
-  }
+  addUtilities(utilities, variants('backgroundPosition'))
 }

--- a/src/plugins/backgroundRepeat.js
+++ b/src/plugins/backgroundRepeat.js
@@ -1,13 +1,11 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.bg-repeat': { 'background-repeat': 'repeat' },
-        '.bg-no-repeat': { 'background-repeat': 'no-repeat' },
-        '.bg-repeat-x': { 'background-repeat': 'repeat-x' },
-        '.bg-repeat-y': { 'background-repeat': 'repeat-y' },
-      },
-      variants('backgroundRepeat')
-    )
-  }
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.bg-repeat': { 'background-repeat': 'repeat' },
+      '.bg-no-repeat': { 'background-repeat': 'no-repeat' },
+      '.bg-repeat-x': { 'background-repeat': 'repeat-x' },
+      '.bg-repeat-y': { 'background-repeat': 'repeat-y' },
+    },
+    variants('backgroundRepeat')
+  )
 }

--- a/src/plugins/backgroundSize.js
+++ b/src/plugins/backgroundSize.js
@@ -1,18 +1,14 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('backgroundSize'), (value, modifier) => {
-        return [
-          `.${e(`bg-${modifier}`)}`,
-          {
-            'background-size': value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(theme('backgroundSize'), (value, modifier) => [
+      `.${e(`bg-${modifier}`)}`,
+      {
+        'background-size': value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('backgroundSize'))
-  }
+  addUtilities(utilities, variants('backgroundSize'))
 }

--- a/src/plugins/borderCollapse.js
+++ b/src/plugins/borderCollapse.js
@@ -1,11 +1,9 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.border-collapse': { 'border-collapse': 'collapse' },
-        '.border-separate': { 'border-collapse': 'separate' },
-      },
-      variants('borderCollapse')
-    )
-  }
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.border-collapse': { 'border-collapse': 'collapse' },
+      '.border-separate': { 'border-collapse': 'separate' },
+    },
+    variants('borderCollapse')
+  )
 }

--- a/src/plugins/borderColor.js
+++ b/src/plugins/borderColor.js
@@ -1,21 +1,17 @@
 import _ from 'lodash'
 import flattenColorPalette from '../util/flattenColorPalette'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const colors = flattenColorPalette(theme('borderColor'))
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const colors = flattenColorPalette(theme('borderColor'))
 
-    const utilities = _.fromPairs(
-      _.map(_.omit(colors, 'default'), (value, modifier) => {
-        return [
-          `.${e(`border-${modifier}`)}`,
-          {
-            'border-color': value,
-          },
-        ]
-      })
-    )
+  const utilities = _.fromPairs(
+    _.map(_.omit(colors, 'default'), (value, modifier) => [
+      `.${e(`border-${modifier}`)}`,
+      {
+        'border-color': value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('borderColor'))
-  }
+  addUtilities(utilities, variants('borderColor'))
 }

--- a/src/plugins/borderRadius.js
+++ b/src/plugins/borderRadius.js
@@ -1,43 +1,41 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const generators = [
-      (value, modifier) => ({
-        [`.${e(`rounded${modifier}`)}`]: { borderRadius: `${value}` },
-      }),
-      (value, modifier) => ({
-        [`.${e(`rounded-t${modifier}`)}`]: {
-          borderTopLeftRadius: `${value}`,
-          borderTopRightRadius: `${value}`,
-        },
-        [`.${e(`rounded-r${modifier}`)}`]: {
-          borderTopRightRadius: `${value}`,
-          borderBottomRightRadius: `${value}`,
-        },
-        [`.${e(`rounded-b${modifier}`)}`]: {
-          borderBottomRightRadius: `${value}`,
-          borderBottomLeftRadius: `${value}`,
-        },
-        [`.${e(`rounded-l${modifier}`)}`]: {
-          borderTopLeftRadius: `${value}`,
-          borderBottomLeftRadius: `${value}`,
-        },
-      }),
-      (value, modifier) => ({
-        [`.${e(`rounded-tl${modifier}`)}`]: { borderTopLeftRadius: `${value}` },
-        [`.${e(`rounded-tr${modifier}`)}`]: { borderTopRightRadius: `${value}` },
-        [`.${e(`rounded-br${modifier}`)}`]: { borderBottomRightRadius: `${value}` },
-        [`.${e(`rounded-bl${modifier}`)}`]: { borderBottomLeftRadius: `${value}` },
-      }),
-    ]
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const generators = [
+    (value, modifier) => ({
+      [`.${e(`rounded${modifier}`)}`]: { borderRadius: `${value}` },
+    }),
+    (value, modifier) => ({
+      [`.${e(`rounded-t${modifier}`)}`]: {
+        borderTopLeftRadius: `${value}`,
+        borderTopRightRadius: `${value}`,
+      },
+      [`.${e(`rounded-r${modifier}`)}`]: {
+        borderTopRightRadius: `${value}`,
+        borderBottomRightRadius: `${value}`,
+      },
+      [`.${e(`rounded-b${modifier}`)}`]: {
+        borderBottomRightRadius: `${value}`,
+        borderBottomLeftRadius: `${value}`,
+      },
+      [`.${e(`rounded-l${modifier}`)}`]: {
+        borderTopLeftRadius: `${value}`,
+        borderBottomLeftRadius: `${value}`,
+      },
+    }),
+    (value, modifier) => ({
+      [`.${e(`rounded-tl${modifier}`)}`]: { borderTopLeftRadius: `${value}` },
+      [`.${e(`rounded-tr${modifier}`)}`]: { borderTopRightRadius: `${value}` },
+      [`.${e(`rounded-br${modifier}`)}`]: { borderBottomRightRadius: `${value}` },
+      [`.${e(`rounded-bl${modifier}`)}`]: { borderBottomLeftRadius: `${value}` },
+    }),
+  ]
 
-    const utilities = _.flatMap(generators, generator => {
-      return _.flatMap(theme('borderRadius'), (value, modifier) => {
-        return generator(value, modifier === 'default' ? '' : `-${modifier}`)
-      })
-    })
+  const utilities = _.flatMap(generators, generator =>
+    _.flatMap(theme('borderRadius'), (value, modifier) =>
+      generator(value, modifier === 'default' ? '' : `-${modifier}`)
+    )
+  )
 
-    addUtilities(utilities, variants('borderRadius'))
-  }
+  addUtilities(utilities, variants('borderRadius'))
 }

--- a/src/plugins/borderStyle.js
+++ b/src/plugins/borderStyle.js
@@ -1,21 +1,19 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.border-solid': {
-          'border-style': 'solid',
-        },
-        '.border-dashed': {
-          'border-style': 'dashed',
-        },
-        '.border-dotted': {
-          'border-style': 'dotted',
-        },
-        '.border-none': {
-          'border-style': 'none',
-        },
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.border-solid': {
+        'border-style': 'solid',
       },
-      variants('borderStyle')
-    )
-  }
+      '.border-dashed': {
+        'border-style': 'dashed',
+      },
+      '.border-dotted': {
+        'border-style': 'dotted',
+      },
+      '.border-none': {
+        'border-style': 'none',
+      },
+    },
+    variants('borderStyle')
+  )
 }

--- a/src/plugins/borderWidth.js
+++ b/src/plugins/borderWidth.js
@@ -1,25 +1,23 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const generators = [
-      (value, modifier) => ({
-        [`.${e(`border${modifier}`)}`]: { borderWidth: `${value}` },
-      }),
-      (value, modifier) => ({
-        [`.${e(`border-t${modifier}`)}`]: { borderTopWidth: `${value}` },
-        [`.${e(`border-r${modifier}`)}`]: { borderRightWidth: `${value}` },
-        [`.${e(`border-b${modifier}`)}`]: { borderBottomWidth: `${value}` },
-        [`.${e(`border-l${modifier}`)}`]: { borderLeftWidth: `${value}` },
-      }),
-    ]
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const generators = [
+    (value, modifier) => ({
+      [`.${e(`border${modifier}`)}`]: { borderWidth: `${value}` },
+    }),
+    (value, modifier) => ({
+      [`.${e(`border-t${modifier}`)}`]: { borderTopWidth: `${value}` },
+      [`.${e(`border-r${modifier}`)}`]: { borderRightWidth: `${value}` },
+      [`.${e(`border-b${modifier}`)}`]: { borderBottomWidth: `${value}` },
+      [`.${e(`border-l${modifier}`)}`]: { borderLeftWidth: `${value}` },
+    }),
+  ]
 
-    const utilities = _.flatMap(generators, generator => {
-      return _.flatMap(theme('borderWidth'), (value, modifier) => {
-        return generator(value, modifier === 'default' ? '' : `-${modifier}`)
-      })
-    })
+  const utilities = _.flatMap(generators, generator =>
+    _.flatMap(theme('borderWidth'), (value, modifier) =>
+      generator(value, modifier === 'default' ? '' : `-${modifier}`)
+    )
+  )
 
-    addUtilities(utilities, variants('borderWidth'))
-  }
+  addUtilities(utilities, variants('borderWidth'))
 }

--- a/src/plugins/boxShadow.js
+++ b/src/plugins/boxShadow.js
@@ -1,19 +1,18 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('boxShadow'), (value, modifier) => {
-        const className = modifier === 'default' ? 'shadow' : `shadow-${modifier}`
-        return [
-          `.${e(className)}`,
-          {
-            'box-shadow': value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(theme('boxShadow'), (value, modifier) => {
+      const className = modifier === 'default' ? 'shadow' : `shadow-${modifier}`
 
-    addUtilities(utilities, variants('boxShadow'))
-  }
+      return [
+        `.${e(className)}`,
+        {
+          'box-shadow': value,
+        },
+      ]
+    })
+  )
+
+  addUtilities(utilities, variants('boxShadow'))
 }

--- a/src/plugins/container.js
+++ b/src/plugins/container.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-shadow */
 import _ from 'lodash'
 
-function extractMinWidths(breakpoints) {
-  return _.flatMap(breakpoints, breakpoints => {
+const extractMinWidths = breakpoints =>
+  _.flatMap(breakpoints, breakpoints => {
     if (_.isString(breakpoints)) {
       breakpoints = { min: breakpoints }
     }
@@ -12,44 +12,35 @@ function extractMinWidths(breakpoints) {
     }
 
     return _(breakpoints)
-      .filter(breakpoint => {
-        return _.has(breakpoint, 'min') || _.has(breakpoint, 'min-width')
-      })
-      .map(breakpoint => {
-        return _.get(breakpoint, 'min-width', breakpoint.min)
-      })
+      .filter(breakpoint => _.has(breakpoint, 'min') || _.has(breakpoint, 'min-width'))
+      .map(breakpoint => _.get(breakpoint, 'min-width', breakpoint.min))
       .value()
   })
-}
 
-module.exports = function() {
-  return function({ addComponents, theme }) {
-    const minWidths = extractMinWidths(theme('container.screens', theme('screens')))
+module.exports = () => ({ addComponents, theme }) => {
+  const minWidths = extractMinWidths(theme('container.screens', theme('screens')))
 
-    const atRules = _.map(minWidths, minWidth => {
-      return {
-        [`@media (min-width: ${minWidth})`]: {
-          '.container': {
-            'max-width': minWidth,
-          },
-        },
-      }
-    })
-
-    addComponents([
-      {
-        '.container': Object.assign(
-          { width: '100%' },
-          theme('container.center', false) ? { marginRight: 'auto', marginLeft: 'auto' } : {},
-          _.has(theme('container', {}), 'padding')
-            ? {
-                paddingRight: theme('container.padding'),
-                paddingLeft: theme('container.padding'),
-              }
-            : {}
-        ),
+  const atRules = _.map(minWidths, minWidth => ({
+    [`@media (min-width: ${minWidth})`]: {
+      '.container': {
+        'max-width': minWidth,
       },
-      ...atRules,
-    ])
-  }
+    },
+  }))
+
+  addComponents([
+    {
+      '.container': {
+        width: '100%',
+        ...(theme('container.center', false) ? { marginRight: 'auto', marginLeft: 'auto' } : {}),
+        ...(_.has(theme('container', {}), 'padding')
+          ? {
+              paddingRight: theme('container.padding'),
+              paddingLeft: theme('container.padding'),
+            }
+          : {}),
+      },
+    },
+    ...atRules,
+  ])
 }

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -129,7 +129,7 @@ textarea::placeholder {
 }
 
 button,
-[role="button"] {
+[role='button'] {
   cursor: pointer;
 }
 
@@ -186,7 +186,16 @@ pre,
 code,
 kbd,
 samp {
-  font-family: theme('fontFamily.mono', SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
+  font-family: theme(
+    'fontFamily.mono',
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    'Liberation Mono',
+    'Courier New',
+    monospace
+  );
 }
 
 /**

--- a/src/plugins/cursor.js
+++ b/src/plugins/cursor.js
@@ -1,18 +1,14 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('cursor'), (value, modifier) => {
-        return [
-          `.${e(`cursor-${modifier}`)}`,
-          {
-            cursor: value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(theme('cursor'), (value, modifier) => [
+      `.${e(`cursor-${modifier}`)}`,
+      {
+        cursor: value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('cursor'))
-  }
+  addUtilities(utilities, variants('cursor'))
 }

--- a/src/plugins/display.js
+++ b/src/plugins/display.js
@@ -1,36 +1,34 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.block': {
-          display: 'block',
-        },
-        '.inline-block': {
-          display: 'inline-block',
-        },
-        '.inline': {
-          display: 'inline',
-        },
-        '.flex': {
-          display: 'flex',
-        },
-        '.inline-flex': {
-          display: 'inline-flex',
-        },
-        '.table': {
-          display: 'table',
-        },
-        '.table-row': {
-          display: 'table-row',
-        },
-        '.table-cell': {
-          display: 'table-cell',
-        },
-        '.hidden': {
-          display: 'none',
-        },
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.block': {
+        display: 'block',
       },
-      variants('display')
-    )
-  }
+      '.inline-block': {
+        display: 'inline-block',
+      },
+      '.inline': {
+        display: 'inline',
+      },
+      '.flex': {
+        display: 'flex',
+      },
+      '.inline-flex': {
+        display: 'inline-flex',
+      },
+      '.table': {
+        display: 'table',
+      },
+      '.table-row': {
+        display: 'table-row',
+      },
+      '.table-cell': {
+        display: 'table-cell',
+      },
+      '.hidden': {
+        display: 'none',
+      },
+    },
+    variants('display')
+  )
 }

--- a/src/plugins/fill.js
+++ b/src/plugins/fill.js
@@ -1,19 +1,15 @@
 import _ from 'lodash'
 import flattenColorPalette from '../util/flattenColorPalette'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(flattenColorPalette(theme('fill')), (value, modifier) => {
-        return [
-          `.${e(`fill-${modifier}`)}`,
-          {
-            fill: value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(flattenColorPalette(theme('fill')), (value, modifier) => [
+      `.${e(`fill-${modifier}`)}`,
+      {
+        fill: value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('fill'))
-  }
+  addUtilities(utilities, variants('fill'))
 }

--- a/src/plugins/flex.js
+++ b/src/plugins/flex.js
@@ -1,18 +1,14 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('flex'), (value, modifier) => {
-        return [
-          `.${e(`flex-${modifier}`)}`,
-          {
-            flex: value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(theme('flex'), (value, modifier) => [
+      `.${e(`flex-${modifier}`)}`,
+      {
+        flex: value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('flex'))
-  }
+  addUtilities(utilities, variants('flex'))
 }

--- a/src/plugins/flexDirection.js
+++ b/src/plugins/flexDirection.js
@@ -1,21 +1,19 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.flex-row': {
-          'flex-direction': 'row',
-        },
-        '.flex-row-reverse': {
-          'flex-direction': 'row-reverse',
-        },
-        '.flex-col': {
-          'flex-direction': 'column',
-        },
-        '.flex-col-reverse': {
-          'flex-direction': 'column-reverse',
-        },
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.flex-row': {
+        'flex-direction': 'row',
       },
-      variants('flexDirection')
-    )
-  }
+      '.flex-row-reverse': {
+        'flex-direction': 'row-reverse',
+      },
+      '.flex-col': {
+        'flex-direction': 'column',
+      },
+      '.flex-col-reverse': {
+        'flex-direction': 'column-reverse',
+      },
+    },
+    variants('flexDirection')
+  )
 }

--- a/src/plugins/flexGrow.js
+++ b/src/plugins/flexGrow.js
@@ -1,20 +1,19 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    addUtilities(
-      _.fromPairs(
-        _.map(theme('flexGrow'), (value, modifier) => {
-          const className = modifier === 'default' ? 'flex-grow' : `flex-grow-${modifier}`
-          return [
-            `.${e(className)}`,
-            {
-              'flex-grow': value,
-            },
-          ]
-        })
-      ),
-      variants('flexGrow')
-    )
-  }
+export default () => ({ addUtilities, e, theme, variants }) => {
+  addUtilities(
+    _.fromPairs(
+      _.map(theme('flexGrow'), (value, modifier) => {
+        const className = modifier === 'default' ? 'flex-grow' : `flex-grow-${modifier}`
+
+        return [
+          `.${e(className)}`,
+          {
+            'flex-grow': value,
+          },
+        ]
+      })
+    ),
+    variants('flexGrow')
+  )
 }

--- a/src/plugins/flexShrink.js
+++ b/src/plugins/flexShrink.js
@@ -1,20 +1,19 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    addUtilities(
-      _.fromPairs(
-        _.map(theme('flexShrink'), (value, modifier) => {
-          const className = modifier === 'default' ? 'flex-shrink' : `flex-shrink-${modifier}`
-          return [
-            `.${e(className)}`,
-            {
-              'flex-shrink': value,
-            },
-          ]
-        })
-      ),
-      variants('flexShrink')
-    )
-  }
+export default () => ({ addUtilities, e, theme, variants }) => {
+  addUtilities(
+    _.fromPairs(
+      _.map(theme('flexShrink'), (value, modifier) => {
+        const className = modifier === 'default' ? 'flex-shrink' : `flex-shrink-${modifier}`
+
+        return [
+          `.${e(className)}`,
+          {
+            'flex-shrink': value,
+          },
+        ]
+      })
+    ),
+    variants('flexShrink')
+  )
 }

--- a/src/plugins/flexWrap.js
+++ b/src/plugins/flexWrap.js
@@ -1,18 +1,16 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.flex-wrap': {
-          'flex-wrap': 'wrap',
-        },
-        '.flex-wrap-reverse': {
-          'flex-wrap': 'wrap-reverse',
-        },
-        '.flex-no-wrap': {
-          'flex-wrap': 'nowrap',
-        },
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.flex-wrap': {
+        'flex-wrap': 'wrap',
       },
-      variants('flexWrap')
-    )
-  }
+      '.flex-wrap-reverse': {
+        'flex-wrap': 'wrap-reverse',
+      },
+      '.flex-no-wrap': {
+        'flex-wrap': 'nowrap',
+      },
+    },
+    variants('flexWrap')
+  )
 }

--- a/src/plugins/float.js
+++ b/src/plugins/float.js
@@ -1,17 +1,15 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.float-right': { float: 'right' },
-        '.float-left': { float: 'left' },
-        '.float-none': { float: 'none' },
-        '.clearfix:after': {
-          content: '""',
-          display: 'table',
-          clear: 'both',
-        },
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.float-right': { float: 'right' },
+      '.float-left': { float: 'left' },
+      '.float-none': { float: 'none' },
+      '.clearfix:after': {
+        content: '""',
+        display: 'table',
+        clear: 'both',
       },
-      variants('float')
-    )
-  }
+    },
+    variants('float')
+  )
 }

--- a/src/plugins/fontFamily.js
+++ b/src/plugins/fontFamily.js
@@ -1,18 +1,14 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('fontFamily'), (value, modifier) => {
-        return [
-          `.${e(`font-${modifier}`)}`,
-          {
-            'font-family': _.isArray(value) ? value.join(', ') : value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(theme('fontFamily'), (value, modifier) => [
+      `.${e(`font-${modifier}`)}`,
+      {
+        'font-family': _.isArray(value) ? value.join(', ') : value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('fontFamily'))
-  }
+  addUtilities(utilities, variants('fontFamily'))
 }

--- a/src/plugins/fontSize.js
+++ b/src/plugins/fontSize.js
@@ -1,18 +1,14 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('fontSize'), (value, modifier) => {
-        return [
-          `.${e(`text-${modifier}`)}`,
-          {
-            'font-size': value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(theme('fontSize'), (value, modifier) => [
+      `.${e(`text-${modifier}`)}`,
+      {
+        'font-size': value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('fontSize'))
-  }
+  addUtilities(utilities, variants('fontSize'))
 }

--- a/src/plugins/fontSmoothing.js
+++ b/src/plugins/fontSmoothing.js
@@ -1,17 +1,15 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.antialiased': {
-          '-webkit-font-smoothing': 'antialiased',
-          '-moz-osx-font-smoothing': 'grayscale',
-        },
-        '.subpixel-antialiased': {
-          '-webkit-font-smoothing': 'auto',
-          '-moz-osx-font-smoothing': 'auto',
-        },
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.antialiased': {
+        '-webkit-font-smoothing': 'antialiased',
+        '-moz-osx-font-smoothing': 'grayscale',
       },
-      variants('fontSmoothing')
-    )
-  }
+      '.subpixel-antialiased': {
+        '-webkit-font-smoothing': 'auto',
+        '-moz-osx-font-smoothing': 'auto',
+      },
+    },
+    variants('fontSmoothing')
+  )
 }

--- a/src/plugins/fontStyle.js
+++ b/src/plugins/fontStyle.js
@@ -1,11 +1,9 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.italic': { 'font-style': 'italic' },
-        '.not-italic': { 'font-style': 'normal' },
-      },
-      variants('fontStyle')
-    )
-  }
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.italic': { 'font-style': 'italic' },
+      '.not-italic': { 'font-style': 'normal' },
+    },
+    variants('fontStyle')
+  )
 }

--- a/src/plugins/fontWeight.js
+++ b/src/plugins/fontWeight.js
@@ -1,18 +1,14 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('fontWeight'), (value, modifier) => {
-        return [
-          `.${e(`font-${modifier}`)}`,
-          {
-            'font-weight': value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(theme('fontWeight'), (value, modifier) => [
+      `.${e(`font-${modifier}`)}`,
+      {
+        'font-weight': value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('fontWeight'))
-  }
+  addUtilities(utilities, variants('fontWeight'))
 }

--- a/src/plugins/height.js
+++ b/src/plugins/height.js
@@ -1,18 +1,14 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('height'), (value, modifier) => {
-        return [
-          `.${e(`h-${modifier}`)}`,
-          {
-            height: value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(theme('height'), (value, modifier) => [
+      `.${e(`h-${modifier}`)}`,
+      {
+        height: value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('height'))
-  }
+  addUtilities(utilities, variants('height'))
 }

--- a/src/plugins/inset.js
+++ b/src/plugins/inset.js
@@ -1,32 +1,28 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const generators = [
-      (size, modifier) => ({
-        [`.${e(`inset-${modifier}`)}`]: {
-          top: `${size}`,
-          right: `${size}`,
-          bottom: `${size}`,
-          left: `${size}`,
-        },
-      }),
-      (size, modifier) => ({
-        [`.${e(`inset-y-${modifier}`)}`]: { top: `${size}`, bottom: `${size}` },
-        [`.${e(`inset-x-${modifier}`)}`]: { right: `${size}`, left: `${size}` },
-      }),
-      (size, modifier) => ({
-        [`.${e(`top-${modifier}`)}`]: { top: `${size}` },
-        [`.${e(`right-${modifier}`)}`]: { right: `${size}` },
-        [`.${e(`bottom-${modifier}`)}`]: { bottom: `${size}` },
-        [`.${e(`left-${modifier}`)}`]: { left: `${size}` },
-      }),
-    ]
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const generators = [
+    (size, modifier) => ({
+      [`.${e(`inset-${modifier}`)}`]: {
+        top: `${size}`,
+        right: `${size}`,
+        bottom: `${size}`,
+        left: `${size}`,
+      },
+    }),
+    (size, modifier) => ({
+      [`.${e(`inset-y-${modifier}`)}`]: { top: `${size}`, bottom: `${size}` },
+      [`.${e(`inset-x-${modifier}`)}`]: { right: `${size}`, left: `${size}` },
+    }),
+    (size, modifier) => ({
+      [`.${e(`top-${modifier}`)}`]: { top: `${size}` },
+      [`.${e(`right-${modifier}`)}`]: { right: `${size}` },
+      [`.${e(`bottom-${modifier}`)}`]: { bottom: `${size}` },
+      [`.${e(`left-${modifier}`)}`]: { left: `${size}` },
+    }),
+  ]
 
-    const utilities = _.flatMap(generators, generator => {
-      return _.flatMap(theme('inset'), generator)
-    })
+  const utilities = _.flatMap(generators, generator => _.flatMap(theme('inset'), generator))
 
-    addUtilities(utilities, variants('inset'))
-  }
+  addUtilities(utilities, variants('inset'))
 }

--- a/src/plugins/justifyContent.js
+++ b/src/plugins/justifyContent.js
@@ -1,24 +1,22 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.justify-start': {
-          'justify-content': 'flex-start',
-        },
-        '.justify-end': {
-          'justify-content': 'flex-end',
-        },
-        '.justify-center': {
-          'justify-content': 'center',
-        },
-        '.justify-between': {
-          'justify-content': 'space-between',
-        },
-        '.justify-around': {
-          'justify-content': 'space-around',
-        },
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.justify-start': {
+        'justify-content': 'flex-start',
       },
-      variants('justifyContent')
-    )
-  }
+      '.justify-end': {
+        'justify-content': 'flex-end',
+      },
+      '.justify-center': {
+        'justify-content': 'center',
+      },
+      '.justify-between': {
+        'justify-content': 'space-between',
+      },
+      '.justify-around': {
+        'justify-content': 'space-around',
+      },
+    },
+    variants('justifyContent')
+  )
 }

--- a/src/plugins/letterSpacing.js
+++ b/src/plugins/letterSpacing.js
@@ -1,18 +1,14 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, theme, variants, e }) {
-    const utilities = _.fromPairs(
-      _.map(theme('letterSpacing'), (value, modifier) => {
-        return [
-          `.${e(`tracking-${modifier}`)}`,
-          {
-            'letter-spacing': value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(theme('letterSpacing'), (value, modifier) => [
+      `.${e(`tracking-${modifier}`)}`,
+      {
+        'letter-spacing': value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('letterSpacing'))
-  }
+  addUtilities(utilities, variants('letterSpacing'))
 }

--- a/src/plugins/lineHeight.js
+++ b/src/plugins/lineHeight.js
@@ -1,18 +1,14 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('lineHeight'), (value, modifier) => {
-        return [
-          `.${e(`leading-${modifier}`)}`,
-          {
-            'line-height': value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(theme('lineHeight'), (value, modifier) => [
+      `.${e(`leading-${modifier}`)}`,
+      {
+        'line-height': value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('lineHeight'))
-  }
+  addUtilities(utilities, variants('lineHeight'))
 }

--- a/src/plugins/listStylePosition.js
+++ b/src/plugins/listStylePosition.js
@@ -1,11 +1,9 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.list-inside': { 'list-style-position': 'inside' },
-        '.list-outside': { 'list-style-position': 'outside' },
-      },
-      variants('listStylePosition')
-    )
-  }
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.list-inside': { 'list-style-position': 'inside' },
+      '.list-outside': { 'list-style-position': 'outside' },
+    },
+    variants('listStylePosition')
+  )
 }

--- a/src/plugins/listStyleType.js
+++ b/src/plugins/listStyleType.js
@@ -1,18 +1,14 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('listStyleType'), (value, modifier) => {
-        return [
-          `.${e(`list-${modifier}`)}`,
-          {
-            'list-style-type': value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(theme('listStyleType'), (value, modifier) => [
+      `.${e(`list-${modifier}`)}`,
+      {
+        'list-style-type': value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('listStyleType'))
-  }
+  addUtilities(utilities, variants('listStyleType'))
 }

--- a/src/plugins/margin.js
+++ b/src/plugins/margin.js
@@ -1,27 +1,23 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const generators = [
-      (size, modifier) => ({
-        [`.${e(`m-${modifier}`)}`]: { margin: `${size}` },
-      }),
-      (size, modifier) => ({
-        [`.${e(`my-${modifier}`)}`]: { 'margin-top': `${size}`, 'margin-bottom': `${size}` },
-        [`.${e(`mx-${modifier}`)}`]: { 'margin-left': `${size}`, 'margin-right': `${size}` },
-      }),
-      (size, modifier) => ({
-        [`.${e(`mt-${modifier}`)}`]: { 'margin-top': `${size}` },
-        [`.${e(`mr-${modifier}`)}`]: { 'margin-right': `${size}` },
-        [`.${e(`mb-${modifier}`)}`]: { 'margin-bottom': `${size}` },
-        [`.${e(`ml-${modifier}`)}`]: { 'margin-left': `${size}` },
-      }),
-    ]
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const generators = [
+    (size, modifier) => ({
+      [`.${e(`m-${modifier}`)}`]: { margin: `${size}` },
+    }),
+    (size, modifier) => ({
+      [`.${e(`my-${modifier}`)}`]: { 'margin-top': `${size}`, 'margin-bottom': `${size}` },
+      [`.${e(`mx-${modifier}`)}`]: { 'margin-left': `${size}`, 'margin-right': `${size}` },
+    }),
+    (size, modifier) => ({
+      [`.${e(`mt-${modifier}`)}`]: { 'margin-top': `${size}` },
+      [`.${e(`mr-${modifier}`)}`]: { 'margin-right': `${size}` },
+      [`.${e(`mb-${modifier}`)}`]: { 'margin-bottom': `${size}` },
+      [`.${e(`ml-${modifier}`)}`]: { 'margin-left': `${size}` },
+    }),
+  ]
 
-    const utilities = _.flatMap(generators, generator => {
-      return _.flatMap(theme('margin'), generator)
-    })
+  const utilities = _.flatMap(generators, generator => _.flatMap(theme('margin'), generator))
 
-    addUtilities(utilities, variants('margin'))
-  }
+  addUtilities(utilities, variants('margin'))
 }

--- a/src/plugins/maxHeight.js
+++ b/src/plugins/maxHeight.js
@@ -1,18 +1,14 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('maxHeight'), (value, modifier) => {
-        return [
-          `.${e(`max-h-${modifier}`)}`,
-          {
-            'max-height': value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(theme('maxHeight'), (value, modifier) => [
+      `.${e(`max-h-${modifier}`)}`,
+      {
+        'max-height': value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('maxHeight'))
-  }
+  addUtilities(utilities, variants('maxHeight'))
 }

--- a/src/plugins/maxWidth.js
+++ b/src/plugins/maxWidth.js
@@ -1,18 +1,14 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('maxWidth'), (value, modifier) => {
-        return [
-          `.${e(`max-w-${modifier}`)}`,
-          {
-            'max-width': value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(theme('maxWidth'), (value, modifier) => [
+      `.${e(`max-w-${modifier}`)}`,
+      {
+        'max-width': value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('maxWidth'))
-  }
+  addUtilities(utilities, variants('maxWidth'))
 }

--- a/src/plugins/minHeight.js
+++ b/src/plugins/minHeight.js
@@ -1,18 +1,14 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('minHeight'), (value, modifier) => {
-        return [
-          `.${e(`min-h-${modifier}`)}`,
-          {
-            'min-height': value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(theme('minHeight'), (value, modifier) => [
+      `.${e(`min-h-${modifier}`)}`,
+      {
+        'min-height': value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('minHeight'))
-  }
+  addUtilities(utilities, variants('minHeight'))
 }

--- a/src/plugins/minWidth.js
+++ b/src/plugins/minWidth.js
@@ -1,18 +1,14 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('minWidth'), (value, modifier) => {
-        return [
-          `.${e(`min-w-${modifier}`)}`,
-          {
-            'min-width': value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(theme('minWidth'), (value, modifier) => [
+      `.${e(`min-w-${modifier}`)}`,
+      {
+        'min-width': value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('minWidth'))
-  }
+  addUtilities(utilities, variants('minWidth'))
 }

--- a/src/plugins/negativeMargin.js
+++ b/src/plugins/negativeMargin.js
@@ -1,29 +1,27 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const generators = [
-      (size, modifier) => ({
-        [`.${e(`-m-${modifier}`)}`]: { margin: `${size}` },
-      }),
-      (size, modifier) => ({
-        [`.${e(`-my-${modifier}`)}`]: { 'margin-top': `${size}`, 'margin-bottom': `${size}` },
-        [`.${e(`-mx-${modifier}`)}`]: { 'margin-left': `${size}`, 'margin-right': `${size}` },
-      }),
-      (size, modifier) => ({
-        [`.${e(`-mt-${modifier}`)}`]: { 'margin-top': `${size}` },
-        [`.${e(`-mr-${modifier}`)}`]: { 'margin-right': `${size}` },
-        [`.${e(`-mb-${modifier}`)}`]: { 'margin-bottom': `${size}` },
-        [`.${e(`-ml-${modifier}`)}`]: { 'margin-left': `${size}` },
-      }),
-    ]
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const generators = [
+    (size, modifier) => ({
+      [`.${e(`-m-${modifier}`)}`]: { margin: `${size}` },
+    }),
+    (size, modifier) => ({
+      [`.${e(`-my-${modifier}`)}`]: { 'margin-top': `${size}`, 'margin-bottom': `${size}` },
+      [`.${e(`-mx-${modifier}`)}`]: { 'margin-left': `${size}`, 'margin-right': `${size}` },
+    }),
+    (size, modifier) => ({
+      [`.${e(`-mt-${modifier}`)}`]: { 'margin-top': `${size}` },
+      [`.${e(`-mr-${modifier}`)}`]: { 'margin-right': `${size}` },
+      [`.${e(`-mb-${modifier}`)}`]: { 'margin-bottom': `${size}` },
+      [`.${e(`-ml-${modifier}`)}`]: { 'margin-left': `${size}` },
+    }),
+  ]
 
-    const utilities = _.flatMap(generators, generator => {
-      return _.flatMap(theme('negativeMargin'), (size, modifier) => {
-        return generator(`${size}` === '0' ? `${size}` : `-${size}`, modifier)
-      })
-    })
+  const utilities = _.flatMap(generators, generator =>
+    _.flatMap(theme('negativeMargin'), (size, modifier) =>
+      generator(`${size}` === '0' ? `${size}` : `-${size}`, modifier)
+    )
+  )
 
-    addUtilities(utilities, variants('negativeMargin'))
-  }
+  addUtilities(utilities, variants('negativeMargin'))
 }

--- a/src/plugins/objectFit.js
+++ b/src/plugins/objectFit.js
@@ -1,14 +1,12 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.object-contain': { 'object-fit': 'contain' },
-        '.object-cover': { 'object-fit': 'cover' },
-        '.object-fill': { 'object-fit': 'fill' },
-        '.object-none': { 'object-fit': 'none' },
-        '.object-scale-down': { 'object-fit': 'scale-down' },
-      },
-      variants('objectFit')
-    )
-  }
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.object-contain': { 'object-fit': 'contain' },
+      '.object-cover': { 'object-fit': 'cover' },
+      '.object-fill': { 'object-fit': 'fill' },
+      '.object-none': { 'object-fit': 'none' },
+      '.object-scale-down': { 'object-fit': 'scale-down' },
+    },
+    variants('objectFit')
+  )
 }

--- a/src/plugins/objectPosition.js
+++ b/src/plugins/objectPosition.js
@@ -1,18 +1,14 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('objectPosition'), (value, modifier) => {
-        return [
-          `.${e(`object-${modifier}`)}`,
-          {
-            'object-position': value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(theme('objectPosition'), (value, modifier) => [
+      `.${e(`object-${modifier}`)}`,
+      {
+        'object-position': value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('objectPosition'))
-  }
+  addUtilities(utilities, variants('objectPosition'))
 }

--- a/src/plugins/opacity.js
+++ b/src/plugins/opacity.js
@@ -1,18 +1,14 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('opacity'), (value, modifier) => {
-        return [
-          `.${e(`opacity-${modifier}`)}`,
-          {
-            opacity: value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(theme('opacity'), (value, modifier) => [
+      `.${e(`opacity-${modifier}`)}`,
+      {
+        opacity: value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('opacity'))
-  }
+  addUtilities(utilities, variants('opacity'))
 }

--- a/src/plugins/outline.js
+++ b/src/plugins/outline.js
@@ -1,10 +1,8 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.outline-none': { outline: '0' },
-      },
-      variants('outline')
-    )
-  }
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.outline-none': { outline: '0' },
+    },
+    variants('outline')
+  )
 }

--- a/src/plugins/overflow.js
+++ b/src/plugins/overflow.js
@@ -1,23 +1,21 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.overflow-auto': { overflow: 'auto' },
-        '.overflow-hidden': { overflow: 'hidden' },
-        '.overflow-visible': { overflow: 'visible' },
-        '.overflow-scroll': { overflow: 'scroll' },
-        '.overflow-x-auto': { 'overflow-x': 'auto' },
-        '.overflow-y-auto': { 'overflow-y': 'auto' },
-        '.overflow-x-hidden': { 'overflow-x': 'hidden' },
-        '.overflow-y-hidden': { 'overflow-y': 'hidden' },
-        '.overflow-x-visible': { 'overflow-x': 'visible' },
-        '.overflow-y-visible': { 'overflow-y': 'visible' },
-        '.overflow-x-scroll': { 'overflow-x': 'scroll' },
-        '.overflow-y-scroll': { 'overflow-y': 'scroll' },
-        '.scrolling-touch': { '-webkit-overflow-scrolling': 'touch' },
-        '.scrolling-auto': { '-webkit-overflow-scrolling': 'auto' },
-      },
-      variants('overflow')
-    )
-  }
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.overflow-auto': { overflow: 'auto' },
+      '.overflow-hidden': { overflow: 'hidden' },
+      '.overflow-visible': { overflow: 'visible' },
+      '.overflow-scroll': { overflow: 'scroll' },
+      '.overflow-x-auto': { 'overflow-x': 'auto' },
+      '.overflow-y-auto': { 'overflow-y': 'auto' },
+      '.overflow-x-hidden': { 'overflow-x': 'hidden' },
+      '.overflow-y-hidden': { 'overflow-y': 'hidden' },
+      '.overflow-x-visible': { 'overflow-x': 'visible' },
+      '.overflow-y-visible': { 'overflow-y': 'visible' },
+      '.overflow-x-scroll': { 'overflow-x': 'scroll' },
+      '.overflow-y-scroll': { 'overflow-y': 'scroll' },
+      '.scrolling-touch': { '-webkit-overflow-scrolling': 'touch' },
+      '.scrolling-auto': { '-webkit-overflow-scrolling': 'auto' },
+    },
+    variants('overflow')
+  )
 }

--- a/src/plugins/padding.js
+++ b/src/plugins/padding.js
@@ -1,27 +1,23 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const generators = [
-      (size, modifier) => ({
-        [`.${e(`p-${modifier}`)}`]: { padding: `${size}` },
-      }),
-      (size, modifier) => ({
-        [`.${e(`py-${modifier}`)}`]: { 'padding-top': `${size}`, 'padding-bottom': `${size}` },
-        [`.${e(`px-${modifier}`)}`]: { 'padding-left': `${size}`, 'padding-right': `${size}` },
-      }),
-      (size, modifier) => ({
-        [`.${e(`pt-${modifier}`)}`]: { 'padding-top': `${size}` },
-        [`.${e(`pr-${modifier}`)}`]: { 'padding-right': `${size}` },
-        [`.${e(`pb-${modifier}`)}`]: { 'padding-bottom': `${size}` },
-        [`.${e(`pl-${modifier}`)}`]: { 'padding-left': `${size}` },
-      }),
-    ]
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const generators = [
+    (size, modifier) => ({
+      [`.${e(`p-${modifier}`)}`]: { padding: `${size}` },
+    }),
+    (size, modifier) => ({
+      [`.${e(`py-${modifier}`)}`]: { 'padding-top': `${size}`, 'padding-bottom': `${size}` },
+      [`.${e(`px-${modifier}`)}`]: { 'padding-left': `${size}`, 'padding-right': `${size}` },
+    }),
+    (size, modifier) => ({
+      [`.${e(`pt-${modifier}`)}`]: { 'padding-top': `${size}` },
+      [`.${e(`pr-${modifier}`)}`]: { 'padding-right': `${size}` },
+      [`.${e(`pb-${modifier}`)}`]: { 'padding-bottom': `${size}` },
+      [`.${e(`pl-${modifier}`)}`]: { 'padding-left': `${size}` },
+    }),
+  ]
 
-    const utilities = _.flatMap(generators, generator => {
-      return _.flatMap(theme('padding'), generator)
-    })
+  const utilities = _.flatMap(generators, generator => _.flatMap(theme('padding'), generator))
 
-    addUtilities(utilities, variants('padding'))
-  }
+  addUtilities(utilities, variants('padding'))
 }

--- a/src/plugins/pointerEvents.js
+++ b/src/plugins/pointerEvents.js
@@ -1,11 +1,9 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.pointer-events-none': { 'pointer-events': 'none' },
-        '.pointer-events-auto': { 'pointer-events': 'auto' },
-      },
-      variants('pointerEvents')
-    )
-  }
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.pointer-events-none': { 'pointer-events': 'none' },
+      '.pointer-events-auto': { 'pointer-events': 'auto' },
+    },
+    variants('pointerEvents')
+  )
 }

--- a/src/plugins/position.js
+++ b/src/plugins/position.js
@@ -1,14 +1,12 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.static': { position: 'static' },
-        '.fixed': { position: 'fixed' },
-        '.absolute': { position: 'absolute' },
-        '.relative': { position: 'relative' },
-        '.sticky': { position: 'sticky' },
-      },
-      variants('position')
-    )
-  }
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.static': { position: 'static' },
+      '.fixed': { position: 'fixed' },
+      '.absolute': { position: 'absolute' },
+      '.relative': { position: 'relative' },
+      '.sticky': { position: 'sticky' },
+    },
+    variants('position')
+  )
 }

--- a/src/plugins/preflight.js
+++ b/src/plugins/preflight.js
@@ -1,10 +1,9 @@
 import fs from 'fs'
 import postcss from 'postcss'
 
-export default function() {
-  return function({ addBase }) {
-    const normalizeStyles = postcss.parse(fs.readFileSync(require.resolve('normalize.css'), 'utf8'))
-    const preflightStyles = postcss.parse(fs.readFileSync(`${__dirname}/css/preflight.css`, 'utf8'))
-    addBase([...normalizeStyles.nodes, ...preflightStyles.nodes])
-  }
+export default () => ({ addBase }) => {
+  const normalizeStyles = postcss.parse(fs.readFileSync(require.resolve('normalize.css'), 'utf8'))
+  const preflightStyles = postcss.parse(fs.readFileSync(`${__dirname}/css/preflight.css`, 'utf8'))
+
+  addBase([...normalizeStyles.nodes, ...preflightStyles.nodes])
 }

--- a/src/plugins/resize.js
+++ b/src/plugins/resize.js
@@ -1,13 +1,11 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.resize-none': { resize: 'none' },
-        '.resize-y': { resize: 'vertical' },
-        '.resize-x': { resize: 'horizontal' },
-        '.resize': { resize: 'both' },
-      },
-      variants('resize')
-    )
-  }
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.resize-none': { resize: 'none' },
+      '.resize-y': { resize: 'vertical' },
+      '.resize-x': { resize: 'horizontal' },
+      '.resize': { resize: 'both' },
+    },
+    variants('resize')
+  )
 }

--- a/src/plugins/stroke.js
+++ b/src/plugins/stroke.js
@@ -1,19 +1,15 @@
 import _ from 'lodash'
 import flattenColorPalette from '../util/flattenColorPalette'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(flattenColorPalette(theme('stroke')), (value, modifier) => {
-        return [
-          `.${e(`stroke-${modifier}`)}`,
-          {
-            stroke: value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(flattenColorPalette(theme('stroke')), (value, modifier) => [
+      `.${e(`stroke-${modifier}`)}`,
+      {
+        stroke: value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('stroke'))
-  }
+  addUtilities(utilities, variants('stroke'))
 }

--- a/src/plugins/tableLayout.js
+++ b/src/plugins/tableLayout.js
@@ -1,11 +1,9 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.table-auto': { 'table-layout': 'auto' },
-        '.table-fixed': { 'table-layout': 'fixed' },
-      },
-      variants('tableLayout')
-    )
-  }
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.table-auto': { 'table-layout': 'auto' },
+      '.table-fixed': { 'table-layout': 'fixed' },
+    },
+    variants('tableLayout')
+  )
 }

--- a/src/plugins/textAlign.js
+++ b/src/plugins/textAlign.js
@@ -1,13 +1,11 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.text-left': { 'text-align': 'left' },
-        '.text-center': { 'text-align': 'center' },
-        '.text-right': { 'text-align': 'right' },
-        '.text-justify': { 'text-align': 'justify' },
-      },
-      variants('textAlign')
-    )
-  }
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.text-left': { 'text-align': 'left' },
+      '.text-center': { 'text-align': 'center' },
+      '.text-right': { 'text-align': 'right' },
+      '.text-justify': { 'text-align': 'justify' },
+    },
+    variants('textAlign')
+  )
 }

--- a/src/plugins/textColor.js
+++ b/src/plugins/textColor.js
@@ -1,19 +1,15 @@
 import _ from 'lodash'
 import flattenColorPalette from '../util/flattenColorPalette'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(flattenColorPalette(theme('textColor')), (value, modifier) => {
-        return [
-          `.${e(`text-${modifier}`)}`,
-          {
-            color: value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(flattenColorPalette(theme('textColor')), (value, modifier) => [
+      `.${e(`text-${modifier}`)}`,
+      {
+        color: value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('textColor'))
-  }
+  addUtilities(utilities, variants('textColor'))
 }

--- a/src/plugins/textDecoration.js
+++ b/src/plugins/textDecoration.js
@@ -1,12 +1,10 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.underline': { 'text-decoration': 'underline' },
-        '.line-through': { 'text-decoration': 'line-through' },
-        '.no-underline': { 'text-decoration': 'none' },
-      },
-      variants('textDecoration')
-    )
-  }
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.underline': { 'text-decoration': 'underline' },
+      '.line-through': { 'text-decoration': 'line-through' },
+      '.no-underline': { 'text-decoration': 'none' },
+    },
+    variants('textDecoration')
+  )
 }

--- a/src/plugins/textTransform.js
+++ b/src/plugins/textTransform.js
@@ -1,13 +1,11 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.uppercase': { 'text-transform': 'uppercase' },
-        '.lowercase': { 'text-transform': 'lowercase' },
-        '.capitalize': { 'text-transform': 'capitalize' },
-        '.normal-case': { 'text-transform': 'none' },
-      },
-      variants('textTransform')
-    )
-  }
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.uppercase': { 'text-transform': 'uppercase' },
+      '.lowercase': { 'text-transform': 'lowercase' },
+      '.capitalize': { 'text-transform': 'capitalize' },
+      '.normal-case': { 'text-transform': 'none' },
+    },
+    variants('textTransform')
+  )
 }

--- a/src/plugins/userSelect.js
+++ b/src/plugins/userSelect.js
@@ -1,11 +1,9 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.select-none': { 'user-select': 'none' },
-        '.select-text': { 'user-select': 'text' },
-      },
-      variants('userSelect')
-    )
-  }
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.select-none': { 'user-select': 'none' },
+      '.select-text': { 'user-select': 'text' },
+    },
+    variants('userSelect')
+  )
 }

--- a/src/plugins/verticalAlign.js
+++ b/src/plugins/verticalAlign.js
@@ -1,15 +1,13 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.align-baseline': { 'vertical-align': 'baseline' },
-        '.align-top': { 'vertical-align': 'top' },
-        '.align-middle': { 'vertical-align': 'middle' },
-        '.align-bottom': { 'vertical-align': 'bottom' },
-        '.align-text-top': { 'vertical-align': 'text-top' },
-        '.align-text-bottom': { 'vertical-align': 'text-bottom' },
-      },
-      variants('verticalAlign')
-    )
-  }
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.align-baseline': { 'vertical-align': 'baseline' },
+      '.align-top': { 'vertical-align': 'top' },
+      '.align-middle': { 'vertical-align': 'middle' },
+      '.align-bottom': { 'vertical-align': 'bottom' },
+      '.align-text-top': { 'vertical-align': 'text-top' },
+      '.align-text-bottom': { 'vertical-align': 'text-bottom' },
+    },
+    variants('verticalAlign')
+  )
 }

--- a/src/plugins/visibility.js
+++ b/src/plugins/visibility.js
@@ -1,11 +1,9 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.visible': { visibility: 'visible' },
-        '.invisible': { visibility: 'hidden' },
-      },
-      variants('visibility')
-    )
-  }
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.visible': { visibility: 'visible' },
+      '.invisible': { visibility: 'hidden' },
+    },
+    variants('visibility')
+  )
 }

--- a/src/plugins/whitespace.js
+++ b/src/plugins/whitespace.js
@@ -1,14 +1,12 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.whitespace-normal': { 'white-space': 'normal' },
-        '.whitespace-no-wrap': { 'white-space': 'nowrap' },
-        '.whitespace-pre': { 'white-space': 'pre' },
-        '.whitespace-pre-line': { 'white-space': 'pre-line' },
-        '.whitespace-pre-wrap': { 'white-space': 'pre-wrap' },
-      },
-      variants('whitespace')
-    )
-  }
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.whitespace-normal': { 'white-space': 'normal' },
+      '.whitespace-no-wrap': { 'white-space': 'nowrap' },
+      '.whitespace-pre': { 'white-space': 'pre' },
+      '.whitespace-pre-line': { 'white-space': 'pre-line' },
+      '.whitespace-pre-wrap': { 'white-space': 'pre-wrap' },
+    },
+    variants('whitespace')
+  )
 }

--- a/src/plugins/width.js
+++ b/src/plugins/width.js
@@ -1,18 +1,14 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('width'), (value, modifier) => {
-        return [
-          `.${e(`w-${modifier}`)}`,
-          {
-            width: value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, e, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(theme('width'), (value, modifier) => [
+      `.${e(`w-${modifier}`)}`,
+      {
+        width: value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('width'))
-  }
+  addUtilities(utilities, variants('width'))
 }

--- a/src/plugins/wordBreak.js
+++ b/src/plugins/wordBreak.js
@@ -1,21 +1,19 @@
-export default function() {
-  return function({ addUtilities, variants }) {
-    addUtilities(
-      {
-        '.break-normal': {
-          'overflow-wrap': 'normal',
-          'word-break': 'normal',
-        },
-        '.break-words': { 'overflow-wrap': 'break-word' },
-        '.break-all': { 'word-break': 'break-all' },
-
-        '.truncate': {
-          overflow: 'hidden',
-          'text-overflow': 'ellipsis',
-          'white-space': 'nowrap',
-        },
+export default () => ({ addUtilities, variants }) => {
+  addUtilities(
+    {
+      '.break-normal': {
+        'overflow-wrap': 'normal',
+        'word-break': 'normal',
       },
-      variants('wordBreak')
-    )
-  }
+      '.break-words': { 'overflow-wrap': 'break-word' },
+      '.break-all': { 'word-break': 'break-all' },
+
+      '.truncate': {
+        overflow: 'hidden',
+        'text-overflow': 'ellipsis',
+        'white-space': 'nowrap',
+      },
+    },
+    variants('wordBreak')
+  )
 }

--- a/src/plugins/zIndex.js
+++ b/src/plugins/zIndex.js
@@ -1,18 +1,14 @@
 import _ from 'lodash'
 
-export default function() {
-  return function({ addUtilities, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('zIndex'), (value, modifier) => {
-        return [
-          `.z-${modifier}`,
-          {
-            'z-index': value,
-          },
-        ]
-      })
-    )
+export default () => ({ addUtilities, theme, variants }) => {
+  const utilities = _.fromPairs(
+    _.map(theme('zIndex'), (value, modifier) => [
+      `.z-${modifier}`,
+      {
+        'z-index': value,
+      },
+    ])
+  )
 
-    addUtilities(utilities, variants('zIndex'))
-  }
+  addUtilities(utilities, variants('zIndex'))
 }

--- a/src/processTailwindFeatures.js
+++ b/src/processTailwindFeatures.js
@@ -11,18 +11,16 @@ import substituteClassApplyAtRules from './lib/substituteClassApplyAtRules'
 import corePlugins from './corePlugins'
 import processPlugins from './util/processPlugins'
 
-export default function(getConfig) {
-  return function(css) {
-    const config = getConfig()
-    const processedPlugins = processPlugins([...corePlugins(config), ...config.plugins], config)
+export default getConfig => css => {
+  const config = getConfig()
+  const processedPlugins = processPlugins([...corePlugins(config), ...config.plugins], config)
 
-    return postcss([
-      substituteTailwindAtRules(config, processedPlugins),
-      evaluateTailwindFunctions(config),
-      substituteVariantsAtRules(config, processedPlugins),
-      substituteResponsiveAtRules(config),
-      substituteScreenAtRules(config),
-      substituteClassApplyAtRules(config, processedPlugins.utilities),
-    ]).process(css, { from: _.get(css, 'source.input.file') })
-  }
+  return postcss([
+    substituteTailwindAtRules(config, processedPlugins),
+    evaluateTailwindFunctions(config),
+    substituteVariantsAtRules(config, processedPlugins),
+    substituteResponsiveAtRules(config),
+    substituteScreenAtRules(config),
+    substituteClassApplyAtRules(config, processedPlugins.utilities),
+  ]).process(css, { from: _.get(css, 'source.input.file') })
 }

--- a/src/util/buildMediaQuery.js
+++ b/src/util/buildMediaQuery.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 
-export default function buildMediaQuery(screens) {
+export default screens => {
   if (_.isString(screens)) {
     screens = { min: screens }
   }

--- a/src/util/buildSelectorVariant.js
+++ b/src/util/buildSelectorVariant.js
@@ -1,8 +1,8 @@
 import parser from 'postcss-selector-parser'
 import tap from 'lodash/tap'
 
-export default function buildSelectorVariant(selector, variantName, separator, onError = () => {}) {
-  return parser(selectors => {
+export default (selector, variantName, separator, onError = () => {}) =>
+  parser(selectors => {
     tap(selectors.first.filter(({ type }) => type === 'class').pop(), classSelector => {
       if (classSelector === undefined) {
         onError('Variant cannot be generated because selector contains no classes.')
@@ -12,4 +12,3 @@ export default function buildSelectorVariant(selector, variantName, separator, o
       classSelector.value = `${variantName}${separator}${classSelector.value}`
     })
   }).processSync(selector)
-}

--- a/src/util/cloneNodes.js
+++ b/src/util/cloneNodes.js
@@ -1,5 +1,3 @@
 import _ from 'lodash'
 
-export default function cloneNodes(nodes) {
-  return _.map(nodes, node => node.clone())
-}
+export default nodes => _.map(nodes, node => node.clone())

--- a/src/util/configurePlugins.js
+++ b/src/util/configurePlugins.js
@@ -1,9 +1,9 @@
-export default function(pluginConfig, plugins) {
+export default (pluginConfig, plugins) => {
   const pluginNames = Array.isArray(pluginConfig)
     ? pluginConfig
-    : Object.keys(plugins).filter(pluginName => {
-        return pluginConfig !== false && pluginConfig[pluginName] !== false
-      })
+    : Object.keys(plugins).filter(
+        pluginName => pluginConfig !== false && pluginConfig[pluginName] !== false
+      )
 
   return pluginNames.map(pluginName => plugins[pluginName]())
 }

--- a/src/util/escapeClassName.js
+++ b/src/util/escapeClassName.js
@@ -1,8 +1,9 @@
-import parser from 'postcss-selector-parser'
 import get from 'lodash/get'
+import parser from 'postcss-selector-parser'
 
-export default function escapeClassName(className) {
+export default className => {
   const node = parser.className()
   node.value = className
+
   return get(node, 'raws.value', node.value)
 }

--- a/src/util/flattenColorPalette.js
+++ b/src/util/flattenColorPalette.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 
-export default function flattenColorPalette(colors) {
-  const result = _(colors)
+export default colors =>
+  _(colors)
     .flatMap((color, name) => {
       if (!_.isObject(color)) {
         return [[name, color]]
@@ -9,11 +9,9 @@ export default function flattenColorPalette(colors) {
 
       return _.map(color, (value, key) => {
         const suffix = key === 'default' ? '' : `-${key}`
+
         return [`${name}${suffix}`, value]
       })
     })
     .fromPairs()
     .value()
-
-  return result
-}

--- a/src/util/generateVariantFunction.js
+++ b/src/util/generateVariantFunction.js
@@ -2,33 +2,32 @@ import _ from 'lodash'
 import postcss from 'postcss'
 import selectorParser from 'postcss-selector-parser'
 
-export default function generateVariantFunction(generator) {
-  return (container, config) => {
-    const cloned = postcss.root({ nodes: container.clone().nodes })
+export default generator => (container, config) => {
+  const cloned = postcss.root({ nodes: container.clone().nodes })
 
-    container.before(
-      _.defaultTo(
-        generator({
-          container: cloned,
-          separator: config.separator,
-          modifySelectors: modifierFunction => {
-            cloned.walkRules(rule => {
-              rule.selectors = rule.selectors.map(selector => {
-                const className = selectorParser(selectors => {
-                  return selectors.first.filter(({ type }) => type === 'class').pop().value
-                }).transformSync(selector)
+  container.before(
+    _.defaultTo(
+      generator({
+        container: cloned,
+        separator: config.separator,
+        modifySelectors: modifierFunction => {
+          cloned.walkRules(rule => {
+            rule.selectors = rule.selectors.map(selector => {
+              const className = selectorParser(
+                selectors => selectors.first.filter(({ type }) => type === 'class').pop().value
+              ).transformSync(selector)
 
-                return modifierFunction({
-                  className,
-                  selector,
-                })
+              return modifierFunction({
+                className,
+                selector,
               })
             })
-            return cloned
-          },
-        }),
-        cloned
-      ).nodes
-    )
-  }
+          })
+
+          return cloned
+        },
+      }),
+      cloned
+    ).nodes
+  )
 }

--- a/src/util/parseObjectStyles.js
+++ b/src/util/parseObjectStyles.js
@@ -3,7 +3,7 @@ import postcss from 'postcss'
 import postcssNested from 'postcss-nested'
 import postcssJs from 'postcss-js'
 
-export default function parseObjectStyles(styles) {
+const parseObjectStyles = styles => {
   if (!Array.isArray(styles)) {
     return parseObjectStyles([styles])
   }
@@ -13,3 +13,5 @@ export default function parseObjectStyles(styles) {
     style => postcss([postcssNested]).process(style, { parser: postcssJs }).root.nodes
   )
 }
+
+export default parseObjectStyles

--- a/src/util/prefixSelector.js
+++ b/src/util/prefixSelector.js
@@ -1,7 +1,7 @@
 import parser from 'postcss-selector-parser'
 import tap from 'lodash/tap'
 
-export default function(prefix, selector) {
+export default (prefix, selector) => {
   const getPrefix = typeof prefix === 'function' ? prefix : () => prefix
 
   return parser(selectors => {

--- a/src/util/processPlugins.js
+++ b/src/util/processPlugins.js
@@ -7,7 +7,7 @@ import parseObjectStyles from '../util/parseObjectStyles'
 import prefixSelector from '../util/prefixSelector'
 import wrapWithVariants from '../util/wrapWithVariants'
 
-function parseStyles(styles) {
+const parseStyles = styles => {
   if (!Array.isArray(styles)) {
     return parseStyles([styles])
   }
@@ -15,15 +15,14 @@ function parseStyles(styles) {
   return _.flatMap(styles, style => (style instanceof Node ? style : parseObjectStyles(style)))
 }
 
-export default function(plugins, config) {
+export default (plugins, config) => {
   const pluginBaseStyles = []
   const pluginComponents = []
   const pluginUtilities = []
   const pluginVariantGenerators = {}
 
-  const applyConfiguredPrefix = selector => {
-    return prefixSelector(config.prefix, selector)
-  }
+  const applyConfiguredPrefix = selector => prefixSelector(config.prefix, selector)
+
   const getConfigValue = (path, defaultValue) => _.get(config, path, defaultValue)
 
   plugins.forEach(plugin => {

--- a/src/util/resolveConfig.js
+++ b/src/util/resolveConfig.js
@@ -4,12 +4,11 @@ import defaults from 'lodash/defaults'
 import map from 'lodash/map'
 import get from 'lodash/get'
 
-function value(valueToResolve, ...args) {
-  return isFunction(valueToResolve) ? valueToResolve(...args) : valueToResolve
-}
+const value = (valueToResolve, ...args) =>
+  isFunction(valueToResolve) ? valueToResolve(...args) : valueToResolve
 
-function mergeExtensions({ extend, ...theme }) {
-  return mergeWith(theme, extend, (themeValue, extensions) => {
+const mergeExtensions = ({ extend, ...theme }) =>
+  mergeWith(theme, extend, (themeValue, extensions) => {
     if (!isFunction(themeValue) && !isFunction(extensions)) {
       return {
         ...themeValue,
@@ -22,28 +21,27 @@ function mergeExtensions({ extend, ...theme }) {
       ...value(extensions, resolveThemePath),
     })
   })
-}
 
-function resolveFunctionKeys(object) {
+const resolveFunctionKeys = object => {
   const resolveObjectPath = (key, defaultValue) => {
     const val = get(object, key, defaultValue)
     return isFunction(val) ? val(resolveObjectPath) : val
   }
 
-  return Object.keys(object).reduce((resolved, key) => {
-    return {
+  return Object.keys(object).reduce(
+    (resolved, key) => ({
       ...resolved,
       [key]: isFunction(object[key]) ? object[key](resolveObjectPath) : object[key],
-    }
-  }, {})
+    }),
+    {}
+  )
 }
 
-export default function resolveConfig(configs) {
-  return defaults(
+export default configs =>
+  defaults(
     {
       theme: resolveFunctionKeys(mergeExtensions(defaults({}, ...map(configs, 'theme')))),
       variants: defaults({}, ...map(configs, 'variants')),
     },
     ...configs
   )
-}

--- a/src/util/responsive.js
+++ b/src/util/responsive.js
@@ -2,10 +2,9 @@ import _ from 'lodash'
 import postcss from 'postcss'
 import cloneNodes from './cloneNodes'
 
-export default function responsive(rules) {
-  return postcss
+export default rules =>
+  postcss
     .atRule({
       name: 'responsive',
     })
     .append(cloneNodes(_.isArray(rules) ? rules : [rules]))
-}

--- a/src/util/wrapWithVariants.js
+++ b/src/util/wrapWithVariants.js
@@ -2,11 +2,10 @@ import _ from 'lodash'
 import postcss from 'postcss'
 import cloneNodes from './cloneNodes'
 
-export default function wrapWithVariants(rules, variants) {
-  return postcss
+export default (rules, variants) =>
+  postcss
     .atRule({
       name: 'variants',
       params: variants.join(', '),
     })
     .append(cloneNodes(_.isArray(rules) ? rules : [rules]))
-}

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -163,14 +163,7 @@ module.exports = {
         '"Noto Color Emoji"',
       ],
       serif: ['Georgia', 'Cambria', '"Times New Roman"', 'Times', 'serif'],
-      mono: [
-        'Menlo',
-        'Monaco',
-        'Consolas',
-        '"Liberation Mono"',
-        '"Courier New"',
-        'monospace',
-      ],
+      mono: ['Menlo', 'Monaco', 'Consolas', '"Liberation Mono"', '"Courier New"', 'monospace'],
     },
     fontSize: {
       xs: '0.75rem',
@@ -373,7 +366,7 @@ module.exports = {
       '0': 0,
       auto: 'auto',
     },
-    container: {}
+    container: {},
   },
   variants: {
     appearance: ['responsive'],

--- a/stubs/simpleConfig.stub.js
+++ b/stubs/simpleConfig.stub.js
@@ -7,5 +7,5 @@ module.exports = {
   },
   plugins: [
     // Some useful comment
-  ]
+  ],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -929,9 +929,26 @@ arr-union@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
 
+array-differ@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/array-differ/-/array-differ-2.1.0.tgz#4b9c1c3f14b906757082925769e8ab904f4801b1"
+  integrity sha512-KbUpJgx909ZscOc/7CLATBFam7P1Z1QRQInvgT0UztM9Q72aGKCunKASAl7WNW0tnPmPyEMeMhdsfWhfmW037w==
+
 array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
+
+array-union@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
+  integrity sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=
+  dependencies:
+    array-uniq "^1.0.1"
+
+array-uniq@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
+  integrity sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -1129,6 +1146,25 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+caller-callsite@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-callsite/-/caller-callsite-2.0.0.tgz#847e0fce0a223750a9a027c54b33731ad3154134"
+  integrity sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=
+  dependencies:
+    callsites "^2.0.0"
+
+caller-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-2.0.0.tgz#468f83044e369ab2010fac5f06ceee15bb2cb1f4"
+  integrity sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=
+  dependencies:
+    caller-callsite "^2.0.0"
+
+callsites@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
+  integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
+
 callsites@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.0.0.tgz#fb7eb569b72ad7a45812f93fd9430a3e410b3dd3"
@@ -1155,7 +1191,7 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   dependencies:
@@ -1319,6 +1355,25 @@ core-js@^2.5.7:
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+cosmiconfig@^5.0.7:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.0.tgz#45038e4d28a7fe787203aede9c25bca4a08b12c8"
+  integrity sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==
+  dependencies:
+    import-fresh "^2.0.0"
+    is-directory "^0.3.1"
+    js-yaml "^3.13.0"
+    parse-json "^4.0.0"
+
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
 
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -1624,6 +1679,19 @@ exec-sh@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.2.tgz#6738de2eb7c8e671d0366aea0b0db8c6f7d7391b"
 
+execa@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
+  integrity sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 execa@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
@@ -1875,6 +1943,11 @@ get-stdin@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
 
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+  integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
+
 get-stream@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
@@ -2019,6 +2092,22 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+husky@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-1.3.1.tgz#26823e399300388ca2afff11cfa8a86b0033fae0"
+  integrity sha512-86U6sVVVf4b5NYSZ0yvv88dRgBSSXXmHaiq5pP4KDj5JVzdwKgBjEtUPOm8hcoytezFwbU+7gotXNhpHdystlg==
+  dependencies:
+    cosmiconfig "^5.0.7"
+    execa "^1.0.0"
+    find-up "^3.0.0"
+    get-stdin "^6.0.0"
+    is-ci "^2.0.0"
+    pkg-dir "^3.0.0"
+    please-upgrade-node "^3.1.1"
+    read-pkg "^4.0.1"
+    run-node "^1.0.0"
+    slash "^2.0.0"
+
 iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
@@ -2041,9 +2130,22 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
+ignore@^3.3.7:
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+  integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
+
 ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
+
+import-fresh@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
+  integrity sha1-2BNVwVYS04bGH53dOSLUMEgipUY=
+  dependencies:
+    caller-path "^2.0.0"
+    resolve-from "^3.0.0"
 
 import-fresh@^3.0.0:
   version "3.0.0"
@@ -2183,6 +2285,11 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
     is-accessor-descriptor "^1.0.0"
     is-data-descriptor "^1.0.0"
     kind-of "^6.0.2"
+
+is-directory@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
+  integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
@@ -2881,6 +2988,14 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^3.0.0"
 
+lru-cache@^4.0.1:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 make-dir@^1.0.0, make-dir@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
@@ -3009,6 +3124,11 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+mri@^1.1.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.4.tgz#7cb1dd1b9b40905f1fac053abe25b6720f44744a"
+  integrity sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -3016,6 +3136,16 @@ ms@2.0.0:
 ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+
+multimatch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-3.0.0.tgz#0e2534cc6bc238d9ab67e1b9cd5fcd85a6dbf70b"
+  integrity sha512-22foS/gqQfANZ3o+W7ST2x25ueHDVNWl/b9OlGcLpy/iKxjCpvcNCM51YCenUi7Mt/jAjjqv8JwZRs8YP5sRjA==
+  dependencies:
+    array-differ "^2.0.3"
+    array-union "^1.0.2"
+    arrify "^1.0.1"
+    minimatch "^3.0.4"
 
 mute-stream@0.0.7:
   version "0.0.7"
@@ -3409,6 +3539,13 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
+please-upgrade-node@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz#ed320051dfcc5024fae696712c8288993595e8ac"
+  integrity sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==
+  dependencies:
+    semver-compare "^1.0.0"
+
 pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
@@ -3486,9 +3623,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.7.4:
+prettier@1.17.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.0.tgz#53b303676eed22cc14a9f0cec09b477b3026c008"
+  integrity sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==
 
 pretty-format@^24.7.0:
   version "24.7.0"
@@ -3502,6 +3640,18 @@ pretty-format@^24.7.0:
 pretty-hrtime@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
+
+pretty-quick@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/pretty-quick/-/pretty-quick-1.10.0.tgz#d86cc46fe92ed8cfcfba6a082ec5949c53858198"
+  integrity sha512-uNvm2N3UWmnZRZrClyQI45hIbV20f5BpSyZY51Spbvn4APp9+XLyX4bCjWRGT3fGyVyQ/2/iw7dbQq1UUaq7SQ==
+  dependencies:
+    chalk "^2.3.0"
+    execa "^0.8.0"
+    find-up "^2.1.0"
+    ignore "^3.3.7"
+    mri "^1.1.0"
+    multimatch "^3.0.0"
 
 private@^0.1.6:
   version "0.1.8"
@@ -3521,6 +3671,11 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.2"
     sisteransi "^1.0.0"
+
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
 psl@^1.1.24:
   version "1.1.29"
@@ -3572,6 +3727,15 @@ read-pkg@^3.0.0:
     load-json-file "^4.0.0"
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
+
+read-pkg@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-4.0.1.tgz#963625378f3e1c4d48c85872b5a6ec7d5d093237"
+  integrity sha1-ljYlN48+HE1IyFhytabsfV0JMjc=
+  dependencies:
+    normalize-package-data "^2.3.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
 
 readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6:
   version "2.3.6"
@@ -3775,6 +3939,11 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
+run-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
+  integrity sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==
+
 rxjs@^6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
@@ -3812,6 +3981,11 @@ sane@^4.0.3:
 sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+
+semver-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
+  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.6.0"
@@ -4410,6 +4584,11 @@ xml-name-validator@^3.0.0:
 "y18n@^3.2.1 || ^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Since we're targeting `node@>=8.9.0`, I thought it would  be a good idea to modernize the codebase and start using arrow functions and implicit returns where possible.

If this PR gets accepted/merged I'm willing to look into the `lodash` use and convert them to ES6+.

Should be merged after #855, since it's using Prettier already.
