### PR TITLE
Add :focus-visible variant

### DIFF
--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -135,6 +135,27 @@ test('it can generate focus-within variants', () => {
   })
 })
 
+test('it can generate focus-visible variants', () => {
+  const input = `
+    @variants focus-visible {
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+    }
+  `
+
+  const output = `
+    .banana { color: yellow; }
+    .chocolate { color: brown; }
+    .focus-visible\\:banana:focus-visible { color: yellow; }
+    .focus-visible\\:chocolate:focus-visible { color: brown; }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('it can generate first-child variants', () => {
   const input = `
     @variants first {
@@ -415,7 +436,7 @@ test('variants are generated in the order specified', () => {
 
 test('the built-in variant pseudo-selectors are appended before any pseudo-elements', () => {
   const input = `
-    @variants hover, focus-within, focus, active, group-hover {
+    @variants hover, focus-within, focus-visible, focus, active, group-hover {
       .placeholder-yellow::placeholder { color: yellow; }
     }
   `
@@ -424,6 +445,7 @@ test('the built-in variant pseudo-selectors are appended before any pseudo-eleme
     .placeholder-yellow::placeholder { color: yellow; }
     .hover\\:placeholder-yellow:hover::placeholder { color: yellow; }
     .focus-within\\:placeholder-yellow:focus-within::placeholder { color: yellow; }
+    .focus-visible\\:placeholder-yellow:focus-visible::placeholder { color: yellow; }
     .focus\\:placeholder-yellow:focus::placeholder { color: yellow; }
     .active\\:placeholder-yellow:active::placeholder { color: yellow; }
     .group:hover .group-hover\\:placeholder-yellow::placeholder { color: yellow; }
@@ -624,7 +646,10 @@ test('plugin variants can wrap rules in another at-rule using the raw PostCSS AP
       ...config.plugins,
       function({ addVariant, e }) {
         addVariant('supports-grid', ({ container, separator }) => {
-          const supportsRule = postcss.atRule({ name: 'supports', params: '(display: grid)' })
+          const supportsRule = postcss.atRule({
+            name: 'supports',
+            params: '(display: grid)',
+          })
           supportsRule.nodes = container.nodes
           container.nodes = [supportsRule]
           supportsRule.walkRules(rule => {

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -51,6 +51,7 @@ const defaultVariantGenerators = config => ({
   }),
   hover: generatePseudoClassVariant('hover'),
   'focus-within': generatePseudoClassVariant('focus-within'),
+  'focus-visible': generatePseudoClassVariant('focus-visible'),
   focus: generatePseudoClassVariant('focus'),
   active: generatePseudoClassVariant('active'),
   visited: generatePseudoClassVariant('visited'),


### PR DESCRIPTION
Closes #1766 

This PR implements the `:focus-visible` variant. It is not enabled by default for any utilities.

## Detail

The `:focus-visible` pseudo-class allows authors to provide clearly identifiable focus styles which are visible when a user is likely to need to understand where focus is, but not visible in other cases.

It is defined in the [Selectors Level 4 specification](https://www.w3.org/TR/selectors-4/#the-focus-visible-pseudo) along with the `:focus-within` variant.

## Documentation

Browser support [is limited](https://caniuse.com/#feat=css-focus-visible), but consumers often use the [postcss-focus-visible](https://github.com/csstools/postcss-focus-visible) plugin along with the [official polyfill](https://github.com/WICG/focus-visible).

If this PR is accepted I will create a follow-on PR for the `docs` repo.
