### PR TITLE
Make resolveConfig available in user land

### DIFF
--- a/resolveConfig.js
+++ b/resolveConfig.js
@@ -1,0 +1,6 @@
+const resolveConfigObjects = require('./lib/util/resolveConfig').default
+const defaultConfig = require('./stubs/defaultConfig.stub.js')
+
+module.exports = function resolveConfig(config) {
+  return resolveConfigObjects([config, defaultConfig])
+}


### PR DESCRIPTION
Adds a new `resolveConfig` file to the project root that can be imported as `tailwindcss/resolveConfig` and used to get a fully merged version of your custom config file.

Useful when you want access to your design tokens in JS.

Usage is like this:

```js
import resolveConfig from 'tailwindcss/resolveConfig'
import tailwindConfig from '../../tailwind.config.js'

const config = resolveConfig(tailwindConfig)
```

Considered having it accept a path but didn't seem that useful. I expect most people needing this would create another file in their `src` directory or similar that sort of proxied to their Tailwind config so they could easily import the fully resolved config instead of having to actually resolve it using the function every time:

```js
// src/tailwindConfig.js
import resolveConfig from 'tailwindcss/resolveConfig'
import config from '../../tailwind.config.js'

export default resolveConfig(tailwindConfig)
```

Closes #832.