### PR TITLE
Remove strange class limitation for `important`

### DIFF
--- a/__tests__/processPlugins.test.js
+++ b/__tests__/processPlugins.test.js
@@ -960,7 +960,7 @@ test('when important is a selector it is used to scope utilities instead of addi
     `)
 })
 
-test('when important contains a class an error is thrown', () => {
+test('when important contains a class an error is NOT thrown', () => {
   expect(() => {
     processPlugins(
       [

--- a/__tests__/processPlugins.test.js
+++ b/__tests__/processPlugins.test.js
@@ -976,7 +976,7 @@ test('when important contains a class an error is thrown', () => {
         important: '#app .project',
       })
     )
-  }).toThrow()
+  }).not.toThrow()
 })
 
 test('when important is a selector it scopes all selectors in a rule, even though defining utilities like this is stupid', () => {

--- a/src/util/processPlugins.js
+++ b/src/util/processPlugins.js
@@ -19,14 +19,6 @@ function parseStyles(styles) {
   return _.flatMap(styles, style => (style instanceof Node ? style : parseObjectStyles(style)))
 }
 
-function containsClass(value) {
-  return selectorParser(selectors => {
-    let classFound = false
-    selectors.walkClasses(() => (classFound = true))
-    return classFound
-  }).transformSync(value)
-}
-
 export default function(plugins, config) {
   const pluginBaseStyles = []
   const pluginComponents = []
@@ -95,12 +87,6 @@ export default function(plugins, config) {
             if (config.important === true) {
               rule.walkDecls(decl => (decl.important = true))
             } else if (typeof config.important === 'string') {
-              if (containsClass(config.important)) {
-                throw rule.error(
-                  `Classes are not allowed when using the \`important\` option with a string argument. Please use an ID instead.`
-                )
-              }
-
               rule.selectors = rule.selectors.map(selector => {
                 return increaseSpecificity(config.important, selector)
               })


### PR DESCRIPTION
I don't see why this has to be here considering it's just a CSS selector.

It really is a strange thing.