### PR TITLE
Fix multiline @apply values

### DIFF
--- a/__tests__/applyComplexClasses.test.js
+++ b/__tests__/applyComplexClasses.test.js
@@ -41,6 +41,8 @@ function run(
 test('it copies class declarations into itself', () => {
   const output = '.a { color: red; } .b { color: red; }'
 
+  expect.assertions(2)
+
   return run('.a { color: red; } .b { @apply a; }').then(result => {
     expect(result.css).toEqual(output)
     expect(result.warnings().length).toBe(0)
@@ -105,6 +107,8 @@ test('selectors with invalid characters do not need to be manually escaped', () 
     .b { color: red; }
   `
 
+  expect.assertions(2)
+
   return run(input).then(result => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
@@ -121,6 +125,8 @@ test('it removes important from applied classes by default', () => {
     .a { color: red !important; }
     .b { color: red; }
   `
+
+  expect.assertions(2)
 
   return run(input).then(result => {
     expect(result.css).toMatchCss(expected)
@@ -139,6 +145,8 @@ test('applied rules can be made !important', () => {
     .b { color: red !important; }
   `
 
+  expect.assertions(2)
+
   return run(input).then(result => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
@@ -155,12 +163,16 @@ test('cssnext custom property sets are no longer supported', () => {
     }
   `
 
+  expect.assertions(1)
+
   return run(input).catch(e => {
     expect(e).toMatchObject({ name: 'CssSyntaxError' })
   })
 })
 
 test('it fails if the class does not exist', () => {
+  expect.assertions(1)
+
   return run('.b { @apply a; }').catch(e => {
     expect(e).toMatchObject({ name: 'CssSyntaxError' })
   })
@@ -185,6 +197,8 @@ test('applying classes that are defined in a media query is supported', () => {
       .b { color: blue; }
     }
   `
+
+  expect.assertions(2)
 
   return run(input).then(result => {
     expect(result.css).toMatchCss(output)
@@ -225,6 +239,8 @@ test('applying classes that are used in a media query is supported', () => {
     }
   `
 
+  expect.assertions(2)
+
   return run(input).then(result => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
@@ -251,6 +267,8 @@ test('it matches classes that include pseudo-selectors', () => {
       color: red;
     }
   `
+
+  expect.assertions(2)
 
   return run(input).then(result => {
     expect(result.css).toMatchCss(output)
@@ -288,6 +306,8 @@ test('it matches classes that have multiple rules', () => {
     }
   `
 
+  expect.assertions(2)
+
   return run(input).then(result => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
@@ -320,6 +340,8 @@ test('applying a class that appears multiple times in one selector', () => {
     }
   `
 
+  expect.assertions(2)
+
   return run(input).then(result => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
@@ -335,6 +357,8 @@ test('you can apply utility classes that do not actually exist as long as they w
     .foo { margin-top: 1rem; }
   `
 
+  expect.assertions(2)
+
   return run(input).then(result => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
@@ -346,6 +370,8 @@ test('the shadow lookup is only used if no @tailwind rules were in the source tr
     @tailwind base;
     .foo { @apply mt-4; }
   `
+
+  expect.assertions(1)
 
   return run(input).catch(e => {
     expect(e).toMatchObject({ name: 'CssSyntaxError' })
@@ -377,6 +403,8 @@ test('you can apply a class that is defined in multiple rules', () => {
     }
   `
 
+  expect.assertions(2)
+
   return run(input).then(result => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
@@ -397,6 +425,8 @@ test('you can apply a class that is defined in a media query', () => {
     }
   `
 
+  expect.assertions(2)
+
   return run(input).then(result => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
@@ -414,6 +444,8 @@ test('you can apply pseudo-class variant utilities', () => {
       opacity: 0.5
     }
   `
+
+  expect.assertions(2)
 
   return run(input).then(result => {
     expect(result.css).toMatchCss(expected)
@@ -434,6 +466,8 @@ test('you can apply responsive pseudo-class variant utilities', () => {
       }
     }
   `
+
+  expect.assertions(2)
 
   return run(input).then(result => {
     expect(result.css).toMatchCss(expected)
@@ -473,6 +507,8 @@ test('you can apply the container component', () => {
     }
   `
 
+  expect.assertions(2)
+
   return run(input).then(result => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
@@ -504,6 +540,8 @@ test('classes are applied according to CSS source order, not apply order', () =>
     }
   `
 
+  expect.assertions(2)
+
   return run(input).then(result => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
@@ -534,6 +572,8 @@ test('you can apply utilities with multi-class selectors like group-hover varian
     }
   `
 
+  expect.assertions(2)
+
   return run(input).then(result => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
@@ -563,6 +603,8 @@ test('you can apply classes recursively', () => {
       color: blue;
     }
   `
+
+  expect.assertions(2)
 
   return run(input).then(result => {
     expect(result.css).toMatchCss(expected)
@@ -599,6 +641,8 @@ test('applied classes are always inserted before subsequent declarations in the 
     }
   `
 
+  expect.assertions(2)
+
   return run(input).then(result => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
@@ -629,6 +673,8 @@ test('adjacent rules are collapsed after being applied', () => {
       }
     }
   `
+
+  expect.assertions(2)
 
   return run(input).then(result => {
     expect(result.css).toMatchCss(expected)
@@ -678,6 +724,8 @@ test('applying a class applies all instances of that class, even complex selecto
     }
   `
 
+  expect.assertions(2)
+
   return run(input).then(result => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
@@ -711,6 +759,8 @@ test('you can apply classes to rules within at-rules', () => {
     }
   `
 
+  expect.assertions(2)
+
   return run(input).then(result => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
@@ -733,6 +783,8 @@ describe('using apply with the prefix option', () => {
         prefix: 'tw-',
       },
     ])
+
+    expect.assertions(2)
 
     return run(input, config).then(result => {
       expect(result.css).toMatchCss(expected)
@@ -758,6 +810,8 @@ describe('using apply with the prefix option', () => {
       },
     ])
 
+    expect.assertions(2)
+
     return run(input, config).then(result => {
       expect(result.css).toMatchCss(expected)
       expect(result.warnings().length).toBe(0)
@@ -775,6 +829,8 @@ describe('using apply with the prefix option', () => {
         prefix: 'tw-',
       },
     ])
+
+    expect.assertions(1)
 
     return run(input, config).catch(e => {
       expect(e).toMatchObject({ name: 'CssSyntaxError' })
@@ -799,6 +855,8 @@ describe('using apply with the prefix option', () => {
       },
     ])
 
+    expect.assertions(2)
+
     return run(input, config).then(result => {
       expect(result.css).toMatchCss(expected)
       expect(result.warnings().length).toBe(0)
@@ -822,6 +880,8 @@ describe('using apply with the prefix option', () => {
         prefix: 'tw-',
       },
     ])
+
+    expect.assertions(2)
 
     return run(input, config).then(result => {
       expect(result.css).toMatchCss(expected)
@@ -868,6 +928,8 @@ describe('using apply with the prefix option', () => {
       },
     ])
 
+    expect.assertions(2)
+
     return run(input, config).then(result => {
       expect(result.css).toMatchCss(expected)
       expect(result.warnings().length).toBe(0)
@@ -890,6 +952,8 @@ describe('using apply with the prefix option', () => {
         important: '#app',
       },
     ])
+
+    expect.assertions(2)
 
     return run(input, config).then(result => {
       expect(result.css).toMatchCss(expected)
@@ -918,6 +982,8 @@ test('you can apply utility classes when a selector is used for the important op
       important: '#app',
     },
   ])
+
+  expect.assertions(2)
 
   return run(input, config).then(result => {
     expect(result.css).toMatchCss(expected)

--- a/__tests__/applyComplexClasses.test.js
+++ b/__tests__/applyComplexClasses.test.js
@@ -47,6 +47,53 @@ test('it copies class declarations into itself', () => {
   })
 })
 
+test('apply values can contain tabs', () => {
+  const input = `
+    .a {
+      @apply p-4\tm-4;
+    }
+  `
+
+  const expected = `
+    .a {
+      margin: 1rem;
+      padding: 1rem;
+    }
+  `
+
+  expect.assertions(2)
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(expected)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('apply values can contain newlines', () => {
+  const input = `
+    .a {
+      @apply p-4 m-4
+      flex flex-col;
+    }
+  `
+
+  const expected = `
+    .a {
+      display: flex;
+      flex-direction: column;
+      margin: 1rem;
+      padding: 1rem;
+    }
+  `
+
+  expect.assertions(2)
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(expected)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('selectors with invalid characters do not need to be manually escaped', () => {
   const input = `
     .a\\:1\\/2 { color: red; }

--- a/src/flagged/applyComplexClasses.js
+++ b/src/flagged/applyComplexClasses.js
@@ -200,7 +200,7 @@ function processApplyAtRules(css, lookupTree, config) {
           importantEntries,
           applyUtilityNames,
           important = importantEntries.length > 0,
-        ] = _.partition(applyRule.params.split(' '), n => n === '!important')
+        ] = _.partition(applyRule.params.split(/[\s\t\n]+/g), n => n === '!important')
 
         const currentUtilityNames = extractUtilityNames(rule.selector)
 


### PR DESCRIPTION
This PR will allow you to use spaces, tabs and newlines in the values of `@apply` rule.

This is a bit of an obscure use case so not 100% sure it will be accepted. However it was not a lot of code 🙃