### PR TITLE
Fix unresolved modules in config watcher

### DIFF
--- a/src/lib/getModuleDependencies.js
+++ b/src/lib/getModuleDependencies.js
@@ -24,7 +24,9 @@ export default function getModuleDependencies(entryFile) {
         const depModule = createModule(depPath)
 
         modules.push(depModule)
-      } catch (_err) {}
+      } catch (_err) {
+        // eslint-disable-next-line no-empty
+      }
     })
   }
 

--- a/src/lib/getModuleDependencies.js
+++ b/src/lib/getModuleDependencies.js
@@ -18,11 +18,13 @@ export default function getModuleDependencies(entryFile) {
   // ones are being added
   for (const mdl of modules) {
     mdl.requires.forEach(dep => {
-      const basedir = path.dirname(mdl.file)
-      const depPath = resolve.sync(dep, { basedir })
-      const depModule = createModule(depPath)
+      try {
+        const basedir = path.dirname(mdl.file)
+        const depPath = resolve.sync(dep, { basedir })
+        const depModule = createModule(depPath)
 
-      modules.push(depModule)
+        modules.push(depModule)
+      } catch (_err) {}
     })
   }
 


### PR DESCRIPTION
#1119 

This solution looks like dirty fix. But it's OK because if we have really unresolved modules in our Tailwind Config, we got exception from config resolver. Otherwise we add everything that we can add ^^