### PR TITLE
Add `selected` variant

### DIFF
--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -72,6 +72,27 @@ test('it can generate checked variants', () => {
   })
 })
 
+test('it can generate selected variants', () => {
+  const input = `
+    @variants selected {
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+    }
+  `
+
+  const output = `
+    .banana { color: yellow; }
+    .chocolate { color: brown; }
+    .selected\\:banana::selection { color: yellow; }
+    .selected\\:chocolate::selection { color: brown; }
+  `
+
+  return run(input).then(result => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('it can generate active variants', () => {
   const input = `
     @variants active {

--- a/perf/tailwind.config.js
+++ b/perf/tailwind.config.js
@@ -11,6 +11,7 @@ module.exports = {
     'motion-reduce',
     'group-hover',
     'group-focus',
+    'selected',
     'hover',
     'focus-within',
     'focus-visible',

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -80,6 +80,7 @@ const defaultVariantGenerators = config => ({
     })
     return modifySelectors(({ selector }) => parser.processSync(selector))
   }),
+  selected: generatePseudoClassVariant(':selection', 'selected'),
   hover: generatePseudoClassVariant('hover'),
   'focus-within': generatePseudoClassVariant('focus-within'),
   'focus-visible': generatePseudoClassVariant('focus-visible'),


### PR DESCRIPTION
This commit adds the `selected` variant -- unused by default --, which allows the styling of selected/highlighted parts of the document (usually, text).

This variant uses the [`::selection`](https://developer.mozilla.org/en-US/docs/Web/CSS/::selection) pseudo-element; as such, it can only be applied to the following current Tailwind utilities:

- Text color
- Background color
- Cursor
- Text decoration

The main purpose for this variant is to improve accessibility of the selection feature in certain browsers, elements and styles, such as on macOS, where eg. a non-stylized selection over a `bg-blue-400` element (`#63b3ed`) will result in a highlight background of `#9fbed4` on Chrome and an even worse `#65b2f6` on Firefox, both of which have terrible contrast by default.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
