### PR TITLE
Replaces use of Lodash isArray with built-in Array.isArray

### DIFF
--- a/src/lib/evaluateTailwindFunctions.js
+++ b/src/lib/evaluateTailwindFunctions.js
@@ -6,7 +6,7 @@ export default function(config) {
     functions: {
       theme: (path, ...defaultValue) => {
         return _.thru(_.get(config.theme, _.trim(path, `'"`), defaultValue), value => {
-          return _.isArray(value) ? value.join(', ') : value
+          return Array.isArray(value) ? value.join(', ') : value
         })
       },
     },

--- a/src/plugins/container.js
+++ b/src/plugins/container.js
@@ -7,7 +7,7 @@ function extractMinWidths(breakpoints) {
       breakpoints = { min: breakpoints }
     }
 
-    if (!_.isArray(breakpoints)) {
+    if (!Array.isArray(breakpoints)) {
       breakpoints = [breakpoints]
     }
 

--- a/src/plugins/fontFamily.js
+++ b/src/plugins/fontFamily.js
@@ -7,7 +7,7 @@ export default function() {
         return [
           `.${e(`font-${modifier}`)}`,
           {
-            'font-family': _.isArray(value) ? value.join(', ') : value,
+            'font-family': Array.isArray(value) ? value.join(', ') : value,
           },
         ]
       })

--- a/src/util/buildMediaQuery.js
+++ b/src/util/buildMediaQuery.js
@@ -5,7 +5,7 @@ export default function buildMediaQuery(screens) {
     screens = { min: screens }
   }
 
-  if (!_.isArray(screens)) {
+  if (!Array.isArray(screens)) {
     screens = [screens]
   }
 

--- a/src/util/processPlugins.js
+++ b/src/util/processPlugins.js
@@ -32,7 +32,7 @@ export default function(plugins, config) {
       config: getConfigValue,
       theme: (path, defaultValue) => getConfigValue(`theme.${path}`, defaultValue),
       variants: (path, defaultValue) => {
-        if (_.isArray(config.variants)) {
+        if (Array.isArray(config.variants)) {
           return config.variants
         }
 

--- a/src/util/responsive.js
+++ b/src/util/responsive.js
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import postcss from 'postcss'
 import cloneNodes from './cloneNodes'
 
@@ -7,5 +6,5 @@ export default function responsive(rules) {
     .atRule({
       name: 'responsive',
     })
-    .append(cloneNodes(_.isArray(rules) ? rules : [rules]))
+    .append(cloneNodes(Array.isArray(rules) ? rules : [rules]))
 }

--- a/src/util/wrapWithVariants.js
+++ b/src/util/wrapWithVariants.js
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import postcss from 'postcss'
 import cloneNodes from './cloneNodes'
 
@@ -8,5 +7,5 @@ export default function wrapWithVariants(rules, variants) {
       name: 'variants',
       params: variants.join(', '),
     })
-    .append(cloneNodes(_.isArray(rules) ? rules : [rules]))
+    .append(cloneNodes(Array.isArray(rules) ? rules : [rules]))
 }


### PR DESCRIPTION
This PR replaces use of `_.isArray` with standard built-in `Array.isArray`

Built-in `isArray` is faster and should be preferred