### PR TITLE
Add group-focus variant

### DIFF
--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -264,6 +264,51 @@ test('group-hover variants respect any configured prefix', () => {
   })
 })
 
+test('it can generate group-focus variants', () => {
+  const input = `
+    @variants group-focus {
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+    }
+  `
+
+  const output = `
+    .banana { color: yellow; }
+    .chocolate { color: brown; }
+    .group:focus .group-focus\\:banana { color: yellow; }
+    .group:focus .group-focus\\:chocolate { color: brown; }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('group-focus variants respect any configured prefix', () => {
+  const input = `
+    @variants group-focus {
+      .tw-banana { color: yellow; }
+      .tw-chocolate { color: brown; }
+    }
+  `
+
+  const output = `
+    .tw-banana { color: yellow; }
+    .tw-chocolate { color: brown; }
+    .tw-group:focus .group-focus\\:tw-banana { color: yellow; }
+    .tw-group:focus .group-focus\\:tw-chocolate { color: brown; }
+  `
+
+  return run(input, {
+    ...config,
+    prefix: 'tw-',
+  }).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('it can generate hover, active and focus variants', () => {
   const input = `
     @variants group-hover, hover, focus, active {

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -36,6 +36,19 @@ const defaultVariantGenerators = config => ({
       }).processSync(selector)
     })
   }),
+  'group-focus': generateVariantFunction(({ modifySelectors, separator }) => {
+    return modifySelectors(({ selector }) => {
+      return selectorParser(selectors => {
+        selectors.walkClasses(sel => {
+          sel.value = `group-focus${separator}${sel.value}`
+          sel.parent.insertBefore(
+            sel,
+            selectorParser().astSync(prefixSelector(config.prefix, '.group:focus '))
+          )
+        })
+      }).processSync(selector)
+    })
+  }),
   hover: generatePseudoClassVariant('hover'),
   'focus-within': generatePseudoClassVariant('focus-within'),
   focus: generatePseudoClassVariant('focus'),


### PR DESCRIPTION
This PR adds support for a new `group-focus` variant that works just like `group-hover`, except for focus.

This is useful when you want to add custom focus style to a button or link that has some nested child you want to style in a specific way, for example, changing the color of an icon inside of a button when the button is focused:

```html
<button class="group text-gray-600 focus:bg-gray-100 focus:text-gray-700 ...">
  <svg class="h-6 w-6 text-gray-400 group-focus:text-gray-500 ...">
    <!-- ... -->
  </svg>
  Submit
</button>
```

This variant is currently not enabled by default for any utilities, but can be enabled in the `variants` section of your config file.