### PR TITLE
Fix container plugin screen order and duplication

### DIFF
--- a/__tests__/containerPlugin.test.js
+++ b/__tests__/containerPlugin.test.js
@@ -64,6 +64,56 @@ test.only('screens can be passed explicitly', () => {
   `)
 })
 
+test.only('screens are ordered ascending by min-width', () => {
+  const { components } = processPlugins(
+    [container()],
+    config({
+      theme: {
+        container: {
+          screens: ['500px', '400px'],
+        },
+      },
+    })
+  )
+
+  expect(css(components)).toMatchCss(`
+    .container { width: 100% }
+    @media (min-width: 400px) {
+      .container { max-width: 400px }
+    }
+    @media (min-width: 500px) {
+      .container { max-width: 500px }
+    }
+  `)
+})
+
+test.only('screens are deduplicated by min-width', () => {
+  const { components } = processPlugins(
+    [container()],
+    config({
+      theme: {
+        container: {
+          screens: {
+            sm: '576px',
+            md: '768px',
+            'sm-only': { min: '576px', max: '767px' },
+          },
+        },
+      },
+    })
+  )
+
+  expect(css(components)).toMatchCss(`
+    .container { width: 100% }
+    @media (min-width: 576px) {
+      .container { max-width: 576px }
+    }
+    @media (min-width: 768px) {
+      .container { max-width: 768px }
+    }
+  `)
+})
+
 test.only('the container can be centered by default', () => {
   const { components } = processPlugins(
     [container()],

--- a/src/plugins/container.js
+++ b/src/plugins/container.js
@@ -26,15 +26,19 @@ module.exports = function() {
   return function({ addComponents, theme }) {
     const minWidths = extractMinWidths(theme('container.screens', theme('screens')))
 
-    const atRules = _.map(minWidths, minWidth => {
-      return {
-        [`@media (min-width: ${minWidth})`]: {
-          '.container': {
-            'max-width': minWidth,
+    const atRules = _(minWidths)
+      .sortBy(minWidth => parseInt(minWidth))
+      .sortedUniq()
+      .map(minWidth => {
+        return {
+          [`@media (min-width: ${minWidth})`]: {
+            '.container': {
+              'max-width': minWidth,
+            },
           },
-        },
-      }
-    })
+        }
+      })
+      .value()
 
     addComponents([
       {


### PR DESCRIPTION
This PR fixes an issue where using the `.container` class with custom screen breakpoints would result in the container always having a `max-width` of the last defined screen. Additionally, when multiple screens would have the same `min-width`, the container definition would be duplicated.

I ran into this when using the following `tailwind.config.js`:

```js
module.exports = {
  important: true,
  theme: {
    extend: {
      screens: {
        'sm-only': { min: '640px', max: '767px' },
      },
    },
  },
  variants: {},
  plugins: [],
};
```

In this case, the `.container` class would always have `max-width: 640px` defined, because it is the last defined breakpoint for the class. It would also result in duplication of the `@media (min-width: 640px)` breakpoint definition.