### PR TITLE
Rename hairline and thin font weights to thin and extralight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Fix [issue](https://github.com/tailwindlabs/tailwindcss/issues/2258) where inserting extra PurgeCSS control comments could break integrated PurgeCSS support
+- Rename `font-hairline` and `font-thin` to `font-thin` and `font-extralight` behind `standardFontWeights` flag ([#2333](https://github.com/tailwindlabs/tailwindcss/pull/2333))
 
 ## [1.8.3] - 2020-09-05
 

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -3,7 +3,7 @@ import chalk from 'chalk'
 import log from './util/log'
 
 const featureFlags = {
-  future: ['removeDeprecatedGapUtilities', 'purgeLayersByDefault'],
+  future: ['removeDeprecatedGapUtilities', 'purgeLayersByDefault', 'standardFontWeights'],
   experimental: [
     'uniformColorPalette',
     'extendedSpacingScale',

--- a/src/flagged/standardFontWeights.js
+++ b/src/flagged/standardFontWeights.js
@@ -1,0 +1,15 @@
+export default {
+  theme: {
+    fontWeight: {
+      thin: '100',
+      extralight: '200',
+      light: '300',
+      normal: '400',
+      medium: '500',
+      semibold: '600',
+      bold: '700',
+      extrabold: '800',
+      black: '900',
+    },
+  },
+}

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ import extendedSpacingScale from './flagged/extendedSpacingScale.js'
 import defaultLineHeights from './flagged/defaultLineHeights.js'
 import extendedFontSizeScale from './flagged/extendedFontSizeScale.js'
 import darkModeVariant from './flagged/darkModeVariant.js'
+import standardFontWeights from './flagged/standardFontWeights'
 
 function getAllConfigs(config) {
   const configs = [defaultConfig]
@@ -36,6 +37,10 @@ function getAllConfigs(config) {
 
   if (flagEnabled(config, 'extendedFontSizeScale')) {
     configs.unshift(extendedFontSizeScale)
+  }
+
+  if (flagEnabled(config, 'standardFontWeights')) {
+    configs.unshift(standardFontWeights)
   }
 
   if (flagEnabled(config, 'darkModeVariant')) {


### PR DESCRIPTION
This PR renames the `font-hairline` and `font-thin` classes to `font-thin` and `font-extralight` respectively to align with the OpenType spec.

This is a breaking chance so this is behind a `future` flag called `standardFontWeights` until 2.0.

Upgrade strategy is find and replace `font-thin` to `font-extralight`, then replace `font-hairline` with `font-thin`. Should be very easy and reliable to change with find and replace.

Resolves #1128.