### PR TITLE
Change button `background` reset in Preflight

### DIFF
--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -25,7 +25,8 @@ pre {
 }
 
 button {
-  background: transparent;
+  background-color: transparent;
+  background-image: none;
   padding: 0;
 }
 


### PR DESCRIPTION
The reason for this proposal is selfish: my [`tailwindcss-reset`](https://github.com/benface/tailwindcss-reset) plugin changes the default `background-position` and `background-repeat` on all elements to more commonly used values (`center center` and `no-repeat`), but I just realized that it doesn't work on `<button>` elements because of [this declaration in Preflight](https://github.com/tailwindcss/tailwindcss/blob/master/src/plugins/css/preflight.css#L28), which comes from SUIT CSS (here's [the commit that introduced this feature](https://github.com/suitcss/base/commit/c0b93e8d2446f17feaf8713acd5d92981e82be07), for reference). Because [the `background` shorthand](https://developer.mozilla.org/en-US/docs/Web/CSS/background) is used instead of `background-color`, it also resets `background-position` and `background-repeat` (among other background properties) to their default value and even though my declarations appear later in the CSS, they are overridden since they have no specificity. I believe a possible reason why they used `background` instead of `background-color` is to also reset `background-image` to `none`, since on some browsers such as [old versions of Firefox for Android](https://bugzilla.mozilla.org/show_bug.cgi?id=763671), buttons have a gradient `background-image` by default. So I suggest replacing `background: transparent` by two declarations: `background-color: transparent` and `background-image: none`, just in case. Being more explicit is always better, right? 😅 