### PR TITLE
[BUG] applyComplexClasse doesn't work properly with important option

### DIFF
--- a/__tests__/applyComplexClasses.test.js
+++ b/__tests__/applyComplexClasses.test.js
@@ -939,7 +939,7 @@ describe('using apply with the prefix option', () => {
 test('you can apply utility classes when a selector is used for the important option', () => {
   const input = `
     .foo {
-      @apply mt-8 mb-8;
+      @apply mt-8 mb-8 sm:mb-16 hover:opacity-0;
     }
   `
 
@@ -948,12 +948,61 @@ test('you can apply utility classes when a selector is used for the important op
       margin-top: 2rem;
       margin-bottom: 2rem;
     }
+
+    .foo:hover {
+      opacity: 0;
+    }
+
+    @media (min-width: 640px) {
+     .foo {
+        margin-bottom: 4rem;
+      }
+    }
   `
 
   const config = resolveConfig([
     {
       ...defaultConfig,
       important: '#app',
+    },
+  ])
+
+  expect.assertions(2)
+
+  return run(input, config).then(result => {
+    expect(result.css).toMatchCss(expected)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('you can apply utility classes when true is used for the important option', () => {
+  const input = `
+    .foo {
+      @apply mt-8 mb-8 sm:mb-16 hover:opacity-0;
+    }
+  `
+
+  const expected = `
+    .foo {
+      margin-top: 2rem;
+      margin-bottom: 2rem;
+    }
+
+    .foo:hover {
+      opacity: 0;
+    }
+
+    @media (min-width: 640px) {
+     .foo {
+        margin-bottom: 4rem;
+      }
+    }
+  `
+
+  const config = resolveConfig([
+    {
+      ...defaultConfig,
+      important: true,
     },
   ])
 


### PR DESCRIPTION
see  in #2255

The tests which are failing are the reproduction.

according your comment : https://github.com/tailwindlabs/tailwindcss/pull/2255#issuecomment-682045913

```css
.foo {
   @apply opacity-0 hover:opacity-50;
}
```

with the important: true option should transpile to:

```css
.foo {
  opacity: 0;
}

.foo:hover {
  opacity: 0.5;
}
```

It transpiles to:
```css
.foo {
  opacity: 0;
}

.foo:hover {
  opacity: 0.5 !important;
}
```


And the same with selectors instead of boolean, and for all pseudo.