### PR TITLE
Fix plugin.withOptions() when no config function is passed

### DIFF
--- a/src/util/createPlugin.js
+++ b/src/util/createPlugin.js
@@ -9,7 +9,7 @@ createPlugin.withOptions = function(pluginFunction, configFunction) {
   const optionsFunction = function(options) {
     return {
       handler: pluginFunction(options),
-      config: configFunction(options),
+      config: configFunction ? configFunction(options) : {},
     }
   }
 


### PR DESCRIPTION
I'm converting a plugin to Tailwind 1.2's new plugin definition syntax. It takes options so I use `plugin.withOptions()`, but it doesn't need any config since it only adds variants. When I omit the second argument of `plugin.withOptions()`, I get the following error:

> TypeError: configFunction is not a function

This PR fixes that, allowing to pass no config function to `plugin.withOptions()`.