### PR TITLE
Add placeholder color utilities

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -5760,6 +5760,378 @@ video {
   padding-left: 1px !important;
 }
 
+.placeholder-transparent::placeholder {
+  color: transparent !important;
+}
+
+.placeholder-black::placeholder {
+  color: #000 !important;
+}
+
+.placeholder-white::placeholder {
+  color: #fff !important;
+}
+
+.placeholder-gray-100::placeholder {
+  color: #f7fafc !important;
+}
+
+.placeholder-gray-200::placeholder {
+  color: #edf2f7 !important;
+}
+
+.placeholder-gray-300::placeholder {
+  color: #e2e8f0 !important;
+}
+
+.placeholder-gray-400::placeholder {
+  color: #cbd5e0 !important;
+}
+
+.placeholder-gray-500::placeholder {
+  color: #a0aec0 !important;
+}
+
+.placeholder-gray-600::placeholder {
+  color: #718096 !important;
+}
+
+.placeholder-gray-700::placeholder {
+  color: #4a5568 !important;
+}
+
+.placeholder-gray-800::placeholder {
+  color: #2d3748 !important;
+}
+
+.placeholder-gray-900::placeholder {
+  color: #1a202c !important;
+}
+
+.placeholder-red-100::placeholder {
+  color: #fff5f5 !important;
+}
+
+.placeholder-red-200::placeholder {
+  color: #fed7d7 !important;
+}
+
+.placeholder-red-300::placeholder {
+  color: #feb2b2 !important;
+}
+
+.placeholder-red-400::placeholder {
+  color: #fc8181 !important;
+}
+
+.placeholder-red-500::placeholder {
+  color: #f56565 !important;
+}
+
+.placeholder-red-600::placeholder {
+  color: #e53e3e !important;
+}
+
+.placeholder-red-700::placeholder {
+  color: #c53030 !important;
+}
+
+.placeholder-red-800::placeholder {
+  color: #9b2c2c !important;
+}
+
+.placeholder-red-900::placeholder {
+  color: #742a2a !important;
+}
+
+.placeholder-orange-100::placeholder {
+  color: #fffaf0 !important;
+}
+
+.placeholder-orange-200::placeholder {
+  color: #feebc8 !important;
+}
+
+.placeholder-orange-300::placeholder {
+  color: #fbd38d !important;
+}
+
+.placeholder-orange-400::placeholder {
+  color: #f6ad55 !important;
+}
+
+.placeholder-orange-500::placeholder {
+  color: #ed8936 !important;
+}
+
+.placeholder-orange-600::placeholder {
+  color: #dd6b20 !important;
+}
+
+.placeholder-orange-700::placeholder {
+  color: #c05621 !important;
+}
+
+.placeholder-orange-800::placeholder {
+  color: #9c4221 !important;
+}
+
+.placeholder-orange-900::placeholder {
+  color: #7b341e !important;
+}
+
+.placeholder-yellow-100::placeholder {
+  color: #fffff0 !important;
+}
+
+.placeholder-yellow-200::placeholder {
+  color: #fefcbf !important;
+}
+
+.placeholder-yellow-300::placeholder {
+  color: #faf089 !important;
+}
+
+.placeholder-yellow-400::placeholder {
+  color: #f6e05e !important;
+}
+
+.placeholder-yellow-500::placeholder {
+  color: #ecc94b !important;
+}
+
+.placeholder-yellow-600::placeholder {
+  color: #d69e2e !important;
+}
+
+.placeholder-yellow-700::placeholder {
+  color: #b7791f !important;
+}
+
+.placeholder-yellow-800::placeholder {
+  color: #975a16 !important;
+}
+
+.placeholder-yellow-900::placeholder {
+  color: #744210 !important;
+}
+
+.placeholder-green-100::placeholder {
+  color: #f0fff4 !important;
+}
+
+.placeholder-green-200::placeholder {
+  color: #c6f6d5 !important;
+}
+
+.placeholder-green-300::placeholder {
+  color: #9ae6b4 !important;
+}
+
+.placeholder-green-400::placeholder {
+  color: #68d391 !important;
+}
+
+.placeholder-green-500::placeholder {
+  color: #48bb78 !important;
+}
+
+.placeholder-green-600::placeholder {
+  color: #38a169 !important;
+}
+
+.placeholder-green-700::placeholder {
+  color: #2f855a !important;
+}
+
+.placeholder-green-800::placeholder {
+  color: #276749 !important;
+}
+
+.placeholder-green-900::placeholder {
+  color: #22543d !important;
+}
+
+.placeholder-teal-100::placeholder {
+  color: #e6fffa !important;
+}
+
+.placeholder-teal-200::placeholder {
+  color: #b2f5ea !important;
+}
+
+.placeholder-teal-300::placeholder {
+  color: #81e6d9 !important;
+}
+
+.placeholder-teal-400::placeholder {
+  color: #4fd1c5 !important;
+}
+
+.placeholder-teal-500::placeholder {
+  color: #38b2ac !important;
+}
+
+.placeholder-teal-600::placeholder {
+  color: #319795 !important;
+}
+
+.placeholder-teal-700::placeholder {
+  color: #2c7a7b !important;
+}
+
+.placeholder-teal-800::placeholder {
+  color: #285e61 !important;
+}
+
+.placeholder-teal-900::placeholder {
+  color: #234e52 !important;
+}
+
+.placeholder-blue-100::placeholder {
+  color: #ebf8ff !important;
+}
+
+.placeholder-blue-200::placeholder {
+  color: #bee3f8 !important;
+}
+
+.placeholder-blue-300::placeholder {
+  color: #90cdf4 !important;
+}
+
+.placeholder-blue-400::placeholder {
+  color: #63b3ed !important;
+}
+
+.placeholder-blue-500::placeholder {
+  color: #4299e1 !important;
+}
+
+.placeholder-blue-600::placeholder {
+  color: #3182ce !important;
+}
+
+.placeholder-blue-700::placeholder {
+  color: #2b6cb0 !important;
+}
+
+.placeholder-blue-800::placeholder {
+  color: #2c5282 !important;
+}
+
+.placeholder-blue-900::placeholder {
+  color: #2a4365 !important;
+}
+
+.placeholder-indigo-100::placeholder {
+  color: #ebf4ff !important;
+}
+
+.placeholder-indigo-200::placeholder {
+  color: #c3dafe !important;
+}
+
+.placeholder-indigo-300::placeholder {
+  color: #a3bffa !important;
+}
+
+.placeholder-indigo-400::placeholder {
+  color: #7f9cf5 !important;
+}
+
+.placeholder-indigo-500::placeholder {
+  color: #667eea !important;
+}
+
+.placeholder-indigo-600::placeholder {
+  color: #5a67d8 !important;
+}
+
+.placeholder-indigo-700::placeholder {
+  color: #4c51bf !important;
+}
+
+.placeholder-indigo-800::placeholder {
+  color: #434190 !important;
+}
+
+.placeholder-indigo-900::placeholder {
+  color: #3c366b !important;
+}
+
+.placeholder-purple-100::placeholder {
+  color: #faf5ff !important;
+}
+
+.placeholder-purple-200::placeholder {
+  color: #e9d8fd !important;
+}
+
+.placeholder-purple-300::placeholder {
+  color: #d6bcfa !important;
+}
+
+.placeholder-purple-400::placeholder {
+  color: #b794f4 !important;
+}
+
+.placeholder-purple-500::placeholder {
+  color: #9f7aea !important;
+}
+
+.placeholder-purple-600::placeholder {
+  color: #805ad5 !important;
+}
+
+.placeholder-purple-700::placeholder {
+  color: #6b46c1 !important;
+}
+
+.placeholder-purple-800::placeholder {
+  color: #553c9a !important;
+}
+
+.placeholder-purple-900::placeholder {
+  color: #44337a !important;
+}
+
+.placeholder-pink-100::placeholder {
+  color: #fff5f7 !important;
+}
+
+.placeholder-pink-200::placeholder {
+  color: #fed7e2 !important;
+}
+
+.placeholder-pink-300::placeholder {
+  color: #fbb6ce !important;
+}
+
+.placeholder-pink-400::placeholder {
+  color: #f687b3 !important;
+}
+
+.placeholder-pink-500::placeholder {
+  color: #ed64a6 !important;
+}
+
+.placeholder-pink-600::placeholder {
+  color: #d53f8c !important;
+}
+
+.placeholder-pink-700::placeholder {
+  color: #b83280 !important;
+}
+
+.placeholder-pink-800::placeholder {
+  color: #97266d !important;
+}
+
+.placeholder-pink-900::placeholder {
+  color: #702459 !important;
+}
+
 .pointer-events-none {
   pointer-events: none !important;
 }

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -6132,6 +6132,378 @@ video {
   color: #702459 !important;
 }
 
+.focus\:placeholder-transparent:focus::placeholder {
+  color: transparent !important;
+}
+
+.focus\:placeholder-black:focus::placeholder {
+  color: #000 !important;
+}
+
+.focus\:placeholder-white:focus::placeholder {
+  color: #fff !important;
+}
+
+.focus\:placeholder-gray-100:focus::placeholder {
+  color: #f7fafc !important;
+}
+
+.focus\:placeholder-gray-200:focus::placeholder {
+  color: #edf2f7 !important;
+}
+
+.focus\:placeholder-gray-300:focus::placeholder {
+  color: #e2e8f0 !important;
+}
+
+.focus\:placeholder-gray-400:focus::placeholder {
+  color: #cbd5e0 !important;
+}
+
+.focus\:placeholder-gray-500:focus::placeholder {
+  color: #a0aec0 !important;
+}
+
+.focus\:placeholder-gray-600:focus::placeholder {
+  color: #718096 !important;
+}
+
+.focus\:placeholder-gray-700:focus::placeholder {
+  color: #4a5568 !important;
+}
+
+.focus\:placeholder-gray-800:focus::placeholder {
+  color: #2d3748 !important;
+}
+
+.focus\:placeholder-gray-900:focus::placeholder {
+  color: #1a202c !important;
+}
+
+.focus\:placeholder-red-100:focus::placeholder {
+  color: #fff5f5 !important;
+}
+
+.focus\:placeholder-red-200:focus::placeholder {
+  color: #fed7d7 !important;
+}
+
+.focus\:placeholder-red-300:focus::placeholder {
+  color: #feb2b2 !important;
+}
+
+.focus\:placeholder-red-400:focus::placeholder {
+  color: #fc8181 !important;
+}
+
+.focus\:placeholder-red-500:focus::placeholder {
+  color: #f56565 !important;
+}
+
+.focus\:placeholder-red-600:focus::placeholder {
+  color: #e53e3e !important;
+}
+
+.focus\:placeholder-red-700:focus::placeholder {
+  color: #c53030 !important;
+}
+
+.focus\:placeholder-red-800:focus::placeholder {
+  color: #9b2c2c !important;
+}
+
+.focus\:placeholder-red-900:focus::placeholder {
+  color: #742a2a !important;
+}
+
+.focus\:placeholder-orange-100:focus::placeholder {
+  color: #fffaf0 !important;
+}
+
+.focus\:placeholder-orange-200:focus::placeholder {
+  color: #feebc8 !important;
+}
+
+.focus\:placeholder-orange-300:focus::placeholder {
+  color: #fbd38d !important;
+}
+
+.focus\:placeholder-orange-400:focus::placeholder {
+  color: #f6ad55 !important;
+}
+
+.focus\:placeholder-orange-500:focus::placeholder {
+  color: #ed8936 !important;
+}
+
+.focus\:placeholder-orange-600:focus::placeholder {
+  color: #dd6b20 !important;
+}
+
+.focus\:placeholder-orange-700:focus::placeholder {
+  color: #c05621 !important;
+}
+
+.focus\:placeholder-orange-800:focus::placeholder {
+  color: #9c4221 !important;
+}
+
+.focus\:placeholder-orange-900:focus::placeholder {
+  color: #7b341e !important;
+}
+
+.focus\:placeholder-yellow-100:focus::placeholder {
+  color: #fffff0 !important;
+}
+
+.focus\:placeholder-yellow-200:focus::placeholder {
+  color: #fefcbf !important;
+}
+
+.focus\:placeholder-yellow-300:focus::placeholder {
+  color: #faf089 !important;
+}
+
+.focus\:placeholder-yellow-400:focus::placeholder {
+  color: #f6e05e !important;
+}
+
+.focus\:placeholder-yellow-500:focus::placeholder {
+  color: #ecc94b !important;
+}
+
+.focus\:placeholder-yellow-600:focus::placeholder {
+  color: #d69e2e !important;
+}
+
+.focus\:placeholder-yellow-700:focus::placeholder {
+  color: #b7791f !important;
+}
+
+.focus\:placeholder-yellow-800:focus::placeholder {
+  color: #975a16 !important;
+}
+
+.focus\:placeholder-yellow-900:focus::placeholder {
+  color: #744210 !important;
+}
+
+.focus\:placeholder-green-100:focus::placeholder {
+  color: #f0fff4 !important;
+}
+
+.focus\:placeholder-green-200:focus::placeholder {
+  color: #c6f6d5 !important;
+}
+
+.focus\:placeholder-green-300:focus::placeholder {
+  color: #9ae6b4 !important;
+}
+
+.focus\:placeholder-green-400:focus::placeholder {
+  color: #68d391 !important;
+}
+
+.focus\:placeholder-green-500:focus::placeholder {
+  color: #48bb78 !important;
+}
+
+.focus\:placeholder-green-600:focus::placeholder {
+  color: #38a169 !important;
+}
+
+.focus\:placeholder-green-700:focus::placeholder {
+  color: #2f855a !important;
+}
+
+.focus\:placeholder-green-800:focus::placeholder {
+  color: #276749 !important;
+}
+
+.focus\:placeholder-green-900:focus::placeholder {
+  color: #22543d !important;
+}
+
+.focus\:placeholder-teal-100:focus::placeholder {
+  color: #e6fffa !important;
+}
+
+.focus\:placeholder-teal-200:focus::placeholder {
+  color: #b2f5ea !important;
+}
+
+.focus\:placeholder-teal-300:focus::placeholder {
+  color: #81e6d9 !important;
+}
+
+.focus\:placeholder-teal-400:focus::placeholder {
+  color: #4fd1c5 !important;
+}
+
+.focus\:placeholder-teal-500:focus::placeholder {
+  color: #38b2ac !important;
+}
+
+.focus\:placeholder-teal-600:focus::placeholder {
+  color: #319795 !important;
+}
+
+.focus\:placeholder-teal-700:focus::placeholder {
+  color: #2c7a7b !important;
+}
+
+.focus\:placeholder-teal-800:focus::placeholder {
+  color: #285e61 !important;
+}
+
+.focus\:placeholder-teal-900:focus::placeholder {
+  color: #234e52 !important;
+}
+
+.focus\:placeholder-blue-100:focus::placeholder {
+  color: #ebf8ff !important;
+}
+
+.focus\:placeholder-blue-200:focus::placeholder {
+  color: #bee3f8 !important;
+}
+
+.focus\:placeholder-blue-300:focus::placeholder {
+  color: #90cdf4 !important;
+}
+
+.focus\:placeholder-blue-400:focus::placeholder {
+  color: #63b3ed !important;
+}
+
+.focus\:placeholder-blue-500:focus::placeholder {
+  color: #4299e1 !important;
+}
+
+.focus\:placeholder-blue-600:focus::placeholder {
+  color: #3182ce !important;
+}
+
+.focus\:placeholder-blue-700:focus::placeholder {
+  color: #2b6cb0 !important;
+}
+
+.focus\:placeholder-blue-800:focus::placeholder {
+  color: #2c5282 !important;
+}
+
+.focus\:placeholder-blue-900:focus::placeholder {
+  color: #2a4365 !important;
+}
+
+.focus\:placeholder-indigo-100:focus::placeholder {
+  color: #ebf4ff !important;
+}
+
+.focus\:placeholder-indigo-200:focus::placeholder {
+  color: #c3dafe !important;
+}
+
+.focus\:placeholder-indigo-300:focus::placeholder {
+  color: #a3bffa !important;
+}
+
+.focus\:placeholder-indigo-400:focus::placeholder {
+  color: #7f9cf5 !important;
+}
+
+.focus\:placeholder-indigo-500:focus::placeholder {
+  color: #667eea !important;
+}
+
+.focus\:placeholder-indigo-600:focus::placeholder {
+  color: #5a67d8 !important;
+}
+
+.focus\:placeholder-indigo-700:focus::placeholder {
+  color: #4c51bf !important;
+}
+
+.focus\:placeholder-indigo-800:focus::placeholder {
+  color: #434190 !important;
+}
+
+.focus\:placeholder-indigo-900:focus::placeholder {
+  color: #3c366b !important;
+}
+
+.focus\:placeholder-purple-100:focus::placeholder {
+  color: #faf5ff !important;
+}
+
+.focus\:placeholder-purple-200:focus::placeholder {
+  color: #e9d8fd !important;
+}
+
+.focus\:placeholder-purple-300:focus::placeholder {
+  color: #d6bcfa !important;
+}
+
+.focus\:placeholder-purple-400:focus::placeholder {
+  color: #b794f4 !important;
+}
+
+.focus\:placeholder-purple-500:focus::placeholder {
+  color: #9f7aea !important;
+}
+
+.focus\:placeholder-purple-600:focus::placeholder {
+  color: #805ad5 !important;
+}
+
+.focus\:placeholder-purple-700:focus::placeholder {
+  color: #6b46c1 !important;
+}
+
+.focus\:placeholder-purple-800:focus::placeholder {
+  color: #553c9a !important;
+}
+
+.focus\:placeholder-purple-900:focus::placeholder {
+  color: #44337a !important;
+}
+
+.focus\:placeholder-pink-100:focus::placeholder {
+  color: #fff5f7 !important;
+}
+
+.focus\:placeholder-pink-200:focus::placeholder {
+  color: #fed7e2 !important;
+}
+
+.focus\:placeholder-pink-300:focus::placeholder {
+  color: #fbb6ce !important;
+}
+
+.focus\:placeholder-pink-400:focus::placeholder {
+  color: #f687b3 !important;
+}
+
+.focus\:placeholder-pink-500:focus::placeholder {
+  color: #ed64a6 !important;
+}
+
+.focus\:placeholder-pink-600:focus::placeholder {
+  color: #d53f8c !important;
+}
+
+.focus\:placeholder-pink-700:focus::placeholder {
+  color: #b83280 !important;
+}
+
+.focus\:placeholder-pink-800:focus::placeholder {
+  color: #97266d !important;
+}
+
+.focus\:placeholder-pink-900:focus::placeholder {
+  color: #702459 !important;
+}
+
 .pointer-events-none {
   pointer-events: none !important;
 }
@@ -13081,6 +13453,750 @@ video {
 
   .sm\:pl-px {
     padding-left: 1px !important;
+  }
+
+  .sm\:placeholder-transparent::placeholder {
+    color: transparent !important;
+  }
+
+  .sm\:placeholder-black::placeholder {
+    color: #000 !important;
+  }
+
+  .sm\:placeholder-white::placeholder {
+    color: #fff !important;
+  }
+
+  .sm\:placeholder-gray-100::placeholder {
+    color: #f7fafc !important;
+  }
+
+  .sm\:placeholder-gray-200::placeholder {
+    color: #edf2f7 !important;
+  }
+
+  .sm\:placeholder-gray-300::placeholder {
+    color: #e2e8f0 !important;
+  }
+
+  .sm\:placeholder-gray-400::placeholder {
+    color: #cbd5e0 !important;
+  }
+
+  .sm\:placeholder-gray-500::placeholder {
+    color: #a0aec0 !important;
+  }
+
+  .sm\:placeholder-gray-600::placeholder {
+    color: #718096 !important;
+  }
+
+  .sm\:placeholder-gray-700::placeholder {
+    color: #4a5568 !important;
+  }
+
+  .sm\:placeholder-gray-800::placeholder {
+    color: #2d3748 !important;
+  }
+
+  .sm\:placeholder-gray-900::placeholder {
+    color: #1a202c !important;
+  }
+
+  .sm\:placeholder-red-100::placeholder {
+    color: #fff5f5 !important;
+  }
+
+  .sm\:placeholder-red-200::placeholder {
+    color: #fed7d7 !important;
+  }
+
+  .sm\:placeholder-red-300::placeholder {
+    color: #feb2b2 !important;
+  }
+
+  .sm\:placeholder-red-400::placeholder {
+    color: #fc8181 !important;
+  }
+
+  .sm\:placeholder-red-500::placeholder {
+    color: #f56565 !important;
+  }
+
+  .sm\:placeholder-red-600::placeholder {
+    color: #e53e3e !important;
+  }
+
+  .sm\:placeholder-red-700::placeholder {
+    color: #c53030 !important;
+  }
+
+  .sm\:placeholder-red-800::placeholder {
+    color: #9b2c2c !important;
+  }
+
+  .sm\:placeholder-red-900::placeholder {
+    color: #742a2a !important;
+  }
+
+  .sm\:placeholder-orange-100::placeholder {
+    color: #fffaf0 !important;
+  }
+
+  .sm\:placeholder-orange-200::placeholder {
+    color: #feebc8 !important;
+  }
+
+  .sm\:placeholder-orange-300::placeholder {
+    color: #fbd38d !important;
+  }
+
+  .sm\:placeholder-orange-400::placeholder {
+    color: #f6ad55 !important;
+  }
+
+  .sm\:placeholder-orange-500::placeholder {
+    color: #ed8936 !important;
+  }
+
+  .sm\:placeholder-orange-600::placeholder {
+    color: #dd6b20 !important;
+  }
+
+  .sm\:placeholder-orange-700::placeholder {
+    color: #c05621 !important;
+  }
+
+  .sm\:placeholder-orange-800::placeholder {
+    color: #9c4221 !important;
+  }
+
+  .sm\:placeholder-orange-900::placeholder {
+    color: #7b341e !important;
+  }
+
+  .sm\:placeholder-yellow-100::placeholder {
+    color: #fffff0 !important;
+  }
+
+  .sm\:placeholder-yellow-200::placeholder {
+    color: #fefcbf !important;
+  }
+
+  .sm\:placeholder-yellow-300::placeholder {
+    color: #faf089 !important;
+  }
+
+  .sm\:placeholder-yellow-400::placeholder {
+    color: #f6e05e !important;
+  }
+
+  .sm\:placeholder-yellow-500::placeholder {
+    color: #ecc94b !important;
+  }
+
+  .sm\:placeholder-yellow-600::placeholder {
+    color: #d69e2e !important;
+  }
+
+  .sm\:placeholder-yellow-700::placeholder {
+    color: #b7791f !important;
+  }
+
+  .sm\:placeholder-yellow-800::placeholder {
+    color: #975a16 !important;
+  }
+
+  .sm\:placeholder-yellow-900::placeholder {
+    color: #744210 !important;
+  }
+
+  .sm\:placeholder-green-100::placeholder {
+    color: #f0fff4 !important;
+  }
+
+  .sm\:placeholder-green-200::placeholder {
+    color: #c6f6d5 !important;
+  }
+
+  .sm\:placeholder-green-300::placeholder {
+    color: #9ae6b4 !important;
+  }
+
+  .sm\:placeholder-green-400::placeholder {
+    color: #68d391 !important;
+  }
+
+  .sm\:placeholder-green-500::placeholder {
+    color: #48bb78 !important;
+  }
+
+  .sm\:placeholder-green-600::placeholder {
+    color: #38a169 !important;
+  }
+
+  .sm\:placeholder-green-700::placeholder {
+    color: #2f855a !important;
+  }
+
+  .sm\:placeholder-green-800::placeholder {
+    color: #276749 !important;
+  }
+
+  .sm\:placeholder-green-900::placeholder {
+    color: #22543d !important;
+  }
+
+  .sm\:placeholder-teal-100::placeholder {
+    color: #e6fffa !important;
+  }
+
+  .sm\:placeholder-teal-200::placeholder {
+    color: #b2f5ea !important;
+  }
+
+  .sm\:placeholder-teal-300::placeholder {
+    color: #81e6d9 !important;
+  }
+
+  .sm\:placeholder-teal-400::placeholder {
+    color: #4fd1c5 !important;
+  }
+
+  .sm\:placeholder-teal-500::placeholder {
+    color: #38b2ac !important;
+  }
+
+  .sm\:placeholder-teal-600::placeholder {
+    color: #319795 !important;
+  }
+
+  .sm\:placeholder-teal-700::placeholder {
+    color: #2c7a7b !important;
+  }
+
+  .sm\:placeholder-teal-800::placeholder {
+    color: #285e61 !important;
+  }
+
+  .sm\:placeholder-teal-900::placeholder {
+    color: #234e52 !important;
+  }
+
+  .sm\:placeholder-blue-100::placeholder {
+    color: #ebf8ff !important;
+  }
+
+  .sm\:placeholder-blue-200::placeholder {
+    color: #bee3f8 !important;
+  }
+
+  .sm\:placeholder-blue-300::placeholder {
+    color: #90cdf4 !important;
+  }
+
+  .sm\:placeholder-blue-400::placeholder {
+    color: #63b3ed !important;
+  }
+
+  .sm\:placeholder-blue-500::placeholder {
+    color: #4299e1 !important;
+  }
+
+  .sm\:placeholder-blue-600::placeholder {
+    color: #3182ce !important;
+  }
+
+  .sm\:placeholder-blue-700::placeholder {
+    color: #2b6cb0 !important;
+  }
+
+  .sm\:placeholder-blue-800::placeholder {
+    color: #2c5282 !important;
+  }
+
+  .sm\:placeholder-blue-900::placeholder {
+    color: #2a4365 !important;
+  }
+
+  .sm\:placeholder-indigo-100::placeholder {
+    color: #ebf4ff !important;
+  }
+
+  .sm\:placeholder-indigo-200::placeholder {
+    color: #c3dafe !important;
+  }
+
+  .sm\:placeholder-indigo-300::placeholder {
+    color: #a3bffa !important;
+  }
+
+  .sm\:placeholder-indigo-400::placeholder {
+    color: #7f9cf5 !important;
+  }
+
+  .sm\:placeholder-indigo-500::placeholder {
+    color: #667eea !important;
+  }
+
+  .sm\:placeholder-indigo-600::placeholder {
+    color: #5a67d8 !important;
+  }
+
+  .sm\:placeholder-indigo-700::placeholder {
+    color: #4c51bf !important;
+  }
+
+  .sm\:placeholder-indigo-800::placeholder {
+    color: #434190 !important;
+  }
+
+  .sm\:placeholder-indigo-900::placeholder {
+    color: #3c366b !important;
+  }
+
+  .sm\:placeholder-purple-100::placeholder {
+    color: #faf5ff !important;
+  }
+
+  .sm\:placeholder-purple-200::placeholder {
+    color: #e9d8fd !important;
+  }
+
+  .sm\:placeholder-purple-300::placeholder {
+    color: #d6bcfa !important;
+  }
+
+  .sm\:placeholder-purple-400::placeholder {
+    color: #b794f4 !important;
+  }
+
+  .sm\:placeholder-purple-500::placeholder {
+    color: #9f7aea !important;
+  }
+
+  .sm\:placeholder-purple-600::placeholder {
+    color: #805ad5 !important;
+  }
+
+  .sm\:placeholder-purple-700::placeholder {
+    color: #6b46c1 !important;
+  }
+
+  .sm\:placeholder-purple-800::placeholder {
+    color: #553c9a !important;
+  }
+
+  .sm\:placeholder-purple-900::placeholder {
+    color: #44337a !important;
+  }
+
+  .sm\:placeholder-pink-100::placeholder {
+    color: #fff5f7 !important;
+  }
+
+  .sm\:placeholder-pink-200::placeholder {
+    color: #fed7e2 !important;
+  }
+
+  .sm\:placeholder-pink-300::placeholder {
+    color: #fbb6ce !important;
+  }
+
+  .sm\:placeholder-pink-400::placeholder {
+    color: #f687b3 !important;
+  }
+
+  .sm\:placeholder-pink-500::placeholder {
+    color: #ed64a6 !important;
+  }
+
+  .sm\:placeholder-pink-600::placeholder {
+    color: #d53f8c !important;
+  }
+
+  .sm\:placeholder-pink-700::placeholder {
+    color: #b83280 !important;
+  }
+
+  .sm\:placeholder-pink-800::placeholder {
+    color: #97266d !important;
+  }
+
+  .sm\:placeholder-pink-900::placeholder {
+    color: #702459 !important;
+  }
+
+  .sm\:focus\:placeholder-transparent:focus::placeholder {
+    color: transparent !important;
+  }
+
+  .sm\:focus\:placeholder-black:focus::placeholder {
+    color: #000 !important;
+  }
+
+  .sm\:focus\:placeholder-white:focus::placeholder {
+    color: #fff !important;
+  }
+
+  .sm\:focus\:placeholder-gray-100:focus::placeholder {
+    color: #f7fafc !important;
+  }
+
+  .sm\:focus\:placeholder-gray-200:focus::placeholder {
+    color: #edf2f7 !important;
+  }
+
+  .sm\:focus\:placeholder-gray-300:focus::placeholder {
+    color: #e2e8f0 !important;
+  }
+
+  .sm\:focus\:placeholder-gray-400:focus::placeholder {
+    color: #cbd5e0 !important;
+  }
+
+  .sm\:focus\:placeholder-gray-500:focus::placeholder {
+    color: #a0aec0 !important;
+  }
+
+  .sm\:focus\:placeholder-gray-600:focus::placeholder {
+    color: #718096 !important;
+  }
+
+  .sm\:focus\:placeholder-gray-700:focus::placeholder {
+    color: #4a5568 !important;
+  }
+
+  .sm\:focus\:placeholder-gray-800:focus::placeholder {
+    color: #2d3748 !important;
+  }
+
+  .sm\:focus\:placeholder-gray-900:focus::placeholder {
+    color: #1a202c !important;
+  }
+
+  .sm\:focus\:placeholder-red-100:focus::placeholder {
+    color: #fff5f5 !important;
+  }
+
+  .sm\:focus\:placeholder-red-200:focus::placeholder {
+    color: #fed7d7 !important;
+  }
+
+  .sm\:focus\:placeholder-red-300:focus::placeholder {
+    color: #feb2b2 !important;
+  }
+
+  .sm\:focus\:placeholder-red-400:focus::placeholder {
+    color: #fc8181 !important;
+  }
+
+  .sm\:focus\:placeholder-red-500:focus::placeholder {
+    color: #f56565 !important;
+  }
+
+  .sm\:focus\:placeholder-red-600:focus::placeholder {
+    color: #e53e3e !important;
+  }
+
+  .sm\:focus\:placeholder-red-700:focus::placeholder {
+    color: #c53030 !important;
+  }
+
+  .sm\:focus\:placeholder-red-800:focus::placeholder {
+    color: #9b2c2c !important;
+  }
+
+  .sm\:focus\:placeholder-red-900:focus::placeholder {
+    color: #742a2a !important;
+  }
+
+  .sm\:focus\:placeholder-orange-100:focus::placeholder {
+    color: #fffaf0 !important;
+  }
+
+  .sm\:focus\:placeholder-orange-200:focus::placeholder {
+    color: #feebc8 !important;
+  }
+
+  .sm\:focus\:placeholder-orange-300:focus::placeholder {
+    color: #fbd38d !important;
+  }
+
+  .sm\:focus\:placeholder-orange-400:focus::placeholder {
+    color: #f6ad55 !important;
+  }
+
+  .sm\:focus\:placeholder-orange-500:focus::placeholder {
+    color: #ed8936 !important;
+  }
+
+  .sm\:focus\:placeholder-orange-600:focus::placeholder {
+    color: #dd6b20 !important;
+  }
+
+  .sm\:focus\:placeholder-orange-700:focus::placeholder {
+    color: #c05621 !important;
+  }
+
+  .sm\:focus\:placeholder-orange-800:focus::placeholder {
+    color: #9c4221 !important;
+  }
+
+  .sm\:focus\:placeholder-orange-900:focus::placeholder {
+    color: #7b341e !important;
+  }
+
+  .sm\:focus\:placeholder-yellow-100:focus::placeholder {
+    color: #fffff0 !important;
+  }
+
+  .sm\:focus\:placeholder-yellow-200:focus::placeholder {
+    color: #fefcbf !important;
+  }
+
+  .sm\:focus\:placeholder-yellow-300:focus::placeholder {
+    color: #faf089 !important;
+  }
+
+  .sm\:focus\:placeholder-yellow-400:focus::placeholder {
+    color: #f6e05e !important;
+  }
+
+  .sm\:focus\:placeholder-yellow-500:focus::placeholder {
+    color: #ecc94b !important;
+  }
+
+  .sm\:focus\:placeholder-yellow-600:focus::placeholder {
+    color: #d69e2e !important;
+  }
+
+  .sm\:focus\:placeholder-yellow-700:focus::placeholder {
+    color: #b7791f !important;
+  }
+
+  .sm\:focus\:placeholder-yellow-800:focus::placeholder {
+    color: #975a16 !important;
+  }
+
+  .sm\:focus\:placeholder-yellow-900:focus::placeholder {
+    color: #744210 !important;
+  }
+
+  .sm\:focus\:placeholder-green-100:focus::placeholder {
+    color: #f0fff4 !important;
+  }
+
+  .sm\:focus\:placeholder-green-200:focus::placeholder {
+    color: #c6f6d5 !important;
+  }
+
+  .sm\:focus\:placeholder-green-300:focus::placeholder {
+    color: #9ae6b4 !important;
+  }
+
+  .sm\:focus\:placeholder-green-400:focus::placeholder {
+    color: #68d391 !important;
+  }
+
+  .sm\:focus\:placeholder-green-500:focus::placeholder {
+    color: #48bb78 !important;
+  }
+
+  .sm\:focus\:placeholder-green-600:focus::placeholder {
+    color: #38a169 !important;
+  }
+
+  .sm\:focus\:placeholder-green-700:focus::placeholder {
+    color: #2f855a !important;
+  }
+
+  .sm\:focus\:placeholder-green-800:focus::placeholder {
+    color: #276749 !important;
+  }
+
+  .sm\:focus\:placeholder-green-900:focus::placeholder {
+    color: #22543d !important;
+  }
+
+  .sm\:focus\:placeholder-teal-100:focus::placeholder {
+    color: #e6fffa !important;
+  }
+
+  .sm\:focus\:placeholder-teal-200:focus::placeholder {
+    color: #b2f5ea !important;
+  }
+
+  .sm\:focus\:placeholder-teal-300:focus::placeholder {
+    color: #81e6d9 !important;
+  }
+
+  .sm\:focus\:placeholder-teal-400:focus::placeholder {
+    color: #4fd1c5 !important;
+  }
+
+  .sm\:focus\:placeholder-teal-500:focus::placeholder {
+    color: #38b2ac !important;
+  }
+
+  .sm\:focus\:placeholder-teal-600:focus::placeholder {
+    color: #319795 !important;
+  }
+
+  .sm\:focus\:placeholder-teal-700:focus::placeholder {
+    color: #2c7a7b !important;
+  }
+
+  .sm\:focus\:placeholder-teal-800:focus::placeholder {
+    color: #285e61 !important;
+  }
+
+  .sm\:focus\:placeholder-teal-900:focus::placeholder {
+    color: #234e52 !important;
+  }
+
+  .sm\:focus\:placeholder-blue-100:focus::placeholder {
+    color: #ebf8ff !important;
+  }
+
+  .sm\:focus\:placeholder-blue-200:focus::placeholder {
+    color: #bee3f8 !important;
+  }
+
+  .sm\:focus\:placeholder-blue-300:focus::placeholder {
+    color: #90cdf4 !important;
+  }
+
+  .sm\:focus\:placeholder-blue-400:focus::placeholder {
+    color: #63b3ed !important;
+  }
+
+  .sm\:focus\:placeholder-blue-500:focus::placeholder {
+    color: #4299e1 !important;
+  }
+
+  .sm\:focus\:placeholder-blue-600:focus::placeholder {
+    color: #3182ce !important;
+  }
+
+  .sm\:focus\:placeholder-blue-700:focus::placeholder {
+    color: #2b6cb0 !important;
+  }
+
+  .sm\:focus\:placeholder-blue-800:focus::placeholder {
+    color: #2c5282 !important;
+  }
+
+  .sm\:focus\:placeholder-blue-900:focus::placeholder {
+    color: #2a4365 !important;
+  }
+
+  .sm\:focus\:placeholder-indigo-100:focus::placeholder {
+    color: #ebf4ff !important;
+  }
+
+  .sm\:focus\:placeholder-indigo-200:focus::placeholder {
+    color: #c3dafe !important;
+  }
+
+  .sm\:focus\:placeholder-indigo-300:focus::placeholder {
+    color: #a3bffa !important;
+  }
+
+  .sm\:focus\:placeholder-indigo-400:focus::placeholder {
+    color: #7f9cf5 !important;
+  }
+
+  .sm\:focus\:placeholder-indigo-500:focus::placeholder {
+    color: #667eea !important;
+  }
+
+  .sm\:focus\:placeholder-indigo-600:focus::placeholder {
+    color: #5a67d8 !important;
+  }
+
+  .sm\:focus\:placeholder-indigo-700:focus::placeholder {
+    color: #4c51bf !important;
+  }
+
+  .sm\:focus\:placeholder-indigo-800:focus::placeholder {
+    color: #434190 !important;
+  }
+
+  .sm\:focus\:placeholder-indigo-900:focus::placeholder {
+    color: #3c366b !important;
+  }
+
+  .sm\:focus\:placeholder-purple-100:focus::placeholder {
+    color: #faf5ff !important;
+  }
+
+  .sm\:focus\:placeholder-purple-200:focus::placeholder {
+    color: #e9d8fd !important;
+  }
+
+  .sm\:focus\:placeholder-purple-300:focus::placeholder {
+    color: #d6bcfa !important;
+  }
+
+  .sm\:focus\:placeholder-purple-400:focus::placeholder {
+    color: #b794f4 !important;
+  }
+
+  .sm\:focus\:placeholder-purple-500:focus::placeholder {
+    color: #9f7aea !important;
+  }
+
+  .sm\:focus\:placeholder-purple-600:focus::placeholder {
+    color: #805ad5 !important;
+  }
+
+  .sm\:focus\:placeholder-purple-700:focus::placeholder {
+    color: #6b46c1 !important;
+  }
+
+  .sm\:focus\:placeholder-purple-800:focus::placeholder {
+    color: #553c9a !important;
+  }
+
+  .sm\:focus\:placeholder-purple-900:focus::placeholder {
+    color: #44337a !important;
+  }
+
+  .sm\:focus\:placeholder-pink-100:focus::placeholder {
+    color: #fff5f7 !important;
+  }
+
+  .sm\:focus\:placeholder-pink-200:focus::placeholder {
+    color: #fed7e2 !important;
+  }
+
+  .sm\:focus\:placeholder-pink-300:focus::placeholder {
+    color: #fbb6ce !important;
+  }
+
+  .sm\:focus\:placeholder-pink-400:focus::placeholder {
+    color: #f687b3 !important;
+  }
+
+  .sm\:focus\:placeholder-pink-500:focus::placeholder {
+    color: #ed64a6 !important;
+  }
+
+  .sm\:focus\:placeholder-pink-600:focus::placeholder {
+    color: #d53f8c !important;
+  }
+
+  .sm\:focus\:placeholder-pink-700:focus::placeholder {
+    color: #b83280 !important;
+  }
+
+  .sm\:focus\:placeholder-pink-800:focus::placeholder {
+    color: #97266d !important;
+  }
+
+  .sm\:focus\:placeholder-pink-900:focus::placeholder {
+    color: #702459 !important;
   }
 
   .sm\:pointer-events-none {
@@ -20035,6 +21151,750 @@ video {
     padding-left: 1px !important;
   }
 
+  .md\:placeholder-transparent::placeholder {
+    color: transparent !important;
+  }
+
+  .md\:placeholder-black::placeholder {
+    color: #000 !important;
+  }
+
+  .md\:placeholder-white::placeholder {
+    color: #fff !important;
+  }
+
+  .md\:placeholder-gray-100::placeholder {
+    color: #f7fafc !important;
+  }
+
+  .md\:placeholder-gray-200::placeholder {
+    color: #edf2f7 !important;
+  }
+
+  .md\:placeholder-gray-300::placeholder {
+    color: #e2e8f0 !important;
+  }
+
+  .md\:placeholder-gray-400::placeholder {
+    color: #cbd5e0 !important;
+  }
+
+  .md\:placeholder-gray-500::placeholder {
+    color: #a0aec0 !important;
+  }
+
+  .md\:placeholder-gray-600::placeholder {
+    color: #718096 !important;
+  }
+
+  .md\:placeholder-gray-700::placeholder {
+    color: #4a5568 !important;
+  }
+
+  .md\:placeholder-gray-800::placeholder {
+    color: #2d3748 !important;
+  }
+
+  .md\:placeholder-gray-900::placeholder {
+    color: #1a202c !important;
+  }
+
+  .md\:placeholder-red-100::placeholder {
+    color: #fff5f5 !important;
+  }
+
+  .md\:placeholder-red-200::placeholder {
+    color: #fed7d7 !important;
+  }
+
+  .md\:placeholder-red-300::placeholder {
+    color: #feb2b2 !important;
+  }
+
+  .md\:placeholder-red-400::placeholder {
+    color: #fc8181 !important;
+  }
+
+  .md\:placeholder-red-500::placeholder {
+    color: #f56565 !important;
+  }
+
+  .md\:placeholder-red-600::placeholder {
+    color: #e53e3e !important;
+  }
+
+  .md\:placeholder-red-700::placeholder {
+    color: #c53030 !important;
+  }
+
+  .md\:placeholder-red-800::placeholder {
+    color: #9b2c2c !important;
+  }
+
+  .md\:placeholder-red-900::placeholder {
+    color: #742a2a !important;
+  }
+
+  .md\:placeholder-orange-100::placeholder {
+    color: #fffaf0 !important;
+  }
+
+  .md\:placeholder-orange-200::placeholder {
+    color: #feebc8 !important;
+  }
+
+  .md\:placeholder-orange-300::placeholder {
+    color: #fbd38d !important;
+  }
+
+  .md\:placeholder-orange-400::placeholder {
+    color: #f6ad55 !important;
+  }
+
+  .md\:placeholder-orange-500::placeholder {
+    color: #ed8936 !important;
+  }
+
+  .md\:placeholder-orange-600::placeholder {
+    color: #dd6b20 !important;
+  }
+
+  .md\:placeholder-orange-700::placeholder {
+    color: #c05621 !important;
+  }
+
+  .md\:placeholder-orange-800::placeholder {
+    color: #9c4221 !important;
+  }
+
+  .md\:placeholder-orange-900::placeholder {
+    color: #7b341e !important;
+  }
+
+  .md\:placeholder-yellow-100::placeholder {
+    color: #fffff0 !important;
+  }
+
+  .md\:placeholder-yellow-200::placeholder {
+    color: #fefcbf !important;
+  }
+
+  .md\:placeholder-yellow-300::placeholder {
+    color: #faf089 !important;
+  }
+
+  .md\:placeholder-yellow-400::placeholder {
+    color: #f6e05e !important;
+  }
+
+  .md\:placeholder-yellow-500::placeholder {
+    color: #ecc94b !important;
+  }
+
+  .md\:placeholder-yellow-600::placeholder {
+    color: #d69e2e !important;
+  }
+
+  .md\:placeholder-yellow-700::placeholder {
+    color: #b7791f !important;
+  }
+
+  .md\:placeholder-yellow-800::placeholder {
+    color: #975a16 !important;
+  }
+
+  .md\:placeholder-yellow-900::placeholder {
+    color: #744210 !important;
+  }
+
+  .md\:placeholder-green-100::placeholder {
+    color: #f0fff4 !important;
+  }
+
+  .md\:placeholder-green-200::placeholder {
+    color: #c6f6d5 !important;
+  }
+
+  .md\:placeholder-green-300::placeholder {
+    color: #9ae6b4 !important;
+  }
+
+  .md\:placeholder-green-400::placeholder {
+    color: #68d391 !important;
+  }
+
+  .md\:placeholder-green-500::placeholder {
+    color: #48bb78 !important;
+  }
+
+  .md\:placeholder-green-600::placeholder {
+    color: #38a169 !important;
+  }
+
+  .md\:placeholder-green-700::placeholder {
+    color: #2f855a !important;
+  }
+
+  .md\:placeholder-green-800::placeholder {
+    color: #276749 !important;
+  }
+
+  .md\:placeholder-green-900::placeholder {
+    color: #22543d !important;
+  }
+
+  .md\:placeholder-teal-100::placeholder {
+    color: #e6fffa !important;
+  }
+
+  .md\:placeholder-teal-200::placeholder {
+    color: #b2f5ea !important;
+  }
+
+  .md\:placeholder-teal-300::placeholder {
+    color: #81e6d9 !important;
+  }
+
+  .md\:placeholder-teal-400::placeholder {
+    color: #4fd1c5 !important;
+  }
+
+  .md\:placeholder-teal-500::placeholder {
+    color: #38b2ac !important;
+  }
+
+  .md\:placeholder-teal-600::placeholder {
+    color: #319795 !important;
+  }
+
+  .md\:placeholder-teal-700::placeholder {
+    color: #2c7a7b !important;
+  }
+
+  .md\:placeholder-teal-800::placeholder {
+    color: #285e61 !important;
+  }
+
+  .md\:placeholder-teal-900::placeholder {
+    color: #234e52 !important;
+  }
+
+  .md\:placeholder-blue-100::placeholder {
+    color: #ebf8ff !important;
+  }
+
+  .md\:placeholder-blue-200::placeholder {
+    color: #bee3f8 !important;
+  }
+
+  .md\:placeholder-blue-300::placeholder {
+    color: #90cdf4 !important;
+  }
+
+  .md\:placeholder-blue-400::placeholder {
+    color: #63b3ed !important;
+  }
+
+  .md\:placeholder-blue-500::placeholder {
+    color: #4299e1 !important;
+  }
+
+  .md\:placeholder-blue-600::placeholder {
+    color: #3182ce !important;
+  }
+
+  .md\:placeholder-blue-700::placeholder {
+    color: #2b6cb0 !important;
+  }
+
+  .md\:placeholder-blue-800::placeholder {
+    color: #2c5282 !important;
+  }
+
+  .md\:placeholder-blue-900::placeholder {
+    color: #2a4365 !important;
+  }
+
+  .md\:placeholder-indigo-100::placeholder {
+    color: #ebf4ff !important;
+  }
+
+  .md\:placeholder-indigo-200::placeholder {
+    color: #c3dafe !important;
+  }
+
+  .md\:placeholder-indigo-300::placeholder {
+    color: #a3bffa !important;
+  }
+
+  .md\:placeholder-indigo-400::placeholder {
+    color: #7f9cf5 !important;
+  }
+
+  .md\:placeholder-indigo-500::placeholder {
+    color: #667eea !important;
+  }
+
+  .md\:placeholder-indigo-600::placeholder {
+    color: #5a67d8 !important;
+  }
+
+  .md\:placeholder-indigo-700::placeholder {
+    color: #4c51bf !important;
+  }
+
+  .md\:placeholder-indigo-800::placeholder {
+    color: #434190 !important;
+  }
+
+  .md\:placeholder-indigo-900::placeholder {
+    color: #3c366b !important;
+  }
+
+  .md\:placeholder-purple-100::placeholder {
+    color: #faf5ff !important;
+  }
+
+  .md\:placeholder-purple-200::placeholder {
+    color: #e9d8fd !important;
+  }
+
+  .md\:placeholder-purple-300::placeholder {
+    color: #d6bcfa !important;
+  }
+
+  .md\:placeholder-purple-400::placeholder {
+    color: #b794f4 !important;
+  }
+
+  .md\:placeholder-purple-500::placeholder {
+    color: #9f7aea !important;
+  }
+
+  .md\:placeholder-purple-600::placeholder {
+    color: #805ad5 !important;
+  }
+
+  .md\:placeholder-purple-700::placeholder {
+    color: #6b46c1 !important;
+  }
+
+  .md\:placeholder-purple-800::placeholder {
+    color: #553c9a !important;
+  }
+
+  .md\:placeholder-purple-900::placeholder {
+    color: #44337a !important;
+  }
+
+  .md\:placeholder-pink-100::placeholder {
+    color: #fff5f7 !important;
+  }
+
+  .md\:placeholder-pink-200::placeholder {
+    color: #fed7e2 !important;
+  }
+
+  .md\:placeholder-pink-300::placeholder {
+    color: #fbb6ce !important;
+  }
+
+  .md\:placeholder-pink-400::placeholder {
+    color: #f687b3 !important;
+  }
+
+  .md\:placeholder-pink-500::placeholder {
+    color: #ed64a6 !important;
+  }
+
+  .md\:placeholder-pink-600::placeholder {
+    color: #d53f8c !important;
+  }
+
+  .md\:placeholder-pink-700::placeholder {
+    color: #b83280 !important;
+  }
+
+  .md\:placeholder-pink-800::placeholder {
+    color: #97266d !important;
+  }
+
+  .md\:placeholder-pink-900::placeholder {
+    color: #702459 !important;
+  }
+
+  .md\:focus\:placeholder-transparent:focus::placeholder {
+    color: transparent !important;
+  }
+
+  .md\:focus\:placeholder-black:focus::placeholder {
+    color: #000 !important;
+  }
+
+  .md\:focus\:placeholder-white:focus::placeholder {
+    color: #fff !important;
+  }
+
+  .md\:focus\:placeholder-gray-100:focus::placeholder {
+    color: #f7fafc !important;
+  }
+
+  .md\:focus\:placeholder-gray-200:focus::placeholder {
+    color: #edf2f7 !important;
+  }
+
+  .md\:focus\:placeholder-gray-300:focus::placeholder {
+    color: #e2e8f0 !important;
+  }
+
+  .md\:focus\:placeholder-gray-400:focus::placeholder {
+    color: #cbd5e0 !important;
+  }
+
+  .md\:focus\:placeholder-gray-500:focus::placeholder {
+    color: #a0aec0 !important;
+  }
+
+  .md\:focus\:placeholder-gray-600:focus::placeholder {
+    color: #718096 !important;
+  }
+
+  .md\:focus\:placeholder-gray-700:focus::placeholder {
+    color: #4a5568 !important;
+  }
+
+  .md\:focus\:placeholder-gray-800:focus::placeholder {
+    color: #2d3748 !important;
+  }
+
+  .md\:focus\:placeholder-gray-900:focus::placeholder {
+    color: #1a202c !important;
+  }
+
+  .md\:focus\:placeholder-red-100:focus::placeholder {
+    color: #fff5f5 !important;
+  }
+
+  .md\:focus\:placeholder-red-200:focus::placeholder {
+    color: #fed7d7 !important;
+  }
+
+  .md\:focus\:placeholder-red-300:focus::placeholder {
+    color: #feb2b2 !important;
+  }
+
+  .md\:focus\:placeholder-red-400:focus::placeholder {
+    color: #fc8181 !important;
+  }
+
+  .md\:focus\:placeholder-red-500:focus::placeholder {
+    color: #f56565 !important;
+  }
+
+  .md\:focus\:placeholder-red-600:focus::placeholder {
+    color: #e53e3e !important;
+  }
+
+  .md\:focus\:placeholder-red-700:focus::placeholder {
+    color: #c53030 !important;
+  }
+
+  .md\:focus\:placeholder-red-800:focus::placeholder {
+    color: #9b2c2c !important;
+  }
+
+  .md\:focus\:placeholder-red-900:focus::placeholder {
+    color: #742a2a !important;
+  }
+
+  .md\:focus\:placeholder-orange-100:focus::placeholder {
+    color: #fffaf0 !important;
+  }
+
+  .md\:focus\:placeholder-orange-200:focus::placeholder {
+    color: #feebc8 !important;
+  }
+
+  .md\:focus\:placeholder-orange-300:focus::placeholder {
+    color: #fbd38d !important;
+  }
+
+  .md\:focus\:placeholder-orange-400:focus::placeholder {
+    color: #f6ad55 !important;
+  }
+
+  .md\:focus\:placeholder-orange-500:focus::placeholder {
+    color: #ed8936 !important;
+  }
+
+  .md\:focus\:placeholder-orange-600:focus::placeholder {
+    color: #dd6b20 !important;
+  }
+
+  .md\:focus\:placeholder-orange-700:focus::placeholder {
+    color: #c05621 !important;
+  }
+
+  .md\:focus\:placeholder-orange-800:focus::placeholder {
+    color: #9c4221 !important;
+  }
+
+  .md\:focus\:placeholder-orange-900:focus::placeholder {
+    color: #7b341e !important;
+  }
+
+  .md\:focus\:placeholder-yellow-100:focus::placeholder {
+    color: #fffff0 !important;
+  }
+
+  .md\:focus\:placeholder-yellow-200:focus::placeholder {
+    color: #fefcbf !important;
+  }
+
+  .md\:focus\:placeholder-yellow-300:focus::placeholder {
+    color: #faf089 !important;
+  }
+
+  .md\:focus\:placeholder-yellow-400:focus::placeholder {
+    color: #f6e05e !important;
+  }
+
+  .md\:focus\:placeholder-yellow-500:focus::placeholder {
+    color: #ecc94b !important;
+  }
+
+  .md\:focus\:placeholder-yellow-600:focus::placeholder {
+    color: #d69e2e !important;
+  }
+
+  .md\:focus\:placeholder-yellow-700:focus::placeholder {
+    color: #b7791f !important;
+  }
+
+  .md\:focus\:placeholder-yellow-800:focus::placeholder {
+    color: #975a16 !important;
+  }
+
+  .md\:focus\:placeholder-yellow-900:focus::placeholder {
+    color: #744210 !important;
+  }
+
+  .md\:focus\:placeholder-green-100:focus::placeholder {
+    color: #f0fff4 !important;
+  }
+
+  .md\:focus\:placeholder-green-200:focus::placeholder {
+    color: #c6f6d5 !important;
+  }
+
+  .md\:focus\:placeholder-green-300:focus::placeholder {
+    color: #9ae6b4 !important;
+  }
+
+  .md\:focus\:placeholder-green-400:focus::placeholder {
+    color: #68d391 !important;
+  }
+
+  .md\:focus\:placeholder-green-500:focus::placeholder {
+    color: #48bb78 !important;
+  }
+
+  .md\:focus\:placeholder-green-600:focus::placeholder {
+    color: #38a169 !important;
+  }
+
+  .md\:focus\:placeholder-green-700:focus::placeholder {
+    color: #2f855a !important;
+  }
+
+  .md\:focus\:placeholder-green-800:focus::placeholder {
+    color: #276749 !important;
+  }
+
+  .md\:focus\:placeholder-green-900:focus::placeholder {
+    color: #22543d !important;
+  }
+
+  .md\:focus\:placeholder-teal-100:focus::placeholder {
+    color: #e6fffa !important;
+  }
+
+  .md\:focus\:placeholder-teal-200:focus::placeholder {
+    color: #b2f5ea !important;
+  }
+
+  .md\:focus\:placeholder-teal-300:focus::placeholder {
+    color: #81e6d9 !important;
+  }
+
+  .md\:focus\:placeholder-teal-400:focus::placeholder {
+    color: #4fd1c5 !important;
+  }
+
+  .md\:focus\:placeholder-teal-500:focus::placeholder {
+    color: #38b2ac !important;
+  }
+
+  .md\:focus\:placeholder-teal-600:focus::placeholder {
+    color: #319795 !important;
+  }
+
+  .md\:focus\:placeholder-teal-700:focus::placeholder {
+    color: #2c7a7b !important;
+  }
+
+  .md\:focus\:placeholder-teal-800:focus::placeholder {
+    color: #285e61 !important;
+  }
+
+  .md\:focus\:placeholder-teal-900:focus::placeholder {
+    color: #234e52 !important;
+  }
+
+  .md\:focus\:placeholder-blue-100:focus::placeholder {
+    color: #ebf8ff !important;
+  }
+
+  .md\:focus\:placeholder-blue-200:focus::placeholder {
+    color: #bee3f8 !important;
+  }
+
+  .md\:focus\:placeholder-blue-300:focus::placeholder {
+    color: #90cdf4 !important;
+  }
+
+  .md\:focus\:placeholder-blue-400:focus::placeholder {
+    color: #63b3ed !important;
+  }
+
+  .md\:focus\:placeholder-blue-500:focus::placeholder {
+    color: #4299e1 !important;
+  }
+
+  .md\:focus\:placeholder-blue-600:focus::placeholder {
+    color: #3182ce !important;
+  }
+
+  .md\:focus\:placeholder-blue-700:focus::placeholder {
+    color: #2b6cb0 !important;
+  }
+
+  .md\:focus\:placeholder-blue-800:focus::placeholder {
+    color: #2c5282 !important;
+  }
+
+  .md\:focus\:placeholder-blue-900:focus::placeholder {
+    color: #2a4365 !important;
+  }
+
+  .md\:focus\:placeholder-indigo-100:focus::placeholder {
+    color: #ebf4ff !important;
+  }
+
+  .md\:focus\:placeholder-indigo-200:focus::placeholder {
+    color: #c3dafe !important;
+  }
+
+  .md\:focus\:placeholder-indigo-300:focus::placeholder {
+    color: #a3bffa !important;
+  }
+
+  .md\:focus\:placeholder-indigo-400:focus::placeholder {
+    color: #7f9cf5 !important;
+  }
+
+  .md\:focus\:placeholder-indigo-500:focus::placeholder {
+    color: #667eea !important;
+  }
+
+  .md\:focus\:placeholder-indigo-600:focus::placeholder {
+    color: #5a67d8 !important;
+  }
+
+  .md\:focus\:placeholder-indigo-700:focus::placeholder {
+    color: #4c51bf !important;
+  }
+
+  .md\:focus\:placeholder-indigo-800:focus::placeholder {
+    color: #434190 !important;
+  }
+
+  .md\:focus\:placeholder-indigo-900:focus::placeholder {
+    color: #3c366b !important;
+  }
+
+  .md\:focus\:placeholder-purple-100:focus::placeholder {
+    color: #faf5ff !important;
+  }
+
+  .md\:focus\:placeholder-purple-200:focus::placeholder {
+    color: #e9d8fd !important;
+  }
+
+  .md\:focus\:placeholder-purple-300:focus::placeholder {
+    color: #d6bcfa !important;
+  }
+
+  .md\:focus\:placeholder-purple-400:focus::placeholder {
+    color: #b794f4 !important;
+  }
+
+  .md\:focus\:placeholder-purple-500:focus::placeholder {
+    color: #9f7aea !important;
+  }
+
+  .md\:focus\:placeholder-purple-600:focus::placeholder {
+    color: #805ad5 !important;
+  }
+
+  .md\:focus\:placeholder-purple-700:focus::placeholder {
+    color: #6b46c1 !important;
+  }
+
+  .md\:focus\:placeholder-purple-800:focus::placeholder {
+    color: #553c9a !important;
+  }
+
+  .md\:focus\:placeholder-purple-900:focus::placeholder {
+    color: #44337a !important;
+  }
+
+  .md\:focus\:placeholder-pink-100:focus::placeholder {
+    color: #fff5f7 !important;
+  }
+
+  .md\:focus\:placeholder-pink-200:focus::placeholder {
+    color: #fed7e2 !important;
+  }
+
+  .md\:focus\:placeholder-pink-300:focus::placeholder {
+    color: #fbb6ce !important;
+  }
+
+  .md\:focus\:placeholder-pink-400:focus::placeholder {
+    color: #f687b3 !important;
+  }
+
+  .md\:focus\:placeholder-pink-500:focus::placeholder {
+    color: #ed64a6 !important;
+  }
+
+  .md\:focus\:placeholder-pink-600:focus::placeholder {
+    color: #d53f8c !important;
+  }
+
+  .md\:focus\:placeholder-pink-700:focus::placeholder {
+    color: #b83280 !important;
+  }
+
+  .md\:focus\:placeholder-pink-800:focus::placeholder {
+    color: #97266d !important;
+  }
+
+  .md\:focus\:placeholder-pink-900:focus::placeholder {
+    color: #702459 !important;
+  }
+
   .md\:pointer-events-none {
     pointer-events: none !important;
   }
@@ -26987,6 +28847,750 @@ video {
     padding-left: 1px !important;
   }
 
+  .lg\:placeholder-transparent::placeholder {
+    color: transparent !important;
+  }
+
+  .lg\:placeholder-black::placeholder {
+    color: #000 !important;
+  }
+
+  .lg\:placeholder-white::placeholder {
+    color: #fff !important;
+  }
+
+  .lg\:placeholder-gray-100::placeholder {
+    color: #f7fafc !important;
+  }
+
+  .lg\:placeholder-gray-200::placeholder {
+    color: #edf2f7 !important;
+  }
+
+  .lg\:placeholder-gray-300::placeholder {
+    color: #e2e8f0 !important;
+  }
+
+  .lg\:placeholder-gray-400::placeholder {
+    color: #cbd5e0 !important;
+  }
+
+  .lg\:placeholder-gray-500::placeholder {
+    color: #a0aec0 !important;
+  }
+
+  .lg\:placeholder-gray-600::placeholder {
+    color: #718096 !important;
+  }
+
+  .lg\:placeholder-gray-700::placeholder {
+    color: #4a5568 !important;
+  }
+
+  .lg\:placeholder-gray-800::placeholder {
+    color: #2d3748 !important;
+  }
+
+  .lg\:placeholder-gray-900::placeholder {
+    color: #1a202c !important;
+  }
+
+  .lg\:placeholder-red-100::placeholder {
+    color: #fff5f5 !important;
+  }
+
+  .lg\:placeholder-red-200::placeholder {
+    color: #fed7d7 !important;
+  }
+
+  .lg\:placeholder-red-300::placeholder {
+    color: #feb2b2 !important;
+  }
+
+  .lg\:placeholder-red-400::placeholder {
+    color: #fc8181 !important;
+  }
+
+  .lg\:placeholder-red-500::placeholder {
+    color: #f56565 !important;
+  }
+
+  .lg\:placeholder-red-600::placeholder {
+    color: #e53e3e !important;
+  }
+
+  .lg\:placeholder-red-700::placeholder {
+    color: #c53030 !important;
+  }
+
+  .lg\:placeholder-red-800::placeholder {
+    color: #9b2c2c !important;
+  }
+
+  .lg\:placeholder-red-900::placeholder {
+    color: #742a2a !important;
+  }
+
+  .lg\:placeholder-orange-100::placeholder {
+    color: #fffaf0 !important;
+  }
+
+  .lg\:placeholder-orange-200::placeholder {
+    color: #feebc8 !important;
+  }
+
+  .lg\:placeholder-orange-300::placeholder {
+    color: #fbd38d !important;
+  }
+
+  .lg\:placeholder-orange-400::placeholder {
+    color: #f6ad55 !important;
+  }
+
+  .lg\:placeholder-orange-500::placeholder {
+    color: #ed8936 !important;
+  }
+
+  .lg\:placeholder-orange-600::placeholder {
+    color: #dd6b20 !important;
+  }
+
+  .lg\:placeholder-orange-700::placeholder {
+    color: #c05621 !important;
+  }
+
+  .lg\:placeholder-orange-800::placeholder {
+    color: #9c4221 !important;
+  }
+
+  .lg\:placeholder-orange-900::placeholder {
+    color: #7b341e !important;
+  }
+
+  .lg\:placeholder-yellow-100::placeholder {
+    color: #fffff0 !important;
+  }
+
+  .lg\:placeholder-yellow-200::placeholder {
+    color: #fefcbf !important;
+  }
+
+  .lg\:placeholder-yellow-300::placeholder {
+    color: #faf089 !important;
+  }
+
+  .lg\:placeholder-yellow-400::placeholder {
+    color: #f6e05e !important;
+  }
+
+  .lg\:placeholder-yellow-500::placeholder {
+    color: #ecc94b !important;
+  }
+
+  .lg\:placeholder-yellow-600::placeholder {
+    color: #d69e2e !important;
+  }
+
+  .lg\:placeholder-yellow-700::placeholder {
+    color: #b7791f !important;
+  }
+
+  .lg\:placeholder-yellow-800::placeholder {
+    color: #975a16 !important;
+  }
+
+  .lg\:placeholder-yellow-900::placeholder {
+    color: #744210 !important;
+  }
+
+  .lg\:placeholder-green-100::placeholder {
+    color: #f0fff4 !important;
+  }
+
+  .lg\:placeholder-green-200::placeholder {
+    color: #c6f6d5 !important;
+  }
+
+  .lg\:placeholder-green-300::placeholder {
+    color: #9ae6b4 !important;
+  }
+
+  .lg\:placeholder-green-400::placeholder {
+    color: #68d391 !important;
+  }
+
+  .lg\:placeholder-green-500::placeholder {
+    color: #48bb78 !important;
+  }
+
+  .lg\:placeholder-green-600::placeholder {
+    color: #38a169 !important;
+  }
+
+  .lg\:placeholder-green-700::placeholder {
+    color: #2f855a !important;
+  }
+
+  .lg\:placeholder-green-800::placeholder {
+    color: #276749 !important;
+  }
+
+  .lg\:placeholder-green-900::placeholder {
+    color: #22543d !important;
+  }
+
+  .lg\:placeholder-teal-100::placeholder {
+    color: #e6fffa !important;
+  }
+
+  .lg\:placeholder-teal-200::placeholder {
+    color: #b2f5ea !important;
+  }
+
+  .lg\:placeholder-teal-300::placeholder {
+    color: #81e6d9 !important;
+  }
+
+  .lg\:placeholder-teal-400::placeholder {
+    color: #4fd1c5 !important;
+  }
+
+  .lg\:placeholder-teal-500::placeholder {
+    color: #38b2ac !important;
+  }
+
+  .lg\:placeholder-teal-600::placeholder {
+    color: #319795 !important;
+  }
+
+  .lg\:placeholder-teal-700::placeholder {
+    color: #2c7a7b !important;
+  }
+
+  .lg\:placeholder-teal-800::placeholder {
+    color: #285e61 !important;
+  }
+
+  .lg\:placeholder-teal-900::placeholder {
+    color: #234e52 !important;
+  }
+
+  .lg\:placeholder-blue-100::placeholder {
+    color: #ebf8ff !important;
+  }
+
+  .lg\:placeholder-blue-200::placeholder {
+    color: #bee3f8 !important;
+  }
+
+  .lg\:placeholder-blue-300::placeholder {
+    color: #90cdf4 !important;
+  }
+
+  .lg\:placeholder-blue-400::placeholder {
+    color: #63b3ed !important;
+  }
+
+  .lg\:placeholder-blue-500::placeholder {
+    color: #4299e1 !important;
+  }
+
+  .lg\:placeholder-blue-600::placeholder {
+    color: #3182ce !important;
+  }
+
+  .lg\:placeholder-blue-700::placeholder {
+    color: #2b6cb0 !important;
+  }
+
+  .lg\:placeholder-blue-800::placeholder {
+    color: #2c5282 !important;
+  }
+
+  .lg\:placeholder-blue-900::placeholder {
+    color: #2a4365 !important;
+  }
+
+  .lg\:placeholder-indigo-100::placeholder {
+    color: #ebf4ff !important;
+  }
+
+  .lg\:placeholder-indigo-200::placeholder {
+    color: #c3dafe !important;
+  }
+
+  .lg\:placeholder-indigo-300::placeholder {
+    color: #a3bffa !important;
+  }
+
+  .lg\:placeholder-indigo-400::placeholder {
+    color: #7f9cf5 !important;
+  }
+
+  .lg\:placeholder-indigo-500::placeholder {
+    color: #667eea !important;
+  }
+
+  .lg\:placeholder-indigo-600::placeholder {
+    color: #5a67d8 !important;
+  }
+
+  .lg\:placeholder-indigo-700::placeholder {
+    color: #4c51bf !important;
+  }
+
+  .lg\:placeholder-indigo-800::placeholder {
+    color: #434190 !important;
+  }
+
+  .lg\:placeholder-indigo-900::placeholder {
+    color: #3c366b !important;
+  }
+
+  .lg\:placeholder-purple-100::placeholder {
+    color: #faf5ff !important;
+  }
+
+  .lg\:placeholder-purple-200::placeholder {
+    color: #e9d8fd !important;
+  }
+
+  .lg\:placeholder-purple-300::placeholder {
+    color: #d6bcfa !important;
+  }
+
+  .lg\:placeholder-purple-400::placeholder {
+    color: #b794f4 !important;
+  }
+
+  .lg\:placeholder-purple-500::placeholder {
+    color: #9f7aea !important;
+  }
+
+  .lg\:placeholder-purple-600::placeholder {
+    color: #805ad5 !important;
+  }
+
+  .lg\:placeholder-purple-700::placeholder {
+    color: #6b46c1 !important;
+  }
+
+  .lg\:placeholder-purple-800::placeholder {
+    color: #553c9a !important;
+  }
+
+  .lg\:placeholder-purple-900::placeholder {
+    color: #44337a !important;
+  }
+
+  .lg\:placeholder-pink-100::placeholder {
+    color: #fff5f7 !important;
+  }
+
+  .lg\:placeholder-pink-200::placeholder {
+    color: #fed7e2 !important;
+  }
+
+  .lg\:placeholder-pink-300::placeholder {
+    color: #fbb6ce !important;
+  }
+
+  .lg\:placeholder-pink-400::placeholder {
+    color: #f687b3 !important;
+  }
+
+  .lg\:placeholder-pink-500::placeholder {
+    color: #ed64a6 !important;
+  }
+
+  .lg\:placeholder-pink-600::placeholder {
+    color: #d53f8c !important;
+  }
+
+  .lg\:placeholder-pink-700::placeholder {
+    color: #b83280 !important;
+  }
+
+  .lg\:placeholder-pink-800::placeholder {
+    color: #97266d !important;
+  }
+
+  .lg\:placeholder-pink-900::placeholder {
+    color: #702459 !important;
+  }
+
+  .lg\:focus\:placeholder-transparent:focus::placeholder {
+    color: transparent !important;
+  }
+
+  .lg\:focus\:placeholder-black:focus::placeholder {
+    color: #000 !important;
+  }
+
+  .lg\:focus\:placeholder-white:focus::placeholder {
+    color: #fff !important;
+  }
+
+  .lg\:focus\:placeholder-gray-100:focus::placeholder {
+    color: #f7fafc !important;
+  }
+
+  .lg\:focus\:placeholder-gray-200:focus::placeholder {
+    color: #edf2f7 !important;
+  }
+
+  .lg\:focus\:placeholder-gray-300:focus::placeholder {
+    color: #e2e8f0 !important;
+  }
+
+  .lg\:focus\:placeholder-gray-400:focus::placeholder {
+    color: #cbd5e0 !important;
+  }
+
+  .lg\:focus\:placeholder-gray-500:focus::placeholder {
+    color: #a0aec0 !important;
+  }
+
+  .lg\:focus\:placeholder-gray-600:focus::placeholder {
+    color: #718096 !important;
+  }
+
+  .lg\:focus\:placeholder-gray-700:focus::placeholder {
+    color: #4a5568 !important;
+  }
+
+  .lg\:focus\:placeholder-gray-800:focus::placeholder {
+    color: #2d3748 !important;
+  }
+
+  .lg\:focus\:placeholder-gray-900:focus::placeholder {
+    color: #1a202c !important;
+  }
+
+  .lg\:focus\:placeholder-red-100:focus::placeholder {
+    color: #fff5f5 !important;
+  }
+
+  .lg\:focus\:placeholder-red-200:focus::placeholder {
+    color: #fed7d7 !important;
+  }
+
+  .lg\:focus\:placeholder-red-300:focus::placeholder {
+    color: #feb2b2 !important;
+  }
+
+  .lg\:focus\:placeholder-red-400:focus::placeholder {
+    color: #fc8181 !important;
+  }
+
+  .lg\:focus\:placeholder-red-500:focus::placeholder {
+    color: #f56565 !important;
+  }
+
+  .lg\:focus\:placeholder-red-600:focus::placeholder {
+    color: #e53e3e !important;
+  }
+
+  .lg\:focus\:placeholder-red-700:focus::placeholder {
+    color: #c53030 !important;
+  }
+
+  .lg\:focus\:placeholder-red-800:focus::placeholder {
+    color: #9b2c2c !important;
+  }
+
+  .lg\:focus\:placeholder-red-900:focus::placeholder {
+    color: #742a2a !important;
+  }
+
+  .lg\:focus\:placeholder-orange-100:focus::placeholder {
+    color: #fffaf0 !important;
+  }
+
+  .lg\:focus\:placeholder-orange-200:focus::placeholder {
+    color: #feebc8 !important;
+  }
+
+  .lg\:focus\:placeholder-orange-300:focus::placeholder {
+    color: #fbd38d !important;
+  }
+
+  .lg\:focus\:placeholder-orange-400:focus::placeholder {
+    color: #f6ad55 !important;
+  }
+
+  .lg\:focus\:placeholder-orange-500:focus::placeholder {
+    color: #ed8936 !important;
+  }
+
+  .lg\:focus\:placeholder-orange-600:focus::placeholder {
+    color: #dd6b20 !important;
+  }
+
+  .lg\:focus\:placeholder-orange-700:focus::placeholder {
+    color: #c05621 !important;
+  }
+
+  .lg\:focus\:placeholder-orange-800:focus::placeholder {
+    color: #9c4221 !important;
+  }
+
+  .lg\:focus\:placeholder-orange-900:focus::placeholder {
+    color: #7b341e !important;
+  }
+
+  .lg\:focus\:placeholder-yellow-100:focus::placeholder {
+    color: #fffff0 !important;
+  }
+
+  .lg\:focus\:placeholder-yellow-200:focus::placeholder {
+    color: #fefcbf !important;
+  }
+
+  .lg\:focus\:placeholder-yellow-300:focus::placeholder {
+    color: #faf089 !important;
+  }
+
+  .lg\:focus\:placeholder-yellow-400:focus::placeholder {
+    color: #f6e05e !important;
+  }
+
+  .lg\:focus\:placeholder-yellow-500:focus::placeholder {
+    color: #ecc94b !important;
+  }
+
+  .lg\:focus\:placeholder-yellow-600:focus::placeholder {
+    color: #d69e2e !important;
+  }
+
+  .lg\:focus\:placeholder-yellow-700:focus::placeholder {
+    color: #b7791f !important;
+  }
+
+  .lg\:focus\:placeholder-yellow-800:focus::placeholder {
+    color: #975a16 !important;
+  }
+
+  .lg\:focus\:placeholder-yellow-900:focus::placeholder {
+    color: #744210 !important;
+  }
+
+  .lg\:focus\:placeholder-green-100:focus::placeholder {
+    color: #f0fff4 !important;
+  }
+
+  .lg\:focus\:placeholder-green-200:focus::placeholder {
+    color: #c6f6d5 !important;
+  }
+
+  .lg\:focus\:placeholder-green-300:focus::placeholder {
+    color: #9ae6b4 !important;
+  }
+
+  .lg\:focus\:placeholder-green-400:focus::placeholder {
+    color: #68d391 !important;
+  }
+
+  .lg\:focus\:placeholder-green-500:focus::placeholder {
+    color: #48bb78 !important;
+  }
+
+  .lg\:focus\:placeholder-green-600:focus::placeholder {
+    color: #38a169 !important;
+  }
+
+  .lg\:focus\:placeholder-green-700:focus::placeholder {
+    color: #2f855a !important;
+  }
+
+  .lg\:focus\:placeholder-green-800:focus::placeholder {
+    color: #276749 !important;
+  }
+
+  .lg\:focus\:placeholder-green-900:focus::placeholder {
+    color: #22543d !important;
+  }
+
+  .lg\:focus\:placeholder-teal-100:focus::placeholder {
+    color: #e6fffa !important;
+  }
+
+  .lg\:focus\:placeholder-teal-200:focus::placeholder {
+    color: #b2f5ea !important;
+  }
+
+  .lg\:focus\:placeholder-teal-300:focus::placeholder {
+    color: #81e6d9 !important;
+  }
+
+  .lg\:focus\:placeholder-teal-400:focus::placeholder {
+    color: #4fd1c5 !important;
+  }
+
+  .lg\:focus\:placeholder-teal-500:focus::placeholder {
+    color: #38b2ac !important;
+  }
+
+  .lg\:focus\:placeholder-teal-600:focus::placeholder {
+    color: #319795 !important;
+  }
+
+  .lg\:focus\:placeholder-teal-700:focus::placeholder {
+    color: #2c7a7b !important;
+  }
+
+  .lg\:focus\:placeholder-teal-800:focus::placeholder {
+    color: #285e61 !important;
+  }
+
+  .lg\:focus\:placeholder-teal-900:focus::placeholder {
+    color: #234e52 !important;
+  }
+
+  .lg\:focus\:placeholder-blue-100:focus::placeholder {
+    color: #ebf8ff !important;
+  }
+
+  .lg\:focus\:placeholder-blue-200:focus::placeholder {
+    color: #bee3f8 !important;
+  }
+
+  .lg\:focus\:placeholder-blue-300:focus::placeholder {
+    color: #90cdf4 !important;
+  }
+
+  .lg\:focus\:placeholder-blue-400:focus::placeholder {
+    color: #63b3ed !important;
+  }
+
+  .lg\:focus\:placeholder-blue-500:focus::placeholder {
+    color: #4299e1 !important;
+  }
+
+  .lg\:focus\:placeholder-blue-600:focus::placeholder {
+    color: #3182ce !important;
+  }
+
+  .lg\:focus\:placeholder-blue-700:focus::placeholder {
+    color: #2b6cb0 !important;
+  }
+
+  .lg\:focus\:placeholder-blue-800:focus::placeholder {
+    color: #2c5282 !important;
+  }
+
+  .lg\:focus\:placeholder-blue-900:focus::placeholder {
+    color: #2a4365 !important;
+  }
+
+  .lg\:focus\:placeholder-indigo-100:focus::placeholder {
+    color: #ebf4ff !important;
+  }
+
+  .lg\:focus\:placeholder-indigo-200:focus::placeholder {
+    color: #c3dafe !important;
+  }
+
+  .lg\:focus\:placeholder-indigo-300:focus::placeholder {
+    color: #a3bffa !important;
+  }
+
+  .lg\:focus\:placeholder-indigo-400:focus::placeholder {
+    color: #7f9cf5 !important;
+  }
+
+  .lg\:focus\:placeholder-indigo-500:focus::placeholder {
+    color: #667eea !important;
+  }
+
+  .lg\:focus\:placeholder-indigo-600:focus::placeholder {
+    color: #5a67d8 !important;
+  }
+
+  .lg\:focus\:placeholder-indigo-700:focus::placeholder {
+    color: #4c51bf !important;
+  }
+
+  .lg\:focus\:placeholder-indigo-800:focus::placeholder {
+    color: #434190 !important;
+  }
+
+  .lg\:focus\:placeholder-indigo-900:focus::placeholder {
+    color: #3c366b !important;
+  }
+
+  .lg\:focus\:placeholder-purple-100:focus::placeholder {
+    color: #faf5ff !important;
+  }
+
+  .lg\:focus\:placeholder-purple-200:focus::placeholder {
+    color: #e9d8fd !important;
+  }
+
+  .lg\:focus\:placeholder-purple-300:focus::placeholder {
+    color: #d6bcfa !important;
+  }
+
+  .lg\:focus\:placeholder-purple-400:focus::placeholder {
+    color: #b794f4 !important;
+  }
+
+  .lg\:focus\:placeholder-purple-500:focus::placeholder {
+    color: #9f7aea !important;
+  }
+
+  .lg\:focus\:placeholder-purple-600:focus::placeholder {
+    color: #805ad5 !important;
+  }
+
+  .lg\:focus\:placeholder-purple-700:focus::placeholder {
+    color: #6b46c1 !important;
+  }
+
+  .lg\:focus\:placeholder-purple-800:focus::placeholder {
+    color: #553c9a !important;
+  }
+
+  .lg\:focus\:placeholder-purple-900:focus::placeholder {
+    color: #44337a !important;
+  }
+
+  .lg\:focus\:placeholder-pink-100:focus::placeholder {
+    color: #fff5f7 !important;
+  }
+
+  .lg\:focus\:placeholder-pink-200:focus::placeholder {
+    color: #fed7e2 !important;
+  }
+
+  .lg\:focus\:placeholder-pink-300:focus::placeholder {
+    color: #fbb6ce !important;
+  }
+
+  .lg\:focus\:placeholder-pink-400:focus::placeholder {
+    color: #f687b3 !important;
+  }
+
+  .lg\:focus\:placeholder-pink-500:focus::placeholder {
+    color: #ed64a6 !important;
+  }
+
+  .lg\:focus\:placeholder-pink-600:focus::placeholder {
+    color: #d53f8c !important;
+  }
+
+  .lg\:focus\:placeholder-pink-700:focus::placeholder {
+    color: #b83280 !important;
+  }
+
+  .lg\:focus\:placeholder-pink-800:focus::placeholder {
+    color: #97266d !important;
+  }
+
+  .lg\:focus\:placeholder-pink-900:focus::placeholder {
+    color: #702459 !important;
+  }
+
   .lg\:pointer-events-none {
     pointer-events: none !important;
   }
@@ -33937,6 +36541,750 @@ video {
 
   .xl\:pl-px {
     padding-left: 1px !important;
+  }
+
+  .xl\:placeholder-transparent::placeholder {
+    color: transparent !important;
+  }
+
+  .xl\:placeholder-black::placeholder {
+    color: #000 !important;
+  }
+
+  .xl\:placeholder-white::placeholder {
+    color: #fff !important;
+  }
+
+  .xl\:placeholder-gray-100::placeholder {
+    color: #f7fafc !important;
+  }
+
+  .xl\:placeholder-gray-200::placeholder {
+    color: #edf2f7 !important;
+  }
+
+  .xl\:placeholder-gray-300::placeholder {
+    color: #e2e8f0 !important;
+  }
+
+  .xl\:placeholder-gray-400::placeholder {
+    color: #cbd5e0 !important;
+  }
+
+  .xl\:placeholder-gray-500::placeholder {
+    color: #a0aec0 !important;
+  }
+
+  .xl\:placeholder-gray-600::placeholder {
+    color: #718096 !important;
+  }
+
+  .xl\:placeholder-gray-700::placeholder {
+    color: #4a5568 !important;
+  }
+
+  .xl\:placeholder-gray-800::placeholder {
+    color: #2d3748 !important;
+  }
+
+  .xl\:placeholder-gray-900::placeholder {
+    color: #1a202c !important;
+  }
+
+  .xl\:placeholder-red-100::placeholder {
+    color: #fff5f5 !important;
+  }
+
+  .xl\:placeholder-red-200::placeholder {
+    color: #fed7d7 !important;
+  }
+
+  .xl\:placeholder-red-300::placeholder {
+    color: #feb2b2 !important;
+  }
+
+  .xl\:placeholder-red-400::placeholder {
+    color: #fc8181 !important;
+  }
+
+  .xl\:placeholder-red-500::placeholder {
+    color: #f56565 !important;
+  }
+
+  .xl\:placeholder-red-600::placeholder {
+    color: #e53e3e !important;
+  }
+
+  .xl\:placeholder-red-700::placeholder {
+    color: #c53030 !important;
+  }
+
+  .xl\:placeholder-red-800::placeholder {
+    color: #9b2c2c !important;
+  }
+
+  .xl\:placeholder-red-900::placeholder {
+    color: #742a2a !important;
+  }
+
+  .xl\:placeholder-orange-100::placeholder {
+    color: #fffaf0 !important;
+  }
+
+  .xl\:placeholder-orange-200::placeholder {
+    color: #feebc8 !important;
+  }
+
+  .xl\:placeholder-orange-300::placeholder {
+    color: #fbd38d !important;
+  }
+
+  .xl\:placeholder-orange-400::placeholder {
+    color: #f6ad55 !important;
+  }
+
+  .xl\:placeholder-orange-500::placeholder {
+    color: #ed8936 !important;
+  }
+
+  .xl\:placeholder-orange-600::placeholder {
+    color: #dd6b20 !important;
+  }
+
+  .xl\:placeholder-orange-700::placeholder {
+    color: #c05621 !important;
+  }
+
+  .xl\:placeholder-orange-800::placeholder {
+    color: #9c4221 !important;
+  }
+
+  .xl\:placeholder-orange-900::placeholder {
+    color: #7b341e !important;
+  }
+
+  .xl\:placeholder-yellow-100::placeholder {
+    color: #fffff0 !important;
+  }
+
+  .xl\:placeholder-yellow-200::placeholder {
+    color: #fefcbf !important;
+  }
+
+  .xl\:placeholder-yellow-300::placeholder {
+    color: #faf089 !important;
+  }
+
+  .xl\:placeholder-yellow-400::placeholder {
+    color: #f6e05e !important;
+  }
+
+  .xl\:placeholder-yellow-500::placeholder {
+    color: #ecc94b !important;
+  }
+
+  .xl\:placeholder-yellow-600::placeholder {
+    color: #d69e2e !important;
+  }
+
+  .xl\:placeholder-yellow-700::placeholder {
+    color: #b7791f !important;
+  }
+
+  .xl\:placeholder-yellow-800::placeholder {
+    color: #975a16 !important;
+  }
+
+  .xl\:placeholder-yellow-900::placeholder {
+    color: #744210 !important;
+  }
+
+  .xl\:placeholder-green-100::placeholder {
+    color: #f0fff4 !important;
+  }
+
+  .xl\:placeholder-green-200::placeholder {
+    color: #c6f6d5 !important;
+  }
+
+  .xl\:placeholder-green-300::placeholder {
+    color: #9ae6b4 !important;
+  }
+
+  .xl\:placeholder-green-400::placeholder {
+    color: #68d391 !important;
+  }
+
+  .xl\:placeholder-green-500::placeholder {
+    color: #48bb78 !important;
+  }
+
+  .xl\:placeholder-green-600::placeholder {
+    color: #38a169 !important;
+  }
+
+  .xl\:placeholder-green-700::placeholder {
+    color: #2f855a !important;
+  }
+
+  .xl\:placeholder-green-800::placeholder {
+    color: #276749 !important;
+  }
+
+  .xl\:placeholder-green-900::placeholder {
+    color: #22543d !important;
+  }
+
+  .xl\:placeholder-teal-100::placeholder {
+    color: #e6fffa !important;
+  }
+
+  .xl\:placeholder-teal-200::placeholder {
+    color: #b2f5ea !important;
+  }
+
+  .xl\:placeholder-teal-300::placeholder {
+    color: #81e6d9 !important;
+  }
+
+  .xl\:placeholder-teal-400::placeholder {
+    color: #4fd1c5 !important;
+  }
+
+  .xl\:placeholder-teal-500::placeholder {
+    color: #38b2ac !important;
+  }
+
+  .xl\:placeholder-teal-600::placeholder {
+    color: #319795 !important;
+  }
+
+  .xl\:placeholder-teal-700::placeholder {
+    color: #2c7a7b !important;
+  }
+
+  .xl\:placeholder-teal-800::placeholder {
+    color: #285e61 !important;
+  }
+
+  .xl\:placeholder-teal-900::placeholder {
+    color: #234e52 !important;
+  }
+
+  .xl\:placeholder-blue-100::placeholder {
+    color: #ebf8ff !important;
+  }
+
+  .xl\:placeholder-blue-200::placeholder {
+    color: #bee3f8 !important;
+  }
+
+  .xl\:placeholder-blue-300::placeholder {
+    color: #90cdf4 !important;
+  }
+
+  .xl\:placeholder-blue-400::placeholder {
+    color: #63b3ed !important;
+  }
+
+  .xl\:placeholder-blue-500::placeholder {
+    color: #4299e1 !important;
+  }
+
+  .xl\:placeholder-blue-600::placeholder {
+    color: #3182ce !important;
+  }
+
+  .xl\:placeholder-blue-700::placeholder {
+    color: #2b6cb0 !important;
+  }
+
+  .xl\:placeholder-blue-800::placeholder {
+    color: #2c5282 !important;
+  }
+
+  .xl\:placeholder-blue-900::placeholder {
+    color: #2a4365 !important;
+  }
+
+  .xl\:placeholder-indigo-100::placeholder {
+    color: #ebf4ff !important;
+  }
+
+  .xl\:placeholder-indigo-200::placeholder {
+    color: #c3dafe !important;
+  }
+
+  .xl\:placeholder-indigo-300::placeholder {
+    color: #a3bffa !important;
+  }
+
+  .xl\:placeholder-indigo-400::placeholder {
+    color: #7f9cf5 !important;
+  }
+
+  .xl\:placeholder-indigo-500::placeholder {
+    color: #667eea !important;
+  }
+
+  .xl\:placeholder-indigo-600::placeholder {
+    color: #5a67d8 !important;
+  }
+
+  .xl\:placeholder-indigo-700::placeholder {
+    color: #4c51bf !important;
+  }
+
+  .xl\:placeholder-indigo-800::placeholder {
+    color: #434190 !important;
+  }
+
+  .xl\:placeholder-indigo-900::placeholder {
+    color: #3c366b !important;
+  }
+
+  .xl\:placeholder-purple-100::placeholder {
+    color: #faf5ff !important;
+  }
+
+  .xl\:placeholder-purple-200::placeholder {
+    color: #e9d8fd !important;
+  }
+
+  .xl\:placeholder-purple-300::placeholder {
+    color: #d6bcfa !important;
+  }
+
+  .xl\:placeholder-purple-400::placeholder {
+    color: #b794f4 !important;
+  }
+
+  .xl\:placeholder-purple-500::placeholder {
+    color: #9f7aea !important;
+  }
+
+  .xl\:placeholder-purple-600::placeholder {
+    color: #805ad5 !important;
+  }
+
+  .xl\:placeholder-purple-700::placeholder {
+    color: #6b46c1 !important;
+  }
+
+  .xl\:placeholder-purple-800::placeholder {
+    color: #553c9a !important;
+  }
+
+  .xl\:placeholder-purple-900::placeholder {
+    color: #44337a !important;
+  }
+
+  .xl\:placeholder-pink-100::placeholder {
+    color: #fff5f7 !important;
+  }
+
+  .xl\:placeholder-pink-200::placeholder {
+    color: #fed7e2 !important;
+  }
+
+  .xl\:placeholder-pink-300::placeholder {
+    color: #fbb6ce !important;
+  }
+
+  .xl\:placeholder-pink-400::placeholder {
+    color: #f687b3 !important;
+  }
+
+  .xl\:placeholder-pink-500::placeholder {
+    color: #ed64a6 !important;
+  }
+
+  .xl\:placeholder-pink-600::placeholder {
+    color: #d53f8c !important;
+  }
+
+  .xl\:placeholder-pink-700::placeholder {
+    color: #b83280 !important;
+  }
+
+  .xl\:placeholder-pink-800::placeholder {
+    color: #97266d !important;
+  }
+
+  .xl\:placeholder-pink-900::placeholder {
+    color: #702459 !important;
+  }
+
+  .xl\:focus\:placeholder-transparent:focus::placeholder {
+    color: transparent !important;
+  }
+
+  .xl\:focus\:placeholder-black:focus::placeholder {
+    color: #000 !important;
+  }
+
+  .xl\:focus\:placeholder-white:focus::placeholder {
+    color: #fff !important;
+  }
+
+  .xl\:focus\:placeholder-gray-100:focus::placeholder {
+    color: #f7fafc !important;
+  }
+
+  .xl\:focus\:placeholder-gray-200:focus::placeholder {
+    color: #edf2f7 !important;
+  }
+
+  .xl\:focus\:placeholder-gray-300:focus::placeholder {
+    color: #e2e8f0 !important;
+  }
+
+  .xl\:focus\:placeholder-gray-400:focus::placeholder {
+    color: #cbd5e0 !important;
+  }
+
+  .xl\:focus\:placeholder-gray-500:focus::placeholder {
+    color: #a0aec0 !important;
+  }
+
+  .xl\:focus\:placeholder-gray-600:focus::placeholder {
+    color: #718096 !important;
+  }
+
+  .xl\:focus\:placeholder-gray-700:focus::placeholder {
+    color: #4a5568 !important;
+  }
+
+  .xl\:focus\:placeholder-gray-800:focus::placeholder {
+    color: #2d3748 !important;
+  }
+
+  .xl\:focus\:placeholder-gray-900:focus::placeholder {
+    color: #1a202c !important;
+  }
+
+  .xl\:focus\:placeholder-red-100:focus::placeholder {
+    color: #fff5f5 !important;
+  }
+
+  .xl\:focus\:placeholder-red-200:focus::placeholder {
+    color: #fed7d7 !important;
+  }
+
+  .xl\:focus\:placeholder-red-300:focus::placeholder {
+    color: #feb2b2 !important;
+  }
+
+  .xl\:focus\:placeholder-red-400:focus::placeholder {
+    color: #fc8181 !important;
+  }
+
+  .xl\:focus\:placeholder-red-500:focus::placeholder {
+    color: #f56565 !important;
+  }
+
+  .xl\:focus\:placeholder-red-600:focus::placeholder {
+    color: #e53e3e !important;
+  }
+
+  .xl\:focus\:placeholder-red-700:focus::placeholder {
+    color: #c53030 !important;
+  }
+
+  .xl\:focus\:placeholder-red-800:focus::placeholder {
+    color: #9b2c2c !important;
+  }
+
+  .xl\:focus\:placeholder-red-900:focus::placeholder {
+    color: #742a2a !important;
+  }
+
+  .xl\:focus\:placeholder-orange-100:focus::placeholder {
+    color: #fffaf0 !important;
+  }
+
+  .xl\:focus\:placeholder-orange-200:focus::placeholder {
+    color: #feebc8 !important;
+  }
+
+  .xl\:focus\:placeholder-orange-300:focus::placeholder {
+    color: #fbd38d !important;
+  }
+
+  .xl\:focus\:placeholder-orange-400:focus::placeholder {
+    color: #f6ad55 !important;
+  }
+
+  .xl\:focus\:placeholder-orange-500:focus::placeholder {
+    color: #ed8936 !important;
+  }
+
+  .xl\:focus\:placeholder-orange-600:focus::placeholder {
+    color: #dd6b20 !important;
+  }
+
+  .xl\:focus\:placeholder-orange-700:focus::placeholder {
+    color: #c05621 !important;
+  }
+
+  .xl\:focus\:placeholder-orange-800:focus::placeholder {
+    color: #9c4221 !important;
+  }
+
+  .xl\:focus\:placeholder-orange-900:focus::placeholder {
+    color: #7b341e !important;
+  }
+
+  .xl\:focus\:placeholder-yellow-100:focus::placeholder {
+    color: #fffff0 !important;
+  }
+
+  .xl\:focus\:placeholder-yellow-200:focus::placeholder {
+    color: #fefcbf !important;
+  }
+
+  .xl\:focus\:placeholder-yellow-300:focus::placeholder {
+    color: #faf089 !important;
+  }
+
+  .xl\:focus\:placeholder-yellow-400:focus::placeholder {
+    color: #f6e05e !important;
+  }
+
+  .xl\:focus\:placeholder-yellow-500:focus::placeholder {
+    color: #ecc94b !important;
+  }
+
+  .xl\:focus\:placeholder-yellow-600:focus::placeholder {
+    color: #d69e2e !important;
+  }
+
+  .xl\:focus\:placeholder-yellow-700:focus::placeholder {
+    color: #b7791f !important;
+  }
+
+  .xl\:focus\:placeholder-yellow-800:focus::placeholder {
+    color: #975a16 !important;
+  }
+
+  .xl\:focus\:placeholder-yellow-900:focus::placeholder {
+    color: #744210 !important;
+  }
+
+  .xl\:focus\:placeholder-green-100:focus::placeholder {
+    color: #f0fff4 !important;
+  }
+
+  .xl\:focus\:placeholder-green-200:focus::placeholder {
+    color: #c6f6d5 !important;
+  }
+
+  .xl\:focus\:placeholder-green-300:focus::placeholder {
+    color: #9ae6b4 !important;
+  }
+
+  .xl\:focus\:placeholder-green-400:focus::placeholder {
+    color: #68d391 !important;
+  }
+
+  .xl\:focus\:placeholder-green-500:focus::placeholder {
+    color: #48bb78 !important;
+  }
+
+  .xl\:focus\:placeholder-green-600:focus::placeholder {
+    color: #38a169 !important;
+  }
+
+  .xl\:focus\:placeholder-green-700:focus::placeholder {
+    color: #2f855a !important;
+  }
+
+  .xl\:focus\:placeholder-green-800:focus::placeholder {
+    color: #276749 !important;
+  }
+
+  .xl\:focus\:placeholder-green-900:focus::placeholder {
+    color: #22543d !important;
+  }
+
+  .xl\:focus\:placeholder-teal-100:focus::placeholder {
+    color: #e6fffa !important;
+  }
+
+  .xl\:focus\:placeholder-teal-200:focus::placeholder {
+    color: #b2f5ea !important;
+  }
+
+  .xl\:focus\:placeholder-teal-300:focus::placeholder {
+    color: #81e6d9 !important;
+  }
+
+  .xl\:focus\:placeholder-teal-400:focus::placeholder {
+    color: #4fd1c5 !important;
+  }
+
+  .xl\:focus\:placeholder-teal-500:focus::placeholder {
+    color: #38b2ac !important;
+  }
+
+  .xl\:focus\:placeholder-teal-600:focus::placeholder {
+    color: #319795 !important;
+  }
+
+  .xl\:focus\:placeholder-teal-700:focus::placeholder {
+    color: #2c7a7b !important;
+  }
+
+  .xl\:focus\:placeholder-teal-800:focus::placeholder {
+    color: #285e61 !important;
+  }
+
+  .xl\:focus\:placeholder-teal-900:focus::placeholder {
+    color: #234e52 !important;
+  }
+
+  .xl\:focus\:placeholder-blue-100:focus::placeholder {
+    color: #ebf8ff !important;
+  }
+
+  .xl\:focus\:placeholder-blue-200:focus::placeholder {
+    color: #bee3f8 !important;
+  }
+
+  .xl\:focus\:placeholder-blue-300:focus::placeholder {
+    color: #90cdf4 !important;
+  }
+
+  .xl\:focus\:placeholder-blue-400:focus::placeholder {
+    color: #63b3ed !important;
+  }
+
+  .xl\:focus\:placeholder-blue-500:focus::placeholder {
+    color: #4299e1 !important;
+  }
+
+  .xl\:focus\:placeholder-blue-600:focus::placeholder {
+    color: #3182ce !important;
+  }
+
+  .xl\:focus\:placeholder-blue-700:focus::placeholder {
+    color: #2b6cb0 !important;
+  }
+
+  .xl\:focus\:placeholder-blue-800:focus::placeholder {
+    color: #2c5282 !important;
+  }
+
+  .xl\:focus\:placeholder-blue-900:focus::placeholder {
+    color: #2a4365 !important;
+  }
+
+  .xl\:focus\:placeholder-indigo-100:focus::placeholder {
+    color: #ebf4ff !important;
+  }
+
+  .xl\:focus\:placeholder-indigo-200:focus::placeholder {
+    color: #c3dafe !important;
+  }
+
+  .xl\:focus\:placeholder-indigo-300:focus::placeholder {
+    color: #a3bffa !important;
+  }
+
+  .xl\:focus\:placeholder-indigo-400:focus::placeholder {
+    color: #7f9cf5 !important;
+  }
+
+  .xl\:focus\:placeholder-indigo-500:focus::placeholder {
+    color: #667eea !important;
+  }
+
+  .xl\:focus\:placeholder-indigo-600:focus::placeholder {
+    color: #5a67d8 !important;
+  }
+
+  .xl\:focus\:placeholder-indigo-700:focus::placeholder {
+    color: #4c51bf !important;
+  }
+
+  .xl\:focus\:placeholder-indigo-800:focus::placeholder {
+    color: #434190 !important;
+  }
+
+  .xl\:focus\:placeholder-indigo-900:focus::placeholder {
+    color: #3c366b !important;
+  }
+
+  .xl\:focus\:placeholder-purple-100:focus::placeholder {
+    color: #faf5ff !important;
+  }
+
+  .xl\:focus\:placeholder-purple-200:focus::placeholder {
+    color: #e9d8fd !important;
+  }
+
+  .xl\:focus\:placeholder-purple-300:focus::placeholder {
+    color: #d6bcfa !important;
+  }
+
+  .xl\:focus\:placeholder-purple-400:focus::placeholder {
+    color: #b794f4 !important;
+  }
+
+  .xl\:focus\:placeholder-purple-500:focus::placeholder {
+    color: #9f7aea !important;
+  }
+
+  .xl\:focus\:placeholder-purple-600:focus::placeholder {
+    color: #805ad5 !important;
+  }
+
+  .xl\:focus\:placeholder-purple-700:focus::placeholder {
+    color: #6b46c1 !important;
+  }
+
+  .xl\:focus\:placeholder-purple-800:focus::placeholder {
+    color: #553c9a !important;
+  }
+
+  .xl\:focus\:placeholder-purple-900:focus::placeholder {
+    color: #44337a !important;
+  }
+
+  .xl\:focus\:placeholder-pink-100:focus::placeholder {
+    color: #fff5f7 !important;
+  }
+
+  .xl\:focus\:placeholder-pink-200:focus::placeholder {
+    color: #fed7e2 !important;
+  }
+
+  .xl\:focus\:placeholder-pink-300:focus::placeholder {
+    color: #fbb6ce !important;
+  }
+
+  .xl\:focus\:placeholder-pink-400:focus::placeholder {
+    color: #f687b3 !important;
+  }
+
+  .xl\:focus\:placeholder-pink-500:focus::placeholder {
+    color: #ed64a6 !important;
+  }
+
+  .xl\:focus\:placeholder-pink-600:focus::placeholder {
+    color: #d53f8c !important;
+  }
+
+  .xl\:focus\:placeholder-pink-700:focus::placeholder {
+    color: #b83280 !important;
+  }
+
+  .xl\:focus\:placeholder-pink-800:focus::placeholder {
+    color: #97266d !important;
+  }
+
+  .xl\:focus\:placeholder-pink-900:focus::placeholder {
+    color: #702459 !important;
   }
 
   .xl\:pointer-events-none {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -5760,6 +5760,378 @@ video {
   padding-left: 1px;
 }
 
+.placeholder-transparent::placeholder {
+  color: transparent;
+}
+
+.placeholder-black::placeholder {
+  color: #000;
+}
+
+.placeholder-white::placeholder {
+  color: #fff;
+}
+
+.placeholder-gray-100::placeholder {
+  color: #f7fafc;
+}
+
+.placeholder-gray-200::placeholder {
+  color: #edf2f7;
+}
+
+.placeholder-gray-300::placeholder {
+  color: #e2e8f0;
+}
+
+.placeholder-gray-400::placeholder {
+  color: #cbd5e0;
+}
+
+.placeholder-gray-500::placeholder {
+  color: #a0aec0;
+}
+
+.placeholder-gray-600::placeholder {
+  color: #718096;
+}
+
+.placeholder-gray-700::placeholder {
+  color: #4a5568;
+}
+
+.placeholder-gray-800::placeholder {
+  color: #2d3748;
+}
+
+.placeholder-gray-900::placeholder {
+  color: #1a202c;
+}
+
+.placeholder-red-100::placeholder {
+  color: #fff5f5;
+}
+
+.placeholder-red-200::placeholder {
+  color: #fed7d7;
+}
+
+.placeholder-red-300::placeholder {
+  color: #feb2b2;
+}
+
+.placeholder-red-400::placeholder {
+  color: #fc8181;
+}
+
+.placeholder-red-500::placeholder {
+  color: #f56565;
+}
+
+.placeholder-red-600::placeholder {
+  color: #e53e3e;
+}
+
+.placeholder-red-700::placeholder {
+  color: #c53030;
+}
+
+.placeholder-red-800::placeholder {
+  color: #9b2c2c;
+}
+
+.placeholder-red-900::placeholder {
+  color: #742a2a;
+}
+
+.placeholder-orange-100::placeholder {
+  color: #fffaf0;
+}
+
+.placeholder-orange-200::placeholder {
+  color: #feebc8;
+}
+
+.placeholder-orange-300::placeholder {
+  color: #fbd38d;
+}
+
+.placeholder-orange-400::placeholder {
+  color: #f6ad55;
+}
+
+.placeholder-orange-500::placeholder {
+  color: #ed8936;
+}
+
+.placeholder-orange-600::placeholder {
+  color: #dd6b20;
+}
+
+.placeholder-orange-700::placeholder {
+  color: #c05621;
+}
+
+.placeholder-orange-800::placeholder {
+  color: #9c4221;
+}
+
+.placeholder-orange-900::placeholder {
+  color: #7b341e;
+}
+
+.placeholder-yellow-100::placeholder {
+  color: #fffff0;
+}
+
+.placeholder-yellow-200::placeholder {
+  color: #fefcbf;
+}
+
+.placeholder-yellow-300::placeholder {
+  color: #faf089;
+}
+
+.placeholder-yellow-400::placeholder {
+  color: #f6e05e;
+}
+
+.placeholder-yellow-500::placeholder {
+  color: #ecc94b;
+}
+
+.placeholder-yellow-600::placeholder {
+  color: #d69e2e;
+}
+
+.placeholder-yellow-700::placeholder {
+  color: #b7791f;
+}
+
+.placeholder-yellow-800::placeholder {
+  color: #975a16;
+}
+
+.placeholder-yellow-900::placeholder {
+  color: #744210;
+}
+
+.placeholder-green-100::placeholder {
+  color: #f0fff4;
+}
+
+.placeholder-green-200::placeholder {
+  color: #c6f6d5;
+}
+
+.placeholder-green-300::placeholder {
+  color: #9ae6b4;
+}
+
+.placeholder-green-400::placeholder {
+  color: #68d391;
+}
+
+.placeholder-green-500::placeholder {
+  color: #48bb78;
+}
+
+.placeholder-green-600::placeholder {
+  color: #38a169;
+}
+
+.placeholder-green-700::placeholder {
+  color: #2f855a;
+}
+
+.placeholder-green-800::placeholder {
+  color: #276749;
+}
+
+.placeholder-green-900::placeholder {
+  color: #22543d;
+}
+
+.placeholder-teal-100::placeholder {
+  color: #e6fffa;
+}
+
+.placeholder-teal-200::placeholder {
+  color: #b2f5ea;
+}
+
+.placeholder-teal-300::placeholder {
+  color: #81e6d9;
+}
+
+.placeholder-teal-400::placeholder {
+  color: #4fd1c5;
+}
+
+.placeholder-teal-500::placeholder {
+  color: #38b2ac;
+}
+
+.placeholder-teal-600::placeholder {
+  color: #319795;
+}
+
+.placeholder-teal-700::placeholder {
+  color: #2c7a7b;
+}
+
+.placeholder-teal-800::placeholder {
+  color: #285e61;
+}
+
+.placeholder-teal-900::placeholder {
+  color: #234e52;
+}
+
+.placeholder-blue-100::placeholder {
+  color: #ebf8ff;
+}
+
+.placeholder-blue-200::placeholder {
+  color: #bee3f8;
+}
+
+.placeholder-blue-300::placeholder {
+  color: #90cdf4;
+}
+
+.placeholder-blue-400::placeholder {
+  color: #63b3ed;
+}
+
+.placeholder-blue-500::placeholder {
+  color: #4299e1;
+}
+
+.placeholder-blue-600::placeholder {
+  color: #3182ce;
+}
+
+.placeholder-blue-700::placeholder {
+  color: #2b6cb0;
+}
+
+.placeholder-blue-800::placeholder {
+  color: #2c5282;
+}
+
+.placeholder-blue-900::placeholder {
+  color: #2a4365;
+}
+
+.placeholder-indigo-100::placeholder {
+  color: #ebf4ff;
+}
+
+.placeholder-indigo-200::placeholder {
+  color: #c3dafe;
+}
+
+.placeholder-indigo-300::placeholder {
+  color: #a3bffa;
+}
+
+.placeholder-indigo-400::placeholder {
+  color: #7f9cf5;
+}
+
+.placeholder-indigo-500::placeholder {
+  color: #667eea;
+}
+
+.placeholder-indigo-600::placeholder {
+  color: #5a67d8;
+}
+
+.placeholder-indigo-700::placeholder {
+  color: #4c51bf;
+}
+
+.placeholder-indigo-800::placeholder {
+  color: #434190;
+}
+
+.placeholder-indigo-900::placeholder {
+  color: #3c366b;
+}
+
+.placeholder-purple-100::placeholder {
+  color: #faf5ff;
+}
+
+.placeholder-purple-200::placeholder {
+  color: #e9d8fd;
+}
+
+.placeholder-purple-300::placeholder {
+  color: #d6bcfa;
+}
+
+.placeholder-purple-400::placeholder {
+  color: #b794f4;
+}
+
+.placeholder-purple-500::placeholder {
+  color: #9f7aea;
+}
+
+.placeholder-purple-600::placeholder {
+  color: #805ad5;
+}
+
+.placeholder-purple-700::placeholder {
+  color: #6b46c1;
+}
+
+.placeholder-purple-800::placeholder {
+  color: #553c9a;
+}
+
+.placeholder-purple-900::placeholder {
+  color: #44337a;
+}
+
+.placeholder-pink-100::placeholder {
+  color: #fff5f7;
+}
+
+.placeholder-pink-200::placeholder {
+  color: #fed7e2;
+}
+
+.placeholder-pink-300::placeholder {
+  color: #fbb6ce;
+}
+
+.placeholder-pink-400::placeholder {
+  color: #f687b3;
+}
+
+.placeholder-pink-500::placeholder {
+  color: #ed64a6;
+}
+
+.placeholder-pink-600::placeholder {
+  color: #d53f8c;
+}
+
+.placeholder-pink-700::placeholder {
+  color: #b83280;
+}
+
+.placeholder-pink-800::placeholder {
+  color: #97266d;
+}
+
+.placeholder-pink-900::placeholder {
+  color: #702459;
+}
+
 .pointer-events-none {
   pointer-events: none;
 }

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -6132,6 +6132,378 @@ video {
   color: #702459;
 }
 
+.focus\:placeholder-transparent:focus::placeholder {
+  color: transparent;
+}
+
+.focus\:placeholder-black:focus::placeholder {
+  color: #000;
+}
+
+.focus\:placeholder-white:focus::placeholder {
+  color: #fff;
+}
+
+.focus\:placeholder-gray-100:focus::placeholder {
+  color: #f7fafc;
+}
+
+.focus\:placeholder-gray-200:focus::placeholder {
+  color: #edf2f7;
+}
+
+.focus\:placeholder-gray-300:focus::placeholder {
+  color: #e2e8f0;
+}
+
+.focus\:placeholder-gray-400:focus::placeholder {
+  color: #cbd5e0;
+}
+
+.focus\:placeholder-gray-500:focus::placeholder {
+  color: #a0aec0;
+}
+
+.focus\:placeholder-gray-600:focus::placeholder {
+  color: #718096;
+}
+
+.focus\:placeholder-gray-700:focus::placeholder {
+  color: #4a5568;
+}
+
+.focus\:placeholder-gray-800:focus::placeholder {
+  color: #2d3748;
+}
+
+.focus\:placeholder-gray-900:focus::placeholder {
+  color: #1a202c;
+}
+
+.focus\:placeholder-red-100:focus::placeholder {
+  color: #fff5f5;
+}
+
+.focus\:placeholder-red-200:focus::placeholder {
+  color: #fed7d7;
+}
+
+.focus\:placeholder-red-300:focus::placeholder {
+  color: #feb2b2;
+}
+
+.focus\:placeholder-red-400:focus::placeholder {
+  color: #fc8181;
+}
+
+.focus\:placeholder-red-500:focus::placeholder {
+  color: #f56565;
+}
+
+.focus\:placeholder-red-600:focus::placeholder {
+  color: #e53e3e;
+}
+
+.focus\:placeholder-red-700:focus::placeholder {
+  color: #c53030;
+}
+
+.focus\:placeholder-red-800:focus::placeholder {
+  color: #9b2c2c;
+}
+
+.focus\:placeholder-red-900:focus::placeholder {
+  color: #742a2a;
+}
+
+.focus\:placeholder-orange-100:focus::placeholder {
+  color: #fffaf0;
+}
+
+.focus\:placeholder-orange-200:focus::placeholder {
+  color: #feebc8;
+}
+
+.focus\:placeholder-orange-300:focus::placeholder {
+  color: #fbd38d;
+}
+
+.focus\:placeholder-orange-400:focus::placeholder {
+  color: #f6ad55;
+}
+
+.focus\:placeholder-orange-500:focus::placeholder {
+  color: #ed8936;
+}
+
+.focus\:placeholder-orange-600:focus::placeholder {
+  color: #dd6b20;
+}
+
+.focus\:placeholder-orange-700:focus::placeholder {
+  color: #c05621;
+}
+
+.focus\:placeholder-orange-800:focus::placeholder {
+  color: #9c4221;
+}
+
+.focus\:placeholder-orange-900:focus::placeholder {
+  color: #7b341e;
+}
+
+.focus\:placeholder-yellow-100:focus::placeholder {
+  color: #fffff0;
+}
+
+.focus\:placeholder-yellow-200:focus::placeholder {
+  color: #fefcbf;
+}
+
+.focus\:placeholder-yellow-300:focus::placeholder {
+  color: #faf089;
+}
+
+.focus\:placeholder-yellow-400:focus::placeholder {
+  color: #f6e05e;
+}
+
+.focus\:placeholder-yellow-500:focus::placeholder {
+  color: #ecc94b;
+}
+
+.focus\:placeholder-yellow-600:focus::placeholder {
+  color: #d69e2e;
+}
+
+.focus\:placeholder-yellow-700:focus::placeholder {
+  color: #b7791f;
+}
+
+.focus\:placeholder-yellow-800:focus::placeholder {
+  color: #975a16;
+}
+
+.focus\:placeholder-yellow-900:focus::placeholder {
+  color: #744210;
+}
+
+.focus\:placeholder-green-100:focus::placeholder {
+  color: #f0fff4;
+}
+
+.focus\:placeholder-green-200:focus::placeholder {
+  color: #c6f6d5;
+}
+
+.focus\:placeholder-green-300:focus::placeholder {
+  color: #9ae6b4;
+}
+
+.focus\:placeholder-green-400:focus::placeholder {
+  color: #68d391;
+}
+
+.focus\:placeholder-green-500:focus::placeholder {
+  color: #48bb78;
+}
+
+.focus\:placeholder-green-600:focus::placeholder {
+  color: #38a169;
+}
+
+.focus\:placeholder-green-700:focus::placeholder {
+  color: #2f855a;
+}
+
+.focus\:placeholder-green-800:focus::placeholder {
+  color: #276749;
+}
+
+.focus\:placeholder-green-900:focus::placeholder {
+  color: #22543d;
+}
+
+.focus\:placeholder-teal-100:focus::placeholder {
+  color: #e6fffa;
+}
+
+.focus\:placeholder-teal-200:focus::placeholder {
+  color: #b2f5ea;
+}
+
+.focus\:placeholder-teal-300:focus::placeholder {
+  color: #81e6d9;
+}
+
+.focus\:placeholder-teal-400:focus::placeholder {
+  color: #4fd1c5;
+}
+
+.focus\:placeholder-teal-500:focus::placeholder {
+  color: #38b2ac;
+}
+
+.focus\:placeholder-teal-600:focus::placeholder {
+  color: #319795;
+}
+
+.focus\:placeholder-teal-700:focus::placeholder {
+  color: #2c7a7b;
+}
+
+.focus\:placeholder-teal-800:focus::placeholder {
+  color: #285e61;
+}
+
+.focus\:placeholder-teal-900:focus::placeholder {
+  color: #234e52;
+}
+
+.focus\:placeholder-blue-100:focus::placeholder {
+  color: #ebf8ff;
+}
+
+.focus\:placeholder-blue-200:focus::placeholder {
+  color: #bee3f8;
+}
+
+.focus\:placeholder-blue-300:focus::placeholder {
+  color: #90cdf4;
+}
+
+.focus\:placeholder-blue-400:focus::placeholder {
+  color: #63b3ed;
+}
+
+.focus\:placeholder-blue-500:focus::placeholder {
+  color: #4299e1;
+}
+
+.focus\:placeholder-blue-600:focus::placeholder {
+  color: #3182ce;
+}
+
+.focus\:placeholder-blue-700:focus::placeholder {
+  color: #2b6cb0;
+}
+
+.focus\:placeholder-blue-800:focus::placeholder {
+  color: #2c5282;
+}
+
+.focus\:placeholder-blue-900:focus::placeholder {
+  color: #2a4365;
+}
+
+.focus\:placeholder-indigo-100:focus::placeholder {
+  color: #ebf4ff;
+}
+
+.focus\:placeholder-indigo-200:focus::placeholder {
+  color: #c3dafe;
+}
+
+.focus\:placeholder-indigo-300:focus::placeholder {
+  color: #a3bffa;
+}
+
+.focus\:placeholder-indigo-400:focus::placeholder {
+  color: #7f9cf5;
+}
+
+.focus\:placeholder-indigo-500:focus::placeholder {
+  color: #667eea;
+}
+
+.focus\:placeholder-indigo-600:focus::placeholder {
+  color: #5a67d8;
+}
+
+.focus\:placeholder-indigo-700:focus::placeholder {
+  color: #4c51bf;
+}
+
+.focus\:placeholder-indigo-800:focus::placeholder {
+  color: #434190;
+}
+
+.focus\:placeholder-indigo-900:focus::placeholder {
+  color: #3c366b;
+}
+
+.focus\:placeholder-purple-100:focus::placeholder {
+  color: #faf5ff;
+}
+
+.focus\:placeholder-purple-200:focus::placeholder {
+  color: #e9d8fd;
+}
+
+.focus\:placeholder-purple-300:focus::placeholder {
+  color: #d6bcfa;
+}
+
+.focus\:placeholder-purple-400:focus::placeholder {
+  color: #b794f4;
+}
+
+.focus\:placeholder-purple-500:focus::placeholder {
+  color: #9f7aea;
+}
+
+.focus\:placeholder-purple-600:focus::placeholder {
+  color: #805ad5;
+}
+
+.focus\:placeholder-purple-700:focus::placeholder {
+  color: #6b46c1;
+}
+
+.focus\:placeholder-purple-800:focus::placeholder {
+  color: #553c9a;
+}
+
+.focus\:placeholder-purple-900:focus::placeholder {
+  color: #44337a;
+}
+
+.focus\:placeholder-pink-100:focus::placeholder {
+  color: #fff5f7;
+}
+
+.focus\:placeholder-pink-200:focus::placeholder {
+  color: #fed7e2;
+}
+
+.focus\:placeholder-pink-300:focus::placeholder {
+  color: #fbb6ce;
+}
+
+.focus\:placeholder-pink-400:focus::placeholder {
+  color: #f687b3;
+}
+
+.focus\:placeholder-pink-500:focus::placeholder {
+  color: #ed64a6;
+}
+
+.focus\:placeholder-pink-600:focus::placeholder {
+  color: #d53f8c;
+}
+
+.focus\:placeholder-pink-700:focus::placeholder {
+  color: #b83280;
+}
+
+.focus\:placeholder-pink-800:focus::placeholder {
+  color: #97266d;
+}
+
+.focus\:placeholder-pink-900:focus::placeholder {
+  color: #702459;
+}
+
 .pointer-events-none {
   pointer-events: none;
 }
@@ -13081,6 +13453,750 @@ video {
 
   .sm\:pl-px {
     padding-left: 1px;
+  }
+
+  .sm\:placeholder-transparent::placeholder {
+    color: transparent;
+  }
+
+  .sm\:placeholder-black::placeholder {
+    color: #000;
+  }
+
+  .sm\:placeholder-white::placeholder {
+    color: #fff;
+  }
+
+  .sm\:placeholder-gray-100::placeholder {
+    color: #f7fafc;
+  }
+
+  .sm\:placeholder-gray-200::placeholder {
+    color: #edf2f7;
+  }
+
+  .sm\:placeholder-gray-300::placeholder {
+    color: #e2e8f0;
+  }
+
+  .sm\:placeholder-gray-400::placeholder {
+    color: #cbd5e0;
+  }
+
+  .sm\:placeholder-gray-500::placeholder {
+    color: #a0aec0;
+  }
+
+  .sm\:placeholder-gray-600::placeholder {
+    color: #718096;
+  }
+
+  .sm\:placeholder-gray-700::placeholder {
+    color: #4a5568;
+  }
+
+  .sm\:placeholder-gray-800::placeholder {
+    color: #2d3748;
+  }
+
+  .sm\:placeholder-gray-900::placeholder {
+    color: #1a202c;
+  }
+
+  .sm\:placeholder-red-100::placeholder {
+    color: #fff5f5;
+  }
+
+  .sm\:placeholder-red-200::placeholder {
+    color: #fed7d7;
+  }
+
+  .sm\:placeholder-red-300::placeholder {
+    color: #feb2b2;
+  }
+
+  .sm\:placeholder-red-400::placeholder {
+    color: #fc8181;
+  }
+
+  .sm\:placeholder-red-500::placeholder {
+    color: #f56565;
+  }
+
+  .sm\:placeholder-red-600::placeholder {
+    color: #e53e3e;
+  }
+
+  .sm\:placeholder-red-700::placeholder {
+    color: #c53030;
+  }
+
+  .sm\:placeholder-red-800::placeholder {
+    color: #9b2c2c;
+  }
+
+  .sm\:placeholder-red-900::placeholder {
+    color: #742a2a;
+  }
+
+  .sm\:placeholder-orange-100::placeholder {
+    color: #fffaf0;
+  }
+
+  .sm\:placeholder-orange-200::placeholder {
+    color: #feebc8;
+  }
+
+  .sm\:placeholder-orange-300::placeholder {
+    color: #fbd38d;
+  }
+
+  .sm\:placeholder-orange-400::placeholder {
+    color: #f6ad55;
+  }
+
+  .sm\:placeholder-orange-500::placeholder {
+    color: #ed8936;
+  }
+
+  .sm\:placeholder-orange-600::placeholder {
+    color: #dd6b20;
+  }
+
+  .sm\:placeholder-orange-700::placeholder {
+    color: #c05621;
+  }
+
+  .sm\:placeholder-orange-800::placeholder {
+    color: #9c4221;
+  }
+
+  .sm\:placeholder-orange-900::placeholder {
+    color: #7b341e;
+  }
+
+  .sm\:placeholder-yellow-100::placeholder {
+    color: #fffff0;
+  }
+
+  .sm\:placeholder-yellow-200::placeholder {
+    color: #fefcbf;
+  }
+
+  .sm\:placeholder-yellow-300::placeholder {
+    color: #faf089;
+  }
+
+  .sm\:placeholder-yellow-400::placeholder {
+    color: #f6e05e;
+  }
+
+  .sm\:placeholder-yellow-500::placeholder {
+    color: #ecc94b;
+  }
+
+  .sm\:placeholder-yellow-600::placeholder {
+    color: #d69e2e;
+  }
+
+  .sm\:placeholder-yellow-700::placeholder {
+    color: #b7791f;
+  }
+
+  .sm\:placeholder-yellow-800::placeholder {
+    color: #975a16;
+  }
+
+  .sm\:placeholder-yellow-900::placeholder {
+    color: #744210;
+  }
+
+  .sm\:placeholder-green-100::placeholder {
+    color: #f0fff4;
+  }
+
+  .sm\:placeholder-green-200::placeholder {
+    color: #c6f6d5;
+  }
+
+  .sm\:placeholder-green-300::placeholder {
+    color: #9ae6b4;
+  }
+
+  .sm\:placeholder-green-400::placeholder {
+    color: #68d391;
+  }
+
+  .sm\:placeholder-green-500::placeholder {
+    color: #48bb78;
+  }
+
+  .sm\:placeholder-green-600::placeholder {
+    color: #38a169;
+  }
+
+  .sm\:placeholder-green-700::placeholder {
+    color: #2f855a;
+  }
+
+  .sm\:placeholder-green-800::placeholder {
+    color: #276749;
+  }
+
+  .sm\:placeholder-green-900::placeholder {
+    color: #22543d;
+  }
+
+  .sm\:placeholder-teal-100::placeholder {
+    color: #e6fffa;
+  }
+
+  .sm\:placeholder-teal-200::placeholder {
+    color: #b2f5ea;
+  }
+
+  .sm\:placeholder-teal-300::placeholder {
+    color: #81e6d9;
+  }
+
+  .sm\:placeholder-teal-400::placeholder {
+    color: #4fd1c5;
+  }
+
+  .sm\:placeholder-teal-500::placeholder {
+    color: #38b2ac;
+  }
+
+  .sm\:placeholder-teal-600::placeholder {
+    color: #319795;
+  }
+
+  .sm\:placeholder-teal-700::placeholder {
+    color: #2c7a7b;
+  }
+
+  .sm\:placeholder-teal-800::placeholder {
+    color: #285e61;
+  }
+
+  .sm\:placeholder-teal-900::placeholder {
+    color: #234e52;
+  }
+
+  .sm\:placeholder-blue-100::placeholder {
+    color: #ebf8ff;
+  }
+
+  .sm\:placeholder-blue-200::placeholder {
+    color: #bee3f8;
+  }
+
+  .sm\:placeholder-blue-300::placeholder {
+    color: #90cdf4;
+  }
+
+  .sm\:placeholder-blue-400::placeholder {
+    color: #63b3ed;
+  }
+
+  .sm\:placeholder-blue-500::placeholder {
+    color: #4299e1;
+  }
+
+  .sm\:placeholder-blue-600::placeholder {
+    color: #3182ce;
+  }
+
+  .sm\:placeholder-blue-700::placeholder {
+    color: #2b6cb0;
+  }
+
+  .sm\:placeholder-blue-800::placeholder {
+    color: #2c5282;
+  }
+
+  .sm\:placeholder-blue-900::placeholder {
+    color: #2a4365;
+  }
+
+  .sm\:placeholder-indigo-100::placeholder {
+    color: #ebf4ff;
+  }
+
+  .sm\:placeholder-indigo-200::placeholder {
+    color: #c3dafe;
+  }
+
+  .sm\:placeholder-indigo-300::placeholder {
+    color: #a3bffa;
+  }
+
+  .sm\:placeholder-indigo-400::placeholder {
+    color: #7f9cf5;
+  }
+
+  .sm\:placeholder-indigo-500::placeholder {
+    color: #667eea;
+  }
+
+  .sm\:placeholder-indigo-600::placeholder {
+    color: #5a67d8;
+  }
+
+  .sm\:placeholder-indigo-700::placeholder {
+    color: #4c51bf;
+  }
+
+  .sm\:placeholder-indigo-800::placeholder {
+    color: #434190;
+  }
+
+  .sm\:placeholder-indigo-900::placeholder {
+    color: #3c366b;
+  }
+
+  .sm\:placeholder-purple-100::placeholder {
+    color: #faf5ff;
+  }
+
+  .sm\:placeholder-purple-200::placeholder {
+    color: #e9d8fd;
+  }
+
+  .sm\:placeholder-purple-300::placeholder {
+    color: #d6bcfa;
+  }
+
+  .sm\:placeholder-purple-400::placeholder {
+    color: #b794f4;
+  }
+
+  .sm\:placeholder-purple-500::placeholder {
+    color: #9f7aea;
+  }
+
+  .sm\:placeholder-purple-600::placeholder {
+    color: #805ad5;
+  }
+
+  .sm\:placeholder-purple-700::placeholder {
+    color: #6b46c1;
+  }
+
+  .sm\:placeholder-purple-800::placeholder {
+    color: #553c9a;
+  }
+
+  .sm\:placeholder-purple-900::placeholder {
+    color: #44337a;
+  }
+
+  .sm\:placeholder-pink-100::placeholder {
+    color: #fff5f7;
+  }
+
+  .sm\:placeholder-pink-200::placeholder {
+    color: #fed7e2;
+  }
+
+  .sm\:placeholder-pink-300::placeholder {
+    color: #fbb6ce;
+  }
+
+  .sm\:placeholder-pink-400::placeholder {
+    color: #f687b3;
+  }
+
+  .sm\:placeholder-pink-500::placeholder {
+    color: #ed64a6;
+  }
+
+  .sm\:placeholder-pink-600::placeholder {
+    color: #d53f8c;
+  }
+
+  .sm\:placeholder-pink-700::placeholder {
+    color: #b83280;
+  }
+
+  .sm\:placeholder-pink-800::placeholder {
+    color: #97266d;
+  }
+
+  .sm\:placeholder-pink-900::placeholder {
+    color: #702459;
+  }
+
+  .sm\:focus\:placeholder-transparent:focus::placeholder {
+    color: transparent;
+  }
+
+  .sm\:focus\:placeholder-black:focus::placeholder {
+    color: #000;
+  }
+
+  .sm\:focus\:placeholder-white:focus::placeholder {
+    color: #fff;
+  }
+
+  .sm\:focus\:placeholder-gray-100:focus::placeholder {
+    color: #f7fafc;
+  }
+
+  .sm\:focus\:placeholder-gray-200:focus::placeholder {
+    color: #edf2f7;
+  }
+
+  .sm\:focus\:placeholder-gray-300:focus::placeholder {
+    color: #e2e8f0;
+  }
+
+  .sm\:focus\:placeholder-gray-400:focus::placeholder {
+    color: #cbd5e0;
+  }
+
+  .sm\:focus\:placeholder-gray-500:focus::placeholder {
+    color: #a0aec0;
+  }
+
+  .sm\:focus\:placeholder-gray-600:focus::placeholder {
+    color: #718096;
+  }
+
+  .sm\:focus\:placeholder-gray-700:focus::placeholder {
+    color: #4a5568;
+  }
+
+  .sm\:focus\:placeholder-gray-800:focus::placeholder {
+    color: #2d3748;
+  }
+
+  .sm\:focus\:placeholder-gray-900:focus::placeholder {
+    color: #1a202c;
+  }
+
+  .sm\:focus\:placeholder-red-100:focus::placeholder {
+    color: #fff5f5;
+  }
+
+  .sm\:focus\:placeholder-red-200:focus::placeholder {
+    color: #fed7d7;
+  }
+
+  .sm\:focus\:placeholder-red-300:focus::placeholder {
+    color: #feb2b2;
+  }
+
+  .sm\:focus\:placeholder-red-400:focus::placeholder {
+    color: #fc8181;
+  }
+
+  .sm\:focus\:placeholder-red-500:focus::placeholder {
+    color: #f56565;
+  }
+
+  .sm\:focus\:placeholder-red-600:focus::placeholder {
+    color: #e53e3e;
+  }
+
+  .sm\:focus\:placeholder-red-700:focus::placeholder {
+    color: #c53030;
+  }
+
+  .sm\:focus\:placeholder-red-800:focus::placeholder {
+    color: #9b2c2c;
+  }
+
+  .sm\:focus\:placeholder-red-900:focus::placeholder {
+    color: #742a2a;
+  }
+
+  .sm\:focus\:placeholder-orange-100:focus::placeholder {
+    color: #fffaf0;
+  }
+
+  .sm\:focus\:placeholder-orange-200:focus::placeholder {
+    color: #feebc8;
+  }
+
+  .sm\:focus\:placeholder-orange-300:focus::placeholder {
+    color: #fbd38d;
+  }
+
+  .sm\:focus\:placeholder-orange-400:focus::placeholder {
+    color: #f6ad55;
+  }
+
+  .sm\:focus\:placeholder-orange-500:focus::placeholder {
+    color: #ed8936;
+  }
+
+  .sm\:focus\:placeholder-orange-600:focus::placeholder {
+    color: #dd6b20;
+  }
+
+  .sm\:focus\:placeholder-orange-700:focus::placeholder {
+    color: #c05621;
+  }
+
+  .sm\:focus\:placeholder-orange-800:focus::placeholder {
+    color: #9c4221;
+  }
+
+  .sm\:focus\:placeholder-orange-900:focus::placeholder {
+    color: #7b341e;
+  }
+
+  .sm\:focus\:placeholder-yellow-100:focus::placeholder {
+    color: #fffff0;
+  }
+
+  .sm\:focus\:placeholder-yellow-200:focus::placeholder {
+    color: #fefcbf;
+  }
+
+  .sm\:focus\:placeholder-yellow-300:focus::placeholder {
+    color: #faf089;
+  }
+
+  .sm\:focus\:placeholder-yellow-400:focus::placeholder {
+    color: #f6e05e;
+  }
+
+  .sm\:focus\:placeholder-yellow-500:focus::placeholder {
+    color: #ecc94b;
+  }
+
+  .sm\:focus\:placeholder-yellow-600:focus::placeholder {
+    color: #d69e2e;
+  }
+
+  .sm\:focus\:placeholder-yellow-700:focus::placeholder {
+    color: #b7791f;
+  }
+
+  .sm\:focus\:placeholder-yellow-800:focus::placeholder {
+    color: #975a16;
+  }
+
+  .sm\:focus\:placeholder-yellow-900:focus::placeholder {
+    color: #744210;
+  }
+
+  .sm\:focus\:placeholder-green-100:focus::placeholder {
+    color: #f0fff4;
+  }
+
+  .sm\:focus\:placeholder-green-200:focus::placeholder {
+    color: #c6f6d5;
+  }
+
+  .sm\:focus\:placeholder-green-300:focus::placeholder {
+    color: #9ae6b4;
+  }
+
+  .sm\:focus\:placeholder-green-400:focus::placeholder {
+    color: #68d391;
+  }
+
+  .sm\:focus\:placeholder-green-500:focus::placeholder {
+    color: #48bb78;
+  }
+
+  .sm\:focus\:placeholder-green-600:focus::placeholder {
+    color: #38a169;
+  }
+
+  .sm\:focus\:placeholder-green-700:focus::placeholder {
+    color: #2f855a;
+  }
+
+  .sm\:focus\:placeholder-green-800:focus::placeholder {
+    color: #276749;
+  }
+
+  .sm\:focus\:placeholder-green-900:focus::placeholder {
+    color: #22543d;
+  }
+
+  .sm\:focus\:placeholder-teal-100:focus::placeholder {
+    color: #e6fffa;
+  }
+
+  .sm\:focus\:placeholder-teal-200:focus::placeholder {
+    color: #b2f5ea;
+  }
+
+  .sm\:focus\:placeholder-teal-300:focus::placeholder {
+    color: #81e6d9;
+  }
+
+  .sm\:focus\:placeholder-teal-400:focus::placeholder {
+    color: #4fd1c5;
+  }
+
+  .sm\:focus\:placeholder-teal-500:focus::placeholder {
+    color: #38b2ac;
+  }
+
+  .sm\:focus\:placeholder-teal-600:focus::placeholder {
+    color: #319795;
+  }
+
+  .sm\:focus\:placeholder-teal-700:focus::placeholder {
+    color: #2c7a7b;
+  }
+
+  .sm\:focus\:placeholder-teal-800:focus::placeholder {
+    color: #285e61;
+  }
+
+  .sm\:focus\:placeholder-teal-900:focus::placeholder {
+    color: #234e52;
+  }
+
+  .sm\:focus\:placeholder-blue-100:focus::placeholder {
+    color: #ebf8ff;
+  }
+
+  .sm\:focus\:placeholder-blue-200:focus::placeholder {
+    color: #bee3f8;
+  }
+
+  .sm\:focus\:placeholder-blue-300:focus::placeholder {
+    color: #90cdf4;
+  }
+
+  .sm\:focus\:placeholder-blue-400:focus::placeholder {
+    color: #63b3ed;
+  }
+
+  .sm\:focus\:placeholder-blue-500:focus::placeholder {
+    color: #4299e1;
+  }
+
+  .sm\:focus\:placeholder-blue-600:focus::placeholder {
+    color: #3182ce;
+  }
+
+  .sm\:focus\:placeholder-blue-700:focus::placeholder {
+    color: #2b6cb0;
+  }
+
+  .sm\:focus\:placeholder-blue-800:focus::placeholder {
+    color: #2c5282;
+  }
+
+  .sm\:focus\:placeholder-blue-900:focus::placeholder {
+    color: #2a4365;
+  }
+
+  .sm\:focus\:placeholder-indigo-100:focus::placeholder {
+    color: #ebf4ff;
+  }
+
+  .sm\:focus\:placeholder-indigo-200:focus::placeholder {
+    color: #c3dafe;
+  }
+
+  .sm\:focus\:placeholder-indigo-300:focus::placeholder {
+    color: #a3bffa;
+  }
+
+  .sm\:focus\:placeholder-indigo-400:focus::placeholder {
+    color: #7f9cf5;
+  }
+
+  .sm\:focus\:placeholder-indigo-500:focus::placeholder {
+    color: #667eea;
+  }
+
+  .sm\:focus\:placeholder-indigo-600:focus::placeholder {
+    color: #5a67d8;
+  }
+
+  .sm\:focus\:placeholder-indigo-700:focus::placeholder {
+    color: #4c51bf;
+  }
+
+  .sm\:focus\:placeholder-indigo-800:focus::placeholder {
+    color: #434190;
+  }
+
+  .sm\:focus\:placeholder-indigo-900:focus::placeholder {
+    color: #3c366b;
+  }
+
+  .sm\:focus\:placeholder-purple-100:focus::placeholder {
+    color: #faf5ff;
+  }
+
+  .sm\:focus\:placeholder-purple-200:focus::placeholder {
+    color: #e9d8fd;
+  }
+
+  .sm\:focus\:placeholder-purple-300:focus::placeholder {
+    color: #d6bcfa;
+  }
+
+  .sm\:focus\:placeholder-purple-400:focus::placeholder {
+    color: #b794f4;
+  }
+
+  .sm\:focus\:placeholder-purple-500:focus::placeholder {
+    color: #9f7aea;
+  }
+
+  .sm\:focus\:placeholder-purple-600:focus::placeholder {
+    color: #805ad5;
+  }
+
+  .sm\:focus\:placeholder-purple-700:focus::placeholder {
+    color: #6b46c1;
+  }
+
+  .sm\:focus\:placeholder-purple-800:focus::placeholder {
+    color: #553c9a;
+  }
+
+  .sm\:focus\:placeholder-purple-900:focus::placeholder {
+    color: #44337a;
+  }
+
+  .sm\:focus\:placeholder-pink-100:focus::placeholder {
+    color: #fff5f7;
+  }
+
+  .sm\:focus\:placeholder-pink-200:focus::placeholder {
+    color: #fed7e2;
+  }
+
+  .sm\:focus\:placeholder-pink-300:focus::placeholder {
+    color: #fbb6ce;
+  }
+
+  .sm\:focus\:placeholder-pink-400:focus::placeholder {
+    color: #f687b3;
+  }
+
+  .sm\:focus\:placeholder-pink-500:focus::placeholder {
+    color: #ed64a6;
+  }
+
+  .sm\:focus\:placeholder-pink-600:focus::placeholder {
+    color: #d53f8c;
+  }
+
+  .sm\:focus\:placeholder-pink-700:focus::placeholder {
+    color: #b83280;
+  }
+
+  .sm\:focus\:placeholder-pink-800:focus::placeholder {
+    color: #97266d;
+  }
+
+  .sm\:focus\:placeholder-pink-900:focus::placeholder {
+    color: #702459;
   }
 
   .sm\:pointer-events-none {
@@ -20035,6 +21151,750 @@ video {
     padding-left: 1px;
   }
 
+  .md\:placeholder-transparent::placeholder {
+    color: transparent;
+  }
+
+  .md\:placeholder-black::placeholder {
+    color: #000;
+  }
+
+  .md\:placeholder-white::placeholder {
+    color: #fff;
+  }
+
+  .md\:placeholder-gray-100::placeholder {
+    color: #f7fafc;
+  }
+
+  .md\:placeholder-gray-200::placeholder {
+    color: #edf2f7;
+  }
+
+  .md\:placeholder-gray-300::placeholder {
+    color: #e2e8f0;
+  }
+
+  .md\:placeholder-gray-400::placeholder {
+    color: #cbd5e0;
+  }
+
+  .md\:placeholder-gray-500::placeholder {
+    color: #a0aec0;
+  }
+
+  .md\:placeholder-gray-600::placeholder {
+    color: #718096;
+  }
+
+  .md\:placeholder-gray-700::placeholder {
+    color: #4a5568;
+  }
+
+  .md\:placeholder-gray-800::placeholder {
+    color: #2d3748;
+  }
+
+  .md\:placeholder-gray-900::placeholder {
+    color: #1a202c;
+  }
+
+  .md\:placeholder-red-100::placeholder {
+    color: #fff5f5;
+  }
+
+  .md\:placeholder-red-200::placeholder {
+    color: #fed7d7;
+  }
+
+  .md\:placeholder-red-300::placeholder {
+    color: #feb2b2;
+  }
+
+  .md\:placeholder-red-400::placeholder {
+    color: #fc8181;
+  }
+
+  .md\:placeholder-red-500::placeholder {
+    color: #f56565;
+  }
+
+  .md\:placeholder-red-600::placeholder {
+    color: #e53e3e;
+  }
+
+  .md\:placeholder-red-700::placeholder {
+    color: #c53030;
+  }
+
+  .md\:placeholder-red-800::placeholder {
+    color: #9b2c2c;
+  }
+
+  .md\:placeholder-red-900::placeholder {
+    color: #742a2a;
+  }
+
+  .md\:placeholder-orange-100::placeholder {
+    color: #fffaf0;
+  }
+
+  .md\:placeholder-orange-200::placeholder {
+    color: #feebc8;
+  }
+
+  .md\:placeholder-orange-300::placeholder {
+    color: #fbd38d;
+  }
+
+  .md\:placeholder-orange-400::placeholder {
+    color: #f6ad55;
+  }
+
+  .md\:placeholder-orange-500::placeholder {
+    color: #ed8936;
+  }
+
+  .md\:placeholder-orange-600::placeholder {
+    color: #dd6b20;
+  }
+
+  .md\:placeholder-orange-700::placeholder {
+    color: #c05621;
+  }
+
+  .md\:placeholder-orange-800::placeholder {
+    color: #9c4221;
+  }
+
+  .md\:placeholder-orange-900::placeholder {
+    color: #7b341e;
+  }
+
+  .md\:placeholder-yellow-100::placeholder {
+    color: #fffff0;
+  }
+
+  .md\:placeholder-yellow-200::placeholder {
+    color: #fefcbf;
+  }
+
+  .md\:placeholder-yellow-300::placeholder {
+    color: #faf089;
+  }
+
+  .md\:placeholder-yellow-400::placeholder {
+    color: #f6e05e;
+  }
+
+  .md\:placeholder-yellow-500::placeholder {
+    color: #ecc94b;
+  }
+
+  .md\:placeholder-yellow-600::placeholder {
+    color: #d69e2e;
+  }
+
+  .md\:placeholder-yellow-700::placeholder {
+    color: #b7791f;
+  }
+
+  .md\:placeholder-yellow-800::placeholder {
+    color: #975a16;
+  }
+
+  .md\:placeholder-yellow-900::placeholder {
+    color: #744210;
+  }
+
+  .md\:placeholder-green-100::placeholder {
+    color: #f0fff4;
+  }
+
+  .md\:placeholder-green-200::placeholder {
+    color: #c6f6d5;
+  }
+
+  .md\:placeholder-green-300::placeholder {
+    color: #9ae6b4;
+  }
+
+  .md\:placeholder-green-400::placeholder {
+    color: #68d391;
+  }
+
+  .md\:placeholder-green-500::placeholder {
+    color: #48bb78;
+  }
+
+  .md\:placeholder-green-600::placeholder {
+    color: #38a169;
+  }
+
+  .md\:placeholder-green-700::placeholder {
+    color: #2f855a;
+  }
+
+  .md\:placeholder-green-800::placeholder {
+    color: #276749;
+  }
+
+  .md\:placeholder-green-900::placeholder {
+    color: #22543d;
+  }
+
+  .md\:placeholder-teal-100::placeholder {
+    color: #e6fffa;
+  }
+
+  .md\:placeholder-teal-200::placeholder {
+    color: #b2f5ea;
+  }
+
+  .md\:placeholder-teal-300::placeholder {
+    color: #81e6d9;
+  }
+
+  .md\:placeholder-teal-400::placeholder {
+    color: #4fd1c5;
+  }
+
+  .md\:placeholder-teal-500::placeholder {
+    color: #38b2ac;
+  }
+
+  .md\:placeholder-teal-600::placeholder {
+    color: #319795;
+  }
+
+  .md\:placeholder-teal-700::placeholder {
+    color: #2c7a7b;
+  }
+
+  .md\:placeholder-teal-800::placeholder {
+    color: #285e61;
+  }
+
+  .md\:placeholder-teal-900::placeholder {
+    color: #234e52;
+  }
+
+  .md\:placeholder-blue-100::placeholder {
+    color: #ebf8ff;
+  }
+
+  .md\:placeholder-blue-200::placeholder {
+    color: #bee3f8;
+  }
+
+  .md\:placeholder-blue-300::placeholder {
+    color: #90cdf4;
+  }
+
+  .md\:placeholder-blue-400::placeholder {
+    color: #63b3ed;
+  }
+
+  .md\:placeholder-blue-500::placeholder {
+    color: #4299e1;
+  }
+
+  .md\:placeholder-blue-600::placeholder {
+    color: #3182ce;
+  }
+
+  .md\:placeholder-blue-700::placeholder {
+    color: #2b6cb0;
+  }
+
+  .md\:placeholder-blue-800::placeholder {
+    color: #2c5282;
+  }
+
+  .md\:placeholder-blue-900::placeholder {
+    color: #2a4365;
+  }
+
+  .md\:placeholder-indigo-100::placeholder {
+    color: #ebf4ff;
+  }
+
+  .md\:placeholder-indigo-200::placeholder {
+    color: #c3dafe;
+  }
+
+  .md\:placeholder-indigo-300::placeholder {
+    color: #a3bffa;
+  }
+
+  .md\:placeholder-indigo-400::placeholder {
+    color: #7f9cf5;
+  }
+
+  .md\:placeholder-indigo-500::placeholder {
+    color: #667eea;
+  }
+
+  .md\:placeholder-indigo-600::placeholder {
+    color: #5a67d8;
+  }
+
+  .md\:placeholder-indigo-700::placeholder {
+    color: #4c51bf;
+  }
+
+  .md\:placeholder-indigo-800::placeholder {
+    color: #434190;
+  }
+
+  .md\:placeholder-indigo-900::placeholder {
+    color: #3c366b;
+  }
+
+  .md\:placeholder-purple-100::placeholder {
+    color: #faf5ff;
+  }
+
+  .md\:placeholder-purple-200::placeholder {
+    color: #e9d8fd;
+  }
+
+  .md\:placeholder-purple-300::placeholder {
+    color: #d6bcfa;
+  }
+
+  .md\:placeholder-purple-400::placeholder {
+    color: #b794f4;
+  }
+
+  .md\:placeholder-purple-500::placeholder {
+    color: #9f7aea;
+  }
+
+  .md\:placeholder-purple-600::placeholder {
+    color: #805ad5;
+  }
+
+  .md\:placeholder-purple-700::placeholder {
+    color: #6b46c1;
+  }
+
+  .md\:placeholder-purple-800::placeholder {
+    color: #553c9a;
+  }
+
+  .md\:placeholder-purple-900::placeholder {
+    color: #44337a;
+  }
+
+  .md\:placeholder-pink-100::placeholder {
+    color: #fff5f7;
+  }
+
+  .md\:placeholder-pink-200::placeholder {
+    color: #fed7e2;
+  }
+
+  .md\:placeholder-pink-300::placeholder {
+    color: #fbb6ce;
+  }
+
+  .md\:placeholder-pink-400::placeholder {
+    color: #f687b3;
+  }
+
+  .md\:placeholder-pink-500::placeholder {
+    color: #ed64a6;
+  }
+
+  .md\:placeholder-pink-600::placeholder {
+    color: #d53f8c;
+  }
+
+  .md\:placeholder-pink-700::placeholder {
+    color: #b83280;
+  }
+
+  .md\:placeholder-pink-800::placeholder {
+    color: #97266d;
+  }
+
+  .md\:placeholder-pink-900::placeholder {
+    color: #702459;
+  }
+
+  .md\:focus\:placeholder-transparent:focus::placeholder {
+    color: transparent;
+  }
+
+  .md\:focus\:placeholder-black:focus::placeholder {
+    color: #000;
+  }
+
+  .md\:focus\:placeholder-white:focus::placeholder {
+    color: #fff;
+  }
+
+  .md\:focus\:placeholder-gray-100:focus::placeholder {
+    color: #f7fafc;
+  }
+
+  .md\:focus\:placeholder-gray-200:focus::placeholder {
+    color: #edf2f7;
+  }
+
+  .md\:focus\:placeholder-gray-300:focus::placeholder {
+    color: #e2e8f0;
+  }
+
+  .md\:focus\:placeholder-gray-400:focus::placeholder {
+    color: #cbd5e0;
+  }
+
+  .md\:focus\:placeholder-gray-500:focus::placeholder {
+    color: #a0aec0;
+  }
+
+  .md\:focus\:placeholder-gray-600:focus::placeholder {
+    color: #718096;
+  }
+
+  .md\:focus\:placeholder-gray-700:focus::placeholder {
+    color: #4a5568;
+  }
+
+  .md\:focus\:placeholder-gray-800:focus::placeholder {
+    color: #2d3748;
+  }
+
+  .md\:focus\:placeholder-gray-900:focus::placeholder {
+    color: #1a202c;
+  }
+
+  .md\:focus\:placeholder-red-100:focus::placeholder {
+    color: #fff5f5;
+  }
+
+  .md\:focus\:placeholder-red-200:focus::placeholder {
+    color: #fed7d7;
+  }
+
+  .md\:focus\:placeholder-red-300:focus::placeholder {
+    color: #feb2b2;
+  }
+
+  .md\:focus\:placeholder-red-400:focus::placeholder {
+    color: #fc8181;
+  }
+
+  .md\:focus\:placeholder-red-500:focus::placeholder {
+    color: #f56565;
+  }
+
+  .md\:focus\:placeholder-red-600:focus::placeholder {
+    color: #e53e3e;
+  }
+
+  .md\:focus\:placeholder-red-700:focus::placeholder {
+    color: #c53030;
+  }
+
+  .md\:focus\:placeholder-red-800:focus::placeholder {
+    color: #9b2c2c;
+  }
+
+  .md\:focus\:placeholder-red-900:focus::placeholder {
+    color: #742a2a;
+  }
+
+  .md\:focus\:placeholder-orange-100:focus::placeholder {
+    color: #fffaf0;
+  }
+
+  .md\:focus\:placeholder-orange-200:focus::placeholder {
+    color: #feebc8;
+  }
+
+  .md\:focus\:placeholder-orange-300:focus::placeholder {
+    color: #fbd38d;
+  }
+
+  .md\:focus\:placeholder-orange-400:focus::placeholder {
+    color: #f6ad55;
+  }
+
+  .md\:focus\:placeholder-orange-500:focus::placeholder {
+    color: #ed8936;
+  }
+
+  .md\:focus\:placeholder-orange-600:focus::placeholder {
+    color: #dd6b20;
+  }
+
+  .md\:focus\:placeholder-orange-700:focus::placeholder {
+    color: #c05621;
+  }
+
+  .md\:focus\:placeholder-orange-800:focus::placeholder {
+    color: #9c4221;
+  }
+
+  .md\:focus\:placeholder-orange-900:focus::placeholder {
+    color: #7b341e;
+  }
+
+  .md\:focus\:placeholder-yellow-100:focus::placeholder {
+    color: #fffff0;
+  }
+
+  .md\:focus\:placeholder-yellow-200:focus::placeholder {
+    color: #fefcbf;
+  }
+
+  .md\:focus\:placeholder-yellow-300:focus::placeholder {
+    color: #faf089;
+  }
+
+  .md\:focus\:placeholder-yellow-400:focus::placeholder {
+    color: #f6e05e;
+  }
+
+  .md\:focus\:placeholder-yellow-500:focus::placeholder {
+    color: #ecc94b;
+  }
+
+  .md\:focus\:placeholder-yellow-600:focus::placeholder {
+    color: #d69e2e;
+  }
+
+  .md\:focus\:placeholder-yellow-700:focus::placeholder {
+    color: #b7791f;
+  }
+
+  .md\:focus\:placeholder-yellow-800:focus::placeholder {
+    color: #975a16;
+  }
+
+  .md\:focus\:placeholder-yellow-900:focus::placeholder {
+    color: #744210;
+  }
+
+  .md\:focus\:placeholder-green-100:focus::placeholder {
+    color: #f0fff4;
+  }
+
+  .md\:focus\:placeholder-green-200:focus::placeholder {
+    color: #c6f6d5;
+  }
+
+  .md\:focus\:placeholder-green-300:focus::placeholder {
+    color: #9ae6b4;
+  }
+
+  .md\:focus\:placeholder-green-400:focus::placeholder {
+    color: #68d391;
+  }
+
+  .md\:focus\:placeholder-green-500:focus::placeholder {
+    color: #48bb78;
+  }
+
+  .md\:focus\:placeholder-green-600:focus::placeholder {
+    color: #38a169;
+  }
+
+  .md\:focus\:placeholder-green-700:focus::placeholder {
+    color: #2f855a;
+  }
+
+  .md\:focus\:placeholder-green-800:focus::placeholder {
+    color: #276749;
+  }
+
+  .md\:focus\:placeholder-green-900:focus::placeholder {
+    color: #22543d;
+  }
+
+  .md\:focus\:placeholder-teal-100:focus::placeholder {
+    color: #e6fffa;
+  }
+
+  .md\:focus\:placeholder-teal-200:focus::placeholder {
+    color: #b2f5ea;
+  }
+
+  .md\:focus\:placeholder-teal-300:focus::placeholder {
+    color: #81e6d9;
+  }
+
+  .md\:focus\:placeholder-teal-400:focus::placeholder {
+    color: #4fd1c5;
+  }
+
+  .md\:focus\:placeholder-teal-500:focus::placeholder {
+    color: #38b2ac;
+  }
+
+  .md\:focus\:placeholder-teal-600:focus::placeholder {
+    color: #319795;
+  }
+
+  .md\:focus\:placeholder-teal-700:focus::placeholder {
+    color: #2c7a7b;
+  }
+
+  .md\:focus\:placeholder-teal-800:focus::placeholder {
+    color: #285e61;
+  }
+
+  .md\:focus\:placeholder-teal-900:focus::placeholder {
+    color: #234e52;
+  }
+
+  .md\:focus\:placeholder-blue-100:focus::placeholder {
+    color: #ebf8ff;
+  }
+
+  .md\:focus\:placeholder-blue-200:focus::placeholder {
+    color: #bee3f8;
+  }
+
+  .md\:focus\:placeholder-blue-300:focus::placeholder {
+    color: #90cdf4;
+  }
+
+  .md\:focus\:placeholder-blue-400:focus::placeholder {
+    color: #63b3ed;
+  }
+
+  .md\:focus\:placeholder-blue-500:focus::placeholder {
+    color: #4299e1;
+  }
+
+  .md\:focus\:placeholder-blue-600:focus::placeholder {
+    color: #3182ce;
+  }
+
+  .md\:focus\:placeholder-blue-700:focus::placeholder {
+    color: #2b6cb0;
+  }
+
+  .md\:focus\:placeholder-blue-800:focus::placeholder {
+    color: #2c5282;
+  }
+
+  .md\:focus\:placeholder-blue-900:focus::placeholder {
+    color: #2a4365;
+  }
+
+  .md\:focus\:placeholder-indigo-100:focus::placeholder {
+    color: #ebf4ff;
+  }
+
+  .md\:focus\:placeholder-indigo-200:focus::placeholder {
+    color: #c3dafe;
+  }
+
+  .md\:focus\:placeholder-indigo-300:focus::placeholder {
+    color: #a3bffa;
+  }
+
+  .md\:focus\:placeholder-indigo-400:focus::placeholder {
+    color: #7f9cf5;
+  }
+
+  .md\:focus\:placeholder-indigo-500:focus::placeholder {
+    color: #667eea;
+  }
+
+  .md\:focus\:placeholder-indigo-600:focus::placeholder {
+    color: #5a67d8;
+  }
+
+  .md\:focus\:placeholder-indigo-700:focus::placeholder {
+    color: #4c51bf;
+  }
+
+  .md\:focus\:placeholder-indigo-800:focus::placeholder {
+    color: #434190;
+  }
+
+  .md\:focus\:placeholder-indigo-900:focus::placeholder {
+    color: #3c366b;
+  }
+
+  .md\:focus\:placeholder-purple-100:focus::placeholder {
+    color: #faf5ff;
+  }
+
+  .md\:focus\:placeholder-purple-200:focus::placeholder {
+    color: #e9d8fd;
+  }
+
+  .md\:focus\:placeholder-purple-300:focus::placeholder {
+    color: #d6bcfa;
+  }
+
+  .md\:focus\:placeholder-purple-400:focus::placeholder {
+    color: #b794f4;
+  }
+
+  .md\:focus\:placeholder-purple-500:focus::placeholder {
+    color: #9f7aea;
+  }
+
+  .md\:focus\:placeholder-purple-600:focus::placeholder {
+    color: #805ad5;
+  }
+
+  .md\:focus\:placeholder-purple-700:focus::placeholder {
+    color: #6b46c1;
+  }
+
+  .md\:focus\:placeholder-purple-800:focus::placeholder {
+    color: #553c9a;
+  }
+
+  .md\:focus\:placeholder-purple-900:focus::placeholder {
+    color: #44337a;
+  }
+
+  .md\:focus\:placeholder-pink-100:focus::placeholder {
+    color: #fff5f7;
+  }
+
+  .md\:focus\:placeholder-pink-200:focus::placeholder {
+    color: #fed7e2;
+  }
+
+  .md\:focus\:placeholder-pink-300:focus::placeholder {
+    color: #fbb6ce;
+  }
+
+  .md\:focus\:placeholder-pink-400:focus::placeholder {
+    color: #f687b3;
+  }
+
+  .md\:focus\:placeholder-pink-500:focus::placeholder {
+    color: #ed64a6;
+  }
+
+  .md\:focus\:placeholder-pink-600:focus::placeholder {
+    color: #d53f8c;
+  }
+
+  .md\:focus\:placeholder-pink-700:focus::placeholder {
+    color: #b83280;
+  }
+
+  .md\:focus\:placeholder-pink-800:focus::placeholder {
+    color: #97266d;
+  }
+
+  .md\:focus\:placeholder-pink-900:focus::placeholder {
+    color: #702459;
+  }
+
   .md\:pointer-events-none {
     pointer-events: none;
   }
@@ -26987,6 +28847,750 @@ video {
     padding-left: 1px;
   }
 
+  .lg\:placeholder-transparent::placeholder {
+    color: transparent;
+  }
+
+  .lg\:placeholder-black::placeholder {
+    color: #000;
+  }
+
+  .lg\:placeholder-white::placeholder {
+    color: #fff;
+  }
+
+  .lg\:placeholder-gray-100::placeholder {
+    color: #f7fafc;
+  }
+
+  .lg\:placeholder-gray-200::placeholder {
+    color: #edf2f7;
+  }
+
+  .lg\:placeholder-gray-300::placeholder {
+    color: #e2e8f0;
+  }
+
+  .lg\:placeholder-gray-400::placeholder {
+    color: #cbd5e0;
+  }
+
+  .lg\:placeholder-gray-500::placeholder {
+    color: #a0aec0;
+  }
+
+  .lg\:placeholder-gray-600::placeholder {
+    color: #718096;
+  }
+
+  .lg\:placeholder-gray-700::placeholder {
+    color: #4a5568;
+  }
+
+  .lg\:placeholder-gray-800::placeholder {
+    color: #2d3748;
+  }
+
+  .lg\:placeholder-gray-900::placeholder {
+    color: #1a202c;
+  }
+
+  .lg\:placeholder-red-100::placeholder {
+    color: #fff5f5;
+  }
+
+  .lg\:placeholder-red-200::placeholder {
+    color: #fed7d7;
+  }
+
+  .lg\:placeholder-red-300::placeholder {
+    color: #feb2b2;
+  }
+
+  .lg\:placeholder-red-400::placeholder {
+    color: #fc8181;
+  }
+
+  .lg\:placeholder-red-500::placeholder {
+    color: #f56565;
+  }
+
+  .lg\:placeholder-red-600::placeholder {
+    color: #e53e3e;
+  }
+
+  .lg\:placeholder-red-700::placeholder {
+    color: #c53030;
+  }
+
+  .lg\:placeholder-red-800::placeholder {
+    color: #9b2c2c;
+  }
+
+  .lg\:placeholder-red-900::placeholder {
+    color: #742a2a;
+  }
+
+  .lg\:placeholder-orange-100::placeholder {
+    color: #fffaf0;
+  }
+
+  .lg\:placeholder-orange-200::placeholder {
+    color: #feebc8;
+  }
+
+  .lg\:placeholder-orange-300::placeholder {
+    color: #fbd38d;
+  }
+
+  .lg\:placeholder-orange-400::placeholder {
+    color: #f6ad55;
+  }
+
+  .lg\:placeholder-orange-500::placeholder {
+    color: #ed8936;
+  }
+
+  .lg\:placeholder-orange-600::placeholder {
+    color: #dd6b20;
+  }
+
+  .lg\:placeholder-orange-700::placeholder {
+    color: #c05621;
+  }
+
+  .lg\:placeholder-orange-800::placeholder {
+    color: #9c4221;
+  }
+
+  .lg\:placeholder-orange-900::placeholder {
+    color: #7b341e;
+  }
+
+  .lg\:placeholder-yellow-100::placeholder {
+    color: #fffff0;
+  }
+
+  .lg\:placeholder-yellow-200::placeholder {
+    color: #fefcbf;
+  }
+
+  .lg\:placeholder-yellow-300::placeholder {
+    color: #faf089;
+  }
+
+  .lg\:placeholder-yellow-400::placeholder {
+    color: #f6e05e;
+  }
+
+  .lg\:placeholder-yellow-500::placeholder {
+    color: #ecc94b;
+  }
+
+  .lg\:placeholder-yellow-600::placeholder {
+    color: #d69e2e;
+  }
+
+  .lg\:placeholder-yellow-700::placeholder {
+    color: #b7791f;
+  }
+
+  .lg\:placeholder-yellow-800::placeholder {
+    color: #975a16;
+  }
+
+  .lg\:placeholder-yellow-900::placeholder {
+    color: #744210;
+  }
+
+  .lg\:placeholder-green-100::placeholder {
+    color: #f0fff4;
+  }
+
+  .lg\:placeholder-green-200::placeholder {
+    color: #c6f6d5;
+  }
+
+  .lg\:placeholder-green-300::placeholder {
+    color: #9ae6b4;
+  }
+
+  .lg\:placeholder-green-400::placeholder {
+    color: #68d391;
+  }
+
+  .lg\:placeholder-green-500::placeholder {
+    color: #48bb78;
+  }
+
+  .lg\:placeholder-green-600::placeholder {
+    color: #38a169;
+  }
+
+  .lg\:placeholder-green-700::placeholder {
+    color: #2f855a;
+  }
+
+  .lg\:placeholder-green-800::placeholder {
+    color: #276749;
+  }
+
+  .lg\:placeholder-green-900::placeholder {
+    color: #22543d;
+  }
+
+  .lg\:placeholder-teal-100::placeholder {
+    color: #e6fffa;
+  }
+
+  .lg\:placeholder-teal-200::placeholder {
+    color: #b2f5ea;
+  }
+
+  .lg\:placeholder-teal-300::placeholder {
+    color: #81e6d9;
+  }
+
+  .lg\:placeholder-teal-400::placeholder {
+    color: #4fd1c5;
+  }
+
+  .lg\:placeholder-teal-500::placeholder {
+    color: #38b2ac;
+  }
+
+  .lg\:placeholder-teal-600::placeholder {
+    color: #319795;
+  }
+
+  .lg\:placeholder-teal-700::placeholder {
+    color: #2c7a7b;
+  }
+
+  .lg\:placeholder-teal-800::placeholder {
+    color: #285e61;
+  }
+
+  .lg\:placeholder-teal-900::placeholder {
+    color: #234e52;
+  }
+
+  .lg\:placeholder-blue-100::placeholder {
+    color: #ebf8ff;
+  }
+
+  .lg\:placeholder-blue-200::placeholder {
+    color: #bee3f8;
+  }
+
+  .lg\:placeholder-blue-300::placeholder {
+    color: #90cdf4;
+  }
+
+  .lg\:placeholder-blue-400::placeholder {
+    color: #63b3ed;
+  }
+
+  .lg\:placeholder-blue-500::placeholder {
+    color: #4299e1;
+  }
+
+  .lg\:placeholder-blue-600::placeholder {
+    color: #3182ce;
+  }
+
+  .lg\:placeholder-blue-700::placeholder {
+    color: #2b6cb0;
+  }
+
+  .lg\:placeholder-blue-800::placeholder {
+    color: #2c5282;
+  }
+
+  .lg\:placeholder-blue-900::placeholder {
+    color: #2a4365;
+  }
+
+  .lg\:placeholder-indigo-100::placeholder {
+    color: #ebf4ff;
+  }
+
+  .lg\:placeholder-indigo-200::placeholder {
+    color: #c3dafe;
+  }
+
+  .lg\:placeholder-indigo-300::placeholder {
+    color: #a3bffa;
+  }
+
+  .lg\:placeholder-indigo-400::placeholder {
+    color: #7f9cf5;
+  }
+
+  .lg\:placeholder-indigo-500::placeholder {
+    color: #667eea;
+  }
+
+  .lg\:placeholder-indigo-600::placeholder {
+    color: #5a67d8;
+  }
+
+  .lg\:placeholder-indigo-700::placeholder {
+    color: #4c51bf;
+  }
+
+  .lg\:placeholder-indigo-800::placeholder {
+    color: #434190;
+  }
+
+  .lg\:placeholder-indigo-900::placeholder {
+    color: #3c366b;
+  }
+
+  .lg\:placeholder-purple-100::placeholder {
+    color: #faf5ff;
+  }
+
+  .lg\:placeholder-purple-200::placeholder {
+    color: #e9d8fd;
+  }
+
+  .lg\:placeholder-purple-300::placeholder {
+    color: #d6bcfa;
+  }
+
+  .lg\:placeholder-purple-400::placeholder {
+    color: #b794f4;
+  }
+
+  .lg\:placeholder-purple-500::placeholder {
+    color: #9f7aea;
+  }
+
+  .lg\:placeholder-purple-600::placeholder {
+    color: #805ad5;
+  }
+
+  .lg\:placeholder-purple-700::placeholder {
+    color: #6b46c1;
+  }
+
+  .lg\:placeholder-purple-800::placeholder {
+    color: #553c9a;
+  }
+
+  .lg\:placeholder-purple-900::placeholder {
+    color: #44337a;
+  }
+
+  .lg\:placeholder-pink-100::placeholder {
+    color: #fff5f7;
+  }
+
+  .lg\:placeholder-pink-200::placeholder {
+    color: #fed7e2;
+  }
+
+  .lg\:placeholder-pink-300::placeholder {
+    color: #fbb6ce;
+  }
+
+  .lg\:placeholder-pink-400::placeholder {
+    color: #f687b3;
+  }
+
+  .lg\:placeholder-pink-500::placeholder {
+    color: #ed64a6;
+  }
+
+  .lg\:placeholder-pink-600::placeholder {
+    color: #d53f8c;
+  }
+
+  .lg\:placeholder-pink-700::placeholder {
+    color: #b83280;
+  }
+
+  .lg\:placeholder-pink-800::placeholder {
+    color: #97266d;
+  }
+
+  .lg\:placeholder-pink-900::placeholder {
+    color: #702459;
+  }
+
+  .lg\:focus\:placeholder-transparent:focus::placeholder {
+    color: transparent;
+  }
+
+  .lg\:focus\:placeholder-black:focus::placeholder {
+    color: #000;
+  }
+
+  .lg\:focus\:placeholder-white:focus::placeholder {
+    color: #fff;
+  }
+
+  .lg\:focus\:placeholder-gray-100:focus::placeholder {
+    color: #f7fafc;
+  }
+
+  .lg\:focus\:placeholder-gray-200:focus::placeholder {
+    color: #edf2f7;
+  }
+
+  .lg\:focus\:placeholder-gray-300:focus::placeholder {
+    color: #e2e8f0;
+  }
+
+  .lg\:focus\:placeholder-gray-400:focus::placeholder {
+    color: #cbd5e0;
+  }
+
+  .lg\:focus\:placeholder-gray-500:focus::placeholder {
+    color: #a0aec0;
+  }
+
+  .lg\:focus\:placeholder-gray-600:focus::placeholder {
+    color: #718096;
+  }
+
+  .lg\:focus\:placeholder-gray-700:focus::placeholder {
+    color: #4a5568;
+  }
+
+  .lg\:focus\:placeholder-gray-800:focus::placeholder {
+    color: #2d3748;
+  }
+
+  .lg\:focus\:placeholder-gray-900:focus::placeholder {
+    color: #1a202c;
+  }
+
+  .lg\:focus\:placeholder-red-100:focus::placeholder {
+    color: #fff5f5;
+  }
+
+  .lg\:focus\:placeholder-red-200:focus::placeholder {
+    color: #fed7d7;
+  }
+
+  .lg\:focus\:placeholder-red-300:focus::placeholder {
+    color: #feb2b2;
+  }
+
+  .lg\:focus\:placeholder-red-400:focus::placeholder {
+    color: #fc8181;
+  }
+
+  .lg\:focus\:placeholder-red-500:focus::placeholder {
+    color: #f56565;
+  }
+
+  .lg\:focus\:placeholder-red-600:focus::placeholder {
+    color: #e53e3e;
+  }
+
+  .lg\:focus\:placeholder-red-700:focus::placeholder {
+    color: #c53030;
+  }
+
+  .lg\:focus\:placeholder-red-800:focus::placeholder {
+    color: #9b2c2c;
+  }
+
+  .lg\:focus\:placeholder-red-900:focus::placeholder {
+    color: #742a2a;
+  }
+
+  .lg\:focus\:placeholder-orange-100:focus::placeholder {
+    color: #fffaf0;
+  }
+
+  .lg\:focus\:placeholder-orange-200:focus::placeholder {
+    color: #feebc8;
+  }
+
+  .lg\:focus\:placeholder-orange-300:focus::placeholder {
+    color: #fbd38d;
+  }
+
+  .lg\:focus\:placeholder-orange-400:focus::placeholder {
+    color: #f6ad55;
+  }
+
+  .lg\:focus\:placeholder-orange-500:focus::placeholder {
+    color: #ed8936;
+  }
+
+  .lg\:focus\:placeholder-orange-600:focus::placeholder {
+    color: #dd6b20;
+  }
+
+  .lg\:focus\:placeholder-orange-700:focus::placeholder {
+    color: #c05621;
+  }
+
+  .lg\:focus\:placeholder-orange-800:focus::placeholder {
+    color: #9c4221;
+  }
+
+  .lg\:focus\:placeholder-orange-900:focus::placeholder {
+    color: #7b341e;
+  }
+
+  .lg\:focus\:placeholder-yellow-100:focus::placeholder {
+    color: #fffff0;
+  }
+
+  .lg\:focus\:placeholder-yellow-200:focus::placeholder {
+    color: #fefcbf;
+  }
+
+  .lg\:focus\:placeholder-yellow-300:focus::placeholder {
+    color: #faf089;
+  }
+
+  .lg\:focus\:placeholder-yellow-400:focus::placeholder {
+    color: #f6e05e;
+  }
+
+  .lg\:focus\:placeholder-yellow-500:focus::placeholder {
+    color: #ecc94b;
+  }
+
+  .lg\:focus\:placeholder-yellow-600:focus::placeholder {
+    color: #d69e2e;
+  }
+
+  .lg\:focus\:placeholder-yellow-700:focus::placeholder {
+    color: #b7791f;
+  }
+
+  .lg\:focus\:placeholder-yellow-800:focus::placeholder {
+    color: #975a16;
+  }
+
+  .lg\:focus\:placeholder-yellow-900:focus::placeholder {
+    color: #744210;
+  }
+
+  .lg\:focus\:placeholder-green-100:focus::placeholder {
+    color: #f0fff4;
+  }
+
+  .lg\:focus\:placeholder-green-200:focus::placeholder {
+    color: #c6f6d5;
+  }
+
+  .lg\:focus\:placeholder-green-300:focus::placeholder {
+    color: #9ae6b4;
+  }
+
+  .lg\:focus\:placeholder-green-400:focus::placeholder {
+    color: #68d391;
+  }
+
+  .lg\:focus\:placeholder-green-500:focus::placeholder {
+    color: #48bb78;
+  }
+
+  .lg\:focus\:placeholder-green-600:focus::placeholder {
+    color: #38a169;
+  }
+
+  .lg\:focus\:placeholder-green-700:focus::placeholder {
+    color: #2f855a;
+  }
+
+  .lg\:focus\:placeholder-green-800:focus::placeholder {
+    color: #276749;
+  }
+
+  .lg\:focus\:placeholder-green-900:focus::placeholder {
+    color: #22543d;
+  }
+
+  .lg\:focus\:placeholder-teal-100:focus::placeholder {
+    color: #e6fffa;
+  }
+
+  .lg\:focus\:placeholder-teal-200:focus::placeholder {
+    color: #b2f5ea;
+  }
+
+  .lg\:focus\:placeholder-teal-300:focus::placeholder {
+    color: #81e6d9;
+  }
+
+  .lg\:focus\:placeholder-teal-400:focus::placeholder {
+    color: #4fd1c5;
+  }
+
+  .lg\:focus\:placeholder-teal-500:focus::placeholder {
+    color: #38b2ac;
+  }
+
+  .lg\:focus\:placeholder-teal-600:focus::placeholder {
+    color: #319795;
+  }
+
+  .lg\:focus\:placeholder-teal-700:focus::placeholder {
+    color: #2c7a7b;
+  }
+
+  .lg\:focus\:placeholder-teal-800:focus::placeholder {
+    color: #285e61;
+  }
+
+  .lg\:focus\:placeholder-teal-900:focus::placeholder {
+    color: #234e52;
+  }
+
+  .lg\:focus\:placeholder-blue-100:focus::placeholder {
+    color: #ebf8ff;
+  }
+
+  .lg\:focus\:placeholder-blue-200:focus::placeholder {
+    color: #bee3f8;
+  }
+
+  .lg\:focus\:placeholder-blue-300:focus::placeholder {
+    color: #90cdf4;
+  }
+
+  .lg\:focus\:placeholder-blue-400:focus::placeholder {
+    color: #63b3ed;
+  }
+
+  .lg\:focus\:placeholder-blue-500:focus::placeholder {
+    color: #4299e1;
+  }
+
+  .lg\:focus\:placeholder-blue-600:focus::placeholder {
+    color: #3182ce;
+  }
+
+  .lg\:focus\:placeholder-blue-700:focus::placeholder {
+    color: #2b6cb0;
+  }
+
+  .lg\:focus\:placeholder-blue-800:focus::placeholder {
+    color: #2c5282;
+  }
+
+  .lg\:focus\:placeholder-blue-900:focus::placeholder {
+    color: #2a4365;
+  }
+
+  .lg\:focus\:placeholder-indigo-100:focus::placeholder {
+    color: #ebf4ff;
+  }
+
+  .lg\:focus\:placeholder-indigo-200:focus::placeholder {
+    color: #c3dafe;
+  }
+
+  .lg\:focus\:placeholder-indigo-300:focus::placeholder {
+    color: #a3bffa;
+  }
+
+  .lg\:focus\:placeholder-indigo-400:focus::placeholder {
+    color: #7f9cf5;
+  }
+
+  .lg\:focus\:placeholder-indigo-500:focus::placeholder {
+    color: #667eea;
+  }
+
+  .lg\:focus\:placeholder-indigo-600:focus::placeholder {
+    color: #5a67d8;
+  }
+
+  .lg\:focus\:placeholder-indigo-700:focus::placeholder {
+    color: #4c51bf;
+  }
+
+  .lg\:focus\:placeholder-indigo-800:focus::placeholder {
+    color: #434190;
+  }
+
+  .lg\:focus\:placeholder-indigo-900:focus::placeholder {
+    color: #3c366b;
+  }
+
+  .lg\:focus\:placeholder-purple-100:focus::placeholder {
+    color: #faf5ff;
+  }
+
+  .lg\:focus\:placeholder-purple-200:focus::placeholder {
+    color: #e9d8fd;
+  }
+
+  .lg\:focus\:placeholder-purple-300:focus::placeholder {
+    color: #d6bcfa;
+  }
+
+  .lg\:focus\:placeholder-purple-400:focus::placeholder {
+    color: #b794f4;
+  }
+
+  .lg\:focus\:placeholder-purple-500:focus::placeholder {
+    color: #9f7aea;
+  }
+
+  .lg\:focus\:placeholder-purple-600:focus::placeholder {
+    color: #805ad5;
+  }
+
+  .lg\:focus\:placeholder-purple-700:focus::placeholder {
+    color: #6b46c1;
+  }
+
+  .lg\:focus\:placeholder-purple-800:focus::placeholder {
+    color: #553c9a;
+  }
+
+  .lg\:focus\:placeholder-purple-900:focus::placeholder {
+    color: #44337a;
+  }
+
+  .lg\:focus\:placeholder-pink-100:focus::placeholder {
+    color: #fff5f7;
+  }
+
+  .lg\:focus\:placeholder-pink-200:focus::placeholder {
+    color: #fed7e2;
+  }
+
+  .lg\:focus\:placeholder-pink-300:focus::placeholder {
+    color: #fbb6ce;
+  }
+
+  .lg\:focus\:placeholder-pink-400:focus::placeholder {
+    color: #f687b3;
+  }
+
+  .lg\:focus\:placeholder-pink-500:focus::placeholder {
+    color: #ed64a6;
+  }
+
+  .lg\:focus\:placeholder-pink-600:focus::placeholder {
+    color: #d53f8c;
+  }
+
+  .lg\:focus\:placeholder-pink-700:focus::placeholder {
+    color: #b83280;
+  }
+
+  .lg\:focus\:placeholder-pink-800:focus::placeholder {
+    color: #97266d;
+  }
+
+  .lg\:focus\:placeholder-pink-900:focus::placeholder {
+    color: #702459;
+  }
+
   .lg\:pointer-events-none {
     pointer-events: none;
   }
@@ -33937,6 +36541,750 @@ video {
 
   .xl\:pl-px {
     padding-left: 1px;
+  }
+
+  .xl\:placeholder-transparent::placeholder {
+    color: transparent;
+  }
+
+  .xl\:placeholder-black::placeholder {
+    color: #000;
+  }
+
+  .xl\:placeholder-white::placeholder {
+    color: #fff;
+  }
+
+  .xl\:placeholder-gray-100::placeholder {
+    color: #f7fafc;
+  }
+
+  .xl\:placeholder-gray-200::placeholder {
+    color: #edf2f7;
+  }
+
+  .xl\:placeholder-gray-300::placeholder {
+    color: #e2e8f0;
+  }
+
+  .xl\:placeholder-gray-400::placeholder {
+    color: #cbd5e0;
+  }
+
+  .xl\:placeholder-gray-500::placeholder {
+    color: #a0aec0;
+  }
+
+  .xl\:placeholder-gray-600::placeholder {
+    color: #718096;
+  }
+
+  .xl\:placeholder-gray-700::placeholder {
+    color: #4a5568;
+  }
+
+  .xl\:placeholder-gray-800::placeholder {
+    color: #2d3748;
+  }
+
+  .xl\:placeholder-gray-900::placeholder {
+    color: #1a202c;
+  }
+
+  .xl\:placeholder-red-100::placeholder {
+    color: #fff5f5;
+  }
+
+  .xl\:placeholder-red-200::placeholder {
+    color: #fed7d7;
+  }
+
+  .xl\:placeholder-red-300::placeholder {
+    color: #feb2b2;
+  }
+
+  .xl\:placeholder-red-400::placeholder {
+    color: #fc8181;
+  }
+
+  .xl\:placeholder-red-500::placeholder {
+    color: #f56565;
+  }
+
+  .xl\:placeholder-red-600::placeholder {
+    color: #e53e3e;
+  }
+
+  .xl\:placeholder-red-700::placeholder {
+    color: #c53030;
+  }
+
+  .xl\:placeholder-red-800::placeholder {
+    color: #9b2c2c;
+  }
+
+  .xl\:placeholder-red-900::placeholder {
+    color: #742a2a;
+  }
+
+  .xl\:placeholder-orange-100::placeholder {
+    color: #fffaf0;
+  }
+
+  .xl\:placeholder-orange-200::placeholder {
+    color: #feebc8;
+  }
+
+  .xl\:placeholder-orange-300::placeholder {
+    color: #fbd38d;
+  }
+
+  .xl\:placeholder-orange-400::placeholder {
+    color: #f6ad55;
+  }
+
+  .xl\:placeholder-orange-500::placeholder {
+    color: #ed8936;
+  }
+
+  .xl\:placeholder-orange-600::placeholder {
+    color: #dd6b20;
+  }
+
+  .xl\:placeholder-orange-700::placeholder {
+    color: #c05621;
+  }
+
+  .xl\:placeholder-orange-800::placeholder {
+    color: #9c4221;
+  }
+
+  .xl\:placeholder-orange-900::placeholder {
+    color: #7b341e;
+  }
+
+  .xl\:placeholder-yellow-100::placeholder {
+    color: #fffff0;
+  }
+
+  .xl\:placeholder-yellow-200::placeholder {
+    color: #fefcbf;
+  }
+
+  .xl\:placeholder-yellow-300::placeholder {
+    color: #faf089;
+  }
+
+  .xl\:placeholder-yellow-400::placeholder {
+    color: #f6e05e;
+  }
+
+  .xl\:placeholder-yellow-500::placeholder {
+    color: #ecc94b;
+  }
+
+  .xl\:placeholder-yellow-600::placeholder {
+    color: #d69e2e;
+  }
+
+  .xl\:placeholder-yellow-700::placeholder {
+    color: #b7791f;
+  }
+
+  .xl\:placeholder-yellow-800::placeholder {
+    color: #975a16;
+  }
+
+  .xl\:placeholder-yellow-900::placeholder {
+    color: #744210;
+  }
+
+  .xl\:placeholder-green-100::placeholder {
+    color: #f0fff4;
+  }
+
+  .xl\:placeholder-green-200::placeholder {
+    color: #c6f6d5;
+  }
+
+  .xl\:placeholder-green-300::placeholder {
+    color: #9ae6b4;
+  }
+
+  .xl\:placeholder-green-400::placeholder {
+    color: #68d391;
+  }
+
+  .xl\:placeholder-green-500::placeholder {
+    color: #48bb78;
+  }
+
+  .xl\:placeholder-green-600::placeholder {
+    color: #38a169;
+  }
+
+  .xl\:placeholder-green-700::placeholder {
+    color: #2f855a;
+  }
+
+  .xl\:placeholder-green-800::placeholder {
+    color: #276749;
+  }
+
+  .xl\:placeholder-green-900::placeholder {
+    color: #22543d;
+  }
+
+  .xl\:placeholder-teal-100::placeholder {
+    color: #e6fffa;
+  }
+
+  .xl\:placeholder-teal-200::placeholder {
+    color: #b2f5ea;
+  }
+
+  .xl\:placeholder-teal-300::placeholder {
+    color: #81e6d9;
+  }
+
+  .xl\:placeholder-teal-400::placeholder {
+    color: #4fd1c5;
+  }
+
+  .xl\:placeholder-teal-500::placeholder {
+    color: #38b2ac;
+  }
+
+  .xl\:placeholder-teal-600::placeholder {
+    color: #319795;
+  }
+
+  .xl\:placeholder-teal-700::placeholder {
+    color: #2c7a7b;
+  }
+
+  .xl\:placeholder-teal-800::placeholder {
+    color: #285e61;
+  }
+
+  .xl\:placeholder-teal-900::placeholder {
+    color: #234e52;
+  }
+
+  .xl\:placeholder-blue-100::placeholder {
+    color: #ebf8ff;
+  }
+
+  .xl\:placeholder-blue-200::placeholder {
+    color: #bee3f8;
+  }
+
+  .xl\:placeholder-blue-300::placeholder {
+    color: #90cdf4;
+  }
+
+  .xl\:placeholder-blue-400::placeholder {
+    color: #63b3ed;
+  }
+
+  .xl\:placeholder-blue-500::placeholder {
+    color: #4299e1;
+  }
+
+  .xl\:placeholder-blue-600::placeholder {
+    color: #3182ce;
+  }
+
+  .xl\:placeholder-blue-700::placeholder {
+    color: #2b6cb0;
+  }
+
+  .xl\:placeholder-blue-800::placeholder {
+    color: #2c5282;
+  }
+
+  .xl\:placeholder-blue-900::placeholder {
+    color: #2a4365;
+  }
+
+  .xl\:placeholder-indigo-100::placeholder {
+    color: #ebf4ff;
+  }
+
+  .xl\:placeholder-indigo-200::placeholder {
+    color: #c3dafe;
+  }
+
+  .xl\:placeholder-indigo-300::placeholder {
+    color: #a3bffa;
+  }
+
+  .xl\:placeholder-indigo-400::placeholder {
+    color: #7f9cf5;
+  }
+
+  .xl\:placeholder-indigo-500::placeholder {
+    color: #667eea;
+  }
+
+  .xl\:placeholder-indigo-600::placeholder {
+    color: #5a67d8;
+  }
+
+  .xl\:placeholder-indigo-700::placeholder {
+    color: #4c51bf;
+  }
+
+  .xl\:placeholder-indigo-800::placeholder {
+    color: #434190;
+  }
+
+  .xl\:placeholder-indigo-900::placeholder {
+    color: #3c366b;
+  }
+
+  .xl\:placeholder-purple-100::placeholder {
+    color: #faf5ff;
+  }
+
+  .xl\:placeholder-purple-200::placeholder {
+    color: #e9d8fd;
+  }
+
+  .xl\:placeholder-purple-300::placeholder {
+    color: #d6bcfa;
+  }
+
+  .xl\:placeholder-purple-400::placeholder {
+    color: #b794f4;
+  }
+
+  .xl\:placeholder-purple-500::placeholder {
+    color: #9f7aea;
+  }
+
+  .xl\:placeholder-purple-600::placeholder {
+    color: #805ad5;
+  }
+
+  .xl\:placeholder-purple-700::placeholder {
+    color: #6b46c1;
+  }
+
+  .xl\:placeholder-purple-800::placeholder {
+    color: #553c9a;
+  }
+
+  .xl\:placeholder-purple-900::placeholder {
+    color: #44337a;
+  }
+
+  .xl\:placeholder-pink-100::placeholder {
+    color: #fff5f7;
+  }
+
+  .xl\:placeholder-pink-200::placeholder {
+    color: #fed7e2;
+  }
+
+  .xl\:placeholder-pink-300::placeholder {
+    color: #fbb6ce;
+  }
+
+  .xl\:placeholder-pink-400::placeholder {
+    color: #f687b3;
+  }
+
+  .xl\:placeholder-pink-500::placeholder {
+    color: #ed64a6;
+  }
+
+  .xl\:placeholder-pink-600::placeholder {
+    color: #d53f8c;
+  }
+
+  .xl\:placeholder-pink-700::placeholder {
+    color: #b83280;
+  }
+
+  .xl\:placeholder-pink-800::placeholder {
+    color: #97266d;
+  }
+
+  .xl\:placeholder-pink-900::placeholder {
+    color: #702459;
+  }
+
+  .xl\:focus\:placeholder-transparent:focus::placeholder {
+    color: transparent;
+  }
+
+  .xl\:focus\:placeholder-black:focus::placeholder {
+    color: #000;
+  }
+
+  .xl\:focus\:placeholder-white:focus::placeholder {
+    color: #fff;
+  }
+
+  .xl\:focus\:placeholder-gray-100:focus::placeholder {
+    color: #f7fafc;
+  }
+
+  .xl\:focus\:placeholder-gray-200:focus::placeholder {
+    color: #edf2f7;
+  }
+
+  .xl\:focus\:placeholder-gray-300:focus::placeholder {
+    color: #e2e8f0;
+  }
+
+  .xl\:focus\:placeholder-gray-400:focus::placeholder {
+    color: #cbd5e0;
+  }
+
+  .xl\:focus\:placeholder-gray-500:focus::placeholder {
+    color: #a0aec0;
+  }
+
+  .xl\:focus\:placeholder-gray-600:focus::placeholder {
+    color: #718096;
+  }
+
+  .xl\:focus\:placeholder-gray-700:focus::placeholder {
+    color: #4a5568;
+  }
+
+  .xl\:focus\:placeholder-gray-800:focus::placeholder {
+    color: #2d3748;
+  }
+
+  .xl\:focus\:placeholder-gray-900:focus::placeholder {
+    color: #1a202c;
+  }
+
+  .xl\:focus\:placeholder-red-100:focus::placeholder {
+    color: #fff5f5;
+  }
+
+  .xl\:focus\:placeholder-red-200:focus::placeholder {
+    color: #fed7d7;
+  }
+
+  .xl\:focus\:placeholder-red-300:focus::placeholder {
+    color: #feb2b2;
+  }
+
+  .xl\:focus\:placeholder-red-400:focus::placeholder {
+    color: #fc8181;
+  }
+
+  .xl\:focus\:placeholder-red-500:focus::placeholder {
+    color: #f56565;
+  }
+
+  .xl\:focus\:placeholder-red-600:focus::placeholder {
+    color: #e53e3e;
+  }
+
+  .xl\:focus\:placeholder-red-700:focus::placeholder {
+    color: #c53030;
+  }
+
+  .xl\:focus\:placeholder-red-800:focus::placeholder {
+    color: #9b2c2c;
+  }
+
+  .xl\:focus\:placeholder-red-900:focus::placeholder {
+    color: #742a2a;
+  }
+
+  .xl\:focus\:placeholder-orange-100:focus::placeholder {
+    color: #fffaf0;
+  }
+
+  .xl\:focus\:placeholder-orange-200:focus::placeholder {
+    color: #feebc8;
+  }
+
+  .xl\:focus\:placeholder-orange-300:focus::placeholder {
+    color: #fbd38d;
+  }
+
+  .xl\:focus\:placeholder-orange-400:focus::placeholder {
+    color: #f6ad55;
+  }
+
+  .xl\:focus\:placeholder-orange-500:focus::placeholder {
+    color: #ed8936;
+  }
+
+  .xl\:focus\:placeholder-orange-600:focus::placeholder {
+    color: #dd6b20;
+  }
+
+  .xl\:focus\:placeholder-orange-700:focus::placeholder {
+    color: #c05621;
+  }
+
+  .xl\:focus\:placeholder-orange-800:focus::placeholder {
+    color: #9c4221;
+  }
+
+  .xl\:focus\:placeholder-orange-900:focus::placeholder {
+    color: #7b341e;
+  }
+
+  .xl\:focus\:placeholder-yellow-100:focus::placeholder {
+    color: #fffff0;
+  }
+
+  .xl\:focus\:placeholder-yellow-200:focus::placeholder {
+    color: #fefcbf;
+  }
+
+  .xl\:focus\:placeholder-yellow-300:focus::placeholder {
+    color: #faf089;
+  }
+
+  .xl\:focus\:placeholder-yellow-400:focus::placeholder {
+    color: #f6e05e;
+  }
+
+  .xl\:focus\:placeholder-yellow-500:focus::placeholder {
+    color: #ecc94b;
+  }
+
+  .xl\:focus\:placeholder-yellow-600:focus::placeholder {
+    color: #d69e2e;
+  }
+
+  .xl\:focus\:placeholder-yellow-700:focus::placeholder {
+    color: #b7791f;
+  }
+
+  .xl\:focus\:placeholder-yellow-800:focus::placeholder {
+    color: #975a16;
+  }
+
+  .xl\:focus\:placeholder-yellow-900:focus::placeholder {
+    color: #744210;
+  }
+
+  .xl\:focus\:placeholder-green-100:focus::placeholder {
+    color: #f0fff4;
+  }
+
+  .xl\:focus\:placeholder-green-200:focus::placeholder {
+    color: #c6f6d5;
+  }
+
+  .xl\:focus\:placeholder-green-300:focus::placeholder {
+    color: #9ae6b4;
+  }
+
+  .xl\:focus\:placeholder-green-400:focus::placeholder {
+    color: #68d391;
+  }
+
+  .xl\:focus\:placeholder-green-500:focus::placeholder {
+    color: #48bb78;
+  }
+
+  .xl\:focus\:placeholder-green-600:focus::placeholder {
+    color: #38a169;
+  }
+
+  .xl\:focus\:placeholder-green-700:focus::placeholder {
+    color: #2f855a;
+  }
+
+  .xl\:focus\:placeholder-green-800:focus::placeholder {
+    color: #276749;
+  }
+
+  .xl\:focus\:placeholder-green-900:focus::placeholder {
+    color: #22543d;
+  }
+
+  .xl\:focus\:placeholder-teal-100:focus::placeholder {
+    color: #e6fffa;
+  }
+
+  .xl\:focus\:placeholder-teal-200:focus::placeholder {
+    color: #b2f5ea;
+  }
+
+  .xl\:focus\:placeholder-teal-300:focus::placeholder {
+    color: #81e6d9;
+  }
+
+  .xl\:focus\:placeholder-teal-400:focus::placeholder {
+    color: #4fd1c5;
+  }
+
+  .xl\:focus\:placeholder-teal-500:focus::placeholder {
+    color: #38b2ac;
+  }
+
+  .xl\:focus\:placeholder-teal-600:focus::placeholder {
+    color: #319795;
+  }
+
+  .xl\:focus\:placeholder-teal-700:focus::placeholder {
+    color: #2c7a7b;
+  }
+
+  .xl\:focus\:placeholder-teal-800:focus::placeholder {
+    color: #285e61;
+  }
+
+  .xl\:focus\:placeholder-teal-900:focus::placeholder {
+    color: #234e52;
+  }
+
+  .xl\:focus\:placeholder-blue-100:focus::placeholder {
+    color: #ebf8ff;
+  }
+
+  .xl\:focus\:placeholder-blue-200:focus::placeholder {
+    color: #bee3f8;
+  }
+
+  .xl\:focus\:placeholder-blue-300:focus::placeholder {
+    color: #90cdf4;
+  }
+
+  .xl\:focus\:placeholder-blue-400:focus::placeholder {
+    color: #63b3ed;
+  }
+
+  .xl\:focus\:placeholder-blue-500:focus::placeholder {
+    color: #4299e1;
+  }
+
+  .xl\:focus\:placeholder-blue-600:focus::placeholder {
+    color: #3182ce;
+  }
+
+  .xl\:focus\:placeholder-blue-700:focus::placeholder {
+    color: #2b6cb0;
+  }
+
+  .xl\:focus\:placeholder-blue-800:focus::placeholder {
+    color: #2c5282;
+  }
+
+  .xl\:focus\:placeholder-blue-900:focus::placeholder {
+    color: #2a4365;
+  }
+
+  .xl\:focus\:placeholder-indigo-100:focus::placeholder {
+    color: #ebf4ff;
+  }
+
+  .xl\:focus\:placeholder-indigo-200:focus::placeholder {
+    color: #c3dafe;
+  }
+
+  .xl\:focus\:placeholder-indigo-300:focus::placeholder {
+    color: #a3bffa;
+  }
+
+  .xl\:focus\:placeholder-indigo-400:focus::placeholder {
+    color: #7f9cf5;
+  }
+
+  .xl\:focus\:placeholder-indigo-500:focus::placeholder {
+    color: #667eea;
+  }
+
+  .xl\:focus\:placeholder-indigo-600:focus::placeholder {
+    color: #5a67d8;
+  }
+
+  .xl\:focus\:placeholder-indigo-700:focus::placeholder {
+    color: #4c51bf;
+  }
+
+  .xl\:focus\:placeholder-indigo-800:focus::placeholder {
+    color: #434190;
+  }
+
+  .xl\:focus\:placeholder-indigo-900:focus::placeholder {
+    color: #3c366b;
+  }
+
+  .xl\:focus\:placeholder-purple-100:focus::placeholder {
+    color: #faf5ff;
+  }
+
+  .xl\:focus\:placeholder-purple-200:focus::placeholder {
+    color: #e9d8fd;
+  }
+
+  .xl\:focus\:placeholder-purple-300:focus::placeholder {
+    color: #d6bcfa;
+  }
+
+  .xl\:focus\:placeholder-purple-400:focus::placeholder {
+    color: #b794f4;
+  }
+
+  .xl\:focus\:placeholder-purple-500:focus::placeholder {
+    color: #9f7aea;
+  }
+
+  .xl\:focus\:placeholder-purple-600:focus::placeholder {
+    color: #805ad5;
+  }
+
+  .xl\:focus\:placeholder-purple-700:focus::placeholder {
+    color: #6b46c1;
+  }
+
+  .xl\:focus\:placeholder-purple-800:focus::placeholder {
+    color: #553c9a;
+  }
+
+  .xl\:focus\:placeholder-purple-900:focus::placeholder {
+    color: #44337a;
+  }
+
+  .xl\:focus\:placeholder-pink-100:focus::placeholder {
+    color: #fff5f7;
+  }
+
+  .xl\:focus\:placeholder-pink-200:focus::placeholder {
+    color: #fed7e2;
+  }
+
+  .xl\:focus\:placeholder-pink-300:focus::placeholder {
+    color: #fbb6ce;
+  }
+
+  .xl\:focus\:placeholder-pink-400:focus::placeholder {
+    color: #f687b3;
+  }
+
+  .xl\:focus\:placeholder-pink-500:focus::placeholder {
+    color: #ed64a6;
+  }
+
+  .xl\:focus\:placeholder-pink-600:focus::placeholder {
+    color: #d53f8c;
+  }
+
+  .xl\:focus\:placeholder-pink-700:focus::placeholder {
+    color: #b83280;
+  }
+
+  .xl\:focus\:placeholder-pink-800:focus::placeholder {
+    color: #97266d;
+  }
+
+  .xl\:focus\:placeholder-pink-900:focus::placeholder {
+    color: #702459;
   }
 
   .xl\:pointer-events-none {

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -42,6 +42,7 @@ import opacity from './plugins/opacity'
 import outline from './plugins/outline'
 import overflow from './plugins/overflow'
 import padding from './plugins/padding'
+import placeholderColor from './plugins/placeholderColor'
 import pointerEvents from './plugins/pointerEvents'
 import position from './plugins/position'
 import inset from './plugins/inset'
@@ -114,6 +115,7 @@ export default function({ corePlugins: corePluginConfig }) {
     outline,
     overflow,
     padding,
+    placeholderColor,
     pointerEvents,
     position,
     inset,

--- a/src/plugins/placeholderColor.js
+++ b/src/plugins/placeholderColor.js
@@ -1,0 +1,19 @@
+import _ from 'lodash'
+import flattenColorPalette from '../util/flattenColorPalette'
+
+export default function() {
+  return function({ addUtilities, e, theme, variants }) {
+    const utilities = _.fromPairs(
+      _.map(flattenColorPalette(theme('placeholderColor')), (value, modifier) => {
+        return [
+          `.${e(`placeholder-${modifier}`)}::placeholder`,
+          {
+            color: value,
+          },
+        ]
+      })
+    )
+
+    addUtilities(utilities, variants('placeholderColor'))
+  }
+}

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -371,6 +371,7 @@ module.exports = {
       '12': '12',
     },
     padding: theme => theme('spacing'),
+    placeholderColor: theme => theme('colors'),
     stroke: {
       current: 'currentColor',
     },

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -468,6 +468,7 @@ module.exports = {
     outline: ['responsive', 'focus'],
     overflow: ['responsive'],
     padding: ['responsive'],
+    placeholderColor: ['responsive', 'focus'],
     pointerEvents: ['responsive'],
     position: ['responsive'],
     resize: ['responsive'],


### PR DESCRIPTION
This PR adds new `placeholder-{color}` utilities for setting the placeholder color of form elements, with responsive and focus variants enabled by default.