### PR TITLE
Switch from `.npmignore` to `files` option

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-/__tests__/
-/jest/
-/src/
-index.html
-yarn-error.log

--- a/package.json
+++ b/package.json
@@ -25,6 +25,14 @@
     "style": "eslint .",
     "test": "jest && eslint ."
   },
+  "files": [
+    "dist/*.css",
+    "lib/*",
+    "scripts/*.js",
+    "stubs/*.stub.js",
+    "*.css",
+    "*.js"
+  ],
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -14,13 +14,9 @@ function buildDistFile(filename) {
         .process(css, {
           from: `./${filename}.css`,
           to: `./dist/${filename}.css`,
-          map: { inline: false },
         })
         .then(result => {
           fs.writeFileSync(`./dist/${filename}.css`, result.css)
-          if (result.map) {
-            fs.writeFileSync(`./dist/${filename}.css.map`, result.map)
-          }
           return result
         })
         .then(result => {


### PR DESCRIPTION
Fixes https://github.com/tailwindcss/tailwindcss/issues/1867

See comparison between what files are published here: https://www.diffchecker.com/NhRXqAQj

I stripped out the most obvious files, but I'm unsure if all CSS/JS files that are published are needed.