### PR TITLE
use percentage value for rounded-full

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -179,7 +179,7 @@ module.exports = {
       default: '0.25rem',
       md: '0.375rem',
       lg: '0.5rem',
-      full: '9999px',
+      full: '50%',
     },
     borderWidth: {
       default: '1px',


### PR DESCRIPTION
Curious to hear if there's a really good reason to use `9999px` - I think the percentage value is more intuitive to see in the inspector tools.

I perhaps would also go as far as renaming this to `rounded-circle` but I didn't want to make a breaking change :) 