### PR TITLE
Bubble @screen at-rules when adding styles through plugins

### DIFF
--- a/src/util/parseObjectStyles.js
+++ b/src/util/parseObjectStyles.js
@@ -10,6 +10,6 @@ export default function parseObjectStyles(styles) {
 
   return _.flatMap(
     styles,
-    style => postcss([postcssNested]).process(style, { parser: postcssJs }).root.nodes
+    style => postcss([postcssNested({ bubble: ['screen'] })]).process(style, { parser: postcssJs }).root.nodes
   )
 }


### PR DESCRIPTION
I noticed that the following code in a plugin:

```
addComponents({
  '.test': {
    display: 'block',
    '@screen sm': {
      display: 'none',
    },
  },
});
```

generates the following CSS:

```
.test {
  display: block;
  @media (min-width: 640px) {
    display: none;
  }
}
```

which isn't valid. It should be:

```
.test {
  display: block;
}

@media (min-width: 640px) {
  .test {
    display: none;
  }
}
```

This change fixes that, thanks to [postcss-nested's `bubble` option](https://github.com/postcss/postcss-nested#bubble). By default, `postcss-nested` bubbles `@media` at-rules, so I think it should do it for `@screen` as well.