### PR TITLE
Add first-class support for "responsive" components and bucket children

### DIFF
--- a/__tests__/processPlugins.test.js
+++ b/__tests__/processPlugins.test.js
@@ -1114,6 +1114,62 @@ test("component declarations can optionally ignore 'prefix' option", () => {
     `)
 })
 
+test('responsive components are generated with the components at-rule argument', () => {
+  const { components } = processPlugins(
+    [
+      function({ addComponents }) {
+        addComponents(
+          {
+            '.btn-blue': {
+              backgroundColor: 'blue',
+            },
+          },
+          { variants: ['responsive'] }
+        )
+      },
+    ],
+    makeConfig()
+  )
+
+  expect(css(components)).toMatchCss(`
+    @responsive components {
+      @variants {
+        .btn-blue {
+          background-color: blue
+        }
+      }
+    }
+    `)
+})
+
+test('components can use the array shorthand to add variants', () => {
+  const { components } = processPlugins(
+    [
+      function({ addComponents }) {
+        addComponents(
+          {
+            '.btn-blue': {
+              backgroundColor: 'blue',
+            },
+          },
+          ['responsive']
+        )
+      },
+    ],
+    makeConfig()
+  )
+
+  expect(css(components)).toMatchCss(`
+    @responsive components {
+      @variants {
+        .btn-blue {
+          background-color: blue
+        }
+      }
+    }
+    `)
+})
+
 test("component declarations are not affected by the 'important' option", () => {
   const { components } = processPlugins(
     [

--- a/__tests__/responsiveAtRule.test.js
+++ b/__tests__/responsiveAtRule.test.js
@@ -13,7 +13,7 @@ test('it can generate responsive variants', () => {
       .chocolate { color: brown; }
     }
 
-    @tailwind screens;
+    @screens utilities;
   `
 
   const output = `
@@ -55,7 +55,7 @@ test('it can generate responsive variants with a custom separator', () => {
       .chocolate { color: brown; }
     }
 
-    @tailwind screens;
+    @screens utilities;
   `
 
   const output = `
@@ -97,7 +97,7 @@ test('it can generate responsive variants when classes have non-standard charact
       .chocolate-2\\.5 { color: brown; }
     }
 
-    @tailwind screens;
+    @screens utilities;
   `
 
   const output = `
@@ -144,7 +144,7 @@ test('responsive variants are grouped', () => {
       .chocolate { color: brown; }
     }
 
-    @tailwind screens;
+    @screens utilities;
   `
 
   const output = `
@@ -190,7 +190,7 @@ test('it can generate responsive variants for nested at-rules', () => {
       }
     }
 
-    @tailwind screens;
+    @screens utilities;
   `
 
   const output = `
@@ -255,7 +255,7 @@ test('it can generate responsive variants for deeply nested at-rules', () => {
       }
     }
 
-    @tailwind screens;
+    @screens utilities;
   `
 
   const output = `
@@ -320,7 +320,7 @@ test('screen prefix is only applied to the last class in a selector', () => {
       .banana li * .sandwich #foo > div { color: yellow; }
     }
 
-    @tailwind screens;
+    @screens utilities;
   `
 
   const output = `
@@ -357,7 +357,7 @@ test('responsive variants are generated for all selectors in a rule', () => {
       .foo, .bar { color: yellow; }
     }
 
-    @tailwind screens;
+    @screens utilities;
   `
 
   const output = `
@@ -394,7 +394,7 @@ test('selectors with no classes cannot be made responsive', () => {
       div { color: yellow; }
     }
 
-    @tailwind screens;
+    @screens utilities;
   `
   expect.assertions(1)
   return run(input, {
@@ -417,7 +417,7 @@ test('all selectors in a rule must contain classes', () => {
       .foo, div { color: yellow; }
     }
 
-    @tailwind screens;
+    @screens utilities;
   `
   expect.assertions(1)
   return run(input, {
@@ -431,5 +431,61 @@ test('all selectors in a rule must contain classes', () => {
     separator: ':',
   }).catch(e => {
     expect(e).toMatchObject({ name: 'CssSyntaxError' })
+  })
+})
+
+test('responsive components are inserted at @screens components', () => {
+  const input = `
+    @responsive components {
+      .banana { color: yellow; }
+    }
+
+    .apple { color: red; }
+
+    @screens components;
+
+    @responsive {
+      .chocolate { color: brown; }
+    }
+
+    @screens utilities;
+  `
+
+  const output = `
+      .banana { color: yellow; }
+      .apple { color: red; }
+      @media (min-width: 500px) {
+        .sm\\:banana { color: yellow; }
+      }
+      @media (min-width: 750px) {
+        .md\\:banana { color: yellow; }
+      }
+      @media (min-width: 1000px) {
+        .lg\\:banana { color: yellow; }
+      }
+      .chocolate { color: brown; }
+      @media (min-width: 500px) {
+        .sm\\:chocolate { color: brown; }
+      }
+      @media (min-width: 750px) {
+        .md\\:chocolate { color: brown; }
+      }
+      @media (min-width: 1000px) {
+        .lg\\:chocolate { color: brown; }
+      }
+  `
+
+  return run(input, {
+    theme: {
+      screens: {
+        sm: '500px',
+        md: '750px',
+        lg: '1000px',
+      },
+    },
+    separator: ':',
+  }).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
   })
 })

--- a/__tests__/tailwindAtRule.test.js
+++ b/__tests__/tailwindAtRule.test.js
@@ -1,0 +1,226 @@
+import postcss from 'postcss'
+import plugin from '../src/lib/substituteTailwindAtRules'
+import processPlugins from '../src/util/processPlugins'
+import config from '../stubs/defaultConfig.stub.js'
+
+function run(input, opts = config) {
+  const plugins = [
+    function({ addBase, addComponents, addUtilities }) {
+      addBase({ base: { property: 'test' } })
+      addComponents({ '.components': { property: 'test' } })
+      addUtilities({ '.utilities': { property: 'test' } })
+    },
+  ]
+  return postcss([plugin(opts, processPlugins(plugins, opts))]).process(input, {
+    from: undefined,
+  })
+}
+
+test('tailwind directives are replaced with their underlying CSS rules', () => {
+  const input = `
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  const output = `
+    /* tailwind start base */
+    base { property: test }
+    /* tailwind end base */
+    /* tailwind start components */
+    .components { property: test }
+    /* tailwind end components */
+    /* tailwind start screens components */
+    @screens components;
+    /* tailwind end screens components */
+    /* tailwind start utilities */
+    @variants {
+      .utilities { property: test }
+    }
+    /* tailwind end utilities */
+    /* tailwind start screens utilities */
+    @screens utilities;
+    /* tailwind end screens utilities */
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('root-level component classes are not part of the components group', () => {
+  const input = `
+    @tailwind base;
+    @tailwind components;
+    .btn { background: blue }
+    @tailwind utilities;
+    `
+
+  const output = `
+    /* tailwind start base */
+    base { property: test }
+    /* tailwind end base */
+
+    /* tailwind start components */
+    .components { property: test }
+    /* tailwind end components */
+
+    /* tailwind start screens components */
+    @screens components;
+    /* tailwind end screens components */
+
+    .btn { background: blue }
+
+    /* tailwind start utilities */
+    @variants {
+      .utilities { property: test }
+    }
+    /* tailwind end utilities */
+
+    /* tailwind start screens utilities */
+    @screens utilities;
+    /* tailwind end screens utilities */
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('nested rules are included in the corresponding bucket', () => {
+  const input = `
+    @tailwind base {
+      html { font-size: 20px }
+    }
+    @tailwind components {
+      .btn { background: blue }
+    }
+    @tailwind utilities {
+      .tabular-nums { font-variant-numeric: tabular-nums }
+    }
+    `
+
+  const output = `
+    /* tailwind start base */
+    base { property: test }
+    html { font-size: 20px }
+    /* tailwind end base */
+
+    /* tailwind start components */
+    .components { property: test }
+    .btn { background: blue }
+    /* tailwind end components */
+
+    /* tailwind start screens components */
+    @screens components;
+    /* tailwind end screens components */
+
+    /* tailwind start utilities */
+    @variants {
+      .utilities { property: test }
+    }
+    .tabular-nums { font-variant-numeric: tabular-nums }
+    /* tailwind end utilities */
+
+    /* tailwind start screens utilities */
+    @screens utilities
+    /* tailwind end screens utilities */
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('nested responsive component classes have the components argument added automatically', () => {
+  const input = `
+    @tailwind base;
+    @tailwind components {
+      @responsive {
+        .btn { background: blue }
+      }
+    }
+    @tailwind utilities;
+    `
+
+  const output = `
+    /* tailwind start base */
+    base { property: test }
+    /* tailwind end base */
+
+    /* tailwind start components */
+    .components { property: test }
+    @responsive components {
+      .btn { background: blue }
+    }
+    /* tailwind end components */
+
+    /* tailwind start screens components */
+    @screens components;
+    /* tailwind end screens components */
+
+    /* tailwind start utilities */
+    @variants {
+      .utilities { property: test }
+    }
+    /* tailwind end utilities */
+
+    /* tailwind start screens utilities */
+    @screens utilities;
+    /* tailwind end screens utilities */
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('nested responsive component classes authored using the variants syntax have the components argument added automatically', () => {
+  const input = `
+    @tailwind base;
+    @tailwind components {
+      @variants responsive {
+        .btn { background: blue }
+      }
+    }
+    @tailwind utilities;
+    `
+
+  const output = `
+    /* tailwind start base */
+    base { property: test }
+    /* tailwind end base */
+
+    /* tailwind start components */
+    .components { property: test }
+    @responsive components {
+      @variants {
+        .btn { background: blue }
+      }
+    }
+    /* tailwind end components */
+
+    /* tailwind start screens components */
+    @screens components;
+    /* tailwind end screens components */
+
+    /* tailwind start utilities */
+    @variants {
+      .utilities { property: test }
+    }
+    /* tailwind end utilities */
+
+    /* tailwind start screens utilities */
+    @screens utilities;
+    /* tailwind end screens utilities */
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})

--- a/src/lib/purgeUnusedStyles.js
+++ b/src/lib/purgeUnusedStyles.js
@@ -8,12 +8,16 @@ import * as emoji from '../cli/emoji'
 function removeTailwindComments(css) {
   css.walkComments(comment => {
     switch (comment.text.trim()) {
+      case 'tailwind start base':
+      case 'tailwind end base':
       case 'tailwind start components':
-      case 'tailwind start utilities':
-      case 'tailwind start screens':
       case 'tailwind end components':
+      case 'tailwind start screens components':
+      case 'tailwind end screens components':
+      case 'tailwind start utilities':
       case 'tailwind end utilities':
-      case 'tailwind end screens':
+      case 'tailwind start screens utilities':
+      case 'tailwind end screens utilities':
         comment.remove()
         break
       default:
@@ -64,11 +68,11 @@ export default function purgeUnusedUtilities(config) {
         css.walkComments(comment => {
           switch (comment.text.trim()) {
             case 'tailwind start utilities':
-            case 'tailwind start screens':
+            case 'tailwind start screens utilities':
               comment.text = 'purgecss end ignore'
               break
             case 'tailwind end utilities':
-            case 'tailwind end screens':
+            case 'tailwind end screens utilities':
               comment.text = 'purgecss start ignore'
               break
             default:

--- a/src/util/processPlugins.js
+++ b/src/util/processPlugins.js
@@ -111,7 +111,11 @@ export default function(plugins, config) {
         pluginUtilities.push(wrapWithVariants(styles.nodes, options.variants))
       },
       addComponents: (components, options) => {
-        options = Object.assign({ respectPrefix: true }, options)
+        const defaultOptions = { variants: [], respectPrefix: true }
+
+        options = Array.isArray(options)
+          ? Object.assign({}, defaultOptions, { variants: options })
+          : _.defaults(options, defaultOptions)
 
         const styles = postcss.root({ nodes: parseStyles(components) })
 
@@ -121,7 +125,11 @@ export default function(plugins, config) {
           }
         })
 
-        pluginComponents.push(...styles.nodes)
+        if (options.variants.length > 0) {
+          pluginComponents.push(wrapWithVariants(styles.nodes, options.variants, 'components'))
+        } else {
+          pluginComponents.push(...styles.nodes)
+        }
       },
       addBase: baseStyles => {
         pluginBaseStyles.push(...parseStyles(baseStyles))

--- a/src/util/wrapWithVariants.js
+++ b/src/util/wrapWithVariants.js
@@ -1,7 +1,23 @@
 import postcss from 'postcss'
 import cloneNodes from './cloneNodes'
 
-export default function wrapWithVariants(rules, variants) {
+export default function wrapWithVariants(rules, variants, bucket = 'utilities') {
+  if (bucket === 'components' && variants.includes('responsive')) {
+    return postcss
+      .atRule({
+        name: 'responsive',
+        params: 'components',
+      })
+      .append(
+        postcss
+          .atRule({
+            name: 'variants',
+            params: variants.filter(v => v !== 'responsive').join(', '),
+          })
+          .append(cloneNodes(Array.isArray(rules) ? rules : [rules]))
+      )
+  }
+
   return postcss
     .atRule({
       name: 'variants',


### PR DESCRIPTION
Earlier today I discovered a bug in how the new `@tailwindcss/typography` plugin interacts with Tailwind's built-in PurgeCSS support.

The issue was that while the base `prose` styles were not being purged by default (correct behavior), the _responsive_ versions of those styles (`sm\:prose` for example) _were_ being purged, even though Tailwind is not supposed to purge components without the user opting in via `mode: 'all'`.

The root of this issue is that Tailwind buckets _all_ "responsive" styles together into one location in the stylesheet (the `@tailwind screens` directive), and our PurgeCSS integration treats anything in that `screens` block as a _utility_ and has no way of knowing what in that block is a component or utility. So _all_ responsive styles are being considered for purging because Tailwind thinks every responsive style is a utility, and doesn't expect any of them to be components.

This was not terribly surprising when I discovered it, because Tailwind has never properly supported "responsive components' anyways, and the only way to create them (in plugin land anyways) was to manually wrap your rules with `@responsive` or `@variants responsive`. So I expected there were probably some quirks, but we didn't detect this one before releasing the plugin.

After a lot of deliberation I decided that the most "correct" solution to this problem was to give Tailwind a way to know whether responsive styles are "components" or "utilities".

So here's what this PR does...

## Adds new `@screens` directive

This PR introduces a new `@screens` directive that is used as a marker for where to output a certain "bucket" of screens. In use it looks like this:

```css
/* Responsive component styles are inserted here */
@screens components;

/* Responsive utility styles are inserted here */
@screens utilities;
```

This replaces `@tailwind screens`, but in a totally backwards compatible way (any existing `@tailwind screens` directives are automatically upgraded to `@screens utilities` in the build process).

Like was the case with `@tailwind screens`, you don't have to add this to your CSS file yourself, Tailwind does it automatically and intelligently. You only need to be concerned with this if you are doing something very custom — I think @benface is the only person who has ever needed this feature 😅 

So why is this new directive useful? Read on...

## Adds argument support to `@responsive`

The `@responsive` at-rule now accepts an optional argument so you can tell Tailwind what "bucket" the wrapped CSS belongs to:

```css
/* Default when not specified is "utilities" */
@responsive {
  .rotate-90 { /* ... */ }
}

/* Output the responsive variants at  "@screens components" */
@responsive components {
  .btn { /* ... */ }
}

/* Output the responsive variants at "@screens utilities" */
@responsive {
  .rotate-90 { /* ... */ }
}
```

This argument is currently not supported using the `@variants responsive { ... }` syntax but we can probably come up with a syntax for it in the future.

You likely won't need to actually use this particular API in your own code though thanks to the next change...

## Rules can be nested within `@tailwind` directives to automatically "bucket" them

Up until now there was no way to tell Tailwind "these are components" or "these are utilities" without using the plugin API. Now you can do so by nesting your rules within the `@tailwind` directives:

```css
@tailwind components {
  .btn { /* ... */ }
}
```

This lets Tailwind "understand" what type of rules you are creating so it can apply its features to those rules in the most intuitive way.

It's important to note that you **do not** write `@tailwind components` multiple times. You just write it once, and all of Tailwind's plugin-generated components will be inserted in that location, along with any nested rules you have provided.

By doing things this way, you don't need to use the `components` argument when making things `@responsive`:

```css
@tailwind components {
  /* Will automatically go in `@screens components`, no need to add the argument */
  @responsive {
    .btn { /* ... */ }
  }
}
```

This works with the `@variants responsive` syntax as well.

You can nest rules in _all_ `@tailwind` directive, including `base` and `utilities`.

## `addComponents` now supports variants

Like `addUtilities`, you can now provide a list of variants when using `addComponents` when writing plugins:

```js
// tailwind.config.js
const plugin = require('tailwindcss/plugin')

module.exports = {
  plugins: [
    plugin(function({ addComponents }) {
      const components = {
        // ...
      }

      addComponents(components, {
        variants: ['responsive']
      })
    })
  ]
}
```

You can also use the array shorthand, just like with utilities:

```js
// tailwind.config.js
const plugin = require('tailwindcss/plugin')

module.exports = {
  plugins: [
    plugin(function({ addComponents }) {
      const components = {
        // ...
      }

      addComponents(components, ['responsive'])
    })
  ]
}
```

## Conclusion

This fixes the annoying issue with the typography plugin, and does so with no breaking changes at all 👍  Thank god.