### PR TITLE
Remove unused variant

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -640,7 +640,6 @@ module.exports = {
     transitionProperty: ['responsive'],
     transitionTimingFunction: ['responsive'],
     transitionDuration: ['responsive'],
-    transitionDelay: ['responsive'],
   },
   corePlugins: {},
   plugins: [],


### PR DESCRIPTION
Hi @adamwathan,

I think transitionDelay are not present so you can remove this variants.

Have a good day, Florian.

