### PR TITLE
Add export to defaultVariantGenerators

### DIFF
--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -21,7 +21,7 @@ function ensureIncludesDefault(variants) {
   return variants.includes('default') ? variants : ['default', ...variants]
 }
 
-const defaultVariantGenerators = config => ({
+export const defaultVariantGenerators = config => ({
   default: generateVariantFunction(() => {}),
   'group-hover': generateVariantFunction(({ modifySelectors, separator }) => {
     return modifySelectors(({ selector }) => {


### PR DESCRIPTION
Hello, I have been working on creating [utility packages](https://github.com/Arthie/tailwindcss.git) that make integrating tailwind with CSS-in-Js and other tools easier.

In package [@tailwindcssinjs/tailwind-data](https://github.com/Arthie/tailwindcssinjs/tree/master/packages/tailwindcss-data) I currently have to hard code the default variants.
Adding export to defaultVariantGenerators would solve this and make the package not rely on any hardcoded values.

It would be awesome if I didn't have to update my package when tailwind adds a new default variant. This was the only change I needed to make to have my package compatible with all new features of tailwind 1.3.x.