### PR TITLE
Add experimental flags to init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -927,7 +927,7 @@ No release notes
 - Everything!
 
 [unreleased]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.10...HEAD
-[1.8.9]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.9...v1.8.10
+[1.8.10]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.9...v1.8.10
 [1.8.9]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.8...v1.8.9
 [1.8.8]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.7...v1.8.8
 [1.8.7]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.6...v1.8.7

--- a/__tests__/applyComplexClasses.test.js
+++ b/__tests__/applyComplexClasses.test.js
@@ -5,7 +5,7 @@ import tailwind from '../src/index'
 
 function run(input, config = {}) {
   return postcss([
-    tailwind({ experimental: { applyComplexClasses: true }, ...config }),
+    tailwind({ ...config, experimental: { applyComplexClasses: true } }),
   ]).process(input, { from: undefined })
 }
 

--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -4,12 +4,11 @@ import cli from '../src/cli/main'
 import * as constants from '../src/constants'
 import * as utils from '../src/cli/utils'
 import runInTempDirectory from '../jest/runInTempDirectory'
+import featureFlags from '../src/featureFlags'
 
 describe('cli', () => {
   const inputCssPath = path.resolve(__dirname, 'fixtures/tailwind-input.css')
   const customConfigPath = path.resolve(__dirname, 'fixtures/custom-config.js')
-  const defaultConfigFixture = utils.readFile(constants.defaultConfigStubFile)
-  const simpleConfigFixture = utils.readFile(constants.simpleConfigStubFile)
   const defaultPostCssConfigFixture = utils.readFile(constants.defaultPostCssConfigStubFile)
 
   beforeEach(() => {
@@ -21,7 +20,7 @@ describe('cli', () => {
     it('creates a Tailwind config file', () => {
       return runInTempDirectory(() => {
         return cli(['init']).then(() => {
-          expect(utils.readFile(constants.defaultConfigFile)).toEqual(simpleConfigFixture)
+          expect(utils.exists(constants.defaultConfigFile)).toEqual(true)
         })
       })
     })
@@ -29,7 +28,7 @@ describe('cli', () => {
     it('creates a Tailwind config file and a postcss.config.js file', () => {
       return runInTempDirectory(() => {
         return cli(['init', '-p']).then(() => {
-          expect(utils.readFile(constants.defaultConfigFile)).toEqual(simpleConfigFixture)
+          expect(utils.exists(constants.defaultConfigFile)).toEqual(true)
           expect(utils.readFile(constants.defaultPostCssConfigFile)).toEqual(
             defaultPostCssConfigFixture
           )
@@ -40,7 +39,7 @@ describe('cli', () => {
     it('creates a full Tailwind config file', () => {
       return runInTempDirectory(() => {
         return cli(['init', '--full']).then(() => {
-          expect(utils.readFile(constants.defaultConfigFile)).toEqual(defaultConfigFixture)
+          expect(utils.exists(constants.defaultConfigFile)).toEqual(true)
         })
       })
     })
@@ -92,6 +91,16 @@ describe('cli', () => {
     it('compiles CSS file without autoprefixer', () => {
       return cli(['build', inputCssPath, '--no-autoprefixer']).then(() => {
         expect(process.stdout.write.mock.calls[0][0]).not.toContain('-ms-input-placeholder')
+      })
+    })
+
+    it('creates a Tailwind config file with future flags', () => {
+      return runInTempDirectory(() => {
+        return cli(['init']).then(() => {
+          featureFlags.future.forEach(flag => {
+            expect(utils.readFile(constants.defaultConfigFile)).toContain(`${flag}: true`)
+          })
+        })
       })
     })
   })

--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -103,5 +103,15 @@ describe('cli', () => {
         })
       })
     })
+
+    it('creates a Tailwind config file with experimental flags', () => {
+      return runInTempDirectory(() => {
+        return cli(['init']).then(() => {
+          featureFlags.experimental.forEach(flag => {
+            expect(utils.readFile(constants.defaultConfigFile)).toContain(`${flag}: true`)
+          })
+        })
+      })
+    })
   })
 })

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -35,15 +35,26 @@ export function run(cliParams, cliOptions) {
   return new Promise(resolve => {
     utils.header()
 
-    const full = cliOptions.full
     const file = cliParams[0] || constants.defaultConfigFile
     const simplePath = utils.getSimplePath(file)
 
     utils.exists(file) && utils.die(colors.file(simplePath), 'already exists.')
 
-    const stubFile = full ? constants.defaultConfigStubFile : constants.simpleConfigStubFile
+    const stubFile = cliOptions.full
+      ? constants.defaultConfigStubFile
+      : constants.simpleConfigStubFile
 
-    utils.copyFile(stubFile, file)
+    const config = require(stubFile)
+    const { future: flags } = require('../../featureFlags').default
+
+    flags.forEach(flag => {
+      config.future[`// ${flag}`] = true
+    })
+
+    utils.writeFile(
+      file,
+      `module.exports = ${JSON.stringify(config, null, 2).replace(/"([^-_\d"]+)":/g, '$1:')}\n`
+    )
 
     utils.log()
     utils.log(emoji.yes, 'Created Tailwind config file:', colors.file(simplePath))

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -45,10 +45,14 @@ export function run(cliParams, cliOptions) {
       : constants.simpleConfigStubFile
 
     const config = require(stubFile)
-    const { future: flags } = require('../../featureFlags').default
+    const { future, experimental } = require('../../featureFlags').default
 
-    flags.forEach(flag => {
+    future.forEach(flag => {
       config.future[`// ${flag}`] = true
+    })
+
+    experimental.forEach(flag => {
+      config.experimental[`// ${flag}`] = true
     })
 
     utils.writeFile(

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -1,8 +1,5 @@
 module.exports = {
-  future: {
-    // removeDeprecatedGapUtilities: true,
-    // purgeLayersByDefault: true,
-  },
+  future: {},
   purge: [],
   target: 'relaxed',
   prefix: '',

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -1,5 +1,6 @@
 module.exports = {
   future: {},
+  experimental: {},
   purge: [],
   target: 'relaxed',
   prefix: '',

--- a/stubs/simpleConfig.stub.js
+++ b/stubs/simpleConfig.stub.js
@@ -1,8 +1,5 @@
 module.exports = {
-  future: {
-    // removeDeprecatedGapUtilities: true,
-    // purgeLayersByDefault: true,
-  },
+  future: {},
   purge: [],
   theme: {
     extend: {},

--- a/stubs/simpleConfig.stub.js
+++ b/stubs/simpleConfig.stub.js
@@ -1,5 +1,6 @@
 module.exports = {
   future: {},
+  experimental: {},
   purge: [],
   theme: {
     extend: {},


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->

Similar to #2379 I've implemented the `featureFlags.experimental` to be automatically, but commented out, added when `init` is ran.
