### PR TITLE
Add option to prepend utilities to the list instead of appending them

### DIFF
--- a/__tests__/processPlugins.test.js
+++ b/__tests__/processPlugins.test.js
@@ -1926,3 +1926,68 @@ test('the configFunction parameter is optional when using the `createPlugin.with
       expect(result.css).toMatchCss(expected)
     })
 })
+
+
+
+test('a plugin can prepend utilities ', () => {
+  const appendPlugin = createPlugin.withOptions(function() {
+    return function({ addUtilities, theme, variants }) {
+      addUtilities({
+        '.text-indigo-100': {
+          'color': '#EBF4FF',
+        },
+        '.bg-indigo-700': {
+          'backgroundColor': '#4C51BF',
+        }
+      })
+    }
+  })
+
+  const prependPlugin = createPlugin.withOptions(function() {
+    return function({ addUtilities, theme, variants }) {
+      addUtilities({
+        '.button-indigo': {
+          'color': '#EBF4FF',
+          'backgroundColor': '#4C51BF',
+        }
+      }, {
+        appendUtilities: false,
+      })
+    }
+  })
+
+  return _postcss([
+    tailwind({
+      corePlugins: [],
+      theme: {},
+      variants: {},
+      plugins: [appendPlugin(), prependPlugin()],
+    }),
+  ])
+    .process(
+      `
+        @tailwind base;
+        @tailwind components;
+        @tailwind utilities;
+      `,
+      { from: undefined }
+    )
+    .then(result => {
+      const expected = `
+        .button-indigo {
+          color: #EBF4FF;
+          background-color: #4C51BF
+        }
+
+        .text-indigo-100 {
+          color: #EBF4FF
+        }
+
+        .bg-indigo-700 {
+          background-color: #4C51BF
+        }
+      `
+
+      expect(result.css).toMatchCss(expected)
+    })
+})

--- a/src/util/processPlugins.js
+++ b/src/util/processPlugins.js
@@ -88,7 +88,12 @@ export default function(plugins, config) {
       e: escapeClassName,
       prefix: applyConfiguredPrefix,
       addUtilities: (utilities, options) => {
-        const defaultOptions = { variants: [], respectPrefix: true, respectImportant: true }
+        const defaultOptions = {
+          variants: [],
+          respectPrefix: true,
+          respectImportant: true,
+          appendUtilities: true,
+        }
 
         options = Array.isArray(options)
           ? Object.assign({}, defaultOptions, { variants: options })
@@ -118,9 +123,16 @@ export default function(plugins, config) {
           }
         })
 
-        pluginUtilities.push(
-          wrapWithLayer(wrapWithVariants(styles.nodes, options.variants), 'utilities')
+        const addedUtilities = wrapWithLayer(
+          wrapWithVariants(styles.nodes, options.variants),
+          'utilities'
         )
+
+        if (config.appendUtilities) {
+          pluginUtilities.push(addedUtilities)
+        } else {
+          pluginUtilities.unshift(addedUtilities)
+        }
       },
       addComponents: (components, options) => {
         const defaultOptions = { variants: [], respectPrefix: true }


### PR DESCRIPTION
The goal of this pull request is simply to offer a single new option to the `addUtilities()` function. This option will allow plugin authors to choose if they want their plugin's utilities appended to the stack instead of appended to the end of the list.

The benefit of this is that it allows a little more control over the resulting cascade rules that will apply.

One example of how this may be used is as an API to create "compound utilities" that apply multiple CSS properties at once that may commonly be used together. For example, a green background on a button may often be paired with a certain colour text and border too. However, this class is still not a complete component - it is still a utility and fits into that paradigm.

```css
.button-green {
  color: #F0FFF4;
  background-color: #48BB78;
  border-color: #2F855A;
}
```

The problem with doing this currently is that it will always be applied _after_ Tailwind's core plugins, so there is no opportunity to override any of these properties on a one-off basis:

```html
<button class="button-green bg-gray-500">
  <!-- The background is still green -->
</button>
```

Other utilities manage to achieve this kind of thing by being part of the same plugin, eg. `mx-1` can still be overridden by `ml-1` and `mr-1` as the order of the utilities is controlled by the internal ordering of the margin plugin. This isn't possible for anything outside that context.

I hope this explanation makes sense - this is something I mentioned to Adam on Twitter a while ago and he said it'd be worth adding, so here we are.

I'm really not sure if this is the correct approach to bring such functionality or if there's another step I'm missing. A few of the tests appear to be failing right now but I'm not 100% sure why they are affected off the top of my head - any pointers in the right direction would be much appreciated.