### PR TITLE
Add touch-action utilities

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -14335,6 +14335,46 @@ video {
     pointer-events: auto !important;
   }
 
+  .sm\:touch-none {
+    touch-action: none !important;
+  }
+
+  .sm\:touch-auto {
+    touch-action: auto !important;
+  }
+
+  .sm\:touch-pan-x {
+    touch-action: pan-x !important;
+  }
+
+  .sm\:touch-pan-left {
+    touch-action: pan-left !important;
+  }
+
+  .sm\:touch-pan-right {
+    touch-action: pan-right !important;
+  }
+
+  .sm\:touch-pan-y {
+    touch-action: pan-y !important;
+  }
+
+  .sm\:touch-pan-up {
+    touch-action: pan-up !important;
+  }
+
+  .sm\:touch-pan-down {
+    touch-action: pan-down !important;
+  }
+
+  .sm\:touch-pinch-zoom {
+    touch-action: pinch-zoom !important;
+  }
+
+  .sm\:touch-manipulation {
+    touch-action: manipulation !important;
+  }
+
   .sm\:static {
     position: static !important;
   }
@@ -22073,6 +22113,46 @@ video {
 
   .md\:pointer-events-auto {
     pointer-events: auto !important;
+  }
+
+  .md\:touch-none {
+    touch-action: none !important;
+  }
+
+  .md\:touch-auto {
+    touch-action: auto !important;
+  }
+
+  .md\:touch-pan-x {
+    touch-action: pan-x !important;
+  }
+
+  .md\:touch-pan-left {
+    touch-action: pan-left !important;
+  }
+
+  .md\:touch-pan-right {
+    touch-action: pan-right !important;
+  }
+
+  .md\:touch-pan-y {
+    touch-action: pan-y !important;
+  }
+
+  .md\:touch-pan-up {
+    touch-action: pan-up !important;
+  }
+
+  .md\:touch-pan-down {
+    touch-action: pan-down !important;
+  }
+
+  .md\:touch-pinch-zoom {
+    touch-action: pinch-zoom !important;
+  }
+
+  .md\:touch-manipulation {
+    touch-action: manipulation !important;
   }
 
   .md\:static {
@@ -29815,6 +29895,46 @@ video {
     pointer-events: auto !important;
   }
 
+  .lg\:touch-none {
+    touch-action: none !important;
+  }
+
+  .lg\:touch-auto {
+    touch-action: auto !important;
+  }
+
+  .lg\:touch-pan-x {
+    touch-action: pan-x !important;
+  }
+
+  .lg\:touch-pan-left {
+    touch-action: pan-left !important;
+  }
+
+  .lg\:touch-pan-right {
+    touch-action: pan-right !important;
+  }
+
+  .lg\:touch-pan-y {
+    touch-action: pan-y !important;
+  }
+
+  .lg\:touch-pan-up {
+    touch-action: pan-up !important;
+  }
+
+  .lg\:touch-pan-down {
+    touch-action: pan-down !important;
+  }
+
+  .lg\:touch-pinch-zoom {
+    touch-action: pinch-zoom !important;
+  }
+
+  .lg\:touch-manipulation {
+    touch-action: manipulation !important;
+  }
+
   .lg\:static {
     position: static !important;
   }
@@ -37553,6 +37673,46 @@ video {
 
   .xl\:pointer-events-auto {
     pointer-events: auto !important;
+  }
+
+  .xl\:touch-none {
+    touch-action: none !important;
+  }
+
+  .xl\:touch-auto {
+    touch-action: auto !important;
+  }
+
+  .xl\:touch-pan-x {
+    touch-action: pan-x !important;
+  }
+
+  .xl\:touch-pan-left {
+    touch-action: pan-left !important;
+  }
+
+  .xl\:touch-pan-right {
+    touch-action: pan-right !important;
+  }
+
+  .xl\:touch-pan-y {
+    touch-action: pan-y !important;
+  }
+
+  .xl\:touch-pan-up {
+    touch-action: pan-up !important;
+  }
+
+  .xl\:touch-pan-down {
+    touch-action: pan-down !important;
+  }
+
+  .xl\:touch-pinch-zoom {
+    touch-action: pinch-zoom !important;
+  }
+
+  .xl\:touch-manipulation {
+    touch-action: manipulation !important;
   }
 
   .xl\:static {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -6549,11 +6549,51 @@ video {
 }
 
 .pointer-events-none {
-  pointer-events: none !important;
+  pointer-events: none;
 }
 
 .pointer-events-auto {
-  pointer-events: auto !important;
+  pointer-events: auto;
+}
+
+.touch-none {
+  touch-action: none;
+}
+
+.touch-auto {
+  touch-action: auto;
+}
+
+.touch-pan-x {
+  touch-action: pan-x;
+}
+
+.touch-pan-left {
+  touch-action: pan-left;
+}
+
+.touch-pan-right {
+  touch-action: pan-right;
+}
+
+.touch-pan-y {
+  touch-action: pan-y;
+}
+
+.touch-pan-up {
+  touch-action: pan-up;
+}
+
+.touch-pan-down {
+  touch-action: pan-down;
+}
+
+.touch-pinch-zoom {
+  touch-action: pinch-zoom;
+}
+
+.touch-manipulation {
+  touch-action: manipulation;
 }
 
 .static {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -6549,51 +6549,51 @@ video {
 }
 
 .pointer-events-none {
-  pointer-events: none;
+  pointer-events: none !important;
 }
 
 .pointer-events-auto {
-  pointer-events: auto;
+  pointer-events: auto !important;
 }
 
 .touch-none {
-  touch-action: none;
+  touch-action: none !important;
 }
 
 .touch-auto {
-  touch-action: auto;
+  touch-action: auto !important;
 }
 
 .touch-pan-x {
-  touch-action: pan-x;
+  touch-action: pan-x !important;
 }
 
 .touch-pan-left {
-  touch-action: pan-left;
+  touch-action: pan-left !important;
 }
 
 .touch-pan-right {
-  touch-action: pan-right;
+  touch-action: pan-right !important;
 }
 
 .touch-pan-y {
-  touch-action: pan-y;
+  touch-action: pan-y !important;
 }
 
 .touch-pan-up {
-  touch-action: pan-up;
+  touch-action: pan-up !important;
 }
 
 .touch-pan-down {
-  touch-action: pan-down;
+  touch-action: pan-down !important;
 }
 
 .touch-pinch-zoom {
-  touch-action: pinch-zoom;
+  touch-action: pinch-zoom !important;
 }
 
 .touch-manipulation {
-  touch-action: manipulation;
+  touch-action: manipulation !important;
 }
 
 .static {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -14335,6 +14335,46 @@ video {
     pointer-events: auto;
   }
 
+  .sm\:touch-none {
+    touch-action: none;
+  }
+
+  .sm\:touch-auto {
+    touch-action: auto;
+  }
+
+  .sm\:touch-pan-x {
+    touch-action: pan-x;
+  }
+
+  .sm\:touch-pan-left {
+    touch-action: pan-left;
+  }
+
+  .sm\:touch-pan-right {
+    touch-action: pan-right;
+  }
+
+  .sm\:touch-pan-y {
+    touch-action: pan-y;
+  }
+
+  .sm\:touch-pan-up {
+    touch-action: pan-up;
+  }
+
+  .sm\:touch-pan-down {
+    touch-action: pan-down;
+  }
+
+  .sm\:touch-pinch-zoom {
+    touch-action: pinch-zoom;
+  }
+
+  .sm\:touch-manipulation {
+    touch-action: manipulation;
+  }
+
   .sm\:static {
     position: static;
   }
@@ -22073,6 +22113,46 @@ video {
 
   .md\:pointer-events-auto {
     pointer-events: auto;
+  }
+
+  .md\:touch-none {
+    touch-action: none;
+  }
+
+  .md\:touch-auto {
+    touch-action: auto;
+  }
+
+  .md\:touch-pan-x {
+    touch-action: pan-x;
+  }
+
+  .md\:touch-pan-left {
+    touch-action: pan-left;
+  }
+
+  .md\:touch-pan-right {
+    touch-action: pan-right;
+  }
+
+  .md\:touch-pan-y {
+    touch-action: pan-y;
+  }
+
+  .md\:touch-pan-up {
+    touch-action: pan-up;
+  }
+
+  .md\:touch-pan-down {
+    touch-action: pan-down;
+  }
+
+  .md\:touch-pinch-zoom {
+    touch-action: pinch-zoom;
+  }
+
+  .md\:touch-manipulation {
+    touch-action: manipulation;
   }
 
   .md\:static {
@@ -29815,6 +29895,46 @@ video {
     pointer-events: auto;
   }
 
+  .lg\:touch-none {
+    touch-action: none;
+  }
+
+  .lg\:touch-auto {
+    touch-action: auto;
+  }
+
+  .lg\:touch-pan-x {
+    touch-action: pan-x;
+  }
+
+  .lg\:touch-pan-left {
+    touch-action: pan-left;
+  }
+
+  .lg\:touch-pan-right {
+    touch-action: pan-right;
+  }
+
+  .lg\:touch-pan-y {
+    touch-action: pan-y;
+  }
+
+  .lg\:touch-pan-up {
+    touch-action: pan-up;
+  }
+
+  .lg\:touch-pan-down {
+    touch-action: pan-down;
+  }
+
+  .lg\:touch-pinch-zoom {
+    touch-action: pinch-zoom;
+  }
+
+  .lg\:touch-manipulation {
+    touch-action: manipulation;
+  }
+
   .lg\:static {
     position: static;
   }
@@ -37553,6 +37673,46 @@ video {
 
   .xl\:pointer-events-auto {
     pointer-events: auto;
+  }
+
+  .xl\:touch-none {
+    touch-action: none;
+  }
+
+  .xl\:touch-auto {
+    touch-action: auto;
+  }
+
+  .xl\:touch-pan-x {
+    touch-action: pan-x;
+  }
+
+  .xl\:touch-pan-left {
+    touch-action: pan-left;
+  }
+
+  .xl\:touch-pan-right {
+    touch-action: pan-right;
+  }
+
+  .xl\:touch-pan-y {
+    touch-action: pan-y;
+  }
+
+  .xl\:touch-pan-up {
+    touch-action: pan-up;
+  }
+
+  .xl\:touch-pan-down {
+    touch-action: pan-down;
+  }
+
+  .xl\:touch-pinch-zoom {
+    touch-action: pinch-zoom;
+  }
+
+  .xl\:touch-manipulation {
+    touch-action: manipulation;
   }
 
   .xl\:static {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -6556,6 +6556,46 @@ video {
   pointer-events: auto;
 }
 
+.touch-none {
+  touch-action: none;
+}
+
+.touch-auto {
+  touch-action: auto;
+}
+
+.touch-pan-x {
+  touch-action: pan-x;
+}
+
+.touch-pan-left {
+  touch-action: pan-left;
+}
+
+.touch-pan-right {
+  touch-action: pan-right;
+}
+
+.touch-pan-y {
+  touch-action: pan-y;
+}
+
+.touch-pan-up {
+  touch-action: pan-up;
+}
+
+.touch-pan-down {
+  touch-action: pan-down;
+}
+
+.touch-pinch-zoom {
+  touch-action: pinch-zoom;
+}
+
+.touch-manipulation {
+  touch-action: manipulation;
+}
+
 .static {
   position: static;
 }

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -44,6 +44,7 @@ import overflow from './plugins/overflow'
 import padding from './plugins/padding'
 import placeholderColor from './plugins/placeholderColor'
 import pointerEvents from './plugins/pointerEvents'
+import touchAction from './plugins/touchAction'
 import position from './plugins/position'
 import inset from './plugins/inset'
 import resize from './plugins/resize'
@@ -117,6 +118,7 @@ export default function({ corePlugins: corePluginConfig }) {
     padding,
     placeholderColor,
     pointerEvents,
+    touchAction,
     position,
     inset,
     resize,

--- a/src/plugins/touchAction.js
+++ b/src/plugins/touchAction.js
@@ -1,24 +1,18 @@
 import _ from 'lodash'
 
 export default function() {
-  return function({ addUtilities, variants }) {
-    const actions = [
-      'none',
-      'auto',
-      'pan-x',
-      'pan-left',
-      'pan-right',
-      'pan-y',
-      'pan-up',
-      'pan-down',
-      'pinch-zoom',
-      'manipulation',
-    ]
-    const utilities = _.map(actions, action => ({
-      [`.touch-${action}`]: {
-        'touch-action': action,
-      },
-    }))
-    addUtilities(utilities, variants('touchActions'))
+  return function({ addUtilities, e, theme, variants }) {
+    const utilities = _.fromPairs(
+      _.map(theme('touchAction'), (value, modifier) => {
+        return [
+          `.${e(`touch-${modifier}`)}`,
+          {
+            'touch-action': Array.isArray(value) ? value.join(' ') : value,
+          },
+        ]
+      })
+    )
+
+    addUtilities(utilities, variants('touchAction'))
   }
 }

--- a/src/plugins/touchAction.js
+++ b/src/plugins/touchAction.js
@@ -1,0 +1,24 @@
+import _ from 'lodash'
+
+export default function() {
+  return function({ addUtilities, variants }) {
+    const actions = [
+      'none',
+      'auto',
+      'pan-x',
+      'pan-left',
+      'pan-right',
+      'pan-y',
+      'pan-up',
+      'pan-down',
+      'pinch-zoom',
+      'manipulation',
+    ]
+    const utilities = _.map(actions, action => ({
+      [`.touch-${action}`]: {
+        'touch-action': action,
+      },
+    }))
+    addUtilities(utilities, variants('touchActions'))
+  }
+}

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -470,6 +470,7 @@ module.exports = {
     padding: ['responsive'],
     placeholderColor: ['responsive', 'focus'],
     pointerEvents: ['responsive'],
+    touchAction: ['responsive'],
     position: ['responsive'],
     resize: ['responsive'],
     stroke: ['responsive'],

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -219,6 +219,18 @@ module.exports = {
       '0': '0',
       default: '1',
     },
+    touchAction: {
+      none: 'none',
+      auto: 'auto',
+      'pan-x': 'pan-x',
+      'pan-left': 'pan-left',
+      'pan-right': 'pan-right',
+      'pan-y': 'pan-y',
+      'pan-up': 'pan-up',
+      'pan-down': 'pan-down',
+      'pinch-zoom': 'pinch-zoom',
+      'manipulation': 'manipulation'
+    },
     fontFamily: {
       sans: [
         '-apple-system',


### PR DESCRIPTION
This PR adds 10 new utilities for [`touch-action`](https://developer.mozilla.org/fr/docs/Web/CSS/touch-action).