### PR TITLE
Add system-ui to the normalized font-family list

### DIFF
--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -63,7 +63,7 @@ ul {
  */
 
 html {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; /* 1 */
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; /* 1 */
   line-height: 1.5; /* 2 */
 }
 


### PR DESCRIPTION
https://caniuse.com/#feat=font-family-system-ui

I believe adding this future proofs the static list and supports the intent of using the platform system font more specifically.

If a browser supports system-ui, it'll choose the best font and won't cascade through the fallback list. This protects tailwind from its static list not being as up to date with platforms fonts as time goes on.

👍 