### PR TITLE
Add `transition-shadow`, transition box-shadow in `transition` also

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -10327,7 +10327,7 @@ video {
 }
 
 .transition {
-  transition-property: background-color, border-color, color, fill, stroke, opacity,transform !important;
+  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform !important;
 }
 
 .transition-colors {
@@ -10336,6 +10336,10 @@ video {
 
 .transition-opacity {
   transition-property: opacity !important;
+}
+
+.transition-shadow {
+  transition-property: box-shadow !important;
 }
 
 .transition-transform {
@@ -20118,7 +20122,7 @@ video {
   }
 
   .sm\:transition {
-    transition-property: background-color, border-color, color, fill, stroke, opacity,transform !important;
+    transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform !important;
   }
 
   .sm\:transition-colors {
@@ -20127,6 +20131,10 @@ video {
 
   .sm\:transition-opacity {
     transition-property: opacity !important;
+  }
+
+  .sm\:transition-shadow {
+    transition-property: box-shadow !important;
   }
 
   .sm\:transition-transform {
@@ -29910,7 +29918,7 @@ video {
   }
 
   .md\:transition {
-    transition-property: background-color, border-color, color, fill, stroke, opacity,transform !important;
+    transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform !important;
   }
 
   .md\:transition-colors {
@@ -29919,6 +29927,10 @@ video {
 
   .md\:transition-opacity {
     transition-property: opacity !important;
+  }
+
+  .md\:transition-shadow {
+    transition-property: box-shadow !important;
   }
 
   .md\:transition-transform {
@@ -39702,7 +39714,7 @@ video {
   }
 
   .lg\:transition {
-    transition-property: background-color, border-color, color, fill, stroke, opacity,transform !important;
+    transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform !important;
   }
 
   .lg\:transition-colors {
@@ -39711,6 +39723,10 @@ video {
 
   .lg\:transition-opacity {
     transition-property: opacity !important;
+  }
+
+  .lg\:transition-shadow {
+    transition-property: box-shadow !important;
   }
 
   .lg\:transition-transform {
@@ -49494,7 +49510,7 @@ video {
   }
 
   .xl\:transition {
-    transition-property: background-color, border-color, color, fill, stroke, opacity,transform !important;
+    transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform !important;
   }
 
   .xl\:transition-colors {
@@ -49503,6 +49519,10 @@ video {
 
   .xl\:transition-opacity {
     transition-property: opacity !important;
+  }
+
+  .xl\:transition-shadow {
+    transition-property: box-shadow !important;
   }
 
   .xl\:transition-transform {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -10327,7 +10327,7 @@ video {
 }
 
 .transition {
-  transition-property: background-color, border-color, color, fill, stroke, opacity,transform;
+  transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
 }
 
 .transition-colors {
@@ -10336,6 +10336,10 @@ video {
 
 .transition-opacity {
   transition-property: opacity;
+}
+
+.transition-shadow {
+  transition-property: box-shadow;
 }
 
 .transition-transform {
@@ -20118,7 +20122,7 @@ video {
   }
 
   .sm\:transition {
-    transition-property: background-color, border-color, color, fill, stroke, opacity,transform;
+    transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
   }
 
   .sm\:transition-colors {
@@ -20127,6 +20131,10 @@ video {
 
   .sm\:transition-opacity {
     transition-property: opacity;
+  }
+
+  .sm\:transition-shadow {
+    transition-property: box-shadow;
   }
 
   .sm\:transition-transform {
@@ -29910,7 +29918,7 @@ video {
   }
 
   .md\:transition {
-    transition-property: background-color, border-color, color, fill, stroke, opacity,transform;
+    transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
   }
 
   .md\:transition-colors {
@@ -29919,6 +29927,10 @@ video {
 
   .md\:transition-opacity {
     transition-property: opacity;
+  }
+
+  .md\:transition-shadow {
+    transition-property: box-shadow;
   }
 
   .md\:transition-transform {
@@ -39702,7 +39714,7 @@ video {
   }
 
   .lg\:transition {
-    transition-property: background-color, border-color, color, fill, stroke, opacity,transform;
+    transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
   }
 
   .lg\:transition-colors {
@@ -39711,6 +39723,10 @@ video {
 
   .lg\:transition-opacity {
     transition-property: opacity;
+  }
+
+  .lg\:transition-shadow {
+    transition-property: box-shadow;
   }
 
   .lg\:transition-transform {
@@ -49494,7 +49510,7 @@ video {
   }
 
   .xl\:transition {
-    transition-property: background-color, border-color, color, fill, stroke, opacity,transform;
+    transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
   }
 
   .xl\:transition-colors {
@@ -49503,6 +49519,10 @@ video {
 
   .xl\:transition-opacity {
     transition-property: opacity;
+  }
+
+  .xl\:transition-shadow {
+    transition-property: box-shadow;
   }
 
   .xl\:transition-transform {

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -528,9 +528,10 @@ module.exports = {
     transitionProperty: {
       none: 'none',
       all: 'all',
-      default: 'background-color, border-color, color, fill, stroke, opacity,transform',
+      default: 'background-color, border-color, color, fill, stroke, opacity, box-shadow, transform',
       colors: 'background-color, border-color, color, fill, stroke',
       opacity: 'opacity',
+      shadow: 'box-shadow',
       transform: 'transform',
     },
     transitionTimingFunction: {


### PR DESCRIPTION
Adds a new `transition-shadow` utility for transitioning `box-shadow`, and adds `box-shadow` to the list of properties transitioned when just applying `transition`.

`box-shadow` is generally considered a "not cheap" property to transform but it falls into the same category as `background-color` generally, and is super common for sites to do, and I want to do it myself, so here we are.