### PR TITLE
Ensure all function properties receive config utils

### DIFF
--- a/__tests__/resolveConfig.test.js
+++ b/__tests__/resolveConfig.test.js
@@ -1059,6 +1059,7 @@ test('theme values in the extend section are lazily evaluated', () => {
 test('lazily evaluated values have access to the config utils', () => {
   const userConfig = {
     theme: {
+      inset: theme => theme('margin'),
       shift: (theme, { negative }) => ({
         ...theme('spacing'),
         ...negative(theme('spacing')),
@@ -1083,6 +1084,10 @@ test('lazily evaluated values have access to the config utils', () => {
         '3': '3px',
         '4': '4px',
       },
+      margin: (theme, { negative }) => ({
+        ...theme('spacing'),
+        ...negative(theme('spacing')),
+      }),
     },
     variants: {},
   }
@@ -1095,6 +1100,26 @@ test('lazily evaluated values have access to the config utils', () => {
     separator: ':',
     theme: {
       spacing: {
+        '1': '1px',
+        '2': '2px',
+        '3': '3px',
+        '4': '4px',
+      },
+      inset: {
+        '-1': '-1px',
+        '-2': '-2px',
+        '-3': '-3px',
+        '-4': '-4px',
+        '1': '1px',
+        '2': '2px',
+        '3': '3px',
+        '4': '4px',
+      },
+      margin: {
+        '-1': '-1px',
+        '-2': '-2px',
+        '-3': '-3px',
+        '-4': '-4px',
         '1': '1px',
         '2': '2px',
         '3': '3px',

--- a/src/util/resolveConfig.js
+++ b/src/util/resolveConfig.js
@@ -48,7 +48,7 @@ function resolveFunctionKeys(object) {
 
     while (val !== undefined && val !== null && index < path.length) {
       val = val[path[index++]]
-      val = isFunction(val) ? val(resolveThemePath) : val
+      val = isFunction(val) ? val(resolveThemePath, configUtils) : val
     }
 
     return val === undefined ? defaultValue : val


### PR DESCRIPTION
This PR makes sure that all function properties in the user's `theme` config receive the config utilities, like `negative`. Previously under certain circumstances, recursively evaluated theme function properties were receiving only the `theme` function and no second argument.