### PR TITLE
[BUG] applyComplexClasse doesn't work properly with important option

### DIFF
--- a/__tests__/applyComplexClasses.test.js
+++ b/__tests__/applyComplexClasses.test.js
@@ -993,3 +993,51 @@ test('you can apply classes to a rule with multiple selectors', () => {
     expect(result.warnings().length).toBe(0)
   })
 })
+
+test('it works properly with important option as boolean', () => {
+  const input = `
+    .foo {
+      @apply opacity-0 hover:opacity-50;
+    }
+  `
+  const expected = `
+    .foo {
+      opacity: 0 !important;
+    }
+
+    .foo:hover {
+      opacity: 0.5 !important;
+    }
+  `
+
+  expect.assertions(2)
+
+  return run(input, { important: true }).then(result => {
+    expect(result.css).toMatchCss(expected)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it works properly with important option as selector', () => {
+  const input = `
+    .foo {
+      @apply opacity-0 hover:opacity-50;
+    }
+  `
+  const expected = `
+    #foo .foo {
+      opacity: 0;
+    }
+
+    #foo .foo:hover {
+      opacity: 0.5
+    }
+  `
+
+  expect.assertions(2)
+
+  return run(input, { important: '#foo' }).then(result => {
+    expect(result.css).toMatchCss(expected)
+    expect(result.warnings().length).toBe(0)
+  })
+})


### PR DESCRIPTION
Hi,
As you can see in the failing tests, for this piece of code : 

```css
.foo {
   @apply opacity-0 hover:opacity-50;
}
```

with the `important: true` option we have:
 
```css
.foo {
  opacity: 0;
}

.foo:hover {
  opacity: 0.5 !important;
}
```

instead of:
```css
.foo {
  opacity: 0 !important;
}

.foo:hover {
  opacity: 0.5 !important;
}
```


and with with the `important: '#foo'` option we have :

```css
.foo {
  opacity: 0;
}

#foo .foo:hover {
  opacity: 0.5;
}
```


instead of :
```css
#foo .foo {
  opacity: 0;
}

#foo .foo:hover {
  opacity: 0.5;
}
```

For now, I've just wrote the tests, I can try to work on it if you want to.

Thanks for your work,
Matt'