### PR TITLE
Add new `plugin` and `plugin.withOptions` functions for creating plugins

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -1,0 +1,3 @@
+const createPlugin = require('./lib/util/createPlugin').default
+
+module.exports = createPlugin

--- a/src/util/createPlugin.js
+++ b/src/util/createPlugin.js
@@ -1,0 +1,21 @@
+function createPlugin(plugin, config) {
+  return {
+    handler: plugin,
+    config,
+  }
+}
+
+createPlugin.withOptions = function(pluginFunction, configFunction) {
+  const optionsFunction = function(options) {
+    return {
+      handler: pluginFunction(options),
+      config: configFunction(options),
+    }
+  }
+
+  optionsFunction.__isOptionsFunction = true
+
+  return optionsFunction
+}
+
+export default createPlugin

--- a/src/util/processPlugins.js
+++ b/src/util/processPlugins.js
@@ -29,6 +29,10 @@ export default function(plugins, config) {
   const getConfigValue = (path, defaultValue) => _.get(config, path, defaultValue)
 
   plugins.forEach(plugin => {
+    if (plugin.__isOptionsFunction) {
+      plugin = plugin()
+    }
+
     const handler = isFunction(plugin) ? plugin : _.get(plugin, 'handler', () => {})
 
     handler({

--- a/src/util/resolveConfig.js
+++ b/src/util/resolveConfig.js
@@ -107,6 +107,9 @@ function extractPluginConfigs(configs) {
     }
 
     plugins.forEach(plugin => {
+      if (plugin.__isOptionsFunction) {
+        plugin = plugin()
+      }
       allConfigs = [...allConfigs, ...extractPluginConfigs([get(plugin, 'config', {})])]
     })
   })


### PR DESCRIPTION
This PR adds support for a new way of creating plugins using a new `plugin` function exposed at `tailwindcss/plugin`.

It allows you to create plugins like this:

```js
// my-plugin.js
const plugin = require('tailwindcss/plugin')

module.exports = plugin(function({ addUtilities, theme, variants }) {
  // Plugin work goes here
}, {
  theme: {
    // ...
  },
  variants: {
    // ...
  },
})
```

The first argument to `plugin` is the traditional Tailwind plugin function. The second argument is your plugin's config object that should be merged with the user's config.

This API replaces the unstable API introduced in #1162 that allowed you to write your plugins as an object with a `config` and `handler` property:

```js
module.exports = {
  config: {
    theme: {
      // ...
    },
    variants: {
      // ...
    },
  },
  handler({ addUtilities, theme, variants }) {
    // ...
  }
}
```

This PR also introduces a `plugin.withOption` function that allows you to author plugins that accept top-level non-config options:

```js
const plugin = require('tailwindcss/plugin')

module.exports = plugin.withOptions(function(options) {
  return function({ addUtilities, theme, variants }) {
    // ...
  }
}, function(options) {
  return {
    theme: {
      // ...
    },
    variants: {
      // ...
    },
  }
})
```

These sorts of plugins are used by end-users like this:

```js
// tailwind.config.js
module.exports = {
  plugins: [
    require('some-fancy-plugin')({ optionA: 'foo', optionB: 'bar' })
  ]
}
```

This is implemented in such a way that if your plugin takes top-level options but those options are optional, the end-user doesn't need to invoke your plugin with no arguments when adding it to their Tailwind config:

```js
// tailwind.config.js
module.exports = {
  plugins: [
    require('some-fancy-plugin')
  ]
}
```

It's worth noting that under the hood we are still using the `{ config: ..., handler: .... }` format (that's what this helper function spits out) so functions authored that way will continue to work, although you're encouraged to migrate to this new API.
