### PR TITLE
Use font-sans as the default font, not the system font

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -407,7 +407,8 @@ ul {
  */
 
 /**
- * 1. Use Tailwind's default sans-serif font stack as a sane default.
+ * 1. Use the user's configured `sans` font-family (with Tailwind's default
+ *    sans-serif font stack as a fallback) as a sane default.
  * 2. Use Tailwind's default "normal" line-height so the user isn't forced
  *    to override it to ensure consistency even when using the default theme.
  */

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -407,7 +407,8 @@ ul {
  */
 
 /**
- * 1. Use Tailwind's default sans-serif font stack as a sane default.
+ * 1. Use the user's configured `sans` font-family (with Tailwind's default
+ *    sans-serif font stack as a fallback) as a sane default.
  * 2. Use Tailwind's default "normal" line-height so the user isn't forced
  *    to override it to ensure consistency even when using the default theme.
  */

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -57,13 +57,14 @@ ul {
  */
 
 /**
- * 1. Use Tailwind's default sans-serif font stack as a sane default.
+ * 1. Use the user's configured `sans` font-family (with Tailwind's default
+ *    sans-serif font stack as a fallback) as a sane default.
  * 2. Use Tailwind's default "normal" line-height so the user isn't forced
  *    to override it to ensure consistency even when using the default theme.
  */
 
 html {
-  font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; /* 1 */
+  font-family: theme('fontFamily.sans', Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"); /* 1 */
   line-height: 1.5; /* 2 */
 }
 


### PR DESCRIPTION
We get so many questions about this on Discord ("I changed my font but it's not showing on my site") that I think it makes sense to change this so the behavior is more intuitive.

Could probably call this a breaking change, but it would literally only affect people who had changed `font-sans` to a different font but wanted the system UI font to be the default font for their site (only using the `font-sans` class in select places to purposely deviate from the system font occasionally).

I think I feel comfortable betting $500 that that is literally _nobody_. I think in hindsight the two most intuitive behaviors for this are:

1. Do what we're doing in this PR.
2. Do literally nothing, so the user just sees `sans-serif` by default, so when they look at dev tools at least it's obvious that it's not that their change to `font-sans` isn't taking effect, since `sans-serif` doesn't match the value they were trying to change either.