### PR TITLE
Add fill and stroke to `transition-colors`

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -10327,11 +10327,11 @@ video {
 }
 
 .transition {
-  transition-property: background-color, border-color, color, opacity, transform !important;
+  transition-property: background-color, border-color, color, fill, stroke, opacity,transform !important;
 }
 
 .transition-colors {
-  transition-property: background-color, border-color, color !important;
+  transition-property: background-color, border-color, color, fill, stroke !important;
 }
 
 .transition-opacity {
@@ -20118,11 +20118,11 @@ video {
   }
 
   .sm\:transition {
-    transition-property: background-color, border-color, color, opacity, transform !important;
+    transition-property: background-color, border-color, color, fill, stroke, opacity,transform !important;
   }
 
   .sm\:transition-colors {
-    transition-property: background-color, border-color, color !important;
+    transition-property: background-color, border-color, color, fill, stroke !important;
   }
 
   .sm\:transition-opacity {
@@ -29910,11 +29910,11 @@ video {
   }
 
   .md\:transition {
-    transition-property: background-color, border-color, color, opacity, transform !important;
+    transition-property: background-color, border-color, color, fill, stroke, opacity,transform !important;
   }
 
   .md\:transition-colors {
-    transition-property: background-color, border-color, color !important;
+    transition-property: background-color, border-color, color, fill, stroke !important;
   }
 
   .md\:transition-opacity {
@@ -39702,11 +39702,11 @@ video {
   }
 
   .lg\:transition {
-    transition-property: background-color, border-color, color, opacity, transform !important;
+    transition-property: background-color, border-color, color, fill, stroke, opacity,transform !important;
   }
 
   .lg\:transition-colors {
-    transition-property: background-color, border-color, color !important;
+    transition-property: background-color, border-color, color, fill, stroke !important;
   }
 
   .lg\:transition-opacity {
@@ -49494,11 +49494,11 @@ video {
   }
 
   .xl\:transition {
-    transition-property: background-color, border-color, color, opacity, transform !important;
+    transition-property: background-color, border-color, color, fill, stroke, opacity,transform !important;
   }
 
   .xl\:transition-colors {
-    transition-property: background-color, border-color, color !important;
+    transition-property: background-color, border-color, color, fill, stroke !important;
   }
 
   .xl\:transition-opacity {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -10327,11 +10327,11 @@ video {
 }
 
 .transition {
-  transition-property: background-color, border-color, color, opacity, transform;
+  transition-property: background-color, border-color, color, fill, stroke, opacity,transform;
 }
 
 .transition-colors {
-  transition-property: background-color, border-color, color;
+  transition-property: background-color, border-color, color, fill, stroke;
 }
 
 .transition-opacity {
@@ -20118,11 +20118,11 @@ video {
   }
 
   .sm\:transition {
-    transition-property: background-color, border-color, color, opacity, transform;
+    transition-property: background-color, border-color, color, fill, stroke, opacity,transform;
   }
 
   .sm\:transition-colors {
-    transition-property: background-color, border-color, color;
+    transition-property: background-color, border-color, color, fill, stroke;
   }
 
   .sm\:transition-opacity {
@@ -29910,11 +29910,11 @@ video {
   }
 
   .md\:transition {
-    transition-property: background-color, border-color, color, opacity, transform;
+    transition-property: background-color, border-color, color, fill, stroke, opacity,transform;
   }
 
   .md\:transition-colors {
-    transition-property: background-color, border-color, color;
+    transition-property: background-color, border-color, color, fill, stroke;
   }
 
   .md\:transition-opacity {
@@ -39702,11 +39702,11 @@ video {
   }
 
   .lg\:transition {
-    transition-property: background-color, border-color, color, opacity, transform;
+    transition-property: background-color, border-color, color, fill, stroke, opacity,transform;
   }
 
   .lg\:transition-colors {
-    transition-property: background-color, border-color, color;
+    transition-property: background-color, border-color, color, fill, stroke;
   }
 
   .lg\:transition-opacity {
@@ -49494,11 +49494,11 @@ video {
   }
 
   .xl\:transition {
-    transition-property: background-color, border-color, color, opacity, transform;
+    transition-property: background-color, border-color, color, fill, stroke, opacity,transform;
   }
 
   .xl\:transition-colors {
-    transition-property: background-color, border-color, color;
+    transition-property: background-color, border-color, color, fill, stroke;
   }
 
   .xl\:transition-opacity {

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -528,8 +528,8 @@ module.exports = {
     transitionProperty: {
       none: 'none',
       all: 'all',
-      default: 'background-color, border-color, color, opacity, transform',
-      colors: 'background-color, border-color, color',
+      default: 'background-color, border-color, color, fill, stroke, opacity,transform',
+      colors: 'background-color, border-color, color, fill, stroke',
       opacity: 'opacity',
       transform: 'transform',
     },


### PR DESCRIPTION
Adds `fill` and `stroke` properties to both `transition` and `transition-colors`, since they are also colors.