### PR TITLE
Allow the use of nested utility classes in @apply

### DIFF
--- a/__tests__/applyAtRule.test.js
+++ b/__tests__/applyAtRule.test.js
@@ -242,3 +242,33 @@ test('you can apply utility classes without using the given prefix when using a 
     expect(result.warnings().length).toBe(0)
   })
 })
+
+test('you can apply utility classes even if they have been nested', () => {
+  const input = `
+    .foo {
+      .mb-4 { margin-bottom: 1rem; }
+    }
+    .bar { @apply .mb-4; }
+  `
+
+  const expected = `
+    .foo {
+      .mb-4 { margin-bottom: 1rem; }
+    }
+    .bar { margin-bottom: 1rem; }
+  `
+
+  const config = resolveConfig([
+    {
+      ...defaultConfig,
+      prefix: () => {
+        return 'tw-'
+      },
+    },
+  ])
+
+  return run(input, config, processPlugins(corePlugins(config), config).utilities).then(result => {
+    expect(result.css).toEqual(expected)
+    expect(result.warnings().length).toBe(0)
+  })
+})

--- a/__tests__/applyAtRule.test.js
+++ b/__tests__/applyAtRule.test.js
@@ -247,15 +247,17 @@ test('you can apply utility classes even if they have been nested', () => {
   const input = `
     .foo {
       .mb-4 { margin-bottom: 1rem; }
+      .tw-mt-4 { margin-top: 1rem; }
     }
-    .bar { @apply .mb-4; }
+    .bar { @apply .mb-4 .tw-mt-4; }
   `
 
   const expected = `
     .foo {
       .mb-4 { margin-bottom: 1rem; }
+      .tw-mt-4 { margin-top: 1rem; }
     }
-    .bar { margin-bottom: 1rem; }
+    .bar { margin-bottom: 1rem; margin-top: 1rem; }
   `
 
   const config = resolveConfig([

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "repository": "https://github.com/tailwindcss/tailwindcss.git",
   "bugs": "https://github.com/tailwindcss/tailwindcss/issues",
   "homepage": "https://tailwindcss.com",
+  "files": ["dist"],
   "bin": {
     "tailwind": "lib/cli.js"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "repository": "https://github.com/tailwindcss/tailwindcss.git",
   "bugs": "https://github.com/tailwindcss/tailwindcss/issues",
   "homepage": "https://tailwindcss.com",
-  "files": ["dist"],
+  "files": ["lib"],
   "bin": {
     "tailwind": "lib/cli.js"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "repository": "https://github.com/tailwindcss/tailwindcss.git",
   "bugs": "https://github.com/tailwindcss/tailwindcss/issues",
   "homepage": "https://tailwindcss.com",
-  "files": ["lib"],
+  "files": ["lib", "stubs"],
   "bin": {
     "tailwind": "lib/cli.js"
   },

--- a/src/lib/substituteClassApplyAtRules.js
+++ b/src/lib/substituteClassApplyAtRules.js
@@ -3,6 +3,8 @@ import postcss from 'postcss'
 import escapeClassName from '../util/escapeClassName'
 import prefixSelector from '../util/prefixSelector'
 
+let generatedSelectors = {}
+
 function buildClassTable(css) {
   const classTable = {}
 
@@ -21,6 +23,12 @@ function buildShadowTable(generatedUtilities) {
 
   postcss.root({ nodes: generatedUtilities }).walkAtRules('variants', atRule => {
     utilities.append(atRule.clone().nodes)
+  })
+  
+  generatedUtilities.map(rule => {
+    rule.nodes.map(node => {
+      generatedSelectors[node.selector] = true
+    })
   })
 
   return buildClassTable(utilities)
@@ -44,7 +52,7 @@ function findClass(classToApply, classTable, onError) {
 
   const [match] = matches
 
-  if (match.parent.type !== 'root') {
+  if (match.parent.type !== 'root' && !generatedSelectors[classToApply]) {
     // prettier-ignore
     throw onError(`\`@apply\` cannot be used with ${classToApply} because ${classToApply} is nested inside of an at-rule (@${match.parent.name}).`)
   }


### PR DESCRIPTION
If a utility class is nested, using `@apply` will throw an error since it's no longer at the "root" level. Using a prefix fixes the issue because it tricks tailwind into using the in-memory lookup. This change will check the classname against a list of globally available (in-memory) classes and use them if found, instead of throwing an error.

```
unhandledRejection CssSyntaxError: /path/to/styles.pcss
           `@apply` cannot be used with .text-small because .text-small is nested inside of an at-rule (@undefined)
```
Example usage:
```
scoped-styles {
   /* Base styling here */
  @tailwind utilities;
}

.some-component {
  @apply .text-small .etc;
}
```
Notes from @adamwathan in chat:
> we might be able to have it use the lookup table as a fallback even if it does find a class in your CSS but cant use it because its nested that is probably doable and would solve your problem