### PR TITLE
Add default border-width to hr elements

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -470,6 +470,10 @@ img {
   border-style: solid;
 }
 
+hr {
+  border-width: 1px;
+}
+
 textarea {
   resize: vertical;
 }

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -470,6 +470,10 @@ img {
   border-style: solid;
 }
 
+hr {
+  border-width: 1px;
+}
+
 textarea {
   resize: vertical;
 }

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -118,6 +118,10 @@ img {
   border-style: solid;
 }
 
+hr {
+  border-width: 1px;
+}
+
 textarea {
   resize: vertical;
 }


### PR DESCRIPTION
Resolves  tailwindcss/tailwindcss#979

The resulting horizontaler ruler has a height of 2 pixels.