### PR TITLE
Automatically add `featureFlags.future` flags to the configuration files whenever the `init` command is ran

### DIFF
--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -4,6 +4,7 @@ import cli from '../src/cli/main'
 import * as constants from '../src/constants'
 import * as utils from '../src/cli/utils'
 import runInTempDirectory from '../jest/runInTempDirectory'
+import featureFlags from '../src/featureFlags'
 
 describe('cli', () => {
   const inputCssPath = path.resolve(__dirname, 'fixtures/tailwind-input.css')
@@ -92,6 +93,16 @@ describe('cli', () => {
     it('compiles CSS file without autoprefixer', () => {
       return cli(['build', inputCssPath, '--no-autoprefixer']).then(() => {
         expect(process.stdout.write.mock.calls[0][0]).not.toContain('-ms-input-placeholder')
+      })
+    })
+
+    it('creates a Tailwind config file with future flags', () => {
+      return runInTempDirectory(() => {
+        return cli(['init']).then(() => {
+          featureFlags.future.forEach(flag => {
+            expect(utils.readFile(constants.defaultConfigFile)).toContain(`${flag}: true`)
+          })
+        })
       })
     })
   })

--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -9,8 +9,6 @@ import featureFlags from '../src/featureFlags'
 describe('cli', () => {
   const inputCssPath = path.resolve(__dirname, 'fixtures/tailwind-input.css')
   const customConfigPath = path.resolve(__dirname, 'fixtures/custom-config.js')
-  const defaultConfigFixture = utils.readFile(constants.defaultConfigStubFile)
-  const simpleConfigFixture = utils.readFile(constants.simpleConfigStubFile)
   const defaultPostCssConfigFixture = utils.readFile(constants.defaultPostCssConfigStubFile)
 
   beforeEach(() => {
@@ -22,7 +20,7 @@ describe('cli', () => {
     it('creates a Tailwind config file', () => {
       return runInTempDirectory(() => {
         return cli(['init']).then(() => {
-          expect(utils.readFile(constants.defaultConfigFile)).toEqual(simpleConfigFixture)
+          expect(utils.exists(constants.defaultConfigFile)).toEqual(true)
         })
       })
     })
@@ -30,7 +28,7 @@ describe('cli', () => {
     it('creates a Tailwind config file and a postcss.config.js file', () => {
       return runInTempDirectory(() => {
         return cli(['init', '-p']).then(() => {
-          expect(utils.readFile(constants.defaultConfigFile)).toEqual(simpleConfigFixture)
+          expect(utils.exists(constants.defaultConfigFile)).toEqual(true)
           expect(utils.readFile(constants.defaultPostCssConfigFile)).toEqual(
             defaultPostCssConfigFixture
           )
@@ -41,7 +39,7 @@ describe('cli', () => {
     it('creates a full Tailwind config file', () => {
       return runInTempDirectory(() => {
         return cli(['init', '--full']).then(() => {
-          expect(utils.readFile(constants.defaultConfigFile)).toEqual(defaultConfigFixture)
+          expect(utils.exists(constants.defaultConfigFile)).toEqual(true)
         })
       })
     })

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -17,16 +17,11 @@ export const options = [
     usage: '-p',
     description: 'Generate postcss.config.js file.',
   },
-  {
-    usage: '--future',
-    description: 'Add enable future flags within simple config stub',
-  },
 ]
 
 export const optionMap = {
   full: ['full'],
   postcss: ['p'],
-  future: ['future'],
 }
 
 /**
@@ -49,21 +44,17 @@ export function run(cliParams, cliOptions) {
       ? constants.defaultConfigStubFile
       : constants.simpleConfigStubFile
 
-    if (!cliOptions.future) {
-      utils.copyFile(stubFile, file)
-    } else {
-      const config = require(stubFile)
-      const { future: flags } = require('../../featureFlags').default
+    const config = require(stubFile)
+    const { future: flags } = require('../../featureFlags').default
 
-      flags.forEach(flag => {
-        config.future[flag] = true
-      })
+    flags.forEach(flag => {
+      config.future[`// ${flag}`] = true
+    })
 
-      utils.writeFile(
-        file,
-        `module.exports = ${JSON.stringify(config, null, 2).replace(/"([^"]+)":/g, '$1:')}\n`
-      )
-    }
+    utils.writeFile(
+      file,
+      `module.exports = ${JSON.stringify(config, null, 2).replace(/"([^-_\d"]+)":/g, '$1:')}\n`
+    )
 
     utils.log()
     utils.log(emoji.yes, 'Created Tailwind config file:', colors.file(simplePath))

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -63,9 +63,6 @@ export function run(cliParams, cliOptions) {
         file,
         `module.exports = ${JSON.stringify(config, null, 2).replace(/"([^"]+)":/g, '$1:')}\n`
       )
-      utils.footer()
-      resolve()
-      return
     }
 
     utils.log()

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -1,8 +1,5 @@
 module.exports = {
-  future: {
-    // removeDeprecatedGapUtilities: true,
-    // purgeLayersByDefault: true,
-  },
+  future: {},
   purge: [],
   target: 'relaxed',
   prefix: '',

--- a/stubs/simpleConfig.stub.js
+++ b/stubs/simpleConfig.stub.js
@@ -1,8 +1,5 @@
 module.exports = {
-  future: {
-    // removeDeprecatedGapUtilities: true,
-    // purgeLayersByDefault: true,
-  },
+  future: {},
   purge: [],
   theme: {
     extend: {},


### PR DESCRIPTION
~This PR implements the `--future` flag on the `init` command which then automatically fill-in and enables the current `featureFlags.future`.~

This PR implements adding commented out `featureFlags.future` flags whenever `init` commend is ran. This could be expanded to fill out all sorts of data and remove the manual processes that once were.

This was previously mentioned in my previous PR (#2372) but I thought I'd take a shot at implementing it myself! Feedback welcome.

✅ Tests updated and passed
✅ Styles updated and passed