### PR TITLE
Add `checked` variant

### DIFF
--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -51,6 +51,27 @@ test('it can generate disabled variants', () => {
   })
 })
 
+test('it can generate checked variants', () => {
+  const input = `
+    @variants checked {
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+    }
+  `
+
+  const output = `
+    .banana { color: yellow; }
+    .chocolate { color: brown; }
+    .checked\\:banana:checked { color: yellow; }
+    .checked\\:chocolate:checked { color: brown; }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('it can generate active variants', () => {
   const input = `
     @variants active {

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -42,6 +42,7 @@ const defaultVariantGenerators = config => ({
   active: generatePseudoClassVariant('active'),
   visited: generatePseudoClassVariant('visited'),
   disabled: generatePseudoClassVariant('disabled'),
+  checked: generatePseudoClassVariant('checked'),
   first: generatePseudoClassVariant('first-child', 'first'),
   last: generatePseudoClassVariant('last-child', 'last'),
   odd: generatePseudoClassVariant('nth-child(odd)', 'odd'),


### PR DESCRIPTION
This PR adds a `checked` variant per #1255 to allow the styling of checked elements like checkboxes and radios. It is not enabled for anything by default.
