### PR TITLE
Add flow-root display utility

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -3388,6 +3388,10 @@ video {
   display: inline !important;
 }
 
+.flow-root {
+  display: flow-root !important;
+}
+
 .flex {
   display: flex !important;
 }
@@ -13699,6 +13703,10 @@ video {
 
   .sm\:inline {
     display: inline !important;
+  }
+
+  .sm\:flow-root {
+    display: flow-root !important;
   }
 
   .sm\:flex {
@@ -24015,6 +24023,10 @@ video {
     display: inline !important;
   }
 
+  .md\:flow-root {
+    display: flow-root !important;
+  }
+
   .md\:flex {
     display: flex !important;
   }
@@ -34329,6 +34341,10 @@ video {
     display: inline !important;
   }
 
+  .lg\:flow-root {
+    display: flow-root !important;
+  }
+
   .lg\:flex {
     display: flex !important;
   }
@@ -44641,6 +44657,10 @@ video {
 
   .xl\:inline {
     display: inline !important;
+  }
+
+  .xl\:flow-root {
+    display: flow-root !important;
   }
 
   .xl\:flex {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3388,6 +3388,10 @@ video {
   display: inline;
 }
 
+.flow-root {
+  display: flow-root;
+}
+
 .flex {
   display: flex;
 }
@@ -13699,6 +13703,10 @@ video {
 
   .sm\:inline {
     display: inline;
+  }
+
+  .sm\:flow-root {
+    display: flow-root;
   }
 
   .sm\:flex {
@@ -24015,6 +24023,10 @@ video {
     display: inline;
   }
 
+  .md\:flow-root {
+    display: flow-root;
+  }
+
   .md\:flex {
     display: flex;
   }
@@ -34329,6 +34341,10 @@ video {
     display: inline;
   }
 
+  .lg\:flow-root {
+    display: flow-root;
+  }
+
   .lg\:flex {
     display: flex;
   }
@@ -44641,6 +44657,10 @@ video {
 
   .xl\:inline {
     display: inline;
+  }
+
+  .xl\:flow-root {
+    display: flow-root;
   }
 
   .xl\:flex {

--- a/src/plugins/display.js
+++ b/src/plugins/display.js
@@ -11,6 +11,9 @@ export default function() {
         '.inline': {
           display: 'inline',
         },
+        '.flow-root': {
+          display: 'flow-root',
+        },
         '.flex': {
           display: 'flex',
         },


### PR DESCRIPTION
The `flow-root` value for the `display` property is [supported in all major browsers](https://caniuse.com/#feat=flow-root) except iOS Safari and it's probably coming soon since it's already in macOS Safari. It's the most straightforward way to create a new [block formatting context](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context), which is notably useful to control/prevent margin collapsing (since margins only collapse within the same block formatting context).