### PR TITLE
Apply configured prefix to the `.group` class for group-hover variants

### DIFF
--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -240,6 +240,30 @@ test('it can generate group-hover variants', () => {
   })
 })
 
+test('group-hover variants respect any configured prefix', () => {
+  const input = `
+    @variants group-hover {
+      .tw-banana { color: yellow; }
+      .tw-chocolate { color: brown; }
+    }
+  `
+
+  const output = `
+    .tw-banana { color: yellow; }
+    .tw-chocolate { color: brown; }
+    .tw-group:hover .group-hover\\:tw-banana { color: yellow; }
+    .tw-group:hover .group-hover\\:tw-chocolate { color: brown; }
+  `
+
+  return run(input, {
+    ...config,
+    prefix: 'tw-',
+  }).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('it can generate hover, active and focus variants', () => {
   const input = `
     @variants group-hover, hover, focus, active {


### PR DESCRIPTION
Fixes #1215, so now if you configure a prefix like `tw-`, group-hover variants will include the prefix on the `.group` portion:

```html
<!-- Before -->
<div class="group">
  <div class="group-hover:tw-bg-blue-500">...</div>
</div>

<!-- After -->
<div class="tw-group">
  <div class="group-hover:tw-bg-blue-500">...</div>
</div>
```

This is one of those "bug fix but also breaking change for anyone who was working around the bug" patches :/ 

Let me know if this change impacts your project, if the impact is widespread enough maybe we will just live with this bug until 2.0.