### PR TITLE
Add background-clip utilities

### DIFF
--- a/__tests__/fixtures/tailwind-output-flagged.css
+++ b/__tests__/fixtures/tailwind-output-flagged.css
@@ -2907,6 +2907,23 @@ video {
   background-attachment: scroll;
 }
 
+.bg-clip-border {
+  background-clip: border-box;
+}
+
+.bg-clip-padding {
+  background-clip: padding-box;
+}
+
+.bg-clip-content {
+  background-clip: content-box;
+}
+
+.bg-clip-text {
+  background-clip: text;
+  -webkit-background-clip: text;
+}
+
 .bg-transparent {
   background-color: transparent;
 }
@@ -27988,6 +28005,23 @@ video {
     background-attachment: scroll;
   }
 
+  .sm\:bg-clip-border {
+    background-clip: border-box;
+  }
+
+  .sm\:bg-clip-padding {
+    background-clip: padding-box;
+  }
+
+  .sm\:bg-clip-content {
+    background-clip: content-box;
+  }
+
+  .sm\:bg-clip-text {
+    background-clip: text;
+    -webkit-background-clip: text;
+  }
+
   .sm\:bg-transparent {
     background-color: transparent;
   }
@@ -53037,6 +53071,23 @@ video {
 
   .md\:bg-scroll {
     background-attachment: scroll;
+  }
+
+  .md\:bg-clip-border {
+    background-clip: border-box;
+  }
+
+  .md\:bg-clip-padding {
+    background-clip: padding-box;
+  }
+
+  .md\:bg-clip-content {
+    background-clip: content-box;
+  }
+
+  .md\:bg-clip-text {
+    background-clip: text;
+    -webkit-background-clip: text;
   }
 
   .md\:bg-transparent {
@@ -78090,6 +78141,23 @@ video {
     background-attachment: scroll;
   }
 
+  .lg\:bg-clip-border {
+    background-clip: border-box;
+  }
+
+  .lg\:bg-clip-padding {
+    background-clip: padding-box;
+  }
+
+  .lg\:bg-clip-content {
+    background-clip: content-box;
+  }
+
+  .lg\:bg-clip-text {
+    background-clip: text;
+    -webkit-background-clip: text;
+  }
+
   .lg\:bg-transparent {
     background-color: transparent;
   }
@@ -103139,6 +103207,23 @@ video {
 
   .xl\:bg-scroll {
     background-attachment: scroll;
+  }
+
+  .xl\:bg-clip-border {
+    background-clip: border-box;
+  }
+
+  .xl\:bg-clip-padding {
+    background-clip: padding-box;
+  }
+
+  .xl\:bg-clip-content {
+    background-clip: content-box;
+  }
+
+  .xl\:bg-clip-text {
+    background-clip: text;
+    -webkit-background-clip: text;
   }
 
   .xl\:bg-transparent {

--- a/__tests__/fixtures/tailwind-output-flagged.css
+++ b/__tests__/fixtures/tailwind-output-flagged.css
@@ -2921,7 +2921,6 @@ video {
 
 .bg-clip-text {
   background-clip: text;
-  -webkit-background-clip: text;
 }
 
 .bg-transparent {
@@ -28019,7 +28018,6 @@ video {
 
   .sm\:bg-clip-text {
     background-clip: text;
-    -webkit-background-clip: text;
   }
 
   .sm\:bg-transparent {
@@ -53087,7 +53085,6 @@ video {
 
   .md\:bg-clip-text {
     background-clip: text;
-    -webkit-background-clip: text;
   }
 
   .md\:bg-transparent {
@@ -78155,7 +78152,6 @@ video {
 
   .lg\:bg-clip-text {
     background-clip: text;
-    -webkit-background-clip: text;
   }
 
   .lg\:bg-transparent {
@@ -103223,7 +103219,6 @@ video {
 
   .xl\:bg-clip-text {
     background-clip: text;
-    -webkit-background-clip: text;
   }
 
   .xl\:bg-transparent {

--- a/__tests__/fixtures/tailwind-output-ie11.css
+++ b/__tests__/fixtures/tailwind-output-ie11.css
@@ -1379,6 +1379,18 @@ video {
   background-attachment: scroll;
 }
 
+.bg-clip-border {
+  background-clip: border-box;
+}
+
+.bg-clip-padding {
+  background-clip: padding-box;
+}
+
+.bg-clip-content {
+  background-clip: content-box;
+}
+
 .bg-transparent {
   background-color: transparent;
 }
@@ -11809,6 +11821,18 @@ video {
     background-attachment: scroll;
   }
 
+  .sm\:bg-clip-border {
+    background-clip: border-box;
+  }
+
+  .sm\:bg-clip-padding {
+    background-clip: padding-box;
+  }
+
+  .sm\:bg-clip-content {
+    background-clip: content-box;
+  }
+
   .sm\:bg-transparent {
     background-color: transparent;
   }
@@ -22207,6 +22231,18 @@ video {
 
   .md\:bg-scroll {
     background-attachment: scroll;
+  }
+
+  .md\:bg-clip-border {
+    background-clip: border-box;
+  }
+
+  .md\:bg-clip-padding {
+    background-clip: padding-box;
+  }
+
+  .md\:bg-clip-content {
+    background-clip: content-box;
   }
 
   .md\:bg-transparent {
@@ -32609,6 +32645,18 @@ video {
     background-attachment: scroll;
   }
 
+  .lg\:bg-clip-border {
+    background-clip: border-box;
+  }
+
+  .lg\:bg-clip-padding {
+    background-clip: padding-box;
+  }
+
+  .lg\:bg-clip-content {
+    background-clip: content-box;
+  }
+
   .lg\:bg-transparent {
     background-color: transparent;
   }
@@ -43007,6 +43055,18 @@ video {
 
   .xl\:bg-scroll {
     background-attachment: scroll;
+  }
+
+  .xl\:bg-clip-border {
+    background-clip: border-box;
+  }
+
+  .xl\:bg-clip-padding {
+    background-clip: padding-box;
+  }
+
+  .xl\:bg-clip-content {
+    background-clip: content-box;
   }
 
   .xl\:bg-transparent {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -1767,6 +1767,23 @@ video {
   background-attachment: scroll !important;
 }
 
+.bg-clip-border {
+  background-clip: border-box !important;
+}
+
+.bg-clip-padding {
+  background-clip: padding-box !important;
+}
+
+.bg-clip-content {
+  background-clip: content-box !important;
+}
+
+.bg-clip-text {
+  background-clip: text !important;
+  -webkit-background-clip: text !important;
+}
+
 .bg-transparent {
   background-color: transparent !important;
 }
@@ -15813,6 +15830,23 @@ video {
     background-attachment: scroll !important;
   }
 
+  .sm\:bg-clip-border {
+    background-clip: border-box !important;
+  }
+
+  .sm\:bg-clip-padding {
+    background-clip: padding-box !important;
+  }
+
+  .sm\:bg-clip-content {
+    background-clip: content-box !important;
+  }
+
+  .sm\:bg-clip-text {
+    background-clip: text !important;
+    -webkit-background-clip: text !important;
+  }
+
   .sm\:bg-transparent {
     background-color: transparent !important;
   }
@@ -29827,6 +29861,23 @@ video {
 
   .md\:bg-scroll {
     background-attachment: scroll !important;
+  }
+
+  .md\:bg-clip-border {
+    background-clip: border-box !important;
+  }
+
+  .md\:bg-clip-padding {
+    background-clip: padding-box !important;
+  }
+
+  .md\:bg-clip-content {
+    background-clip: content-box !important;
+  }
+
+  .md\:bg-clip-text {
+    background-clip: text !important;
+    -webkit-background-clip: text !important;
   }
 
   .md\:bg-transparent {
@@ -43845,6 +43896,23 @@ video {
     background-attachment: scroll !important;
   }
 
+  .lg\:bg-clip-border {
+    background-clip: border-box !important;
+  }
+
+  .lg\:bg-clip-padding {
+    background-clip: padding-box !important;
+  }
+
+  .lg\:bg-clip-content {
+    background-clip: content-box !important;
+  }
+
+  .lg\:bg-clip-text {
+    background-clip: text !important;
+    -webkit-background-clip: text !important;
+  }
+
   .lg\:bg-transparent {
     background-color: transparent !important;
   }
@@ -57859,6 +57927,23 @@ video {
 
   .xl\:bg-scroll {
     background-attachment: scroll !important;
+  }
+
+  .xl\:bg-clip-border {
+    background-clip: border-box !important;
+  }
+
+  .xl\:bg-clip-padding {
+    background-clip: padding-box !important;
+  }
+
+  .xl\:bg-clip-content {
+    background-clip: content-box !important;
+  }
+
+  .xl\:bg-clip-text {
+    background-clip: text !important;
+    -webkit-background-clip: text !important;
   }
 
   .xl\:bg-transparent {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -1781,7 +1781,6 @@ video {
 
 .bg-clip-text {
   background-clip: text !important;
-  -webkit-background-clip: text !important;
 }
 
 .bg-transparent {
@@ -15844,7 +15843,6 @@ video {
 
   .sm\:bg-clip-text {
     background-clip: text !important;
-    -webkit-background-clip: text !important;
   }
 
   .sm\:bg-transparent {
@@ -29877,7 +29875,6 @@ video {
 
   .md\:bg-clip-text {
     background-clip: text !important;
-    -webkit-background-clip: text !important;
   }
 
   .md\:bg-transparent {
@@ -43910,7 +43907,6 @@ video {
 
   .lg\:bg-clip-text {
     background-clip: text !important;
-    -webkit-background-clip: text !important;
   }
 
   .lg\:bg-transparent {
@@ -57943,7 +57939,6 @@ video {
 
   .xl\:bg-clip-text {
     background-clip: text !important;
-    -webkit-background-clip: text !important;
   }
 
   .xl\:bg-transparent {

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -1563,6 +1563,23 @@ video {
   background-attachment: scroll;
 }
 
+.bg-clip-border {
+  background-clip: border-box;
+}
+
+.bg-clip-padding {
+  background-clip: padding-box;
+}
+
+.bg-clip-content {
+  background-clip: content-box;
+}
+
+.bg-clip-text {
+  background-clip: text;
+  -webkit-background-clip: text;
+}
+
 .bg-transparent {
   background-color: transparent;
 }
@@ -13161,6 +13178,23 @@ video {
     background-attachment: scroll;
   }
 
+  .sm\:bg-clip-border {
+    background-clip: border-box;
+  }
+
+  .sm\:bg-clip-padding {
+    background-clip: padding-box;
+  }
+
+  .sm\:bg-clip-content {
+    background-clip: content-box;
+  }
+
+  .sm\:bg-clip-text {
+    background-clip: text;
+    -webkit-background-clip: text;
+  }
+
   .sm\:bg-transparent {
     background-color: transparent;
   }
@@ -24727,6 +24761,23 @@ video {
 
   .md\:bg-scroll {
     background-attachment: scroll;
+  }
+
+  .md\:bg-clip-border {
+    background-clip: border-box;
+  }
+
+  .md\:bg-clip-padding {
+    background-clip: padding-box;
+  }
+
+  .md\:bg-clip-content {
+    background-clip: content-box;
+  }
+
+  .md\:bg-clip-text {
+    background-clip: text;
+    -webkit-background-clip: text;
   }
 
   .md\:bg-transparent {
@@ -36297,6 +36348,23 @@ video {
     background-attachment: scroll;
   }
 
+  .lg\:bg-clip-border {
+    background-clip: border-box;
+  }
+
+  .lg\:bg-clip-padding {
+    background-clip: padding-box;
+  }
+
+  .lg\:bg-clip-content {
+    background-clip: content-box;
+  }
+
+  .lg\:bg-clip-text {
+    background-clip: text;
+    -webkit-background-clip: text;
+  }
+
   .lg\:bg-transparent {
     background-color: transparent;
   }
@@ -47863,6 +47931,23 @@ video {
 
   .xl\:bg-scroll {
     background-attachment: scroll;
+  }
+
+  .xl\:bg-clip-border {
+    background-clip: border-box;
+  }
+
+  .xl\:bg-clip-padding {
+    background-clip: padding-box;
+  }
+
+  .xl\:bg-clip-content {
+    background-clip: content-box;
+  }
+
+  .xl\:bg-clip-text {
+    background-clip: text;
+    -webkit-background-clip: text;
   }
 
   .xl\:bg-transparent {

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -1577,7 +1577,6 @@ video {
 
 .bg-clip-text {
   background-clip: text;
-  -webkit-background-clip: text;
 }
 
 .bg-transparent {
@@ -13192,7 +13191,6 @@ video {
 
   .sm\:bg-clip-text {
     background-clip: text;
-    -webkit-background-clip: text;
   }
 
   .sm\:bg-transparent {
@@ -24777,7 +24775,6 @@ video {
 
   .md\:bg-clip-text {
     background-clip: text;
-    -webkit-background-clip: text;
   }
 
   .md\:bg-transparent {
@@ -36362,7 +36359,6 @@ video {
 
   .lg\:bg-clip-text {
     background-clip: text;
-    -webkit-background-clip: text;
   }
 
   .lg\:bg-transparent {
@@ -47947,7 +47943,6 @@ video {
 
   .xl\:bg-clip-text {
     background-clip: text;
-    -webkit-background-clip: text;
   }
 
   .xl\:bg-transparent {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -1767,6 +1767,23 @@ video {
   background-attachment: scroll;
 }
 
+.bg-clip-border {
+  background-clip: border-box;
+}
+
+.bg-clip-padding {
+  background-clip: padding-box;
+}
+
+.bg-clip-content {
+  background-clip: content-box;
+}
+
+.bg-clip-text {
+  background-clip: text;
+  -webkit-background-clip: text;
+}
+
 .bg-transparent {
   background-color: transparent;
 }
@@ -15813,6 +15830,23 @@ video {
     background-attachment: scroll;
   }
 
+  .sm\:bg-clip-border {
+    background-clip: border-box;
+  }
+
+  .sm\:bg-clip-padding {
+    background-clip: padding-box;
+  }
+
+  .sm\:bg-clip-content {
+    background-clip: content-box;
+  }
+
+  .sm\:bg-clip-text {
+    background-clip: text;
+    -webkit-background-clip: text;
+  }
+
   .sm\:bg-transparent {
     background-color: transparent;
   }
@@ -29827,6 +29861,23 @@ video {
 
   .md\:bg-scroll {
     background-attachment: scroll;
+  }
+
+  .md\:bg-clip-border {
+    background-clip: border-box;
+  }
+
+  .md\:bg-clip-padding {
+    background-clip: padding-box;
+  }
+
+  .md\:bg-clip-content {
+    background-clip: content-box;
+  }
+
+  .md\:bg-clip-text {
+    background-clip: text;
+    -webkit-background-clip: text;
   }
 
   .md\:bg-transparent {
@@ -43845,6 +43896,23 @@ video {
     background-attachment: scroll;
   }
 
+  .lg\:bg-clip-border {
+    background-clip: border-box;
+  }
+
+  .lg\:bg-clip-padding {
+    background-clip: padding-box;
+  }
+
+  .lg\:bg-clip-content {
+    background-clip: content-box;
+  }
+
+  .lg\:bg-clip-text {
+    background-clip: text;
+    -webkit-background-clip: text;
+  }
+
   .lg\:bg-transparent {
     background-color: transparent;
   }
@@ -57859,6 +57927,23 @@ video {
 
   .xl\:bg-scroll {
     background-attachment: scroll;
+  }
+
+  .xl\:bg-clip-border {
+    background-clip: border-box;
+  }
+
+  .xl\:bg-clip-padding {
+    background-clip: padding-box;
+  }
+
+  .xl\:bg-clip-content {
+    background-clip: content-box;
+  }
+
+  .xl\:bg-clip-text {
+    background-clip: text;
+    -webkit-background-clip: text;
   }
 
   .xl\:bg-transparent {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -1781,7 +1781,6 @@ video {
 
 .bg-clip-text {
   background-clip: text;
-  -webkit-background-clip: text;
 }
 
 .bg-transparent {
@@ -15844,7 +15843,6 @@ video {
 
   .sm\:bg-clip-text {
     background-clip: text;
-    -webkit-background-clip: text;
   }
 
   .sm\:bg-transparent {
@@ -29877,7 +29875,6 @@ video {
 
   .md\:bg-clip-text {
     background-clip: text;
-    -webkit-background-clip: text;
   }
 
   .md\:bg-transparent {
@@ -43910,7 +43907,6 @@ video {
 
   .lg\:bg-clip-text {
     background-clip: text;
-    -webkit-background-clip: text;
   }
 
   .lg\:bg-transparent {
@@ -57943,7 +57939,6 @@ video {
 
   .xl\:bg-clip-text {
     background-clip: text;
-    -webkit-background-clip: text;
   }
 
   .xl\:bg-transparent {

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -6,6 +6,7 @@ import divideColor from './plugins/divideColor'
 import accessibility from './plugins/accessibility'
 import appearance from './plugins/appearance'
 import backgroundAttachment from './plugins/backgroundAttachment'
+import backgroundClip from './plugins/backgroundClip'
 import backgroundColor from './plugins/backgroundColor'
 import backgroundPosition from './plugins/backgroundPosition'
 import backgroundRepeat from './plugins/backgroundRepeat'
@@ -113,6 +114,7 @@ export default function({ corePlugins: corePluginConfig }) {
     accessibility,
     appearance,
     backgroundAttachment,
+    backgroundClip,
     backgroundColor,
     backgroundOpacity,
     backgroundPosition,

--- a/src/plugins/backgroundClip.js
+++ b/src/plugins/backgroundClip.js
@@ -8,7 +8,7 @@ export default function() {
         ...(target('display') === 'ie11'
           ? {}
           : {
-              '.bg-clip-text': { 'background-clip': 'text', '-webkit-background-clip': 'text' },
+              '.bg-clip-text': { 'background-clip': 'text' },
             }),
       },
       variants('backgroundClip')

--- a/src/plugins/backgroundClip.js
+++ b/src/plugins/backgroundClip.js
@@ -1,0 +1,17 @@
+export default function() {
+  return function({ addUtilities, variants, target }) {
+    addUtilities(
+      {
+        '.bg-clip-border': { 'background-clip': 'border-box' },
+        '.bg-clip-padding': { 'background-clip': 'padding-box' },
+        '.bg-clip-content': { 'background-clip': 'content-box' },
+        ...(target('display') === 'ie11'
+          ? {}
+          : {
+              '.bg-clip-text': { 'background-clip': 'text', '-webkit-background-clip': 'text' },
+            }),
+      },
+      variants('backgroundClip')
+    )
+  }
+}

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -658,6 +658,7 @@ module.exports = {
     alignSelf: ['responsive'],
     appearance: ['responsive'],
     backgroundAttachment: ['responsive'],
+    backgroundClip: ['responsive'],
     backgroundColor: ['responsive', 'hover', 'focus'],
     backgroundOpacity: ['responsive', 'hover', 'focus'],
     backgroundPosition: ['responsive'],


### PR DESCRIPTION
This PR adds new [background-clip](https://developer.mozilla.org/en-US/docs/Web/CSS/background-clip) utilities to Tailwind, that I'm pretty much only adding for `bg-clip-text` so we can do trendy gradient stuff with the default build after we add gradient support 👀 

New classes:

| Class | CSS |
| --- | --- |
| `bg-clip-border`| `background-clip: border-box` |
| `bg-clip-padding`| `background-clip: padding-box` |
| `bg-clip-content`| `background-clip: content-box` |
| `bg-clip-text`| `background-clip: text` |

