### PR TITLE
Support built-in variants for utilities that include pseudo-elements

### DIFF
--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -220,7 +220,7 @@ test('variants are generated in the order specified', () => {
 
 test('the built-in variant pseudo-selectors are appended before any pseudo-elements', () => {
   const input = `
-    @variants hover, focus-within, focus, active {
+    @variants hover, focus-within, focus, active, group-hover {
       .placeholder-yellow::placeholder { color: yellow; }
     }
   `
@@ -231,6 +231,7 @@ test('the built-in variant pseudo-selectors are appended before any pseudo-eleme
     .focus-within\\:placeholder-yellow:focus-within::placeholder { color: yellow; }
     .focus\\:placeholder-yellow:focus::placeholder { color: yellow; }
     .active\\:placeholder-yellow:active::placeholder { color: yellow; }
+    .group:hover .group-hover\\:placeholder-yellow::placeholder { color: yellow; }
   `
 
   return run(input).then(result => {

--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -218,6 +218,27 @@ test('variants are generated in the order specified', () => {
   })
 })
 
+test('the built-in variant pseudo-selectors are appended before any pseudo-elements', () => {
+  const input = `
+    @variants hover, focus-within, focus, active {
+      .placeholder-yellow::placeholder { color: yellow; }
+    }
+  `
+
+  const output = `
+    .placeholder-yellow::placeholder { color: yellow; }
+    .hover\\:placeholder-yellow:hover::placeholder { color: yellow; }
+    .focus-within\\:placeholder-yellow:focus-within::placeholder { color: yellow; }
+    .focus\\:placeholder-yellow:focus::placeholder { color: yellow; }
+    .active\\:placeholder-yellow:active::placeholder { color: yellow; }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('the default variant can be generated in a specified position', () => {
   const input = `
     @variants focus, active, default, hover {

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -1,12 +1,18 @@
 import _ from 'lodash'
 import postcss from 'postcss'
+import selectorParser from 'postcss-selector-parser'
 import generateVariantFunction from '../util/generateVariantFunction'
 import e from '../util/escapeClassName'
 
 function generatePseudoClassVariant(pseudoClass) {
   return generateVariantFunction(({ modifySelectors, separator }) => {
-    return modifySelectors(({ className }) => {
-      return `.${e(`${pseudoClass}${separator}${className}`)}:${pseudoClass}`
+    return modifySelectors(({ selector }) => {
+      return selectorParser(selectors => {
+        selectors.walkClasses(sel => {
+          sel.value = `${pseudoClass}${separator}${sel.value}`
+          sel.parent.insertAfter(sel, selectorParser.pseudo({ value: `:${pseudoClass}` }))
+        })
+      }).processSync(selector)
     })
   })
 }

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -2,7 +2,6 @@ import _ from 'lodash'
 import postcss from 'postcss'
 import selectorParser from 'postcss-selector-parser'
 import generateVariantFunction from '../util/generateVariantFunction'
-import e from '../util/escapeClassName'
 
 function generatePseudoClassVariant(pseudoClass) {
   return generateVariantFunction(({ modifySelectors, separator }) => {

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -24,8 +24,13 @@ function ensureIncludesDefault(variants) {
 const defaultVariantGenerators = {
   default: generateVariantFunction(() => {}),
   'group-hover': generateVariantFunction(({ modifySelectors, separator }) => {
-    return modifySelectors(({ className }) => {
-      return `.group:hover .${e(`group-hover${separator}${className}`)}`
+    return modifySelectors(({ selector }) => {
+      return selectorParser(selectors => {
+        selectors.walkClasses(sel => {
+          sel.value = `group-hover${separator}${sel.value}`
+          sel.parent.insertBefore(sel, selectorParser().astSync('.group:hover '))
+        })
+      }).processSync(selector)
     })
   }),
   hover: generatePseudoClassVariant('hover'),


### PR DESCRIPTION
This PR tries to improve the behavior of our built-in `hover`, `active`, `focus`, and `focus-within` variant plugins to handle utilities that include pseudo-elements more gracefully.

Prior to this PR, this code:

```css
@variants focus {
  .placeholder-gray-400::placeholder { color: theme('colors.gray.400') }
}
```

...would generate this CSS:

```css
.placeholder-gray-400::placeholder { color: #CBD5E0 }
.focus\:placeholder-gray-400:focus { color: #CBD5E0 }
```

Notice that the `::placeholder` pseudo-element is completely gone in the `focus` variant.

This PR changes this behavior to create this output:

```css
.placeholder-gray-400::placeholder { color: #CBD5E0 }
.focus\:placeholder-gray-400:focus::placeholder { color: #CBD5E0 }
```

This feels much more correct to me at least in this situation, but there is a concern that for some reason using some pseudo-element, someone might actually want this sort of output:

```css
.hover\:foo::before:hover { ... }
```

...where the hover pseudo-class is added to the pseudo-element itself, rather than the element to which the pseudo-element belongs.

I'm not convinced it's worth trying to solve that problem right now as I don't believe it's possible to give the end user control over how this works without introducing a breaking change, but the new behavior in this PR certainly feels like an improvement over what is currently completely broken.

One thing to note is that the specifics of this implementation actually cause all classes in a selector to receive the pseudo-class prefix:

```css
/* Input */
@variants focus {
  .foo .bar .baz { ... }
}

/* Output */
.hover\:foo:hover .hover\:bar:hover .hover\:baz:hover { ... }
```

I don't really want people to depend on this and consider it undefined behavior, but can't decide if it's worth trying to detect and throwing an explicit error, mostly because I'm unsure exactly what the heuristic would be for "this is weird don't do this". Would it be any selector that includes multiple classes? An element + a class?

Also, anyone who has authored a variant plugin (like for `disabled` or something) may want to update their own implementations to behave the way this PR behaves, which makes me wonder if I should try to implement this in a way that makes that automatic, although I'm pretty convinced that couldn't be done in a non-hacky non-bandaid-y way.

Feedback from variant plugin authors on this PR overall would be appreciated.