### PR TITLE
Add default 'transition-duration' to transitionProperty utility

### DIFF
--- a/__tests__/fixtures/tailwind-output-ie11.css
+++ b/__tests__/fixtures/tailwind-output-ie11.css
@@ -10884,30 +10884,37 @@ video {
 
 .transition-none {
   transition-property: none;
+  transition-duration: 250ms;
 }
 
 .transition-all {
   transition-property: all;
+  transition-duration: 250ms;
 }
 
 .transition {
   transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
+  transition-duration: 250ms;
 }
 
 .transition-colors {
   transition-property: background-color, border-color, color, fill, stroke;
+  transition-duration: 250ms;
 }
 
 .transition-opacity {
   transition-property: opacity;
+  transition-duration: 250ms;
 }
 
 .transition-shadow {
   transition-property: box-shadow;
+  transition-duration: 250ms;
 }
 
 .transition-transform {
   transition-property: transform;
+  transition-duration: 250ms;
 }
 
 .ease-linear {
@@ -21354,30 +21361,37 @@ video {
 
   .sm\:transition-none {
     transition-property: none;
+    transition-duration: 250ms;
   }
 
   .sm\:transition-all {
     transition-property: all;
+    transition-duration: 250ms;
   }
 
   .sm\:transition {
     transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
+    transition-duration: 250ms;
   }
 
   .sm\:transition-colors {
     transition-property: background-color, border-color, color, fill, stroke;
+    transition-duration: 250ms;
   }
 
   .sm\:transition-opacity {
     transition-property: opacity;
+    transition-duration: 250ms;
   }
 
   .sm\:transition-shadow {
     transition-property: box-shadow;
+    transition-duration: 250ms;
   }
 
   .sm\:transition-transform {
     transition-property: transform;
+    transition-duration: 250ms;
   }
 
   .sm\:ease-linear {
@@ -31794,30 +31808,37 @@ video {
 
   .md\:transition-none {
     transition-property: none;
+    transition-duration: 250ms;
   }
 
   .md\:transition-all {
     transition-property: all;
+    transition-duration: 250ms;
   }
 
   .md\:transition {
     transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
+    transition-duration: 250ms;
   }
 
   .md\:transition-colors {
     transition-property: background-color, border-color, color, fill, stroke;
+    transition-duration: 250ms;
   }
 
   .md\:transition-opacity {
     transition-property: opacity;
+    transition-duration: 250ms;
   }
 
   .md\:transition-shadow {
     transition-property: box-shadow;
+    transition-duration: 250ms;
   }
 
   .md\:transition-transform {
     transition-property: transform;
+    transition-duration: 250ms;
   }
 
   .md\:ease-linear {
@@ -42234,30 +42255,37 @@ video {
 
   .lg\:transition-none {
     transition-property: none;
+    transition-duration: 250ms;
   }
 
   .lg\:transition-all {
     transition-property: all;
+    transition-duration: 250ms;
   }
 
   .lg\:transition {
     transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
+    transition-duration: 250ms;
   }
 
   .lg\:transition-colors {
     transition-property: background-color, border-color, color, fill, stroke;
+    transition-duration: 250ms;
   }
 
   .lg\:transition-opacity {
     transition-property: opacity;
+    transition-duration: 250ms;
   }
 
   .lg\:transition-shadow {
     transition-property: box-shadow;
+    transition-duration: 250ms;
   }
 
   .lg\:transition-transform {
     transition-property: transform;
+    transition-duration: 250ms;
   }
 
   .lg\:ease-linear {
@@ -52674,30 +52702,37 @@ video {
 
   .xl\:transition-none {
     transition-property: none;
+    transition-duration: 250ms;
   }
 
   .xl\:transition-all {
     transition-property: all;
+    transition-duration: 250ms;
   }
 
   .xl\:transition {
     transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
+    transition-duration: 250ms;
   }
 
   .xl\:transition-colors {
     transition-property: background-color, border-color, color, fill, stroke;
+    transition-duration: 250ms;
   }
 
   .xl\:transition-opacity {
     transition-property: opacity;
+    transition-duration: 250ms;
   }
 
   .xl\:transition-shadow {
     transition-property: box-shadow;
+    transition-duration: 250ms;
   }
 
   .xl\:transition-transform {
     transition-property: transform;
+    transition-duration: 250ms;
   }
 
   .xl\:ease-linear {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -18637,30 +18637,37 @@ video {
 
 .transition-none {
   transition-property: none !important;
+  transition-duration: 250ms !important;
 }
 
 .transition-all {
   transition-property: all !important;
+  transition-duration: 250ms !important;
 }
 
 .transition {
   transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform !important;
+  transition-duration: 250ms !important;
 }
 
 .transition-colors {
   transition-property: background-color, border-color, color, fill, stroke !important;
+  transition-duration: 250ms !important;
 }
 
 .transition-opacity {
   transition-property: opacity !important;
+  transition-duration: 250ms !important;
 }
 
 .transition-shadow {
   transition-property: box-shadow !important;
+  transition-duration: 250ms !important;
 }
 
 .transition-transform {
   transition-property: transform !important;
+  transition-duration: 250ms !important;
 }
 
 .ease-linear {
@@ -36860,30 +36867,37 @@ video {
 
   .sm\:transition-none {
     transition-property: none !important;
+    transition-duration: 250ms !important;
   }
 
   .sm\:transition-all {
     transition-property: all !important;
+    transition-duration: 250ms !important;
   }
 
   .sm\:transition {
     transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform !important;
+    transition-duration: 250ms !important;
   }
 
   .sm\:transition-colors {
     transition-property: background-color, border-color, color, fill, stroke !important;
+    transition-duration: 250ms !important;
   }
 
   .sm\:transition-opacity {
     transition-property: opacity !important;
+    transition-duration: 250ms !important;
   }
 
   .sm\:transition-shadow {
     transition-property: box-shadow !important;
+    transition-duration: 250ms !important;
   }
 
   .sm\:transition-transform {
     transition-property: transform !important;
+    transition-duration: 250ms !important;
   }
 
   .sm\:ease-linear {
@@ -55053,30 +55067,37 @@ video {
 
   .md\:transition-none {
     transition-property: none !important;
+    transition-duration: 250ms !important;
   }
 
   .md\:transition-all {
     transition-property: all !important;
+    transition-duration: 250ms !important;
   }
 
   .md\:transition {
     transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform !important;
+    transition-duration: 250ms !important;
   }
 
   .md\:transition-colors {
     transition-property: background-color, border-color, color, fill, stroke !important;
+    transition-duration: 250ms !important;
   }
 
   .md\:transition-opacity {
     transition-property: opacity !important;
+    transition-duration: 250ms !important;
   }
 
   .md\:transition-shadow {
     transition-property: box-shadow !important;
+    transition-duration: 250ms !important;
   }
 
   .md\:transition-transform {
     transition-property: transform !important;
+    transition-duration: 250ms !important;
   }
 
   .md\:ease-linear {
@@ -73246,30 +73267,37 @@ video {
 
   .lg\:transition-none {
     transition-property: none !important;
+    transition-duration: 250ms !important;
   }
 
   .lg\:transition-all {
     transition-property: all !important;
+    transition-duration: 250ms !important;
   }
 
   .lg\:transition {
     transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform !important;
+    transition-duration: 250ms !important;
   }
 
   .lg\:transition-colors {
     transition-property: background-color, border-color, color, fill, stroke !important;
+    transition-duration: 250ms !important;
   }
 
   .lg\:transition-opacity {
     transition-property: opacity !important;
+    transition-duration: 250ms !important;
   }
 
   .lg\:transition-shadow {
     transition-property: box-shadow !important;
+    transition-duration: 250ms !important;
   }
 
   .lg\:transition-transform {
     transition-property: transform !important;
+    transition-duration: 250ms !important;
   }
 
   .lg\:ease-linear {
@@ -91439,30 +91467,37 @@ video {
 
   .xl\:transition-none {
     transition-property: none !important;
+    transition-duration: 250ms !important;
   }
 
   .xl\:transition-all {
     transition-property: all !important;
+    transition-duration: 250ms !important;
   }
 
   .xl\:transition {
     transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform !important;
+    transition-duration: 250ms !important;
   }
 
   .xl\:transition-colors {
     transition-property: background-color, border-color, color, fill, stroke !important;
+    transition-duration: 250ms !important;
   }
 
   .xl\:transition-opacity {
     transition-property: opacity !important;
+    transition-duration: 250ms !important;
   }
 
   .xl\:transition-shadow {
     transition-property: box-shadow !important;
+    transition-duration: 250ms !important;
   }
 
   .xl\:transition-transform {
     transition-property: transform !important;
+    transition-duration: 250ms !important;
   }
 
   .xl\:ease-linear {

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -16189,30 +16189,37 @@ video {
 
 .transition-none {
   transition-property: none;
+  transition-duration: 250ms;
 }
 
 .transition-all {
   transition-property: all;
+  transition-duration: 250ms;
 }
 
 .transition {
   transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
+  transition-duration: 250ms;
 }
 
 .transition-colors {
   transition-property: background-color, border-color, color, fill, stroke;
+  transition-duration: 250ms;
 }
 
 .transition-opacity {
   transition-property: opacity;
+  transition-duration: 250ms;
 }
 
 .transition-shadow {
   transition-property: box-shadow;
+  transition-duration: 250ms;
 }
 
 .transition-transform {
   transition-property: transform;
+  transition-duration: 250ms;
 }
 
 .ease-linear {
@@ -31964,30 +31971,37 @@ video {
 
   .sm\:transition-none {
     transition-property: none;
+    transition-duration: 250ms;
   }
 
   .sm\:transition-all {
     transition-property: all;
+    transition-duration: 250ms;
   }
 
   .sm\:transition {
     transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
+    transition-duration: 250ms;
   }
 
   .sm\:transition-colors {
     transition-property: background-color, border-color, color, fill, stroke;
+    transition-duration: 250ms;
   }
 
   .sm\:transition-opacity {
     transition-property: opacity;
+    transition-duration: 250ms;
   }
 
   .sm\:transition-shadow {
     transition-property: box-shadow;
+    transition-duration: 250ms;
   }
 
   .sm\:transition-transform {
     transition-property: transform;
+    transition-duration: 250ms;
   }
 
   .sm\:ease-linear {
@@ -47709,30 +47723,37 @@ video {
 
   .md\:transition-none {
     transition-property: none;
+    transition-duration: 250ms;
   }
 
   .md\:transition-all {
     transition-property: all;
+    transition-duration: 250ms;
   }
 
   .md\:transition {
     transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
+    transition-duration: 250ms;
   }
 
   .md\:transition-colors {
     transition-property: background-color, border-color, color, fill, stroke;
+    transition-duration: 250ms;
   }
 
   .md\:transition-opacity {
     transition-property: opacity;
+    transition-duration: 250ms;
   }
 
   .md\:transition-shadow {
     transition-property: box-shadow;
+    transition-duration: 250ms;
   }
 
   .md\:transition-transform {
     transition-property: transform;
+    transition-duration: 250ms;
   }
 
   .md\:ease-linear {
@@ -63454,30 +63475,37 @@ video {
 
   .lg\:transition-none {
     transition-property: none;
+    transition-duration: 250ms;
   }
 
   .lg\:transition-all {
     transition-property: all;
+    transition-duration: 250ms;
   }
 
   .lg\:transition {
     transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
+    transition-duration: 250ms;
   }
 
   .lg\:transition-colors {
     transition-property: background-color, border-color, color, fill, stroke;
+    transition-duration: 250ms;
   }
 
   .lg\:transition-opacity {
     transition-property: opacity;
+    transition-duration: 250ms;
   }
 
   .lg\:transition-shadow {
     transition-property: box-shadow;
+    transition-duration: 250ms;
   }
 
   .lg\:transition-transform {
     transition-property: transform;
+    transition-duration: 250ms;
   }
 
   .lg\:ease-linear {
@@ -79199,30 +79227,37 @@ video {
 
   .xl\:transition-none {
     transition-property: none;
+    transition-duration: 250ms;
   }
 
   .xl\:transition-all {
     transition-property: all;
+    transition-duration: 250ms;
   }
 
   .xl\:transition {
     transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
+    transition-duration: 250ms;
   }
 
   .xl\:transition-colors {
     transition-property: background-color, border-color, color, fill, stroke;
+    transition-duration: 250ms;
   }
 
   .xl\:transition-opacity {
     transition-property: opacity;
+    transition-duration: 250ms;
   }
 
   .xl\:transition-shadow {
     transition-property: box-shadow;
+    transition-duration: 250ms;
   }
 
   .xl\:transition-transform {
     transition-property: transform;
+    transition-duration: 250ms;
   }
 
   .xl\:ease-linear {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -18637,30 +18637,37 @@ video {
 
 .transition-none {
   transition-property: none;
+  transition-duration: 250ms;
 }
 
 .transition-all {
   transition-property: all;
+  transition-duration: 250ms;
 }
 
 .transition {
   transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
+  transition-duration: 250ms;
 }
 
 .transition-colors {
   transition-property: background-color, border-color, color, fill, stroke;
+  transition-duration: 250ms;
 }
 
 .transition-opacity {
   transition-property: opacity;
+  transition-duration: 250ms;
 }
 
 .transition-shadow {
   transition-property: box-shadow;
+  transition-duration: 250ms;
 }
 
 .transition-transform {
   transition-property: transform;
+  transition-duration: 250ms;
 }
 
 .ease-linear {
@@ -36860,30 +36867,37 @@ video {
 
   .sm\:transition-none {
     transition-property: none;
+    transition-duration: 250ms;
   }
 
   .sm\:transition-all {
     transition-property: all;
+    transition-duration: 250ms;
   }
 
   .sm\:transition {
     transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
+    transition-duration: 250ms;
   }
 
   .sm\:transition-colors {
     transition-property: background-color, border-color, color, fill, stroke;
+    transition-duration: 250ms;
   }
 
   .sm\:transition-opacity {
     transition-property: opacity;
+    transition-duration: 250ms;
   }
 
   .sm\:transition-shadow {
     transition-property: box-shadow;
+    transition-duration: 250ms;
   }
 
   .sm\:transition-transform {
     transition-property: transform;
+    transition-duration: 250ms;
   }
 
   .sm\:ease-linear {
@@ -55053,30 +55067,37 @@ video {
 
   .md\:transition-none {
     transition-property: none;
+    transition-duration: 250ms;
   }
 
   .md\:transition-all {
     transition-property: all;
+    transition-duration: 250ms;
   }
 
   .md\:transition {
     transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
+    transition-duration: 250ms;
   }
 
   .md\:transition-colors {
     transition-property: background-color, border-color, color, fill, stroke;
+    transition-duration: 250ms;
   }
 
   .md\:transition-opacity {
     transition-property: opacity;
+    transition-duration: 250ms;
   }
 
   .md\:transition-shadow {
     transition-property: box-shadow;
+    transition-duration: 250ms;
   }
 
   .md\:transition-transform {
     transition-property: transform;
+    transition-duration: 250ms;
   }
 
   .md\:ease-linear {
@@ -73246,30 +73267,37 @@ video {
 
   .lg\:transition-none {
     transition-property: none;
+    transition-duration: 250ms;
   }
 
   .lg\:transition-all {
     transition-property: all;
+    transition-duration: 250ms;
   }
 
   .lg\:transition {
     transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
+    transition-duration: 250ms;
   }
 
   .lg\:transition-colors {
     transition-property: background-color, border-color, color, fill, stroke;
+    transition-duration: 250ms;
   }
 
   .lg\:transition-opacity {
     transition-property: opacity;
+    transition-duration: 250ms;
   }
 
   .lg\:transition-shadow {
     transition-property: box-shadow;
+    transition-duration: 250ms;
   }
 
   .lg\:transition-transform {
     transition-property: transform;
+    transition-duration: 250ms;
   }
 
   .lg\:ease-linear {
@@ -91439,30 +91467,37 @@ video {
 
   .xl\:transition-none {
     transition-property: none;
+    transition-duration: 250ms;
   }
 
   .xl\:transition-all {
     transition-property: all;
+    transition-duration: 250ms;
   }
 
   .xl\:transition {
     transition-property: background-color, border-color, color, fill, stroke, opacity, box-shadow, transform;
+    transition-duration: 250ms;
   }
 
   .xl\:transition-colors {
     transition-property: background-color, border-color, color, fill, stroke;
+    transition-duration: 250ms;
   }
 
   .xl\:transition-opacity {
     transition-property: opacity;
+    transition-duration: 250ms;
   }
 
   .xl\:transition-shadow {
     transition-property: box-shadow;
+    transition-duration: 250ms;
   }
 
   .xl\:transition-transform {
     transition-property: transform;
+    transition-duration: 250ms;
   }
 
   .xl\:ease-linear {

--- a/src/plugins/transitionProperty.js
+++ b/src/plugins/transitionProperty.js
@@ -5,7 +5,7 @@ export default function() {
     const utilities = _.fromPairs(
       _.map(theme('transitionProperty'), (value, modifier) => {
         return [
-          `.${e(`transition-${modifier}`)}`,
+          `.${e(`${modifier !== 'default' ? `transition-${modifier}` : 'transition'}`)}`,
           {
             transitionProperty: value,
             transitionDuration: '250ms',

--- a/src/plugins/transitionProperty.js
+++ b/src/plugins/transitionProperty.js
@@ -1,5 +1,19 @@
-import createUtilityPlugin from '../util/createUtilityPlugin'
+import _ from 'lodash'
 
 export default function() {
-  return createUtilityPlugin('transitionProperty', [['transition', ['transitionProperty']]])
+  return function({ addUtilities, e, theme, variants }) {
+    const utilities = _.fromPairs(
+      _.map(theme('transitionProperty'), (value, modifier) => {
+        return [
+          `.${e(`transition-${modifier}`)}`,
+          {
+            transitionProperty: value,
+            transitionDuration: '250ms',
+          },
+        ]
+      })
+    )
+
+    addUtilities(utilities, variants('transitionProperty'))
+  }
 }


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
This PR adds a default 'transition-duration' value, set to 250ms, to each of 'transitionProperty' variants.

This closes #2334 
