### PR TITLE
Reference theme values no matter how deep they are referenced from

### DIFF
--- a/src/util/resolveConfig.js
+++ b/src/util/resolveConfig.js
@@ -58,7 +58,9 @@ function resolveFunctionKeys(object) {
       if (isFunction(otherObject[key])) {
         return otherObject[key](resolveThemePath, configUtils)
       } else {
-        if (typeof otherObject === 'object' && otherObject.isArray === false) {
+        if (Array.isArray(otherObject[key])) {
+          return otherObject[key]
+        } else if (typeof object === 'object') {
           return createObject(otherObject[key])
         }
         return otherObject[key]

--- a/src/util/resolveConfig.js
+++ b/src/util/resolveConfig.js
@@ -53,12 +53,31 @@ function resolveFunctionKeys(object) {
     return val === undefined ? defaultValue : val
   }
 
-  return Object.keys(object).reduce((resolved, key) => {
-    return {
-      ...resolved,
-      [key]: isFunction(object[key]) ? object[key](resolveThemePath, configUtils) : object[key],
+  function createObject(newObject) {
+    function resolveFunction(otherObject, key) {
+      if (isFunction(otherObject[key])) {
+        return otherObject[key](resolveThemePath, configUtils)
+      } else {
+        if (typeof otherObject === 'object' && otherObject.isArray === false) {
+          return createObject(otherObject[key])
+        }
+        return otherObject[key]
+      }
     }
-  }, {})
+
+    if (typeof newObject === 'object') {
+      return Object.keys(newObject).reduce((resolved, key) => {
+        return {
+          ...resolved,
+          [key]: resolveFunction(newObject, key),
+        }
+      }, {})
+    } else {
+      return newObject
+    }
+  }
+
+  return createObject(object)
 }
 
 export default function resolveConfig(configs) {


### PR DESCRIPTION
In my own project, I'm using `tailwind.config.js` as a place to define design tokens. For me, it is really important to be able to reference any value from anywhere so that I can create dynamic relationships between styles.

It was therefore important that I could do the following.

```js
theme {
    foo: "green",
    bar: {
        baz: theme => theme("foo")
    }
}
```
Some use cases are explained in this issue #1007 

I was able to get it working on my local machine, although I have no real formal programming experience so the code is likely littered with things that go against best practices (I'm almost certain it does). But someone who knows what they're doing can probably help rewrite the code more elegantly.

@adamwathan I appreciate you haven't cast your thoughts and opinions on this already, but feel free to use any or none of what I've done.

This is my first pull request so forgive me if something is not quite right.
