### PR TITLE
:not([hidden])

### DIFF
--- a/src/plugins/space.js
+++ b/src/plugins/space.js
@@ -8,12 +8,12 @@ export default function() {
         (size, modifier) => ({
           [`.${e(
             prefixNegativeModifiers('space-y', modifier)
-          )} > :not(template) ~ :not(template)`]: {
+          )} > :not(template):not([hidden]) ~ :not(template):not([hidden])`]: {
             'margin-top': size,
           },
           [`.${e(
             prefixNegativeModifiers('space-x', modifier)
-          )} > :not(template) ~ :not(template)`]: {
+          )} > :not(template):not([hidden]) ~ :not(template):not([hidden])`]: {
             'margin-left': size,
           },
         }),
@@ -30,12 +30,12 @@ export default function() {
 
     const generators = [
       (size, modifier) => ({
-        [`.${e(prefixNegativeModifiers('space-y', modifier))} > :not(template) ~ :not(template)`]: {
+        [`.${e(prefixNegativeModifiers('space-y', modifier))} > :not(template):not([hidden]) ~ :not(template):not([hidden])`]: {
           '--space-y-reverse': '0',
           'margin-top': `calc(${size === '0' ? '0px' : size} * calc(1 - var(--space-y-reverse)))`,
           'margin-bottom': `calc(${size === '0' ? '0px' : size} * var(--space-y-reverse))`,
         },
-        [`.${e(prefixNegativeModifiers('space-x', modifier))} > :not(template) ~ :not(template)`]: {
+        [`.${e(prefixNegativeModifiers('space-x', modifier))} > :not(template):not([hidden]) ~ :not(template):not([hidden])`]: {
           '--space-x-reverse': '0',
           'margin-right': `calc(${size === '0' ? '0px' : size} * var(--space-x-reverse))`,
           'margin-left': `calc(${size === '0' ? '0px' : size} * calc(1 - var(--space-x-reverse)))`,
@@ -47,10 +47,10 @@ export default function() {
       return [
         ..._.flatMap(theme('space'), generator),
         {
-          '.space-y-reverse > :not(template) ~ :not(template)': {
+          '.space-y-reverse > :not(template):not([hidden]) ~ :not(template):not([hidden])': {
             '--space-y-reverse': '1',
           },
-          '.space-x-reverse > :not(template) ~ :not(template)': {
+          '.space-x-reverse > :not(template):not([hidden]) ~ :not(template):not([hidden])': {
             '--space-x-reverse': '1',
           },
         },


### PR DESCRIPTION
In this case the Label is getting a margin left when it shouldn't be, this can be fixed by adding a `hidden` attribute to the Input instead of the inline style.

```html
<li class="flex space-x-2">
   <input type="radio" id="1" style="display:none" />
   <label for="1">Click This</label>
   <button type="text">Button</button>
</li>
```
