### PR TITLE
Use hard-coded default placeholder color

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -484,8 +484,7 @@ textarea {
 
 input::placeholder,
 textarea::placeholder {
-  color: inherit;
-  opacity: 0.5;
+  color: #a0aec0;
 }
 
 button,

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -484,8 +484,7 @@ textarea {
 
 input::placeholder,
 textarea::placeholder {
-  color: inherit;
-  opacity: 0.5;
+  color: #a0aec0;
 }
 
 button,

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -131,8 +131,7 @@ textarea {
 
 input::placeholder,
 textarea::placeholder {
-  color: inherit;
-  opacity: 0.5;
+  color: #a0aec0;
 }
 
 button,


### PR DESCRIPTION
IE 11 doesn't support opacity properly on placeholders and causes the entire input to render with that opacity. This fixes that bug.

I've chosen to use Tailwind's `gray-500` color by default so that things are at least cohesive out of the box but it's hard-coded rather than coming from the theme, as I don't want it tied to the configuration. We may introduce a configuration option for setting default placeholder colors eventually but until then the recommended approach is to just write a line of custom CSS to set your own custom default placeholder color.

This is technically a small breaking change but also a bug-fix. Going to include it in v1.1 anyways.

Fixes #1028.