### PR TITLE
Add text-shadow plugin (another suggestion)

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -55,6 +55,7 @@ import textAlign from './plugins/textAlign'
 import textColor from './plugins/textColor'
 import fontSize from './plugins/fontSize'
 import fontStyle from './plugins/fontStyle'
+import textShadow from './plugins/textShadow'
 import textTransform from './plugins/textTransform'
 import textDecoration from './plugins/textDecoration'
 import fontSmoothing from './plugins/fontSmoothing'
@@ -128,6 +129,7 @@ export default function({ corePlugins: corePluginConfig }) {
     textColor,
     fontSize,
     fontStyle,
+    textShadow,
     textTransform,
     textDecoration,
     fontSmoothing,

--- a/src/plugins/textShadow.js
+++ b/src/plugins/textShadow.js
@@ -1,0 +1,21 @@
+import _ from 'lodash'
+import prefixNegativeModifiers from '../util/prefixNegativeModifiers'
+
+export default function() {
+  return function({ addUtilities, e, theme, variants }) {
+    const utilities = _.fromPairs(
+      _.map(theme('textShadow'), (value, modifier) => {
+        const className =
+          modifier === 'default' ? 'text-shadow' : `${e(prefixNegativeModifiers('text-shadow', modifier))}`
+        return [
+          `.${className}`,
+          {
+            'text-shadow': value,
+          },
+        ]
+      })
+    )
+
+    addUtilities(utilities, variants('textShadow'))
+  }
+}

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -482,7 +482,7 @@ module.exports = {
     textColor: ['responsive', 'hover', 'focus'],
     textDecoration: ['responsive', 'hover', 'focus'],
     textTransform: ['responsive'],
-    textShadow: ['responsive', 'hover', 'focus'],
+    textShadow: ['responsive'],
     userSelect: ['responsive'],
     verticalAlign: ['responsive'],
     visibility: ['responsive'],

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -250,6 +250,10 @@ module.exports = {
         'monospace',
       ],
     },
+    textShadow:{
+      default: '0em 0.05em 0.1em rgba(72, 72, 103, 0.6)',
+      none: 'none',
+    },
     fontSize: {
       xs: '0.75rem',
       sm: '0.875rem',
@@ -478,6 +482,7 @@ module.exports = {
     textColor: ['responsive', 'hover', 'focus'],
     textDecoration: ['responsive', 'hover', 'focus'],
     textTransform: ['responsive'],
+    textShadow: ['responsive', 'hover', 'focus'],
     userSelect: ['responsive'],
     verticalAlign: ['responsive'],
     visibility: ['responsive'],

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -482,7 +482,6 @@ module.exports = {
     textColor: ['responsive', 'hover', 'focus'],
     textDecoration: ['responsive', 'hover', 'focus'],
     textTransform: ['responsive'],
-    textShadow: ['responsive'],
     userSelect: ['responsive'],
     verticalAlign: ['responsive'],
     visibility: ['responsive'],


### PR DESCRIPTION
I see someone else already add text-shadow property #978  but I though the values inconsistent with the hole design of tailwind. Picking myself some values and colors, I just see this proprety has to be simple and adapted.

The shadow will be on consistent size with any size of text and merge with color scheme of tailwind.

![wretr](https://user-images.githubusercontent.com/1420545/65735855-4ac78880-e0af-11e9-9bb0-addb2083c1f3.png)

**Keeping though about it:** I guess the values don't need so extravagant and only put modifiers with some variation of colours or/and strength of blurry shadow.
