### PR TITLE
feat: extend list container reset to <menu> tag

### DIFF
--- a/css/preflight.css
+++ b/css/preflight.css
@@ -411,7 +411,8 @@ fieldset {
 }
 
 ol,
-ul {
+ul,
+menu {
   margin: 0;
 }
 


### PR DESCRIPTION
I just noticed that the menu tag has some strange defaults and extending the magin reset from other list types seems to fix this.
