### PR TITLE
Provide a default tracking with Font Size config

### DIFF
--- a/src/plugins/fontSize.js
+++ b/src/plugins/fontSize.js
@@ -4,7 +4,11 @@ export default function() {
   return function({ addUtilities, e, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('fontSize'), (value, modifier) => {
-        const [fontSize, lineHeight] = Array.isArray(value) ? value : [value]
+        const [fontSize, options] = Array.isArray(value) ? value : [value]
+        // Tailwind 1.3+ syntax allowed line height to be specified in the array like
+        // ['16px', '24px'], so we can get it from there as well as from object syntax
+        const lineHeight = options instanceof Object ? options.lineHeight : options
+        const letterSpacing = options && options.letterSpacing
 
         return [
           `.${e(`text-${modifier}`)}`,
@@ -14,6 +18,11 @@ export default function() {
               ? {}
               : {
                   'line-height': lineHeight,
+                }),
+            ...(letterSpacing === undefined
+              ? {}
+              : {
+                  'letter-spacing': letterSpacing,
                 }),
           },
         ]


### PR DESCRIPTION
We can already configure line-height with font sizes, but this allows
us to also specify the default tracking for these sizes too.

This can be overwritten with tracking utilities.

I asked here but got no response: #1874 
