### PR TITLE
[Tooling] Add the getConfig function to the postcss plugin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,12 +67,18 @@ const plugin = postcss.plugin('tailwind', config => {
   if (!_.isUndefined(resolvedConfigPath)) {
     plugins.push(registerConfigAsDependency(resolvedConfigPath))
   }
+  
+  const getConfig = getConfigFunction(resolvedConfigPath || config)
 
-  return postcss([
+  const plugin = postcss([
     ...plugins,
-    processTailwindFeatures(getConfigFunction(resolvedConfigPath || config)),
+    processTailwindFeatures(getConfig),
     formatCSS,
   ])
+  
+  plugin.getConfig = getConfig
+  
+  return plugin
 })
 
 module.exports = plugin


### PR DESCRIPTION
Hi,

I'm currently working on a utility to generate constants and Typescript types definition from tailwind (for usage with classnames, ensure classes are known, and without special ide plugins).

<img width="816" alt="Screenshot 2020-04-11 at 13 27 56" src="https://user-images.githubusercontent.com/11351322/79065435-90951880-7cb0-11ea-80b3-ad45f3d385bc.png">

It works pretty well, but I would like to have access to the actual tailwind config instead of assuming it's the default one.

For that, I need to access the real config object parsed by the postcss plugin.
In index.js you construct this object, wrap it in a function, and pass it to postcss. The problem is we can't access that function from anywhere outside.

This PR adds the getConfig function to the plugin, so we can get it from postcss.

```js
const { plugins } = postcssrc.sync()
const tailwindPlugin = plugins.find(pathEq(['postcss', 'postcssPlugin'], 'tailwind'))
const config = tailwindPlugin.postcss.getConfig()
```

This is for special and tooling purpose, so it doesn't change anything to the tailwind behavior, is not a breaking change, and should be merged without problem.

If you're ok with that, I can add a test to ensure the config is present.

Thanks for you're work.