### PR TITLE
support for named grid lines

### DIFF
--- a/__tests__/plugins/gridColumnEnd.test.js
+++ b/__tests__/plugins/gridColumnEnd.test.js
@@ -1,0 +1,131 @@
+import _ from 'lodash'
+import escapeClassName from '../../src/util/escapeClassName'
+import plugin from '../../src/plugins/gridColumnEnd'
+
+test('default behaviour (no gridTemplateColumns)', () => {
+  const addedUtilities = []
+
+  const config = {
+    target: 'relaxed',
+    theme: {
+      gridColumnEnd: {
+        auto: 'auto',
+        '1': '1',
+      },
+    },
+    variants: {
+      gridColumnEnd: ['responsive'],
+    },
+  }
+
+  const getConfigValue = (path, defaultValue) => _.get(config, path, defaultValue)
+  const pluginApi = {
+    config: getConfigValue,
+    e: escapeClassName,
+    target: () => {
+      return 'relaxed'
+    },
+    theme: (path, defaultValue) => getConfigValue(`theme.${path}`, defaultValue),
+    variants: (path, defaultValue) => {
+      if (_.isArray(config.variants)) {
+        return config.variants
+      }
+
+      return getConfigValue(`variants.${path}`, defaultValue)
+    },
+    addUtilities(utilities, variants) {
+      addedUtilities.push({
+        utilities,
+        variants,
+      })
+    },
+  }
+
+  plugin()(pluginApi)
+
+  expect(addedUtilities).toEqual([
+    {
+      utilities: {
+        '.col-end-auto': {
+          'grid-column-end': 'auto',
+        },
+        '.col-end-1': {
+          'grid-column-end': '1',
+        },
+      },
+      variants: ['responsive'],
+    },
+  ])
+})
+
+test('multiple templates with different names', () => {
+  const addedUtilities = []
+
+  const config = {
+    target: 'relaxed',
+    theme: {
+      gridTemplateColumns: {
+        layout: '1fr [left] 1fr [right] 1fr',
+        multi: '1fr [column] 1fr [column] 1fr',
+      },
+      gridColumnEnd: {
+        auto: 'auto',
+        '1': '1',
+      },
+    },
+    variants: {
+      gridColumnEnd: ['responsive'],
+    },
+  }
+
+  const getConfigValue = (path, defaultValue) => _.get(config, path, defaultValue)
+  const pluginApi = {
+    config: getConfigValue,
+    e: escapeClassName,
+    target: () => {
+      return 'relaxed'
+    },
+    theme: (path, defaultValue) => getConfigValue(`theme.${path}`, defaultValue),
+    variants: (path, defaultValue) => {
+      if (_.isArray(config.variants)) {
+        return config.variants
+      }
+
+      return getConfigValue(`variants.${path}`, defaultValue)
+    },
+    addUtilities(utilities, variants) {
+      addedUtilities.push({
+        utilities,
+        variants,
+      })
+    },
+  }
+
+  plugin()(pluginApi)
+
+  expect(addedUtilities).toEqual([
+    {
+      utilities: {
+        '.col-end-auto': {
+          'grid-column-end': 'auto',
+        },
+        '.col-end-1': {
+          'grid-column-end': '1',
+        },
+        '.col-end-left': {
+          'grid-column-end': 'left',
+        },
+        '.col-end-right': {
+          'grid-column-end': 'right',
+        },
+        '.col-end-column-1': {
+          'grid-column-end': 'column-1',
+        },
+        '.col-end-column-2': {
+          'grid-column-end': 'column-2',
+        },
+      },
+      variants: ['responsive'],
+    },
+  ])
+})

--- a/__tests__/plugins/gridColumnStart.test.js
+++ b/__tests__/plugins/gridColumnStart.test.js
@@ -1,0 +1,131 @@
+import _ from 'lodash'
+import escapeClassName from '../../src/util/escapeClassName'
+import plugin from '../../src/plugins/gridColumnStart'
+
+test('default behaviour (no gridTemplateColumns)', () => {
+  const addedUtilities = []
+
+  const config = {
+    target: 'relaxed',
+    theme: {
+      gridColumnStart: {
+        auto: 'auto',
+        '1': '1',
+      },
+    },
+    variants: {
+      gridColumnStart: ['responsive'],
+    },
+  }
+
+  const getConfigValue = (path, defaultValue) => _.get(config, path, defaultValue)
+  const pluginApi = {
+    config: getConfigValue,
+    e: escapeClassName,
+    target: () => {
+      return 'relaxed'
+    },
+    theme: (path, defaultValue) => getConfigValue(`theme.${path}`, defaultValue),
+    variants: (path, defaultValue) => {
+      if (_.isArray(config.variants)) {
+        return config.variants
+      }
+
+      return getConfigValue(`variants.${path}`, defaultValue)
+    },
+    addUtilities(utilities, variants) {
+      addedUtilities.push({
+        utilities,
+        variants,
+      })
+    },
+  }
+
+  plugin()(pluginApi)
+
+  expect(addedUtilities).toEqual([
+    {
+      utilities: {
+        '.col-start-auto': {
+          'grid-column-start': 'auto',
+        },
+        '.col-start-1': {
+          'grid-column-start': '1',
+        },
+      },
+      variants: ['responsive'],
+    },
+  ])
+})
+
+test('multiple templates with different names', () => {
+  const addedUtilities = []
+
+  const config = {
+    target: 'relaxed',
+    theme: {
+      gridTemplateColumns: {
+        layout: '1fr [left] 1fr [right] 1fr',
+        multi: '1fr [column] 1fr [column] 1fr',
+      },
+      gridColumnStart: {
+        auto: 'auto',
+        '1': '1',
+      },
+    },
+    variants: {
+      gridColumnStart: ['responsive'],
+    },
+  }
+
+  const getConfigValue = (path, defaultValue) => _.get(config, path, defaultValue)
+  const pluginApi = {
+    config: getConfigValue,
+    e: escapeClassName,
+    target: () => {
+      return 'relaxed'
+    },
+    theme: (path, defaultValue) => getConfigValue(`theme.${path}`, defaultValue),
+    variants: (path, defaultValue) => {
+      if (_.isArray(config.variants)) {
+        return config.variants
+      }
+
+      return getConfigValue(`variants.${path}`, defaultValue)
+    },
+    addUtilities(utilities, variants) {
+      addedUtilities.push({
+        utilities,
+        variants,
+      })
+    },
+  }
+
+  plugin()(pluginApi)
+
+  expect(addedUtilities).toEqual([
+    {
+      utilities: {
+        '.col-start-auto': {
+          'grid-column-start': 'auto',
+        },
+        '.col-start-1': {
+          'grid-column-start': '1',
+        },
+        '.col-start-left': {
+          'grid-column-start': 'left',
+        },
+        '.col-start-right': {
+          'grid-column-start': 'right',
+        },
+        '.col-start-column-1': {
+          'grid-column-start': 'column-1',
+        },
+        '.col-start-column-2': {
+          'grid-column-start': 'column-2',
+        },
+      },
+      variants: ['responsive'],
+    },
+  ])
+})

--- a/__tests__/plugins/gridRowEnd.test.js
+++ b/__tests__/plugins/gridRowEnd.test.js
@@ -1,0 +1,131 @@
+import _ from 'lodash'
+import escapeClassName from '../../src/util/escapeClassName'
+import plugin from '../../src/plugins/gridRowEnd'
+
+test('default behaviour (no gridTemplateRows)', () => {
+  const addedUtilities = []
+
+  const config = {
+    target: 'relaxed',
+    theme: {
+      gridRowEnd: {
+        auto: 'auto',
+        '1': '1',
+      },
+    },
+    variants: {
+      gridRowEnd: ['responsive'],
+    },
+  }
+
+  const getConfigValue = (path, defaultValue) => _.get(config, path, defaultValue)
+  const pluginApi = {
+    config: getConfigValue,
+    e: escapeClassName,
+    target: () => {
+      return 'relaxed'
+    },
+    theme: (path, defaultValue) => getConfigValue(`theme.${path}`, defaultValue),
+    variants: (path, defaultValue) => {
+      if (_.isArray(config.variants)) {
+        return config.variants
+      }
+
+      return getConfigValue(`variants.${path}`, defaultValue)
+    },
+    addUtilities(utilities, variants) {
+      addedUtilities.push({
+        utilities,
+        variants,
+      })
+    },
+  }
+
+  plugin()(pluginApi)
+
+  expect(addedUtilities).toEqual([
+    {
+      utilities: {
+        '.row-end-auto': {
+          'grid-row-end': 'auto',
+        },
+        '.row-end-1': {
+          'grid-row-end': '1',
+        },
+      },
+      variants: ['responsive'],
+    },
+  ])
+})
+
+test('multiple templates with different names', () => {
+  const addedUtilities = []
+
+  const config = {
+    target: 'relaxed',
+    theme: {
+      gridTemplateRows: {
+        layout: '1fr [top] 1fr [bottom] 1fr',
+        multi: '1fr [fold] 1fr [fold] 1fr',
+      },
+      gridRowEnd: {
+        auto: 'auto',
+        '1': '1',
+      },
+    },
+    variants: {
+      gridRowEnd: ['responsive'],
+    },
+  }
+
+  const getConfigValue = (path, defaultValue) => _.get(config, path, defaultValue)
+  const pluginApi = {
+    config: getConfigValue,
+    e: escapeClassName,
+    target: () => {
+      return 'relaxed'
+    },
+    theme: (path, defaultValue) => getConfigValue(`theme.${path}`, defaultValue),
+    variants: (path, defaultValue) => {
+      if (_.isArray(config.variants)) {
+        return config.variants
+      }
+
+      return getConfigValue(`variants.${path}`, defaultValue)
+    },
+    addUtilities(utilities, variants) {
+      addedUtilities.push({
+        utilities,
+        variants,
+      })
+    },
+  }
+
+  plugin()(pluginApi)
+
+  expect(addedUtilities).toEqual([
+    {
+      utilities: {
+        '.row-end-auto': {
+          'grid-row-end': 'auto',
+        },
+        '.row-end-1': {
+          'grid-row-end': '1',
+        },
+        '.row-end-top': {
+          'grid-row-end': 'top',
+        },
+        '.row-end-bottom': {
+          'grid-row-end': 'bottom',
+        },
+        '.row-end-fold-1': {
+          'grid-row-end': 'fold-1',
+        },
+        '.row-end-fold-2': {
+          'grid-row-end': 'fold-2',
+        },
+      },
+      variants: ['responsive'],
+    },
+  ])
+})

--- a/__tests__/plugins/gridRowStart.test.js
+++ b/__tests__/plugins/gridRowStart.test.js
@@ -1,0 +1,131 @@
+import _ from 'lodash'
+import escapeClassName from '../../src/util/escapeClassName'
+import plugin from '../../src/plugins/gridRowStart'
+
+test('default behaviour (no gridTemplateRows)', () => {
+  const addedUtilities = []
+
+  const config = {
+    target: 'relaxed',
+    theme: {
+      gridRowStart: {
+        auto: 'auto',
+        '1': '1',
+      },
+    },
+    variants: {
+      gridRowStart: ['responsive'],
+    },
+  }
+
+  const getConfigValue = (path, defaultValue) => _.get(config, path, defaultValue)
+  const pluginApi = {
+    config: getConfigValue,
+    e: escapeClassName,
+    target: () => {
+      return 'relaxed'
+    },
+    theme: (path, defaultValue) => getConfigValue(`theme.${path}`, defaultValue),
+    variants: (path, defaultValue) => {
+      if (_.isArray(config.variants)) {
+        return config.variants
+      }
+
+      return getConfigValue(`variants.${path}`, defaultValue)
+    },
+    addUtilities(utilities, variants) {
+      addedUtilities.push({
+        utilities,
+        variants,
+      })
+    },
+  }
+
+  plugin()(pluginApi)
+
+  expect(addedUtilities).toEqual([
+    {
+      utilities: {
+        '.row-start-auto': {
+          'grid-row-start': 'auto',
+        },
+        '.row-start-1': {
+          'grid-row-start': '1',
+        },
+      },
+      variants: ['responsive'],
+    },
+  ])
+})
+
+test('multiple templates with different names', () => {
+  const addedUtilities = []
+
+  const config = {
+    target: 'relaxed',
+    theme: {
+      gridTemplateRows: {
+        layout: '1fr [top] 1fr [bottom] 1fr',
+        multi: '1fr [fold] 1fr [fold] 1fr',
+      },
+      gridRowStart: {
+        auto: 'auto',
+        '1': '1',
+      },
+    },
+    variants: {
+      gridRowStart: ['responsive'],
+    },
+  }
+
+  const getConfigValue = (path, defaultValue) => _.get(config, path, defaultValue)
+  const pluginApi = {
+    config: getConfigValue,
+    e: escapeClassName,
+    target: () => {
+      return 'relaxed'
+    },
+    theme: (path, defaultValue) => getConfigValue(`theme.${path}`, defaultValue),
+    variants: (path, defaultValue) => {
+      if (_.isArray(config.variants)) {
+        return config.variants
+      }
+
+      return getConfigValue(`variants.${path}`, defaultValue)
+    },
+    addUtilities(utilities, variants) {
+      addedUtilities.push({
+        utilities,
+        variants,
+      })
+    },
+  }
+
+  plugin()(pluginApi)
+
+  expect(addedUtilities).toEqual([
+    {
+      utilities: {
+        '.row-start-auto': {
+          'grid-row-start': 'auto',
+        },
+        '.row-start-1': {
+          'grid-row-start': '1',
+        },
+        '.row-start-top': {
+          'grid-row-start': 'top',
+        },
+        '.row-start-bottom': {
+          'grid-row-start': 'bottom',
+        },
+        '.row-start-fold-1': {
+          'grid-row-start': 'fold-1',
+        },
+        '.row-start-fold-2': {
+          'grid-row-start': 'fold-2',
+        },
+      },
+      variants: ['responsive'],
+    },
+  ])
+})

--- a/__tests__/util/extractGridLineNames.test.js
+++ b/__tests__/util/extractGridLineNames.test.js
@@ -1,0 +1,55 @@
+import extractGridLineNames from '../../src/util/extractGridLineNames'
+
+test('passing nothing gives you an empty list', () => {
+  expect(extractGridLineNames()).toEqual([])
+})
+
+test('no names in the gridTemplate definition gives an empty list', () => {
+  const gridTemplateRows = {
+    layout: '1fr 1fr 1fr',
+  }
+
+  expect(extractGridLineNames(gridTemplateRows)).toEqual([])
+})
+
+test('lists the named grid lines', () => {
+  const gridTemplateRows = {
+    layout: '1fr [left] 1fr [right] 1fr',
+  }
+
+  expect(extractGridLineNames(gridTemplateRows)).toEqual(['left', 'right'])
+})
+
+test('grid lines with the same name are indexed', () => {
+  const gridTemplateRows = {
+    layout: '1fr [column] 1fr [column] 1fr',
+  }
+
+  expect(extractGridLineNames(gridTemplateRows)).toEqual(['column-1', 'column-2'])
+})
+
+test('multiple names on the same grid line are valid', () => {
+  const gridTemplateRows = {
+    layout: '1fr [left middle] 1fr [right] 1fr',
+  }
+
+  expect(extractGridLineNames(gridTemplateRows)).toEqual(['left', 'middle', 'right'])
+})
+
+test('spaces between multiple names are not important', () => {
+  const gridTemplateRows = {
+    layout: '1fr [left     middle] 1fr [right] 1fr',
+  }
+
+  expect(extractGridLineNames(gridTemplateRows)).toEqual(['left', 'middle', 'right'])
+})
+
+test('multiple gridTemplates can use the same grid line names', () => {
+  const gridTemplateRows = {
+    layout: '1fr [left] 1fr [right] 1fr',
+    other: '[left] 1fr [right] 1fr',
+    multi: '1fr [column] 1fr [column] 1fr',
+  }
+
+  expect(extractGridLineNames(gridTemplateRows)).toEqual(['left', 'right', 'column-1', 'column-2'])
+})

--- a/package.json
+++ b/package.json
@@ -91,9 +91,8 @@
     "setupFilesAfterEnv": [
       "<rootDir>/jest/customMatchers.js"
     ],
-    "testPathIgnorePatterns": [
-      "<rootDir>/__tests__/fixtures/",
-      "<rootDir>/__tests__/util/"
+    "testMatch": [
+      "<rootDir>/__tests__/**/*.test.js"
     ]
   },
   "engines": {

--- a/src/plugins/gridColumnEnd.js
+++ b/src/plugins/gridColumnEnd.js
@@ -1,11 +1,32 @@
-import createUtilityPlugin from '../util/createUtilityPlugin'
+import _ from 'lodash'
+import extractGridLineNames from '../util/extractGridLineNames'
 
 export default function() {
-  return function({ target, ...args }) {
+  return function({ addUtilities, target, theme, variants }) {
     if (target('gridColumnEnd') === 'ie11') {
       return
     }
 
-    createUtilityPlugin('gridColumnEnd', [['col-end', ['gridColumnEnd']]])({ target, ...args })
+    const utilities = _.fromPairs(
+      _.map(theme('gridColumnEnd'), value => {
+        return [
+          `.col-end-${value}`,
+          {
+            'grid-column-end': value,
+          },
+        ]
+      })
+    )
+
+    const namedLines = _.fromPairs(
+      _.map(extractGridLineNames(theme('gridTemplateColumns')), name => [
+        `.col-end-${name}`,
+        {
+          'grid-column-end': name,
+        },
+      ])
+    )
+
+    addUtilities({ ...utilities, ...namedLines }, variants('gridColumnEnd'))
   }
 }

--- a/src/plugins/gridColumnStart.js
+++ b/src/plugins/gridColumnStart.js
@@ -1,14 +1,32 @@
-import createUtilityPlugin from '../util/createUtilityPlugin'
+import _ from 'lodash'
+import extractGridLineNames from '../util/extractGridLineNames'
 
 export default function() {
-  return function({ target, ...args }) {
+  return function({ addUtilities, target, theme, variants }) {
     if (target('gridColumnStart') === 'ie11') {
       return
     }
 
-    createUtilityPlugin('gridColumnStart', [['col-start', ['gridColumnStart']]])({
-      target,
-      ...args,
-    })
+    const utilities = _.fromPairs(
+      _.map(theme('gridColumnStart'), value => {
+        return [
+          `.col-start-${value}`,
+          {
+            'grid-column-start': value,
+          },
+        ]
+      })
+    )
+
+    const namedLines = _.fromPairs(
+      _.map(extractGridLineNames(theme('gridTemplateColumns')), name => [
+        `.col-start-${name}`,
+        {
+          'grid-column-start': name,
+        },
+      ])
+    )
+
+    addUtilities({ ...utilities, ...namedLines }, variants('gridColumnStart'))
   }
 }

--- a/src/plugins/gridRowEnd.js
+++ b/src/plugins/gridRowEnd.js
@@ -1,11 +1,32 @@
-import createUtilityPlugin from '../util/createUtilityPlugin'
+import _ from 'lodash'
+import extractGridLineNames from '../util/extractGridLineNames'
 
 export default function() {
-  return function({ target, ...args }) {
+  return function({ addUtilities, target, theme, variants }) {
     if (target('gridRowEnd') === 'ie11') {
       return
     }
 
-    createUtilityPlugin('gridRowEnd', [['row-end', ['gridRowEnd']]])({ target, ...args })
+    const utilities = _.fromPairs(
+      _.map(theme('gridRowEnd'), value => {
+        return [
+          `.row-end-${value}`,
+          {
+            'grid-row-end': value,
+          },
+        ]
+      })
+    )
+
+    const namedLines = _.fromPairs(
+      _.map(extractGridLineNames(theme('gridTemplateRows')), name => [
+        `.row-end-${name}`,
+        {
+          'grid-row-end': name,
+        },
+      ])
+    )
+
+    addUtilities({ ...utilities, ...namedLines }, variants('gridRowEnd'))
   }
 }

--- a/src/plugins/gridRowStart.js
+++ b/src/plugins/gridRowStart.js
@@ -1,11 +1,32 @@
-import createUtilityPlugin from '../util/createUtilityPlugin'
+import _ from 'lodash'
+import extractGridLineNames from '../util/extractGridLineNames'
 
 export default function() {
-  return function({ target, ...args }) {
+  return function({ addUtilities, target, theme, variants }) {
     if (target('gridRowStart') === 'ie11') {
       return
     }
 
-    createUtilityPlugin('gridRowStart', [['row-start', ['gridRowStart']]])({ target, ...args })
+    const utilities = _.fromPairs(
+      _.map(theme('gridRowStart'), value => {
+        return [
+          `.row-start-${value}`,
+          {
+            'grid-row-start': value,
+          },
+        ]
+      })
+    )
+
+    const namedLines = _.fromPairs(
+      _.map(extractGridLineNames(theme('gridTemplateRows')), name => [
+        `.row-start-${name}`,
+        {
+          'grid-row-start': name,
+        },
+      ])
+    )
+
+    addUtilities({ ...utilities, ...namedLines }, variants('gridRowStart'))
   }
 }

--- a/src/util/extractGridLineNames.js
+++ b/src/util/extractGridLineNames.js
@@ -1,0 +1,42 @@
+import _ from 'lodash'
+
+export default function extractGridLineNames(gridTemplate) {
+  return _.uniq(
+    _.flatMap(gridTemplate, value => {
+      if (!value.match(/\[([^\]]*)\]/g)) {
+        return []
+      }
+
+      // extract grid line names from the gridTemplate
+      const matches = _.flatMap(value.match(/\[([^\]]*)\]/g), match => {
+        return match.substring(1, match.length - 1).split(/\s+/)
+      })
+
+      // create a unique list of names, including counts of how many times that name is used
+      const counts = _.fromPairs(
+        matches
+          .filter((v, i, a) => a.indexOf(v) === i)
+          .map(match => {
+            return [
+              match,
+              {
+                count: 1,
+                total: matches.reduce((count, m) => {
+                  return match === m ? ++count : count
+                }, 0),
+              },
+            ]
+          })
+      )
+
+      // create a list of grid line names for this template, indexing repeated names
+      return matches.map(match => {
+        if (counts[match].total === 1) {
+          return match
+        }
+
+        return `${match}-${counts[match].count++}`
+      })
+    })
+  )
+}


### PR DESCRIPTION
Parse the gridTemplateRows and gridTemplateColumns configuration and add any named grid lines to the col/row-start/end utilities.

Being able to refer to named grid lines increases readability, and allows for greater flexibility in creating responsive layouts.

See the #2295 for more details on how this ability can be put use.