### PR TITLE
Add support for :visited state variant

### DIFF
--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -51,6 +51,27 @@ test('it can generate active variants', () => {
   })
 })
 
+test('it can generate visited variants', () => {
+  const input = `
+    @variants visited {
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+    }
+  `
+
+  const output = `
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+      .visited\\:banana:visited { color: yellow; }
+      .visited\\:chocolate:visited { color: brown; }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('it can generate focus variants', () => {
   const input = `
     @variants focus {

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -26,6 +26,7 @@ const defaultVariantGenerators = {
   'focus-within': generatePseudoClassVariant('focus-within'),
   focus: generatePseudoClassVariant('focus'),
   active: generatePseudoClassVariant('active'),
+  visited: generatePseudoClassVariant('visited'),
 }
 
 export default function(config, { variantGenerators: pluginVariantGenerators }) {


### PR DESCRIPTION
This PR adds the `visited` state variant to Tailwind core.  It can be used as follows:

```html
<a class="visited:text-pink" href="#">Visited Link</a>
```

It should be placed before the hover and active variants in the configuration or it will override their behavior.

This feature was requested in issue #501, not sure if the implementation is what @adamwathan had in mind.   Based this solution on https://github.com/tailwindcss/tailwindcss/pull/732