### PR TITLE
Avoid test collisions by using different directories in runInTempDirectory

### DIFF
--- a/jest/runInTempDirectory.js
+++ b/jest/runInTempDirectory.js
@@ -5,8 +5,8 @@ import rimraf from 'rimraf'
 
 export default function(callback) {
   return new Promise(resolve => {
-    const timestamp = new Date().valueOf()
-    const tmpPath = path.resolve(__dirname, `../__tmp_${timestamp}`)
+    const workerId = process.env.JEST_WORKER_ID
+    const tmpPath = path.resolve(__dirname, `../__tmp_${workerId}`)
     const currentPath = process.cwd()
 
     rimraf.sync(tmpPath)

--- a/jest/runInTempDirectory.js
+++ b/jest/runInTempDirectory.js
@@ -3,10 +3,10 @@ import path from 'path'
 
 import rimraf from 'rimraf'
 
-const tmpPath = path.resolve(__dirname, '../__tmp')
-
 export default function(callback) {
   return new Promise(resolve => {
+    const timestamp = new Date().valueOf()
+    const tmpPath = path.resolve(__dirname, `../__tmp_${timestamp}`)
     const currentPath = process.cwd()
 
     rimraf.sync(tmpPath)


### PR DESCRIPTION
The tests were randomly failing for me:

```js
 FAIL  __tests__/cli.test.js (7.722s)
  ● cli › build › creates compiled CSS file

    ENOENT: no such file or directory, open 'output.css'

      128 |  */
      129 | export function writeFile(path, content) {
    > 130 |   ensureFileSync(path)
          |   ^
      131 |
      132 |   return outputFileSync(path, content)
      133 | }

      at createFileSync (node_modules/fs-extra/lib/ensure/file.js:43:6)
      at Object.writeFile (src/cli/utils.js:130:3)
      at writeFile (src/cli/commands/build.js:86:11)
```

I believe it's a timing issue with the tests being run in parallel.
This PR fixes that by using a different temporary directory for each test.