### PR TITLE
Preserve HTML elements by default when purging unused styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "color": "^3.1.2",
     "detective": "^5.2.0",
     "fs-extra": "^8.0.0",
+    "html-tags": "^3.1.0",
     "lodash": "^4.17.20",
     "node-emoji": "^1.8.1",
     "normalize.css": "^8.0.1",

--- a/src/lib/purgeUnusedStyles.js
+++ b/src/lib/purgeUnusedStyles.js
@@ -2,6 +2,7 @@ import _ from 'lodash'
 import postcss from 'postcss'
 import purgecss from '@fullhuman/postcss-purgecss'
 import log from '../util/log'
+import htmlTags from 'html-tags'
 
 function removeTailwindMarkers(css) {
   css.walkAtRules('tailwind', rule => rule.remove())
@@ -75,7 +76,11 @@ export default function purgeUnusedUtilities(config, configChanged) {
         // Capture classes within other delimiters like .block(class="w-1/2") in Pug
         const innerMatches = content.match(/[^<>"'`\s.(){}[\]#=%]*[^<>"'`\s.(){}[\]#=%:]/g) || []
 
-        return broadMatches.concat(innerMatches)
+        if (_.get(config, 'purge.preserveHtmlElements', true)) {
+          return [...htmlTags].concat(broadMatches).concat(innerMatches)
+        } else {
+          return broadMatches.concat(innerMatches)
+        }
       },
       ...config.purge.options,
     }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2761,6 +2761,11 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.0.tgz#71e87f931de3fe09e56661ab9a29aadec707b491"
   integrity sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==
 
+html-tags@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.1.0.tgz#7b5e6f7e665e9fb41f30007ed9e0d41e97fb2140"
+  integrity sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==
+
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"


### PR DESCRIPTION
This PR introduces a new `preserveHtmlElements` option to the `purge` configuration that allows you to safelist all plain HTML elements, like `p`, `blockquote`, `body`, `video`, etc.

```js
// tailwind.config.js
module.exports = {
  purge: {
    content: [
      // Paths...
    ],
    preserveHtmlElements: true,
  },
}
```

This helps avoid accidentally purging things like heading elements when your source files are in a format that compiles to HTML, like markdown (since your markdown won't actually contain the string `h1` anywhere).

This option is set to `true` by default.

On its own this PR won't change anything for anyone really, but I plan to change things to purge all of `base`, `components`, and `utilities` going forward (not just `utilities`), as this was the only real footgun until now, and with the new typography plugin gaining traction it would be nice to make those styles purgeable by default.