### PR TITLE
Add future property to simpleconfig stub

### DIFF
--- a/stubs/simpleConfig.stub.js
+++ b/stubs/simpleConfig.stub.js
@@ -4,6 +4,9 @@ module.exports = {
   theme: {
     extend: {},
   },
-  future: {},
+  future: {
+    // removeDeprecatedGapUtilities: true,
+    // purgeLayersByDefault: true,
+  },
   variants: {},
 }

--- a/stubs/simpleConfig.stub.js
+++ b/stubs/simpleConfig.stub.js
@@ -1,8 +1,9 @@
 module.exports = {
   purge: [],
+  plugins: [],
   theme: {
     extend: {},
   },
+  future: {},
   variants: {},
-  plugins: [],
 }


### PR DESCRIPTION
Here's a start to adding the future property to the simpleconfig stub. I'm not sure on the best way to put the `featureFlags.future` into the file, but with some direction I'll gladly implement that too.

Closes #2370
