### PR TITLE
Remove `negativeMargin` variants

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -453,7 +453,6 @@ module.exports = {
     maxWidth: ['responsive'],
     minHeight: ['responsive'],
     minWidth: ['responsive'],
-    negativeMargin: ['responsive'],
     objectFit: ['responsive'],
     objectPosition: ['responsive'],
     opacity: ['responsive'],


### PR DESCRIPTION
Since the `negativeMargin` plugin has been removed we no longer have to specify variants for it.