### PR TITLE
Refactor color functions

### DIFF
--- a/src/plugins/backgroundColor.js
+++ b/src/plugins/backgroundColor.js
@@ -24,10 +24,7 @@ export default function() {
 
     const utilities = _.fromPairs(
       _.map(colors, (value, modifier) => {
-        return [
-          `.${e(`bg-${modifier}`)}`,
-          getProperties(value),
-        ]
+        return [`.${e(`bg-${modifier}`)}`, getProperties(value)]
       })
     )
 

--- a/src/plugins/backgroundColor.js
+++ b/src/plugins/backgroundColor.js
@@ -9,7 +9,10 @@ export default function() {
     if (target('backgroundColor') === 'ie11') {
       const utilities = _.fromPairs(
         _.map(colors, (value, modifier) => {
-          return [`.${e(`bg-${modifier}`)}`, { 'background-color': value }]
+          return [
+            `.${e(`bg-${modifier}`)}`,
+            { 'background-color': value },
+          ]
         })
       )
 

--- a/src/plugins/backgroundColor.js
+++ b/src/plugins/backgroundColor.js
@@ -6,32 +6,27 @@ export default function() {
   return function({ addUtilities, e, theme, variants, target, corePlugins }) {
     const colors = flattenColorPalette(theme('backgroundColor'))
 
-    if (target('backgroundColor') === 'ie11') {
-      const utilities = _.fromPairs(
-        _.map(colors, (value, modifier) => {
-          return [
-            `.${e(`bg-${modifier}`)}`,
-            { 'background-color': value },
-          ]
+    const getProperties = value => {
+      if (target('backgroundColor') === 'ie11') {
+        return { 'background-color': value }
+      }
+
+      if (corePlugins('backgroundOpacity')) {
+        return withAlphaVariable({
+          color: value,
+          property: 'background-color',
+          variable: '--bg-opacity',
         })
-      )
+      }
 
-      addUtilities(utilities, variants('backgroundColor'))
-
-      return
+      return { 'background-color': value }
     }
 
     const utilities = _.fromPairs(
       _.map(colors, (value, modifier) => {
         return [
           `.${e(`bg-${modifier}`)}`,
-          corePlugins('backgroundOpacity')
-            ? withAlphaVariable({
-                color: value,
-                property: 'background-color',
-                variable: '--bg-opacity',
-              })
-            : { 'background-color': value },
+          getProperties(value),
         ]
       })
     )

--- a/src/plugins/backgroundColor.js
+++ b/src/plugins/backgroundColor.js
@@ -4,9 +4,11 @@ import withAlphaVariable from '../util/withAlphaVariable'
 
 export default function() {
   return function({ addUtilities, e, theme, variants, target, corePlugins }) {
+    const colors = flattenColorPalette(theme('backgroundColor'))
+
     if (target('backgroundColor') === 'ie11') {
       const utilities = _.fromPairs(
-        _.map(flattenColorPalette(theme('backgroundColor')), (value, modifier) => {
+        _.map(colors, (value, modifier) => {
           return [`.${e(`bg-${modifier}`)}`, { 'background-color': value }]
         })
       )
@@ -17,7 +19,7 @@ export default function() {
     }
 
     const utilities = _.fromPairs(
-      _.map(flattenColorPalette(theme('backgroundColor')), (value, modifier) => {
+      _.map(colors, (value, modifier) => {
         return [
           `.${e(`bg-${modifier}`)}`,
           corePlugins('backgroundOpacity')

--- a/src/plugins/borderColor.js
+++ b/src/plugins/borderColor.js
@@ -9,7 +9,10 @@ export default function() {
     if (target('borderColor') === 'ie11') {
       const utilities = _.fromPairs(
         _.map(_.omit(colors, 'default'), (value, modifier) => {
-          return [`.${e(`border-${modifier}`)}`, { 'border-color': value }]
+          return [
+            `.${e(`border-${modifier}`)}`,
+            { 'border-color': value },
+          ]
         })
       )
 

--- a/src/plugins/borderColor.js
+++ b/src/plugins/borderColor.js
@@ -6,32 +6,27 @@ export default function() {
   return function({ addUtilities, e, theme, variants, target, corePlugins }) {
     const colors = flattenColorPalette(theme('borderColor'))
 
-    if (target('borderColor') === 'ie11') {
-      const utilities = _.fromPairs(
-        _.map(_.omit(colors, 'default'), (value, modifier) => {
-          return [
-            `.${e(`border-${modifier}`)}`,
-            { 'border-color': value },
-          ]
+    const getProperties = value => {
+      if (target('borderColor') === 'ie11') {
+        return { 'border-color': value }
+      }
+
+      if (corePlugins('borderOpacity')) {
+        return withAlphaVariable({
+          color: value,
+          property: 'border-color',
+          variable: '--border-opacity',
         })
-      )
+      }
 
-      addUtilities(utilities, variants('borderColor'))
-
-      return
+      return { 'border-color': value }
     }
 
     const utilities = _.fromPairs(
       _.map(_.omit(colors, 'default'), (value, modifier) => {
         return [
           `.${e(`border-${modifier}`)}`,
-          corePlugins('borderOpacity')
-            ? withAlphaVariable({
-                color: value,
-                property: 'border-color',
-                variable: '--border-opacity',
-              })
-            : { 'border-color': value },
+          getProperties(value),
         ]
       })
     )

--- a/src/plugins/borderColor.js
+++ b/src/plugins/borderColor.js
@@ -4,9 +4,9 @@ import withAlphaVariable from '../util/withAlphaVariable'
 
 export default function() {
   return function({ addUtilities, e, theme, variants, target, corePlugins }) {
-    if (target('borderColor') === 'ie11') {
-      const colors = flattenColorPalette(theme('borderColor'))
+    const colors = flattenColorPalette(theme('borderColor'))
 
+    if (target('borderColor') === 'ie11') {
       const utilities = _.fromPairs(
         _.map(_.omit(colors, 'default'), (value, modifier) => {
           return [`.${e(`border-${modifier}`)}`, { 'border-color': value }]
@@ -17,8 +17,6 @@ export default function() {
 
       return
     }
-
-    const colors = flattenColorPalette(theme('borderColor'))
 
     const utilities = _.fromPairs(
       _.map(_.omit(colors, 'default'), (value, modifier) => {

--- a/src/plugins/borderColor.js
+++ b/src/plugins/borderColor.js
@@ -24,10 +24,7 @@ export default function() {
 
     const utilities = _.fromPairs(
       _.map(_.omit(colors, 'default'), (value, modifier) => {
-        return [
-          `.${e(`border-${modifier}`)}`,
-          getProperties(value),
-        ]
+        return [`.${e(`border-${modifier}`)}`, getProperties(value)]
       })
     )
 

--- a/src/plugins/divideColor.js
+++ b/src/plugins/divideColor.js
@@ -6,32 +6,27 @@ export default function() {
   return function({ addUtilities, e, theme, variants, target, corePlugins }) {
     const colors = flattenColorPalette(theme('divideColor'))
 
-    if (target('divideColor') === 'ie11') {
-      const utilities = _.fromPairs(
-        _.map(_.omit(colors, 'default'), (value, modifier) => {
-          return [
-            `.${e(`divide-${modifier}`)} > :not(template) ~ :not(template)`,
-            { 'border-color': value },
-          ]
+    const getProperties = value => {
+      if (target('divideColor') === 'ie11') {
+        return { 'border-color': value }
+      }
+
+      if (corePlugins('divideOpacity')) {
+        return withAlphaVariable({
+          color: value,
+          property: 'border-color',
+          variable: '--divide-opacity',
         })
-      )
+      }
 
-      addUtilities(utilities, variants('divideColor'))
-
-      return
+      return { 'border-color': value }
     }
 
     const utilities = _.fromPairs(
       _.map(_.omit(colors, 'default'), (value, modifier) => {
         return [
           `.${e(`divide-${modifier}`)} > :not(template) ~ :not(template)`,
-          corePlugins('divideOpacity')
-            ? withAlphaVariable({
-                color: value,
-                property: 'border-color',
-                variable: '--divide-opacity',
-              })
-            : { 'border-color': value },
+          getProperties(value),
         ]
       })
     )

--- a/src/plugins/fill.js
+++ b/src/plugins/fill.js
@@ -7,10 +7,7 @@ export default function() {
 
     const utilities = _.fromPairs(
       _.map(colors, (value, modifier) => {
-        return [
-          `.${e(`fill-${modifier}`)}`,
-          { fill: value },
-        ]
+        return [`.${e(`fill-${modifier}`)}`, { fill: value }]
       })
     )
 

--- a/src/plugins/fill.js
+++ b/src/plugins/fill.js
@@ -9,9 +9,7 @@ export default function() {
       _.map(colors, (value, modifier) => {
         return [
           `.${e(`fill-${modifier}`)}`,
-          {
-            fill: value,
-          },
+          { fill: value },
         ]
       })
     )

--- a/src/plugins/fill.js
+++ b/src/plugins/fill.js
@@ -3,8 +3,10 @@ import flattenColorPalette from '../util/flattenColorPalette'
 
 export default function() {
   return function({ addUtilities, e, theme, variants }) {
+    const colors = flattenColorPalette(theme('fill'))
+
     const utilities = _.fromPairs(
-      _.map(flattenColorPalette(theme('fill')), (value, modifier) => {
+      _.map(colors, (value, modifier) => {
         return [
           `.${e(`fill-${modifier}`)}`,
           {

--- a/src/plugins/placeholderColor.js
+++ b/src/plugins/placeholderColor.js
@@ -6,32 +6,27 @@ export default function() {
   return function({ addUtilities, e, theme, variants, target, corePlugins }) {
     const colors = flattenColorPalette(theme('placeholderColor'))
 
-    if (target('placeholderColor') === 'ie11') {
-      const utilities = _.fromPairs(
-        _.map(colors, (value, modifier) => {
-          return [
-            `.${e(`placeholder-${modifier}`)}::placeholder`,
-            { color: value },
-          ]
+    const getProperties = value => {
+      if (target('placeholderColor') === 'ie11') {
+        return { color: value }
+      }
+
+      if (corePlugins('placeholderOpacity')) {
+        return withAlphaVariable({
+          color: value,
+          property: 'color',
+          variable: '--placeholder-opacity',
         })
-      )
+      }
 
-      addUtilities(utilities, variants('placeholderColor'))
-
-      return
+      return { color: value }
     }
 
     const utilities = _.fromPairs(
       _.map(colors, (value, modifier) => {
         return [
           `.${e(`placeholder-${modifier}`)}::placeholder`,
-          corePlugins('placeholderOpacity')
-            ? withAlphaVariable({
-                color: value,
-                property: 'color',
-                variable: '--placeholder-opacity',
-              })
-            : { color: value },
+          getProperties(value),
         ]
       })
     )

--- a/src/plugins/placeholderColor.js
+++ b/src/plugins/placeholderColor.js
@@ -9,7 +9,10 @@ export default function() {
     if (target('placeholderColor') === 'ie11') {
       const utilities = _.fromPairs(
         _.map(colors, (value, modifier) => {
-          return [`.${e(`placeholder-${modifier}`)}::placeholder`, { color: value }]
+          return [
+            `.${e(`placeholder-${modifier}`)}::placeholder`,
+            { color: value },
+          ]
         })
       )
 

--- a/src/plugins/placeholderColor.js
+++ b/src/plugins/placeholderColor.js
@@ -4,9 +4,11 @@ import withAlphaVariable from '../util/withAlphaVariable'
 
 export default function() {
   return function({ addUtilities, e, theme, variants, target, corePlugins }) {
+    const colors = flattenColorPalette(theme('placeholderColor'))
+
     if (target('placeholderColor') === 'ie11') {
       const utilities = _.fromPairs(
-        _.map(flattenColorPalette(theme('placeholderColor')), (value, modifier) => {
+        _.map(colors, (value, modifier) => {
           return [`.${e(`placeholder-${modifier}`)}::placeholder`, { color: value }]
         })
       )
@@ -17,7 +19,7 @@ export default function() {
     }
 
     const utilities = _.fromPairs(
-      _.map(flattenColorPalette(theme('placeholderColor')), (value, modifier) => {
+      _.map(colors, (value, modifier) => {
         return [
           `.${e(`placeholder-${modifier}`)}::placeholder`,
           corePlugins('placeholderOpacity')

--- a/src/plugins/placeholderColor.js
+++ b/src/plugins/placeholderColor.js
@@ -24,10 +24,7 @@ export default function() {
 
     const utilities = _.fromPairs(
       _.map(colors, (value, modifier) => {
-        return [
-          `.${e(`placeholder-${modifier}`)}::placeholder`,
-          getProperties(value),
-        ]
+        return [`.${e(`placeholder-${modifier}`)}::placeholder`, getProperties(value)]
       })
     )
 

--- a/src/plugins/stroke.js
+++ b/src/plugins/stroke.js
@@ -7,10 +7,7 @@ export default function() {
 
     const utilities = _.fromPairs(
       _.map(colors, (value, modifier) => {
-        return [
-          `.${e(`stroke-${modifier}`)}`,
-          { stroke: value },
-        ]
+        return [`.${e(`stroke-${modifier}`)}`, { stroke: value }]
       })
     )
 

--- a/src/plugins/stroke.js
+++ b/src/plugins/stroke.js
@@ -9,9 +9,7 @@ export default function() {
       _.map(colors, (value, modifier) => {
         return [
           `.${e(`stroke-${modifier}`)}`,
-          {
-            stroke: value,
-          },
+          { stroke: value },
         ]
       })
     )

--- a/src/plugins/stroke.js
+++ b/src/plugins/stroke.js
@@ -3,8 +3,10 @@ import flattenColorPalette from '../util/flattenColorPalette'
 
 export default function() {
   return function({ addUtilities, e, theme, variants }) {
+    const colors = flattenColorPalette(theme('stroke'))
+
     const utilities = _.fromPairs(
-      _.map(flattenColorPalette(theme('stroke')), (value, modifier) => {
+      _.map(colors, (value, modifier) => {
         return [
           `.${e(`stroke-${modifier}`)}`,
           {

--- a/src/plugins/textColor.js
+++ b/src/plugins/textColor.js
@@ -9,7 +9,10 @@ export default function() {
     if (target('textColor') === 'ie11') {
       const utilities = _.fromPairs(
         _.map(colors, (value, modifier) => {
-          return [`.${e(`text-${modifier}`)}`, { color: value }]
+          return [
+            `.${e(`text-${modifier}`)}`,
+            { color: value },
+          ]
         })
       )
 

--- a/src/plugins/textColor.js
+++ b/src/plugins/textColor.js
@@ -4,9 +4,11 @@ import withAlphaVariable from '../util/withAlphaVariable'
 
 export default function() {
   return function({ addUtilities, e, theme, variants, target, corePlugins }) {
+    const colors = flattenColorPalette(theme('textColor'))
+
     if (target('textColor') === 'ie11') {
       const utilities = _.fromPairs(
-        _.map(flattenColorPalette(theme('textColor')), (value, modifier) => {
+        _.map(colors, (value, modifier) => {
           return [`.${e(`text-${modifier}`)}`, { color: value }]
         })
       )
@@ -17,7 +19,7 @@ export default function() {
     }
 
     const utilities = _.fromPairs(
-      _.map(flattenColorPalette(theme('textColor')), (value, modifier) => {
+      _.map(colors, (value, modifier) => {
         return [
           `.${e(`text-${modifier}`)}`,
           corePlugins('textOpacity')

--- a/src/plugins/textColor.js
+++ b/src/plugins/textColor.js
@@ -24,10 +24,7 @@ export default function() {
 
     const utilities = _.fromPairs(
       _.map(colors, (value, modifier) => {
-        return [
-          `.${e(`text-${modifier}`)}`,
-          getProperties(value),
-        ]
+        return [`.${e(`text-${modifier}`)}`, getProperties(value)]
       })
     )
 

--- a/src/plugins/textColor.js
+++ b/src/plugins/textColor.js
@@ -26,7 +26,11 @@ export default function() {
         return [
           `.${e(`text-${modifier}`)}`,
           corePlugins('textOpacity')
-            ? withAlphaVariable({ color: value, property: 'color', variable: '--text-opacity' })
+            ? withAlphaVariable({
+                color: value,
+                property: 'color',
+                variable: '--text-opacity',
+              })
             : { color: value },
         ]
       })

--- a/src/plugins/textColor.js
+++ b/src/plugins/textColor.js
@@ -6,32 +6,27 @@ export default function() {
   return function({ addUtilities, e, theme, variants, target, corePlugins }) {
     const colors = flattenColorPalette(theme('textColor'))
 
-    if (target('textColor') === 'ie11') {
-      const utilities = _.fromPairs(
-        _.map(colors, (value, modifier) => {
-          return [
-            `.${e(`text-${modifier}`)}`,
-            { color: value },
-          ]
+    const getProperties = value => {
+      if (target('textColor') === 'ie11') {
+        return { color: value }
+      }
+
+      if (corePlugins('textOpacity')) {
+        return withAlphaVariable({
+          color: value,
+          property: 'color',
+          variable: '--text-opacity',
         })
-      )
+      }
 
-      addUtilities(utilities, variants('textColor'))
-
-      return
+      return { color: value }
     }
 
     const utilities = _.fromPairs(
       _.map(colors, (value, modifier) => {
         return [
           `.${e(`text-${modifier}`)}`,
-          corePlugins('textOpacity')
-            ? withAlphaVariable({
-                color: value,
-                property: 'color',
-                variable: '--text-opacity',
-              })
-            : { color: value },
+          getProperties(value),
         ]
       })
     )


### PR DESCRIPTION
Hi there, this is a small PR to refactor color functions.

### Change list
- Reduce calls of `flattenColorPalette`
- Create `getProperties` to dry `utilities`

