### PR TITLE
add backgroundSize useful aliases

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -1855,6 +1855,18 @@ video {
   background-size: contain !important;
 }
 
+.bg-full {
+  background-size: 100% 100% !important;
+}
+
+.bg-full-h {
+  background-size: 100% auto !important;
+}
+
+.bg-full-w {
+  background-size: auto 100% !important;
+}
+
 .border-collapse {
   border-collapse: collapse !important;
 }
@@ -11632,6 +11644,18 @@ video {
 
   .sm\:bg-contain {
     background-size: contain !important;
+  }
+
+  .sm\:bg-full {
+    background-size: 100% 100% !important;
+  }
+
+  .sm\:bg-full-h {
+    background-size: 100% auto !important;
+  }
+
+  .sm\:bg-full-w {
+    background-size: auto 100% !important;
   }
 
   .sm\:border-collapse {
@@ -21414,6 +21438,18 @@ video {
     background-size: contain !important;
   }
 
+  .md\:bg-full {
+    background-size: 100% 100% !important;
+  }
+
+  .md\:bg-full-h {
+    background-size: 100% auto !important;
+  }
+
+  .md\:bg-full-w {
+    background-size: auto 100% !important;
+  }
+
   .md\:border-collapse {
     border-collapse: collapse !important;
   }
@@ -31194,6 +31230,18 @@ video {
     background-size: contain !important;
   }
 
+  .lg\:bg-full {
+    background-size: 100% 100% !important;
+  }
+
+  .lg\:bg-full-h {
+    background-size: 100% auto !important;
+  }
+
+  .lg\:bg-full-w {
+    background-size: auto 100% !important;
+  }
+
   .lg\:border-collapse {
     border-collapse: collapse !important;
   }
@@ -40972,6 +41020,18 @@ video {
 
   .xl\:bg-contain {
     background-size: contain !important;
+  }
+
+  .xl\:bg-full {
+    background-size: 100% 100% !important;
+  }
+
+  .xl\:bg-full-h {
+    background-size: 100% auto !important;
+  }
+
+  .xl\:bg-full-w {
+    background-size: auto 100% !important;
   }
 
   .xl\:border-collapse {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -1855,6 +1855,18 @@ video {
   background-size: contain;
 }
 
+.bg-full {
+  background-size: 100% 100%;
+}
+
+.bg-full-h {
+  background-size: 100% auto;
+}
+
+.bg-full-w {
+  background-size: auto 100%;
+}
+
 .border-collapse {
   border-collapse: collapse;
 }
@@ -11632,6 +11644,18 @@ video {
 
   .sm\:bg-contain {
     background-size: contain;
+  }
+
+  .sm\:bg-full {
+    background-size: 100% 100%;
+  }
+
+  .sm\:bg-full-h {
+    background-size: 100% auto;
+  }
+
+  .sm\:bg-full-w {
+    background-size: auto 100%;
   }
 
   .sm\:border-collapse {
@@ -21414,6 +21438,18 @@ video {
     background-size: contain;
   }
 
+  .md\:bg-full {
+    background-size: 100% 100%;
+  }
+
+  .md\:bg-full-h {
+    background-size: 100% auto;
+  }
+
+  .md\:bg-full-w {
+    background-size: auto 100%;
+  }
+
   .md\:border-collapse {
     border-collapse: collapse;
   }
@@ -31194,6 +31230,18 @@ video {
     background-size: contain;
   }
 
+  .lg\:bg-full {
+    background-size: 100% 100%;
+  }
+
+  .lg\:bg-full-h {
+    background-size: 100% auto;
+  }
+
+  .lg\:bg-full-w {
+    background-size: auto 100%;
+  }
+
   .lg\:border-collapse {
     border-collapse: collapse;
   }
@@ -40972,6 +41020,18 @@ video {
 
   .xl\:bg-contain {
     background-size: contain;
+  }
+
+  .xl\:bg-full {
+    background-size: 100% 100%;
+  }
+
+  .xl\:bg-full-h {
+    background-size: 100% auto;
+  }
+
+  .xl\:bg-full-w {
+    background-size: auto 100%;
   }
 
   .xl\:border-collapse {

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -163,6 +163,9 @@ module.exports = {
       auto: 'auto',
       cover: 'cover',
       contain: 'contain',
+      full: '100% 100%',
+      'full-h': '100% auto',
+      'full-w': 'auto 100%'
     },
     borderColor: theme => ({
       ...theme('colors'),


### PR DESCRIPTION
This PR add 3 new backgroundSize aliases:

`bg-full` to have an image that completely occupy space, even if it get stretch
`bg-full-h` to have an image that occupy space horizontally without stretching
`bg-full-v` to have an image that occupy space vertically without stretching

I think they are very useful when you work with a lot of background images.

