### PR TITLE
Rename utilities like self-center to align-self-center

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -3346,23 +3346,23 @@ video {
   align-items: stretch !important;
 }
 
-.self-auto {
+.align-self-auto {
   align-self: auto !important;
 }
 
-.self-start {
+.align-self-start {
   align-self: flex-start !important;
 }
 
-.self-end {
+.align-self-end {
   align-self: flex-end !important;
 }
 
-.self-center {
+.align-self-center {
   align-self: center !important;
 }
 
-.self-stretch {
+.align-self-stretch {
   align-self: stretch !important;
 }
 
@@ -10099,23 +10099,23 @@ video {
     align-items: stretch !important;
   }
 
-  .sm\:self-auto {
+  .sm\:align-self-auto {
     align-self: auto !important;
   }
 
-  .sm\:self-start {
+  .sm\:align-self-start {
     align-self: flex-start !important;
   }
 
-  .sm\:self-end {
+  .sm\:align-self-end {
     align-self: flex-end !important;
   }
 
-  .sm\:self-center {
+  .sm\:align-self-center {
     align-self: center !important;
   }
 
-  .sm\:self-stretch {
+  .sm\:align-self-stretch {
     align-self: stretch !important;
   }
 
@@ -16837,23 +16837,23 @@ video {
     align-items: stretch !important;
   }
 
-  .md\:self-auto {
+  .md\:align-self-auto {
     align-self: auto !important;
   }
 
-  .md\:self-start {
+  .md\:align-self-start {
     align-self: flex-start !important;
   }
 
-  .md\:self-end {
+  .md\:align-self-end {
     align-self: flex-end !important;
   }
 
-  .md\:self-center {
+  .md\:align-self-center {
     align-self: center !important;
   }
 
-  .md\:self-stretch {
+  .md\:align-self-stretch {
     align-self: stretch !important;
   }
 
@@ -23575,23 +23575,23 @@ video {
     align-items: stretch !important;
   }
 
-  .lg\:self-auto {
+  .lg\:align-self-auto {
     align-self: auto !important;
   }
 
-  .lg\:self-start {
+  .lg\:align-self-start {
     align-self: flex-start !important;
   }
 
-  .lg\:self-end {
+  .lg\:align-self-end {
     align-self: flex-end !important;
   }
 
-  .lg\:self-center {
+  .lg\:align-self-center {
     align-self: center !important;
   }
 
-  .lg\:self-stretch {
+  .lg\:align-self-stretch {
     align-self: stretch !important;
   }
 
@@ -30313,23 +30313,23 @@ video {
     align-items: stretch !important;
   }
 
-  .xl\:self-auto {
+  .xl\:align-self-auto {
     align-self: auto !important;
   }
 
-  .xl\:self-start {
+  .xl\:align-self-start {
     align-self: flex-start !important;
   }
 
-  .xl\:self-end {
+  .xl\:align-self-end {
     align-self: flex-end !important;
   }
 
-  .xl\:self-center {
+  .xl\:align-self-center {
     align-self: center !important;
   }
 
-  .xl\:self-stretch {
+  .xl\:align-self-stretch {
     align-self: stretch !important;
   }
 

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3346,23 +3346,23 @@ video {
   align-items: stretch;
 }
 
-.self-auto {
+.align-self-auto {
   align-self: auto;
 }
 
-.self-start {
+.align-self-start {
   align-self: flex-start;
 }
 
-.self-end {
+.align-self-end {
   align-self: flex-end;
 }
 
-.self-center {
+.align-self-center {
   align-self: center;
 }
 
-.self-stretch {
+.align-self-stretch {
   align-self: stretch;
 }
 
@@ -10099,23 +10099,23 @@ video {
     align-items: stretch;
   }
 
-  .sm\:self-auto {
+  .sm\:align-self-auto {
     align-self: auto;
   }
 
-  .sm\:self-start {
+  .sm\:align-self-start {
     align-self: flex-start;
   }
 
-  .sm\:self-end {
+  .sm\:align-self-end {
     align-self: flex-end;
   }
 
-  .sm\:self-center {
+  .sm\:align-self-center {
     align-self: center;
   }
 
-  .sm\:self-stretch {
+  .sm\:align-self-stretch {
     align-self: stretch;
   }
 
@@ -16837,23 +16837,23 @@ video {
     align-items: stretch;
   }
 
-  .md\:self-auto {
+  .md\:align-self-auto {
     align-self: auto;
   }
 
-  .md\:self-start {
+  .md\:align-self-start {
     align-self: flex-start;
   }
 
-  .md\:self-end {
+  .md\:align-self-end {
     align-self: flex-end;
   }
 
-  .md\:self-center {
+  .md\:align-self-center {
     align-self: center;
   }
 
-  .md\:self-stretch {
+  .md\:align-self-stretch {
     align-self: stretch;
   }
 
@@ -23575,23 +23575,23 @@ video {
     align-items: stretch;
   }
 
-  .lg\:self-auto {
+  .lg\:align-self-auto {
     align-self: auto;
   }
 
-  .lg\:self-start {
+  .lg\:align-self-start {
     align-self: flex-start;
   }
 
-  .lg\:self-end {
+  .lg\:align-self-end {
     align-self: flex-end;
   }
 
-  .lg\:self-center {
+  .lg\:align-self-center {
     align-self: center;
   }
 
-  .lg\:self-stretch {
+  .lg\:align-self-stretch {
     align-self: stretch;
   }
 
@@ -30313,23 +30313,23 @@ video {
     align-items: stretch;
   }
 
-  .xl\:self-auto {
+  .xl\:align-self-auto {
     align-self: auto;
   }
 
-  .xl\:self-start {
+  .xl\:align-self-start {
     align-self: flex-start;
   }
 
-  .xl\:self-end {
+  .xl\:align-self-end {
     align-self: flex-end;
   }
 
-  .xl\:self-center {
+  .xl\:align-self-center {
     align-self: center;
   }
 
-  .xl\:self-stretch {
+  .xl\:align-self-stretch {
     align-self: stretch;
   }
 

--- a/src/plugins/alignSelf.js
+++ b/src/plugins/alignSelf.js
@@ -2,19 +2,19 @@ export default function() {
   return function({ addUtilities, variants }) {
     addUtilities(
       {
-        '.self-auto': {
+        '.align-self-auto': {
           'align-self': 'auto',
         },
-        '.self-start': {
+        '.align-self-start': {
           'align-self': 'flex-start',
         },
-        '.self-end': {
+        '.align-self-end': {
           'align-self': 'flex-end',
         },
-        '.self-center': {
+        '.align-self-center': {
           'align-self': 'center',
         },
-        '.self-stretch': {
+        '.align-self-stretch': {
           'align-self': 'stretch',
         },
       },


### PR DESCRIPTION
Since there is also a `justify-self` property, keeping the existing `self-center` style class names means there is no good name for `justify-self` utilities if we introduce them later. This PR changes those class names to be slightly more verbose so that there is no ambiguity.

| Old | New |
| --- | --- |
| `self-auto` | `align-self-auto` |
| `self-start` | `align-self-start` |
| `self-end` | `align-self-end` |
| `self-center` | `align-self-center` |
| `self-stretch` | `align-self-stretch` |