### PR TITLE
Add trailing commas to `simpleConfig.stub.js`

### DIFF
--- a/stubs/simpleConfig.stub.js
+++ b/stubs/simpleConfig.stub.js
@@ -1,7 +1,7 @@
 module.exports = {
   theme: {
-    extend: {}
+    extend: {},
   },
   variants: {},
-  plugins: []
+  plugins: [],
 }


### PR DESCRIPTION
Makes it consistent with `defaultConfig.stub.js` and saves people like me from adding them manually every time they start a project.

Feel free to close if you'd rather not touch this 👍 