### PR TITLE
Fix `purgeEnabled` evaluating to true when `config.purge.enabled` is false

### DIFF
--- a/__tests__/purgeUnusedStyles.test.js
+++ b/__tests__/purgeUnusedStyles.test.js
@@ -149,6 +149,30 @@ test('does not purge if the array is empty', () => {
     })
 })
 
+test('does not purge if explicitly disabled', () => {
+  const OLD_NODE_ENV = process.env.NODE_ENV
+  process.env.NODE_ENV = 'production'
+  const inputPath = path.resolve(`${__dirname}/fixtures/tailwind-input.css`)
+  const input = fs.readFileSync(inputPath, 'utf8')
+
+  return postcss([
+    tailwind({
+      ...defaultConfig,
+      purge: { enabled: false },
+    }),
+  ])
+    .process(input, { from: inputPath })
+    .then(result => {
+      process.env.NODE_ENV = OLD_NODE_ENV
+      const expected = fs.readFileSync(
+        path.resolve(`${__dirname}/fixtures/tailwind-output.css`),
+        'utf8'
+      )
+
+      expect(result.css).toBe(expected)
+    })
+})
+
 test('purges outside of production if explicitly enabled', () => {
   const OLD_NODE_ENV = process.env.NODE_ENV
   process.env.NODE_ENV = 'development'

--- a/src/lib/purgeUnusedStyles.js
+++ b/src/lib/purgeUnusedStyles.js
@@ -20,9 +20,7 @@ function removeTailwindComments(css) {
 }
 
 export default function purgeUnusedUtilities(config) {
-  const purgeEnabled =
-    _.get(config, 'purge.enabled', false) === true ||
-    (config.purge !== undefined && process.env.NODE_ENV === 'production')
+  const purgeEnabled = _.get(config, 'purge.enabled', config.purge !== undefined && process.env.NODE_ENV === 'production')
 
   if (!purgeEnabled) {
     return removeTailwindComments

--- a/src/lib/purgeUnusedStyles.js
+++ b/src/lib/purgeUnusedStyles.js
@@ -20,7 +20,11 @@ function removeTailwindComments(css) {
 }
 
 export default function purgeUnusedUtilities(config) {
-  const purgeEnabled = _.get(config, 'purge.enabled', config.purge !== undefined && process.env.NODE_ENV === 'production')
+  const purgeEnabled = _.get(
+    config,
+    'purge.enabled',
+    config.purge !== undefined && process.env.NODE_ENV === 'production'
+  )
 
   if (!purgeEnabled) {
     return removeTailwindComments


### PR DESCRIPTION
Hi!

This is a quick bugfix regarding the new `config.purge` options, basically the following:
```javascript
const purgeEnabled =
  _.get(config, 'purge.enabled', false) === true ||
  (config.purge !== undefined && process.env.NODE_ENV === 'production')
```
Evaluate to `true` even when the purge option is explicitely disabled in the config like that:
```javascript
module.exports = {
  purge: {
    enabled: false
  }
  /* ... */
}
```
The first test evaluates to false so only the value of the `or` condition is taken into account but this one evaluate to true when in production regardless of the `config.purge.enabled` value, this pull request fix that.

To give more context over how I came across that I was annoyed by my build spamming `Skipping purge because no template paths provided...` because my `config.purge` was undefined and fallbacking to Tailwind default config value (an empty array), so I decided to explicitly disable the purge option the way above but then my build started failing. So I dug a bit and found that. I would like to also propose to change Tailwind default purge config to the one above in order to omit the warning when no purge config is set by default, but that's open to discussion.

Cheers~!