### PR TITLE
Improve Preflight styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -927,7 +927,7 @@ No release notes
 - Everything!
 
 [unreleased]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.10...HEAD
-[1.8.9]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.9...v1.8.10
+[1.8.10]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.9...v1.8.10
 [1.8.9]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.8...v1.8.9
 [1.8.8]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.7...v1.8.8
 [1.8.7]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.6...v1.8.7

--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -4,12 +4,11 @@ import cli from '../src/cli/main'
 import * as constants from '../src/constants'
 import * as utils from '../src/cli/utils'
 import runInTempDirectory from '../jest/runInTempDirectory'
+import featureFlags from '../src/featureFlags'
 
 describe('cli', () => {
   const inputCssPath = path.resolve(__dirname, 'fixtures/tailwind-input.css')
   const customConfigPath = path.resolve(__dirname, 'fixtures/custom-config.js')
-  const defaultConfigFixture = utils.readFile(constants.defaultConfigStubFile)
-  const simpleConfigFixture = utils.readFile(constants.simpleConfigStubFile)
   const defaultPostCssConfigFixture = utils.readFile(constants.defaultPostCssConfigStubFile)
 
   beforeEach(() => {
@@ -21,7 +20,7 @@ describe('cli', () => {
     it('creates a Tailwind config file', () => {
       return runInTempDirectory(() => {
         return cli(['init']).then(() => {
-          expect(utils.readFile(constants.defaultConfigFile)).toEqual(simpleConfigFixture)
+          expect(utils.exists(constants.defaultConfigFile)).toEqual(true)
         })
       })
     })
@@ -29,7 +28,7 @@ describe('cli', () => {
     it('creates a Tailwind config file and a postcss.config.js file', () => {
       return runInTempDirectory(() => {
         return cli(['init', '-p']).then(() => {
-          expect(utils.readFile(constants.defaultConfigFile)).toEqual(simpleConfigFixture)
+          expect(utils.exists(constants.defaultConfigFile)).toEqual(true)
           expect(utils.readFile(constants.defaultPostCssConfigFile)).toEqual(
             defaultPostCssConfigFixture
           )
@@ -40,7 +39,7 @@ describe('cli', () => {
     it('creates a full Tailwind config file', () => {
       return runInTempDirectory(() => {
         return cli(['init', '--full']).then(() => {
-          expect(utils.readFile(constants.defaultConfigFile)).toEqual(defaultConfigFixture)
+          expect(utils.exists(constants.defaultConfigFile)).toEqual(true)
         })
       })
     })
@@ -92,6 +91,16 @@ describe('cli', () => {
     it('compiles CSS file without autoprefixer', () => {
       return cli(['build', inputCssPath, '--no-autoprefixer']).then(() => {
         expect(process.stdout.write.mock.calls[0][0]).not.toContain('-ms-input-placeholder')
+      })
+    })
+
+    it('creates a Tailwind config file with future flags', () => {
+      return runInTempDirectory(() => {
+        return cli(['init']).then(() => {
+          featureFlags.future.forEach(flag => {
+            expect(utils.readFile(constants.defaultConfigFile)).toContain(`${flag}: true`)
+          })
+        })
       })
     })
   })

--- a/__tests__/fixtures/tailwind-output-ie11.css
+++ b/__tests__/fixtures/tailwind-output-ie11.css
@@ -350,6 +350,7 @@ template {
 
 /**
  * Manually forked from SUIT CSS Base: https://github.com/suitcss/base
+ * Modern reset obtained from: https://github.com/kripod/css-homogenizer
  * A thin layer on top of normalize.css that provides a starting point more
  * suitable for web applications.
  */
@@ -358,20 +359,40 @@ template {
  * Removes the default spacing and border for appropriate elements.
  */
 
-blockquote,
-dl,
-dd,
+p,
 h1,
 h2,
 h3,
 h4,
 h5,
 h6,
-hr,
+blockquote,
+dl,
+dd,
 figure,
-p,
-pre {
+pre,
+hr,
+fieldset,
+ol,
+ul,
+menu {
   margin: 0;
+}
+
+th,
+td,
+legend,
+fieldset,
+ol,
+ul,
+menu {
+  padding: 0;
+}
+
+hr,
+fieldset,
+iframe {
+  border: 0;
 }
 
 button {
@@ -389,16 +410,10 @@ button:focus {
   outline: 5px auto -webkit-focus-ring-color;
 }
 
-fieldset {
-  margin: 0;
-  padding: 0;
-}
-
 ol,
-ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+ul,
+menu {
+  list-style: none; /* list-style-type */
 }
 
 /**
@@ -410,11 +425,13 @@ ul {
  *    sans-serif font stack as a fallback) as a sane default.
  * 2. Use Tailwind's default "normal" line-height so the user isn't forced
  *    to override it to ensure consistency even when using the default theme.
+ * 3. Prevent overflow caused by long words when absolutely necessary.
  */
 
 html {
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; /* 1 */
   line-height: 1.5; /* 2 */
+  overflow-wrap: break-word; /* 3 */
 }
 
 /**
@@ -489,7 +506,12 @@ button,
 }
 
 table {
+  border-spacing: 0;
   border-collapse: collapse;
+}
+
+th {
+  text-align: inherit;
 }
 
 h1,
@@ -497,9 +519,10 @@ h2,
 h3,
 h4,
 h5,
-h6 {
-  font-size: inherit;
-  font-weight: inherit;
+h6,
+th,
+address {
+  font: inherit; /* font-size, font-weight, font-style */
 }
 
 /**
@@ -525,7 +548,6 @@ input,
 optgroup,
 select,
 textarea {
-  padding: 0;
   line-height: inherit;
   color: inherit;
 }

--- a/__tests__/fixtures/tailwind-output-ie11.css
+++ b/__tests__/fixtures/tailwind-output-ie11.css
@@ -548,6 +548,7 @@ input,
 optgroup,
 select,
 textarea {
+  padding: 0;
   line-height: inherit;
   color: inherit;
 }

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -350,6 +350,7 @@ template {
 
 /**
  * Manually forked from SUIT CSS Base: https://github.com/suitcss/base
+ * Modern reset obtained from: https://github.com/kripod/css-homogenizer
  * A thin layer on top of normalize.css that provides a starting point more
  * suitable for web applications.
  */
@@ -358,20 +359,40 @@ template {
  * Removes the default spacing and border for appropriate elements.
  */
 
-blockquote,
-dl,
-dd,
+p,
 h1,
 h2,
 h3,
 h4,
 h5,
 h6,
-hr,
+blockquote,
+dl,
+dd,
 figure,
-p,
-pre {
+pre,
+hr,
+fieldset,
+ol,
+ul,
+menu {
   margin: 0;
+}
+
+th,
+td,
+legend,
+fieldset,
+ol,
+ul,
+menu {
+  padding: 0;
+}
+
+hr,
+fieldset,
+iframe {
+  border: 0;
 }
 
 button {
@@ -389,16 +410,10 @@ button:focus {
   outline: 5px auto -webkit-focus-ring-color;
 }
 
-fieldset {
-  margin: 0;
-  padding: 0;
-}
-
 ol,
-ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+ul,
+menu {
+  list-style: none; /* list-style-type */
 }
 
 /**
@@ -410,11 +425,13 @@ ul {
  *    sans-serif font stack as a fallback) as a sane default.
  * 2. Use Tailwind's default "normal" line-height so the user isn't forced
  *    to override it to ensure consistency even when using the default theme.
+ * 3. Prevent overflow caused by long words when absolutely necessary.
  */
 
 html {
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; /* 1 */
   line-height: 1.5; /* 2 */
+  overflow-wrap: break-word; /* 3 */
 }
 
 /**
@@ -489,7 +506,12 @@ button,
 }
 
 table {
+  border-spacing: 0;
   border-collapse: collapse;
+}
+
+th {
+  text-align: inherit;
 }
 
 h1,
@@ -497,9 +519,10 @@ h2,
 h3,
 h4,
 h5,
-h6 {
-  font-size: inherit;
-  font-weight: inherit;
+h6,
+th,
+address {
+  font: inherit; /* font-size, font-weight, font-style */
 }
 
 /**
@@ -525,7 +548,6 @@ input,
 optgroup,
 select,
 textarea {
-  padding: 0;
   line-height: inherit;
   color: inherit;
 }

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -548,6 +548,7 @@ input,
 optgroup,
 select,
 textarea {
+  padding: 0;
   line-height: inherit;
   color: inherit;
 }

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -350,6 +350,7 @@ template {
 
 /**
  * Manually forked from SUIT CSS Base: https://github.com/suitcss/base
+ * Modern reset obtained from: https://github.com/kripod/css-homogenizer
  * A thin layer on top of normalize.css that provides a starting point more
  * suitable for web applications.
  */
@@ -358,20 +359,40 @@ template {
  * Removes the default spacing and border for appropriate elements.
  */
 
-blockquote,
-dl,
-dd,
+p,
 h1,
 h2,
 h3,
 h4,
 h5,
 h6,
-hr,
+blockquote,
+dl,
+dd,
 figure,
-p,
-pre {
+pre,
+hr,
+fieldset,
+ol,
+ul,
+menu {
   margin: 0;
+}
+
+th,
+td,
+legend,
+fieldset,
+ol,
+ul,
+menu {
+  padding: 0;
+}
+
+hr,
+fieldset,
+iframe {
+  border: 0;
 }
 
 button {
@@ -389,16 +410,10 @@ button:focus {
   outline: 5px auto -webkit-focus-ring-color;
 }
 
-fieldset {
-  margin: 0;
-  padding: 0;
-}
-
 ol,
-ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+ul,
+menu {
+  list-style: none; /* list-style-type */
 }
 
 /**
@@ -410,11 +425,13 @@ ul {
  *    sans-serif font stack as a fallback) as a sane default.
  * 2. Use Tailwind's default "normal" line-height so the user isn't forced
  *    to override it to ensure consistency even when using the default theme.
+ * 3. Prevent overflow caused by long words when absolutely necessary.
  */
 
 html {
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; /* 1 */
   line-height: 1.5; /* 2 */
+  overflow-wrap: break-word; /* 3 */
 }
 
 /**
@@ -489,7 +506,12 @@ button,
 }
 
 table {
+  border-spacing: 0;
   border-collapse: collapse;
+}
+
+th {
+  text-align: inherit;
 }
 
 h1,
@@ -497,9 +519,10 @@ h2,
 h3,
 h4,
 h5,
-h6 {
-  font-size: inherit;
-  font-weight: inherit;
+h6,
+th,
+address {
+  font: inherit; /* font-size, font-weight, font-style */
 }
 
 /**
@@ -525,7 +548,6 @@ input,
 optgroup,
 select,
 textarea {
-  padding: 0;
   line-height: inherit;
   color: inherit;
 }

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -548,6 +548,7 @@ input,
 optgroup,
 select,
 textarea {
+  padding: 0;
   line-height: inherit;
   color: inherit;
 }

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -350,6 +350,7 @@ template {
 
 /**
  * Manually forked from SUIT CSS Base: https://github.com/suitcss/base
+ * Modern reset obtained from: https://github.com/kripod/css-homogenizer
  * A thin layer on top of normalize.css that provides a starting point more
  * suitable for web applications.
  */
@@ -358,20 +359,40 @@ template {
  * Removes the default spacing and border for appropriate elements.
  */
 
-blockquote,
-dl,
-dd,
+p,
 h1,
 h2,
 h3,
 h4,
 h5,
 h6,
-hr,
+blockquote,
+dl,
+dd,
 figure,
-p,
-pre {
+pre,
+hr,
+fieldset,
+ol,
+ul,
+menu {
   margin: 0;
+}
+
+th,
+td,
+legend,
+fieldset,
+ol,
+ul,
+menu {
+  padding: 0;
+}
+
+hr,
+fieldset,
+iframe {
+  border: 0;
 }
 
 button {
@@ -389,16 +410,10 @@ button:focus {
   outline: 5px auto -webkit-focus-ring-color;
 }
 
-fieldset {
-  margin: 0;
-  padding: 0;
-}
-
 ol,
-ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+ul,
+menu {
+  list-style: none; /* list-style-type */
 }
 
 /**
@@ -410,11 +425,13 @@ ul {
  *    sans-serif font stack as a fallback) as a sane default.
  * 2. Use Tailwind's default "normal" line-height so the user isn't forced
  *    to override it to ensure consistency even when using the default theme.
+ * 3. Prevent overflow caused by long words when absolutely necessary.
  */
 
 html {
   font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; /* 1 */
   line-height: 1.5; /* 2 */
+  overflow-wrap: break-word; /* 3 */
 }
 
 /**
@@ -489,7 +506,12 @@ button,
 }
 
 table {
+  border-spacing: 0;
   border-collapse: collapse;
+}
+
+th {
+  text-align: inherit;
 }
 
 h1,
@@ -497,9 +519,10 @@ h2,
 h3,
 h4,
 h5,
-h6 {
-  font-size: inherit;
-  font-weight: inherit;
+h6,
+th,
+address {
+  font: inherit; /* font-size, font-weight, font-style */
 }
 
 /**
@@ -525,7 +548,6 @@ input,
 optgroup,
 select,
 textarea {
-  padding: 0;
   line-height: inherit;
   color: inherit;
 }

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -548,6 +548,7 @@ input,
 optgroup,
 select,
 textarea {
+  padding: 0;
   line-height: inherit;
   color: inherit;
 }

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -35,15 +35,26 @@ export function run(cliParams, cliOptions) {
   return new Promise(resolve => {
     utils.header()
 
-    const full = cliOptions.full
     const file = cliParams[0] || constants.defaultConfigFile
     const simplePath = utils.getSimplePath(file)
 
     utils.exists(file) && utils.die(colors.file(simplePath), 'already exists.')
 
-    const stubFile = full ? constants.defaultConfigStubFile : constants.simpleConfigStubFile
+    const stubFile = cliOptions.full
+      ? constants.defaultConfigStubFile
+      : constants.simpleConfigStubFile
 
-    utils.copyFile(stubFile, file)
+    const config = require(stubFile)
+    const { future: flags } = require('../../featureFlags').default
+
+    flags.forEach(flag => {
+      config.future[`// ${flag}`] = true
+    })
+
+    utils.writeFile(
+      file,
+      `module.exports = ${JSON.stringify(config, null, 2).replace(/"([^-_\d"]+)":/g, '$1:')}\n`
+    )
 
     utils.log()
     utils.log(emoji.yes, 'Created Tailwind config file:', colors.file(simplePath))

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -248,12 +248,3 @@ video {
   max-width: 100%;
   height: auto;
 }
-
-/**
- * Cater for the 'hidden' attribute:
- * https://css-tricks.com/the-hidden-attribute-is-visibly-weak/
- */
-
-[hidden] {
-	display: none !important;
-}

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -198,6 +198,7 @@ input,
 optgroup,
 select,
 textarea {
+  padding: 0;
   line-height: inherit;
   color: inherit;
 }

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -1,5 +1,6 @@
 /**
  * Manually forked from SUIT CSS Base: https://github.com/suitcss/base
+ * Modern reset obtained from: https://github.com/kripod/css-homogenizer
  * A thin layer on top of normalize.css that provides a starting point more
  * suitable for web applications.
  */
@@ -8,20 +9,40 @@
  * Removes the default spacing and border for appropriate elements.
  */
 
-blockquote,
-dl,
-dd,
+p,
 h1,
 h2,
 h3,
 h4,
 h5,
 h6,
-hr,
+blockquote,
+dl,
+dd,
 figure,
-p,
-pre {
-  margin: 0;
+pre,
+hr,
+fieldset,
+ol,
+ul,
+menu {
+	margin: 0;
+}
+
+th,
+td,
+legend,
+fieldset,
+ol,
+ul,
+menu {
+	padding: 0;
+}
+
+hr,
+fieldset,
+iframe {
+	border: 0;
 }
 
 button {
@@ -39,16 +60,10 @@ button:focus {
   outline: 5px auto -webkit-focus-ring-color;
 }
 
-fieldset {
-  margin: 0;
-  padding: 0;
-}
-
 ol,
-ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+ul,
+menu {
+	list-style: none; /* list-style-type */
 }
 
 /**
@@ -60,11 +75,13 @@ ul {
  *    sans-serif font stack as a fallback) as a sane default.
  * 2. Use Tailwind's default "normal" line-height so the user isn't forced
  *    to override it to ensure consistency even when using the default theme.
+ * 3. Prevent overflow caused by long words when absolutely necessary.
  */
 
 html {
   font-family: theme('fontFamily.sans', system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"); /* 1 */
   line-height: 1.5; /* 2 */
+  overflow-wrap: break-word; /* 3 */
 }
 
 /**
@@ -139,7 +156,12 @@ button,
 }
 
 table {
+  border-spacing: 0;
   border-collapse: collapse;
+}
+
+th {
+	text-align: inherit;
 }
 
 h1,
@@ -147,9 +169,10 @@ h2,
 h3,
 h4,
 h5,
-h6 {
-  font-size: inherit;
-  font-weight: inherit;
+h6,
+th,
+address {
+	font: inherit; /* font-size, font-weight, font-style */
 }
 
 /**
@@ -175,7 +198,6 @@ input,
 optgroup,
 select,
 textarea {
-  padding: 0;
   line-height: inherit;
   color: inherit;
 }
@@ -225,4 +247,13 @@ img,
 video {
   max-width: 100%;
   height: auto;
+}
+
+/**
+ * Cater for the 'hidden' attribute:
+ * https://css-tricks.com/the-hidden-attribute-is-visibly-weak/
+ */
+
+[hidden] {
+	display: none !important;
 }

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -1,8 +1,5 @@
 module.exports = {
-  future: {
-    // removeDeprecatedGapUtilities: true,
-    // purgeLayersByDefault: true,
-  },
+  future: {},
   purge: [],
   target: 'relaxed',
   prefix: '',

--- a/stubs/simpleConfig.stub.js
+++ b/stubs/simpleConfig.stub.js
@@ -1,8 +1,5 @@
 module.exports = {
-  future: {
-    // removeDeprecatedGapUtilities: true,
-    // purgeLayersByDefault: true,
-  },
+  future: {},
   purge: [],
   theme: {
     extend: {},


### PR DESCRIPTION
Most of the following changes were inspired by [css-homogenizer](https://github.com/kripod/css-homogenizer):

- Reset styles are now more extensive:
  - `menu` margins are nullified.
  - Paddings of `legend`, `th`, `td` and `menu` elements have been reset.
  - The border styling of `hr`, `fieldset` and `iframe` elements has been reset.
  - `border-spacing: 0`, instead of the `2px` default.
  - `th` and `address` elements are de-styled to only maintain their semantic meaning.
- A new opinionated rule has been added:
  - Prevent overflow caused by long words when absolutely necessary.