### PR TITLE
Use 9999 for both order-first and order-last

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -3499,11 +3499,11 @@ video {
 }
 
 .order-first {
-  order: -1 !important;
+  order: -9999 !important;
 }
 
 .order-last {
-  order: 999 !important;
+  order: 9999 !important;
 }
 
 .order-none {
@@ -10404,11 +10404,11 @@ video {
   }
 
   .sm\:order-first {
-    order: -1 !important;
+    order: -9999 !important;
   }
 
   .sm\:order-last {
-    order: 999 !important;
+    order: 9999 !important;
   }
 
   .sm\:order-none {
@@ -17310,11 +17310,11 @@ video {
   }
 
   .md\:order-first {
-    order: -1 !important;
+    order: -9999 !important;
   }
 
   .md\:order-last {
-    order: 999 !important;
+    order: 9999 !important;
   }
 
   .md\:order-none {
@@ -24216,11 +24216,11 @@ video {
   }
 
   .lg\:order-first {
-    order: -1 !important;
+    order: -9999 !important;
   }
 
   .lg\:order-last {
-    order: 999 !important;
+    order: 9999 !important;
   }
 
   .lg\:order-none {
@@ -31122,11 +31122,11 @@ video {
   }
 
   .xl\:order-first {
-    order: -1 !important;
+    order: -9999 !important;
   }
 
   .xl\:order-last {
-    order: 999 !important;
+    order: 9999 !important;
   }
 
   .xl\:order-none {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3499,11 +3499,11 @@ video {
 }
 
 .order-first {
-  order: -1;
+  order: -9999;
 }
 
 .order-last {
-  order: 999;
+  order: 9999;
 }
 
 .order-none {
@@ -10404,11 +10404,11 @@ video {
   }
 
   .sm\:order-first {
-    order: -1;
+    order: -9999;
   }
 
   .sm\:order-last {
-    order: 999;
+    order: 9999;
   }
 
   .sm\:order-none {
@@ -17310,11 +17310,11 @@ video {
   }
 
   .md\:order-first {
-    order: -1;
+    order: -9999;
   }
 
   .md\:order-last {
-    order: 999;
+    order: 9999;
   }
 
   .md\:order-none {
@@ -24216,11 +24216,11 @@ video {
   }
 
   .lg\:order-first {
-    order: -1;
+    order: -9999;
   }
 
   .lg\:order-last {
-    order: 999;
+    order: 9999;
   }
 
   .lg\:order-none {
@@ -31122,11 +31122,11 @@ video {
   }
 
   .xl\:order-first {
-    order: -1;
+    order: -9999;
   }
 
   .xl\:order-last {
-    order: 999;
+    order: 9999;
   }
 
   .xl\:order-none {

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -390,8 +390,8 @@ module.exports = {
       default: '1',
     },
     order: {
-      first: '-1',
-      last: '999',
+      first: '-9999',
+      last: '9999',
       none: '0',
       '1': '1',
       '2': '2',


### PR DESCRIPTION
This PR updates order-first and order-last to both use `9999` for their values, as we've sort of set a precedent for `9999` being our "infinity" value with `rounded-full`.