### PR TITLE
Add Node.js 14.x to test matrix

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [8.x, 10.x, 12.x, 14.x]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Seeing how more and more people will be using Node.js 14.x to interact with this repository, it makes sense (to me at least) that it's part of the testing matrix. This shouldn't – as far as I can tell – require any major semver bumps either.
