### PR TITLE
Support passing config path via object

### DIFF
--- a/__tests__/customConfig.test.js
+++ b/__tests__/customConfig.test.js
@@ -133,3 +133,42 @@ test('tailwind.config.js is picked up by default', () => {
       })
   })
 })
+
+test('tailwind.config.js is picked up by default when passing an empty object', () => {
+  return inTempDirectory(() => {
+    fs.writeFileSync(
+      path.resolve(defaultConfigFile),
+      `module.exports = {
+        theme: {
+          screens: {
+            mobile: '400px',
+          },
+        },
+      }`
+    )
+
+    return postcss([tailwind({})])
+      .process(
+        `
+          @responsive {
+            .foo {
+              color: blue;
+            }
+          }
+        `,
+        { from: undefined }
+      )
+      .then(result => {
+        expect(result.css).toMatchCss(`
+          .foo {
+            color: blue;
+          }
+          @media (min-width: 400px) {
+            .mobile\\:foo {
+              color: blue;
+            }
+          }
+        `)
+      })
+  })
+})

--- a/__tests__/customConfig.test.js
+++ b/__tests__/customConfig.test.js
@@ -68,6 +68,33 @@ test('custom config can be passed as an object', () => {
     })
 })
 
+test('custom config path can be passed using `config` property in an object', () => {
+  return postcss([tailwind({ config: path.resolve(`${__dirname}/fixtures/custom-config.js`) })])
+    .process(
+      `
+        @responsive {
+          .foo {
+            color: blue;
+          }
+        }
+      `,
+      { from: undefined }
+    )
+    .then(result => {
+      const expected = `
+        .foo {
+          color: blue;
+        }
+        @media (min-width: 400px) {
+          .mobile\\:foo {
+            color: blue;
+          }
+        }
+      `
+      expect(result.css).toMatchCss(expected)
+    })
+})
+
 test('tailwind.config.js is picked up by default', () => {
   return inTempDirectory(() => {
     fs.writeFileSync(

--- a/__tests__/customConfig.test.js
+++ b/__tests__/customConfig.test.js
@@ -95,6 +95,44 @@ test('custom config path can be passed using `config` property in an object', ()
     })
 })
 
+test('custom config can be passed under the `config` property', () => {
+  return postcss([
+    tailwind({
+      config: {
+        theme: {
+          screens: {
+            mobile: '400px',
+          },
+        },
+      },
+    }),
+  ])
+    .process(
+      `
+        @responsive {
+          .foo {
+            color: blue;
+          }
+        }
+      `,
+      { from: undefined }
+    )
+    .then(result => {
+      const expected = `
+        .foo {
+          color: blue;
+        }
+        @media (min-width: 400px) {
+          .mobile\\:foo {
+            color: blue;
+          }
+        }
+      `
+
+      expect(result.css).toMatchCss(expected)
+    })
+})
+
 test('tailwind.config.js is picked up by default', () => {
   return inTempDirectory(() => {
     fs.writeFileSync(

--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,12 @@ import { defaultConfigFile } from './constants'
 import defaultConfig from '../stubs/defaultConfig.stub.js'
 
 function resolveConfigPath(filePath) {
-  if (_.isObject(filePath)) {
+  if (_.isObject(filePath) && !_.has(filePath, 'config')) {
     return undefined
+  }
+
+  if (_.isObject(filePath) && _.has(filePath, 'config')) {
+    return path.resolve(filePath.config)
   }
 
   if (!_.isUndefined(filePath)) {

--- a/src/index.js
+++ b/src/index.js
@@ -13,18 +13,27 @@ import { defaultConfigFile } from './constants'
 import defaultConfig from '../stubs/defaultConfig.stub.js'
 
 function resolveConfigPath(filePath) {
+  // require('tailwindcss')({ theme: ..., variants: ... })
   if (_.isObject(filePath) && !_.has(filePath, 'config') && !_.isEmpty(filePath)) {
     return undefined
   }
 
-  if (_.isObject(filePath) && _.has(filePath, 'config')) {
+  // require('tailwindcss')({ config: 'custom-config.js' })
+  if (_.isObject(filePath) && _.has(filePath, 'config') && _.isString(filePath.config)) {
     return path.resolve(filePath.config)
   }
 
+  // require('tailwindcss')({ config: { theme: ..., variants: ... } })
+  if (_.isObject(filePath) && _.has(filePath, 'config') && _.isObject(filePath.config)) {
+    undefined
+  }
+
+  // require('tailwindcss')('custom-config.js')
   if (_.isString(filePath)) {
     return path.resolve(filePath)
   }
 
+  // require('tailwindcss')
   try {
     const defaultConfigPath = path.resolve(defaultConfigFile)
     fs.accessSync(defaultConfigPath)
@@ -43,7 +52,10 @@ const getConfigFunction = config => () => {
     delete require.cache[require.resolve(config)]
   }
 
-  return resolveConfig([_.isObject(config) ? config : require(config), defaultConfig])
+  return resolveConfig([
+    _.isObject(config) ? _.get(config, 'config', config) : require(config),
+    defaultConfig,
+  ])
 }
 
 const plugin = postcss.plugin('tailwind', config => {

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ import { defaultConfigFile } from './constants'
 import defaultConfig from '../stubs/defaultConfig.stub.js'
 
 function resolveConfigPath(filePath) {
-  if (_.isObject(filePath) && !_.has(filePath, 'config')) {
+  if (_.isObject(filePath) && !_.has(filePath, 'config') && !_.isEmpty(filePath)) {
     return undefined
   }
 
@@ -21,7 +21,7 @@ function resolveConfigPath(filePath) {
     return path.resolve(filePath.config)
   }
 
-  if (!_.isUndefined(filePath)) {
+  if (_.isString(filePath)) {
     return path.resolve(filePath)
   }
 


### PR DESCRIPTION
This PR adds support for specifying the path to your Tailwind config using an object in addition to just passing the file path directly:

```js
// postcss.config.js
module.exports = {
  plugins: [
    // Existing syntax:
    require('tailwindcss')('custom-config.js'),

    // Added syntax:
    require('tailwindcss')({ config: 'custom-config.js' }),
  ]
}
```

This makes Tailwind easier to use with PostCSS's object configuration syntax:

```js
// postcss.config.js
module.exports = {
  plugins: {
    tailwindcss: { config: 'custom-config.js' },
  }
}
```

This is helpful particularly with Nuxt because they have deprecated use of a regular postcss.config.js file and their custom config file doesn't support the array syntax.

This PR also allows using an empty object to signal to Tailwind to just use the default config file path:

```js
// postcss.config.js
module.exports = {
  plugins: {
    tailwindcss: {},
  }
}

// Same as:
module.exports = {
  plugins: [
    require('tailwindcss'),
  ]
}
```

Many other tools *only* document the object syntax for PostCSS configuration and it has left many people stumped trying to figure out how to include Tailwind when using that syntax, so this change makes it easier for people to fall into the pit of success since an empty object is how all other PostCSS plugins signal to use the defaults.

It also means you can now configure Tailwind inside the `postcss` key of your `package.json` file if you don't want to have a separate postcss.config.js file.

This is *sort of* a breaking change if you want to be very technical about it, because although undocumented, we do support passing your config object to Tailwind directly rather than a path:

```js
// postcss.config.js
module.exports = {
  plugins: {
    // You can pass your custom config directly here:
    tailwindcss: {
      theme: { ... },
      variants: { ... },
    },
  }
}
```

So with this PR, passing `{}` tells Tailwind "use a tailwind.config.js file if you find one", whereas before this PR it said "use Tailwind's default config with no modifications".

I would be incredibly surprised if this affects even a single person, as there is no reason to have a tailwind.config.js file in your project yet not even be using it because you are passing a config object directly.

This PR also allows you to pass your config object directly under the config key for consistency:

```js
// postcss.config.js
module.exports = {
  plugins: {
    tailwindcss: {
      config: {
        theme: { ... },
        variants: { ... },
      },
    },
  }
}
```

For 2.0 I'd like to remove the ability to pass your config object directly as the only argument, and instead have people nest that config object under the `config` key so there's only one way of doing things and things are less ambiguous.