### PR TITLE
Change default purge config value to be a new object instead of array

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -1,5 +1,5 @@
 module.exports = {
-  purge: [],
+  purge: {},
   target: 'relaxed',
   prefix: '',
   important: false,

--- a/stubs/simpleConfig.stub.js
+++ b/stubs/simpleConfig.stub.js
@@ -1,5 +1,5 @@
 module.exports = {
-  purge: [],
+  purge: {},
   theme: {
     extend: {},
   },


### PR DESCRIPTION
This pull request just changes the default value when creating the tailwind config file in CLI to be a new object instead of array. I saw myself changing it by default in many projects since I think controlling the purge option from there is a more declarative way when working the tailwind. 

It isn't a new feature, just a small modification to the default behaviour.

