### PR TITLE
Add experimental extendedFontSizeScale

### DIFF
--- a/__tests__/fixtures/tailwind-output-flagged.css
+++ b/__tests__/fixtures/tailwind-output-flagged.css
@@ -7967,6 +7967,21 @@ video {
   line-height: 1;
 }
 
+.text-7xl {
+  font-size: 5rem;
+  line-height: 1;
+}
+
+.text-8xl {
+  font-size: 6rem;
+  line-height: 1;
+}
+
+.text-9xl {
+  font-size: 8rem;
+  line-height: 1;
+}
+
 .leading-3 {
   line-height: .75rem;
 }
@@ -33029,6 +33044,21 @@ video {
     line-height: 1;
   }
 
+  .sm\:text-7xl {
+    font-size: 5rem;
+    line-height: 1;
+  }
+
+  .sm\:text-8xl {
+    font-size: 6rem;
+    line-height: 1;
+  }
+
+  .sm\:text-9xl {
+    font-size: 8rem;
+    line-height: 1;
+  }
+
   .sm\:leading-3 {
     line-height: .75rem;
   }
@@ -58058,6 +58088,21 @@ video {
 
   .md\:text-6xl {
     font-size: 4rem;
+    line-height: 1;
+  }
+
+  .md\:text-7xl {
+    font-size: 5rem;
+    line-height: 1;
+  }
+
+  .md\:text-8xl {
+    font-size: 6rem;
+    line-height: 1;
+  }
+
+  .md\:text-9xl {
+    font-size: 8rem;
     line-height: 1;
   }
 
@@ -83093,6 +83138,21 @@ video {
     line-height: 1;
   }
 
+  .lg\:text-7xl {
+    font-size: 5rem;
+    line-height: 1;
+  }
+
+  .lg\:text-8xl {
+    font-size: 6rem;
+    line-height: 1;
+  }
+
+  .lg\:text-9xl {
+    font-size: 8rem;
+    line-height: 1;
+  }
+
   .lg\:leading-3 {
     line-height: .75rem;
   }
@@ -108122,6 +108182,21 @@ video {
 
   .xl\:text-6xl {
     font-size: 4rem;
+    line-height: 1;
+  }
+
+  .xl\:text-7xl {
+    font-size: 5rem;
+    line-height: 1;
+  }
+
+  .xl\:text-8xl {
+    font-size: 6rem;
+    line-height: 1;
+  }
+
+  .xl\:text-9xl {
+    font-size: 8rem;
     line-height: 1;
   }
 

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -3,7 +3,12 @@ import chalk from 'chalk'
 
 const featureFlags = {
   future: ['removeDeprecatedGapUtilities'],
-  experimental: ['uniformColorPalette', 'extendedSpacingScale', 'defaultLineHeights'],
+  experimental: [
+    'uniformColorPalette',
+    'extendedSpacingScale',
+    'defaultLineHeights',
+    'extendedFontSizeScale',
+  ],
 }
 
 export function flagEnabled(config, flag) {

--- a/src/flagged/extendedFontSizeScale.js
+++ b/src/flagged/extendedFontSizeScale.js
@@ -1,0 +1,11 @@
+export default {
+  theme: {
+    extend: {
+      fontSize: {
+        '7xl': ['5rem', { lineHeight: '1' }],
+        '8xl': ['6rem', { lineHeight: '1' }],
+        '9xl': ['8rem', { lineHeight: '1' }],
+      },
+    },
+  },
+}

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import { flagEnabled } from './featureFlags'
 import uniformColorPalette from './flagged/uniformColorPalette.js'
 import extendedSpacingScale from './flagged/extendedSpacingScale.js'
 import defaultLineHeights from './flagged/defaultLineHeights.js'
+import extendedFontSizeScale from './flagged/extendedFontSizeScale.js'
 
 function getDefaultConfigs(config) {
   const configs = [defaultConfig]
@@ -30,6 +31,10 @@ function getDefaultConfigs(config) {
 
   if (flagEnabled(config, 'defaultLineHeights')) {
     configs.unshift(defaultLineHeights)
+  }
+
+  if (flagEnabled(config, 'extendedFontSizeScale')) {
+    configs.unshift(extendedFontSizeScale)
   }
 
   return configs


### PR DESCRIPTION
This PR extends the font size scale with new `7xl`, `8xl`, and `9xl` values behind an experimental `extendedFontSizeScale` flag.

The goal here is to make sure Tailwind's default design system is capable of keeping up with modern design trends, which lately includes huge text on landing pages.

![image](https://user-images.githubusercontent.com/4323180/89680185-749d2e80-d8c0-11ea-8a8e-53f779a383d8.png)

I've included default line heights for these as well.