### PR TITLE
Allow colors to be defined as closures

### DIFF
--- a/__tests__/withAlphaVariable.test.js
+++ b/__tests__/withAlphaVariable.test.js
@@ -99,7 +99,7 @@ test('it ignores colors that already have an alpha channel', () => {
 test('it allows a closure to be passed', () => {
   expect(
     withAlphaVariable({
-      color: variable => `rgba(0, 0, 0, var(${variable}))`,
+      color: ({ opacityVariable }) => `rgba(0, 0, 0, var(${opacityVariable}))`,
       property: 'background-color',
       variable: '--bg-opacity',
     })

--- a/__tests__/withAlphaVariable.test.js
+++ b/__tests__/withAlphaVariable.test.js
@@ -95,3 +95,15 @@ test('it ignores colors that already have an alpha channel', () => {
     'background-color': 'hsla(240, 100%, 50%, 0.5)',
   })
 })
+
+test('it allows a closure to be passed', () => {
+  expect(
+    withAlphaVariable({
+      color: variable => `rgba(0, 0, 0, var(${variable}))`,
+      property: 'background-color',
+      variable: '--bg-opacity',
+    })
+  ).toEqual({
+    'background-color': 'rgba(0, 0, 0, var(--bg-opacity))',
+  })
+})

--- a/src/util/withAlphaVariable.js
+++ b/src/util/withAlphaVariable.js
@@ -21,7 +21,7 @@ function toRgba(color) {
 export default function withAlphaVariable({ color, property, variable }) {
   if (_.isFunction(color)) {
     return {
-      [property]: color(variable),
+      [property]: color({ opacityVariable: variable }),
     }
   }
 

--- a/src/util/withAlphaVariable.js
+++ b/src/util/withAlphaVariable.js
@@ -1,4 +1,5 @@
 import createColor from 'color'
+import _ from 'lodash'
 
 function hasAlpha(color) {
   return (
@@ -18,6 +19,12 @@ function toRgba(color) {
 }
 
 export default function withAlphaVariable({ color, property, variable }) {
+  if (_.isFunction(color)) {
+    return {
+      [property]: color(variable),
+    }
+  }
+
   try {
     const [r, g, b, a] = toRgba(color)
 


### PR DESCRIPTION
This pull request allows colors to be defined using closures. The closure takes an `opacityVariableName` as a parameter, which allows to use the opacity variable's name in the color definition:

```js
// tailwind.config.js
module.exports = {
  theme: {
    colors: {
      primary: variable => `rgba(32, 32, 32, var(${variable}, 1))`,
    },
  },
}
``` 

This allows to take advantage of the new [`opacity` utilities](https://github.com/tailwindcss/tailwindcss/pull/1627). It is especially useful for theming, as seen in the example above. 

This example will generate the following `text` and `background` color utilities (and other ones which I omitted for simplicity's sake):

```css
.bg-primary {
  background-color: rgba(32, 32, 32, var(--bg-opacity, 1));
}

.text-primary {
  color: rgba(32, 32, 32, var(--text-opacity, 1));
}
``` 

This allows us to use any `opacity` utility with our custom `color` implementation:

```html
<div class="bg-primary bg-opacity-50"></div>
``` 

This is actually needed for me to integrate the `opacity` utilities to [`tailwindcss-theming`](https://github.com/hawezo/tailwindcss-theming), but it would benefit anyone who wants to use a custom color implementation using CSS variables.