### PR TITLE
Allows users to use "tailwind build" without requiring an input file

### DIFF
--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -43,9 +43,17 @@ describe('cli', () => {
   })
 
   describe('build', () => {
-    it('compiles CSS file', () => {
+    it('compiles CSS file using an input css file', () => {
       return cli(['build', inputCssPath]).then(() => {
         expect(process.stdout.write.mock.calls[0][0]).toContain('.example')
+      })
+    })
+
+    it('compiles CSS file without an input css file', () => {
+      return cli(['build']).then(() => {
+        expect(process.stdout.write.mock.calls[0][0]).toContain('normalize.css') // base
+        expect(process.stdout.write.mock.calls[0][0]).toContain('.container') // components
+        expect(process.stdout.write.mock.calls[0][0]).toContain('.mx-auto') // utilities
       })
     })
 

--- a/src/cli/commands/build.js
+++ b/src/cli/commands/build.js
@@ -80,7 +80,11 @@ function buildToFile(compileOptions, startTime) {
 
   utils.header()
   utils.log()
-  utils.log(emoji.go, 'Building...', colors.file(inputFileSimplePath || 'defaults: @base, @components and @utilities.'))
+  utils.log(
+    emoji.go,
+    'Building...',
+    colors.file(inputFileSimplePath || 'defaults: @base, @components and @utilities.')
+  )
 
   return compile(compileOptions).then(result => {
     utils.writeFile(compileOptions.outputFile, result.css)

--- a/src/cli/commands/build.js
+++ b/src/cli/commands/build.js
@@ -80,7 +80,7 @@ function buildToFile(compileOptions, startTime) {
 
   utils.header()
   utils.log()
-  utils.log(emoji.go, 'Building...', colors.file(inputFileSimplePath))
+  utils.log(emoji.go, 'Building...', colors.file(inputFileSimplePath || 'defaults: @base, @components and @utilities.'))
 
   return compile(compileOptions).then(result => {
     utils.writeFile(compileOptions.outputFile, result.css)
@@ -112,8 +112,9 @@ export function run(cliParams, cliOptions) {
     const inputFileSimplePath = utils.getSimplePath(inputFile)
     const configFileSimplePath = utils.getSimplePath(configFile)
 
-    !inputFile && stopWithHelp('CSS file is required.')
-    !utils.exists(inputFile) && stop(colors.file(inputFileSimplePath), 'does not exist.')
+    if (inputFile) {
+      !utils.exists(inputFile) && stop(colors.file(inputFileSimplePath), 'does not exist.')
+    }
 
     configFile &&
       !utils.exists(configFile) &&

--- a/src/cli/compile.js
+++ b/src/cli/compile.js
@@ -25,7 +25,12 @@ const defaultOptions = {
  */
 export default function compile(options = {}) {
   const config = { ...defaultOptions, ...options }
-  const css = utils.readFile(config.inputFile)
+
+  const css = config.inputFile ? utils.readFile(config.inputFile) : `
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `;
 
   return new Promise((resolve, reject) => {
     postcss(config.plugins)

--- a/src/cli/compile.js
+++ b/src/cli/compile.js
@@ -26,11 +26,13 @@ const defaultOptions = {
 export default function compile(options = {}) {
   const config = { ...defaultOptions, ...options }
 
-  const css = config.inputFile ? utils.readFile(config.inputFile) : `
+  const css = config.inputFile
+    ? utils.readFile(config.inputFile)
+    : `
     @tailwind base;
     @tailwind components;
     @tailwind utilities;
-  `;
+  `
 
   return new Promise((resolve, reject) => {
     postcss(config.plugins)


### PR DESCRIPTION
Hi,

This has cropped up a handful of times throughout Discord, and the solution is pretty simple to add to the Tailwind CLI core, however for less experienced users without knowledge of creating Node scripts and using the PostCSS API it's a little more complicated.

Effectively a handful of people have wanted to just generate the .css file based off their config, without having to create an additional .css entry point file which won't be used for anything.

With this in mind this PR allows users to omit the `<file>` param - If they do not pass in an entry file it will fall back to generate the output based off:

```css
@tailwind base;
@tailwind components;
@tailwind utilities;
```

Example usage would be:

```shell
npx tailwind build -o styles.css
```

Might be handy 🤷🏻‍♂️ What do people think?

(P.S. - PR needs cleaning up, e.g. eslint etc - didn't want to spend the time if people don't like the idea of this)