### PR TITLE
Support reverse order for space and divide utilities

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -607,195 +607,307 @@ video {
 }
 
 .space-y-0 > :not(template) ~ :not(template) {
-  margin-top: 0 !important;
+  --space-y-reverse: 0 !important;
+  margin-top: calc(0 * calc(1 - var(--space-y-reverse))) !important;
+  margin-bottom: calc(0 * var(--space-y-reverse)) !important;
 }
 
 .space-x-0 > :not(template) ~ :not(template) {
-  margin-left: 0 !important;
+  --space-x-reverse: 0 !important;
+  margin-right: calc(0 * var(--space-y-reverse)) !important;
+  margin-left: calc(0 * calc(1 - var(--space-y-reverse))) !important;
 }
 
 .space-y-1 > :not(template) ~ :not(template) {
-  margin-top: 0.25rem !important;
+  --space-y-reverse: 0 !important;
+  margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse))) !important;
+  margin-bottom: calc(0.25rem * var(--space-y-reverse)) !important;
 }
 
 .space-x-1 > :not(template) ~ :not(template) {
-  margin-left: 0.25rem !important;
+  --space-x-reverse: 0 !important;
+  margin-right: calc(0.25rem * var(--space-y-reverse)) !important;
+  margin-left: calc(0.25rem * calc(1 - var(--space-y-reverse))) !important;
 }
 
 .space-y-2 > :not(template) ~ :not(template) {
-  margin-top: 0.5rem !important;
+  --space-y-reverse: 0 !important;
+  margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse))) !important;
+  margin-bottom: calc(0.5rem * var(--space-y-reverse)) !important;
 }
 
 .space-x-2 > :not(template) ~ :not(template) {
-  margin-left: 0.5rem !important;
+  --space-x-reverse: 0 !important;
+  margin-right: calc(0.5rem * var(--space-y-reverse)) !important;
+  margin-left: calc(0.5rem * calc(1 - var(--space-y-reverse))) !important;
 }
 
 .space-y-3 > :not(template) ~ :not(template) {
-  margin-top: 0.75rem !important;
+  --space-y-reverse: 0 !important;
+  margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse))) !important;
+  margin-bottom: calc(0.75rem * var(--space-y-reverse)) !important;
 }
 
 .space-x-3 > :not(template) ~ :not(template) {
-  margin-left: 0.75rem !important;
+  --space-x-reverse: 0 !important;
+  margin-right: calc(0.75rem * var(--space-y-reverse)) !important;
+  margin-left: calc(0.75rem * calc(1 - var(--space-y-reverse))) !important;
 }
 
 .space-y-4 > :not(template) ~ :not(template) {
-  margin-top: 1rem !important;
+  --space-y-reverse: 0 !important;
+  margin-top: calc(1rem * calc(1 - var(--space-y-reverse))) !important;
+  margin-bottom: calc(1rem * var(--space-y-reverse)) !important;
 }
 
 .space-x-4 > :not(template) ~ :not(template) {
-  margin-left: 1rem !important;
+  --space-x-reverse: 0 !important;
+  margin-right: calc(1rem * var(--space-y-reverse)) !important;
+  margin-left: calc(1rem * calc(1 - var(--space-y-reverse))) !important;
 }
 
 .space-y-5 > :not(template) ~ :not(template) {
-  margin-top: 1.25rem !important;
+  --space-y-reverse: 0 !important;
+  margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse))) !important;
+  margin-bottom: calc(1.25rem * var(--space-y-reverse)) !important;
 }
 
 .space-x-5 > :not(template) ~ :not(template) {
-  margin-left: 1.25rem !important;
+  --space-x-reverse: 0 !important;
+  margin-right: calc(1.25rem * var(--space-y-reverse)) !important;
+  margin-left: calc(1.25rem * calc(1 - var(--space-y-reverse))) !important;
 }
 
 .space-y-6 > :not(template) ~ :not(template) {
-  margin-top: 1.5rem !important;
+  --space-y-reverse: 0 !important;
+  margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse))) !important;
+  margin-bottom: calc(1.5rem * var(--space-y-reverse)) !important;
 }
 
 .space-x-6 > :not(template) ~ :not(template) {
-  margin-left: 1.5rem !important;
+  --space-x-reverse: 0 !important;
+  margin-right: calc(1.5rem * var(--space-y-reverse)) !important;
+  margin-left: calc(1.5rem * calc(1 - var(--space-y-reverse))) !important;
 }
 
 .space-y-8 > :not(template) ~ :not(template) {
-  margin-top: 2rem !important;
+  --space-y-reverse: 0 !important;
+  margin-top: calc(2rem * calc(1 - var(--space-y-reverse))) !important;
+  margin-bottom: calc(2rem * var(--space-y-reverse)) !important;
 }
 
 .space-x-8 > :not(template) ~ :not(template) {
-  margin-left: 2rem !important;
+  --space-x-reverse: 0 !important;
+  margin-right: calc(2rem * var(--space-y-reverse)) !important;
+  margin-left: calc(2rem * calc(1 - var(--space-y-reverse))) !important;
 }
 
 .space-y-10 > :not(template) ~ :not(template) {
-  margin-top: 2.5rem !important;
+  --space-y-reverse: 0 !important;
+  margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse))) !important;
+  margin-bottom: calc(2.5rem * var(--space-y-reverse)) !important;
 }
 
 .space-x-10 > :not(template) ~ :not(template) {
-  margin-left: 2.5rem !important;
+  --space-x-reverse: 0 !important;
+  margin-right: calc(2.5rem * var(--space-y-reverse)) !important;
+  margin-left: calc(2.5rem * calc(1 - var(--space-y-reverse))) !important;
 }
 
 .space-y-12 > :not(template) ~ :not(template) {
-  margin-top: 3rem !important;
+  --space-y-reverse: 0 !important;
+  margin-top: calc(3rem * calc(1 - var(--space-y-reverse))) !important;
+  margin-bottom: calc(3rem * var(--space-y-reverse)) !important;
 }
 
 .space-x-12 > :not(template) ~ :not(template) {
-  margin-left: 3rem !important;
+  --space-x-reverse: 0 !important;
+  margin-right: calc(3rem * var(--space-y-reverse)) !important;
+  margin-left: calc(3rem * calc(1 - var(--space-y-reverse))) !important;
 }
 
 .space-y-16 > :not(template) ~ :not(template) {
-  margin-top: 4rem !important;
+  --space-y-reverse: 0 !important;
+  margin-top: calc(4rem * calc(1 - var(--space-y-reverse))) !important;
+  margin-bottom: calc(4rem * var(--space-y-reverse)) !important;
 }
 
 .space-x-16 > :not(template) ~ :not(template) {
-  margin-left: 4rem !important;
+  --space-x-reverse: 0 !important;
+  margin-right: calc(4rem * var(--space-y-reverse)) !important;
+  margin-left: calc(4rem * calc(1 - var(--space-y-reverse))) !important;
 }
 
 .space-y-20 > :not(template) ~ :not(template) {
-  margin-top: 5rem !important;
+  --space-y-reverse: 0 !important;
+  margin-top: calc(5rem * calc(1 - var(--space-y-reverse))) !important;
+  margin-bottom: calc(5rem * var(--space-y-reverse)) !important;
 }
 
 .space-x-20 > :not(template) ~ :not(template) {
-  margin-left: 5rem !important;
+  --space-x-reverse: 0 !important;
+  margin-right: calc(5rem * var(--space-y-reverse)) !important;
+  margin-left: calc(5rem * calc(1 - var(--space-y-reverse))) !important;
 }
 
 .space-y-24 > :not(template) ~ :not(template) {
-  margin-top: 6rem !important;
+  --space-y-reverse: 0 !important;
+  margin-top: calc(6rem * calc(1 - var(--space-y-reverse))) !important;
+  margin-bottom: calc(6rem * var(--space-y-reverse)) !important;
 }
 
 .space-x-24 > :not(template) ~ :not(template) {
-  margin-left: 6rem !important;
+  --space-x-reverse: 0 !important;
+  margin-right: calc(6rem * var(--space-y-reverse)) !important;
+  margin-left: calc(6rem * calc(1 - var(--space-y-reverse))) !important;
 }
 
 .space-y-32 > :not(template) ~ :not(template) {
-  margin-top: 8rem !important;
+  --space-y-reverse: 0 !important;
+  margin-top: calc(8rem * calc(1 - var(--space-y-reverse))) !important;
+  margin-bottom: calc(8rem * var(--space-y-reverse)) !important;
 }
 
 .space-x-32 > :not(template) ~ :not(template) {
-  margin-left: 8rem !important;
+  --space-x-reverse: 0 !important;
+  margin-right: calc(8rem * var(--space-y-reverse)) !important;
+  margin-left: calc(8rem * calc(1 - var(--space-y-reverse))) !important;
 }
 
 .space-y-40 > :not(template) ~ :not(template) {
-  margin-top: 10rem !important;
+  --space-y-reverse: 0 !important;
+  margin-top: calc(10rem * calc(1 - var(--space-y-reverse))) !important;
+  margin-bottom: calc(10rem * var(--space-y-reverse)) !important;
 }
 
 .space-x-40 > :not(template) ~ :not(template) {
-  margin-left: 10rem !important;
+  --space-x-reverse: 0 !important;
+  margin-right: calc(10rem * var(--space-y-reverse)) !important;
+  margin-left: calc(10rem * calc(1 - var(--space-y-reverse))) !important;
 }
 
 .space-y-48 > :not(template) ~ :not(template) {
-  margin-top: 12rem !important;
+  --space-y-reverse: 0 !important;
+  margin-top: calc(12rem * calc(1 - var(--space-y-reverse))) !important;
+  margin-bottom: calc(12rem * var(--space-y-reverse)) !important;
 }
 
 .space-x-48 > :not(template) ~ :not(template) {
-  margin-left: 12rem !important;
+  --space-x-reverse: 0 !important;
+  margin-right: calc(12rem * var(--space-y-reverse)) !important;
+  margin-left: calc(12rem * calc(1 - var(--space-y-reverse))) !important;
 }
 
 .space-y-56 > :not(template) ~ :not(template) {
-  margin-top: 14rem !important;
+  --space-y-reverse: 0 !important;
+  margin-top: calc(14rem * calc(1 - var(--space-y-reverse))) !important;
+  margin-bottom: calc(14rem * var(--space-y-reverse)) !important;
 }
 
 .space-x-56 > :not(template) ~ :not(template) {
-  margin-left: 14rem !important;
+  --space-x-reverse: 0 !important;
+  margin-right: calc(14rem * var(--space-y-reverse)) !important;
+  margin-left: calc(14rem * calc(1 - var(--space-y-reverse))) !important;
 }
 
 .space-y-64 > :not(template) ~ :not(template) {
-  margin-top: 16rem !important;
+  --space-y-reverse: 0 !important;
+  margin-top: calc(16rem * calc(1 - var(--space-y-reverse))) !important;
+  margin-bottom: calc(16rem * var(--space-y-reverse)) !important;
 }
 
 .space-x-64 > :not(template) ~ :not(template) {
-  margin-left: 16rem !important;
+  --space-x-reverse: 0 !important;
+  margin-right: calc(16rem * var(--space-y-reverse)) !important;
+  margin-left: calc(16rem * calc(1 - var(--space-y-reverse))) !important;
 }
 
 .space-y-px > :not(template) ~ :not(template) {
-  margin-top: 1px !important;
+  --space-y-reverse: 0 !important;
+  margin-top: calc(1px * calc(1 - var(--space-y-reverse))) !important;
+  margin-bottom: calc(1px * var(--space-y-reverse)) !important;
 }
 
 .space-x-px > :not(template) ~ :not(template) {
-  margin-left: 1px !important;
+  --space-x-reverse: 0 !important;
+  margin-right: calc(1px * var(--space-y-reverse)) !important;
+  margin-left: calc(1px * calc(1 - var(--space-y-reverse))) !important;
+}
+
+.space-y-reverse > :not(template) ~ :not(template) {
+  --space-y-reverse: 1 !important;
+}
+
+.space-x-reverse > :not(template) ~ :not(template) {
+  --space-x-reverse: 1 !important;
 }
 
 .divide-y-0 > :not(template) ~ :not(template) {
-  border-top-width: 0 !important;
+  --divide-y-reverse: 0 !important;
+  border-top: calc(0 * calc(1 - var(--divide-y-reverse))) !important;
+  border-bottom: calc(0 * var(--divide-y-reverse)) !important;
 }
 
 .divide-x-0 > :not(template) ~ :not(template) {
-  border-left-width: 0 !important;
+  --divide-x-reverse: 0 !important;
+  border-right: calc(0 * var(--divide-y-reverse)) !important;
+  border-left: calc(0 * calc(1 - var(--divide-y-reverse))) !important;
 }
 
 .divide-y-2 > :not(template) ~ :not(template) {
-  border-top-width: 2px !important;
+  --divide-y-reverse: 0 !important;
+  border-top: calc(2px * calc(1 - var(--divide-y-reverse))) !important;
+  border-bottom: calc(2px * var(--divide-y-reverse)) !important;
 }
 
 .divide-x-2 > :not(template) ~ :not(template) {
-  border-left-width: 2px !important;
+  --divide-x-reverse: 0 !important;
+  border-right: calc(2px * var(--divide-y-reverse)) !important;
+  border-left: calc(2px * calc(1 - var(--divide-y-reverse))) !important;
 }
 
 .divide-y-4 > :not(template) ~ :not(template) {
-  border-top-width: 4px !important;
+  --divide-y-reverse: 0 !important;
+  border-top: calc(4px * calc(1 - var(--divide-y-reverse))) !important;
+  border-bottom: calc(4px * var(--divide-y-reverse)) !important;
 }
 
 .divide-x-4 > :not(template) ~ :not(template) {
-  border-left-width: 4px !important;
+  --divide-x-reverse: 0 !important;
+  border-right: calc(4px * var(--divide-y-reverse)) !important;
+  border-left: calc(4px * calc(1 - var(--divide-y-reverse))) !important;
 }
 
 .divide-y-8 > :not(template) ~ :not(template) {
-  border-top-width: 8px !important;
+  --divide-y-reverse: 0 !important;
+  border-top: calc(8px * calc(1 - var(--divide-y-reverse))) !important;
+  border-bottom: calc(8px * var(--divide-y-reverse)) !important;
 }
 
 .divide-x-8 > :not(template) ~ :not(template) {
-  border-left-width: 8px !important;
+  --divide-x-reverse: 0 !important;
+  border-right: calc(8px * var(--divide-y-reverse)) !important;
+  border-left: calc(8px * calc(1 - var(--divide-y-reverse))) !important;
 }
 
 .divide-y > :not(template) ~ :not(template) {
-  border-top-width: 1px !important;
+  --divide-y-reverse: 0 !important;
+  border-top: calc(1px * calc(1 - var(--divide-y-reverse))) !important;
+  border-bottom: calc(1px * var(--divide-y-reverse)) !important;
 }
 
 .divide-x > :not(template) ~ :not(template) {
-  border-left-width: 1px !important;
+  --divide-x-reverse: 0 !important;
+  border-right: calc(1px * var(--divide-y-reverse)) !important;
+  border-left: calc(1px * calc(1 - var(--divide-y-reverse))) !important;
+}
+
+.divide-y-reverse > :not(template) ~ :not(template) {
+  --divide-y-reverse: 1 !important;
+}
+
+.divide-x-reverse > :not(template) ~ :not(template) {
+  --divide-x-reverse: 1 !important;
 }
 
 .divide-transparent > :not(template) ~ :not(template) {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -607,195 +607,307 @@ video {
 }
 
 .space-y-0 > :not(template) ~ :not(template) {
-  margin-top: 0;
+  --space-y-reverse: 0;
+  margin-top: calc(0 * calc(1 - var(--space-y-reverse)));
+  margin-bottom: calc(0 * var(--space-y-reverse));
 }
 
 .space-x-0 > :not(template) ~ :not(template) {
-  margin-left: 0;
+  --space-x-reverse: 0;
+  margin-right: calc(0 * var(--space-y-reverse));
+  margin-left: calc(0 * calc(1 - var(--space-y-reverse)));
 }
 
 .space-y-1 > :not(template) ~ :not(template) {
-  margin-top: 0.25rem;
+  --space-y-reverse: 0;
+  margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse)));
+  margin-bottom: calc(0.25rem * var(--space-y-reverse));
 }
 
 .space-x-1 > :not(template) ~ :not(template) {
-  margin-left: 0.25rem;
+  --space-x-reverse: 0;
+  margin-right: calc(0.25rem * var(--space-y-reverse));
+  margin-left: calc(0.25rem * calc(1 - var(--space-y-reverse)));
 }
 
 .space-y-2 > :not(template) ~ :not(template) {
-  margin-top: 0.5rem;
+  --space-y-reverse: 0;
+  margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse)));
+  margin-bottom: calc(0.5rem * var(--space-y-reverse));
 }
 
 .space-x-2 > :not(template) ~ :not(template) {
-  margin-left: 0.5rem;
+  --space-x-reverse: 0;
+  margin-right: calc(0.5rem * var(--space-y-reverse));
+  margin-left: calc(0.5rem * calc(1 - var(--space-y-reverse)));
 }
 
 .space-y-3 > :not(template) ~ :not(template) {
-  margin-top: 0.75rem;
+  --space-y-reverse: 0;
+  margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse)));
+  margin-bottom: calc(0.75rem * var(--space-y-reverse));
 }
 
 .space-x-3 > :not(template) ~ :not(template) {
-  margin-left: 0.75rem;
+  --space-x-reverse: 0;
+  margin-right: calc(0.75rem * var(--space-y-reverse));
+  margin-left: calc(0.75rem * calc(1 - var(--space-y-reverse)));
 }
 
 .space-y-4 > :not(template) ~ :not(template) {
-  margin-top: 1rem;
+  --space-y-reverse: 0;
+  margin-top: calc(1rem * calc(1 - var(--space-y-reverse)));
+  margin-bottom: calc(1rem * var(--space-y-reverse));
 }
 
 .space-x-4 > :not(template) ~ :not(template) {
-  margin-left: 1rem;
+  --space-x-reverse: 0;
+  margin-right: calc(1rem * var(--space-y-reverse));
+  margin-left: calc(1rem * calc(1 - var(--space-y-reverse)));
 }
 
 .space-y-5 > :not(template) ~ :not(template) {
-  margin-top: 1.25rem;
+  --space-y-reverse: 0;
+  margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse)));
+  margin-bottom: calc(1.25rem * var(--space-y-reverse));
 }
 
 .space-x-5 > :not(template) ~ :not(template) {
-  margin-left: 1.25rem;
+  --space-x-reverse: 0;
+  margin-right: calc(1.25rem * var(--space-y-reverse));
+  margin-left: calc(1.25rem * calc(1 - var(--space-y-reverse)));
 }
 
 .space-y-6 > :not(template) ~ :not(template) {
-  margin-top: 1.5rem;
+  --space-y-reverse: 0;
+  margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse)));
+  margin-bottom: calc(1.5rem * var(--space-y-reverse));
 }
 
 .space-x-6 > :not(template) ~ :not(template) {
-  margin-left: 1.5rem;
+  --space-x-reverse: 0;
+  margin-right: calc(1.5rem * var(--space-y-reverse));
+  margin-left: calc(1.5rem * calc(1 - var(--space-y-reverse)));
 }
 
 .space-y-8 > :not(template) ~ :not(template) {
-  margin-top: 2rem;
+  --space-y-reverse: 0;
+  margin-top: calc(2rem * calc(1 - var(--space-y-reverse)));
+  margin-bottom: calc(2rem * var(--space-y-reverse));
 }
 
 .space-x-8 > :not(template) ~ :not(template) {
-  margin-left: 2rem;
+  --space-x-reverse: 0;
+  margin-right: calc(2rem * var(--space-y-reverse));
+  margin-left: calc(2rem * calc(1 - var(--space-y-reverse)));
 }
 
 .space-y-10 > :not(template) ~ :not(template) {
-  margin-top: 2.5rem;
+  --space-y-reverse: 0;
+  margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse)));
+  margin-bottom: calc(2.5rem * var(--space-y-reverse));
 }
 
 .space-x-10 > :not(template) ~ :not(template) {
-  margin-left: 2.5rem;
+  --space-x-reverse: 0;
+  margin-right: calc(2.5rem * var(--space-y-reverse));
+  margin-left: calc(2.5rem * calc(1 - var(--space-y-reverse)));
 }
 
 .space-y-12 > :not(template) ~ :not(template) {
-  margin-top: 3rem;
+  --space-y-reverse: 0;
+  margin-top: calc(3rem * calc(1 - var(--space-y-reverse)));
+  margin-bottom: calc(3rem * var(--space-y-reverse));
 }
 
 .space-x-12 > :not(template) ~ :not(template) {
-  margin-left: 3rem;
+  --space-x-reverse: 0;
+  margin-right: calc(3rem * var(--space-y-reverse));
+  margin-left: calc(3rem * calc(1 - var(--space-y-reverse)));
 }
 
 .space-y-16 > :not(template) ~ :not(template) {
-  margin-top: 4rem;
+  --space-y-reverse: 0;
+  margin-top: calc(4rem * calc(1 - var(--space-y-reverse)));
+  margin-bottom: calc(4rem * var(--space-y-reverse));
 }
 
 .space-x-16 > :not(template) ~ :not(template) {
-  margin-left: 4rem;
+  --space-x-reverse: 0;
+  margin-right: calc(4rem * var(--space-y-reverse));
+  margin-left: calc(4rem * calc(1 - var(--space-y-reverse)));
 }
 
 .space-y-20 > :not(template) ~ :not(template) {
-  margin-top: 5rem;
+  --space-y-reverse: 0;
+  margin-top: calc(5rem * calc(1 - var(--space-y-reverse)));
+  margin-bottom: calc(5rem * var(--space-y-reverse));
 }
 
 .space-x-20 > :not(template) ~ :not(template) {
-  margin-left: 5rem;
+  --space-x-reverse: 0;
+  margin-right: calc(5rem * var(--space-y-reverse));
+  margin-left: calc(5rem * calc(1 - var(--space-y-reverse)));
 }
 
 .space-y-24 > :not(template) ~ :not(template) {
-  margin-top: 6rem;
+  --space-y-reverse: 0;
+  margin-top: calc(6rem * calc(1 - var(--space-y-reverse)));
+  margin-bottom: calc(6rem * var(--space-y-reverse));
 }
 
 .space-x-24 > :not(template) ~ :not(template) {
-  margin-left: 6rem;
+  --space-x-reverse: 0;
+  margin-right: calc(6rem * var(--space-y-reverse));
+  margin-left: calc(6rem * calc(1 - var(--space-y-reverse)));
 }
 
 .space-y-32 > :not(template) ~ :not(template) {
-  margin-top: 8rem;
+  --space-y-reverse: 0;
+  margin-top: calc(8rem * calc(1 - var(--space-y-reverse)));
+  margin-bottom: calc(8rem * var(--space-y-reverse));
 }
 
 .space-x-32 > :not(template) ~ :not(template) {
-  margin-left: 8rem;
+  --space-x-reverse: 0;
+  margin-right: calc(8rem * var(--space-y-reverse));
+  margin-left: calc(8rem * calc(1 - var(--space-y-reverse)));
 }
 
 .space-y-40 > :not(template) ~ :not(template) {
-  margin-top: 10rem;
+  --space-y-reverse: 0;
+  margin-top: calc(10rem * calc(1 - var(--space-y-reverse)));
+  margin-bottom: calc(10rem * var(--space-y-reverse));
 }
 
 .space-x-40 > :not(template) ~ :not(template) {
-  margin-left: 10rem;
+  --space-x-reverse: 0;
+  margin-right: calc(10rem * var(--space-y-reverse));
+  margin-left: calc(10rem * calc(1 - var(--space-y-reverse)));
 }
 
 .space-y-48 > :not(template) ~ :not(template) {
-  margin-top: 12rem;
+  --space-y-reverse: 0;
+  margin-top: calc(12rem * calc(1 - var(--space-y-reverse)));
+  margin-bottom: calc(12rem * var(--space-y-reverse));
 }
 
 .space-x-48 > :not(template) ~ :not(template) {
-  margin-left: 12rem;
+  --space-x-reverse: 0;
+  margin-right: calc(12rem * var(--space-y-reverse));
+  margin-left: calc(12rem * calc(1 - var(--space-y-reverse)));
 }
 
 .space-y-56 > :not(template) ~ :not(template) {
-  margin-top: 14rem;
+  --space-y-reverse: 0;
+  margin-top: calc(14rem * calc(1 - var(--space-y-reverse)));
+  margin-bottom: calc(14rem * var(--space-y-reverse));
 }
 
 .space-x-56 > :not(template) ~ :not(template) {
-  margin-left: 14rem;
+  --space-x-reverse: 0;
+  margin-right: calc(14rem * var(--space-y-reverse));
+  margin-left: calc(14rem * calc(1 - var(--space-y-reverse)));
 }
 
 .space-y-64 > :not(template) ~ :not(template) {
-  margin-top: 16rem;
+  --space-y-reverse: 0;
+  margin-top: calc(16rem * calc(1 - var(--space-y-reverse)));
+  margin-bottom: calc(16rem * var(--space-y-reverse));
 }
 
 .space-x-64 > :not(template) ~ :not(template) {
-  margin-left: 16rem;
+  --space-x-reverse: 0;
+  margin-right: calc(16rem * var(--space-y-reverse));
+  margin-left: calc(16rem * calc(1 - var(--space-y-reverse)));
 }
 
 .space-y-px > :not(template) ~ :not(template) {
-  margin-top: 1px;
+  --space-y-reverse: 0;
+  margin-top: calc(1px * calc(1 - var(--space-y-reverse)));
+  margin-bottom: calc(1px * var(--space-y-reverse));
 }
 
 .space-x-px > :not(template) ~ :not(template) {
-  margin-left: 1px;
+  --space-x-reverse: 0;
+  margin-right: calc(1px * var(--space-y-reverse));
+  margin-left: calc(1px * calc(1 - var(--space-y-reverse)));
+}
+
+.space-y-reverse > :not(template) ~ :not(template) {
+  --space-y-reverse: 1;
+}
+
+.space-x-reverse > :not(template) ~ :not(template) {
+  --space-x-reverse: 1;
 }
 
 .divide-y-0 > :not(template) ~ :not(template) {
-  border-top-width: 0;
+  --divide-y-reverse: 0;
+  border-top: calc(0 * calc(1 - var(--divide-y-reverse)));
+  border-bottom: calc(0 * var(--divide-y-reverse));
 }
 
 .divide-x-0 > :not(template) ~ :not(template) {
-  border-left-width: 0;
+  --divide-x-reverse: 0;
+  border-right: calc(0 * var(--divide-y-reverse));
+  border-left: calc(0 * calc(1 - var(--divide-y-reverse)));
 }
 
 .divide-y-2 > :not(template) ~ :not(template) {
-  border-top-width: 2px;
+  --divide-y-reverse: 0;
+  border-top: calc(2px * calc(1 - var(--divide-y-reverse)));
+  border-bottom: calc(2px * var(--divide-y-reverse));
 }
 
 .divide-x-2 > :not(template) ~ :not(template) {
-  border-left-width: 2px;
+  --divide-x-reverse: 0;
+  border-right: calc(2px * var(--divide-y-reverse));
+  border-left: calc(2px * calc(1 - var(--divide-y-reverse)));
 }
 
 .divide-y-4 > :not(template) ~ :not(template) {
-  border-top-width: 4px;
+  --divide-y-reverse: 0;
+  border-top: calc(4px * calc(1 - var(--divide-y-reverse)));
+  border-bottom: calc(4px * var(--divide-y-reverse));
 }
 
 .divide-x-4 > :not(template) ~ :not(template) {
-  border-left-width: 4px;
+  --divide-x-reverse: 0;
+  border-right: calc(4px * var(--divide-y-reverse));
+  border-left: calc(4px * calc(1 - var(--divide-y-reverse)));
 }
 
 .divide-y-8 > :not(template) ~ :not(template) {
-  border-top-width: 8px;
+  --divide-y-reverse: 0;
+  border-top: calc(8px * calc(1 - var(--divide-y-reverse)));
+  border-bottom: calc(8px * var(--divide-y-reverse));
 }
 
 .divide-x-8 > :not(template) ~ :not(template) {
-  border-left-width: 8px;
+  --divide-x-reverse: 0;
+  border-right: calc(8px * var(--divide-y-reverse));
+  border-left: calc(8px * calc(1 - var(--divide-y-reverse)));
 }
 
 .divide-y > :not(template) ~ :not(template) {
-  border-top-width: 1px;
+  --divide-y-reverse: 0;
+  border-top: calc(1px * calc(1 - var(--divide-y-reverse)));
+  border-bottom: calc(1px * var(--divide-y-reverse));
 }
 
 .divide-x > :not(template) ~ :not(template) {
-  border-left-width: 1px;
+  --divide-x-reverse: 0;
+  border-right: calc(1px * var(--divide-y-reverse));
+  border-left: calc(1px * calc(1 - var(--divide-y-reverse)));
+}
+
+.divide-y-reverse > :not(template) ~ :not(template) {
+  --divide-y-reverse: 1;
+}
+
+.divide-x-reverse > :not(template) ~ :not(template) {
+  --divide-x-reverse: 1;
 }
 
 .divide-transparent > :not(template) ~ :not(template) {

--- a/__tests__/plugins/divideWidth.test.js
+++ b/__tests__/plugins/divideWidth.test.js
@@ -8,7 +8,6 @@ test('generating divide width utilities', () => {
         default: '1px',
         '2': '2px',
         '4': '4px',
-        '8': '8px',
       },
     },
     variants: {
@@ -21,14 +20,42 @@ test('generating divide width utilities', () => {
   expect(utilities).toEqual([
     [
       {
-        '.divide-y-2 > :not(template) ~ :not(template)': { 'border-top-width': '2px' },
-        '.divide-x-2 > :not(template) ~ :not(template)': { 'border-left-width': '2px' },
-        '.divide-y-4 > :not(template) ~ :not(template)': { 'border-top-width': '4px' },
-        '.divide-x-4 > :not(template) ~ :not(template)': { 'border-left-width': '4px' },
-        '.divide-y-8 > :not(template) ~ :not(template)': { 'border-top-width': '8px' },
-        '.divide-x-8 > :not(template) ~ :not(template)': { 'border-left-width': '8px' },
-        '.divide-y > :not(template) ~ :not(template)': { 'border-top-width': '1px' },
-        '.divide-x > :not(template) ~ :not(template)': { 'border-left-width': '1px' },
+        '.divide-y > :not(template) ~ :not(template)': {
+          '--divide-y-reverse': '0',
+          'border-top': 'calc(1px * calc(1 - var(--divide-y-reverse)))',
+          'border-bottom': 'calc(1px * var(--divide-y-reverse))',
+        },
+        '.divide-x > :not(template) ~ :not(template)': {
+          '--divide-x-reverse': '0',
+          'border-right': 'calc(1px * var(--divide-y-reverse))',
+          'border-left': 'calc(1px * calc(1 - var(--divide-y-reverse)))',
+        },
+        '.divide-y-2 > :not(template) ~ :not(template)': {
+          '--divide-y-reverse': '0',
+          'border-top': 'calc(2px * calc(1 - var(--divide-y-reverse)))',
+          'border-bottom': 'calc(2px * var(--divide-y-reverse))',
+        },
+        '.divide-x-2 > :not(template) ~ :not(template)': {
+          '--divide-x-reverse': '0',
+          'border-right': 'calc(2px * var(--divide-y-reverse))',
+          'border-left': 'calc(2px * calc(1 - var(--divide-y-reverse)))',
+        },
+        '.divide-y-4 > :not(template) ~ :not(template)': {
+          '--divide-y-reverse': '0',
+          'border-top': 'calc(4px * calc(1 - var(--divide-y-reverse)))',
+          'border-bottom': 'calc(4px * var(--divide-y-reverse))',
+        },
+        '.divide-x-4 > :not(template) ~ :not(template)': {
+          '--divide-x-reverse': '0',
+          'border-right': 'calc(4px * var(--divide-y-reverse))',
+          'border-left': 'calc(4px * calc(1 - var(--divide-y-reverse)))',
+        },
+        '.divide-y-reverse > :not(template) ~ :not(template)': {
+          '--divide-y-reverse': '1',
+        },
+        '.divide-x-reverse > :not(template) ~ :not(template)': {
+          '--divide-x-reverse': '1',
+        },
       },
       ['responsive'],
     ],

--- a/__tests__/plugins/space.test.js
+++ b/__tests__/plugins/space.test.js
@@ -8,7 +8,6 @@ test('generating space utilities', () => {
         '1': '1px',
         '2': '2px',
         '4': '4px',
-        '8': '8px',
       },
     },
     variants: {
@@ -21,14 +20,42 @@ test('generating space utilities', () => {
   expect(utilities).toEqual([
     [
       {
-        '.space-y-1 > :not(template) ~ :not(template)': { 'margin-top': '1px' },
-        '.space-x-1 > :not(template) ~ :not(template)': { 'margin-left': '1px' },
-        '.space-y-2 > :not(template) ~ :not(template)': { 'margin-top': '2px' },
-        '.space-x-2 > :not(template) ~ :not(template)': { 'margin-left': '2px' },
-        '.space-y-4 > :not(template) ~ :not(template)': { 'margin-top': '4px' },
-        '.space-x-4 > :not(template) ~ :not(template)': { 'margin-left': '4px' },
-        '.space-y-8 > :not(template) ~ :not(template)': { 'margin-top': '8px' },
-        '.space-x-8 > :not(template) ~ :not(template)': { 'margin-left': '8px' },
+        '.space-y-1 > :not(template) ~ :not(template)': {
+          '--space-y-reverse': '0',
+          'margin-top': 'calc(1px * calc(1 - var(--space-y-reverse)))',
+          'margin-bottom': 'calc(1px * var(--space-y-reverse))',
+        },
+        '.space-x-1 > :not(template) ~ :not(template)': {
+          '--space-x-reverse': '0',
+          'margin-right': 'calc(1px * var(--space-y-reverse))',
+          'margin-left': 'calc(1px * calc(1 - var(--space-y-reverse)))',
+        },
+        '.space-y-2 > :not(template) ~ :not(template)': {
+          '--space-y-reverse': '0',
+          'margin-top': 'calc(2px * calc(1 - var(--space-y-reverse)))',
+          'margin-bottom': 'calc(2px * var(--space-y-reverse))',
+        },
+        '.space-x-2 > :not(template) ~ :not(template)': {
+          '--space-x-reverse': '0',
+          'margin-right': 'calc(2px * var(--space-y-reverse))',
+          'margin-left': 'calc(2px * calc(1 - var(--space-y-reverse)))',
+        },
+        '.space-y-4 > :not(template) ~ :not(template)': {
+          '--space-y-reverse': '0',
+          'margin-top': 'calc(4px * calc(1 - var(--space-y-reverse)))',
+          'margin-bottom': 'calc(4px * var(--space-y-reverse))',
+        },
+        '.space-x-4 > :not(template) ~ :not(template)': {
+          '--space-x-reverse': '0',
+          'margin-right': 'calc(4px * var(--space-y-reverse))',
+          'margin-left': 'calc(4px * calc(1 - var(--space-y-reverse)))',
+        },
+        '.space-y-reverse > :not(template) ~ :not(template)': {
+          '--space-y-reverse': '1',
+        },
+        '.space-x-reverse > :not(template) ~ :not(template)': {
+          '--space-x-reverse': '1',
+        },
       },
       ['responsive'],
     ],

--- a/src/plugins/divideWidth.js
+++ b/src/plugins/divideWidth.js
@@ -3,20 +3,34 @@ import _ from 'lodash'
 export default function() {
   return function({ addUtilities, e, theme, variants }) {
     const generators = [
-      (value, modifier) => ({
+      (size, modifier) => ({
         [`.${e(`divide-y${modifier}`)} > :not(template) ~ :not(template)`]: {
-          'border-top-width': `${value}`,
+          '--divide-y-reverse': '0',
+          'border-top': `calc(${size} * calc(1 - var(--divide-y-reverse)))`,
+          'border-bottom': `calc(${size} * var(--divide-y-reverse))`,
         },
         [`.${e(`divide-x${modifier}`)} > :not(template) ~ :not(template)`]: {
-          'border-left-width': `${value}`,
+          '--divide-x-reverse': '0',
+          'border-right': `calc(${size} * var(--divide-y-reverse))`,
+          'border-left': `calc(${size} * calc(1 - var(--divide-y-reverse)))`,
         },
       }),
     ]
 
     const utilities = _.flatMap(generators, generator => {
-      return _.flatMap(theme('divideWidth'), (value, modifier) => {
-        return generator(value, modifier === 'default' ? '' : `-${modifier}`)
-      })
+      return [
+        ..._.flatMap(theme('divideWidth'), (value, modifier) => {
+          return generator(value, modifier === 'default' ? '' : `-${modifier}`)
+        }),
+        {
+          '.divide-y-reverse > :not(template) ~ :not(template)': {
+            '--divide-y-reverse': '1',
+          },
+          '.divide-x-reverse > :not(template) ~ :not(template)': {
+            '--divide-x-reverse': '1',
+          },
+        },
+      ]
     })
 
     addUtilities(utilities, variants('divideWidth'))

--- a/src/plugins/space.js
+++ b/src/plugins/space.js
@@ -5,16 +5,30 @@ export default function() {
     const generators = [
       (size, modifier) => ({
         [`.${e(`space-y-${modifier}`)} > :not(template) ~ :not(template)`]: {
-          'margin-top': `${size}`,
+          '--space-y-reverse': '0',
+          'margin-top': `calc(${size} * calc(1 - var(--space-y-reverse)))`,
+          'margin-bottom': `calc(${size} * var(--space-y-reverse))`,
         },
         [`.${e(`space-x-${modifier}`)} > :not(template) ~ :not(template)`]: {
-          'margin-left': `${size}`,
+          '--space-x-reverse': '0',
+          'margin-right': `calc(${size} * var(--space-y-reverse))`,
+          'margin-left': `calc(${size} * calc(1 - var(--space-y-reverse)))`,
         },
       }),
     ]
 
     const utilities = _.flatMap(generators, generator => {
-      return _.flatMap(theme('space'), generator)
+      return [
+        ..._.flatMap(theme('space'), generator),
+        {
+          '.space-y-reverse > :not(template) ~ :not(template)': {
+            '--space-y-reverse': '1',
+          },
+          '.space-x-reverse > :not(template) ~ :not(template)': {
+            '--space-x-reverse': '1',
+          },
+        },
+      ]
     })
 
     addUtilities(utilities, variants('space'))


### PR DESCRIPTION
This PR uses CSS Custom Properties to add support for reversing the direction of items in a spaced or divided stack.

Prior to this, you'd get margin in the wrong place if you had a simple reversed set of items like this:

```html
<div class="flex flex-row-reverse space-x-4">
  <span>1</span>
  <span>2</span>
  <span>3</span>
</div>
```

...because the `space-x` utilities use `margin-left`, and when reversing the order the margin is added to the wrong side.

This PR adds new `stack-x-reverse`, `stack-y-reverse`, `divide-x-reverse`, and `divide-y-reverse` modifier utilities that you can add to an element to tell it to add the margin or border to the opposite side:

```html
<div class="flex flex-row-reverse space-x-4 space-x-reverse">
  <span>1</span>
  <span>2</span>
  <span>3</span>
</div>
```

This is achieved using custom `--space-x-reverse`, `--space-y-reverse`, `--divide-x-reverse`, and `--divide-y-reverse` variables that are used to essentially perform a logical operation and apply the correct margin/border.

This makes these new features incompatible with IE11, but I'm personally completely fine with that. Using [postcss-custom-properties](https://github.com/postcss/postcss-custom-properties) would at least make the non-reversed versions work, so it's not even that bad really.

### Why not set the variables in `flex-row/col-reverse`?

I considered updating the relevant flex utilities to have them set this variable, but decided against it because then users couldn't opt-in to reversed spacing when combining these features with their own custom CSS that changed the flex-direction. By making it a separate class, you can change the direction of the spacing/borders explicitly, separate from whether you are even using utilities to control the flex direction.

### Why not use a compound selector like `.space-x-reverse.space-x-4 > * + *`?

I decided against this because it increases the specificity of the selector even more, and also increases the number of generated CSS rules.