### PR TITLE
add weights for black & white colours

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -15,8 +15,30 @@ module.exports = {
       transparent: 'transparent',
       current: 'currentColor',
 
-      black: '#000',
-      white: '#fff',
+      black: {
+        default: '#fff',
+        100: '#000',
+        200: '#000',
+        300: '#000',
+        400: '#000',
+        500: '#000',
+        600: '#000',
+        700: '#000',
+        800: '#000',
+        900: '#000',
+      },
+      white: {
+        default: '#fff',
+        100: '#fff',
+        200: '#fff',
+        300: '#fff',
+        400: '#fff',
+        500: '#fff',
+        600: '#fff',
+        700: '#fff',
+        800: '#fff',
+        900: '#fff',
+      },
 
       gray: {
         100: '#f7fafc',


### PR DESCRIPTION
When using dynamically generated classes, it is possible that you could have a string like this:
```js
const style = `text-${colour}-${weight}`
```
While this will normally work, it does not when the `colour` variable is either black or white, as there aren't any different weights for those colours.

This PR should fix that by adding all the usual weights to both black and white, while keeping the default colour in place to avoid breaking changes.

**Notes:** When I ran the tests, it told me that a few of the tests failed, but the output of the command was trimmed, so I couldn't see the full context and which tests were the ones that were failing. If anyone could point me in the right direction on how to fix the tests to account for this that would be great, thanks!