### PR TITLE
Purge integration improvements

### DIFF
--- a/__tests__/purgeUnusedStyles.test.js
+++ b/__tests__/purgeUnusedStyles.test.js
@@ -68,6 +68,51 @@ test('purges unused classes', () => {
     })
 })
 
+test('does not purge components', () => {
+  const OLD_NODE_ENV = process.env.NODE_ENV
+  process.env.NODE_ENV = 'production'
+  const inputPath = path.resolve(`${__dirname}/fixtures/tailwind-input.css`)
+  const input = fs.readFileSync(inputPath, 'utf8')
+
+  return postcss([
+    tailwind({
+      ...config,
+      purge: [path.resolve(`${__dirname}/fixtures/**/*.html`)],
+    }),
+  ])
+    .process(input, { from: inputPath })
+    .then(result => {
+      process.env.NODE_ENV = OLD_NODE_ENV
+
+      expect(result.css).toContain('.container')
+
+      expect(result.css).not.toContain('.bg-red-600')
+      expect(result.css).not.toContain('.w-1\\/3')
+      expect(result.css).not.toContain('.flex')
+      expect(result.css).not.toContain('.font-sans')
+      expect(result.css).not.toContain('.text-right')
+      expect(result.css).not.toContain('.px-4')
+      expect(result.css).not.toContain('.h-full')
+
+      expect(result.css).toContain('.bg-red-500')
+      expect(result.css).toContain('.md\\:bg-blue-300')
+      expect(result.css).toContain('.w-1\\/2')
+      expect(result.css).toContain('.block')
+      expect(result.css).toContain('.md\\:flow-root')
+      expect(result.css).toContain('.h-screen')
+      expect(result.css).toContain('.min-h-\\(screen-4\\)')
+      expect(result.css).toContain('.bg-black\\!')
+      expect(result.css).toContain('.font-\\%\\#\\$\\@')
+      expect(result.css).toContain('.w-\\(1\\/2\\+8\\)')
+      expect(result.css).toContain('.inline-grid')
+      expect(result.css).toContain('.grid-cols-3')
+      expect(result.css).toContain('.px-1\\.5')
+      expect(result.css).toContain('.col-span-2')
+      expect(result.css).toContain('.col-span-1')
+      expect(result.css).toContain('.text-center')
+    })
+})
+
 test('does not purge except in production', () => {
   const OLD_NODE_ENV = process.env.NODE_ENV
   process.env.NODE_ENV = 'development'
@@ -78,6 +123,30 @@ test('does not purge except in production', () => {
     tailwind({
       ...defaultConfig,
       purge: [path.resolve(`${__dirname}/fixtures/**/*.html`)],
+    }),
+  ])
+    .process(input, { from: inputPath })
+    .then(result => {
+      process.env.NODE_ENV = OLD_NODE_ENV
+      const expected = fs.readFileSync(
+        path.resolve(`${__dirname}/fixtures/tailwind-output.css`),
+        'utf8'
+      )
+
+      expect(result.css).toBe(expected)
+    })
+})
+
+test('does not purge if the array is empty', () => {
+  const OLD_NODE_ENV = process.env.NODE_ENV
+  process.env.NODE_ENV = 'production'
+  const inputPath = path.resolve(`${__dirname}/fixtures/tailwind-input.css`)
+  const input = fs.readFileSync(inputPath, 'utf8')
+
+  return postcss([
+    tailwind({
+      ...defaultConfig,
+      purge: [],
     }),
   ])
     .process(input, { from: inputPath })

--- a/src/lib/purgeUnusedStyles.js
+++ b/src/lib/purgeUnusedStyles.js
@@ -28,6 +28,12 @@ export default function purgeUnusedUtilities(config) {
     return removeTailwindComments
   }
 
+  // Skip if `purge: []` since that's part of the default config
+  if (Array.isArray(config.purge) && config.purge.length === 0) {
+    console.log('Skipping purge because no template paths provided...')
+    return removeTailwindComments
+  }
+
   return postcss([
     function(css) {
       const mode = _.get(config, 'purge.mode', 'conservative')
@@ -38,12 +44,10 @@ export default function purgeUnusedUtilities(config) {
 
         css.walkComments(comment => {
           switch (comment.text.trim()) {
-            case 'tailwind start components':
             case 'tailwind start utilities':
             case 'tailwind start screens':
               comment.text = 'purgecss end ignore'
               break
-            case 'tailwind end components':
             case 'tailwind end utilities':
             case 'tailwind end screens':
               comment.text = 'purgecss start ignore'

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -1,4 +1,5 @@
 module.exports = {
+  purge: [],
   prefix: '',
   important: false,
   separator: ':',

--- a/stubs/simpleConfig.stub.js
+++ b/stubs/simpleConfig.stub.js
@@ -1,4 +1,5 @@
 module.exports = {
+  purge: [],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
Few small tweaks:

- Don't purge components by default. Specifically this is because of component classes like `markdown` that target a bunch of nested elements, and if you are actually styling real markdown files, the HTML-rendered version of those markdown files can't be scanned since they don't exist.

    Ultimately this feels like it barely makes a difference in file size — we don't generate variants for components anyways so it's already only a small amount of styles.

- Don't purge if `purge: []`. This is so we can provide that key in the scaffolded config file when you run `tailwindcss init` so that people are more inclined to actually use it, but we don't want to purge all your CSS if you haven't actually provided any paths. We may want to show a more serious warning in the console during production builds that aren't being purged, just so people know they are shipping a development build to production.

