### PR TITLE
Remove slash at the beginning of href prop

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -48,7 +48,7 @@ This will create new CSS files in the `/dist` folder which you can reference in 
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    <link rel="stylesheet" href="/dist/tailwind.css" />
+    <link rel="stylesheet" href="dist/tailwind.css" />
     <title>Hello, world!</title>
   </head>
   <body>


### PR DESCRIPTION
With the slash, it was trying to reference the file outside of the root folder.
Without it, it reference the dist folder inside the root folder.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
