### PR TITLE
Add first-child and last-child variants

### DIFF
--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -137,7 +137,7 @@ test('it can generate focus-within variants', () => {
 
 test('it can generate first-child variants', () => {
   const input = `
-    @variants first-child {
+    @variants first {
       .banana { color: yellow; }
       .chocolate { color: brown; }
     }
@@ -146,8 +146,8 @@ test('it can generate first-child variants', () => {
   const output = `
       .banana { color: yellow; }
       .chocolate { color: brown; }
-      .first-child\\:banana:first-child { color: yellow; }
-      .first-child\\:chocolate:first-child { color: brown; }
+      .first\\:banana:first-child { color: yellow; }
+      .first\\:chocolate:first-child { color: brown; }
   `
 
   return run(input).then(result => {
@@ -158,7 +158,7 @@ test('it can generate first-child variants', () => {
 
 test('it can generate last-child variants', () => {
   const input = `
-    @variants last-child {
+    @variants last {
       .banana { color: yellow; }
       .chocolate { color: brown; }
     }
@@ -167,8 +167,8 @@ test('it can generate last-child variants', () => {
   const output = `
       .banana { color: yellow; }
       .chocolate { color: brown; }
-      .last-child\\:banana:last-child { color: yellow; }
-      .last-child\\:chocolate:last-child { color: brown; }
+      .last\\:banana:last-child { color: yellow; }
+      .last\\:chocolate:last-child { color: brown; }
   `
 
   return run(input).then(result => {

--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -135,6 +135,48 @@ test('it can generate focus-within variants', () => {
   })
 })
 
+test('it can generate first-child variants', () => {
+  const input = `
+    @variants first-child {
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+    }
+  `
+
+  const output = `
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+      .first-child\\:banana:first-child { color: yellow; }
+      .first-child\\:chocolate:first-child { color: brown; }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it can generate last-child variants', () => {
+  const input = `
+    @variants last-child {
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+    }
+  `
+
+  const output = `
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+      .last-child\\:banana:last-child { color: yellow; }
+      .last-child\\:chocolate:last-child { color: brown; }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('it can generate group-hover variants', () => {
   const input = `
     @variants group-hover {

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -3,12 +3,12 @@ import postcss from 'postcss'
 import selectorParser from 'postcss-selector-parser'
 import generateVariantFunction from '../util/generateVariantFunction'
 
-function generatePseudoClassVariant(pseudoClass) {
+function generatePseudoClassVariant(pseudoClass, selectorPrefix = pseudoClass) {
   return generateVariantFunction(({ modifySelectors, separator }) => {
     return modifySelectors(({ selector }) => {
       return selectorParser(selectors => {
         selectors.walkClasses(sel => {
-          sel.value = `${pseudoClass}${separator}${sel.value}`
+          sel.value = `${selectorPrefix}${separator}${sel.value}`
           sel.parent.insertAfter(sel, selectorParser.pseudo({ value: `:${pseudoClass}` }))
         })
       }).processSync(selector)
@@ -38,8 +38,8 @@ const defaultVariantGenerators = {
   active: generatePseudoClassVariant('active'),
   visited: generatePseudoClassVariant('visited'),
   disabled: generatePseudoClassVariant('disabled'),
-  'first-child': generatePseudoClassVariant('first-child'),
-  'last-child': generatePseudoClassVariant('last-child'),
+  first: generatePseudoClassVariant('first-child', 'first'),
+  last: generatePseudoClassVariant('last-child', 'last'),
 }
 
 export default function(config, { variantGenerators: pluginVariantGenerators }) {

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -38,6 +38,8 @@ const defaultVariantGenerators = {
   active: generatePseudoClassVariant('active'),
   visited: generatePseudoClassVariant('visited'),
   disabled: generatePseudoClassVariant('disabled'),
+  'first-child': generatePseudoClassVariant('first-child'),
+  'last-child': generatePseudoClassVariant('last-child'),
 }
 
 export default function(config, { variantGenerators: pluginVariantGenerators }) {


### PR DESCRIPTION
This PR adds new `first-child` and `last-child` variants to the framework, but disabled by default for all core plugins.

These allow you to apply a utility to an element only when it is the first child or last child of its parent. Very useful for things like "put a border between all of these items that are generated in a loop" for example:

```html
<ul>
  <li v-for="item in items" class="border-t first-child:border-t-0">{{ item }}</li>
</ul>
```

Something worth emphasizing is that these variants apply to the child element itself, *not* to the children of the element with the utility. This is consistent with how other pseudo-class variants in Tailwind work, and how the `:first/last-child` pseudo selectors work in CSS.

Said again in code:

```html
<!-- This is *not* how the plugin is meant to be used -->
<ul class="first-child:border-t-0">
  <li v-for="item in items" class="border-t">{{ item }}</li>
</ul>

<!-- The utilities should be used on the child itself, not the parent -->
<ul>
  <li v-for="item in items" class="border-t first-child:border-t-0">{{ item }}</li>
</ul>
```