### PR TITLE
Add corePlugins function to plugin API

### DIFF
--- a/__tests__/processPlugins.test.js
+++ b/__tests__/processPlugins.test.js
@@ -744,6 +744,62 @@ test('plugins apply all global variants when variants are configured globally', 
     `)
 })
 
+test('plugins can check if corePlugins are enabled', () => {
+  const { components, utilities } = processPlugins(
+    [
+      function({ addUtilities, corePlugins }) {
+        addUtilities({
+          '.test': {
+            'text-color': corePlugins('textColor') ? 'true' : 'false',
+            opacity: corePlugins('opacity') ? 'true' : 'false',
+          },
+        })
+      },
+    ],
+    makeConfig({
+      corePlugins: { textColor: false },
+    })
+  )
+
+  expect(components.length).toBe(0)
+  expect(css(utilities)).toMatchCss(`
+    @variants {
+      .test {
+        text-color: false;
+        opacity: true
+      }
+    }
+    `)
+})
+
+test('plugins can check if corePlugins are enabled when using array white-listing', () => {
+  const { components, utilities } = processPlugins(
+    [
+      function({ addUtilities, corePlugins }) {
+        addUtilities({
+          '.test': {
+            'text-color': corePlugins('textColor') ? 'true' : 'false',
+            opacity: corePlugins('opacity') ? 'true' : 'false',
+          },
+        })
+      },
+    ],
+    makeConfig({
+      corePlugins: ['textColor'],
+    })
+  )
+
+  expect(components.length).toBe(0)
+  expect(css(utilities)).toMatchCss(`
+    @variants {
+      .test {
+        text-color: true;
+        opacity: false
+      }
+    }
+    `)
+})
+
 test('plugins can provide fallbacks to keys missing from the config', () => {
   const { components, utilities } = processPlugins(
     [

--- a/src/util/processPlugins.js
+++ b/src/util/processPlugins.js
@@ -41,6 +41,13 @@ export default function(plugins, config) {
       postcss,
       config: getConfigValue,
       theme: (path, defaultValue) => getConfigValue(`theme.${path}`, defaultValue),
+      corePlugins: path => {
+        if (Array.isArray(config.corePlugins)) {
+          return config.corePlugins.includes(path)
+        }
+
+        return getConfigValue(`corePlugins.${path}`, true)
+      },
       variants: (path, defaultValue) => {
         if (Array.isArray(config.variants)) {
           return config.variants


### PR DESCRIPTION
This PR adds a new `corePlugins` function to the plugin API that lets you easily find out if a particular core plugin is enabled.

Concrete example is the `backgroundColor` omitting all of the code it uses to interact with the `backgroundOpacity` plugin if it detects the user has disabled the `backgroundOpacity` plugin:

```js
export default function() {
  return function({ addUtilities, e, theme, variants, target, corePlugins }) {
    const utilities = _.fromPairs(
      _.map(flattenColorPalette(theme('backgroundColor')), (value, modifier) => {
        return [
          `.${e(`bg-${modifier}`)}`,
          corePlugins('backgroundOpacity')
            ? withAlphaVariable({
                color: value,
                property: 'background-color',
                variable: '--bg-opacity',
              })
            : { 'background-color': value },
        ]
      })
    )

    addUtilities(utilities, variants('backgroundColor'))
  }
}
```