### PR TITLE
Add negative spacing values to inset plugin

### DIFF
--- a/src/flagged/extendedSpacingScale.js
+++ b/src/flagged/extendedSpacingScale.js
@@ -66,9 +66,10 @@ export default {
       '11/12': '91.666667%',
       full: '100%',
     },
-    inset: theme => ({
+    inset: (theme, { negative }) => ({
       auto: 'auto',
       ...theme('spacing'),
+      ...negative(theme('spacing')),
     }),
     minWidth: {
       '0': '0',


### PR DESCRIPTION
The `extendedSpacingScale` experiment from #2141 which should add _all_ spacing values to the `inset` plugin, but it only adds positive values. This updates the flagged config so that negative spacing classes get created just like for the `margin` and `padding` plugins.
