### PR TITLE
Remove duplicate `padding: 0` from `button`s

### DIFF
--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -27,7 +27,6 @@ pre {
 button {
   background-color: transparent;
   background-image: none;
-  padding: 0;
 }
 
 /**


### PR DESCRIPTION
It's redeclared later on:
https://github.com/tailwindcss/tailwindcss/blob/50ce88ab373a76e3666173dc317d0f4ab6d86412/src/plugins/css/preflight.css#L179