### PR TITLE
simplify code contributions by fully automating the dev setup with gitpod

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,6 +8,17 @@ Thanks for your interest in contributing to Tailwind CSS! Please take a moment t
 
 It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create [an issue](https://github.com/tailwindcss/tailwindcss/issues) to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, etc.
 
+### Contribute using one-click online setup
+
+You can use gitpod(a free online VS Code-like IDE) for contributing. With a single click it'll launch a workspace and automatically:
+
+- clone the tailwindcss repo.
+- install the dependencies.
+
+so that you can start contributing straight away.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 ## Coding standards
 
 Our code formatting rules are defined in [.eslintrc](https://github.com/tailwindcss/tailwindcss/blob/master/.eslintrc.json). You can check your code against these standards by running:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,2 @@
+tasks:
+  - init: yarn install

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
     <a href="https://www.npmjs.com/package/tailwindcss"><img src="https://img.shields.io/npm/dt/tailwindcss.svg" alt="Total Downloads"></a>
     <a href="https://github.com/tailwindcss/tailwindcss/releases"><img src="https://img.shields.io/npm/v/tailwindcss.svg" alt="Latest Release"></a>
     <a href="https://github.com/tailwindcss/tailwindcss/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/tailwindcss.svg" alt="License"></a>
+    <a href="https://gitpod.io/#https://github.com/tailwindcss/tailwindcss"><img src="https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod" alt="Gitpod Ready-to-Code"></a>
 </p>
 
 ------


### PR DESCRIPTION
Hi! :slightly_smiling_face:

This Pr simplifies code contributions by fully automating the dev setup with Gitpod(A free online VS Code like IDE).

With a single click, it'll launch a workspace and automatically:

- clone the tailwindcss repo.
- install the dependencies.

So that anyone interested in contributing can start coding straight away.

You can give it a try on my fork of the repo via the link below:

https://gitpod.io/#https://github.com/nisarhassan12/tailwindcss

![image](https://user-images.githubusercontent.com/46004116/74727921-b4fde700-5263-11ea-88e9-e03d55452599.png)

