### PR TITLE
Add support for multiple config resolving

### DIFF
--- a/resolveConfig.js
+++ b/resolveConfig.js
@@ -1,6 +1,6 @@
 const resolveConfigObjects = require('./lib/util/resolveConfig').default
 const defaultConfig = require('./stubs/defaultConfig.stub.js')
 
-module.exports = function resolveConfig(config) {
-  return resolveConfigObjects([config, defaultConfig])
+module.exports = function resolveConfig(...configs) {
+  return resolveConfigObjects([defaultConfig].concat(configs).reverse())
 }


### PR DESCRIPTION
Problem:
I have Tailwind Config in my design-system(one repo) and I want to extend it in my app(another repo). How can I do this?

Example of my solution:
```js
  const resolveConfig = require('tailwindcss/resolveConfig')
  const designSystemConfig = require('@my-org/my-design-system/tailwind.config')

  module.exports = resolveConfig(designSystemConfig, {
    theme: { colors: { kek: '#123456' } }
  })
```

(NO breaking changes!)