### PR TITLE
Add text-shadow utility

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -7056,6 +7056,14 @@ video {
   color: #702459 !important;
 }
 
+.text-shadow {
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25) !important;
+}
+
+.text-shadow-none {
+  text-shadow: none !important;
+}
+
 .text-xs {
   font-size: 0.75rem !important;
 }
@@ -13955,6 +13963,14 @@ video {
 
   .sm\:focus\:text-pink-900:focus {
     color: #702459 !important;
+  }
+
+  .sm\:text-shadow {
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25) !important;
+  }
+
+  .sm\:text-shadow-none {
+    text-shadow: none !important;
   }
 
   .sm\:text-xs {
@@ -20859,6 +20875,14 @@ video {
     color: #702459 !important;
   }
 
+  .md\:text-shadow {
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25) !important;
+  }
+
+  .md\:text-shadow-none {
+    text-shadow: none !important;
+  }
+
   .md\:text-xs {
     font-size: 0.75rem !important;
   }
@@ -27761,6 +27785,14 @@ video {
     color: #702459 !important;
   }
 
+  .lg\:text-shadow {
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25) !important;
+  }
+
+  .lg\:text-shadow-none {
+    text-shadow: none !important;
+  }
+
   .lg\:text-xs {
     font-size: 0.75rem !important;
   }
@@ -34661,6 +34693,14 @@ video {
 
   .xl\:focus\:text-pink-900:focus {
     color: #702459 !important;
+  }
+
+  .xl\:text-shadow {
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25) !important;
+  }
+
+  .xl\:text-shadow-none {
+    text-shadow: none !important;
   }
 
   .xl\:text-xs {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -7057,7 +7057,11 @@ video {
 }
 
 .text-shadow {
-  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25) !important;
+  text-shadow: 0 2px 5px rgba(0, 0, 0, 0.5) !important;
+}
+
+.text-shadow-lg {
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.5) !important;
 }
 
 .text-shadow-none {
@@ -13966,7 +13970,11 @@ video {
   }
 
   .sm\:text-shadow {
-    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25) !important;
+    text-shadow: 0 2px 5px rgba(0, 0, 0, 0.5) !important;
+  }
+
+  .sm\:text-shadow-lg {
+    text-shadow: 0 2px 10px rgba(0, 0, 0, 0.5) !important;
   }
 
   .sm\:text-shadow-none {
@@ -20876,7 +20884,11 @@ video {
   }
 
   .md\:text-shadow {
-    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25) !important;
+    text-shadow: 0 2px 5px rgba(0, 0, 0, 0.5) !important;
+  }
+
+  .md\:text-shadow-lg {
+    text-shadow: 0 2px 10px rgba(0, 0, 0, 0.5) !important;
   }
 
   .md\:text-shadow-none {
@@ -27786,7 +27798,11 @@ video {
   }
 
   .lg\:text-shadow {
-    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25) !important;
+    text-shadow: 0 2px 5px rgba(0, 0, 0, 0.5) !important;
+  }
+
+  .lg\:text-shadow-lg {
+    text-shadow: 0 2px 10px rgba(0, 0, 0, 0.5) !important;
   }
 
   .lg\:text-shadow-none {
@@ -34696,7 +34712,11 @@ video {
   }
 
   .xl\:text-shadow {
-    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25) !important;
+    text-shadow: 0 2px 5px rgba(0, 0, 0, 0.5) !important;
+  }
+
+  .xl\:text-shadow-lg {
+    text-shadow: 0 2px 10px rgba(0, 0, 0, 0.5) !important;
   }
 
   .xl\:text-shadow-none {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -7057,7 +7057,11 @@ video {
 }
 
 .text-shadow {
-  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+  text-shadow: 0 2px 5px rgba(0, 0, 0, 0.5);
+}
+
+.text-shadow-lg {
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
 }
 
 .text-shadow-none {
@@ -13966,7 +13970,11 @@ video {
   }
 
   .sm\:text-shadow {
-    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+    text-shadow: 0 2px 5px rgba(0, 0, 0, 0.5);
+  }
+
+  .sm\:text-shadow-lg {
+    text-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
   }
 
   .sm\:text-shadow-none {
@@ -20876,7 +20884,11 @@ video {
   }
 
   .md\:text-shadow {
-    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+    text-shadow: 0 2px 5px rgba(0, 0, 0, 0.5);
+  }
+
+  .md\:text-shadow-lg {
+    text-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
   }
 
   .md\:text-shadow-none {
@@ -27786,7 +27798,11 @@ video {
   }
 
   .lg\:text-shadow {
-    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+    text-shadow: 0 2px 5px rgba(0, 0, 0, 0.5);
+  }
+
+  .lg\:text-shadow-lg {
+    text-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
   }
 
   .lg\:text-shadow-none {
@@ -34696,7 +34712,11 @@ video {
   }
 
   .xl\:text-shadow {
-    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+    text-shadow: 0 2px 5px rgba(0, 0, 0, 0.5);
+  }
+
+  .xl\:text-shadow-lg {
+    text-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
   }
 
   .xl\:text-shadow-none {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -7056,6 +7056,14 @@ video {
   color: #702459;
 }
 
+.text-shadow {
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+}
+
+.text-shadow-none {
+  text-shadow: none;
+}
+
 .text-xs {
   font-size: 0.75rem;
 }
@@ -13955,6 +13963,14 @@ video {
 
   .sm\:focus\:text-pink-900:focus {
     color: #702459;
+  }
+
+  .sm\:text-shadow {
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+  }
+
+  .sm\:text-shadow-none {
+    text-shadow: none;
   }
 
   .sm\:text-xs {
@@ -20859,6 +20875,14 @@ video {
     color: #702459;
   }
 
+  .md\:text-shadow {
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+  }
+
+  .md\:text-shadow-none {
+    text-shadow: none;
+  }
+
   .md\:text-xs {
     font-size: 0.75rem;
   }
@@ -27761,6 +27785,14 @@ video {
     color: #702459;
   }
 
+  .lg\:text-shadow {
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+  }
+
+  .lg\:text-shadow-none {
+    text-shadow: none;
+  }
+
   .lg\:text-xs {
     font-size: 0.75rem;
   }
@@ -34661,6 +34693,14 @@ video {
 
   .xl\:focus\:text-pink-900:focus {
     color: #702459;
+  }
+
+  .xl\:text-shadow {
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+  }
+
+  .xl\:text-shadow-none {
+    text-shadow: none;
   }
 
   .xl\:text-xs {

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -51,6 +51,7 @@ import stroke from './plugins/stroke'
 import tableLayout from './plugins/tableLayout'
 import textAlign from './plugins/textAlign'
 import textColor from './plugins/textColor'
+import textShadow from './plugins/textShadow'
 import fontSize from './plugins/fontSize'
 import fontStyle from './plugins/fontStyle'
 import textTransform from './plugins/textTransform'
@@ -122,6 +123,7 @@ export default function({ corePlugins: corePluginConfig }) {
     tableLayout,
     textAlign,
     textColor,
+    textShadow,
     fontSize,
     fontStyle,
     textTransform,

--- a/src/plugins/textShadow.js
+++ b/src/plugins/textShadow.js
@@ -1,0 +1,19 @@
+import _ from 'lodash'
+
+export default function() {
+  return function({ addUtilities, e, theme, variants }) {
+    const utilities = _.fromPairs(
+      _.map(theme('textShadow'), (value, modifier) => {
+        const className = modifier === 'default' ? 'text-shadow' : `text-shadow-${modifier}`
+        return [
+          `.${e(className)}`,
+          {
+            'text-shadow': value,
+          },
+        ]
+      })
+    )
+
+    addUtilities(utilities, variants('textShadow'))
+  }
+}

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -375,6 +375,10 @@ module.exports = {
       current: 'currentColor',
     },
     textColor: theme => theme('colors'),
+    textShadow: {
+      default: '0 1px 3px rgba(0, 0, 0, 0.25)',
+      none: 'none',
+    },
     width: theme => ({
       auto: 'auto',
       ...theme('spacing'),
@@ -474,6 +478,7 @@ module.exports = {
     textAlign: ['responsive'],
     textColor: ['responsive', 'hover', 'focus'],
     textDecoration: ['responsive', 'hover', 'focus'],
+    textShadow: ['responsive'],
     textTransform: ['responsive'],
     userSelect: ['responsive'],
     verticalAlign: ['responsive'],

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -376,7 +376,8 @@ module.exports = {
     },
     textColor: theme => theme('colors'),
     textShadow: {
-      default: '0 1px 3px rgba(0, 0, 0, 0.25)',
+      default: '0 2px 5px rgba(0, 0, 0, 0.5)',
+      lg: '0 2px 10px rgba(0, 0, 0, 0.5)',
       none: 'none',
     },
     width: theme => ({


### PR DESCRIPTION
This is a resubmission of https://github.com/tailwindcss/tailwindcss/pull/881. I used @benface's original commit so his works doesn't gets lost. I updated the styles with the current version of his https://github.com/benface/tailwindcss-typography plugin. 

At the moment I'm not sure if the current styling is the wanted one. I tried it out locally and it seems to be ok but not sure if `sm` & `xl` versions are needed or if the current styling needs tweaking. It seems to be that opinions could differ quite a bit on this.

Closes https://github.com/tailwindcss/tailwindcss/issues/307