### PR TITLE
Don't treat the `default` key as special in `createUtilityPlugin()`, add `mapTheme` argument and `convertDefaultKey` helper function for plugins that need it

### DIFF
--- a/src/plugins/transitionProperty.js
+++ b/src/plugins/transitionProperty.js
@@ -1,5 +1,9 @@
 import createUtilityPlugin, { convertDefaultKey } from '../util/createUtilityPlugin'
 
 export default function() {
-  return createUtilityPlugin('transitionProperty', [['transition', ['transitionProperty']]], convertDefaultKey)
+  return createUtilityPlugin(
+    'transitionProperty',
+    [['transition', ['transitionProperty']]],
+    convertDefaultKey
+  )
 }

--- a/src/plugins/transitionProperty.js
+++ b/src/plugins/transitionProperty.js
@@ -1,5 +1,5 @@
-import createUtilityPlugin from '../util/createUtilityPlugin'
+import createUtilityPlugin, { convertDefaultKey } from '../util/createUtilityPlugin'
 
 export default function() {
-  return createUtilityPlugin('transitionProperty', [['transition', ['transitionProperty']]])
+  return createUtilityPlugin('transitionProperty', [['transition', ['transitionProperty']]], convertDefaultKey)
 }

--- a/src/util/createUtilityPlugin.js
+++ b/src/util/createUtilityPlugin.js
@@ -1,9 +1,10 @@
+import _ from 'lodash'
 import fromPairs from 'lodash/fromPairs'
 import toPairs from 'lodash/toPairs'
 import castArray from 'lodash/castArray'
 
 function className(classPrefix, key) {
-  if (key === 'default') {
+  if (key === '') {
     return classPrefix
   }
 
@@ -14,11 +15,11 @@ function className(classPrefix, key) {
   return `${classPrefix}-${key}`
 }
 
-export default function createUtilityPlugin(themeKey, utilityVariations) {
+export default function createUtilityPlugin(themeKey, utilityVariations, mapTheme = theme => theme) {
   return function({ e, addUtilities, variants, theme }) {
     const utilities = utilityVariations.map(([classPrefix, properties]) => {
       return fromPairs(
-        toPairs(theme(themeKey)).map(([key, value]) => {
+        toPairs(mapTheme(theme(themeKey))).map(([key, value]) => {
           return [
             `.${e(className(classPrefix, key))}`,
             fromPairs(castArray(properties).map(property => [property, value])),
@@ -28,4 +29,8 @@ export default function createUtilityPlugin(themeKey, utilityVariations) {
     })
     return addUtilities(utilities, variants(themeKey))
   }
+}
+
+export function convertDefaultKey(theme) {
+  return _.mapKeys(theme, (value, key) => key === 'default' ? '' : key)
 }

--- a/src/util/createUtilityPlugin.js
+++ b/src/util/createUtilityPlugin.js
@@ -15,7 +15,11 @@ function className(classPrefix, key) {
   return `${classPrefix}-${key}`
 }
 
-export default function createUtilityPlugin(themeKey, utilityVariations, mapTheme = theme => theme) {
+export default function createUtilityPlugin(
+  themeKey,
+  utilityVariations,
+  mapTheme = theme => theme
+) {
   return function({ e, addUtilities, variants, theme }) {
     const utilities = utilityVariations.map(([classPrefix, properties]) => {
       return fromPairs(
@@ -32,5 +36,5 @@ export default function createUtilityPlugin(themeKey, utilityVariations, mapThem
 }
 
 export function convertDefaultKey(theme) {
-  return _.mapKeys(theme, (value, key) => key === 'default' ? '' : key)
+  return _.mapKeys(theme, (value, key) => (key === 'default' ? '' : key))
 }


### PR DESCRIPTION
As discussed on Discord. This fixes the "issue" that a `default` key in the `transitionDuration` theme object generates a `duration` class instead of `duration-default` which makes more sense.