### PR TITLE
use word-wrap instead of overflow-wrap when targeting ie11

### DIFF
--- a/__tests__/fixtures/tailwind-output-ie11.css
+++ b/__tests__/fixtures/tailwind-output-ie11.css
@@ -9012,12 +9012,12 @@ video {
 }
 
 .break-normal {
-  overflow-wrap: normal;
+  word-wrap: normal;
   word-break: normal;
 }
 
 .break-words {
-  overflow-wrap: break-word;
+  word-wrap: break-word;
 }
 
 .break-all {
@@ -19482,12 +19482,12 @@ video {
   }
 
   .sm\:break-normal {
-    overflow-wrap: normal;
+    word-wrap: normal;
     word-break: normal;
   }
 
   .sm\:break-words {
-    overflow-wrap: break-word;
+    word-wrap: break-word;
   }
 
   .sm\:break-all {
@@ -29922,12 +29922,12 @@ video {
   }
 
   .md\:break-normal {
-    overflow-wrap: normal;
+    word-wrap: normal;
     word-break: normal;
   }
 
   .md\:break-words {
-    overflow-wrap: break-word;
+    word-wrap: break-word;
   }
 
   .md\:break-all {
@@ -40362,12 +40362,12 @@ video {
   }
 
   .lg\:break-normal {
-    overflow-wrap: normal;
+    word-wrap: normal;
     word-break: normal;
   }
 
   .lg\:break-words {
-    overflow-wrap: break-word;
+    word-wrap: break-word;
   }
 
   .lg\:break-all {
@@ -50802,12 +50802,12 @@ video {
   }
 
   .xl\:break-normal {
-    overflow-wrap: normal;
+    word-wrap: normal;
     word-break: normal;
   }
 
   .xl\:break-words {
-    overflow-wrap: break-word;
+    word-wrap: break-word;
   }
 
   .xl\:break-all {

--- a/src/plugins/wordBreak.js
+++ b/src/plugins/wordBreak.js
@@ -1,12 +1,14 @@
 export default function() {
-  return function({ addUtilities, variants }) {
+  return function({ addUtilities, variants, target }) {
+    const wrapPropertyName = target('wordBreak') === 'ie11' ? 'word-wrap' : 'overflow-wrap'
+
     addUtilities(
       {
         '.break-normal': {
-          'overflow-wrap': 'normal',
+          [wrapPropertyName]: 'normal',
           'word-break': 'normal',
         },
-        '.break-words': { 'overflow-wrap': 'break-word' },
+        '.break-words': { [wrapPropertyName]: 'break-word' },
         '.break-all': { 'word-break': 'break-all' },
 
         '.truncate': {


### PR DESCRIPTION
IE11 uses old `word-wrap` property instead of `overflow-wrap`. This adjusts the output of the `wordBreak` plugin.