### PR TITLE
Add keep-all utility

### DIFF
--- a/src/plugins/wordBreak.js
+++ b/src/plugins/wordBreak.js
@@ -8,7 +8,7 @@ export default function() {
         },
         '.break-words': { 'overflow-wrap': 'break-word' },
         '.break-all': { 'word-break': 'break-all' },
-
+        '.keep-all': { 'word-break': 'keep-all' },
         '.truncate': {
           overflow: 'hidden',
           'text-overflow': 'ellipsis',


### PR DESCRIPTION
This is necessary for CJK languages when you're doing stuff like x-axis overflow and horizontal scrolling. Text will start to collapse and go vertical without this property.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
