### PR TITLE
Update issue templates with new interface

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,6 +6,6 @@ Please only open an issue here if you have a bug to report or a feature proposal
 
 If you need help, have questions about best practices, or want to start a discussion about anything else related to Tailwind, open an issue on the `tailwindcss/discuss` repo instead:
 
-https://github.com/tailwindcss/discuss/issues
+https://github.com/tailwindcss/tailwindcss/discussions
 
 -->

--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,0 +1,60 @@
+---
+name: "\U0001F41B Bug report"
+about: "Bugs, missing documentation, or unexpected behavior "
+title: ""
+labels: ""
+assignees: ""
+---
+
+<!--
+
+* Please fill out this template with all the relevant information so we can
+  understand what's going on and fix the issue. We appreciate bugs filed and PRs
+  submitted!
+
+* Please make sure that you are familiar with and follow the Code of Conduct for
+  this project (found in the CODE_OF_CONDUCT.md file).
+
+-->
+
+- `Tailwind CSS` version:
+- Are you using plugins? List them:
+
+### Relevant code or config:
+
+```html
+<!-- your code here -->
+```
+
+<!--
+If this is an issue with documentation, please file an issue on the docs repo:
+https://github.com/tailwindcss/docs
+-->
+
+### What you did:
+
+<!-- What you were doing -->
+
+### What happened:
+
+<!-- Please provide the full error message/screenshots/anything -->
+
+### Reproduction:
+
+<!--
+If possible, please create a repository that reproduces the issue with the
+minimal amount of code possible
+
+Or if you can, try to reproduce the issue in a Codesandbox or CodePen
+-->
+
+### Problem description:
+
+<!-- Please describe why the current behavior is a problem -->
+
+### Suggested solution:
+
+<!--
+It's ok if you don't have a suggested solution, but it really helps if you could
+do a little digging to come up with some suggestion of how to improve things.
+-->

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -1,0 +1,20 @@
+---
+name: "\U0001F4A1 Feature request"
+about: 'I have a suggestion (and might want to implement myself)! '
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/--need-help-support.md
+++ b/.github/ISSUE_TEMPLATE/--need-help-support.md
@@ -1,0 +1,27 @@
+---
+name: "❓ Need help/support"
+about: Describe this issue template's purpose here.
+title: ""
+labels: ""
+assignees: ""
+---
+
+-------------- 👆 Click "Preview"!
+
+Issues on GitHub are intended to be related to problems with the library itself
+and feature requests so we recommend not using this medium to ask them here 😁.
+
+---
+
+## ❓ Support Forums
+
+💬 Right here in the repo, there is a tab called "Discussions" (it's to the right of "Pull Requests" tab) you can go there using this link https://github.com/tailwindcss/tailwindcss/discussions There you can search for questions or create one.
+
+📚 Ask on [StackOverflow](https://stackoverflow.com/questions/tagged/tailwind-css)
+
+🚀 Join our [Discord community](https://tailwindcss.com/discord)
+
+For questions related to using the library, please visit a support community
+instead of filing an issue on GitHub.
+
+**ISSUES WHICH ARE QUESTIONS WILL BE CLOSED**


### PR DESCRIPTION
closes #1764 

But will also help solving future issues.

It adds 3 new templates

![Screenshot_2020-05-17 estevanmaito library-boilerplate](https://user-images.githubusercontent.com/8527573/82151371-b1add380-9831-11ea-8da5-3cc468551d10.png)

---

## _This is what a Bug Report would look like_

This PR shows `Tailwind CSS version` instead of `library`

![Screenshot_2020-05-17 estevanmaito library-boilerplate(1)](https://user-images.githubusercontent.com/8527573/82151391-df931800-9831-11ea-9a02-b9782fb067a7.png)

---

## _This is what a Feature Request would look like_

![Screenshot_2020-05-17 estevanmaito library-boilerplate(2)](https://user-images.githubusercontent.com/8527573/82151394-e28e0880-9831-11ea-83e2-b518dc543a28.png)

---

## _This is what a Help question would look like_

This is formatted in a way that when the person opens the issue, she is pointed to the preview, where text is better formatted and show community links to solve the questions. This pic was taken on one of my repositories. The proposed layout of this PR also includes a link to the Discord channel and correct links.

![Screenshot_2020-05-17 estevanmaito library-boilerplate(3)](https://user-images.githubusercontent.com/8527573/82151399-e91c8000-9831-11ea-9a55-ab61a273db4c.png)

These templates are almost the same as the ones used by https://github.com/testing-library/react-testing-library with some minor changes.