### PR TITLE
Extend text-decoration capabilities

### DIFF
--- a/__tests__/fixtures/tailwind-output-ie11.css
+++ b/__tests__/fixtures/tailwind-output-ie11.css
@@ -9590,8 +9590,28 @@ video {
   text-decoration: underline;
 }
 
+.overline {
+  text-decoration: overline;
+}
+
 .line-through {
   text-decoration: line-through;
+}
+
+.underline.overline {
+  text-decoration: underline overline;
+}
+
+.underline.line-through {
+  text-decoration: underline line-through;
+}
+
+.overline.line-through {
+  text-decoration: overline line-through;
+}
+
+.underline.overline.line-through {
+  text-decoration: underline overline line-through;
 }
 
 .no-underline {
@@ -9602,8 +9622,28 @@ video {
   text-decoration: underline;
 }
 
+.hover\:overline:hover {
+  text-decoration: overline;
+}
+
 .hover\:line-through:hover {
   text-decoration: line-through;
+}
+
+.hover\:underline:hover.hover\:overline:hover {
+  text-decoration: underline overline;
+}
+
+.hover\:underline:hover.hover\:line-through:hover {
+  text-decoration: underline line-through;
+}
+
+.hover\:overline:hover.hover\:line-through:hover {
+  text-decoration: overline line-through;
+}
+
+.hover\:underline:hover.hover\:overline:hover.hover\:line-through:hover {
+  text-decoration: underline overline line-through;
 }
 
 .hover\:no-underline:hover {
@@ -9614,8 +9654,28 @@ video {
   text-decoration: underline;
 }
 
+.focus\:overline:focus {
+  text-decoration: overline;
+}
+
 .focus\:line-through:focus {
   text-decoration: line-through;
+}
+
+.focus\:underline:focus.focus\:overline:focus {
+  text-decoration: underline overline;
+}
+
+.focus\:underline:focus.focus\:line-through:focus {
+  text-decoration: underline line-through;
+}
+
+.focus\:overline:focus.focus\:line-through:focus {
+  text-decoration: overline line-through;
+}
+
+.focus\:underline:focus.focus\:overline:focus.focus\:line-through:focus {
+  text-decoration: underline overline line-through;
 }
 
 .focus\:no-underline:focus {
@@ -20693,8 +20753,28 @@ video {
     text-decoration: underline;
   }
 
+  .sm\:overline {
+    text-decoration: overline;
+  }
+
   .sm\:line-through {
     text-decoration: line-through;
+  }
+
+  .underline.sm\:overline {
+    text-decoration: underline overline;
+  }
+
+  .underline.sm\:line-through {
+    text-decoration: underline line-through;
+  }
+
+  .overline.sm\:line-through {
+    text-decoration: overline line-through;
+  }
+
+  .underline.overline.sm\:line-through {
+    text-decoration: underline overline line-through;
   }
 
   .sm\:no-underline {
@@ -20705,8 +20785,28 @@ video {
     text-decoration: underline;
   }
 
+  .sm\:hover\:overline:hover {
+    text-decoration: overline;
+  }
+
   .sm\:hover\:line-through:hover {
     text-decoration: line-through;
+  }
+
+  .hover\:underline:hover.sm\:hover\:overline:hover {
+    text-decoration: underline overline;
+  }
+
+  .hover\:underline:hover.sm\:hover\:line-through:hover {
+    text-decoration: underline line-through;
+  }
+
+  .hover\:overline:hover.sm\:hover\:line-through:hover {
+    text-decoration: overline line-through;
+  }
+
+  .hover\:underline:hover.hover\:overline:hover.sm\:hover\:line-through:hover {
+    text-decoration: underline overline line-through;
   }
 
   .sm\:hover\:no-underline:hover {
@@ -20717,8 +20817,28 @@ video {
     text-decoration: underline;
   }
 
+  .sm\:focus\:overline:focus {
+    text-decoration: overline;
+  }
+
   .sm\:focus\:line-through:focus {
     text-decoration: line-through;
+  }
+
+  .focus\:underline:focus.sm\:focus\:overline:focus {
+    text-decoration: underline overline;
+  }
+
+  .focus\:underline:focus.sm\:focus\:line-through:focus {
+    text-decoration: underline line-through;
+  }
+
+  .focus\:overline:focus.sm\:focus\:line-through:focus {
+    text-decoration: overline line-through;
+  }
+
+  .focus\:underline:focus.focus\:overline:focus.sm\:focus\:line-through:focus {
+    text-decoration: underline overline line-through;
   }
 
   .sm\:focus\:no-underline:focus {
@@ -31797,8 +31917,28 @@ video {
     text-decoration: underline;
   }
 
+  .md\:overline {
+    text-decoration: overline;
+  }
+
   .md\:line-through {
     text-decoration: line-through;
+  }
+
+  .underline.md\:overline {
+    text-decoration: underline overline;
+  }
+
+  .underline.md\:line-through {
+    text-decoration: underline line-through;
+  }
+
+  .overline.md\:line-through {
+    text-decoration: overline line-through;
+  }
+
+  .underline.overline.md\:line-through {
+    text-decoration: underline overline line-through;
   }
 
   .md\:no-underline {
@@ -31809,8 +31949,28 @@ video {
     text-decoration: underline;
   }
 
+  .md\:hover\:overline:hover {
+    text-decoration: overline;
+  }
+
   .md\:hover\:line-through:hover {
     text-decoration: line-through;
+  }
+
+  .hover\:underline:hover.md\:hover\:overline:hover {
+    text-decoration: underline overline;
+  }
+
+  .hover\:underline:hover.md\:hover\:line-through:hover {
+    text-decoration: underline line-through;
+  }
+
+  .hover\:overline:hover.md\:hover\:line-through:hover {
+    text-decoration: overline line-through;
+  }
+
+  .hover\:underline:hover.hover\:overline:hover.md\:hover\:line-through:hover {
+    text-decoration: underline overline line-through;
   }
 
   .md\:hover\:no-underline:hover {
@@ -31821,8 +31981,28 @@ video {
     text-decoration: underline;
   }
 
+  .md\:focus\:overline:focus {
+    text-decoration: overline;
+  }
+
   .md\:focus\:line-through:focus {
     text-decoration: line-through;
+  }
+
+  .focus\:underline:focus.md\:focus\:overline:focus {
+    text-decoration: underline overline;
+  }
+
+  .focus\:underline:focus.md\:focus\:line-through:focus {
+    text-decoration: underline line-through;
+  }
+
+  .focus\:overline:focus.md\:focus\:line-through:focus {
+    text-decoration: overline line-through;
+  }
+
+  .focus\:underline:focus.focus\:overline:focus.md\:focus\:line-through:focus {
+    text-decoration: underline overline line-through;
   }
 
   .md\:focus\:no-underline:focus {
@@ -42901,8 +43081,28 @@ video {
     text-decoration: underline;
   }
 
+  .lg\:overline {
+    text-decoration: overline;
+  }
+
   .lg\:line-through {
     text-decoration: line-through;
+  }
+
+  .underline.lg\:overline {
+    text-decoration: underline overline;
+  }
+
+  .underline.lg\:line-through {
+    text-decoration: underline line-through;
+  }
+
+  .overline.lg\:line-through {
+    text-decoration: overline line-through;
+  }
+
+  .underline.overline.lg\:line-through {
+    text-decoration: underline overline line-through;
   }
 
   .lg\:no-underline {
@@ -42913,8 +43113,28 @@ video {
     text-decoration: underline;
   }
 
+  .lg\:hover\:overline:hover {
+    text-decoration: overline;
+  }
+
   .lg\:hover\:line-through:hover {
     text-decoration: line-through;
+  }
+
+  .hover\:underline:hover.lg\:hover\:overline:hover {
+    text-decoration: underline overline;
+  }
+
+  .hover\:underline:hover.lg\:hover\:line-through:hover {
+    text-decoration: underline line-through;
+  }
+
+  .hover\:overline:hover.lg\:hover\:line-through:hover {
+    text-decoration: overline line-through;
+  }
+
+  .hover\:underline:hover.hover\:overline:hover.lg\:hover\:line-through:hover {
+    text-decoration: underline overline line-through;
   }
 
   .lg\:hover\:no-underline:hover {
@@ -42925,8 +43145,28 @@ video {
     text-decoration: underline;
   }
 
+  .lg\:focus\:overline:focus {
+    text-decoration: overline;
+  }
+
   .lg\:focus\:line-through:focus {
     text-decoration: line-through;
+  }
+
+  .focus\:underline:focus.lg\:focus\:overline:focus {
+    text-decoration: underline overline;
+  }
+
+  .focus\:underline:focus.lg\:focus\:line-through:focus {
+    text-decoration: underline line-through;
+  }
+
+  .focus\:overline:focus.lg\:focus\:line-through:focus {
+    text-decoration: overline line-through;
+  }
+
+  .focus\:underline:focus.focus\:overline:focus.lg\:focus\:line-through:focus {
+    text-decoration: underline overline line-through;
   }
 
   .lg\:focus\:no-underline:focus {
@@ -54005,8 +54245,28 @@ video {
     text-decoration: underline;
   }
 
+  .xl\:overline {
+    text-decoration: overline;
+  }
+
   .xl\:line-through {
     text-decoration: line-through;
+  }
+
+  .underline.xl\:overline {
+    text-decoration: underline overline;
+  }
+
+  .underline.xl\:line-through {
+    text-decoration: underline line-through;
+  }
+
+  .overline.xl\:line-through {
+    text-decoration: overline line-through;
+  }
+
+  .underline.overline.xl\:line-through {
+    text-decoration: underline overline line-through;
   }
 
   .xl\:no-underline {
@@ -54017,8 +54277,28 @@ video {
     text-decoration: underline;
   }
 
+  .xl\:hover\:overline:hover {
+    text-decoration: overline;
+  }
+
   .xl\:hover\:line-through:hover {
     text-decoration: line-through;
+  }
+
+  .hover\:underline:hover.xl\:hover\:overline:hover {
+    text-decoration: underline overline;
+  }
+
+  .hover\:underline:hover.xl\:hover\:line-through:hover {
+    text-decoration: underline line-through;
+  }
+
+  .hover\:overline:hover.xl\:hover\:line-through:hover {
+    text-decoration: overline line-through;
+  }
+
+  .hover\:underline:hover.hover\:overline:hover.xl\:hover\:line-through:hover {
+    text-decoration: underline overline line-through;
   }
 
   .xl\:hover\:no-underline:hover {
@@ -54029,8 +54309,28 @@ video {
     text-decoration: underline;
   }
 
+  .xl\:focus\:overline:focus {
+    text-decoration: overline;
+  }
+
   .xl\:focus\:line-through:focus {
     text-decoration: line-through;
+  }
+
+  .focus\:underline:focus.xl\:focus\:overline:focus {
+    text-decoration: underline overline;
+  }
+
+  .focus\:underline:focus.xl\:focus\:line-through:focus {
+    text-decoration: underline line-through;
+  }
+
+  .focus\:overline:focus.xl\:focus\:line-through:focus {
+    text-decoration: overline line-through;
+  }
+
+  .focus\:underline:focus.focus\:overline:focus.xl\:focus\:line-through:focus {
+    text-decoration: underline overline line-through;
   }
 
   .xl\:focus\:no-underline:focus {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -11542,8 +11542,28 @@ video {
   text-decoration: underline !important;
 }
 
+.overline {
+  text-decoration: overline !important;
+}
+
 .line-through {
   text-decoration: line-through !important;
+}
+
+.underline.overline {
+  text-decoration: underline overline !important;
+}
+
+.underline.line-through {
+  text-decoration: underline line-through !important;
+}
+
+.overline.line-through {
+  text-decoration: overline line-through !important;
+}
+
+.underline.overline.line-through {
+  text-decoration: underline overline line-through !important;
 }
 
 .no-underline {
@@ -11554,8 +11574,28 @@ video {
   text-decoration: underline !important;
 }
 
+.hover\:overline:hover {
+  text-decoration: overline !important;
+}
+
 .hover\:line-through:hover {
   text-decoration: line-through !important;
+}
+
+.hover\:underline:hover.hover\:overline:hover {
+  text-decoration: underline overline !important;
+}
+
+.hover\:underline:hover.hover\:line-through:hover {
+  text-decoration: underline line-through !important;
+}
+
+.hover\:overline:hover.hover\:line-through:hover {
+  text-decoration: overline line-through !important;
+}
+
+.hover\:underline:hover.hover\:overline:hover.hover\:line-through:hover {
+  text-decoration: underline overline line-through !important;
 }
 
 .hover\:no-underline:hover {
@@ -11566,8 +11606,28 @@ video {
   text-decoration: underline !important;
 }
 
+.focus\:overline:focus {
+  text-decoration: overline !important;
+}
+
 .focus\:line-through:focus {
   text-decoration: line-through !important;
+}
+
+.focus\:underline:focus.focus\:overline:focus {
+  text-decoration: underline overline !important;
+}
+
+.focus\:underline:focus.focus\:line-through:focus {
+  text-decoration: underline line-through !important;
+}
+
+.focus\:overline:focus.focus\:line-through:focus {
+  text-decoration: overline line-through !important;
+}
+
+.focus\:underline:focus.focus\:overline:focus.focus\:line-through:focus {
+  text-decoration: underline overline line-through !important;
 }
 
 .focus\:no-underline:focus {
@@ -25279,8 +25339,28 @@ video {
     text-decoration: underline !important;
   }
 
+  .sm\:overline {
+    text-decoration: overline !important;
+  }
+
   .sm\:line-through {
     text-decoration: line-through !important;
+  }
+
+  .underline.sm\:overline {
+    text-decoration: underline overline !important;
+  }
+
+  .underline.sm\:line-through {
+    text-decoration: underline line-through !important;
+  }
+
+  .overline.sm\:line-through {
+    text-decoration: overline line-through !important;
+  }
+
+  .underline.overline.sm\:line-through {
+    text-decoration: underline overline line-through !important;
   }
 
   .sm\:no-underline {
@@ -25291,8 +25371,28 @@ video {
     text-decoration: underline !important;
   }
 
+  .sm\:hover\:overline:hover {
+    text-decoration: overline !important;
+  }
+
   .sm\:hover\:line-through:hover {
     text-decoration: line-through !important;
+  }
+
+  .hover\:underline:hover.sm\:hover\:overline:hover {
+    text-decoration: underline overline !important;
+  }
+
+  .hover\:underline:hover.sm\:hover\:line-through:hover {
+    text-decoration: underline line-through !important;
+  }
+
+  .hover\:overline:hover.sm\:hover\:line-through:hover {
+    text-decoration: overline line-through !important;
+  }
+
+  .hover\:underline:hover.hover\:overline:hover.sm\:hover\:line-through:hover {
+    text-decoration: underline overline line-through !important;
   }
 
   .sm\:hover\:no-underline:hover {
@@ -25303,8 +25403,28 @@ video {
     text-decoration: underline !important;
   }
 
+  .sm\:focus\:overline:focus {
+    text-decoration: overline !important;
+  }
+
   .sm\:focus\:line-through:focus {
     text-decoration: line-through !important;
+  }
+
+  .focus\:underline:focus.sm\:focus\:overline:focus {
+    text-decoration: underline overline !important;
+  }
+
+  .focus\:underline:focus.sm\:focus\:line-through:focus {
+    text-decoration: underline line-through !important;
+  }
+
+  .focus\:overline:focus.sm\:focus\:line-through:focus {
+    text-decoration: overline line-through !important;
+  }
+
+  .focus\:underline:focus.focus\:overline:focus.sm\:focus\:line-through:focus {
+    text-decoration: underline overline line-through !important;
   }
 
   .sm\:focus\:no-underline:focus {
@@ -39017,8 +39137,28 @@ video {
     text-decoration: underline !important;
   }
 
+  .md\:overline {
+    text-decoration: overline !important;
+  }
+
   .md\:line-through {
     text-decoration: line-through !important;
+  }
+
+  .underline.md\:overline {
+    text-decoration: underline overline !important;
+  }
+
+  .underline.md\:line-through {
+    text-decoration: underline line-through !important;
+  }
+
+  .overline.md\:line-through {
+    text-decoration: overline line-through !important;
+  }
+
+  .underline.overline.md\:line-through {
+    text-decoration: underline overline line-through !important;
   }
 
   .md\:no-underline {
@@ -39029,8 +39169,28 @@ video {
     text-decoration: underline !important;
   }
 
+  .md\:hover\:overline:hover {
+    text-decoration: overline !important;
+  }
+
   .md\:hover\:line-through:hover {
     text-decoration: line-through !important;
+  }
+
+  .hover\:underline:hover.md\:hover\:overline:hover {
+    text-decoration: underline overline !important;
+  }
+
+  .hover\:underline:hover.md\:hover\:line-through:hover {
+    text-decoration: underline line-through !important;
+  }
+
+  .hover\:overline:hover.md\:hover\:line-through:hover {
+    text-decoration: overline line-through !important;
+  }
+
+  .hover\:underline:hover.hover\:overline:hover.md\:hover\:line-through:hover {
+    text-decoration: underline overline line-through !important;
   }
 
   .md\:hover\:no-underline:hover {
@@ -39041,8 +39201,28 @@ video {
     text-decoration: underline !important;
   }
 
+  .md\:focus\:overline:focus {
+    text-decoration: overline !important;
+  }
+
   .md\:focus\:line-through:focus {
     text-decoration: line-through !important;
+  }
+
+  .focus\:underline:focus.md\:focus\:overline:focus {
+    text-decoration: underline overline !important;
+  }
+
+  .focus\:underline:focus.md\:focus\:line-through:focus {
+    text-decoration: underline line-through !important;
+  }
+
+  .focus\:overline:focus.md\:focus\:line-through:focus {
+    text-decoration: overline line-through !important;
+  }
+
+  .focus\:underline:focus.focus\:overline:focus.md\:focus\:line-through:focus {
+    text-decoration: underline overline line-through !important;
   }
 
   .md\:focus\:no-underline:focus {
@@ -52755,8 +52935,28 @@ video {
     text-decoration: underline !important;
   }
 
+  .lg\:overline {
+    text-decoration: overline !important;
+  }
+
   .lg\:line-through {
     text-decoration: line-through !important;
+  }
+
+  .underline.lg\:overline {
+    text-decoration: underline overline !important;
+  }
+
+  .underline.lg\:line-through {
+    text-decoration: underline line-through !important;
+  }
+
+  .overline.lg\:line-through {
+    text-decoration: overline line-through !important;
+  }
+
+  .underline.overline.lg\:line-through {
+    text-decoration: underline overline line-through !important;
   }
 
   .lg\:no-underline {
@@ -52767,8 +52967,28 @@ video {
     text-decoration: underline !important;
   }
 
+  .lg\:hover\:overline:hover {
+    text-decoration: overline !important;
+  }
+
   .lg\:hover\:line-through:hover {
     text-decoration: line-through !important;
+  }
+
+  .hover\:underline:hover.lg\:hover\:overline:hover {
+    text-decoration: underline overline !important;
+  }
+
+  .hover\:underline:hover.lg\:hover\:line-through:hover {
+    text-decoration: underline line-through !important;
+  }
+
+  .hover\:overline:hover.lg\:hover\:line-through:hover {
+    text-decoration: overline line-through !important;
+  }
+
+  .hover\:underline:hover.hover\:overline:hover.lg\:hover\:line-through:hover {
+    text-decoration: underline overline line-through !important;
   }
 
   .lg\:hover\:no-underline:hover {
@@ -52779,8 +52999,28 @@ video {
     text-decoration: underline !important;
   }
 
+  .lg\:focus\:overline:focus {
+    text-decoration: overline !important;
+  }
+
   .lg\:focus\:line-through:focus {
     text-decoration: line-through !important;
+  }
+
+  .focus\:underline:focus.lg\:focus\:overline:focus {
+    text-decoration: underline overline !important;
+  }
+
+  .focus\:underline:focus.lg\:focus\:line-through:focus {
+    text-decoration: underline line-through !important;
+  }
+
+  .focus\:overline:focus.lg\:focus\:line-through:focus {
+    text-decoration: overline line-through !important;
+  }
+
+  .focus\:underline:focus.focus\:overline:focus.lg\:focus\:line-through:focus {
+    text-decoration: underline overline line-through !important;
   }
 
   .lg\:focus\:no-underline:focus {
@@ -66493,8 +66733,28 @@ video {
     text-decoration: underline !important;
   }
 
+  .xl\:overline {
+    text-decoration: overline !important;
+  }
+
   .xl\:line-through {
     text-decoration: line-through !important;
+  }
+
+  .underline.xl\:overline {
+    text-decoration: underline overline !important;
+  }
+
+  .underline.xl\:line-through {
+    text-decoration: underline line-through !important;
+  }
+
+  .overline.xl\:line-through {
+    text-decoration: overline line-through !important;
+  }
+
+  .underline.overline.xl\:line-through {
+    text-decoration: underline overline line-through !important;
   }
 
   .xl\:no-underline {
@@ -66505,8 +66765,28 @@ video {
     text-decoration: underline !important;
   }
 
+  .xl\:hover\:overline:hover {
+    text-decoration: overline !important;
+  }
+
   .xl\:hover\:line-through:hover {
     text-decoration: line-through !important;
+  }
+
+  .hover\:underline:hover.xl\:hover\:overline:hover {
+    text-decoration: underline overline !important;
+  }
+
+  .hover\:underline:hover.xl\:hover\:line-through:hover {
+    text-decoration: underline line-through !important;
+  }
+
+  .hover\:overline:hover.xl\:hover\:line-through:hover {
+    text-decoration: overline line-through !important;
+  }
+
+  .hover\:underline:hover.hover\:overline:hover.xl\:hover\:line-through:hover {
+    text-decoration: underline overline line-through !important;
   }
 
   .xl\:hover\:no-underline:hover {
@@ -66517,8 +66797,28 @@ video {
     text-decoration: underline !important;
   }
 
+  .xl\:focus\:overline:focus {
+    text-decoration: overline !important;
+  }
+
   .xl\:focus\:line-through:focus {
     text-decoration: line-through !important;
+  }
+
+  .focus\:underline:focus.xl\:focus\:overline:focus {
+    text-decoration: underline overline !important;
+  }
+
+  .focus\:underline:focus.xl\:focus\:line-through:focus {
+    text-decoration: underline line-through !important;
+  }
+
+  .focus\:overline:focus.xl\:focus\:line-through:focus {
+    text-decoration: overline line-through !important;
+  }
+
+  .focus\:underline:focus.focus\:overline:focus.xl\:focus\:line-through:focus {
+    text-decoration: underline overline line-through !important;
   }
 
   .xl\:focus\:no-underline:focus {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -11542,8 +11542,28 @@ video {
   text-decoration: underline;
 }
 
+.overline {
+  text-decoration: overline;
+}
+
 .line-through {
   text-decoration: line-through;
+}
+
+.underline.overline {
+  text-decoration: underline overline;
+}
+
+.underline.line-through {
+  text-decoration: underline line-through;
+}
+
+.overline.line-through {
+  text-decoration: overline line-through;
+}
+
+.underline.overline.line-through {
+  text-decoration: underline overline line-through;
 }
 
 .no-underline {
@@ -11554,8 +11574,28 @@ video {
   text-decoration: underline;
 }
 
+.hover\:overline:hover {
+  text-decoration: overline;
+}
+
 .hover\:line-through:hover {
   text-decoration: line-through;
+}
+
+.hover\:underline:hover.hover\:overline:hover {
+  text-decoration: underline overline;
+}
+
+.hover\:underline:hover.hover\:line-through:hover {
+  text-decoration: underline line-through;
+}
+
+.hover\:overline:hover.hover\:line-through:hover {
+  text-decoration: overline line-through;
+}
+
+.hover\:underline:hover.hover\:overline:hover.hover\:line-through:hover {
+  text-decoration: underline overline line-through;
 }
 
 .hover\:no-underline:hover {
@@ -11566,8 +11606,28 @@ video {
   text-decoration: underline;
 }
 
+.focus\:overline:focus {
+  text-decoration: overline;
+}
+
 .focus\:line-through:focus {
   text-decoration: line-through;
+}
+
+.focus\:underline:focus.focus\:overline:focus {
+  text-decoration: underline overline;
+}
+
+.focus\:underline:focus.focus\:line-through:focus {
+  text-decoration: underline line-through;
+}
+
+.focus\:overline:focus.focus\:line-through:focus {
+  text-decoration: overline line-through;
+}
+
+.focus\:underline:focus.focus\:overline:focus.focus\:line-through:focus {
+  text-decoration: underline overline line-through;
 }
 
 .focus\:no-underline:focus {
@@ -25279,8 +25339,28 @@ video {
     text-decoration: underline;
   }
 
+  .sm\:overline {
+    text-decoration: overline;
+  }
+
   .sm\:line-through {
     text-decoration: line-through;
+  }
+
+  .underline.sm\:overline {
+    text-decoration: underline overline;
+  }
+
+  .underline.sm\:line-through {
+    text-decoration: underline line-through;
+  }
+
+  .overline.sm\:line-through {
+    text-decoration: overline line-through;
+  }
+
+  .underline.overline.sm\:line-through {
+    text-decoration: underline overline line-through;
   }
 
   .sm\:no-underline {
@@ -25291,8 +25371,28 @@ video {
     text-decoration: underline;
   }
 
+  .sm\:hover\:overline:hover {
+    text-decoration: overline;
+  }
+
   .sm\:hover\:line-through:hover {
     text-decoration: line-through;
+  }
+
+  .hover\:underline:hover.sm\:hover\:overline:hover {
+    text-decoration: underline overline;
+  }
+
+  .hover\:underline:hover.sm\:hover\:line-through:hover {
+    text-decoration: underline line-through;
+  }
+
+  .hover\:overline:hover.sm\:hover\:line-through:hover {
+    text-decoration: overline line-through;
+  }
+
+  .hover\:underline:hover.hover\:overline:hover.sm\:hover\:line-through:hover {
+    text-decoration: underline overline line-through;
   }
 
   .sm\:hover\:no-underline:hover {
@@ -25303,8 +25403,28 @@ video {
     text-decoration: underline;
   }
 
+  .sm\:focus\:overline:focus {
+    text-decoration: overline;
+  }
+
   .sm\:focus\:line-through:focus {
     text-decoration: line-through;
+  }
+
+  .focus\:underline:focus.sm\:focus\:overline:focus {
+    text-decoration: underline overline;
+  }
+
+  .focus\:underline:focus.sm\:focus\:line-through:focus {
+    text-decoration: underline line-through;
+  }
+
+  .focus\:overline:focus.sm\:focus\:line-through:focus {
+    text-decoration: overline line-through;
+  }
+
+  .focus\:underline:focus.focus\:overline:focus.sm\:focus\:line-through:focus {
+    text-decoration: underline overline line-through;
   }
 
   .sm\:focus\:no-underline:focus {
@@ -39017,8 +39137,28 @@ video {
     text-decoration: underline;
   }
 
+  .md\:overline {
+    text-decoration: overline;
+  }
+
   .md\:line-through {
     text-decoration: line-through;
+  }
+
+  .underline.md\:overline {
+    text-decoration: underline overline;
+  }
+
+  .underline.md\:line-through {
+    text-decoration: underline line-through;
+  }
+
+  .overline.md\:line-through {
+    text-decoration: overline line-through;
+  }
+
+  .underline.overline.md\:line-through {
+    text-decoration: underline overline line-through;
   }
 
   .md\:no-underline {
@@ -39029,8 +39169,28 @@ video {
     text-decoration: underline;
   }
 
+  .md\:hover\:overline:hover {
+    text-decoration: overline;
+  }
+
   .md\:hover\:line-through:hover {
     text-decoration: line-through;
+  }
+
+  .hover\:underline:hover.md\:hover\:overline:hover {
+    text-decoration: underline overline;
+  }
+
+  .hover\:underline:hover.md\:hover\:line-through:hover {
+    text-decoration: underline line-through;
+  }
+
+  .hover\:overline:hover.md\:hover\:line-through:hover {
+    text-decoration: overline line-through;
+  }
+
+  .hover\:underline:hover.hover\:overline:hover.md\:hover\:line-through:hover {
+    text-decoration: underline overline line-through;
   }
 
   .md\:hover\:no-underline:hover {
@@ -39041,8 +39201,28 @@ video {
     text-decoration: underline;
   }
 
+  .md\:focus\:overline:focus {
+    text-decoration: overline;
+  }
+
   .md\:focus\:line-through:focus {
     text-decoration: line-through;
+  }
+
+  .focus\:underline:focus.md\:focus\:overline:focus {
+    text-decoration: underline overline;
+  }
+
+  .focus\:underline:focus.md\:focus\:line-through:focus {
+    text-decoration: underline line-through;
+  }
+
+  .focus\:overline:focus.md\:focus\:line-through:focus {
+    text-decoration: overline line-through;
+  }
+
+  .focus\:underline:focus.focus\:overline:focus.md\:focus\:line-through:focus {
+    text-decoration: underline overline line-through;
   }
 
   .md\:focus\:no-underline:focus {
@@ -52755,8 +52935,28 @@ video {
     text-decoration: underline;
   }
 
+  .lg\:overline {
+    text-decoration: overline;
+  }
+
   .lg\:line-through {
     text-decoration: line-through;
+  }
+
+  .underline.lg\:overline {
+    text-decoration: underline overline;
+  }
+
+  .underline.lg\:line-through {
+    text-decoration: underline line-through;
+  }
+
+  .overline.lg\:line-through {
+    text-decoration: overline line-through;
+  }
+
+  .underline.overline.lg\:line-through {
+    text-decoration: underline overline line-through;
   }
 
   .lg\:no-underline {
@@ -52767,8 +52967,28 @@ video {
     text-decoration: underline;
   }
 
+  .lg\:hover\:overline:hover {
+    text-decoration: overline;
+  }
+
   .lg\:hover\:line-through:hover {
     text-decoration: line-through;
+  }
+
+  .hover\:underline:hover.lg\:hover\:overline:hover {
+    text-decoration: underline overline;
+  }
+
+  .hover\:underline:hover.lg\:hover\:line-through:hover {
+    text-decoration: underline line-through;
+  }
+
+  .hover\:overline:hover.lg\:hover\:line-through:hover {
+    text-decoration: overline line-through;
+  }
+
+  .hover\:underline:hover.hover\:overline:hover.lg\:hover\:line-through:hover {
+    text-decoration: underline overline line-through;
   }
 
   .lg\:hover\:no-underline:hover {
@@ -52779,8 +52999,28 @@ video {
     text-decoration: underline;
   }
 
+  .lg\:focus\:overline:focus {
+    text-decoration: overline;
+  }
+
   .lg\:focus\:line-through:focus {
     text-decoration: line-through;
+  }
+
+  .focus\:underline:focus.lg\:focus\:overline:focus {
+    text-decoration: underline overline;
+  }
+
+  .focus\:underline:focus.lg\:focus\:line-through:focus {
+    text-decoration: underline line-through;
+  }
+
+  .focus\:overline:focus.lg\:focus\:line-through:focus {
+    text-decoration: overline line-through;
+  }
+
+  .focus\:underline:focus.focus\:overline:focus.lg\:focus\:line-through:focus {
+    text-decoration: underline overline line-through;
   }
 
   .lg\:focus\:no-underline:focus {
@@ -66493,8 +66733,28 @@ video {
     text-decoration: underline;
   }
 
+  .xl\:overline {
+    text-decoration: overline;
+  }
+
   .xl\:line-through {
     text-decoration: line-through;
+  }
+
+  .underline.xl\:overline {
+    text-decoration: underline overline;
+  }
+
+  .underline.xl\:line-through {
+    text-decoration: underline line-through;
+  }
+
+  .overline.xl\:line-through {
+    text-decoration: overline line-through;
+  }
+
+  .underline.overline.xl\:line-through {
+    text-decoration: underline overline line-through;
   }
 
   .xl\:no-underline {
@@ -66505,8 +66765,28 @@ video {
     text-decoration: underline;
   }
 
+  .xl\:hover\:overline:hover {
+    text-decoration: overline;
+  }
+
   .xl\:hover\:line-through:hover {
     text-decoration: line-through;
+  }
+
+  .hover\:underline:hover.xl\:hover\:overline:hover {
+    text-decoration: underline overline;
+  }
+
+  .hover\:underline:hover.xl\:hover\:line-through:hover {
+    text-decoration: underline line-through;
+  }
+
+  .hover\:overline:hover.xl\:hover\:line-through:hover {
+    text-decoration: overline line-through;
+  }
+
+  .hover\:underline:hover.hover\:overline:hover.xl\:hover\:line-through:hover {
+    text-decoration: underline overline line-through;
   }
 
   .xl\:hover\:no-underline:hover {
@@ -66517,8 +66797,28 @@ video {
     text-decoration: underline;
   }
 
+  .xl\:focus\:overline:focus {
+    text-decoration: overline;
+  }
+
   .xl\:focus\:line-through:focus {
     text-decoration: line-through;
+  }
+
+  .focus\:underline:focus.xl\:focus\:overline:focus {
+    text-decoration: underline overline;
+  }
+
+  .focus\:underline:focus.xl\:focus\:line-through:focus {
+    text-decoration: underline line-through;
+  }
+
+  .focus\:overline:focus.xl\:focus\:line-through:focus {
+    text-decoration: overline line-through;
+  }
+
+  .focus\:underline:focus.focus\:overline:focus.xl\:focus\:line-through:focus {
+    text-decoration: underline overline line-through;
   }
 
   .xl\:focus\:no-underline:focus {

--- a/src/plugins/textDecoration.js
+++ b/src/plugins/textDecoration.js
@@ -3,7 +3,18 @@ export default function() {
     addUtilities(
       {
         '.underline': { 'text-decoration': 'underline' },
+        '.overline': { 'text-decoration': 'overline' },
         '.line-through': { 'text-decoration': 'line-through' },
+        '.underline.overline': { 'text-decoration': 'underline overline' },
+        '.underline.line-through': {
+          'text-decoration': 'underline line-through',
+        },
+        '.overline.line-through': {
+          'text-decoration': 'overline line-through',
+        },
+        '.underline.overline.line-through': {
+          'text-decoration': 'underline overline line-through',
+        },
         '.no-underline': { 'text-decoration': 'none' },
       },
       variants('textDecoration')


### PR DESCRIPTION
I noticed that giving an element both the "underline" and "line-through" class resulted in only a line-through and no underline (due to .line-through being declared lower in the css file and overriding it). I created a small fix for this that allows you to use both classes at once and also added an .overline class for the sake of completeness. This is the HTML code I used to test my changes:
```
<!doctype html>
<html lang="en">
  <head>
    <meta charset="utf-8">
    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
    <link rel="stylesheet" href="tailwind.css">
    <title>Hello, world!</title>
  </head>
  <body>
    <h2 class='underline'>Underline</h2>
    <h2 class='overline'>Overline</h2>
    <h2 class='line-through'>Line-through</h2>
    <h2 class='underline overline'>Underline Overline</h2>
    <h2 class='underline line-through'>Underline Line-through</h2>
    <h2 class='overline line-through'>Overline Line-through</h2>
    <h2 class='underline overline line-through'>Underline Overline Line-through</h2>
    <h2 class='hover:underline hover:overline line-through'>Underline Overline on Hover, Line-Through without Hover</h2>
  </body>
</html>
```
This PR will change the textDecoration.js file, adding combined classes, and the output files in \_\_tests\_\_/fixtures so that the changes don't cause the tests to fail. One test is failing but it seems unrelated and might be a separate issue or maybe even fixed by now, other than that all tests are successful and there are no linting errors.