### PR TITLE
Add experimental 2xl breakpoint

### DIFF
--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -12,6 +12,7 @@ const featureFlags = {
     'applyComplexClasses',
     'darkModeVariant',
     'standardFontWeights',
+    'additionalBreakpoint',
   ],
 }
 

--- a/src/flagged/additionalBreakpoint.js
+++ b/src/flagged/additionalBreakpoint.js
@@ -1,0 +1,11 @@
+export default {
+  theme: {
+    screens: {
+      sm: '640px',
+      md: '768px',
+      lg: '1024px',
+      xl: '1280px',
+      '2xl': '1536px',
+    },
+  },
+}

--- a/src/util/getAllConfigs.js
+++ b/src/util/getAllConfigs.js
@@ -6,33 +6,25 @@ import defaultLineHeights from '../flagged/defaultLineHeights.js'
 import extendedFontSizeScale from '../flagged/extendedFontSizeScale.js'
 import darkModeVariant from '../flagged/darkModeVariant.js'
 import standardFontWeights from '../flagged/standardFontWeights'
+import additionalBreakpoint from '../flagged/additionalBreakpoint'
 
 export default function getAllConfigs(config) {
   const configs = [defaultConfig]
-
-  if (flagEnabled(config, 'uniformColorPalette')) {
-    configs.unshift(uniformColorPalette)
+  const features = {
+    uniformColorPalette,
+    extendedSpacingScale,
+    defaultLineHeights,
+    extendedFontSizeScale,
+    standardFontWeights,
+    darkModeVariant,
+    additionalBreakpoint,
   }
 
-  if (flagEnabled(config, 'extendedSpacingScale')) {
-    configs.unshift(extendedSpacingScale)
-  }
-
-  if (flagEnabled(config, 'defaultLineHeights')) {
-    configs.unshift(defaultLineHeights)
-  }
-
-  if (flagEnabled(config, 'extendedFontSizeScale')) {
-    configs.unshift(extendedFontSizeScale)
-  }
-
-  if (flagEnabled(config, 'standardFontWeights')) {
-    configs.unshift(standardFontWeights)
-  }
-
-  if (flagEnabled(config, 'darkModeVariant')) {
-    configs.unshift(darkModeVariant)
-  }
+  Object.keys(features).forEach(feature => {
+    if (flagEnabled(config, feature)) {
+      configs.unshift(features[feature])
+    }
+  })
 
   return [config, ...configs]
 }


### PR DESCRIPTION
This PR adds a new `2xl` breakpoint behind an experimental `additionalBreakpoint` flag.

Adding bigger breakpoints is a really common Tailwind customization, and as devices continue to get bigger with higher resolution, I think we're going to eventually wish we had something a little bigger than 1280. Bootstrap is even adding a 1400px breakpoint in Bootstrap 5, so we're not alone in thinking an additional large breakpoint would be helpful.

I considered a few different sizes for different reasons:

- **1440px**, because that's the default resolution of a 13" MacBook Pro and just generally a common screen size. I opted against this because it's only 160px wider than our 1280 breakpoint, and the jump from 1024 to 1280 is 256 so for the next jump to be smaller just didn't really make sense.
- **1680px**, another common resolution (default on the 15" MacBook Pro, before the 16" model was released). This just felt like too far of a jump from 1280, and selfishly I run my 16" MBP at 1536px (which is the real retina mode), and it felt silly to me to add a breakpoint that I wouldn't benefit from on that display 👀 

I settled on 1536px after looking at some Google Analytics results with @reinink for multiple sites we both run and noticing that it was a surprisingly popular resolution (more popular than 1440px in a lot of cases). It appears to be very common for Windows machines, and since it's also the exact resolution I run on my 16" MBP, and a nice even 256px jump over our 1280 breakpoint, it felt like a great choice. Wide enough to let you make significant changes vs a 1280 breakpoint, but not so wide that you can't trigger it on large laptop displays.

Going to keep this experimental for now in case any issues come up with the name `2xl`, because it needs to be escaped in a weird way and I worry there may be some tooling out there that doesn't play nice with it, so lets test it for a bit to double check we're safe.

This increases the default file size significantly, but whatever, you should be removing unused styles anyways. I'm going to work on a PR for a "lite" mode with a significantly reduced bundle size soon for people who have to use Tailwind from a CDN and don't want to serve a large file.