### PR TITLE
Optimize rebuilds in long-running processes

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "lodash": "^4.17.15",
     "node-emoji": "^1.8.1",
     "normalize.css": "^8.0.1",
+    "object-hash": "^2.0.3",
     "postcss": "^7.0.11",
     "postcss-functions": "^3.0.0",
     "postcss-js": "^2.0.0",

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import chalk from 'chalk'
+import log from './util/log'
 
 const featureFlags = {
   future: ['removeDeprecatedGapUtilities'],
@@ -55,27 +56,6 @@ function futureFlagsAvailable(config) {
 export function issueFlagNotices(config) {
   if (process.env.JEST_WORKER_ID !== undefined) {
     return
-  }
-
-  const log = {
-    info(messages) {
-      console.log('')
-      messages.forEach(message => {
-        console.log(chalk.bold.cyan('info'), '-', message)
-      })
-    },
-    warn(messages) {
-      console.log('')
-      messages.forEach(message => {
-        console.log(chalk.bold.yellow('warn'), '-', message)
-      })
-    },
-    risk(messages) {
-      console.log('')
-      messages.forEach(message => {
-        console.log(chalk.bold.magenta('risk'), '-', message)
-      })
-    },
   }
 
   if (futureFlagsEnabled(config).length > 0) {

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -53,6 +53,10 @@ function futureFlagsAvailable(config) {
 }
 
 export function issueFlagNotices(config) {
+  if (process.env.JEST_WORKER_ID !== undefined) {
+    return
+  }
+
   const log = {
     info(messages) {
       console.log('')

--- a/src/lib/purgeUnusedStyles.js
+++ b/src/lib/purgeUnusedStyles.js
@@ -1,9 +1,7 @@
 import _ from 'lodash'
 import postcss from 'postcss'
 import purgecss from '@fullhuman/postcss-purgecss'
-import chalk from 'chalk'
-import { log } from '../cli/utils'
-import * as emoji from '../cli/emoji'
+import log from '../util/log'
 
 function removeTailwindMarkers(css) {
   css.walkAtRules('tailwind', rule => rule.remove())
@@ -21,7 +19,7 @@ function removeTailwindMarkers(css) {
   })
 }
 
-export default function purgeUnusedUtilities(config) {
+export default function purgeUnusedUtilities(config, configChanged) {
   const purgeEnabled = _.get(
     config,
     'purge.enabled',
@@ -34,21 +32,14 @@ export default function purgeUnusedUtilities(config) {
 
   // Skip if `purge: []` since that's part of the default config
   if (Array.isArray(config.purge) && config.purge.length === 0) {
-    log()
-    log(
-      emoji.warning,
-      chalk.yellow(
-        ' Tailwind is not purging unused styles because no template paths have been provided.'
-      )
-    )
-    log(
-      chalk.white(
-        '   If you have manually configured PurgeCSS outside of Tailwind or are deliberately not\n      removing unused styles, set `purge: false` in your Tailwind config file to silence\n      this warning.'
-      )
-    )
-    log(
-      chalk.white('\n      https://tailwindcss.com/docs/controlling-file-size/#removing-unused-css')
-    )
+    if (configChanged) {
+      log.warn([
+        'Tailwind is not purging unused styles because no template paths have been provided.',
+        'If you have manually configured PurgeCSS outside of Tailwind or are deliberately not removing unused styles, set `purge: false` in your Tailwind config file to silence this warning.',
+        'https://tailwindcss.com/docs/controlling-file-size/#removing-unused-css',
+      ])
+    }
+
     return removeTailwindMarkers
   }
 

--- a/src/lib/substituteClassApplyAtRules.js
+++ b/src/lib/substituteClassApplyAtRules.js
@@ -56,14 +56,19 @@ function findClass(classToApply, classTable, onError) {
   return match.clone().nodes
 }
 
-export default function(config, getProcessedPlugins) {
+let shadowLookup = null
+
+export default function(config, getProcessedPlugins, configChanged) {
   if (flagEnabled(config, 'applyComplexClasses')) {
-    return applyComplexClasses(config, getProcessedPlugins)
+    return applyComplexClasses(config, getProcessedPlugins, configChanged)
   }
 
   return function(css) {
     const classLookup = buildClassTable(css)
-    const shadowLookup = buildShadowTable(getProcessedPlugins().utilities)
+    shadowLookup =
+      configChanged || !shadowLookup
+        ? buildShadowTable(getProcessedPlugins().utilities)
+        : shadowLookup
 
     css.walkRules(rule => {
       rule.walkAtRules('apply', atRule => {

--- a/src/processTailwindFeatures.js
+++ b/src/processTailwindFeatures.js
@@ -16,25 +16,33 @@ import processPlugins from './util/processPlugins'
 import cloneNodes from './util/cloneNodes'
 import { issueFlagNotices } from './featureFlags.js'
 
+import hash from 'object-hash'
+
 let flagsIssued = null
+let previousConfig = null
+let processedPlugins = null
+let getProcessedPlugins = null
 
 export default function(getConfig) {
   return function(css) {
     const config = getConfig()
+    const configChanged = hash(previousConfig) !== hash(config)
+    previousConfig = config
 
     if (!flagsIssued || !_.isEqual(flagsIssued, _.pick(config, ['future', 'experimental']))) {
       flagsIssued = _.pick(config, ['future', 'experimental'])
       issueFlagNotices(config)
     }
 
-    const processedPlugins = processPlugins([...corePlugins(config), ...config.plugins], config)
-
-    const getProcessedPlugins = function() {
-      return {
-        ...processedPlugins,
-        base: cloneNodes(processedPlugins.base),
-        components: cloneNodes(processedPlugins.components),
-        utilities: cloneNodes(processedPlugins.utilities),
+    if (configChanged) {
+      processedPlugins = processPlugins([...corePlugins(config), ...config.plugins], config)
+      getProcessedPlugins = function() {
+        return {
+          ...processedPlugins,
+          base: cloneNodes(processedPlugins.base),
+          components: cloneNodes(processedPlugins.components),
+          utilities: cloneNodes(processedPlugins.utilities),
+        }
       }
     }
 
@@ -45,7 +53,7 @@ export default function(getConfig) {
       substituteResponsiveAtRules(config),
       convertLayerAtRulesToControlComments(config),
       substituteScreenAtRules(config),
-      substituteClassApplyAtRules(config, getProcessedPlugins),
+      substituteClassApplyAtRules(config, getProcessedPlugins, configChanged),
       applyImportantConfiguration(config),
       purgeUnusedStyles(config),
     ]).process(css, { from: _.get(css, 'source.input.file') })

--- a/src/processTailwindFeatures.js
+++ b/src/processTailwindFeatures.js
@@ -18,7 +18,6 @@ import { issueFlagNotices } from './featureFlags.js'
 
 import hash from 'object-hash'
 
-let flagsIssued = null
 let previousConfig = null
 let processedPlugins = null
 let getProcessedPlugins = null
@@ -29,12 +28,9 @@ export default function(getConfig) {
     const configChanged = hash(previousConfig) !== hash(config)
     previousConfig = config
 
-    if (!flagsIssued || !_.isEqual(flagsIssued, _.pick(config, ['future', 'experimental']))) {
-      flagsIssued = _.pick(config, ['future', 'experimental'])
-      issueFlagNotices(config)
-    }
-
     if (configChanged) {
+      issueFlagNotices(config)
+
       processedPlugins = processPlugins([...corePlugins(config), ...config.plugins], config)
       getProcessedPlugins = function() {
         return {
@@ -55,7 +51,7 @@ export default function(getConfig) {
       substituteScreenAtRules(config),
       substituteClassApplyAtRules(config, getProcessedPlugins, configChanged),
       applyImportantConfiguration(config),
-      purgeUnusedStyles(config),
+      purgeUnusedStyles(config, configChanged),
     ]).process(css, { from: _.get(css, 'source.input.file') })
   }
 }

--- a/src/util/log.js
+++ b/src/util/log.js
@@ -1,0 +1,22 @@
+import chalk from 'chalk'
+
+export default {
+  info(messages) {
+    console.log('')
+    messages.forEach(message => {
+      console.log(chalk.bold.cyan('info'), '-', message)
+    })
+  },
+  warn(messages) {
+    console.log('')
+    messages.forEach(message => {
+      console.log(chalk.bold.yellow('warn'), '-', message)
+    })
+  },
+  risk(messages) {
+    console.log('')
+    messages.forEach(message => {
+      console.log(chalk.bold.magenta('risk'), '-', message)
+    })
+  },
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4122,6 +4122,11 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-hash@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.0.3.tgz#d12db044e03cd2ca3d77c0570d87225b02e1e6ea"
+  integrity sha512-JPKn0GMu+Fa3zt3Bmr66JhokJU5BaNBIh4ZeTlaCBzrBsOeXzwcKKAK1tbLiPKgvwmPXsDvvLHoWh5Bm7ofIYg==
+
 object-keys@^1.0.11, object-keys@^1.0.12:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"


### PR DESCRIPTION
This PR introduces a bunch of caching of expensive calculations at the module level to avoid wasteful processing when Tailwind is used in long-running processes, like watchers, or even when building a project that runs Tailwind multiple times, like something using CSS modules, or Vue SFCs with `<style>` blocks.

In my (non-scientific) testing, I was able to get the production build for a Next.js site with ~25 CSS modules files that all used `@apply` down from 38s to 13s.

Overall the difference in rebuild speed should feel quite dramatic for most users.