### PR TITLE
Make resolveConfig compatible with feature flag configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+- Fix issue where `resolveConfig` didn't take into account configs added by feature flags ([#2347](https://github.com/tailwindlabs/tailwindcss/pull/2347))
 
 ## [1.8.4] - 2020-09-06
 

--- a/resolveConfig.js
+++ b/resolveConfig.js
@@ -1,6 +1,11 @@
 const resolveConfigObjects = require('./lib/util/resolveConfig').default
-const defaultConfig = require('./stubs/defaultConfig.stub.js')
+const getAllConfigs = require('./lib/util/getAllConfigs').default
 
 module.exports = function resolveConfig(...configs) {
-  return resolveConfigObjects([...configs, defaultConfig])
+  // Make sure the correct config object is mutated to include flagged config plugins.
+  // This sucks, refactor soon.
+  const firstConfigWithPlugins = configs.find(c => Array.isArray(c.plugins)) || configs[0]
+  const [, ...defaultConfigs] = getAllConfigs(firstConfigWithPlugins)
+
+  return resolveConfigObjects([...configs, ...defaultConfigs])
 }

--- a/src/index.js
+++ b/src/index.js
@@ -9,49 +9,9 @@ import registerConfigAsDependency from './lib/registerConfigAsDependency'
 import processTailwindFeatures from './processTailwindFeatures'
 import formatCSS from './lib/formatCSS'
 import resolveConfig from './util/resolveConfig'
+import getAllConfigs from './util/getAllConfigs'
 import { defaultConfigFile } from './constants'
 import defaultConfig from '../stubs/defaultConfig.stub.js'
-import { flagEnabled } from './featureFlags'
-
-import uniformColorPalette from './flagged/uniformColorPalette.js'
-import extendedSpacingScale from './flagged/extendedSpacingScale.js'
-import defaultLineHeights from './flagged/defaultLineHeights.js'
-import extendedFontSizeScale from './flagged/extendedFontSizeScale.js'
-import darkModeVariant from './flagged/darkModeVariant.js'
-import standardFontWeights from './flagged/standardFontWeights'
-
-function getAllConfigs(config) {
-  const configs = [defaultConfig]
-
-  if (flagEnabled(config, 'uniformColorPalette')) {
-    configs.unshift(uniformColorPalette)
-  }
-
-  if (flagEnabled(config, 'extendedSpacingScale')) {
-    configs.unshift(extendedSpacingScale)
-  }
-
-  if (flagEnabled(config, 'defaultLineHeights')) {
-    configs.unshift(defaultLineHeights)
-  }
-
-  if (flagEnabled(config, 'extendedFontSizeScale')) {
-    configs.unshift(extendedFontSizeScale)
-  }
-
-  if (flagEnabled(config, 'standardFontWeights')) {
-    configs.unshift(standardFontWeights)
-  }
-
-  if (flagEnabled(config, 'darkModeVariant')) {
-    configs.unshift(darkModeVariant)
-    if (Array.isArray(config.plugins)) {
-      config.plugins = [...darkModeVariant.plugins, ...config.plugins]
-    }
-  }
-
-  return [config, ...configs]
-}
 
 function resolveConfigPath(filePath) {
   // require('tailwindcss')({ theme: ..., variants: ... })

--- a/src/util/getAllConfigs.js
+++ b/src/util/getAllConfigs.js
@@ -1,0 +1,41 @@
+import defaultConfig from '../../stubs/defaultConfig.stub.js'
+import { flagEnabled } from '../featureFlags'
+import uniformColorPalette from '../flagged/uniformColorPalette.js'
+import extendedSpacingScale from '../flagged/extendedSpacingScale.js'
+import defaultLineHeights from '../flagged/defaultLineHeights.js'
+import extendedFontSizeScale from '../flagged/extendedFontSizeScale.js'
+import darkModeVariant from '../flagged/darkModeVariant.js'
+import standardFontWeights from '../flagged/standardFontWeights'
+
+export default function getAllConfigs(config) {
+  const configs = [defaultConfig]
+
+  if (flagEnabled(config, 'uniformColorPalette')) {
+    configs.unshift(uniformColorPalette)
+  }
+
+  if (flagEnabled(config, 'extendedSpacingScale')) {
+    configs.unshift(extendedSpacingScale)
+  }
+
+  if (flagEnabled(config, 'defaultLineHeights')) {
+    configs.unshift(defaultLineHeights)
+  }
+
+  if (flagEnabled(config, 'extendedFontSizeScale')) {
+    configs.unshift(extendedFontSizeScale)
+  }
+
+  if (flagEnabled(config, 'standardFontWeights')) {
+    configs.unshift(standardFontWeights)
+  }
+
+  if (flagEnabled(config, 'darkModeVariant')) {
+    configs.unshift(darkModeVariant)
+    if (Array.isArray(config.plugins)) {
+      config.plugins = [...darkModeVariant.plugins, ...config.plugins]
+    }
+  }
+
+  return [config, ...configs]
+}


### PR DESCRIPTION
Fixes #2345. Not the prettiest solution but this is broken and I'd rather fix it fast.

Basically we need to make sure the user-expected `resolveConfig` function imports all of the feature flagged config files as well, which isn't too nasty on its own, except that because flagged configs register plugins (like dark mode), we need to mutate the incoming config too to prepend any plugins added by flagged configs, since there is no "extend" API for plugins right now.

Grim but works.