### PR TITLE
Support negative prefix syntax for boxShadow and letterSpacing

### DIFF
--- a/__tests__/plugins/boxShadow.test.js
+++ b/__tests__/plugins/boxShadow.test.js
@@ -1,0 +1,63 @@
+import _ from 'lodash'
+import escapeClassName from '../../src/util/escapeClassName'
+import plugin from '../../src/plugins/boxShadow'
+
+test('box shadow can use default keyword and negative prefix syntax', () => {
+  const addedUtilities = []
+
+  const config = {
+    theme: {
+      boxShadow: {
+        default: '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
+        md: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
+        '-': 'inset 0 2px 4px 0 rgba(0, 0, 0, 0.06)',
+        '-md': '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
+      },
+    },
+    variants: {
+      boxShadow: ['responsive'],
+    },
+  }
+
+  const getConfigValue = (path, defaultValue) => _.get(config, path, defaultValue)
+  const pluginApi = {
+    config: getConfigValue,
+    e: escapeClassName,
+    theme: (path, defaultValue) => getConfigValue(`theme.${path}`, defaultValue),
+    variants: (path, defaultValue) => {
+      if (_.isArray(config.variants)) {
+        return config.variants
+      }
+
+      return getConfigValue(`variants.${path}`, defaultValue)
+    },
+    addUtilities(utilities, variants) {
+      addedUtilities.push({
+        utilities,
+        variants,
+      })
+    },
+  }
+
+  plugin()(pluginApi)
+
+  expect(addedUtilities).toEqual([
+    {
+      utilities: {
+        '.shadow': {
+          'box-shadow': '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
+        },
+        '.shadow-md': {
+          'box-shadow': '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
+        },
+        '.-shadow': {
+          'box-shadow': 'inset 0 2px 4px 0 rgba(0, 0, 0, 0.06)',
+        },
+        '.-shadow-md': {
+          'box-shadow': '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
+        },
+      },
+      variants: ['responsive'],
+    },
+  ])
+})

--- a/__tests__/plugins/letterSpacing.test.js
+++ b/__tests__/plugins/letterSpacing.test.js
@@ -1,0 +1,55 @@
+import _ from 'lodash'
+import escapeClassName from '../../src/util/escapeClassName'
+import plugin from '../../src/plugins/letterSpacing'
+
+test('letter spacing can use default keyword and negative prefix syntax', () => {
+  const addedUtilities = []
+
+  const config = {
+    theme: {
+      letterSpacing: {
+        '-1': '-0.05em',
+        '-': '-0.025em',
+        default: '0.025em',
+        '1': '0.05em',
+      },
+    },
+    variants: {
+      letterSpacing: ['responsive'],
+    },
+  }
+
+  const getConfigValue = (path, defaultValue) => _.get(config, path, defaultValue)
+  const pluginApi = {
+    config: getConfigValue,
+    e: escapeClassName,
+    theme: (path, defaultValue) => getConfigValue(`theme.${path}`, defaultValue),
+    variants: (path, defaultValue) => {
+      if (_.isArray(config.variants)) {
+        return config.variants
+      }
+
+      return getConfigValue(`variants.${path}`, defaultValue)
+    },
+    addUtilities(utilities, variants) {
+      addedUtilities.push({
+        utilities,
+        variants,
+      })
+    },
+  }
+
+  plugin()(pluginApi)
+
+  expect(addedUtilities).toEqual([
+    {
+      utilities: {
+        '.-tracking-1': { 'letter-spacing': '-0.05em' },
+        '.-tracking': { 'letter-spacing': '-0.025em' },
+        '.tracking': { 'letter-spacing': '0.025em' },
+        '.tracking-1': { 'letter-spacing': '0.05em' },
+      },
+      variants: ['responsive'],
+    },
+  ])
+})

--- a/__tests__/plugins/letterSpacing.test.js
+++ b/__tests__/plugins/letterSpacing.test.js
@@ -2,16 +2,14 @@ import _ from 'lodash'
 import escapeClassName from '../../src/util/escapeClassName'
 import plugin from '../../src/plugins/letterSpacing'
 
-test('letter spacing can use default keyword and negative prefix syntax', () => {
+test('letter spacing can use negative prefix syntax', () => {
   const addedUtilities = []
 
   const config = {
     theme: {
       letterSpacing: {
-        '-1': '-0.05em',
-        '-': '-0.025em',
-        default: '0.025em',
-        '1': '0.05em',
+        '-1': '-0.025em',
+        '1': '0.025em',
       },
     },
     variants: {
@@ -44,10 +42,8 @@ test('letter spacing can use default keyword and negative prefix syntax', () => 
   expect(addedUtilities).toEqual([
     {
       utilities: {
-        '.-tracking-1': { 'letter-spacing': '-0.05em' },
-        '.-tracking': { 'letter-spacing': '-0.025em' },
-        '.tracking': { 'letter-spacing': '0.025em' },
-        '.tracking-1': { 'letter-spacing': '0.05em' },
+        '.-tracking-1': { 'letter-spacing': '-0.025em' },
+        '.tracking-1': { 'letter-spacing': '0.025em' },
       },
       variants: ['responsive'],
     },

--- a/__tests__/plugins/zIndex.test.js
+++ b/__tests__/plugins/zIndex.test.js
@@ -1,0 +1,55 @@
+import _ from 'lodash'
+import escapeClassName from '../../src/util/escapeClassName'
+import plugin from '../../src/plugins/zIndex'
+
+test('z index can use default keyword and negative prefix syntax', () => {
+  const addedUtilities = []
+
+  const config = {
+    theme: {
+      zIndex: {
+        '-20': '-20',
+        '-': '-10',
+        default: '10',
+        '20': '20',
+      },
+    },
+    variants: {
+      zIndex: ['responsive'],
+    },
+  }
+
+  const getConfigValue = (path, defaultValue) => _.get(config, path, defaultValue)
+  const pluginApi = {
+    config: getConfigValue,
+    e: escapeClassName,
+    theme: (path, defaultValue) => getConfigValue(`theme.${path}`, defaultValue),
+    variants: (path, defaultValue) => {
+      if (_.isArray(config.variants)) {
+        return config.variants
+      }
+
+      return getConfigValue(`variants.${path}`, defaultValue)
+    },
+    addUtilities(utilities, variants) {
+      addedUtilities.push({
+        utilities,
+        variants,
+      })
+    },
+  }
+
+  plugin()(pluginApi)
+
+  expect(addedUtilities).toEqual([
+    {
+      utilities: {
+        '.-z-20': { 'z-index': '-20' },
+        '.-z': { 'z-index': '-10' },
+        '.z': { 'z-index': '10' },
+        '.z-20': { 'z-index': '20' },
+      },
+      variants: ['responsive'],
+    },
+  ])
+})

--- a/__tests__/plugins/zIndex.test.js
+++ b/__tests__/plugins/zIndex.test.js
@@ -2,15 +2,15 @@ import _ from 'lodash'
 import escapeClassName from '../../src/util/escapeClassName'
 import plugin from '../../src/plugins/zIndex'
 
-test('z index can use default keyword and negative prefix syntax', () => {
+test('z index can use negative prefix syntax', () => {
   const addedUtilities = []
 
   const config = {
     theme: {
       zIndex: {
         '-20': '-20',
-        '-': '-10',
-        default: '10',
+        '-10': '-10',
+        '10': '10',
         '20': '20',
       },
     },
@@ -45,8 +45,8 @@ test('z index can use default keyword and negative prefix syntax', () => {
     {
       utilities: {
         '.-z-20': { 'z-index': '-20' },
-        '.-z': { 'z-index': '-10' },
-        '.z': { 'z-index': '10' },
+        '.-z-10': { 'z-index': '-10' },
+        '.z-10': { 'z-index': '10' },
         '.z-20': { 'z-index': '20' },
       },
       variants: ['responsive'],

--- a/__tests__/prefixNegativeModifiers.test.js
+++ b/__tests__/prefixNegativeModifiers.test.js
@@ -1,0 +1,13 @@
+import prefixNegativeModifiers from '../src/util/prefixNegativeModifiers'
+
+test('it does not prefix classes using standard syntax', () => {
+  expect(prefixNegativeModifiers('base', 'modifier')).toEqual('base-modifier')
+})
+
+test('it prefixes classes using negative syntax', () => {
+  expect(prefixNegativeModifiers('base', '-modifier')).toEqual('-base-modifier')
+})
+
+test('it prefixes classes and omits suffix using default negative syntax', () => {
+  expect(prefixNegativeModifiers('base', '-')).toEqual('-base')
+})

--- a/src/plugins/boxShadow.js
+++ b/src/plugins/boxShadow.js
@@ -1,4 +1,5 @@
 import _ from 'lodash'
+import prefixNegativeModifiers from '../util/prefixNegativeModifiers'
 
 export default function() {
   return function({ addUtilities, e, theme, variants }) {
@@ -6,7 +7,7 @@ export default function() {
       _.map(theme('boxShadow'), (value, modifier) => {
         const className = modifier === 'default' ? 'shadow' : `shadow-${modifier}`
         return [
-          `.${e(className)}`,
+          `.${e(prefixNegativeModifiers('shadow', modifier))}`,
           {
             'box-shadow': value,
           },

--- a/src/plugins/boxShadow.js
+++ b/src/plugins/boxShadow.js
@@ -5,9 +5,10 @@ export default function() {
   return function({ addUtilities, e, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('boxShadow'), (value, modifier) => {
-        const className = modifier === 'default' ? 'shadow' : `shadow-${modifier}`
+        const className =
+          modifier === 'default' ? 'shadow' : `${e(prefixNegativeModifiers('shadow', modifier))}`
         return [
-          `.${e(prefixNegativeModifiers('shadow', modifier))}`,
+          `.${className}`,
           {
             'box-shadow': value,
           },

--- a/src/plugins/letterSpacing.js
+++ b/src/plugins/letterSpacing.js
@@ -1,11 +1,12 @@
 import _ from 'lodash'
+import prefixNegativeModifiers from '../util/prefixNegativeModifiers'
 
 export default function() {
   return function({ addUtilities, theme, variants, e }) {
     const utilities = _.fromPairs(
       _.map(theme('letterSpacing'), (value, modifier) => {
         return [
-          `.${e(`tracking-${modifier}`)}`,
+          `.${e(prefixNegativeModifiers('tracking', modifier))}`,
           {
             'letter-spacing': value,
           },

--- a/src/plugins/letterSpacing.js
+++ b/src/plugins/letterSpacing.js
@@ -5,12 +5,8 @@ export default function() {
   return function({ addUtilities, theme, variants, e }) {
     const utilities = _.fromPairs(
       _.map(theme('letterSpacing'), (value, modifier) => {
-        const className =
-          modifier === 'default'
-            ? 'tracking'
-            : `${e(prefixNegativeModifiers('tracking', modifier))}`
         return [
-          `.${className}`,
+          `.${e(prefixNegativeModifiers('tracking', modifier))}`,
           {
             'letter-spacing': value,
           },

--- a/src/plugins/letterSpacing.js
+++ b/src/plugins/letterSpacing.js
@@ -5,8 +5,12 @@ export default function() {
   return function({ addUtilities, theme, variants, e }) {
     const utilities = _.fromPairs(
       _.map(theme('letterSpacing'), (value, modifier) => {
+        const className =
+          modifier === 'default'
+            ? 'tracking'
+            : `${e(prefixNegativeModifiers('tracking', modifier))}`
         return [
-          `.${e(prefixNegativeModifiers('tracking', modifier))}`,
+          `.${className}`,
           {
             'letter-spacing': value,
           },

--- a/src/plugins/zIndex.js
+++ b/src/plugins/zIndex.js
@@ -5,8 +5,10 @@ export default function() {
   return function({ addUtilities, e, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('zIndex'), (value, modifier) => {
+        const className =
+          modifier === 'default' ? 'z' : `${e(prefixNegativeModifiers('z', modifier))}`
         return [
-          `.${e(prefixNegativeModifiers('z', modifier))}`,
+          `.${className}`,
           {
             'z-index': value,
           },

--- a/src/plugins/zIndex.js
+++ b/src/plugins/zIndex.js
@@ -5,10 +5,8 @@ export default function() {
   return function({ addUtilities, e, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('zIndex'), (value, modifier) => {
-        const className =
-          modifier === 'default' ? 'z' : `${e(prefixNegativeModifiers('z', modifier))}`
         return [
-          `.${className}`,
+          `.${e(prefixNegativeModifiers('z', modifier))}`,
           {
             'z-index': value,
           },

--- a/src/util/prefixNegativeModifiers.js
+++ b/src/util/prefixNegativeModifiers.js
@@ -1,5 +1,9 @@
 import _ from 'lodash'
 
 export default function prefixNegativeModifiers(base, modifier) {
-  return _.startsWith(modifier, '-') ? `-${base}-${modifier.slice(1)}` : `${base}-${modifier}`
+  return modifier === '-'
+    ? `-${base}`
+    : _.startsWith(modifier, '-')
+      ? `-${base}-${modifier.slice(1)}`
+      : `${base}-${modifier}`
 }

--- a/src/util/prefixNegativeModifiers.js
+++ b/src/util/prefixNegativeModifiers.js
@@ -1,9 +1,11 @@
 import _ from 'lodash'
 
 export default function prefixNegativeModifiers(base, modifier) {
-  return modifier === '-'
-    ? `-${base}`
-    : _.startsWith(modifier, '-')
-      ? `-${base}-${modifier.slice(1)}`
-      : `${base}-${modifier}`
+  if (modifier === '-') {
+    return `-${base}`
+  } else if (_.startsWith(modifier, '-')) {
+    return `-${base}-${modifier.slice(1)}`
+  } else {
+    return `${base}-${modifier}`
+  }
 }


### PR DESCRIPTION
Closes #982 

This PR takes the z-index negative prefix feature and applies it for letter spacing and box shadow. I was also going to support line height, but I discovered that negative line heights are invalid CSS, so I don't think there's a use case for it.

This PR also tweaks the `prefixNegativeModifiers` util so that you can create classes like `-shadow` simply by putting `'-'` as the name of your config key. It's kind of like the `default` keyword, but for negative prefixed classes (see example below).

Here's an example of how it would allow you to configure tailwind (resulting classes are in the comments on each line):

```
// tailwind.config.js

module.exports = {
  theme: {
    lineHeight: {
      '-2': '-0.05em', // -tracking-2
      '-1': '-0.025em', // -tracking-1
    },
    boxShadow: {
      '-': 'inset 0 2px 4px 0 rgba(0, 0, 0, 0.06)', // -shadow
      '-md': 'inset 0 4px 6px 0 rgba(0, 0, 0, 0.10), inset 0 2px 4px 0 rgba(0, 0, 0, 0.06)', // -shadow-md
    }
  }
}
```

**linting note**: linter was telling me not to use nested ternaries in `prefixNegativeModifiers`, I'll refactor that to if/else if it's a problem