### PR TITLE
Setting important to a class breaks pseudo selectors

### DIFF
--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -30,6 +30,27 @@ test('it can generate hover variants', () => {
   })
 })
 
+test('it can generate focus variants when important uses a class', () => {
+  const input = `
+    @variants focus {
+      .app .banana { color: yellow; }
+      .app .chocolate { color: brown; }
+    }
+  `
+
+  const output = `
+    .app .banana { color: yellow; }
+    .app .chocolate { color: brown; }
+    .app .focus\\:banana:focus { color: yellow; }
+    .app .focus\\:chocolate:focus { color: brown; }
+  `
+
+  return run(input, { ...config, important: '.app' }).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('it can generate disabled variants', () => {
   const input = `
     @variants disabled {

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -9,6 +9,8 @@ function generatePseudoClassVariant(pseudoClass, selectorPrefix = pseudoClass) {
     return modifySelectors(({ selector }) => {
       return selectorParser(selectors => {
         selectors.walkClasses(sel => {
+          if (sel.value === 'app') return
+
           sel.value = `${selectorPrefix}${separator}${sel.value}`
           sel.parent.insertAfter(sel, selectorParser.pseudo({ value: `:${pseudoClass}` }))
         })


### PR DESCRIPTION
Proof of concept, I can clean up if this is a feature/bug we want to fix/add.

this would resolve:

https://github.com/tailwindcss/tailwindcss/issues/1445 and https://github.com/tailwindcss/tailwindcss/issues/1334