### PR TITLE
PurgeCSS | trim NODE_ENV before checking

### DIFF
--- a/src/lib/purgeUnusedStyles.js
+++ b/src/lib/purgeUnusedStyles.js
@@ -26,7 +26,10 @@ export default function purgeUnusedUtilities(config) {
   const purgeEnabled = _.get(
     config,
     'purge.enabled',
-    config.purge !== false && config.purge !== undefined && process.env.NODE_ENV !== undefined && process.env.NODE_ENV.trim() === 'production'
+    config.purge !== false &&
+      config.purge !== undefined &&
+      process.env.NODE_ENV !== undefined &&
+      process.env.NODE_ENV.trim() === 'production'
   )
 
   if (!purgeEnabled) {

--- a/src/lib/purgeUnusedStyles.js
+++ b/src/lib/purgeUnusedStyles.js
@@ -26,7 +26,7 @@ export default function purgeUnusedUtilities(config) {
   const purgeEnabled = _.get(
     config,
     'purge.enabled',
-    config.purge !== false && config.purge !== undefined && process.env.NODE_ENV === 'production'
+    config.purge !== false && config.purge !== undefined && process.env.NODE_ENV !== undefined && process.env.NODE_ENV.trim() === 'production'
   )
 
   if (!purgeEnabled) {


### PR DESCRIPTION
We have the problem that PurgeCSS is disabled even when NODE_ENV is set to production. We are using webpack as a bundler and have a build script in `package.json` which sets the NODE_ENV with `set NODE_ENV=production && webpack`.

When looking at the NODE_ENV during execution of the config the value is "production " with a trailing space. So this Pull Requests trims the NODE_ENV before checking.
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
