### PR TITLE
Add bg-none utility

### DIFF
--- a/__tests__/fixtures/tailwind-output-flagged.css
+++ b/__tests__/fixtures/tailwind-output-flagged.css
@@ -4803,6 +4803,10 @@ video {
   background-color: rgba(117, 26, 61, var(--bg-opacity));
 }
 
+.bg-none {
+  background-image: none;
+}
+
 .bg-gradient-to-t {
   background-image: linear-gradient(to top, var(--gradient-color-stops));
 }
@@ -34320,6 +34324,10 @@ video {
     background-color: rgba(117, 26, 61, var(--bg-opacity));
   }
 
+  .sm\:bg-none {
+    background-image: none;
+  }
+
   .sm\:bg-gradient-to-t {
     background-image: linear-gradient(to top, var(--gradient-color-stops));
   }
@@ -63805,6 +63813,10 @@ video {
     --bg-opacity: 1;
     background-color: #751a3d;
     background-color: rgba(117, 26, 61, var(--bg-opacity));
+  }
+
+  .md\:bg-none {
+    background-image: none;
   }
 
   .md\:bg-gradient-to-t {
@@ -93294,6 +93306,10 @@ video {
     background-color: rgba(117, 26, 61, var(--bg-opacity));
   }
 
+  .lg\:bg-none {
+    background-image: none;
+  }
+
   .lg\:bg-gradient-to-t {
     background-image: linear-gradient(to top, var(--gradient-color-stops));
   }
@@ -122779,6 +122795,10 @@ video {
     --bg-opacity: 1;
     background-color: #751a3d;
     background-color: rgba(117, 26, 61, var(--bg-opacity));
+  }
+
+  .xl\:bg-none {
+    background-image: none;
   }
 
   .xl\:bg-gradient-to-t {

--- a/__tests__/fixtures/tailwind-output-ie11.css
+++ b/__tests__/fixtures/tailwind-output-ie11.css
@@ -2539,6 +2539,10 @@ video {
   background-color: #702459;
 }
 
+.bg-none {
+  background-image: none;
+}
+
 .bg-bottom {
   background-position: bottom;
 }
@@ -13001,6 +13005,10 @@ video {
     background-color: #702459;
   }
 
+  .sm\:bg-none {
+    background-image: none;
+  }
+
   .sm\:bg-bottom {
     background-position: bottom;
   }
@@ -23431,6 +23439,10 @@ video {
 
   .md\:focus\:bg-pink-900:focus {
     background-color: #702459;
+  }
+
+  .md\:bg-none {
+    background-image: none;
   }
 
   .md\:bg-bottom {
@@ -33865,6 +33877,10 @@ video {
     background-color: #702459;
   }
 
+  .lg\:bg-none {
+    background-image: none;
+  }
+
   .lg\:bg-bottom {
     background-position: bottom;
   }
@@ -44295,6 +44311,10 @@ video {
 
   .xl\:focus\:bg-pink-900:focus {
     background-color: #702459;
+  }
+
+  .xl\:bg-none {
+    background-image: none;
   }
 
   .xl\:bg-bottom {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -3483,6 +3483,10 @@ video {
   background-color: rgba(112, 36, 89, var(--bg-opacity)) !important;
 }
 
+.bg-none {
+  background-image: none !important;
+}
+
 .bg-gradient-to-t {
   background-image: linear-gradient(to top, var(--gradient-color-stops)) !important;
 }
@@ -21545,6 +21549,10 @@ video {
     background-color: rgba(112, 36, 89, var(--bg-opacity)) !important;
   }
 
+  .sm\:bg-none {
+    background-image: none !important;
+  }
+
   .sm\:bg-gradient-to-t {
     background-image: linear-gradient(to top, var(--gradient-color-stops)) !important;
   }
@@ -39575,6 +39583,10 @@ video {
     --bg-opacity: 1 !important;
     background-color: #702459 !important;
     background-color: rgba(112, 36, 89, var(--bg-opacity)) !important;
+  }
+
+  .md\:bg-none {
+    background-image: none !important;
   }
 
   .md\:bg-gradient-to-t {
@@ -57609,6 +57621,10 @@ video {
     background-color: rgba(112, 36, 89, var(--bg-opacity)) !important;
   }
 
+  .lg\:bg-none {
+    background-image: none !important;
+  }
+
   .lg\:bg-gradient-to-t {
     background-image: linear-gradient(to top, var(--gradient-color-stops)) !important;
   }
@@ -75639,6 +75655,10 @@ video {
     --bg-opacity: 1 !important;
     background-color: #702459 !important;
     background-color: rgba(112, 36, 89, var(--bg-opacity)) !important;
+  }
+
+  .xl\:bg-none {
+    background-image: none !important;
   }
 
   .xl\:bg-gradient-to-t {

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -2727,6 +2727,10 @@ video {
   background-color: #702459;
 }
 
+.bg-none {
+  background-image: none;
+}
+
 .bg-gradient-to-t {
   background-image: linear-gradient(to top, var(--gradient-color-stops));
 }
@@ -18341,6 +18345,10 @@ video {
     background-color: #702459;
   }
 
+  .sm\:bg-none {
+    background-image: none;
+  }
+
   .sm\:bg-gradient-to-t {
     background-image: linear-gradient(to top, var(--gradient-color-stops));
   }
@@ -33923,6 +33931,10 @@ video {
 
   .md\:focus\:bg-pink-900:focus {
     background-color: #702459;
+  }
+
+  .md\:bg-none {
+    background-image: none;
   }
 
   .md\:bg-gradient-to-t {
@@ -49509,6 +49521,10 @@ video {
     background-color: #702459;
   }
 
+  .lg\:bg-none {
+    background-image: none;
+  }
+
   .lg\:bg-gradient-to-t {
     background-image: linear-gradient(to top, var(--gradient-color-stops));
   }
@@ -65091,6 +65107,10 @@ video {
 
   .xl\:focus\:bg-pink-900:focus {
     background-color: #702459;
+  }
+
+  .xl\:bg-none {
+    background-image: none;
   }
 
   .xl\:bg-gradient-to-t {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -3483,6 +3483,10 @@ video {
   background-color: rgba(112, 36, 89, var(--bg-opacity));
 }
 
+.bg-none {
+  background-image: none;
+}
+
 .bg-gradient-to-t {
   background-image: linear-gradient(to top, var(--gradient-color-stops));
 }
@@ -21545,6 +21549,10 @@ video {
     background-color: rgba(112, 36, 89, var(--bg-opacity));
   }
 
+  .sm\:bg-none {
+    background-image: none;
+  }
+
   .sm\:bg-gradient-to-t {
     background-image: linear-gradient(to top, var(--gradient-color-stops));
   }
@@ -39575,6 +39583,10 @@ video {
     --bg-opacity: 1;
     background-color: #702459;
     background-color: rgba(112, 36, 89, var(--bg-opacity));
+  }
+
+  .md\:bg-none {
+    background-image: none;
   }
 
   .md\:bg-gradient-to-t {
@@ -57609,6 +57621,10 @@ video {
     background-color: rgba(112, 36, 89, var(--bg-opacity));
   }
 
+  .lg\:bg-none {
+    background-image: none;
+  }
+
   .lg\:bg-gradient-to-t {
     background-image: linear-gradient(to top, var(--gradient-color-stops));
   }
@@ -75639,6 +75655,10 @@ video {
     --bg-opacity: 1;
     background-color: #702459;
     background-color: rgba(112, 36, 89, var(--bg-opacity));
+  }
+
+  .xl\:bg-none {
+    background-image: none;
   }
 
   .xl\:bg-gradient-to-t {

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -152,6 +152,7 @@ module.exports = {
     },
     backgroundColor: theme => theme('colors'),
     backgroundImage: {
+      none: 'none',
       'gradient-to-t': 'linear-gradient(to top, var(--gradient-color-stops))',
       'gradient-to-tr': 'linear-gradient(to top right, var(--gradient-color-stops))',
       'gradient-to-r': 'linear-gradient(to right, var(--gradient-color-stops))',


### PR DESCRIPTION
This PR adds a new `bg-none` utility that sets `background-image: none` so you can responsively disable gradient backgrounds like this:

```html
<div class="bg-gradient-to-r md:bg-none">...</div>
```

Not having this in v1.7.0 was a mistake and I consider this a bugfix (it was impossible to undo the styles) so going to sneak this into a patch release 👀 