### PR TITLE
Safeguard against trailing slash in purge matches

### DIFF
--- a/__tests__/fixtures/purge-example.html
+++ b/__tests__/fixtures/purge-example.html
@@ -37,3 +37,8 @@ span.inline-grid.grid-cols-3(class="px-1.5")
     %samp.font-mono{:data-foo => "bar"}= output
     .col-span-4[aria-hidden=true]
     .tracking-tight#headline
+
+<!-- JSON -->
+{
+  "helloThere": "Hello there, <span class=\"whitespace-no-wrap\">Mr. Jones</span>"
+}

--- a/__tests__/purgeUnusedStyles.test.js
+++ b/__tests__/purgeUnusedStyles.test.js
@@ -90,7 +90,7 @@ function assertPurged(result) {
   expect(result.css).toContain('.font-mono')
   expect(result.css).toContain('.col-span-4')
   expect(result.css).toContain('.tracking-tight')
-  expect(result.css).toContain('.tracking-tight')
+  expect(result.css).toContain('.whitespace-no-wrap')
 }
 
 test('purges unused classes', () => {

--- a/src/lib/purgeUnusedStyles.js
+++ b/src/lib/purgeUnusedStyles.js
@@ -112,14 +112,17 @@ export default function purgeUnusedUtilities(config, configChanged) {
       defaultExtractor: content => {
         // Capture as liberally as possible, including things like `h-(screen-1.5)`
         const broadMatches = content.match(/[^<>"'`\s]*[^<>"'`\s:]/g) || []
+        const broadMatchesWithoutTrailingSlash = broadMatches.map(match => _.trimEnd(match, '\\'))
 
         // Capture classes within other delimiters like .block(class="w-1/2") in Pug
         const innerMatches = content.match(/[^<>"'`\s.(){}[\]#=%]*[^<>"'`\s.(){}[\]#=%:]/g) || []
 
+        const matches = broadMatches.concat(broadMatchesWithoutTrailingSlash).concat(innerMatches)
+
         if (_.get(config, 'purge.preserveHtmlElements', true)) {
-          return [...htmlTags].concat(broadMatches).concat(innerMatches)
+          return [...htmlTags].concat(matches)
         } else {
-          return broadMatches.concat(innerMatches)
+          return matches
         }
       },
       ...config.purge.options,


### PR DESCRIPTION
Resolves #2360.

This PR adds another set of matches for purge to consider which are the original broad matches, minus any trailing slashes. This means in this string:

```
class=\"foo\"
```

...both `foo\` and `foo` will be checked in the stylesheet.