### PR TITLE
Don't watch files in node_modules

### DIFF
--- a/src/lib/getModuleDependencies.js
+++ b/src/lib/getModuleDependencies.js
@@ -17,17 +17,22 @@ export default function getModuleDependencies(entryFile) {
   // Iterate over the modules, even when new
   // ones are being added
   for (const mdl of modules) {
-    mdl.requires.forEach(dep => {
-      try {
-        const basedir = path.dirname(mdl.file)
-        const depPath = resolve.sync(dep, { basedir })
-        const depModule = createModule(depPath)
+    mdl.requires
+      .filter(dep => {
+        // Only track local modules, not node_modules
+        return dep.startsWith('./') || dep.startsWith('../')
+      })
+      .forEach(dep => {
+        try {
+          const basedir = path.dirname(mdl.file)
+          const depPath = resolve.sync(dep, { basedir })
+          const depModule = createModule(depPath)
 
-        modules.push(depModule)
-      } catch (_err) {
-        // eslint-disable-next-line no-empty
-      }
-    })
+          modules.push(depModule)
+        } catch (_err) {
+          // eslint-disable-next-line no-empty
+        }
+      })
   }
 
   return modules


### PR DESCRIPTION
Right now any `require` statements in your Tailwind config file incur a very significant build performance penalty, because we are crawling those dependencies recursively to register files that need to be watched for changes.

Really we only need to watch _your_ files for changes, not files pulled in from npm, so this PR only watches requires that are local (starting with `./` or `../`).