### PR TITLE
change 0% to 0 on flex["1"] in default config

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -206,7 +206,7 @@ module.exports = {
       current: 'currentColor',
     },
     flex: {
-      '1': '1 1 0%',
+      '1': '1 1 0',
       auto: '1 1 auto',
       initial: '0 1 auto',
       none: 'none',


### PR DESCRIPTION
Some css parsers fail when 0 has units.

Can we just change this so less people run into this issue?

https://github.com/styled-components/css-to-react-native/issues/114