### PR TITLE
Fix format for empty root nodes case

### DIFF
--- a/src/lib/formatCSS.js
+++ b/src/lib/formatCSS.js
@@ -11,5 +11,7 @@ function indentRecursive(node, indent = 0) {
 
 export default function formatNodes(root) {
   indentRecursive(root)
-  root.first.raws.before = ''
+  if (root.first) {
+    root.first.raws.before = ''
+  }
 }


### PR DESCRIPTION
It's possible for a PostCSS AST root to have no nodes (i.e. from an empty file or only `@` directives), which means that `root.first` may be undefined. #847 creates some build errors for me with beta 5.

Not sure if there's a better way to go about this, but hopefully it's helpful. Thanks as always!