### PR TITLE
Ability to have responsive .container padding

### DIFF
--- a/__tests__/containerPlugin.test.js
+++ b/__tests__/containerPlugin.test.js
@@ -180,6 +180,56 @@ test.only('horizontal padding can be included by default', () => {
   `)
 })
 
+test.only('responsive horizontal padding can be included by default', () => {
+  const { components } = processPlugins(
+    [container()],
+    config({
+      theme: {
+        container: {
+          padding: {
+            default: '1rem',
+            sm: '2rem',
+            lg: '4rem',
+            xl: '5rem',
+          },
+        },
+      },
+    })
+  )
+
+  expect(css(components)).toMatchCss(`
+    .container {
+      width: 100%;
+      padding-right: 1rem;
+      padding-left: 1rem
+    }
+    @media (min-width: 576px) {
+      .container {
+        max-width: 576px;
+        padding-right: 2rem;
+        padding-left: 2rem
+      }
+    }
+    @media (min-width: 768px) {
+      .container { max-width: 768px }
+    }
+    @media (min-width: 992px) {
+      .container {
+        max-width: 992px;
+        padding-right: 4rem;
+        padding-left: 4rem
+      }
+    }
+    @media (min-width: 1200px) {
+      .container {
+        max-width: 1200px;
+        padding-right: 5rem;
+        padding-left: 5rem
+      }
+    }
+  `)
+})
+
 test.only('setting all options at once', () => {
   const { components } = processPlugins(
     [container()],


### PR DESCRIPTION
Briefly mentioned via Twitter about this: https://twitter.com/OwenMelbz/status/1232404123041107975

This expands the ability of the padding option on the container plugin.

Before you had to option to set a global padding on the container via

```js
theme: {
  container: {
    padding: '2rem',
  },
},
```

This allows you the option to provide an object of screen names which represent breakpoints and allows a different padding per breakpoint instead e.g.

```js
theme: {
  container: {
    padding: {
      default: '1rem',
      sm: '2rem',
      lg: '4rem',
      xl: '5rem',
    },
  },
},
```

----

A side note around this, I'm not massively familiar with creating tailwind/postcss plugins so I appreciate that the way the logic has been written may not be what you'd consider as "best" for Tailwind, I may have even recreated the wheel for certain functionality - so more than happy for it to be refactored into a more satisfactory style.

Thanks!