### PR TITLE
Add support for `@apply` with complex classes, including responsive and pseudo-class variants

### DIFF
--- a/__tests__/applyAtRule.test.js
+++ b/__tests__/applyAtRule.test.js
@@ -13,7 +13,11 @@ const { utilities: defaultUtilities } = processPlugins(
 )
 
 function run(input, config = resolvedDefaultConfig, utilities = defaultUtilities) {
-  return postcss([substituteClassApplyAtRules(config, utilities)]).process(input, {
+  return postcss([
+    substituteClassApplyAtRules(config, () => ({
+      utilities,
+    })),
+  ]).process(input, {
     from: undefined,
   })
 }

--- a/__tests__/applyComplexClasses.test.js
+++ b/__tests__/applyComplexClasses.test.js
@@ -279,7 +279,7 @@ test('you can apply a class that is defined in multiple rules', () => {
       @apply foo;
     }
     .foo {
-      oapcity: .5;
+      opacity: .5;
     }
   `
   const expected = `
@@ -288,10 +288,10 @@ test('you can apply a class that is defined in multiple rules', () => {
     }
     .bar {
       color: red;
-      oapcity: .5;
+      opacity: .5;
     }
     .foo {
-      oapcity: .5;
+      opacity: .5;
     }
   `
 

--- a/__tests__/applyComplexClasses.test.js
+++ b/__tests__/applyComplexClasses.test.js
@@ -773,7 +773,7 @@ describe('using apply with the prefix option', () => {
   })
 })
 
-test.skip('you can apply utility classes without specificity prefix even if important (selector) is used', () => {
+test.skip('you can apply utility classes when a selector is used for the important option', () => {
   const input = `
     .foo {
       @apply mt-8 mb-8;

--- a/__tests__/applyComplexClasses.test.js
+++ b/__tests__/applyComplexClasses.test.js
@@ -81,7 +81,7 @@ test.skip('applied rules can be made !important', () => {
   })
 })
 
-test.skip('cssnext custom property sets are preserved', () => {
+test('cssnext custom property sets are no longer supported', () => {
   const input = `
     .a {
       color: red;
@@ -101,9 +101,8 @@ test.skip('cssnext custom property sets are preserved', () => {
     }
   `
 
-  return run(input).then(result => {
-    expect(result.css).toEqual(expected)
-    expect(result.warnings().length).toBe(0)
+  return run(input).catch(e => {
+    expect(e).toMatchObject({ name: 'CssSyntaxError' })
   })
 })
 

--- a/__tests__/applyComplexClasses.test.js
+++ b/__tests__/applyComplexClasses.test.js
@@ -91,16 +91,6 @@ test('cssnext custom property sets are no longer supported', () => {
     }
   `
 
-  const expected = `
-    .a {
-      color: red;
-    }
-    .b {
-      color: red;
-      @apply --custom-property-set;
-    }
-  `
-
   return run(input).catch(e => {
     expect(e).toMatchObject({ name: 'CssSyntaxError' })
   })

--- a/__tests__/applyComplexClasses.test.js
+++ b/__tests__/applyComplexClasses.test.js
@@ -247,6 +247,38 @@ test('it matches classes that have multiple rules', () => {
   })
 })
 
+test('applying a class that appears multiple times in one selector', () => {
+  const input = `
+    .a + .a > .a {
+      color: red;
+    }
+
+    .b {
+      @apply a;
+    }
+  `
+
+  const output = `
+    .a + .a > .a {
+      color: red;
+    }
+    .b + .a > .a {
+      color: red;
+    }
+    .a + .b > .a {
+      color: red;
+    }
+    .a + .a > .b {
+      color: red;
+    }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('you can apply utility classes that do not actually exist as long as they would exist if utilities were being generated', () => {
   const input = `
     .foo { @apply mt-4; }

--- a/__tests__/applyComplexClasses.test.js
+++ b/__tests__/applyComplexClasses.test.js
@@ -25,7 +25,10 @@ const defaultGetProcessedPlugins = function() {
 function run(
   input,
   config = resolvedDefaultConfig,
-  getProcessedPlugins = defaultGetProcessedPlugins
+  getProcessedPlugins = () =>
+    config === resolvedDefaultConfig
+      ? defaultGetProcessedPlugins()
+      : processPlugins(corePlugins(config), config)
 ) {
   config.experimental = {
     applyComplexClasses: true,

--- a/__tests__/applyComplexClasses.test.js
+++ b/__tests__/applyComplexClasses.test.js
@@ -655,7 +655,7 @@ describe('using apply with the prefix option', () => {
       },
     ])
 
-    return run(input, config, () => processPlugins(corePlugins(config), config)).then(result => {
+    return run(input, config).then(result => {
       expect(result.css).toMatchCss(expected)
       expect(result.warnings().length).toBe(0)
     })
@@ -679,7 +679,7 @@ describe('using apply with the prefix option', () => {
       },
     ])
 
-    return run(input, config, () => processPlugins(corePlugins(config), config)).then(result => {
+    return run(input, config).then(result => {
       expect(result.css).toMatchCss(expected)
       expect(result.warnings().length).toBe(0)
     })
@@ -697,7 +697,7 @@ describe('using apply with the prefix option', () => {
       },
     ])
 
-    return run(input, config, () => processPlugins(corePlugins(config), config)).catch(e => {
+    return run(input, config).catch(e => {
       expect(e).toMatchObject({ name: 'CssSyntaxError' })
     })
   })
@@ -720,7 +720,7 @@ describe('using apply with the prefix option', () => {
       },
     ])
 
-    return run(input, config, () => processPlugins(corePlugins(config), config)).then(result => {
+    return run(input, config).then(result => {
       expect(result.css).toMatchCss(expected)
       expect(result.warnings().length).toBe(0)
     })
@@ -744,7 +744,7 @@ describe('using apply with the prefix option', () => {
       },
     ])
 
-    return run(input, config, () => processPlugins(corePlugins(config), config)).then(result => {
+    return run(input, config).then(result => {
       expect(result.css).toMatchCss(expected)
       expect(result.warnings().length).toBe(0)
     })
@@ -764,16 +764,62 @@ describe('using apply with the prefix option', () => {
 
     expect.assertions(1)
 
-    return run(input, config, () => processPlugins(corePlugins(config), config)).catch(e => {
+    return run(input, config).catch(e => {
       expect(e).toMatchObject({
         name: 'CssSyntaxError',
         reason: 'The `mt-4` class does not exist, but `tw-mt-4` does. Did you forget the prefix?',
       })
     })
   })
+
+  test('you can apply classes with important and a prefix enabled', () => {
+    const input = `
+      .foo { @apply tw-mt-4; }
+    `
+
+    const expected = `
+      .foo { margin-top: 1rem; }
+    `
+
+    const config = resolveConfig([
+      {
+        ...defaultConfig,
+        prefix: 'tw-',
+        important: true,
+      },
+    ])
+
+    return run(input, config).then(result => {
+      expect(result.css).toMatchCss(expected)
+      expect(result.warnings().length).toBe(0)
+    })
+  })
+
+  test('you can apply classes with an important selector and a prefix enabled', () => {
+    const input = `
+      .foo { @apply tw-mt-4; }
+    `
+
+    const expected = `
+      .foo { margin-top: 1rem; }
+    `
+
+    const config = resolveConfig([
+      {
+        ...defaultConfig,
+        prefix: 'tw-',
+        important: '#app',
+      },
+    ])
+
+    return run(input, config).then(result => {
+      expect(result.css).toMatchCss(expected)
+      expect(result.warnings().length).toBe(0)
+    })
+  })
 })
 
-test.skip('you can apply utility classes when a selector is used for the important option', () => {
+test('you can apply utility classes when a selector is used for the important option', () => {
   const input = `
     .foo {
       @apply mt-8 mb-8;
@@ -794,30 +840,7 @@ test.skip('you can apply utility classes when a selector is used for the importa
     },
   ])
 
-  return run(input, config, processPlugins(corePlugins(config), config).utilities).then(result => {
-    expect(result.css).toMatchCss(expected)
-    expect(result.warnings().length).toBe(0)
-  })
-})
-
-test.skip('you can apply utility classes without using the given prefix even if important (selector) is used', () => {
-  const input = `
-    .foo { @apply .tw-mt-4 .mb-4; }
-  `
-
-  const expected = `
-    .foo { margin-top: 1rem; margin-bottom: 1rem; }
-  `
-
-  const config = resolveConfig([
-    {
-      ...defaultConfig,
-      prefix: 'tw-',
-      important: '#app',
-    },
-  ])
-
-  return run(input, config, processPlugins(corePlugins(config), config).utilities).then(result => {
+  return run(input, config).then(result => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })

--- a/__tests__/applyComplexClasses.test.js
+++ b/__tests__/applyComplexClasses.test.js
@@ -259,6 +259,17 @@ test('you can apply utility classes that do not actually exist as long as they w
   })
 })
 
+test('the shadow lookup is only used if no @tailwind rules were in the source tree', () => {
+  const input = `
+    @tailwind base;
+    .foo { @apply mt-4; }
+  `
+
+  return run(input).catch(e => {
+    expect(e).toMatchObject({ name: 'CssSyntaxError' })
+  })
+})
+
 test.skip('you can apply utility classes without using the given prefix', () => {
   const input = `
     .foo { @apply .tw-mt-4 .mb-4; }

--- a/__tests__/applyComplexClasses.test.js
+++ b/__tests__/applyComplexClasses.test.js
@@ -1,0 +1,348 @@
+import postcss from 'postcss'
+import substituteClassApplyAtRules from '../src/lib/substituteClassApplyAtRules'
+import processPlugins from '../src/util/processPlugins'
+import resolveConfig from '../src/util/resolveConfig'
+import corePlugins from '../src/corePlugins'
+import defaultConfig from '../stubs/defaultConfig.stub.js'
+
+const resolvedDefaultConfig = resolveConfig([defaultConfig])
+
+const { utilities: defaultUtilities } = processPlugins(
+  corePlugins(resolvedDefaultConfig),
+  resolvedDefaultConfig
+)
+
+function run(input, config = resolvedDefaultConfig, utilities = defaultUtilities) {
+  config.experimental = {
+    applyComplexClasses: true,
+  }
+  return postcss([substituteClassApplyAtRules(config, utilities)]).process(input, {
+    from: undefined,
+  })
+}
+
+test('it copies class declarations into itself', () => {
+  const output = '.a { color: red; } .b { color: red; }'
+
+  return run('.a { color: red; } .b { @apply a; }').then(result => {
+    expect(result.css).toEqual(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('selectors with invalid characters do not need to be manually escaped', () => {
+  const input = `
+    .a\\:1\\/2 { color: red; }
+    .b { @apply a:1/2; }
+  `
+
+  const expected = `
+    .a\\:1\\/2 { color: red; }
+    .b { color: red; }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toEqual(expected)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test.skip('it removes important from applied classes by default', () => {
+  const input = `
+    .a { color: red !important; }
+    .b { @apply a; }
+  `
+
+  const expected = `
+    .a { color: red !important; }
+    .b { color: red; }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toEqual(expected)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test.skip('applied rules can be made !important', () => {
+  const input = `
+    .a { color: red; }
+    .b { @apply a !important; }
+  `
+
+  const expected = `
+    .a { color: red; }
+    .b { color: red !important; }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toEqual(expected)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test.skip('cssnext custom property sets are preserved', () => {
+  const input = `
+    .a {
+      color: red;
+    }
+    .b {
+      @apply a --custom-property-set;
+    }
+  `
+
+  const expected = `
+    .a {
+      color: red;
+    }
+    .b {
+      color: red;
+      @apply --custom-property-set;
+    }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toEqual(expected)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it fails if the class does not exist', () => {
+  return run('.b { @apply a; }').catch(e => {
+    expect(e).toMatchObject({ name: 'CssSyntaxError' })
+  })
+})
+
+test('applying classes that are defined in a media query is supported', () => {
+  const input = `
+    @media (min-width: 300px) {
+      .a { color: blue; }
+    }
+
+    .b {
+      @apply a;
+    }
+  `
+
+  const output = `
+    @media (min-width: 300px) {
+      .a { color: blue; }
+    }
+    @media (min-width: 300px) {
+      .b { color: blue; }
+    }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('applying classes that are used in a media query is supported', () => {
+  const input = `
+    .a {
+      color: red;
+    }
+
+    @media (min-width: 300px) {
+      .a { color: blue; }
+    }
+
+    .b {
+      @apply a;
+    }
+  `
+
+  const output = `
+    .a {
+      color: red;
+    }
+
+    @media (min-width: 300px) {
+      .a { color: blue; }
+    }
+
+    .b {
+      color: red;
+    }
+
+    @media (min-width: 300px) {
+      .b { color: blue; }
+    }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it matches classes that include pseudo-selectors', () => {
+  const input = `
+    .a:hover {
+      color: red;
+    }
+
+    .b {
+      @apply a;
+    }
+  `
+
+  const output = `
+    .a:hover {
+      color: red;
+    }
+
+    .b:hover {
+      color: red;
+    }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it matches classes that have multiple rules', () => {
+  const input = `
+    .a {
+      color: red;
+    }
+
+    .b {
+      @apply a;
+    }
+
+    .a {
+      color: blue;
+    }
+  `
+
+  const output = `
+    .a {
+      color: red;
+    }
+
+    .b {
+      color: red;
+      color: blue;
+    }
+
+    .a {
+      color: blue;
+    }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test.skip('you can apply utility classes that do not actually exist as long as they would exist if utilities were being generated', () => {
+  const input = `
+    .foo { @apply mt-4; }
+  `
+
+  const expected = `
+    .foo { margin-top: 1rem; }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toEqual(expected)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test.skip('you can apply utility classes without using the given prefix', () => {
+  const input = `
+    .foo { @apply .tw-mt-4 .mb-4; }
+  `
+
+  const expected = `
+    .foo { margin-top: 1rem; margin-bottom: 1rem; }
+  `
+
+  const config = resolveConfig([
+    {
+      ...defaultConfig,
+      prefix: 'tw-',
+    },
+  ])
+
+  return run(input, config, processPlugins(corePlugins(config), config).utilities).then(result => {
+    expect(result.css).toEqual(expected)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test.skip('you can apply utility classes without using the given prefix when using a function for the prefix', () => {
+  const input = `
+    .foo { @apply .tw-mt-4 .mb-4; }
+  `
+
+  const expected = `
+    .foo { margin-top: 1rem; margin-bottom: 1rem; }
+  `
+
+  const config = resolveConfig([
+    {
+      ...defaultConfig,
+      prefix: () => {
+        return 'tw-'
+      },
+    },
+  ])
+
+  return run(input, config, processPlugins(corePlugins(config), config).utilities).then(result => {
+    expect(result.css).toEqual(expected)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test.skip('you can apply utility classes without specificity prefix even if important (selector) is used', () => {
+  const input = `
+    .foo { @apply .mt-8 .mb-8; }
+  `
+
+  const expected = `
+    .foo { margin-top: 2rem; margin-bottom: 2rem; }
+  `
+
+  const config = resolveConfig([
+    {
+      ...defaultConfig,
+      important: '#app',
+    },
+  ])
+
+  return run(input, config, processPlugins(corePlugins(config), config).utilities).then(result => {
+    expect(result.css).toEqual(expected)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test.skip('you can apply utility classes without using the given prefix even if important (selector) is used', () => {
+  const input = `
+    .foo { @apply .tw-mt-4 .mb-4; }
+  `
+
+  const expected = `
+    .foo { margin-top: 1rem; margin-bottom: 1rem; }
+  `
+
+  const config = resolveConfig([
+    {
+      ...defaultConfig,
+      prefix: 'tw-',
+      important: '#app',
+    },
+  ])
+
+  return run(input, config, processPlugins(corePlugins(config), config).utilities).then(result => {
+    expect(result.css).toEqual(expected)
+    expect(result.warnings().length).toBe(0)
+  })
+})

--- a/__tests__/fixtures/tailwind-input.css
+++ b/__tests__/fixtures/tailwind-input.css
@@ -6,7 +6,7 @@
 
 @responsive {
   .example {
-    @apply .font-bold;
+    @apply font-bold;
     color: theme('colors.red.500');
   }
 }

--- a/__tests__/processPlugins.test.js
+++ b/__tests__/processPlugins.test.js
@@ -979,64 +979,12 @@ test('plugins can add multiple sets of utilities and components', () => {
 })
 
 test('plugins respect prefix and important options by default when adding utilities', () => {
-  const { utilities } = processPlugins(
-    [
-      function({ addUtilities }) {
-        addUtilities({
-          '.rotate-90': {
-            transform: 'rotate(90deg)',
-          },
-        })
-      },
-    ],
-    makeConfig({
+  return _postcss([
+    tailwind({
       prefix: 'tw-',
       important: true,
-    })
-  )
-
-  expect(css(utilities)).toMatchCss(`
-    @layer utilities {
-      @variants {
-        .tw-rotate-90 {
-          transform: rotate(90deg) !important
-        }
-      }
-    }
-  `)
-})
-
-test('when important is a selector it is used to scope utilities instead of adding !important', () => {
-  const { utilities } = processPlugins(
-    [
-      function({ addUtilities }) {
-        addUtilities({
-          '.rotate-90': {
-            transform: 'rotate(90deg)',
-          },
-        })
-      },
-    ],
-    makeConfig({
-      important: '#app',
-    })
-  )
-
-  expect(css(utilities)).toMatchCss(`
-    @layer utilities {
-      @variants {
-        #app .rotate-90 {
-          transform: rotate(90deg)
-        }
-      }
-    }
-  `)
-})
-
-test('when important contains a class an error is thrown', () => {
-  expect(() => {
-    processPlugins(
-      [
+      corePlugins: [],
+      plugins: [
         function({ addUtilities }) {
           addUtilities({
             '.rotate-90': {
@@ -1045,65 +993,123 @@ test('when important contains a class an error is thrown', () => {
           })
         },
       ],
-      makeConfig({
-        important: '#app .project',
-      })
+    }),
+  ])
+    .process(
+      `
+        @tailwind utilities;
+      `,
+      { from: undefined }
     )
-  }).toThrow()
+    .then(result => {
+      const expected = `
+        .tw-rotate-90 {
+          transform: rotate(90deg) !important
+        }
+      `
+
+      expect(result.css).toMatchCss(expected)
+    })
+})
+
+test('when important is a selector it is used to scope utilities instead of adding !important', () => {
+  return _postcss([
+    tailwind({
+      prefix: 'tw-',
+      important: '#app',
+      corePlugins: [],
+      plugins: [
+        function({ addUtilities }) {
+          addUtilities({
+            '.rotate-90': {
+              transform: 'rotate(90deg)',
+            },
+          })
+        },
+      ],
+    }),
+  ])
+    .process(
+      `
+        @tailwind utilities;
+      `,
+      { from: undefined }
+    )
+    .then(result => {
+      const expected = `
+        #app .tw-rotate-90 {
+          transform: rotate(90deg)
+        }
+      `
+
+      expect(result.css).toMatchCss(expected)
+    })
 })
 
 test('when important is a selector it scopes all selectors in a rule, even though defining utilities like this is stupid', () => {
-  const { utilities } = processPlugins(
-    [
-      function({ addUtilities }) {
-        addUtilities({
-          '.rotate-90, .rotate-1\\/4': {
-            transform: 'rotate(90deg)',
-          },
-        })
-      },
-    ],
-    makeConfig({
+  return _postcss([
+    tailwind({
       important: '#app',
-    })
-  )
-
-  expect(css(utilities)).toMatchCss(`
-    @layer utilities {
-      @variants {
+      corePlugins: [],
+      plugins: [
+        function({ addUtilities }) {
+          addUtilities({
+            '.rotate-90, .rotate-1\\/4': {
+              transform: 'rotate(90deg)',
+            },
+          })
+        },
+      ],
+    }),
+  ])
+    .process(
+      `
+        @tailwind utilities;
+      `,
+      { from: undefined }
+    )
+    .then(result => {
+      const expected = `
         #app .rotate-90, #app .rotate-1\\/4 {
           transform: rotate(90deg)
         }
-      }
-    }
-  `)
+      `
+
+      expect(result.css).toMatchCss(expected)
+    })
 })
 
 test('important utilities are not made double important when important option is used', () => {
-  const { utilities } = processPlugins(
-    [
-      function({ addUtilities }) {
-        addUtilities({
-          '.rotate-90': {
-            transform: 'rotate(90deg) !important',
-          },
-        })
-      },
-    ],
-    makeConfig({
+  return _postcss([
+    tailwind({
       important: true,
-    })
-  )
-
-  expect(css(utilities)).toMatchCss(`
-    @layer utilities {
-      @variants {
+      corePlugins: [],
+      plugins: [
+        function({ addUtilities }) {
+          addUtilities({
+            '.rotate-90': {
+              transform: 'rotate(90deg) !important',
+            },
+          })
+        },
+      ],
+    }),
+  ])
+    .process(
+      `
+        @tailwind utilities;
+      `,
+      { from: undefined }
+    )
+    .then(result => {
+      const expected = `
         .rotate-90 {
           transform: rotate(90deg) !important
         }
-      }
-    }
-  `)
+      `
+
+      expect(result.css).toMatchCss(expected)
+    })
 })
 
 test("component declarations respect the 'prefix' option by default", () => {
@@ -1346,69 +1352,79 @@ test("plugins can apply the user's chosen prefix to components manually", () => 
 })
 
 test('prefix can optionally be ignored for utilities', () => {
-  const { utilities } = processPlugins(
-    [
-      function({ addUtilities }) {
-        addUtilities(
-          {
-            '.rotate-90': {
-              transform: 'rotate(90deg)',
-            },
-          },
-          {
-            respectPrefix: false,
-          }
-        )
-      },
-    ],
-    makeConfig({
+  return _postcss([
+    tailwind({
       prefix: 'tw-',
-      important: true,
-    })
-  )
-
-  expect(css(utilities)).toMatchCss(`
-    @layer utilities {
-      @variants {
+      corePlugins: [],
+      plugins: [
+        function({ addUtilities }) {
+          addUtilities(
+            {
+              '.rotate-90': {
+                transform: 'rotate(90deg)',
+              },
+            },
+            {
+              respectPrefix: false,
+            }
+          )
+        },
+      ],
+    }),
+  ])
+    .process(
+      `
+        @tailwind utilities;
+      `,
+      { from: undefined }
+    )
+    .then(result => {
+      const expected = `
         .rotate-90 {
-          transform: rotate(90deg) !important
+          transform: rotate(90deg)
         }
-      }
-    }
-  `)
+      `
+
+      expect(result.css).toMatchCss(expected)
+    })
 })
 
 test('important can optionally be ignored for utilities', () => {
-  const { utilities } = processPlugins(
-    [
-      function({ addUtilities }) {
-        addUtilities(
-          {
-            '.rotate-90': {
-              transform: 'rotate(90deg)',
-            },
-          },
-          {
-            respectImportant: false,
-          }
-        )
-      },
-    ],
-    makeConfig({
-      prefix: 'tw-',
+  return _postcss([
+    tailwind({
       important: true,
-    })
-  )
-
-  expect(css(utilities)).toMatchCss(`
-    @layer utilities {
-      @variants {
-        .tw-rotate-90 {
+      corePlugins: [],
+      plugins: [
+        function({ addUtilities }) {
+          addUtilities(
+            {
+              '.rotate-90': {
+                transform: 'rotate(90deg)',
+              },
+            },
+            {
+              respectImportant: false,
+            }
+          )
+        },
+      ],
+    }),
+  ])
+    .process(
+      `
+        @tailwind utilities;
+      `,
+      { from: undefined }
+    )
+    .then(result => {
+      const expected = `
+        .rotate-90 {
           transform: rotate(90deg)
         }
-      }
-    }
-  `)
+      `
+
+      expect(result.css).toMatchCss(expected)
+    })
 })
 
 test('variants can still be specified when ignoring prefix and important options', () => {

--- a/jest/customMatchers.js
+++ b/jest/customMatchers.js
@@ -3,7 +3,7 @@ expect.extend({
   // This is probably naive but it's fast and works well enough.
   toMatchCss(received, argument) {
     function stripped(str) {
-      return str.replace(/\s/g, '')
+      return str.replace(/\s/g, '').replace(/;/g, '')
     }
 
     if (stripped(received) === stripped(argument)) {

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -8,6 +8,7 @@ const featureFlags = {
     'extendedSpacingScale',
     'defaultLineHeights',
     'extendedFontSizeScale',
+    'applyComplexClasses',
   ],
 }
 

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -70,8 +70,7 @@ export function issueFlagNotices(config) {
       .map(s => chalk.cyan(s))
       .join(', ')
 
-    console.log()
-    log.info(`You have opted-in to future-facing breaking changes: ${changes}`)
+    log.info(`\nYou have opted-in to future-facing breaking changes: ${changes}`)
     log.info(
       'These changes are stable and will be the default behavior in the next major version of Tailwind.'
     )
@@ -82,8 +81,7 @@ export function issueFlagNotices(config) {
       .map(s => chalk.yellow(s))
       .join(', ')
 
-    console.log()
-    log.warn(`You have enabled experimental features: ${changes}`)
+    log.warn(`\nYou have enabled experimental features: ${changes}`)
     log.warn(
       'Experimental features are not covered by semver, may introduce breaking changes, and can change at any time.'
     )
@@ -94,8 +92,7 @@ export function issueFlagNotices(config) {
       .map(s => chalk.magenta(s))
       .join(', ')
 
-    console.log()
-    log.risk(`There are upcoming breaking changes: ${changes}`)
+    log.risk(`\nThere are upcoming breaking changes: ${changes}`)
     log.risk(
       'We highly recommend opting-in to these changes now to simplify upgrading Tailwind in the future.'
     )

--- a/src/flagged/applyComplexClasses.js
+++ b/src/flagged/applyComplexClasses.js
@@ -1,8 +1,18 @@
 import _ from 'lodash'
 import selectorParser from 'postcss-selector-parser'
 
+function hasInject(css) {
+  let foundInject = false
+
+  css.walkAtRules('apply', () => {
+    foundInject = true
+    return false
+  })
+
+  return foundInject
+}
 function applyUtility(rule, className, replaceWith) {
-  const selectors = rule.selectors.map(selector => {
+  const processedSelectors = rule.selectors.map(selector => {
     const processor = selectorParser(selectors => {
       selectors.walkClasses(c => {
         if (c.value === className) {
@@ -34,7 +44,7 @@ function applyUtility(rule, className, replaceWith) {
     parent = parent.parent
   }
 
-  cloned.selectors = selectors
+  cloned.selectors = processedSelectors
   return current
 }
 
@@ -115,7 +125,7 @@ function mergeAdjacentRules(initialRule, rulesToInsert) {
 function makeExtractUtilityRules(css) {
   const utilityMap = buildUtilityMap(css)
   const orderUtilityMap = Object.fromEntries(
-    Object.entries(utilityMap).flatMap(([utilityName, utilities]) => {
+    Object.entries(utilityMap).flatMap(([_utilityName, utilities]) => {
       return utilities.map(utility => {
         return [utility.index, utility]
       })
@@ -135,17 +145,6 @@ function makeExtractUtilityRules(css) {
       .sort((a, b) => a - b)
       .map(i => orderUtilityMap[i])
   }
-}
-
-function hasInject(css) {
-  let foundInject = false
-
-  css.walkAtRules('apply', () => {
-    foundInject = true
-    return false
-  })
-
-  return foundInject
 }
 
 export default function applyComplexClasses(css) {

--- a/src/flagged/applyComplexClasses.js
+++ b/src/flagged/applyComplexClasses.js
@@ -124,8 +124,8 @@ function mergeAdjacentRules(initialRule, rulesToInsert) {
 
 function makeExtractUtilityRules(css) {
   const utilityMap = buildUtilityMap(css)
-  const orderUtilityMap = Object.fromEntries(
-    _.flatMap(Object.entries(utilityMap), ([_utilityName, utilities]) => {
+  const orderUtilityMap = _.fromPairs(
+    _.flatMap(_.toPairs(utilityMap), ([_utilityName, utilities]) => {
       return utilities.map(utility => {
         return [utility.index, utility]
       })

--- a/src/flagged/applyComplexClasses.js
+++ b/src/flagged/applyComplexClasses.js
@@ -210,11 +210,11 @@ function processApplyAtRules(css, lookupTree, config) {
           afterRule,
         ]
 
-        const root = _.tap(postcss.root({ nodes: rulesToInsert }), root =>
+        const { nodes } = _.tap(postcss.root({ nodes: rulesToInsert }), root =>
           root.walkDecls(d => (d.important = important))
         )
 
-        const mergedRules = mergeAdjacentRules(rule, root.nodes)
+        const mergedRules = mergeAdjacentRules(rule, nodes)
 
         inject.remove()
         rule.after(mergedRules)

--- a/src/flagged/applyComplexClasses.js
+++ b/src/flagged/applyComplexClasses.js
@@ -241,6 +241,8 @@ export default function applyComplexClasses(config, getProcessedPlugins) {
       return processApplyAtRules(css, css, config)
     }
 
+    // Tree contains no @tailwind rules, so generate all of Tailwind's styles and
+    // prepend them to the user's CSS. Important for <style> blocks in Vue components.
     return postcss([
       substituteTailwindAtRules(config, getProcessedPlugins()),
       evaluateTailwindFunctions(config),

--- a/src/flagged/applyComplexClasses.js
+++ b/src/flagged/applyComplexClasses.js
@@ -1,0 +1,207 @@
+import _ from 'lodash'
+import selectorParser from 'postcss-selector-parser'
+
+function applyUtility(rule, className, replaceWith) {
+  const selectors = rule.selectors.map(selector => {
+    const processor = selectorParser(selectors => {
+      selectors.walkClasses(c => {
+        if (c.value === className) {
+          c.replaceWith(selectorParser.attribute({ attribute: '__TAILWIND-APPLY-PLACEHOLDER__' }))
+        }
+      })
+    })
+
+    // You could argue we should make this replacement at the AST level, but if we believe
+    // the placeholder string is safe from collisions then it is safe to do this is a simple
+    // string replacement, and much, much faster.
+    const processedSelector = processor
+      .processSync(selector)
+      .replace('[__TAILWIND-APPLY-PLACEHOLDER__]', replaceWith)
+
+    return processedSelector
+  })
+
+  const cloned = rule.clone()
+  let current = cloned
+  let parent = rule.parent
+
+  while (parent && parent.type !== 'root') {
+    const parentClone = parent.clone()
+    parentClone.removeAll()
+    parentClone.append(current)
+    current.parent = parentClone
+    current = parentClone
+    parent = parent.parent
+  }
+
+  cloned.selectors = selectors
+  return current
+}
+
+function extractUtilityNames(selector) {
+  const processor = selectorParser(selectors => {
+    let classes = []
+
+    selectors.walkClasses(c => {
+      classes.push(c)
+    })
+
+    return classes.map(c => c.value)
+  })
+
+  return processor.transformSync(selector)
+}
+
+function buildUtilityMap(css) {
+  let index = 0
+  const utilityMap = {}
+
+  css.walkRules(rule => {
+    const utilityNames = extractUtilityNames(rule.selector)
+
+    utilityNames.forEach(utilityName => {
+      if (utilityMap[utilityName] === undefined) {
+        utilityMap[utilityName] = []
+      }
+
+      utilityMap[utilityName].push({
+        index,
+        utilityName,
+        rule: rule.clone({ parent: rule.parent }),
+        containsApply: hasInject(rule),
+      })
+      index++
+    })
+  })
+
+  return utilityMap
+}
+
+function mergeAdjacentRules(initialRule, rulesToInsert) {
+  let previousRule = initialRule
+
+  rulesToInsert.forEach(toInsert => {
+    if (
+      toInsert.type === 'rule' &&
+      previousRule.type === 'rule' &&
+      toInsert.selector === previousRule.selector
+    ) {
+      previousRule.append(toInsert.nodes)
+    } else if (
+      toInsert.type === 'atrule' &&
+      previousRule.type === 'atrule' &&
+      toInsert.params === previousRule.params
+    ) {
+      const merged = mergeAdjacentRules(
+        previousRule.nodes[previousRule.nodes.length - 1],
+        toInsert.nodes
+      )
+
+      previousRule.append(merged)
+    } else {
+      previousRule = toInsert
+    }
+
+    toInsert.walk(n => {
+      if (n.nodes && n.nodes.length === 0) {
+        n.remove()
+      }
+    })
+  })
+
+  return rulesToInsert.filter(r => r.nodes.length > 0)
+}
+
+function makeExtractUtilityRules(css) {
+  const utilityMap = buildUtilityMap(css)
+  const orderUtilityMap = Object.fromEntries(
+    Object.entries(utilityMap).flatMap(([utilityName, utilities]) => {
+      return utilities.map(utility => {
+        return [utility.index, utility]
+      })
+    })
+  )
+  return function(utilityNames, rule) {
+    return utilityNames
+      .flatMap(utilityName => {
+        if (utilityMap[utilityName] === undefined) {
+          throw rule.error(
+            `The \`${utilityName}\` utility does not exist. If you're sure that \`${utilityName}\` exists, make sure that any \`@import\` statements are being properly processed before Tailwind CSS sees your CSS, as \`@apply\` can only be used for classes in the same CSS tree.`,
+            { word: utilityName }
+          )
+        }
+        return utilityMap[utilityName].map(({ index }) => index)
+      })
+      .sort((a, b) => a - b)
+      .map(i => orderUtilityMap[i])
+  }
+}
+
+function hasInject(css) {
+  let foundInject = false
+
+  css.walkAtRules('apply', () => {
+    foundInject = true
+    return false
+  })
+
+  return foundInject
+}
+
+export default function applyComplexClasses(css) {
+  const extractUtilityRules = makeExtractUtilityRules(css)
+
+  while (hasInject(css)) {
+    css.walkRules(rule => {
+      const injectRules = []
+
+      // Only walk direct children to avoid issues with nesting plugins
+      rule.each(child => {
+        if (child.type === 'atrule' && child.name === 'apply') {
+          injectRules.unshift(child)
+        }
+      })
+
+      injectRules.forEach(inject => {
+        const injectUtilityNames = inject.params.split(' ')
+        const currentUtilityNames = extractUtilityNames(rule.selector)
+
+        if (_.intersection(injectUtilityNames, currentUtilityNames).length > 0) {
+          const currentUtilityName = _.intersection(injectUtilityNames, currentUtilityNames)[0]
+          throw rule.error(
+            `You cannot \`@apply\` the \`${currentUtilityName}\` utility here because it creates a circular dependency.`
+          )
+        }
+
+        // Extract any post-inject declarations and re-insert them after inject rules
+        const afterRule = rule.clone({ raws: {} })
+        afterRule.nodes = afterRule.nodes.slice(rule.index(inject) + 1)
+        rule.nodes = rule.nodes.slice(0, rule.index(inject) + 1)
+
+        // Sort injects to match CSS source order
+        const injects = extractUtilityRules(injectUtilityNames, inject)
+
+        // Get new rules with the utility portion of the selector replaced with the new selector
+        const rulesToInsert = [
+          ...injects.map(injectUtility => {
+            return applyUtility(injectUtility.rule, injectUtility.utilityName, rule.selector)
+          }),
+          afterRule,
+        ]
+
+        const mergedRules = mergeAdjacentRules(rule, rulesToInsert)
+
+        inject.remove()
+        rule.after(mergedRules)
+      })
+
+      // If the base rule has nothing in it (all injects were pseudo or responsive variants),
+      // remove the rule fuggit.
+      if (rule.nodes.length === 0) {
+        rule.remove()
+      }
+    })
+  }
+
+  return css
+}

--- a/src/flagged/applyComplexClasses.js
+++ b/src/flagged/applyComplexClasses.js
@@ -125,23 +125,22 @@ function mergeAdjacentRules(initialRule, rulesToInsert) {
 function makeExtractUtilityRules(css) {
   const utilityMap = buildUtilityMap(css)
   const orderUtilityMap = Object.fromEntries(
-    Object.entries(utilityMap).flatMap(([_utilityName, utilities]) => {
+    _.flatMap(Object.entries(utilityMap), ([_utilityName, utilities]) => {
       return utilities.map(utility => {
         return [utility.index, utility]
       })
     })
   )
   return function(utilityNames, rule) {
-    return utilityNames
-      .flatMap(utilityName => {
-        if (utilityMap[utilityName] === undefined) {
-          throw rule.error(
-            `The \`${utilityName}\` utility does not exist. If you're sure that \`${utilityName}\` exists, make sure that any \`@import\` statements are being properly processed before Tailwind CSS sees your CSS, as \`@apply\` can only be used for classes in the same CSS tree.`,
-            { word: utilityName }
-          )
-        }
-        return utilityMap[utilityName].map(({ index }) => index)
-      })
+    return _.flatMap(utilityNames, utilityName => {
+      if (utilityMap[utilityName] === undefined) {
+        throw rule.error(
+          `The \`${utilityName}\` utility does not exist. If you're sure that \`${utilityName}\` exists, make sure that any \`@import\` statements are being properly processed before Tailwind CSS sees your CSS, as \`@apply\` can only be used for classes in the same CSS tree.`,
+          { word: utilityName }
+        )
+      }
+      return utilityMap[utilityName].map(({ index }) => index)
+    })
       .sort((a, b) => a - b)
       .map(i => orderUtilityMap[i])
   }

--- a/src/flagged/applyComplexClasses.js
+++ b/src/flagged/applyComplexClasses.js
@@ -255,9 +255,8 @@ export default function applyComplexClasses(config, getProcessedPlugins) {
         { from: undefined }
       )
       .then(result => {
-        // if css already contains tailwind, css is the lookup tree
+        // Prepend Tailwind's generated classes to the tree so they are available for `@apply`
         const lookupTree = _.tap(css.clone(), tree => tree.prepend(result.root))
-
         return processApplyAtRules(css, lookupTree, config)
       })
   }

--- a/src/lib/applyImportantConfiguration.js
+++ b/src/lib/applyImportantConfiguration.js
@@ -1,0 +1,19 @@
+export default function applyImportantConfiguration(_config) {
+  return function(css) {
+    css.walkRules(rule => {
+      const important = rule.__tailwind ? rule.__tailwind.important : false
+
+      if (!important) {
+        return
+      }
+
+      if (typeof important === 'string') {
+        rule.selectors = rule.selectors.map(selector => {
+          return `${rule.__tailwind.important} ${selector}`
+        })
+      } else {
+        rule.walkDecls(decl => (decl.important = true))
+      }
+    })
+  }
+}

--- a/src/lib/purgeUnusedStyles.js
+++ b/src/lib/purgeUnusedStyles.js
@@ -5,7 +5,8 @@ import chalk from 'chalk'
 import { log } from '../cli/utils'
 import * as emoji from '../cli/emoji'
 
-function removeTailwindComments(css) {
+function removeTailwindMarkers(css) {
+  css.walkAtRules('tailwind', rule => rule.remove())
   css.walkComments(comment => {
     switch (comment.text.trim()) {
       case 'tailwind start components':
@@ -28,7 +29,7 @@ export default function purgeUnusedUtilities(config) {
   )
 
   if (!purgeEnabled) {
-    return removeTailwindComments
+    return removeTailwindMarkers
   }
 
   // Skip if `purge: []` since that's part of the default config
@@ -48,7 +49,7 @@ export default function purgeUnusedUtilities(config) {
     log(
       chalk.white('\n      https://tailwindcss.com/docs/controlling-file-size/#removing-unused-css')
     )
-    return removeTailwindComments
+    return removeTailwindMarkers
   }
 
   return postcss([
@@ -73,7 +74,7 @@ export default function purgeUnusedUtilities(config) {
         })
       }
     },
-    removeTailwindComments,
+    removeTailwindMarkers,
     purgecss({
       content: Array.isArray(config.purge) ? config.purge : config.purge.content,
       defaultExtractor: content => {

--- a/src/lib/substituteClassApplyAtRules.js
+++ b/src/lib/substituteClassApplyAtRules.js
@@ -4,6 +4,9 @@ import escapeClassName from '../util/escapeClassName'
 import prefixSelector from '../util/prefixSelector'
 import increaseSpecificity from '../util/increaseSpecificity'
 
+import { flagEnabled } from '../featureFlags'
+import applyComplexClasses from '../flagged/applyComplexClasses'
+
 function buildClassTable(css) {
   const classTable = {}
 
@@ -54,6 +57,10 @@ function findClass(classToApply, classTable, onError) {
 }
 
 export default function(config, generatedUtilities) {
+  if (flagEnabled(config, 'applyComplexClasses')) {
+    return applyComplexClasses
+  }
+
   return function(css) {
     const classLookup = buildClassTable(css)
     const shadowLookup = buildShadowTable(generatedUtilities)

--- a/src/lib/substituteClassApplyAtRules.js
+++ b/src/lib/substituteClassApplyAtRules.js
@@ -56,14 +56,14 @@ function findClass(classToApply, classTable, onError) {
   return match.clone().nodes
 }
 
-export default function(config, generatedUtilities) {
+export default function(config, getProcessedPlugins) {
   if (flagEnabled(config, 'applyComplexClasses')) {
-    return applyComplexClasses
+    return applyComplexClasses(config, getProcessedPlugins)
   }
 
   return function(css) {
     const classLookup = buildClassTable(css)
-    const shadowLookup = buildShadowTable(generatedUtilities)
+    const shadowLookup = buildShadowTable(getProcessedPlugins().utilities)
 
     css.walkRules(rule => {
       rule.walkAtRules('apply', atRule => {

--- a/src/lib/substituteTailwindAtRules.js
+++ b/src/lib/substituteTailwindAtRules.js
@@ -49,18 +49,15 @@ export default function(
       }
 
       if (atRule.params === 'base') {
-        atRule.before(updateSource(pluginBase, atRule.source))
-        atRule.remove()
+        atRule.after(updateSource(pluginBase, atRule.source))
       }
 
       if (atRule.params === 'components') {
-        atRule.before(updateSource(pluginComponents, atRule.source))
-        atRule.remove()
+        atRule.after(updateSource(pluginComponents, atRule.source))
       }
 
       if (atRule.params === 'utilities') {
-        atRule.before(updateSource(pluginUtilities, atRule.source))
-        atRule.remove()
+        atRule.after(updateSource(pluginUtilities, atRule.source))
       }
 
       if (atRule.params === 'screens') {

--- a/src/processTailwindFeatures.js
+++ b/src/processTailwindFeatures.js
@@ -39,7 +39,7 @@ export default function(getConfig) {
       substituteResponsiveAtRules(config),
       convertLayerAtRulesToControlComments(config),
       substituteScreenAtRules(config),
-      substituteClassApplyAtRules(config, getProcessedPlugins().utilities),
+      substituteClassApplyAtRules(config, getProcessedPlugins),
       purgeUnusedStyles(config),
     ]).process(css, { from: _.get(css, 'source.input.file') })
   }

--- a/src/processTailwindFeatures.js
+++ b/src/processTailwindFeatures.js
@@ -8,6 +8,7 @@ import substituteResponsiveAtRules from './lib/substituteResponsiveAtRules'
 import convertLayerAtRulesToControlComments from './lib/convertLayerAtRulesToControlComments'
 import substituteScreenAtRules from './lib/substituteScreenAtRules'
 import substituteClassApplyAtRules from './lib/substituteClassApplyAtRules'
+import applyImportantConfiguration from './lib/applyImportantConfiguration'
 import purgeUnusedStyles from './lib/purgeUnusedStyles'
 
 import corePlugins from './corePlugins'
@@ -40,9 +41,7 @@ export default function(getConfig) {
       convertLayerAtRulesToControlComments(config),
       substituteScreenAtRules(config),
       substituteClassApplyAtRules(config, getProcessedPlugins),
-      function(css) {
-        css.walkAtRules('tailwind', rule => rule.remove())
-      },
+      applyImportantConfiguration(config),
       purgeUnusedStyles(config),
     ]).process(css, { from: _.get(css, 'source.input.file') })
   }

--- a/src/processTailwindFeatures.js
+++ b/src/processTailwindFeatures.js
@@ -40,6 +40,9 @@ export default function(getConfig) {
       convertLayerAtRulesToControlComments(config),
       substituteScreenAtRules(config),
       substituteClassApplyAtRules(config, getProcessedPlugins),
+      function(css) {
+        css.walkAtRules('tailwind', rule => rule.remove())
+      },
       purgeUnusedStyles(config),
     ]).process(css, { from: _.get(css, 'source.input.file') })
   }

--- a/src/util/processPlugins.js
+++ b/src/util/processPlugins.js
@@ -9,8 +9,6 @@ import parseObjectStyles from '../util/parseObjectStyles'
 import prefixSelector from '../util/prefixSelector'
 import wrapWithVariants from '../util/wrapWithVariants'
 import cloneNodes from '../util/cloneNodes'
-import increaseSpecificity from '../util/increaseSpecificity'
-import selectorParser from 'postcss-selector-parser'
 
 function parseStyles(styles) {
   if (!Array.isArray(styles)) {
@@ -18,14 +16,6 @@ function parseStyles(styles) {
   }
 
   return _.flatMap(styles, style => (style instanceof Node ? style : parseObjectStyles(style)))
-}
-
-function containsClass(value) {
-  return selectorParser(selectors => {
-    let classFound = false
-    selectors.walkClasses(() => (classFound = true))
-    return classFound
-  }).transformSync(value)
 }
 
 function wrapWithLayer(rules, layer) {
@@ -102,19 +92,10 @@ export default function(plugins, config) {
             rule.selector = applyConfiguredPrefix(rule.selector)
           }
 
-          if (options.respectImportant && _.get(config, 'important')) {
-            if (config.important === true) {
-              rule.walkDecls(decl => (decl.important = true))
-            } else if (typeof config.important === 'string') {
-              if (containsClass(config.important)) {
-                throw rule.error(
-                  `Classes are not allowed when using the \`important\` option with a string argument. Please use an ID instead.`
-                )
-              }
-
-              rule.selectors = rule.selectors.map(selector => {
-                return increaseSpecificity(config.important, selector)
-              })
+          if (options.respectImportant && config.important) {
+            rule.__tailwind = {
+              ...rule.__tailwind,
+              important: config.important,
             }
           }
         })


### PR DESCRIPTION
This PR introduces support for using `@apply` with any class, and finally (3 years later!) resolves #313, which is probably the most requested feature in the history of the framework.

TL;DR, this works now:

```css
.btn {
  @apply bg-indigo hover:bg-indigo-700 sm:text-lg;
}
```

Pending merge, this will be available under a feature flag in Tailwind 1.x until it becomes the default in Tailwind 2.0 in the Fall:

```js
// tailwind.config.js
module.exports = {
  experimental: {
    applyComplexClasses: true,
  },
}
```

## Motivation

Previously, this sort of code would throw an error:

```css
.btn {
  @apply bg-indigo-600 hover:bg-indigo-700;
}
```

You would have to write this instead:

```css
.btn {
  @apply bg-indigo-600;
}
.btn:hover {
  @apply hover:bg-indigo-700;
}
```

This totally kills the "copy the classes from your HTML class attribute and paste it after `@apply`" workflow that the framework promises.

There were also a handful of other classes you couldn't apply that have always surprised people, like `clearfix`, or more recently the space between and divide utilities like `space-x-4` and `divide-y-2`.

This is because of a fundamental limitation with the original implementation that prevented `@apply` from working with any selector that contained _anything_ more than a single class name and was at the root of the CSS tree (so not nested within an at-rule like a media query).

This is a major source of confusion for new users, and we get new GitHub issues and Discord questions all the time that can be traced back to this fundamental problem

## New functionality

This PR makes it possible to use `@apply` with _any_ class:

```css
/* Input */
.btn {
  @apply bg-indigo-600 hover:bg-indigo-700 group-hover:opacity-50 sm:text-lg;
}

/* Output */
.btn {
  background-color: #5a67d8;
}
.btn:hover {
  background-color: #4c51bf;
}
.group:hover .btn {
  opacity: 0.5;
}
@media (min-width: 640px) {
  .btn {
    font-size: 1.125rem;
  }
}
```

### Responsive variants

The `@apply` directive can now be used with all of Tailwind's responsive utilities, like `md:text-center`, and even things like `md:hover:opacity-50`:

```css
/* Input */
.btn {
  @apply md:text-center md:hover:opacity-50;
}

/* Output */
@media (min-width: 768px) {
  .btn {
    text-align: center;
  }
  .btn:hover {
    opacity: 0.5;
  }
}
```

### Pseudo-class variants

The `@apply` directive can now be used with pseudo-class variants, like `hover:opacity-75`:

```css
/* Input */
.btn {
  @apply hover:opacity-50;
}

/* Output */
.btn:hover {
  opacity: 0.5;
}
```

### Complex selectors

The `@apply` directive can now be used to apply classes that appear in complex selectors:

```css
/* Input */
.btn {
  @apply complex-class;
}

.foo .complex-class:hover * {
  color: red;
}

/* Output */
.foo .btn:hover * {
  color: red;
}

.foo .complex-class:hover * {
  color: red;
}
```

### Classes used in multiple rules

The `@apply` directive can now be used to apply classes that appear in multiple rules:

```css
/* Input */
.btn {
  @apply example-class;
}

.example-class {
  background: red;
  font-weight: bold;
}

.example-class.is-active {
  opacity: 1;
}

@media (min-width: 1024px) {
  .example-class {
    font-size: 24px;
  }
}

/* Output */
.btn {
  background: red;
  font-weight: bold;
}

.btn.is-active {
  opacity: 1;
}

@media (min-width: 1024px) {
  .btn {
    font-size: 24px;
  }
}

.example-class {
  background: red;
}

.example-class {
  font-weight: bold;
}

.example-class.is-active {
  opacity: 1;
}

@media (min-width: 1024px) {
  .example-class {
    font-size: 24px;
  }
}
```

This makes it possible to `@apply` the `container` class for example:

```css
/* Input */
.custom-class {
  @apply container;
}

/* Output */
.custom-class {
  width: 100%;
}
@media (min-width: 640px) {
  .custom-class {
    max-width: 640px;
  }
}
@media (min-width: 768px) {
  .custom-class {
    max-width: 768px;
  }
}
@media (min-width: 1024px) {
  .custom-class {
    max-width: 1024px;
  }
}
@media (min-width: 1280px) {
  .custom-class {
    max-width: 1280px;
  }
}
```

### Recursive `@apply`

The `@apply` directive can now be used recursively

## Detailed explanation of behavior

This new implementation is designed around a single guiding principle:

> Copying a list of classes from your HTML, pasting them after `@apply`, then replacing the list of classes with the new class should result in the exact same observed behavior as keeping the list of classes in your HTML.

Sounds simple in theory but following it does lead to behavior you might initially find unintuitive or think is undesirable, so let's discuss the particularly controversial implications...

### All declarations relating to a class are included

Following the guiding principle, we now apply the declarations from _all_ rules where the class being applied is included.

To understand why this is the correct behavior, consider this example:

```html
<style>
  .link {
    color: black;
    font-weight: bold;
  }
  .link.is-active {
    background: yellow;
  }
</style>

<a href="#" class="link text-lg leading-7">Link</a>
```

If we wanted to extract a new class here, we would write this CSS:

```css
.link-lg {
  @apply link text-lg leading-7;
}
```

Now we can replace the class list like so:

```html
<a href="#" class="link-lg">Link</a>
```

Now consider what happens if in the original example, we add the `is-active` class:

```html
<a href="#" class="link text-lg leading-7 is-active">Link</a>
```

This gives the link a yellow background color. If we are following the guiding principle outlined above, then this should also have a yellow background color:

```html
<a href="#" class="link-lg is-active">Link</a>
```

If it doesn't, then the extraction we performed wasn't safe — it changed the behavior of the design.

For that reason, it is important that given this input:

```css
.link {
  color: black;
  font-weight: bold;
}
.link.is-active {
  background: yellow;
}

.link-lg {
  @apply link text-lg leading-7;
}
```

...we generate this output:

```css
.link {
  color: black;
  font-weight: bold;
}
.link.is-active {
  background: yellow;
}
.link-lg {
  color: black;
  font-weight: bold;
  font-size: 1.125rem;
  leading: 1.75rem;
}
.link-lg.is-active {
  background: yellow;
}
```

### Applied classes follow CSS source order, not apply order

Consider this example:

```html
<div class="bg-white bg-black">
  <!-- ... -->
</div>
<div class="bg-black bg-white">
  <!-- ... -->
</div>
```

Both of these `div` elements will have a **white** background color, because the order of classes in the HTML _does not matter_. What matters is the order of the rules in the stylesheet (and specificity, but that's not relevant to this example).

So following that, this input CSS:

```css
.foo {
  @apply bg-white bg-black;
}
.bar {
  @apply bg-white bg-black;
}
```

...needs to generate this output:

```css
.foo {
  background-color: black;
  background-color: white;
}
.bar {
  background-color: black;
  background-color: white;
}
```

Otherwise the behavior of `@apply` will differ from the behavior of using the utilities in your HTML, which breaks our guiding principle and means extracting with `@apply` is not a pure refactoring.

### The shadow lookup table is merged with the user's CSS, not treated as a fallback

Prior to this PR, Tailwind would use a "shadow lookup table" to find a utility that was used in `@apply` if it couldn't find it in the user's CSS tree.

In practice this was useful for Vue components, where you might try to use `@apply` in the `<style>` block, because Vue runs PostCSS for each style block _in isolation_, which means Tailwind can't "see" anything outside of that block, so `@apply flex` would fail because there was no `flex` class in the style block.

In this PR, the shadow lookup table still exists to support this use case, but because you can apply classes that appear in multiple rules, we _prepend_ the lookup table to your custom CSS. This means **it is not treated as a fallback**, and will always be considered, even if Tailwind finds the class you are trying to apply in your custom CSS.

Consider this _weird_ situation that you better not be doing you animal:

```vue
<!-- Some Vue component -->
<template>
  <!-- ... -->
</template>

<style>
.pt-4 {
  background-color: lol;
}
.foo {
  @apply pt-4;
}
</style>
```

In Tailwind currently, this would compile to this CSS output:

```css
.pt-4 {
  background-color: lol;
}
.foo {
  background-color: lol;
}
```

This is because when Tailwind tried to find `pt-4`, it found your _custom_ version of it and used that. It doesn't consider the _default_ `pt-4` unless it _can't find_ `pt-4` in your own CSS.

In this PR, you'd get this output:

```css
.pt-4 {
  background-color: lol;
}
.foo {
  padding-top: 1rem;
  background-color: lol;
}
```

Odds of this affecting you are basically zero, but it's a different mental model so worth explaining.

Related, **Tailwind only prepends the shadow lookup if it cannot find evidence of Tailwind's styles existing in your CSS tree**. The way it checks this is if your CSS contains _any_ `@tailwind` rules.

If Tailwind finds a single `@tailwind` rule in the tree, it will _not_ prepend the lookup table, and will _only_ search in your CSS.

### Declarations are always inserted relative to the position of `@apply`

Consider this input:

```css
.foo {
  background-color: red;
  @apply text-white font-normal hover:font-bold;
  text-align: center;
}
```

This PR generates this output:

```css
.foo {
  background-color: red;
  color: white;
  font-weight: normal;
}
.foo:hover {
  font-weight: bold;
}
.foo {
  text-align: center;
}
```

Seem a little confusing? Think about it in expanded form:

```css
.foo {
  background-color: red;
}

/* Start of `@apply`'d classes */
.foo {
  color: white;
  font-weight: normal;
}
.foo:hover {
  font-weight: bold;
}

/* End of `@apply`'d classes */
.foo {
  text-align: center;
}
```

All of the classes added with `@apply` are inserted _at the position of `@apply` itself_, even if that means pushing existing declarations out of the parent rule and into a clone of that parent rule that is added after the last `@apply`-related rule.

This is a weird one because it _sort of_ breaks the guiding principle, and you could argue that the applied declarations should be added relative to the source order of the class you are applying into, but after a bunch of trial and error, this _felt_ the most intuitive to us.

## Breaking changes

This PR necessitates a few small breaking changes to how `@apply` currently works. They will affect very few people.

### Applied classes now follow source order

Like discussed above, the order of utilities after `@apply` no longer maps to the order that the declarations are actually inserted.

In Tailwind currently, things work like this:

```css
/* Input */
.foo {
  @apply bg-white bg-black;
}
.bar {
  @apply bg-black bg-white;
}

/* Output */
.foo {
  background-color: white;
  background-color: black;
}
.bar {
  background-color: black;
  background-color: white;
}
```

With this PR, things will work like this:

```css
/* Input */
.foo {
  @apply bg-white bg-black;
}
.bar {
  @apply bg-black bg-white;
}

/* Output */
.foo {
  background-color: black;
  background-color: white;
}
.bar {
  background-color: black;
  background-color: white;
}
```

This new behavior is without a doubt correct if we agree that `@apply` is a tool for extracting a list of classes, and I would argue the current behavior is almost a bug.

When migrating to this new implementation, you will need to be careful that you were not relying on the old behavior. In practice it is _very unlikely_ you actually depended on this behavior anyways, you would almost never apply two classes that targeted the same CSS property, and if you did it would be situations like this:

```css
.foo {
  @apply p-4 pt-2;
}
```

...which you would have had to explicitly put in that order to get it to work, and Tailwind uses that order out of the box.

### Can't apply utilities without your configured prefix

If you have a prefix configured in your `tailwind.config.js` file, you need to include that prefix when using `@apply`:

```css
.foo {
  @apply tw-mt-6;
}
```

Previously this was optional, but now because Tailwind supports applying classes that appear in multiple rules, it's impossible for this behavior to not be ambiguous so we are removing it as a result. It breaks the guiding principle anyways, as using unprefixed classes in your HTML does not work if you have the prefix configured.

### Using a leading dot in front of utilities is no longer supported

This no longer works with the new implementation:

```css
.foo {
  @apply .bg-white;
}
```

We can make this work if there's some really good reason, but it hasn't been documented for like two years. No good reason to support both syntaxes.

### Interoperability with the old `@apply` that used to be included in cssnext has been removed

There used to be a draft for an `@apply` rule that worked with these custom property bag things like this:

```css
.foo {
  @apply --custom-thing;
}
```

Prior to this PR, Tailwind supported mixing that functionality with Tailwind's version of `@apply`, so you could do this:

```css
/* Input */
.foo {
  @apply --custom-thing text-center;
}

/* Output */
.foo {
  @apply --custom-thing;
  text-align: center;
}
```

That proposal is deprecated and that feature will never exist now, so we have removed interop support.

## FAQ

The most common question I've seen so far is _"why aren't declarations with the same selector being grouped together?"_ in situations like this:

```css
/* Input */
.foo {
  @apply font-normal hover:font-bold text-white hover:text-black;
}

/* Output */
.foo {
  font-weight: normal;
}
.foo:hover {
  font-weight: bold;
}
.foo {
  color: white;
}
.foo:hover {
  color: black;
}
```

The simple answer is that this is the only way to make the applied class order match the CSS source order, because that is the order those rules appear in the CSS.

It's true that it is safe to optimize this in this case and collapse them, because there are no conflicting properties, but I consider this to be outside the scope of Tailwind itself. Use cssnano or CleanCSS for this, you should be using one of them for your production builds anyways and they are very smart dedicated tools that handle this beautifully.

## Release strategy

Because this includes breaking changes it is slated for Tailwind 2.0, but will be available to try as an experimental feature in the next release under the `applyComplexClasses` key:

```js
// tailwind.config.js
module.exports = {
  experimental: {
    applyComplexClasses: true,
  },
}
```

We will release it as experimental for now so we can make changes if necessary once it's out in the wild and people can provide feedback, then we will promote it to `future` when it is stable, and finally turn it on by default in Tailwind 2.0.
