### PR TITLE
Added border x and y

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -3224,6 +3224,56 @@ video {
   border-width: 1px !important;
 }
 
+.border-y-0 {
+  border-top-width: 0 !important;
+  border-bottom-width: 0 !important;
+}
+
+.border-x-0 {
+  border-left-width: 0 !important;
+  border-right-width: 0 !important;
+}
+
+.border-y-2 {
+  border-top-width: 2px !important;
+  border-bottom-width: 2px !important;
+}
+
+.border-x-2 {
+  border-left-width: 2px !important;
+  border-right-width: 2px !important;
+}
+
+.border-y-4 {
+  border-top-width: 4px !important;
+  border-bottom-width: 4px !important;
+}
+
+.border-x-4 {
+  border-left-width: 4px !important;
+  border-right-width: 4px !important;
+}
+
+.border-y-8 {
+  border-top-width: 8px !important;
+  border-bottom-width: 8px !important;
+}
+
+.border-x-8 {
+  border-left-width: 8px !important;
+  border-right-width: 8px !important;
+}
+
+.border-y {
+  border-top-width: 1px !important;
+  border-bottom-width: 1px !important;
+}
+
+.border-x {
+  border-left-width: 1px !important;
+  border-right-width: 1px !important;
+}
+
 .border-t-0 {
   border-top-width: 0 !important;
 }
@@ -10961,6 +11011,56 @@ video {
 
   .sm\:border {
     border-width: 1px !important;
+  }
+
+  .sm\:border-y-0 {
+    border-top-width: 0 !important;
+    border-bottom-width: 0 !important;
+  }
+
+  .sm\:border-x-0 {
+    border-left-width: 0 !important;
+    border-right-width: 0 !important;
+  }
+
+  .sm\:border-y-2 {
+    border-top-width: 2px !important;
+    border-bottom-width: 2px !important;
+  }
+
+  .sm\:border-x-2 {
+    border-left-width: 2px !important;
+    border-right-width: 2px !important;
+  }
+
+  .sm\:border-y-4 {
+    border-top-width: 4px !important;
+    border-bottom-width: 4px !important;
+  }
+
+  .sm\:border-x-4 {
+    border-left-width: 4px !important;
+    border-right-width: 4px !important;
+  }
+
+  .sm\:border-y-8 {
+    border-top-width: 8px !important;
+    border-bottom-width: 8px !important;
+  }
+
+  .sm\:border-x-8 {
+    border-left-width: 8px !important;
+    border-right-width: 8px !important;
+  }
+
+  .sm\:border-y {
+    border-top-width: 1px !important;
+    border-bottom-width: 1px !important;
+  }
+
+  .sm\:border-x {
+    border-left-width: 1px !important;
+    border-right-width: 1px !important;
   }
 
   .sm\:border-t-0 {
@@ -18703,6 +18803,56 @@ video {
     border-width: 1px !important;
   }
 
+  .md\:border-y-0 {
+    border-top-width: 0 !important;
+    border-bottom-width: 0 !important;
+  }
+
+  .md\:border-x-0 {
+    border-left-width: 0 !important;
+    border-right-width: 0 !important;
+  }
+
+  .md\:border-y-2 {
+    border-top-width: 2px !important;
+    border-bottom-width: 2px !important;
+  }
+
+  .md\:border-x-2 {
+    border-left-width: 2px !important;
+    border-right-width: 2px !important;
+  }
+
+  .md\:border-y-4 {
+    border-top-width: 4px !important;
+    border-bottom-width: 4px !important;
+  }
+
+  .md\:border-x-4 {
+    border-left-width: 4px !important;
+    border-right-width: 4px !important;
+  }
+
+  .md\:border-y-8 {
+    border-top-width: 8px !important;
+    border-bottom-width: 8px !important;
+  }
+
+  .md\:border-x-8 {
+    border-left-width: 8px !important;
+    border-right-width: 8px !important;
+  }
+
+  .md\:border-y {
+    border-top-width: 1px !important;
+    border-bottom-width: 1px !important;
+  }
+
+  .md\:border-x {
+    border-left-width: 1px !important;
+    border-right-width: 1px !important;
+  }
+
   .md\:border-t-0 {
     border-top-width: 0 !important;
   }
@@ -26443,6 +26593,56 @@ video {
     border-width: 1px !important;
   }
 
+  .lg\:border-y-0 {
+    border-top-width: 0 !important;
+    border-bottom-width: 0 !important;
+  }
+
+  .lg\:border-x-0 {
+    border-left-width: 0 !important;
+    border-right-width: 0 !important;
+  }
+
+  .lg\:border-y-2 {
+    border-top-width: 2px !important;
+    border-bottom-width: 2px !important;
+  }
+
+  .lg\:border-x-2 {
+    border-left-width: 2px !important;
+    border-right-width: 2px !important;
+  }
+
+  .lg\:border-y-4 {
+    border-top-width: 4px !important;
+    border-bottom-width: 4px !important;
+  }
+
+  .lg\:border-x-4 {
+    border-left-width: 4px !important;
+    border-right-width: 4px !important;
+  }
+
+  .lg\:border-y-8 {
+    border-top-width: 8px !important;
+    border-bottom-width: 8px !important;
+  }
+
+  .lg\:border-x-8 {
+    border-left-width: 8px !important;
+    border-right-width: 8px !important;
+  }
+
+  .lg\:border-y {
+    border-top-width: 1px !important;
+    border-bottom-width: 1px !important;
+  }
+
+  .lg\:border-x {
+    border-left-width: 1px !important;
+    border-right-width: 1px !important;
+  }
+
   .lg\:border-t-0 {
     border-top-width: 0 !important;
   }
@@ -34181,6 +34381,56 @@ video {
 
   .xl\:border {
     border-width: 1px !important;
+  }
+
+  .xl\:border-y-0 {
+    border-top-width: 0 !important;
+    border-bottom-width: 0 !important;
+  }
+
+  .xl\:border-x-0 {
+    border-left-width: 0 !important;
+    border-right-width: 0 !important;
+  }
+
+  .xl\:border-y-2 {
+    border-top-width: 2px !important;
+    border-bottom-width: 2px !important;
+  }
+
+  .xl\:border-x-2 {
+    border-left-width: 2px !important;
+    border-right-width: 2px !important;
+  }
+
+  .xl\:border-y-4 {
+    border-top-width: 4px !important;
+    border-bottom-width: 4px !important;
+  }
+
+  .xl\:border-x-4 {
+    border-left-width: 4px !important;
+    border-right-width: 4px !important;
+  }
+
+  .xl\:border-y-8 {
+    border-top-width: 8px !important;
+    border-bottom-width: 8px !important;
+  }
+
+  .xl\:border-x-8 {
+    border-left-width: 8px !important;
+    border-right-width: 8px !important;
+  }
+
+  .xl\:border-y {
+    border-top-width: 1px !important;
+    border-bottom-width: 1px !important;
+  }
+
+  .xl\:border-x {
+    border-left-width: 1px !important;
+    border-right-width: 1px !important;
   }
 
   .xl\:border-t-0 {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3224,6 +3224,56 @@ video {
   border-width: 1px;
 }
 
+.border-y-0 {
+  border-top-width: 0;
+  border-bottom-width: 0;
+}
+
+.border-x-0 {
+  border-left-width: 0;
+  border-right-width: 0;
+}
+
+.border-y-2 {
+  border-top-width: 2px;
+  border-bottom-width: 2px;
+}
+
+.border-x-2 {
+  border-left-width: 2px;
+  border-right-width: 2px;
+}
+
+.border-y-4 {
+  border-top-width: 4px;
+  border-bottom-width: 4px;
+}
+
+.border-x-4 {
+  border-left-width: 4px;
+  border-right-width: 4px;
+}
+
+.border-y-8 {
+  border-top-width: 8px;
+  border-bottom-width: 8px;
+}
+
+.border-x-8 {
+  border-left-width: 8px;
+  border-right-width: 8px;
+}
+
+.border-y {
+  border-top-width: 1px;
+  border-bottom-width: 1px;
+}
+
+.border-x {
+  border-left-width: 1px;
+  border-right-width: 1px;
+}
+
 .border-t-0 {
   border-top-width: 0;
 }
@@ -10961,6 +11011,56 @@ video {
 
   .sm\:border {
     border-width: 1px;
+  }
+
+  .sm\:border-y-0 {
+    border-top-width: 0;
+    border-bottom-width: 0;
+  }
+
+  .sm\:border-x-0 {
+    border-left-width: 0;
+    border-right-width: 0;
+  }
+
+  .sm\:border-y-2 {
+    border-top-width: 2px;
+    border-bottom-width: 2px;
+  }
+
+  .sm\:border-x-2 {
+    border-left-width: 2px;
+    border-right-width: 2px;
+  }
+
+  .sm\:border-y-4 {
+    border-top-width: 4px;
+    border-bottom-width: 4px;
+  }
+
+  .sm\:border-x-4 {
+    border-left-width: 4px;
+    border-right-width: 4px;
+  }
+
+  .sm\:border-y-8 {
+    border-top-width: 8px;
+    border-bottom-width: 8px;
+  }
+
+  .sm\:border-x-8 {
+    border-left-width: 8px;
+    border-right-width: 8px;
+  }
+
+  .sm\:border-y {
+    border-top-width: 1px;
+    border-bottom-width: 1px;
+  }
+
+  .sm\:border-x {
+    border-left-width: 1px;
+    border-right-width: 1px;
   }
 
   .sm\:border-t-0 {
@@ -18703,6 +18803,56 @@ video {
     border-width: 1px;
   }
 
+  .md\:border-y-0 {
+    border-top-width: 0;
+    border-bottom-width: 0;
+  }
+
+  .md\:border-x-0 {
+    border-left-width: 0;
+    border-right-width: 0;
+  }
+
+  .md\:border-y-2 {
+    border-top-width: 2px;
+    border-bottom-width: 2px;
+  }
+
+  .md\:border-x-2 {
+    border-left-width: 2px;
+    border-right-width: 2px;
+  }
+
+  .md\:border-y-4 {
+    border-top-width: 4px;
+    border-bottom-width: 4px;
+  }
+
+  .md\:border-x-4 {
+    border-left-width: 4px;
+    border-right-width: 4px;
+  }
+
+  .md\:border-y-8 {
+    border-top-width: 8px;
+    border-bottom-width: 8px;
+  }
+
+  .md\:border-x-8 {
+    border-left-width: 8px;
+    border-right-width: 8px;
+  }
+
+  .md\:border-y {
+    border-top-width: 1px;
+    border-bottom-width: 1px;
+  }
+
+  .md\:border-x {
+    border-left-width: 1px;
+    border-right-width: 1px;
+  }
+
   .md\:border-t-0 {
     border-top-width: 0;
   }
@@ -26443,6 +26593,56 @@ video {
     border-width: 1px;
   }
 
+  .lg\:border-y-0 {
+    border-top-width: 0;
+    border-bottom-width: 0;
+  }
+
+  .lg\:border-x-0 {
+    border-left-width: 0;
+    border-right-width: 0;
+  }
+
+  .lg\:border-y-2 {
+    border-top-width: 2px;
+    border-bottom-width: 2px;
+  }
+
+  .lg\:border-x-2 {
+    border-left-width: 2px;
+    border-right-width: 2px;
+  }
+
+  .lg\:border-y-4 {
+    border-top-width: 4px;
+    border-bottom-width: 4px;
+  }
+
+  .lg\:border-x-4 {
+    border-left-width: 4px;
+    border-right-width: 4px;
+  }
+
+  .lg\:border-y-8 {
+    border-top-width: 8px;
+    border-bottom-width: 8px;
+  }
+
+  .lg\:border-x-8 {
+    border-left-width: 8px;
+    border-right-width: 8px;
+  }
+
+  .lg\:border-y {
+    border-top-width: 1px;
+    border-bottom-width: 1px;
+  }
+
+  .lg\:border-x {
+    border-left-width: 1px;
+    border-right-width: 1px;
+  }
+
   .lg\:border-t-0 {
     border-top-width: 0;
   }
@@ -34181,6 +34381,56 @@ video {
 
   .xl\:border {
     border-width: 1px;
+  }
+
+  .xl\:border-y-0 {
+    border-top-width: 0;
+    border-bottom-width: 0;
+  }
+
+  .xl\:border-x-0 {
+    border-left-width: 0;
+    border-right-width: 0;
+  }
+
+  .xl\:border-y-2 {
+    border-top-width: 2px;
+    border-bottom-width: 2px;
+  }
+
+  .xl\:border-x-2 {
+    border-left-width: 2px;
+    border-right-width: 2px;
+  }
+
+  .xl\:border-y-4 {
+    border-top-width: 4px;
+    border-bottom-width: 4px;
+  }
+
+  .xl\:border-x-4 {
+    border-left-width: 4px;
+    border-right-width: 4px;
+  }
+
+  .xl\:border-y-8 {
+    border-top-width: 8px;
+    border-bottom-width: 8px;
+  }
+
+  .xl\:border-x-8 {
+    border-left-width: 8px;
+    border-right-width: 8px;
+  }
+
+  .xl\:border-y {
+    border-top-width: 1px;
+    border-bottom-width: 1px;
+  }
+
+  .xl\:border-x {
+    border-left-width: 1px;
+    border-right-width: 1px;
   }
 
   .xl\:border-t-0 {

--- a/src/plugins/borderWidth.js
+++ b/src/plugins/borderWidth.js
@@ -6,6 +6,16 @@ export default function() {
       (value, modifier) => ({
         [`.${e(`border${modifier}`)}`]: { borderWidth: `${value}` },
       }),
+      (size, modifier) => ({
+        [`.${e(`border-y${modifier}`)}`]: {
+          borderTopWidth: `${size}`,
+          borderBottomWidth: `${size}`,
+        },
+        [`.${e(`border-x${modifier}`)}`]: {
+          borderLeftWidth: `${size}`,
+          borderRightWidth: `${size}`,
+        },
+      }),
       (value, modifier) => ({
         [`.${e(`border-t${modifier}`)}`]: { borderTopWidth: `${value}` },
         [`.${e(`border-r${modifier}`)}`]: { borderRightWidth: `${value}` },


### PR DESCRIPTION
It's a little strange that there are classes like `px-` and `py-`.
But not `border-x` and `border-y`. This pull request adds this. I think this makes tailwind consistent.

I followed the contribution guide, but when I run `npm test` the test fails on the `sanity.test.js` on the compare with the output file. I'm not sure how to re-render this/how to let this test pass.

I tested this manually by copying `/dist/tailwind.css` to my own project and used classes like `border-x`, `border-y`, `border-x-8`, etc.

**Edit:**
After some digging through discord, I found that you have to add the differences manually in output and output important. (maybe add this to the contribution docs)