### PR TITLE
feat(boxShadow): automatically join arrays

### DIFF
--- a/src/plugins/boxShadow.js
+++ b/src/plugins/boxShadow.js
@@ -10,7 +10,7 @@ export default function() {
         return [
           `.${className}`,
           {
-            'box-shadow': value,
+            'box-shadow': Array.isArray(value) ? value.join(', ') : value,
           },
         ]
       })


### PR DESCRIPTION
Automatically join arrays if the `boxShadow` value is an array.

## What does it solve

Configuration is a huge thing in Tailwind CSS and there's nothing better than a clean configuration file. Currently you manually have to join the array which adds unnecessary "bloat" to the configuration file. This PR solves it by joining the array if the value is an array.

### Current implementation

```js
boxShadow: {
  default: [
    "0 1px 1px 0 rgba(0, 0, 0, 0.12)",
    "0 2px 4px 0 rgba(0, 0, 0, 0.04)",
    "0 2px 8px 0 rgba(0, 0, 0, 0.02)"
  ].join(", "),
  sm: [
    "0 1px 1px 0 rgba(0, 0, 0, 0.08)",
    "0 2px 3px 0 rgba(0, 0, 0, 0.02)",
    "0 3px 6px 0 rgba(0, 0, 0, 0.01)"
  ].join(", "),
}
```

or

```js
boxShadow: {
  default: "0 1px 1px 0 rgba(0, 0, 0, 0.12), 0 2px 4px 0 rgba(0, 0, 0, 0.04), 0 2px 8px 0 rgba(0, 0, 0, 0.02)",
  sm: "0 1px 1px 0 rgba(0, 0, 0, 0.08), 0 2px 3px 0 rgba(0, 0, 0, 0.02), 0 3px 6px 0 rgba(0, 0, 0, 0.01)",
}
```

### After PR

```js
boxShadow: {
  default: [
    "0 1px 1px 0 rgba(0, 0, 0, 0.12)",
    "0 2px 4px 0 rgba(0, 0, 0, 0.04)",
    "0 2px 8px 0 rgba(0, 0, 0, 0.02)"
  ],
  sm: [
    "0 1px 1px 0 rgba(0, 0, 0, 0.08)",
    "0 2px 3px 0 rgba(0, 0, 0, 0.02)",
    "0 3px 6px 0 rgba(0, 0, 0, 0.01)"
  ],
}
```

or still

```js
boxShadow: {
  default: "0 1px 1px 0 rgba(0, 0, 0, 0.12), 0 2px 4px 0 rgba(0, 0, 0, 0.04), 0 2px 8px 0 rgba(0, 0, 0, 0.02)",
  sm: "0 1px 1px 0 rgba(0, 0, 0, 0.08), 0 2px 3px 0 rgba(0, 0, 0, 0.02), 0 3px 6px 0 rgba(0, 0, 0, 0.01)",
}
```