### PR TITLE
Allow variant plugins to tell Tailwind they should stack

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,7 @@
   "extends": ["eslint-config-postcss", "prettier"],
   "plugins": ["prettier"],
   "rules": {
+    "camelcase": ["error", { "allow": ["^unstable_"] }],
     "no-unused-vars": [2, { "args": "all", "argsIgnorePattern": "^_" }],
     "no-warning-comments": 0,
     "prettier/prettier": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Prevent new `dark` experiment from causing third-party `dark` variants to inherit stacking behavior ([#2382](https://github.com/tailwindlabs/tailwindcss/pull/2382))
 
 ## [1.8.9] - 2020-09-13
 

--- a/__tests__/darkMode.test.js
+++ b/__tests__/darkMode.test.js
@@ -1,5 +1,6 @@
 import postcss from 'postcss'
 import tailwind from '../src/index'
+import createPlugin from '../src/util/createPlugin'
 
 function run(input, config = {}) {
   return postcss([tailwind({ experimental: { darkModeVariant: true }, ...config })]).process(
@@ -19,6 +20,45 @@ test('dark mode variants cannot be generated without enabling the dark mode expe
 
   expect.assertions(1)
   return expect(run(input, { experimental: {} })).rejects.toThrow()
+})
+
+test("user-defined dark mode variants won't stack when the dark mode experiment is disabled", () => {
+  const input = `
+    @variants dark, hover {
+      .text-red {
+        color: red;
+      }
+    }
+  `
+
+  const expected = `
+    .text-red {
+      color: red;
+    }
+    .custom-dark .custom-dark\\:text-red {
+      color: red;
+    }
+    .hover\\:text-red:hover {
+      color: red;
+    }
+  `
+
+  const userPlugin = createPlugin(function({ addVariant }) {
+    addVariant('dark', function({ modifySelectors }) {
+      modifySelectors(function({ className }) {
+        return `.custom-dark .custom-dark\\:${className}`
+      })
+    })
+  })
+
+  expect.assertions(2)
+
+  return postcss([tailwind({ experimental: { darkModeVariant: false }, plugins: [userPlugin] })])
+    .process(input, { from: undefined })
+    .then(result => {
+      expect(result.css).toMatchCss(expected)
+      expect(result.warnings().length).toBe(0)
+    })
 })
 
 test('generating dark mode variants uses the media strategy by default', () => {

--- a/__tests__/darkMode.test.js
+++ b/__tests__/darkMode.test.js
@@ -22,7 +22,7 @@ test('dark mode variants cannot be generated without enabling the dark mode expe
   return expect(run(input, { experimental: {} })).rejects.toThrow()
 })
 
-test("user-defined dark mode variants won't stack when the dark mode experiment is disabled", () => {
+test('user-defined dark mode variants do not stack when the dark mode experiment is disabled', () => {
   const input = `
     @variants dark, hover {
       .text-red {

--- a/src/flagged/darkModeVariantPlugin.js
+++ b/src/flagged/darkModeVariantPlugin.js
@@ -1,38 +1,42 @@
 import buildSelectorVariant from '../util/buildSelectorVariant'
 
 export default function({ addVariant, config, postcss, prefix }) {
-  addVariant('dark', ({ container, separator, modifySelectors }) => {
-    if (config('dark') === 'media') {
-      const modified = modifySelectors(({ selector }) => {
-        return buildSelectorVariant(selector, 'dark', separator, message => {
-          throw container.error(message)
+  addVariant(
+    'dark',
+    ({ container, separator, modifySelectors }) => {
+      if (config('dark') === 'media') {
+        const modified = modifySelectors(({ selector }) => {
+          return buildSelectorVariant(selector, 'dark', separator, message => {
+            throw container.error(message)
+          })
         })
-      })
-      const mediaQuery = postcss.atRule({
-        name: 'media',
-        params: '(prefers-color-scheme: dark)',
-      })
-      mediaQuery.append(modified)
-      container.append(mediaQuery)
-      return container
-    }
-
-    if (config('dark') === 'class') {
-      const modified = modifySelectors(({ selector }) => {
-        return buildSelectorVariant(selector, 'dark', separator, message => {
-          throw container.error(message)
+        const mediaQuery = postcss.atRule({
+          name: 'media',
+          params: '(prefers-color-scheme: dark)',
         })
-      })
+        mediaQuery.append(modified)
+        container.append(mediaQuery)
+        return container
+      }
 
-      modified.walkRules(rule => {
-        rule.selectors = rule.selectors.map(selector => {
-          return `${prefix('.dark')} ${selector}`
+      if (config('dark') === 'class') {
+        const modified = modifySelectors(({ selector }) => {
+          return buildSelectorVariant(selector, 'dark', separator, message => {
+            throw container.error(message)
+          })
         })
-      })
 
-      return modified
-    }
+        modified.walkRules(rule => {
+          rule.selectors = rule.selectors.map(selector => {
+            return `${prefix('.dark')} ${selector}`
+          })
+        })
 
-    throw new Error("The `dark` config option must be either 'media' or 'class'.")
-  })
+        return modified
+      }
+
+      throw new Error("The `dark` config option must be either 'media' or 'class'.")
+    },
+    { unstable_stack: true }
+  )
 }

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -88,9 +88,7 @@ const defaultVariantGenerators = config => ({
   even: generatePseudoClassVariant('nth-child(even)', 'even'),
 })
 
-function prependStackableVariants(atRule, variants) {
-  const stackableVariants = ['dark', 'motion-safe', 'motion-reduce']
-
+function prependStackableVariants(atRule, variants, stackableVariants) {
   if (!_.some(variants, v => stackableVariants.includes(v))) {
     return variants
   }
@@ -117,6 +115,11 @@ export default function(config, { variantGenerators: pluginVariantGenerators }) 
       ...pluginVariantGenerators,
     }
 
+    const stackableVariants = ['motion-safe', 'motion-reduce']
+    const darkEnabled =
+      config.experimental === 'all' || _.get(config, ['experimental', 'darkModeVariant'], false)
+    if (darkEnabled) stackableVariants.unshift('dark')
+
     let variantsFound = false
 
     do {
@@ -132,7 +135,7 @@ export default function(config, { variantGenerators: pluginVariantGenerators }) 
           responsiveParent.append(atRule)
         }
 
-        const remainingVariants = prependStackableVariants(atRule, variants)
+        const remainingVariants = prependStackableVariants(atRule, variants, stackableVariants)
 
         _.forEach(_.without(ensureIncludesDefault(remainingVariants), 'responsive'), variant => {
           if (!variantGenerators[variant]) {

--- a/src/util/generateVariantFunction.js
+++ b/src/util/generateVariantFunction.js
@@ -12,35 +12,38 @@ const getClassNameFromSelector = useMemo(
   selector => selector
 )
 
-export default function generateVariantFunction(generator) {
-  return (container, config) => {
-    const cloned = postcss.root({ nodes: container.clone().nodes })
+export default function generateVariantFunction(generator, options = {}) {
+  return {
+    options,
+    handler: (container, config) => {
+      const cloned = postcss.root({ nodes: container.clone().nodes })
 
-    container.before(
-      _.defaultTo(
-        generator({
-          container: cloned,
-          separator: config.separator,
-          modifySelectors: modifierFunction => {
-            cloned.each(rule => {
-              if (rule.type !== 'rule') {
-                return
-              }
+      container.before(
+        _.defaultTo(
+          generator({
+            container: cloned,
+            separator: config.separator,
+            modifySelectors: modifierFunction => {
+              cloned.each(rule => {
+                if (rule.type !== 'rule') {
+                  return
+                }
 
-              rule.selectors = rule.selectors.map(selector => {
-                return modifierFunction({
-                  get className() {
-                    return getClassNameFromSelector(selector)
-                  },
-                  selector,
+                rule.selectors = rule.selectors.map(selector => {
+                  return modifierFunction({
+                    get className() {
+                      return getClassNameFromSelector(selector)
+                    },
+                    selector,
+                  })
                 })
               })
-            })
-            return cloned
-          },
-        }),
-        cloned
-      ).nodes
-    )
+              return cloned
+            },
+          }),
+          cloned
+        ).nodes
+      )
+    },
   }
 }

--- a/src/util/processPlugins.js
+++ b/src/util/processPlugins.js
@@ -126,8 +126,8 @@ export default function(plugins, config) {
       addBase: baseStyles => {
         pluginBaseStyles.push(wrapWithLayer(parseStyles(baseStyles), 'base'))
       },
-      addVariant: (name, generator) => {
-        pluginVariantGenerators[name] = generateVariantFunction(generator)
+      addVariant: (name, generator, options = {}) => {
+        pluginVariantGenerators[name] = generateVariantFunction(generator, options)
       },
     })
   })


### PR DESCRIPTION
This PR makes it possible for variants to tell Tailwind they should "stack" using a new `unstable_stack` option, passed in through an options object to the `addVariant` function exposed through the plugin API:

```js
tailwind.plugin(function({ addVariant }) {
  addVariant('motion-safe', ({ modifySelectors }) => {
    // ...
  }, { unstable_stack: true })
})
```

This ensures that if a user overrides a default variant by registering their own variant with the same name, that the user's variant does not automatically inherit the hard-coded stacking behavior of the built-in variant.

Marking it as unstable for now as I'm not sure this is going to be the best approach to a public stacking API going forward but it's fine for our internal use and solves the problem.

Resolves #2378.