### PR TITLE
Add support for negative prefixes in zIndex plugin

### DIFF
--- a/src/plugins/zIndex.js
+++ b/src/plugins/zIndex.js
@@ -1,11 +1,12 @@
 import _ from 'lodash'
+import prefixNegativeModifiers from '../util/prefixNegativeModifiers'
 
 export default function() {
-  return function({ addUtilities, theme, variants }) {
+  return function({ addUtilities, e, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('zIndex'), (value, modifier) => {
         return [
-          `.z-${modifier}`,
+          `.${e(prefixNegativeModifiers('z', modifier))}`,
           {
             'z-index': value,
           },


### PR DESCRIPTION
This PR makes it possible to create classes like `-z-10` using the same convention as the `inset` and `margin` plugins where config keys beginning with a `-` translate to classes beginning with a dash:

Example:

```
zIndex: {
  '-10': '-10',
}
```

The above config will create a class called `-z-10`, not `z--10` like you might otherwise expect.