### PR TITLE
Improve error message for missing variant

### DIFF
--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -78,6 +78,9 @@ export default function(config, { variantGenerators: pluginVariantGenerators }) 
       }
 
       _.forEach(_.without(ensureIncludesDefault(variants), 'responsive'), variant => {
+        if (!variantGenerators[variant]) {
+          throw new Error(`Your config mentions the "${variant}" variant, but "${variant}" doesn't appear to be a variant. Did you forget or misconfigure a plugin that supplies that variant?`);
+        }
         variantGenerators[variant](atRule, config)
       })
 


### PR DESCRIPTION
If you mistype a variant, or if you misconfigure a plugin that supplies a variant implementation, you'll get a cryptic error:

```
 🚫 TypeError: variantGenerators[variant] is not a function
```

This PR improves the error messaging:

```
🚫 Error: Your config mentions the "group-focus" variant, but "group-focus" doesn't appear to be a variant. Did you forget or misconfigure a plugin that supplies that variant?
```
