### PR TITLE
Add only-child variant

### DIFF
--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -219,6 +219,27 @@ test('it can generate even variants', () => {
   })
 })
 
+test('it can generate only-child variants', () => {
+  const input = `
+    @variants only {
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+    }
+  `
+
+  const output = `
+    .banana { color: yellow; }
+    .chocolate { color: brown; }
+    .only\\:banana:only-child { color: yellow; }
+    .only\\:chocolate:only-child { color: brown; }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('it can generate group-hover variants', () => {
   const input = `
     @variants group-hover {

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -46,6 +46,7 @@ const defaultVariantGenerators = config => ({
   last: generatePseudoClassVariant('last-child', 'last'),
   odd: generatePseudoClassVariant('nth-child(odd)', 'odd'),
   even: generatePseudoClassVariant('nth-child(even)', 'even'),
+  only: generatePseudoClassVariant('only-child', 'only'),
 })
 
 export default function(config, { variantGenerators: pluginVariantGenerators }) {


### PR DESCRIPTION
Based off the work down for [first-child and last-child](https://github.com/tailwindcss/tailwindcss/pull/1024) variants this PR adds new only-child variant to the framework, but disabled by default for all core plugins.

Just like the first-child, last-child PR these pseudo selectors effect the element itself not the children of the element.

Ex:
```HTML
<body>
  <h1 class="text-2xl font-bold text-center invisible only:visible">Create your first Todo!</h1>
</body>
```
Ex:
```jsx
<body>
  <div>
	<h1 class="hidden only:inline-block" >None items yet! Create one now!</h1>
	{todos.map(todo => <p>{todo}</p>)}
 </div>
</body>
```