### PR TITLE
Support manual `@variants` in addComponents for <1.5 backwards compat

### DIFF
--- a/__tests__/processPlugins.test.js
+++ b/__tests__/processPlugins.test.js
@@ -1261,6 +1261,33 @@ test('plugins can use the array shorthand to add variants to components', () => 
   `)
 })
 
+test('components that add variants manually do not add an extra variants wrapper', () => {
+  const { components } = processPlugins(
+    [
+      function({ addComponents }) {
+        addComponents({
+          '@variants responsive': {
+            '.btn-blue': {
+              backgroundColor: 'blue',
+            },
+          },
+        })
+      },
+    ],
+    makeConfig()
+  )
+
+  expect(css(components)).toMatchCss(`
+    @layer components {
+      @variants responsive {
+        .btn-blue {
+          background-color: blue
+        }
+      }
+    }
+  `)
+})
+
 test("component declarations are not affected by the 'important' option", () => {
   const { components } = processPlugins(
     [

--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -684,3 +684,32 @@ test('plugin variants can wrap rules in another at-rule using the raw PostCSS AP
     expect(result.warnings().length).toBe(0)
   })
 })
+
+test('nested variants are all applied', () => {
+  const input = `
+    @variants responsive {
+      @variants hover {
+        @variants focus {
+          .banana { color: yellow; }
+          .chocolate { color: brown; }
+        }
+      }
+    }
+  `
+
+  const output = `
+    @responsive {
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+      .focus\\:banana:focus { color: yellow; }
+      .focus\\:chocolate:focus { color: brown; }
+      .hover\\:banana:hover { color: yellow; }
+      .hover\\:chocolate:hover { color: brown; }
+    }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})

--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -684,32 +684,3 @@ test('plugin variants can wrap rules in another at-rule using the raw PostCSS AP
     expect(result.warnings().length).toBe(0)
   })
 })
-
-test('nested variants are all applied', () => {
-  const input = `
-    @variants responsive {
-      @variants hover {
-        @variants focus {
-          .banana { color: yellow; }
-          .chocolate { color: brown; }
-        }
-      }
-    }
-  `
-
-  const output = `
-    @responsive {
-      .banana { color: yellow; }
-      .chocolate { color: brown; }
-      .focus\\:banana:focus { color: yellow; }
-      .focus\\:chocolate:focus { color: brown; }
-      .hover\\:banana:hover { color: yellow; }
-      .hover\\:chocolate:hover { color: brown; }
-    }
-  `
-
-  return run(input).then(result => {
-    expect(result.css).toMatchCss(output)
-    expect(result.warnings().length).toBe(0)
-  })
-})

--- a/src/util/wrapWithVariants.js
+++ b/src/util/wrapWithVariants.js
@@ -2,6 +2,16 @@ import postcss from 'postcss'
 import cloneNodes from './cloneNodes'
 
 export default function wrapWithVariants(rules, variants) {
+  let foundVariantAtRule = false
+
+  postcss.root({ nodes: rules }).walkAtRules('variants', () => {
+    foundVariantAtRule = true
+  })
+
+  if (foundVariantAtRule) {
+    return cloneNodes(rules)
+  }
+
   return postcss
     .atRule({
       name: 'variants',


### PR DESCRIPTION
Fixes accidental breaking change introduced in 1.5.0. We can probably fix this in an even more robust/intelligent way but this should fix it for 99.9999% of people as-is.