### PR TITLE
vertical-align ignored

### DIFF
--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -210,7 +210,6 @@ iframe,
 embed,
 object {
   display: block;
-  vertical-align: middle;
 }
 
 /**


### PR DESCRIPTION
Property is ignored due to the display. With `display: block`, `vertical-align` should not be used.
