### PR TITLE
Fix base styles for horizontal rules

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -384,6 +384,7 @@ h3,
 h4,
 h5,
 h6,
+hr,
 figure,
 p,
 pre {
@@ -461,7 +462,7 @@ html {
  */
 
 hr {
-  border-width: 1px;
+  border-top-width: 1px;
 }
 
 /**

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -384,6 +384,7 @@ h3,
 h4,
 h5,
 h6,
+hr,
 figure,
 p,
 pre {
@@ -461,7 +462,7 @@ html {
  */
 
 hr {
-  border-width: 1px;
+  border-top-width: 1px;
 }
 
 /**

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -34,6 +34,7 @@ h3,
 h4,
 h5,
 h6,
+hr,
 figure,
 p,
 pre {
@@ -109,7 +110,7 @@ html {
  * Ensure horizontal rules are visible by default
  */
 hr {
-  border-width: 1px;
+  border-top-width: 1px;
 }
 
 /**


### PR DESCRIPTION
v1.1 fixed an unintended issue where horizontal rules were invisible by default because they had a border-width of 0 but it fixed it in a way that made them 2px tall.

2px borders look nice but it's a bit too opinionated as a base style in Tailwind. This PR fixes that by only setting a top border of 1px, so now horizontal rules are 1px tall instead of 2px.

This PR also removes the default margin on horizontal rules for the same reason we remove it on all other elements — it introduces values into your site that don't align with your design system.

This is one of those annoying bug fixes that could change how people's sites look depending on how much or little styling they've added to their `hr` elements :/ Sorry.