### PR TITLE
Fixes linting issues due to prettier errors

### DIFF
--- a/__tests__/applyAtRule.test.js
+++ b/__tests__/applyAtRule.test.js
@@ -8,7 +8,7 @@ function run(input, config = {}) {
 test('it copies the declarations from a class into itself', () => {
   const output = '.a { color: red; } .b { color: red; }'
 
-  return run('.a { color: red; } .b { @apply .a; }').then(result => {
+  return run('.a { color: red; } .b { @apply .a; }').then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -25,7 +25,7 @@ test('selectors with invalid characters do not need to be manually escaped', () 
     .b { color: red; }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -42,7 +42,7 @@ test('it removes important from applied classes by default', () => {
     .b { color: red; }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -59,7 +59,7 @@ test('applied rules can be made !important', () => {
     .b { color: red !important; }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -85,14 +85,14 @@ test('cssnext custom property sets are preserved', () => {
     }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
 })
 
 test('it fails if the class does not exist', () => {
-  return run('.b { @apply .a; }').catch(e => {
+  return run('.b { @apply .a; }').catch((e) => {
     expect(e).toMatchObject({ name: 'CssSyntaxError' })
   })
 })
@@ -108,7 +108,7 @@ test('applying classes that are defined in a media query is not supported', () =
     }
   `
   expect.assertions(1)
-  return run(input).catch(e => {
+  return run(input).catch((e) => {
     expect(e).toMatchObject({ name: 'CssSyntaxError' })
   })
 })
@@ -128,7 +128,7 @@ test('applying classes that are ever used in a media query is not supported', ()
     }
   `
   expect.assertions(1)
-  return run(input).catch(e => {
+  return run(input).catch((e) => {
     expect(e).toMatchObject({ name: 'CssSyntaxError' })
   })
 })
@@ -144,7 +144,7 @@ test('it does not match classes that include pseudo-selectors', () => {
     }
   `
   expect.assertions(1)
-  return run(input).catch(e => {
+  return run(input).catch((e) => {
     expect(e).toMatchObject({ name: 'CssSyntaxError' })
   })
 })
@@ -164,7 +164,7 @@ test('it does not match classes that have multiple rules', () => {
     }
   `
   expect.assertions(1)
-  return run(input).catch(e => {
+  return run(input).catch((e) => {
     expect(e).toMatchObject({ name: 'CssSyntaxError' })
   })
 })
@@ -178,7 +178,7 @@ test('you can apply utility classes that do not actually exist as long as they w
     .foo { margin-top: 1rem; }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -193,7 +193,7 @@ test('you can apply utility classes without using the given prefix', () => {
     .foo { margin-top: 1rem; margin-bottom: 1rem; }
   `
 
-  return run(input, { prefix: 'tw-' }).then(result => {
+  return run(input, { prefix: 'tw-' }).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -212,7 +212,7 @@ test('you can apply utility classes without using the given prefix when using a 
     prefix: () => {
       return 'tw-'
     },
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -227,7 +227,7 @@ test('you can apply utility classes without specificity prefix even if important
     .foo { margin-top: 2rem; margin-bottom: 2rem; }
   `
 
-  return run(input, { important: '#app' }).then(result => {
+  return run(input, { important: '#app' }).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -245,7 +245,7 @@ test('you can apply utility classes without using the given prefix even if impor
   return run(input, {
     prefix: 'tw-',
     important: '#app',
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })

--- a/__tests__/applyComplexClasses.test.js
+++ b/__tests__/applyComplexClasses.test.js
@@ -14,7 +14,7 @@ test('it copies class declarations into itself', () => {
 
   expect.assertions(2)
 
-  return run('.a { color: red; } .b { @apply a; }').then(result => {
+  return run('.a { color: red; } .b { @apply a; }').then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -36,7 +36,7 @@ test('apply values can contain tabs', () => {
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -61,7 +61,7 @@ test('apply values can contain newlines', () => {
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -80,7 +80,7 @@ test('selectors with invalid characters do not need to be manually escaped', () 
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -102,7 +102,7 @@ test('it removes important from applied classes by default', () => {
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -121,7 +121,7 @@ test('applied rules can be made !important', () => {
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -139,7 +139,7 @@ test('cssnext custom property sets are no longer supported', () => {
 
   expect.assertions(1)
 
-  return run(input).catch(e => {
+  return run(input).catch((e) => {
     expect(e).toMatchObject({ name: 'CssSyntaxError' })
   })
 })
@@ -147,7 +147,7 @@ test('cssnext custom property sets are no longer supported', () => {
 test('it fails if the class does not exist', () => {
   expect.assertions(1)
 
-  return run('.b { @apply a; }').catch(e => {
+  return run('.b { @apply a; }').catch((e) => {
     expect(e).toMatchObject({ name: 'CssSyntaxError' })
   })
 })
@@ -174,7 +174,7 @@ test('applying classes that are defined in a media query is supported', () => {
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -215,7 +215,7 @@ test('applying classes that are used in a media query is supported', () => {
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -244,7 +244,7 @@ test('it matches classes that include pseudo-selectors', () => {
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -282,7 +282,7 @@ test('it matches classes that have multiple rules', () => {
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -316,7 +316,7 @@ test('applying a class that appears multiple times in one selector', () => {
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -333,7 +333,7 @@ test('you can apply utility classes that do not actually exist as long as they w
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -347,7 +347,7 @@ test('the shadow lookup is only used if no @tailwind rules were in the source tr
 
   expect.assertions(1)
 
-  return run(input).catch(e => {
+  return run(input).catch((e) => {
     expect(e).toMatchObject({ name: 'CssSyntaxError' })
   })
 })
@@ -379,7 +379,7 @@ test('you can apply a class that is defined in multiple rules', () => {
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -401,7 +401,7 @@ test('you can apply a class that is defined in a media query', () => {
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -421,7 +421,7 @@ test('you can apply pseudo-class variant utilities', () => {
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -443,7 +443,7 @@ test('you can apply responsive pseudo-class variant utilities', () => {
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -483,7 +483,7 @@ test('you can apply the container component', () => {
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -516,7 +516,7 @@ test('classes are applied according to CSS source order, not apply order', () =>
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -548,7 +548,7 @@ test('you can apply utilities with multi-class selectors like group-hover varian
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -580,7 +580,7 @@ test('you can apply classes recursively', () => {
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -617,7 +617,7 @@ test('applied classes are always inserted before subsequent declarations in the 
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -650,7 +650,7 @@ test('adjacent rules are collapsed after being applied', () => {
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -700,7 +700,7 @@ test('applying a class applies all instances of that class, even complex selecto
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -735,7 +735,7 @@ test('you can apply classes to rules within at-rules', () => {
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -760,7 +760,7 @@ describe('using apply with the prefix option', () => {
 
     expect.assertions(2)
 
-    return run(input, config).then(result => {
+    return run(input, config).then((result) => {
       expect(result.css).toMatchCss(expected)
       expect(result.warnings().length).toBe(0)
     })
@@ -786,7 +786,7 @@ describe('using apply with the prefix option', () => {
 
     expect.assertions(2)
 
-    return run(input, config).then(result => {
+    return run(input, config).then((result) => {
       expect(result.css).toMatchCss(expected)
       expect(result.warnings().length).toBe(0)
     })
@@ -806,7 +806,7 @@ describe('using apply with the prefix option', () => {
 
     expect.assertions(1)
 
-    return run(input, config).catch(e => {
+    return run(input, config).catch((e) => {
       expect(e).toMatchObject({ name: 'CssSyntaxError' })
     })
   })
@@ -831,7 +831,7 @@ describe('using apply with the prefix option', () => {
 
     expect.assertions(2)
 
-    return run(input, config).then(result => {
+    return run(input, config).then((result) => {
       expect(result.css).toMatchCss(expected)
       expect(result.warnings().length).toBe(0)
     })
@@ -857,7 +857,7 @@ describe('using apply with the prefix option', () => {
 
     expect.assertions(2)
 
-    return run(input, config).then(result => {
+    return run(input, config).then((result) => {
       expect(result.css).toMatchCss(expected)
       expect(result.warnings().length).toBe(0)
     })
@@ -877,7 +877,7 @@ describe('using apply with the prefix option', () => {
 
     expect.assertions(1)
 
-    return run(input, config).catch(e => {
+    return run(input, config).catch((e) => {
       expect(e).toMatchObject({
         name: 'CssSyntaxError',
         reason: 'The `mt-4` class does not exist, but `tw-mt-4` does. Did you forget the prefix?',
@@ -904,7 +904,7 @@ describe('using apply with the prefix option', () => {
 
     expect.assertions(2)
 
-    return run(input, config).then(result => {
+    return run(input, config).then((result) => {
       expect(result.css).toMatchCss(expected)
       expect(result.warnings().length).toBe(0)
     })
@@ -929,7 +929,7 @@ describe('using apply with the prefix option', () => {
 
     expect.assertions(2)
 
-    return run(input, config).then(result => {
+    return run(input, config).then((result) => {
       expect(result.css).toMatchCss(expected)
       expect(result.warnings().length).toBe(0)
     })
@@ -959,7 +959,7 @@ test('you can apply utility classes when a selector is used for the important op
 
   expect.assertions(2)
 
-  return run(input, config).then(result => {
+  return run(input, config).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -991,7 +991,7 @@ test('you can apply classes to a rule with multiple selectors', () => {
     }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -1016,7 +1016,7 @@ test('you can apply classes in a nested rule', () => {
     }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -1039,7 +1039,7 @@ test('you can apply classes in a nested @atrule', () => {
     }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -1062,7 +1062,7 @@ test('you can apply classes in a custom nested @atrule', () => {
     }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -1089,7 +1089,7 @@ test('you can deeply apply classes in a custom nested @atrule', () => {
     }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -1114,7 +1114,7 @@ test('declarations within a rule that uses @apply can be !important', () => {
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -1139,7 +1139,7 @@ test('declarations within a rule that uses @apply with !important remain not !im
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })

--- a/__tests__/cli.compile.test.js
+++ b/__tests__/cli.compile.test.js
@@ -11,7 +11,7 @@ describe('cli compile', () => {
   const plugins = [tailwind(), autoprefixer]
 
   it('compiles CSS file', () => {
-    return compile({ inputFile, outputFile, plugins }).then(result => {
+    return compile({ inputFile, outputFile, plugins }).then((result) => {
       expect(result.css).toContain('.example')
       expect(result.css).toContain('-ms-input-placeholder')
     })

--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -97,7 +97,7 @@ describe('cli', () => {
     it('creates a Tailwind config file with future flags', () => {
       return runInTempDirectory(() => {
         return cli(['init']).then(() => {
-          featureFlags.future.forEach(flag => {
+          featureFlags.future.forEach((flag) => {
             expect(utils.readFile(constants.defaultConfigFile)).toContain(`${flag}: true`)
           })
         })

--- a/__tests__/customConfig.test.js
+++ b/__tests__/customConfig.test.js
@@ -17,7 +17,7 @@ test('it uses the values from the custom config file', () => {
       `,
       { from: undefined }
     )
-    .then(result => {
+    .then((result) => {
       const expected = `
         .foo {
           color: blue;
@@ -52,7 +52,7 @@ test('custom config can be passed as an object', () => {
       `,
       { from: undefined }
     )
-    .then(result => {
+    .then((result) => {
       const expected = `
         .foo {
           color: blue;
@@ -80,7 +80,7 @@ test('custom config path can be passed using `config` property in an object', ()
       `,
       { from: undefined }
     )
-    .then(result => {
+    .then((result) => {
       const expected = `
         .foo {
           color: blue;
@@ -117,7 +117,7 @@ test('custom config can be passed under the `config` property', () => {
       `,
       { from: undefined }
     )
-    .then(result => {
+    .then((result) => {
       const expected = `
         .foo {
           color: blue;
@@ -157,7 +157,7 @@ test('tailwind.config.js is picked up by default', () => {
         `,
         { from: undefined }
       )
-      .then(result => {
+      .then((result) => {
         expect(result.css).toMatchCss(`
           .foo {
             color: blue;
@@ -196,7 +196,7 @@ test('tailwind.config.js is picked up by default when passing an empty object', 
         `,
         { from: undefined }
       )
-      .then(result => {
+      .then((result) => {
         expect(result.css).toMatchCss(`
           .foo {
             color: blue;

--- a/__tests__/darkMode.test.js
+++ b/__tests__/darkMode.test.js
@@ -55,7 +55,7 @@ test('user-defined dark mode variants do not stack when the dark mode experiment
 
   return postcss([tailwind({ experimental: { darkModeVariant: false }, plugins: [userPlugin] })])
     .process(input, { from: undefined })
-    .then(result => {
+    .then((result) => {
       expect(result.css).toMatchCss(expected)
       expect(result.warnings().length).toBe(0)
     })
@@ -83,7 +83,7 @@ test('generating dark mode variants uses the media strategy by default', () => {
 
   expect.assertions(2)
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -111,7 +111,7 @@ test('dark mode variants can be generated even when the user has their own plugi
 
   expect.assertions(2)
 
-  return run(input, { plugins: [] }).then(result => {
+  return run(input, { plugins: [] }).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -137,7 +137,7 @@ test('dark mode variants can be generated using the class strategy', () => {
 
   expect.assertions(2)
 
-  return run(input, { dark: 'class' }).then(result => {
+  return run(input, { dark: 'class' }).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -221,7 +221,7 @@ test('dark mode variants stack with other variants', () => {
 
   expect.assertions(2)
 
-  return run(input, { theme: { screens: { sm: '500px', lg: '800px' } } }).then(result => {
+  return run(input, { theme: { screens: { sm: '500px', lg: '800px' } } }).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
@@ -318,7 +318,7 @@ test('dark mode variants stack with other variants when using the class strategy
   expect.assertions(2)
 
   return run(input, { dark: 'class', theme: { screens: { sm: '500px', lg: '800px' } } }).then(
-    result => {
+    (result) => {
       expect(result.css).toMatchCss(expected)
       expect(result.warnings().length).toBe(0)
     }

--- a/__tests__/layerAtRule.test.js
+++ b/__tests__/layerAtRule.test.js
@@ -86,7 +86,7 @@ test('layers are grouped and inserted at the matching @tailwind rule', () => {
         })
       },
     ],
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })

--- a/__tests__/plugins/gradientColorStops.test.js
+++ b/__tests__/plugins/gradientColorStops.test.js
@@ -31,7 +31,7 @@ test('opacity variables are given to colors defined as closures', () => {
     }),
   ])
     .process('@tailwind utilities', { from: undefined })
-    .then(result => {
+    .then((result) => {
       const expected = `
         .text-primary {
           color: rgba(31,31,31,var(--text-opacity,1))

--- a/__tests__/prefixSelector.test.js
+++ b/__tests__/prefixSelector.test.js
@@ -5,7 +5,7 @@ test('it prefixes classes with the provided prefix', () => {
 })
 
 test('it handles a function as the prefix', () => {
-  const prefixFunc = selector => {
+  const prefixFunc = (selector) => {
     return selector === '.foo' ? 'tw-' : ''
   }
 

--- a/__tests__/processPlugins.test.js
+++ b/__tests__/processPlugins.test.js
@@ -651,7 +651,7 @@ test('plugins can access the current config', () => {
           },
         ]
 
-        _.forEach(config('screens'), breakpoint => {
+        _.forEach(config('screens'), (breakpoint) => {
           containerClasses.push({
             [`@media (min-width: ${breakpoint})`]: {
               '.container': { maxWidth: breakpoint },
@@ -1005,7 +1005,7 @@ test('plugins respect prefix and important options by default when adding utilit
       `,
       { from: undefined }
     )
-    .then(result => {
+    .then((result) => {
       const expected = `
         .tw-rotate-90 {
           transform: rotate(90deg) !important
@@ -1039,7 +1039,7 @@ test('when important is a selector it is used to scope utilities instead of addi
       `,
       { from: undefined }
     )
-    .then(result => {
+    .then((result) => {
       const expected = `
         #app .tw-rotate-90 {
           transform: rotate(90deg)
@@ -1072,7 +1072,7 @@ test('when important is a selector it scopes all selectors in a rule, even thoug
       `,
       { from: undefined }
     )
-    .then(result => {
+    .then((result) => {
       const expected = `
         #app .rotate-90, #app .rotate-1\\/4 {
           transform: rotate(90deg)
@@ -1105,7 +1105,7 @@ test('important utilities are not made double important when important option is
       `,
       { from: undefined }
     )
-    .then(result => {
+    .then((result) => {
       const expected = `
         .rotate-90 {
           transform: rotate(90deg) !important
@@ -1382,7 +1382,7 @@ test('prefix can optionally be ignored for utilities', () => {
       `,
       { from: undefined }
     )
-    .then(result => {
+    .then((result) => {
       const expected = `
         .rotate-90 {
           transform: rotate(90deg)
@@ -1420,7 +1420,7 @@ test('important can optionally be ignored for utilities', () => {
       `,
       { from: undefined }
     )
-    .then(result => {
+    .then((result) => {
       const expected = `
         .rotate-90 {
           transform: rotate(90deg)
@@ -1623,7 +1623,7 @@ test('plugins can be created using the `createPlugin` function', () => {
       `,
       { from: undefined }
     )
-    .then(result => {
+    .then((result) => {
       const expected = `
         .test-sm {
           test-property: 1rem
@@ -1719,7 +1719,7 @@ test('plugins with extra options can be created using the `createPlugin.withOpti
       `,
       { from: undefined }
     )
-    .then(result => {
+    .then((result) => {
       const expected = `
         .banana-sm {
           test-property: 1rem
@@ -1815,7 +1815,7 @@ test('plugins created using `createPlugin.withOptions` do not need to be invoked
       `,
       { from: undefined }
     )
-    .then(result => {
+    .then((result) => {
       const expected = `
         .banana-sm {
           test-property: 1rem
@@ -1900,7 +1900,7 @@ test('the configFunction parameter is optional when using the `createPlugin.with
       `,
       { from: undefined }
     )
-    .then(result => {
+    .then((result) => {
       const expected = `
         .banana-sm {
           test-property: 1px
@@ -1972,7 +1972,7 @@ test('plugins can extend variants', () => {
       `,
       { from: undefined }
     )
-    .then(result => {
+    .then((result) => {
       const expected = `
         .opacity-0 {
           opacity: 0

--- a/__tests__/purgeUnusedStyles.test.js
+++ b/__tests__/purgeUnusedStyles.test.js
@@ -21,7 +21,7 @@ function suppressConsoleLogs(cb, type = 'warn') {
 function extractRules(root) {
   let rules = []
 
-  root.walkRules(r => {
+  root.walkRules((r) => {
     rules = rules.concat(r.selectors)
   })
 
@@ -106,7 +106,7 @@ test('purges unused classes', () => {
         }),
       ])
         .process(input, { from: inputPath })
-        .then(result => {
+        .then((result) => {
           assertPurged(result)
         })
     })
@@ -137,7 +137,7 @@ test('custom css is not purged by default', () => {
       `,
           { from: null }
         )
-        .then(result => {
+        .then((result) => {
           const rules = extractRules(result.root)
           assertPurged(result)
           expect(rules).toContain('.example')
@@ -172,7 +172,7 @@ test('custom css that uses @responsive is not purged by default', () => {
       `,
           { from: null }
         )
-        .then(result => {
+        .then((result) => {
           const rules = extractRules(result.root)
           assertPurged(result)
           expect(rules).toContain('.example')
@@ -210,7 +210,7 @@ test('custom css in a layer is purged by default when using layers mode', () => 
         `,
           { from: null }
         )
-        .then(result => {
+        .then((result) => {
           const rules = extractRules(result.root)
           assertPurged(result)
           expect(rules).not.toContain('.example')
@@ -250,7 +250,7 @@ test('custom css in a layer in a @responsive at-rule is purged by default', () =
       `,
           { from: null }
         )
-        .then(result => {
+        .then((result) => {
           const rules = extractRules(result.root)
           assertPurged(result)
           expect(rules).not.toContain('.example')
@@ -273,7 +273,7 @@ test('purges unused classes with important string', () => {
         }),
       ])
         .process(input, { from: inputPath })
-        .then(result => {
+        .then((result) => {
           assertPurged(result)
         })
     })
@@ -317,7 +317,7 @@ test('components are purged by default in layers mode', () => {
         }),
       ])
         .process(input, { from: inputPath })
-        .then(result => {
+        .then((result) => {
           expect(result.css).not.toContain('.container')
           assertPurged(result)
         })
@@ -345,7 +345,7 @@ test('you can specify which layers to purge', () => {
         }),
       ])
         .process(input, { from: inputPath })
-        .then(result => {
+        .then((result) => {
           const rules = extractRules(result.root)
           expect(rules).toContain('optgroup')
           expect(rules).toContain('.container')
@@ -375,7 +375,7 @@ test('you can purge just base and component layers (but why)', () => {
         }),
       ])
         .process(input, { from: inputPath })
-        .then(result => {
+        .then((result) => {
           const rules = extractRules(result.root)
           expect(rules).not.toContain('[type="checkbox"]')
           expect(rules).not.toContain('.container')
@@ -403,7 +403,7 @@ test('does not purge components when mode is conservative', () => {
         }),
       ])
         .process(input, { from: inputPath })
-        .then(result => {
+        .then((result) => {
           expect(result.css).toContain('.container')
           assertPurged(result)
         })
@@ -437,7 +437,7 @@ test('extra purgecss control comments can be added manually', () => {
         }),
       ])
         .process(input, { from: null })
-        .then(result => {
+        .then((result) => {
           const rules = extractRules(result.root)
 
           expect(rules).toContain('.btn')
@@ -461,7 +461,7 @@ test(
       }),
     ])
       .process(input, { from: inputPath })
-      .then(result => {
+      .then((result) => {
         const expected = fs.readFileSync(
           path.resolve(`${__dirname}/fixtures/tailwind-output.css`),
           'utf8'
@@ -487,7 +487,7 @@ test('does not purge if the array is empty', () => {
         }),
       ])
         .process(input, { from: inputPath })
-        .then(result => {
+        .then((result) => {
           process.env.NODE_ENV = OLD_NODE_ENV
           const expected = fs.readFileSync(
             path.resolve(`${__dirname}/fixtures/tailwind-output.css`),
@@ -513,7 +513,7 @@ test('does not purge if explicitly disabled', () => {
         }),
       ])
         .process(input, { from: inputPath })
-        .then(result => {
+        .then((result) => {
           const expected = fs.readFileSync(
             path.resolve(`${__dirname}/fixtures/tailwind-output.css`),
             'utf8'
@@ -538,7 +538,7 @@ test('does not purge if purge is simply false', () => {
         }),
       ])
         .process(input, { from: inputPath })
-        .then(result => {
+        .then((result) => {
           const expected = fs.readFileSync(
             path.resolve(`${__dirname}/fixtures/tailwind-output.css`),
             'utf8'
@@ -563,7 +563,7 @@ test('purges outside of production if explicitly enabled', () => {
         }),
       ])
         .process(input, { from: inputPath })
-        .then(result => {
+        .then((result) => {
           assertPurged(result)
         })
     })
@@ -589,7 +589,7 @@ test(
       }),
     ])
       .process(input, { from: inputPath })
-      .then(result => {
+      .then((result) => {
         expect(result.css).toContain('.md\\:bg-green-500')
         assertPurged(result)
       })
@@ -614,11 +614,11 @@ test(
       function(css) {
         // Remove any comments to avoid accidentally asserting against them
         // instead of against real CSS rules.
-        css.walkComments(c => c.remove())
+        css.walkComments((c) => c.remove())
       },
     ])
       .process(input, { from: inputPath })
-      .then(result => {
+      .then((result) => {
         expect(result.css).toContain('html')
         expect(result.css).toContain('body')
         expect(result.css).toContain('samp')
@@ -646,7 +646,7 @@ test('the `conservative` mode can be set explicitly', () => {
         }),
       ])
         .process(input, { from: inputPath })
-        .then(result => {
+        .then((result) => {
           expect(result.css).not.toContain('.bg-red-600')
           expect(result.css).not.toContain('.w-1\\/3')
           expect(result.css).not.toContain('.flex')
@@ -692,7 +692,7 @@ test('element selectors are preserved by default', () => {
         }),
       ])
         .process(input, { from: inputPath })
-        .then(result => {
+        .then((result) => {
           const rules = extractRules(result.root)
           ;[
             'a',
@@ -718,7 +718,7 @@ test('element selectors are preserved by default', () => {
             'sup',
             'table',
             'ul',
-          ].forEach(e => expect(rules).toContain(e))
+          ].forEach((e) => expect(rules).toContain(e))
 
           assertPurged(result)
         })
@@ -743,7 +743,7 @@ test('preserving element selectors can be disabled', () => {
         }),
       ])
         .process(input, { from: inputPath })
-        .then(result => {
+        .then((result) => {
           const rules = extractRules(result.root)
 
           ;[
@@ -768,7 +768,7 @@ test('preserving element selectors can be disabled', () => {
             'sup',
             'table',
             'ul',
-          ].forEach(e => expect(rules).not.toContain(e))
+          ].forEach((e) => expect(rules).not.toContain(e))
 
           assertPurged(result)
         })

--- a/__tests__/resolveConfig.test.js
+++ b/__tests__/resolveConfig.test.js
@@ -426,8 +426,8 @@ test('functions in the default theme section are lazily evaluated', () => {
         magenta: 'magenta',
         yellow: 'yellow',
       },
-      backgroundColors: theme => theme('colors'),
-      textColors: theme => theme('colors'),
+      backgroundColors: (theme) => theme('colors'),
+      textColors: (theme) => theme('colors'),
     },
     variants: {
       backgroundColors: ['responsive', 'hover', 'focus'],
@@ -473,11 +473,11 @@ test('functions in the user theme section are lazily evaluated', () => {
         green: 'green',
         blue: 'blue',
       },
-      backgroundColors: theme => ({
+      backgroundColors: (theme) => ({
         ...theme('colors'),
         customBackground: '#bada55',
       }),
-      textColors: theme => ({
+      textColors: (theme) => ({
         ...theme('colors'),
         customText: '#facade',
       }),
@@ -565,7 +565,7 @@ test('theme values in the extend section extend the existing theme', () => {
         '50': '.5',
         '100': '1',
       },
-      backgroundColors: theme => theme('colors'),
+      backgroundColors: (theme) => theme('colors'),
     },
     variants: {
       backgroundColors: ['responsive', 'hover', 'focus'],
@@ -614,7 +614,7 @@ test('theme values in the extend section extend the user theme', () => {
         '20': '.2',
         '40': '.4',
       },
-      height: theme => theme('width'),
+      height: (theme) => theme('width'),
       extend: {
         opacity: {
           '60': '.6',
@@ -722,7 +722,7 @@ test('theme values in the extend section can extend values that are depended on 
         magenta: 'magenta',
         yellow: 'yellow',
       },
-      backgroundColors: theme => theme('colors'),
+      backgroundColors: (theme) => theme('colors'),
     },
     variants: {
       backgroundColors: ['responsive', 'hover', 'focus'],
@@ -827,7 +827,7 @@ test('the theme function can use a default value if the key is missing', () => {
         magenta: 'magenta',
         yellow: 'yellow',
       },
-      borderColor: theme => ({
+      borderColor: (theme) => ({
         default: theme('colors.gray', 'currentColor'),
         ...theme('colors'),
       }),
@@ -865,15 +865,15 @@ test('the theme function can use a default value if the key is missing', () => {
 test('the theme function can resolve function values', () => {
   const userConfig = {
     theme: {
-      textColor: theme => ({
+      textColor: (theme) => ({
         lime: 'lime',
         ...theme('colors'),
       }),
-      backgroundColor: theme => ({
+      backgroundColor: (theme) => ({
         orange: 'orange',
         ...theme('textColor'),
       }),
-      borderColor: theme => theme('backgroundColor'),
+      borderColor: (theme) => theme('backgroundColor'),
     },
   }
 
@@ -937,7 +937,7 @@ test('the theme function can resolve function values', () => {
 test('the theme function can resolve deep function values', () => {
   const userConfig = {
     theme: {
-      minWidth: theme => ({
+      minWidth: (theme) => ({
         '1/3': theme('width.1/3'),
       }),
     },
@@ -951,7 +951,7 @@ test('the theme function can resolve deep function values', () => {
       spacing: {
         '0': '0',
       },
-      width: theme => ({
+      width: (theme) => ({
         ...theme('spacing'),
         '1/3': '33.33333%',
       }),
@@ -999,7 +999,7 @@ test('theme values in the extend section are lazily evaluated', () => {
         colors: {
           orange: 'orange',
         },
-        borderColor: theme => ({
+        borderColor: (theme) => ({
           foo: theme('colors.orange'),
           bar: theme('colors.red'),
         }),
@@ -1017,7 +1017,7 @@ test('theme values in the extend section are lazily evaluated', () => {
         magenta: 'magenta',
         yellow: 'yellow',
       },
-      borderColor: theme => ({
+      borderColor: (theme) => ({
         default: theme('colors.yellow', 'currentColor'),
         ...theme('colors'),
       }),
@@ -1059,7 +1059,7 @@ test('theme values in the extend section are lazily evaluated', () => {
 test('lazily evaluated values have access to the config utils', () => {
   const userConfig = {
     theme: {
-      inset: theme => theme('margin'),
+      inset: (theme) => theme('margin'),
       shift: (theme, { negative }) => ({
         ...theme('spacing'),
         ...negative(theme('spacing')),
@@ -1295,7 +1295,7 @@ test('more than two config objects can be resolved', () => {
         backgroundColor: {
           customBackgroundTwo: '#facade',
         },
-        textDecorationColor: theme => theme('colors'),
+        textDecorationColor: (theme) => theme('colors'),
       },
     },
   }
@@ -1334,7 +1334,7 @@ test('more than two config objects can be resolved', () => {
       colors: {
         blue: 'blue',
       },
-      backgroundColor: theme => theme('colors'),
+      backgroundColor: (theme) => theme('colors'),
     },
     variants: {
       backgroundColor: ['responsive', 'hover', 'focus'],

--- a/__tests__/responsiveAtRule.test.js
+++ b/__tests__/responsiveAtRule.test.js
@@ -42,7 +42,7 @@ test('it can generate responsive variants', () => {
       },
     },
     separator: ':',
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -84,7 +84,7 @@ test('it can generate responsive variants with a custom separator', () => {
       },
     },
     separator: '__',
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -131,7 +131,7 @@ test('it can generate responsive variants when classes have non-standard charact
       },
     },
     separator: ':',
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -179,7 +179,7 @@ test('responsive variants are grouped', () => {
       },
     },
     separator: ':',
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -242,7 +242,7 @@ test('it can generate responsive variants for nested at-rules', () => {
       },
     },
     separator: ':',
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -313,7 +313,7 @@ test('it can generate responsive variants for deeply nested at-rules', () => {
       },
     },
     separator: ':',
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -350,7 +350,7 @@ test('screen prefix is only applied to the last class in a selector', () => {
       },
     },
     separator: ':',
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -387,7 +387,7 @@ test('responsive variants are generated for all selectors in a rule', () => {
       },
     },
     separator: ':',
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -411,7 +411,7 @@ test('selectors with no classes cannot be made responsive', () => {
       },
     },
     separator: ':',
-  }).catch(e => {
+  }).catch((e) => {
     expect(e).toMatchObject({ name: 'CssSyntaxError' })
   })
 })
@@ -434,7 +434,7 @@ test('all selectors in a rule must contain classes', () => {
       },
     },
     separator: ':',
-  }).catch(e => {
+  }).catch((e) => {
     expect(e).toMatchObject({ name: 'CssSyntaxError' })
   })
 })

--- a/__tests__/sanity.test.js
+++ b/__tests__/sanity.test.js
@@ -10,7 +10,7 @@ it('generates the right CSS', () => {
 
   return postcss([tailwind()])
     .process(input, { from: inputPath })
-    .then(result => {
+    .then((result) => {
       const expected = fs.readFileSync(
         path.resolve(`${__dirname}/fixtures/tailwind-output.css`),
         'utf8'
@@ -26,7 +26,7 @@ it('generates the right CSS when "important" is enabled', () => {
 
   return postcss([tailwind({ ...config, important: true })])
     .process(input, { from: inputPath })
-    .then(result => {
+    .then((result) => {
       const expected = fs.readFileSync(
         path.resolve(`${__dirname}/fixtures/tailwind-output-important.css`),
         'utf8'
@@ -42,7 +42,7 @@ it('generates the right CSS when using @import instead of @tailwind', () => {
 
   return postcss([tailwind()])
     .process(input, { from: inputPath })
-    .then(result => {
+    .then((result) => {
       const expected = fs.readFileSync(
         path.resolve(`${__dirname}/fixtures/tailwind-output.css`),
         'utf8'
@@ -63,7 +63,7 @@ it('generates the right CSS when enabling flagged features', () => {
     }),
   ])
     .process(input, { from: inputPath })
-    .then(result => {
+    .then((result) => {
       const expected = fs.readFileSync(
         path.resolve(`${__dirname}/fixtures/tailwind-output-flagged.css`),
         'utf8'
@@ -91,7 +91,7 @@ it('generates the right CSS when color opacity plugins are disabled', () => {
     }),
   ])
     .process(input, { from: inputPath })
-    .then(result => {
+    .then((result) => {
       const expected = fs.readFileSync(
         path.resolve(`${__dirname}/fixtures/tailwind-output-no-color-opacity.css`),
         'utf8'
@@ -104,7 +104,7 @@ it('generates the right CSS when color opacity plugins are disabled', () => {
 it('does not add any CSS if no Tailwind features are used', () => {
   return postcss([tailwind()])
     .process('.foo { color: blue; }', { from: undefined })
-    .then(result => {
+    .then((result) => {
       expect(result.css).toMatchCss('.foo { color: blue; }')
     })
 })
@@ -117,7 +117,7 @@ it('generates the right CSS with implicit screen utilities', () => {
 
   return postcss([tailwind()])
     .process(input, { from: inputPath })
-    .then(result => {
+    .then((result) => {
       const expected = fs.readFileSync(
         path.resolve(`${__dirname}/fixtures/tailwind-output-with-explicit-screen-utilities.css`),
         'utf8'
@@ -133,7 +133,7 @@ it('generates the right CSS when "important" is enabled', () => {
 
   return postcss([tailwind({ ...config, important: true })])
     .process(input, { from: inputPath })
-    .then(result => {
+    .then((result) => {
       const expected = fs.readFileSync(
         path.resolve(`${__dirname}/fixtures/tailwind-output-important.css`),
         'utf8'

--- a/__tests__/screenAtRule.test.js
+++ b/__tests__/screenAtRule.test.js
@@ -40,7 +40,7 @@ test('it can generate media queries from configured screen sizes', () => {
       },
     },
     separator: ':',
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })

--- a/__tests__/targetMode.test.js
+++ b/__tests__/targetMode.test.js
@@ -16,7 +16,7 @@ it('generates the right CSS in IE11 mode', () => {
 
   return postcss([tailwind({ ...config, target: 'ie11' })])
     .process(input, { from: inputPath })
-    .then(result => {
+    .then((result) => {
       const expected = fs.readFileSync(
         path.resolve(`${__dirname}/fixtures/tailwind-output-ie11.css`),
         'utf8'

--- a/__tests__/themeFunction.test.js
+++ b/__tests__/themeFunction.test.js
@@ -20,7 +20,7 @@ test('it looks up values in the theme using dot notation', () => {
         yellow: '#f7cc50',
       },
     },
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toEqual(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -41,7 +41,7 @@ test('quotes are optional around the lookup path', () => {
         yellow: '#f7cc50',
       },
     },
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toEqual(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -62,7 +62,7 @@ test('a default value can be provided', () => {
         yellow: '#f7cc50',
       },
     },
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toEqual(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -83,7 +83,7 @@ test('quotes are preserved around default values', () => {
         serif: 'Constantia',
       },
     },
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toEqual(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -104,7 +104,7 @@ test('an unquoted list is valid as a default value', () => {
         serif: 'Constantia',
       },
     },
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toEqual(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -125,7 +125,7 @@ test('array values are joined by default', () => {
         sans: ['Inter', 'Helvetica', 'sans-serif'],
       },
     },
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toEqual(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -149,7 +149,7 @@ test('font sizes are retrieved without default line-heights or letter-spacing', 
         xl: ['24px', { lineHeight: '32px', letterSpacing: '-0.01em' }],
       },
     },
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toEqual(output)
     expect(result.warnings().length).toBe(0)
   })

--- a/__tests__/util/invokePlugin.js
+++ b/__tests__/util/invokePlugin.js
@@ -16,7 +16,7 @@ export default function(plugin, config) {
 
       return getConfigValue(`variants.${path}`, defaultValue)
     },
-    target: path => {
+    target: (path) => {
       if (_.isString(config.target)) {
         return config.target
       }

--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -24,7 +24,7 @@ test('it can generate hover variants', () => {
     .hover\\:chocolate:hover { color: brown; }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -45,7 +45,7 @@ test('it can generate disabled variants', () => {
     .disabled\\:chocolate:disabled { color: brown; }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -66,7 +66,7 @@ test('it can generate checked variants', () => {
     .checked\\:chocolate:checked { color: brown; }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -87,7 +87,7 @@ test('it can generate active variants', () => {
     .active\\:chocolate:active { color: brown; }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -108,7 +108,7 @@ test('it can generate visited variants', () => {
     .visited\\:chocolate:visited { color: brown; }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -129,7 +129,7 @@ test('it can generate focus variants', () => {
     .focus\\:chocolate:focus { color: brown; }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -150,7 +150,7 @@ test('it can generate focus-within variants', () => {
     .focus-within\\:chocolate:focus-within { color: brown; }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -171,7 +171,7 @@ test('it can generate focus-visible variants', () => {
     .focus-visible\\:chocolate:focus-visible { color: brown; }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -194,7 +194,7 @@ test('it can generate motion-reduce variants', () => {
     }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -217,7 +217,7 @@ test('it can generate motion-safe variants', () => {
     }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -244,7 +244,7 @@ test('it can generate motion-safe and motion-reduce variants', () => {
     }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -275,7 +275,7 @@ test('motion-reduce variants stack with basic variants', () => {
     }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -306,7 +306,7 @@ test('motion-safe variants stack with basic variants', () => {
     }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -339,7 +339,7 @@ test('motion-safe and motion-reduce variants stack with basic variants', () => {
     }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -360,7 +360,7 @@ test('it can generate first-child variants', () => {
     .first\\:chocolate:first-child { color: brown; }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -381,7 +381,7 @@ test('it can generate odd variants', () => {
     .odd\\:chocolate:nth-child(odd) { color: brown; }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -402,7 +402,7 @@ test('it can generate last-child variants', () => {
     .last\\:chocolate:last-child { color: brown; }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -423,7 +423,7 @@ test('it can generate even variants', () => {
     .even\\:chocolate:nth-child(even) { color: brown; }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -444,7 +444,7 @@ test('it can generate group-hover variants', () => {
     .group:hover .group-hover\\:chocolate { color: brown; }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -468,7 +468,7 @@ test('group-hover variants respect any configured prefix', () => {
   return run(input, {
     ...config,
     prefix: 'tw-',
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -489,7 +489,7 @@ test('it can generate group-focus variants', () => {
     .group:focus .group-focus\\:chocolate { color: brown; }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -513,7 +513,7 @@ test('group-focus variants respect any configured prefix', () => {
   return run(input, {
     ...config,
     prefix: 'tw-',
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -540,7 +540,7 @@ test('it can generate hover, active and focus variants', () => {
     .active\\:chocolate:active { color: brown; }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -565,7 +565,7 @@ test('it can generate hover, active and focus variants for multiple classes in o
     .active\\:chocolate:active, .active\\:coconut:active { color: brown; }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -590,7 +590,7 @@ test('it wraps the output in a responsive at-rule if responsive is included as a
     }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -617,7 +617,7 @@ test('variants are generated in the order specified', () => {
 
   return run(input, {
     ...config,
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -640,7 +640,7 @@ test('the built-in variant pseudo-selectors are appended before any pseudo-eleme
     .group:hover .group-hover\\:placeholder-yellow::placeholder { color: yellow; }
   `
 
-  return run(input).then(result => {
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -667,7 +667,7 @@ test('the default variant can be generated in a specified position', () => {
 
   return run(input, {
     ...config,
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -704,7 +704,7 @@ test('nested rules are not modified', () => {
 
   return run(input, {
     ...config,
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -731,16 +731,16 @@ test('plugin variants can modify rules using the raw PostCSS API', () => {
       ...config.plugins,
       function({ addVariant }) {
         addVariant('important', ({ container }) => {
-          container.walkRules(rule => {
+          container.walkRules((rule) => {
             rule.selector = `.\\!${rule.selector.slice(1)}`
-            rule.walkDecls(decl => {
+            rule.walkDecls((decl) => {
               decl.important = true
             })
           })
         })
       },
     ],
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -773,7 +773,7 @@ test('plugin variants can modify selectors with a simplified API', () => {
         })
       },
     ],
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -806,7 +806,7 @@ test('plugin variants that use modify selectors need to manually escape the clas
         })
       },
     ],
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })
@@ -841,13 +841,13 @@ test('plugin variants can wrap rules in another at-rule using the raw PostCSS AP
           })
           supportsRule.nodes = container.nodes
           container.nodes = [supportsRule]
-          supportsRule.walkRules(rule => {
+          supportsRule.walkRules((rule) => {
             rule.selector = `.${e(`supports-grid${separator}${rule.selector.slice(1)}`)}`
           })
         })
       },
     ],
-  }).then(result => {
+  }).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })

--- a/jest/runInTempDirectory.js
+++ b/jest/runInTempDirectory.js
@@ -4,7 +4,7 @@ import path from 'path'
 import rimraf from 'rimraf'
 
 export default function(callback) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     const workerId = process.env.JEST_WORKER_ID
     const tmpPath = path.resolve(__dirname, `../__tmp_${workerId}`)
     const currentPath = process.cwd()

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -15,16 +15,16 @@ function buildDistFile(filename, config = {}, outFilename = filename) {
           from: `./${filename}.css`,
           to: `./dist/${outFilename}.css`,
         })
-        .then(result => {
+        .then((result) => {
           fs.writeFileSync(`./dist/${outFilename}.css`, result.css)
           return result
         })
-        .then(result => {
+        .then((result) => {
           const minified = new CleanCSS().minify(result.css)
           fs.writeFileSync(`./dist/${outFilename}.min.css`, minified.styles)
         })
         .then(resolve)
-        .catch(error => {
+        .catch((error) => {
           console.log(error)
           reject()
         })

--- a/scripts/rebuildFixtures.js
+++ b/scripts/rebuildFixtures.js
@@ -13,12 +13,12 @@ function build({ from, to, config }) {
         .process(css, {
           from: undefined,
         })
-        .then(result => {
+        .then((result) => {
           fs.writeFileSync(`./${to}`, result.css)
           return result
         })
         .then(resolve)
-        .catch(error => {
+        .catch((error) => {
           console.log(error)
           reject()
         })

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,4 +3,4 @@
 import main from './cli/main'
 import * as utils from './cli/utils'
 
-main(process.argv.slice(2)).catch(error => utils.die(error.stack))
+main(process.argv.slice(2)).catch((error) => utils.die(error.stack))

--- a/src/cli/commands/build.js
+++ b/src/cli/commands/build.js
@@ -51,7 +51,7 @@ function stop(...msgs) {
  * @return {Promise}
  */
 function buildToStdout(compileOptions) {
-  return compile(compileOptions).then(result => process.stdout.write(result.css))
+  return compile(compileOptions).then((result) => process.stdout.write(result.css))
 }
 
 /**
@@ -74,7 +74,7 @@ function buildToFile(compileOptions, startTime) {
       : ['Building from default CSS...', colors.info('(No input file provided)')])
   )
 
-  return compile(compileOptions).then(result => {
+  return compile(compileOptions).then((result) => {
     utils.writeFile(compileOptions.outputFile, result.css)
 
     const prettyTime = prettyHrtime(process.hrtime(startTime))

--- a/src/cli/commands/help.js
+++ b/src/cli/commands/help.js
@@ -21,7 +21,7 @@ export function forApp() {
   utils.log('  ', colors.bold(constants.cli + ' <command> [options]'))
   utils.log()
   utils.log('Commands:')
-  forEach(commands, command => {
+  forEach(commands, (command) => {
     utils.log('  ', colors.bold(padEnd(command.usage, pad)), command.description)
   })
 }
@@ -44,7 +44,7 @@ export function forCommand(command) {
 
     utils.log()
     utils.log('Options:')
-    forEach(command.options, option => {
+    forEach(command.options, (option) => {
       utils.log('  ', colors.bold(padEnd(option.usage, pad)), option.description)
     })
   }
@@ -68,7 +68,7 @@ export function invalidCommand(commandName) {
  * @return {Promise}
  */
 export function run(cliParams) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     utils.header()
 
     const commandName = cliParams[0]

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -32,7 +32,7 @@ export const optionMap = {
  * @return {Promise}
  */
 export function run(cliParams, cliOptions) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     utils.header()
 
     const file = cliParams[0] || constants.defaultConfigFile
@@ -47,7 +47,7 @@ export function run(cliParams, cliOptions) {
     const config = require(stubFile)
     const { future: flags } = require('../../featureFlags').default
 
-    flags.forEach(flag => {
+    flags.forEach((flag) => {
       config.future[`// ${flag}`] = true
     })
 

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -12,7 +12,7 @@ import packageJson from '../../package.json'
  * @return {string[]}
  */
 export function parseCliParams(cliArgs) {
-  const firstOptionIndex = cliArgs.findIndex(cliArg => cliArg.startsWith('-'))
+  const firstOptionIndex = cliArgs.findIndex((cliArg) => cliArg.startsWith('-'))
 
   return firstOptionIndex > -1 ? cliArgs.slice(0, firstOptionIndex) : cliArgs
 }
@@ -28,9 +28,9 @@ export function parseCliOptions(cliArgs, optionMap = {}) {
   let options = {}
   let currentOption = []
 
-  cliArgs.forEach(cliArg => {
+  cliArgs.forEach((cliArg) => {
     const option = cliArg.startsWith('-') && trimStart(cliArg, '-').toLowerCase()
-    const resolvedOption = findKey(optionMap, aliases => aliases.includes(option))
+    const resolvedOption = findKey(optionMap, (aliases) => aliases.includes(option))
 
     if (resolvedOption) {
       currentOption = options[resolvedOption] || (options[resolvedOption] = [])

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -37,7 +37,7 @@ function experimentalFlagsEnabled(config) {
   }
 
   return Object.keys(_.get(config, 'experimental', {})).filter(
-    flag => featureFlags.experimental.includes(flag) && config.experimental[flag]
+    (flag) => featureFlags.experimental.includes(flag) && config.experimental[flag]
   )
 }
 
@@ -46,7 +46,7 @@ function futureFlagsAvailable(config) {
     return []
   }
 
-  return featureFlags.future.filter(flag => !_.has(config, ['future', flag]))
+  return featureFlags.future.filter((flag) => !_.has(config, ['future', flag]))
 }
 
 export function issueFlagNotices(config) {
@@ -56,7 +56,7 @@ export function issueFlagNotices(config) {
 
   if (experimentalFlagsEnabled(config).length > 0) {
     const changes = experimentalFlagsEnabled(config)
-      .map(s => chalk.yellow(s))
+      .map((s) => chalk.yellow(s))
       .join(', ')
 
     log.warn([
@@ -67,7 +67,7 @@ export function issueFlagNotices(config) {
 
   if (futureFlagsAvailable(config).length > 0) {
     const changes = futureFlagsAvailable(config)
-      .map(s => chalk.magenta(s))
+      .map((s) => chalk.magenta(s))
       .join(', ')
 
     log.risk([

--- a/src/flagged/applyComplexClasses.js
+++ b/src/flagged/applyComplexClasses.js
@@ -40,20 +40,20 @@ const tailwindApplyPlaceholder = selectorParser.attribute({
 })
 
 function generateRulesFromApply({ rule, utilityName: className, classPosition }, replaceWiths) {
-  const parser = selectorParser(selectors => {
+  const parser = selectorParser((selectors) => {
     let i = 0
-    selectors.walkClasses(c => {
+    selectors.walkClasses((c) => {
       if (classPosition === i++ && c.value === className) {
         c.replaceWith(tailwindApplyPlaceholder)
       }
     })
   })
 
-  const processedSelectors = _.flatMap(rule.selectors, selector => {
+  const processedSelectors = _.flatMap(rule.selectors, (selector) => {
     // You could argue we should make this replacement at the AST level, but if we believe
     // the placeholder string is safe from collisions then it is safe to do this is a simple
     // string replacement, and much, much faster.
-    return replaceWiths.map(replaceWith =>
+    return replaceWiths.map((replaceWith) =>
       parser.processSync(selector).replace('[__TAILWIND-APPLY-PLACEHOLDER__]', replaceWith)
     )
   })
@@ -75,20 +75,20 @@ function generateRulesFromApply({ rule, utilityName: className, classPosition },
   return current
 }
 
-const extractUtilityNamesParser = selectorParser(selectors => {
+const extractUtilityNamesParser = selectorParser((selectors) => {
   let classes = []
-  selectors.walkClasses(c => classes.push(c.value))
+  selectors.walkClasses((c) => classes.push(c.value))
   return classes
 })
 
 const extractUtilityNames = useMemo(
-  selector => extractUtilityNamesParser.transformSync(selector),
-  selector => selector
+  (selector) => extractUtilityNamesParser.transformSync(selector),
+  (selector) => selector
 )
 
 const cloneRuleWithParent = useMemo(
-  rule => rule.clone({ parent: rule.parent }),
-  rule => rule
+  (rule) => rule.clone({ parent: rule.parent }),
+  (rule) => rule
 )
 
 function buildUtilityMap(css, lookupTree) {
@@ -124,7 +124,7 @@ function buildUtilityMap(css, lookupTree) {
 function mergeAdjacentRules(initialRule, rulesToInsert) {
   let previousRule = initialRule
 
-  rulesToInsert.forEach(toInsert => {
+  rulesToInsert.forEach((toInsert) => {
     if (
       toInsert.type === 'rule' &&
       previousRule.type === 'rule' &&
@@ -146,14 +146,14 @@ function mergeAdjacentRules(initialRule, rulesToInsert) {
       previousRule = toInsert
     }
 
-    toInsert.walk(n => {
+    toInsert.walk((n) => {
       if (n.nodes && n.nodes.length === 0) {
         n.remove()
       }
     })
   })
 
-  return rulesToInsert.filter(r => r.nodes.length > 0)
+  return rulesToInsert.filter((r) => r.nodes.length > 0)
 }
 
 function makeExtractUtilityRules(css, lookupTree, config) {
@@ -162,7 +162,7 @@ function makeExtractUtilityRules(css, lookupTree, config) {
   return function extractUtilityRules(utilityNames, rule) {
     const combined = []
 
-    utilityNames.forEach(utilityName => {
+    utilityNames.forEach((utilityName) => {
       if (utilityMap[utilityName] === undefined) {
         // Look for prefixed utility in case the user has goofed
         const prefixedUtility = prefixSelector(config.prefix, `.${utilityName}`).slice(1)
@@ -203,16 +203,16 @@ function processApplyAtRules(css, lookupTree, config) {
   const extractUtilityRules = makeExtractUtilityRules(css, lookupTree, config)
 
   do {
-    css.walkAtRules('apply', applyRule => {
+    css.walkAtRules('apply', (applyRule) => {
       const parent = applyRule.parent // Direct parent
-      const nearestParentRule = findParent(applyRule, r => r.type === 'rule')
+      const nearestParentRule = findParent(applyRule, (r) => r.type === 'rule')
       const currentUtilityNames = extractUtilityNames(nearestParentRule.selector)
 
       const [
         importantEntries,
         applyUtilityNames,
         important = importantEntries.length > 0,
-      ] = _.partition(applyRule.params.split(/[\s\t\n]+/g), n => n === '!important')
+      ] = _.partition(applyRule.params.split(/[\s\t\n]+/g), (n) => n === '!important')
 
       if (_.intersection(applyUtilityNames, currentUtilityNames).length > 0) {
         const currentUtilityName = _.intersection(applyUtilityNames, currentUtilityNames)[0]
@@ -234,12 +234,12 @@ function processApplyAtRules(css, lookupTree, config) {
 
       applys.forEach(
         nearestParentRule === parent
-          ? util => rulesToInsert.push(generateRulesFromApply(util, parent.selectors))
-          : util => util.rule.nodes.forEach(n => afterRule.append(n.clone()))
+          ? (util) => rulesToInsert.push(generateRulesFromApply(util, parent.selectors))
+          : (util) => util.rule.nodes.forEach((n) => afterRule.append(n.clone()))
       )
 
-      const { nodes } = _.tap(postcss.root({ nodes: rulesToInsert }), root =>
-        root.walkDecls(d => {
+      const { nodes } = _.tap(postcss.root({ nodes: rulesToInsert }), (root) =>
+        root.walkDecls((d) => {
           d.important = important
         })
       )
@@ -306,14 +306,14 @@ export default function applyComplexClasses(config, getProcessedPlugins, configC
                 `,
                 { from: undefined }
               )
-              .then(result => {
+              .then((result) => {
                 defaultTailwindTree = result
                 return defaultTailwindTree
               })
           }
         : () => Promise.resolve(defaultTailwindTree)
 
-    return generateLookupTree().then(result => {
+    return generateLookupTree().then((result) => {
       return processApplyAtRules(css, result.root, config)
     })
   }

--- a/src/flagged/darkModeVariantPlugin.js
+++ b/src/flagged/darkModeVariantPlugin.js
@@ -6,7 +6,7 @@ export default function({ addVariant, config, postcss, prefix }) {
     ({ container, separator, modifySelectors }) => {
       if (config('dark') === 'media') {
         const modified = modifySelectors(({ selector }) => {
-          return buildSelectorVariant(selector, 'dark', separator, message => {
+          return buildSelectorVariant(selector, 'dark', separator, (message) => {
             throw container.error(message)
           })
         })
@@ -21,13 +21,13 @@ export default function({ addVariant, config, postcss, prefix }) {
 
       if (config('dark') === 'class') {
         const modified = modifySelectors(({ selector }) => {
-          return buildSelectorVariant(selector, 'dark', separator, message => {
+          return buildSelectorVariant(selector, 'dark', separator, (message) => {
             throw container.error(message)
           })
         })
 
-        modified.walkRules(rule => {
-          rule.selectors = rule.selectors.map(selector => {
+        modified.walkRules((rule) => {
+          rule.selectors = rule.selectors.map((selector) => {
             return `${prefix('.dark')} ${selector}`
           })
         })

--- a/src/flagged/extendedSpacingScale.js
+++ b/src/flagged/extendedSpacingScale.js
@@ -77,7 +77,7 @@ export default {
       'min-content': 'min-content',
       'max-content': 'max-content',
     },
-    width: theme => ({
+    width: (theme) => ({
       auto: 'auto',
       ...theme('spacing'),
       screen: '100vw',
@@ -103,7 +103,7 @@ export default {
       'max-content': 'max-content',
       ...breakpoints(theme('screens')),
     }),
-    maxHeight: theme => ({
+    maxHeight: (theme) => ({
       screen: '100vh',
       ...theme('spacing'),
     }),

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ function resolveConfigPath(filePath) {
   }
 }
 
-const getConfigFunction = config => () => {
+const getConfigFunction = (config) => () => {
   if (_.isUndefined(config) && !_.isObject(config)) {
     return resolveConfig([...getAllConfigs(defaultConfig)])
   }
@@ -52,7 +52,7 @@ const getConfigFunction = config => () => {
   // Skip this if Jest is running: https://github.com/facebook/jest/pull/9841#issuecomment-621417584
   if (process.env.JEST_WORKER_ID === undefined) {
     if (!_.isObject(config)) {
-      getModuleDependencies(config).forEach(mdl => {
+      getModuleDependencies(config).forEach((mdl) => {
         delete require.cache[require.resolve(mdl.file)]
       })
     }
@@ -63,7 +63,7 @@ const getConfigFunction = config => () => {
   return resolveConfig([...getAllConfigs(configObject)])
 }
 
-const plugin = postcss.plugin('tailwind', config => {
+const plugin = postcss.plugin('tailwind', (config) => {
   const plugins = []
   const resolvedConfigPath = resolveConfigPath(config)
 

--- a/src/lib/applyImportantConfiguration.js
+++ b/src/lib/applyImportantConfiguration.js
@@ -1,6 +1,6 @@
 export default function applyImportantConfiguration(_config) {
   return function(css) {
-    css.walkRules(rule => {
+    css.walkRules((rule) => {
       const important = rule.__tailwind ? rule.__tailwind.important : false
 
       if (!important) {
@@ -8,11 +8,11 @@ export default function applyImportantConfiguration(_config) {
       }
 
       if (typeof important === 'string') {
-        rule.selectors = rule.selectors.map(selector => {
+        rule.selectors = rule.selectors.map((selector) => {
           return `${rule.__tailwind.important} ${selector}`
         })
       } else {
-        rule.walkDecls(decl => (decl.important = true))
+        rule.walkDecls((decl) => (decl.important = true))
       }
     })
   }

--- a/src/lib/convertLayerAtRulesToControlComments.js
+++ b/src/lib/convertLayerAtRulesToControlComments.js
@@ -2,7 +2,7 @@ import postcss from 'postcss'
 
 export default function convertLayerAtRulesToControlComments() {
   return function(css) {
-    css.walkAtRules('layer', atRule => {
+    css.walkAtRules('layer', (atRule) => {
       const layer = atRule.params
 
       if (!['base', 'components', 'utilities'].includes(layer)) {

--- a/src/lib/evaluateTailwindFunctions.js
+++ b/src/lib/evaluateTailwindFunctions.js
@@ -16,7 +16,7 @@ export default function(config) {
     functions: {
       theme: (path, ...defaultValue) => {
         const trimmedPath = _.trim(path, `'"`)
-        return _.thru(_.get(config.theme, trimmedPath, defaultValue), value => {
+        return _.thru(_.get(config.theme, trimmedPath, defaultValue), (value) => {
           const [themeSection] = trimmedPath.split('.')
 
           return _.get(themeTransforms, themeSection, defaultTransform)(value)

--- a/src/lib/getModuleDependencies.js
+++ b/src/lib/getModuleDependencies.js
@@ -18,11 +18,11 @@ export default function getModuleDependencies(entryFile) {
   // ones are being added
   for (const mdl of modules) {
     mdl.requires
-      .filter(dep => {
+      .filter((dep) => {
         // Only track local modules, not node_modules
         return dep.startsWith('./') || dep.startsWith('../')
       })
-      .forEach(dep => {
+      .forEach((dep) => {
         try {
           const basedir = path.dirname(mdl.file)
           const depPath = resolve.sync(dep, { basedir })

--- a/src/lib/purgeUnusedStyles.js
+++ b/src/lib/purgeUnusedStyles.js
@@ -6,8 +6,8 @@ import htmlTags from 'html-tags'
 import { flagEnabled } from '../featureFlags'
 
 function removeTailwindMarkers(css) {
-  css.walkAtRules('tailwind', rule => rule.remove())
-  css.walkComments(comment => {
+  css.walkAtRules('tailwind', (rule) => rule.remove())
+  css.walkComments((comment) => {
     switch (comment.text.trim()) {
       case 'tailwind start base':
       case 'tailwind end base':
@@ -77,7 +77,7 @@ export default function purgeUnusedUtilities(config, configChanged) {
           ? ['utilities']
           : _.get(config, 'purge.layers', ['base', 'components', 'utilities'])
 
-      css.walkComments(comment => {
+      css.walkComments((comment) => {
         switch (comment.text.trim()) {
           case `purgecss start ignore`:
             comment.before(postcss.comment({ text: 'purgecss end ignore' }))
@@ -89,7 +89,7 @@ export default function purgeUnusedUtilities(config, configChanged) {
           default:
             break
         }
-        layers.forEach(layer => {
+        layers.forEach((layer) => {
           switch (comment.text.trim()) {
             case `tailwind start ${layer}`:
               comment.text = 'purgecss end ignore'
@@ -109,10 +109,10 @@ export default function purgeUnusedUtilities(config, configChanged) {
     removeTailwindMarkers,
     purgecss({
       content: Array.isArray(config.purge) ? config.purge : config.purge.content,
-      defaultExtractor: content => {
+      defaultExtractor: (content) => {
         // Capture as liberally as possible, including things like `h-(screen-1.5)`
         const broadMatches = content.match(/[^<>"'`\s]*[^<>"'`\s:]/g) || []
-        const broadMatchesWithoutTrailingSlash = broadMatches.map(match => _.trimEnd(match, '\\'))
+        const broadMatchesWithoutTrailingSlash = broadMatches.map((match) => _.trimEnd(match, '\\'))
 
         // Capture classes within other delimiters like .block(class="w-1/2") in Pug
         const innerMatches = content.match(/[^<>"'`\s.(){}[\]#=%]*[^<>"'`\s.(){}[\]#=%:]/g) || []

--- a/src/lib/registerConfigAsDependency.js
+++ b/src/lib/registerConfigAsDependency.js
@@ -7,7 +7,7 @@ export default function(configFile) {
   }
 
   return function(css, opts) {
-    getModuleDependencies(configFile).forEach(mdl => {
+    getModuleDependencies(configFile).forEach((mdl) => {
       opts.messages.push({
         type: 'dependency',
         parent: css.source.input.file,

--- a/src/lib/substituteClassApplyAtRules.js
+++ b/src/lib/substituteClassApplyAtRules.js
@@ -10,7 +10,7 @@ import applyComplexClasses from '../flagged/applyComplexClasses'
 function buildClassTable(css) {
   const classTable = {}
 
-  css.walkRules(rule => {
+  css.walkRules((rule) => {
     if (!_.has(classTable, rule.selector)) {
       classTable[rule.selector] = []
     }
@@ -23,7 +23,7 @@ function buildClassTable(css) {
 function buildShadowTable(generatedUtilities) {
   const utilities = postcss.root()
 
-  postcss.root({ nodes: generatedUtilities }).walkAtRules('variants', atRule => {
+  postcss.root({ nodes: generatedUtilities }).walkAtRules('variants', (atRule) => {
     utilities.append(atRule.clone().nodes)
   })
 
@@ -70,8 +70,8 @@ export default function(config, getProcessedPlugins, configChanged) {
         ? buildShadowTable(getProcessedPlugins().utilities)
         : shadowLookup
 
-    css.walkRules(rule => {
-      rule.walkAtRules('apply', atRule => {
+    css.walkRules((rule) => {
+      rule.walkAtRules('apply', (atRule) => {
         const classesAndProperties = postcss.list.space(atRule.params)
 
         /*
@@ -81,15 +81,15 @@ export default function(config, getProcessedPlugins, configChanged) {
          * These are deprecated in CSSNext but still playing it safe for now.
          * We might consider renaming this at-rule.
          */
-        const [customProperties, classes] = _.partition(classesAndProperties, classOrProperty => {
+        const [customProperties, classes] = _.partition(classesAndProperties, (classOrProperty) => {
           return _.startsWith(classOrProperty, '--')
         })
 
         const decls = _(classes)
-          .reject(cssClass => cssClass === '!important')
-          .flatMap(cssClass => {
+          .reject((cssClass) => cssClass === '!important')
+          .flatMap((cssClass) => {
             const classToApply = normalizeClassName(cssClass)
-            const onError = message => {
+            const onError = (message) => {
               return atRule.error(message)
             }
 
@@ -141,8 +141,8 @@ export default function(config, getProcessedPlugins, configChanged) {
           })
           .value()
 
-        _.tap(_.last(classesAndProperties) === '!important', important => {
-          decls.forEach(decl => (decl.important = important))
+        _.tap(_.last(classesAndProperties) === '!important', (important) => {
+          decls.forEach((decl) => (decl.important = important))
         })
 
         atRule.before(decls)

--- a/src/lib/substituteResponsiveAtRules.js
+++ b/src/lib/substituteResponsiveAtRules.js
@@ -19,9 +19,9 @@ export default function(config) {
   return function(css) {
     // Wrap any `responsive` rules with a copy of their parent `layer` to
     // ensure the layer isn't lost when copying to the `screens` location.
-    css.walkAtRules('layer', layerAtRule => {
+    css.walkAtRules('layer', (layerAtRule) => {
       const layer = layerAtRule.params
-      layerAtRule.walkAtRules('responsive', responsiveAtRule => {
+      layerAtRule.walkAtRules('responsive', (responsiveAtRule) => {
         const nestedlayerAtRule = postcss.atRule({
           name: 'layer',
           params: layer,
@@ -39,7 +39,7 @@ export default function(config) {
     const responsiveRules = postcss.root()
     const finalRules = []
 
-    css.walkAtRules('responsive', atRule => {
+    css.walkAtRules('responsive', (atRule) => {
       const nodes = atRule.nodes
       responsiveRules.append(...cloneNodes(nodes))
 
@@ -55,17 +55,17 @@ export default function(config) {
       atRule.remove()
     })
 
-    _.keys(screens).forEach(screen => {
+    _.keys(screens).forEach((screen) => {
       const mediaQuery = postcss.atRule({
         name: 'media',
         params: buildMediaQuery(screens[screen]),
       })
 
       mediaQuery.append(
-        _.tap(responsiveRules.clone(), clonedRoot => {
-          clonedRoot.walkRules(rule => {
-            rule.selectors = _.map(rule.selectors, selector =>
-              buildSelectorVariant(selector, screen, separator, message => {
+        _.tap(responsiveRules.clone(), (clonedRoot) => {
+          clonedRoot.walkRules((rule) => {
+            rule.selectors = _.map(rule.selectors, (selector) =>
+              buildSelectorVariant(selector, screen, separator, (message) => {
                 throw rule.error(message)
               })
             )
@@ -76,9 +76,9 @@ export default function(config) {
       finalRules.push(mediaQuery)
     })
 
-    const hasScreenRules = finalRules.some(i => i.nodes.length !== 0)
+    const hasScreenRules = finalRules.some((i) => i.nodes.length !== 0)
 
-    css.walkAtRules('tailwind', atRule => {
+    css.walkAtRules('tailwind', (atRule) => {
       if (atRule.params !== 'screens') {
         return
       }

--- a/src/lib/substituteScreenAtRules.js
+++ b/src/lib/substituteScreenAtRules.js
@@ -3,7 +3,7 @@ import buildMediaQuery from '../util/buildMediaQuery'
 
 export default function({ theme }) {
   return function(css) {
-    css.walkAtRules('screen', atRule => {
+    css.walkAtRules('screen', (atRule) => {
       const screen = atRule.params
 
       if (!_.has(theme.screens, screen)) {

--- a/src/lib/substituteTailwindAtRules.js
+++ b/src/lib/substituteTailwindAtRules.js
@@ -2,8 +2,8 @@ import _ from 'lodash'
 import postcss from 'postcss'
 
 function updateSource(nodes, source) {
-  return _.tap(Array.isArray(nodes) ? postcss.root({ nodes }) : nodes, tree => {
-    tree.walk(node => (node.source = source))
+  return _.tap(Array.isArray(nodes) ? postcss.root({ nodes }) : nodes, (tree) => {
+    tree.walk((node) => (node.source = source))
   })
 }
 
@@ -12,7 +12,7 @@ export default function(
   { base: pluginBase, components: pluginComponents, utilities: pluginUtilities }
 ) {
   return function(css) {
-    css.walkAtRules('import', atRule => {
+    css.walkAtRules('import', (atRule) => {
       if (atRule.params === '"tailwindcss/base"' || atRule.params === "'tailwindcss/base'") {
         atRule.name = 'tailwind'
         atRule.params = 'base'
@@ -47,7 +47,7 @@ export default function(
       utilities: [],
     }
 
-    css.walkAtRules('layer', atRule => {
+    css.walkAtRules('layer', (atRule) => {
       if (!['base', 'components', 'utilities'].includes(atRule.params)) {
         return
       }
@@ -55,7 +55,7 @@ export default function(
       layers[atRule.params].push(atRule)
     })
 
-    css.walkAtRules('tailwind', atRule => {
+    css.walkAtRules('tailwind', (atRule) => {
       if (atRule.params === 'preflight') {
         // prettier-ignore
         throw atRule.error("`@tailwind preflight` is not a valid at-rule in Tailwind v1.0, use `@tailwind base` instead.", { word: 'preflight' })

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -7,8 +7,8 @@ import buildSelectorVariant from '../util/buildSelectorVariant'
 
 function generatePseudoClassVariant(pseudoClass, selectorPrefix = pseudoClass) {
   return generateVariantFunction(({ modifySelectors, separator }) => {
-    const parser = selectorParser(selectors => {
-      selectors.walkClasses(sel => {
+    const parser = selectorParser((selectors) => {
+      selectors.walkClasses((sel) => {
         sel.value = `${selectorPrefix}${separator}${sel.value}`
         sel.parent.insertAfter(sel, selectorParser.pseudo({ value: `:${pseudoClass}` }))
       })
@@ -22,12 +22,12 @@ function ensureIncludesDefault(variants) {
   return variants.includes('default') ? variants : ['default', ...variants]
 }
 
-const defaultVariantGenerators = config => ({
+const defaultVariantGenerators = (config) => ({
   default: generateVariantFunction(() => {}),
   'motion-safe': generateVariantFunction(
     ({ container, separator, modifySelectors }) => {
       const modified = modifySelectors(({ selector }) => {
-        return buildSelectorVariant(selector, 'motion-safe', separator, message => {
+        return buildSelectorVariant(selector, 'motion-safe', separator, (message) => {
           throw container.error(message)
         })
       })
@@ -43,7 +43,7 @@ const defaultVariantGenerators = config => ({
   'motion-reduce': generateVariantFunction(
     ({ container, separator, modifySelectors }) => {
       const modified = modifySelectors(({ selector }) => {
-        return buildSelectorVariant(selector, 'motion-reduce', separator, message => {
+        return buildSelectorVariant(selector, 'motion-reduce', separator, (message) => {
           throw container.error(message)
         })
       })
@@ -57,8 +57,8 @@ const defaultVariantGenerators = config => ({
     { unstable_stack: true }
   ),
   'group-hover': generateVariantFunction(({ modifySelectors, separator }) => {
-    const parser = selectorParser(selectors => {
-      selectors.walkClasses(sel => {
+    const parser = selectorParser((selectors) => {
+      selectors.walkClasses((sel) => {
         sel.value = `group-hover${separator}${sel.value}`
         sel.parent.insertBefore(
           sel,
@@ -69,8 +69,8 @@ const defaultVariantGenerators = config => ({
     return modifySelectors(({ selector }) => parser.processSync(selector))
   }),
   'group-focus': generateVariantFunction(({ modifySelectors, separator }) => {
-    const parser = selectorParser(selectors => {
-      selectors.walkClasses(sel => {
+    const parser = selectorParser((selectors) => {
+      selectors.walkClasses((sel) => {
         sel.value = `group-focus${separator}${sel.value}`
         sel.parent.insertBefore(
           sel,
@@ -95,17 +95,17 @@ const defaultVariantGenerators = config => ({
 })
 
 function prependStackableVariants(atRule, variants, stackableVariants) {
-  if (!_.some(variants, v => stackableVariants.includes(v))) {
+  if (!_.some(variants, (v) => stackableVariants.includes(v))) {
     return variants
   }
 
-  if (_.every(variants, v => stackableVariants.includes(v))) {
+  if (_.every(variants, (v) => stackableVariants.includes(v))) {
     return variants
   }
 
   const variantsParent = postcss.atRule({
     name: 'variants',
-    params: variants.filter(v => stackableVariants.includes(v)).join(', '),
+    params: variants.filter((v) => stackableVariants.includes(v)).join(', '),
   })
   atRule.before(variantsParent)
   variantsParent.append(atRule)
@@ -129,10 +129,10 @@ export default function(config, { variantGenerators: pluginVariantGenerators }) 
 
     do {
       variantsFound = false
-      css.walkAtRules('variants', atRule => {
+      css.walkAtRules('variants', (atRule) => {
         variantsFound = true
 
-        let variants = postcss.list.comma(atRule.params).filter(variant => variant !== '')
+        let variants = postcss.list.comma(atRule.params).filter((variant) => variant !== '')
 
         if (variants.includes('responsive')) {
           const responsiveParent = postcss.atRule({ name: 'responsive' })
@@ -142,7 +142,7 @@ export default function(config, { variantGenerators: pluginVariantGenerators }) 
 
         const remainingVariants = prependStackableVariants(atRule, variants, stackableVariants)
 
-        _.forEach(_.without(ensureIncludesDefault(remainingVariants), 'responsive'), variant => {
+        _.forEach(_.without(ensureIncludesDefault(remainingVariants), 'responsive'), (variant) => {
           if (!variantGenerators[variant]) {
             throw new Error(
               `Your config mentions the "${variant}" variant, but "${variant}" doesn't appear to be a variant. Did you forget or misconfigure a plugin that supplies that variant?`

--- a/src/plugins/backgroundColor.js
+++ b/src/plugins/backgroundColor.js
@@ -6,7 +6,7 @@ export default function() {
   return function({ addUtilities, e, theme, variants, target, corePlugins }) {
     const colors = flattenColorPalette(theme('backgroundColor'))
 
-    const getProperties = value => {
+    const getProperties = (value) => {
       if (target('backgroundColor') === 'ie11') {
         return { 'background-color': value }
       }

--- a/src/plugins/borderColor.js
+++ b/src/plugins/borderColor.js
@@ -6,7 +6,7 @@ export default function() {
   return function({ addUtilities, e, theme, variants, target, corePlugins }) {
     const colors = flattenColorPalette(theme('borderColor'))
 
-    const getProperties = value => {
+    const getProperties = (value) => {
       if (target('borderColor') === 'ie11') {
         return { 'border-color': value }
       }

--- a/src/plugins/borderRadius.js
+++ b/src/plugins/borderRadius.js
@@ -32,7 +32,7 @@ export default function() {
       }),
     ]
 
-    const utilities = _.flatMap(generators, generator => {
+    const utilities = _.flatMap(generators, (generator) => {
       return _.flatMap(theme('borderRadius'), (value, modifier) => {
         return generator(value, modifier === 'default' ? '' : `-${modifier}`)
       })

--- a/src/plugins/borderWidth.js
+++ b/src/plugins/borderWidth.js
@@ -14,7 +14,7 @@ export default function() {
       }),
     ]
 
-    const utilities = _.flatMap(generators, generator => {
+    const utilities = _.flatMap(generators, (generator) => {
       return _.flatMap(theme('borderWidth'), (value, modifier) => {
         return generator(value, modifier === 'default' ? '' : `-${modifier}`)
       })

--- a/src/plugins/container.js
+++ b/src/plugins/container.js
@@ -2,7 +2,7 @@
 import _ from 'lodash'
 
 function extractMinWidths(breakpoints) {
-  return _.flatMap(breakpoints, breakpoints => {
+  return _.flatMap(breakpoints, (breakpoints) => {
     if (_.isString(breakpoints)) {
       breakpoints = { min: breakpoints }
     }
@@ -12,10 +12,10 @@ function extractMinWidths(breakpoints) {
     }
 
     return _(breakpoints)
-      .filter(breakpoint => {
+      .filter((breakpoint) => {
         return _.has(breakpoint, 'min') || _.has(breakpoint, 'min-width')
       })
-      .map(breakpoint => {
+      .map((breakpoint) => {
         return _.get(breakpoint, 'min-width', breakpoint.min)
       })
       .value()
@@ -47,8 +47,8 @@ function mapMinWidthsToPadding(minWidths, screens, paddings) {
     })
   }
 
-  _.each(minWidths, minWidth => {
-    Object.keys(screens).forEach(screen => {
+  _.each(minWidths, (minWidth) => {
+    Object.keys(screens).forEach((screen) => {
       const screenMinWidth = _.isPlainObject(screens[screen])
         ? screens[screen].min || screens[screen]['min-width']
         : screens[screen]
@@ -72,8 +72,8 @@ module.exports = function() {
     const minWidths = extractMinWidths(screens)
     const paddings = mapMinWidthsToPadding(minWidths, screens, theme('container.padding'))
 
-    const generatePaddingFor = minWidth => {
-      const paddingConfig = _.find(paddings, padding => `${padding.minWidth}` === `${minWidth}`)
+    const generatePaddingFor = (minWidth) => {
+      const paddingConfig = _.find(paddings, (padding) => `${padding.minWidth}` === `${minWidth}`)
 
       if (!paddingConfig) {
         return {}
@@ -86,9 +86,9 @@ module.exports = function() {
     }
 
     const atRules = _(minWidths)
-      .sortBy(minWidth => parseInt(minWidth))
+      .sortBy((minWidth) => parseInt(minWidth))
       .sortedUniq()
-      .map(minWidth => {
+      .map((minWidth) => {
         return {
           [`@media (min-width: ${minWidth})`]: {
             '.container': {

--- a/src/plugins/divideColor.js
+++ b/src/plugins/divideColor.js
@@ -6,7 +6,7 @@ export default function() {
   return function({ addUtilities, e, theme, variants, target, corePlugins }) {
     const colors = flattenColorPalette(theme('divideColor'))
 
-    const getProperties = value => {
+    const getProperties = (value) => {
       if (target('divideColor') === 'ie11') {
         return { 'border-color': value }
       }

--- a/src/plugins/divideWidth.js
+++ b/src/plugins/divideWidth.js
@@ -14,7 +14,7 @@ export default function() {
         }),
       ]
 
-      const utilities = _.flatMap(generators, generator => {
+      const utilities = _.flatMap(generators, (generator) => {
         return _.flatMap(theme('divideWidth'), (value, modifier) => {
           return generator(value, modifier === 'default' ? '' : `-${modifier}`)
         })
@@ -44,7 +44,7 @@ export default function() {
       }),
     ]
 
-    const utilities = _.flatMap(generators, generator => {
+    const utilities = _.flatMap(generators, (generator) => {
       return [
         ..._.flatMap(theme('divideWidth'), (value, modifier) => {
           return generator(value, modifier === 'default' ? '' : `-${modifier}`)

--- a/src/plugins/gradientColorStops.js
+++ b/src/plugins/gradientColorStops.js
@@ -12,7 +12,7 @@ export default function() {
 
     const utilities = _(colors)
       .map((value, modifier) => {
-        const getColorValue = color => {
+        const getColorValue = (color) => {
           if (_.isFunction(color)) {
             return value({})
           }

--- a/src/plugins/inset.js
+++ b/src/plugins/inset.js
@@ -30,7 +30,7 @@ export default function() {
       }),
     ]
 
-    const utilities = _.flatMap(generators, generator => {
+    const utilities = _.flatMap(generators, (generator) => {
       return _.flatMap(theme('inset'), generator)
     })
 

--- a/src/plugins/margin.js
+++ b/src/plugins/margin.js
@@ -25,7 +25,7 @@ export default function() {
       }),
     ]
 
-    const utilities = _.flatMap(generators, generator => {
+    const utilities = _.flatMap(generators, (generator) => {
       return _.flatMap(theme('margin'), generator)
     })
 

--- a/src/plugins/padding.js
+++ b/src/plugins/padding.js
@@ -18,7 +18,7 @@ export default function() {
       }),
     ]
 
-    const utilities = _.flatMap(generators, generator => {
+    const utilities = _.flatMap(generators, (generator) => {
       return _.flatMap(theme('padding'), generator)
     })
 

--- a/src/plugins/placeholderColor.js
+++ b/src/plugins/placeholderColor.js
@@ -6,7 +6,7 @@ export default function() {
   return function({ addUtilities, e, theme, variants, target, corePlugins }) {
     const colors = flattenColorPalette(theme('placeholderColor'))
 
-    const getProperties = value => {
+    const getProperties = (value) => {
       if (target('placeholderColor') === 'ie11') {
         return { color: value }
       }

--- a/src/plugins/rotate.js
+++ b/src/plugins/rotate.js
@@ -3,7 +3,7 @@ import createUtilityPlugin from '../util/createUtilityPlugin'
 export default function() {
   return function({ target, ...args }) {
     if (target('rotate') === 'ie11') {
-      createUtilityPlugin('rotate', [['rotate', ['transform'], value => `rotate(${value})`]])({
+      createUtilityPlugin('rotate', [['rotate', ['transform'], (value) => `rotate(${value})`]])({
         target,
         ...args,
       })

--- a/src/plugins/scale.js
+++ b/src/plugins/scale.js
@@ -4,9 +4,9 @@ export default function() {
   return function({ target, ...args }) {
     if (target('scale') === 'ie11') {
       createUtilityPlugin('scale', [
-        ['scale', ['transform'], value => `scale(${value})`],
-        ['scale-x', ['transform'], value => `scaleX(${value})`],
-        ['scale-y', ['transform'], value => `scaleY(${value})`],
+        ['scale', ['transform'], (value) => `scale(${value})`],
+        ['scale-x', ['transform'], (value) => `scaleX(${value})`],
+        ['scale-y', ['transform'], (value) => `scaleY(${value})`],
       ])({ target, ...args })
 
       return

--- a/src/plugins/skew.js
+++ b/src/plugins/skew.js
@@ -4,8 +4,8 @@ export default function() {
   return function({ target, ...args }) {
     if (target('skew') === 'ie11') {
       createUtilityPlugin('skew', [
-        ['skew-x', ['transform'], value => `skewX(${value})`],
-        ['skew-y', ['transform'], value => `skewY(${value})`],
+        ['skew-x', ['transform'], (value) => `skewX(${value})`],
+        ['skew-y', ['transform'], (value) => `skewY(${value})`],
       ])({ target, ...args })
 
       return

--- a/src/plugins/space.js
+++ b/src/plugins/space.js
@@ -19,7 +19,7 @@ export default function() {
         }),
       ]
 
-      const utilities = _.flatMap(generators, generator => {
+      const utilities = _.flatMap(generators, (generator) => {
         return _.flatMap(theme('space'), generator)
       })
 
@@ -43,7 +43,7 @@ export default function() {
       }),
     ]
 
-    const utilities = _.flatMap(generators, generator => {
+    const utilities = _.flatMap(generators, (generator) => {
       return [
         ..._.flatMap(theme('space'), generator),
         {

--- a/src/plugins/textColor.js
+++ b/src/plugins/textColor.js
@@ -6,7 +6,7 @@ export default function() {
   return function({ addUtilities, e, theme, variants, target, corePlugins }) {
     const colors = flattenColorPalette(theme('textColor'))
 
-    const getProperties = value => {
+    const getProperties = (value) => {
       if (target('textColor') === 'ie11') {
         return { color: value }
       }

--- a/src/plugins/translate.js
+++ b/src/plugins/translate.js
@@ -4,8 +4,8 @@ export default function() {
   return function({ target, ...args }) {
     if (target('translate') === 'ie11') {
       createUtilityPlugin('translate', [
-        ['translate-x', ['transform'], value => `translateX(${value})`],
-        ['translate-y', ['transform'], value => `translateY(${value})`],
+        ['translate-x', ['transform'], (value) => `translateX(${value})`],
+        ['translate-y', ['transform'], (value) => `translateY(${value})`],
       ])({ target, ...args })
 
       return

--- a/src/util/buildMediaQuery.js
+++ b/src/util/buildMediaQuery.js
@@ -10,7 +10,7 @@ export default function buildMediaQuery(screens) {
   }
 
   return _(screens)
-    .map(screen => {
+    .map((screen) => {
       if (_.has(screen, 'raw')) {
         return screen.raw
       }

--- a/src/util/buildSelectorVariant.js
+++ b/src/util/buildSelectorVariant.js
@@ -4,8 +4,8 @@ import { useMemo } from './useMemo'
 
 const buildSelectorVariant = useMemo(
   (selector, variantName, separator, onError = () => {}) => {
-    return parser(selectors => {
-      tap(selectors.first.filter(({ type }) => type === 'class').pop(), classSelector => {
+    return parser((selectors) => {
+      tap(selectors.first.filter(({ type }) => type === 'class').pop(), (classSelector) => {
         if (classSelector === undefined) {
           onError('Variant cannot be generated because selector contains no classes.')
           return

--- a/src/util/cloneNodes.js
+++ b/src/util/cloneNodes.js
@@ -1,5 +1,5 @@
 import _ from 'lodash'
 
 export default function cloneNodes(nodes) {
-  return _.map(nodes, node => node.clone())
+  return _.map(nodes, (node) => node.clone())
 }

--- a/src/util/configurePlugins.js
+++ b/src/util/configurePlugins.js
@@ -1,9 +1,9 @@
 export default function(pluginConfig, plugins) {
   const pluginNames = Array.isArray(pluginConfig)
     ? pluginConfig
-    : Object.keys(plugins).filter(pluginName => {
+    : Object.keys(plugins).filter((pluginName) => {
         return pluginConfig !== false && pluginConfig[pluginName] !== false
       })
 
-  return pluginNames.map(pluginName => plugins[pluginName]())
+  return pluginNames.map((pluginName) => plugins[pluginName]())
 }

--- a/src/util/createUtilityPlugin.js
+++ b/src/util/createUtilityPlugin.js
@@ -23,7 +23,7 @@ export default function createUtilityPlugin(themeKey, utilityVariations) {
           toPairs(theme(themeKey)).map(([key, value]) => {
             return [
               `.${e(className(classPrefix, key))}`,
-              fromPairs(castArray(properties).map(property => [property, transformValue(value)])),
+              fromPairs(castArray(properties).map((property) => [property, transformValue(value)])),
             ]
           })
         )

--- a/src/util/generateVariantFunction.js
+++ b/src/util/generateVariantFunction.js
@@ -3,13 +3,13 @@ import postcss from 'postcss'
 import selectorParser from 'postcss-selector-parser'
 import { useMemo } from './useMemo'
 
-const classNameParser = selectorParser(selectors => {
+const classNameParser = selectorParser((selectors) => {
   return selectors.first.filter(({ type }) => type === 'class').pop().value
 })
 
 const getClassNameFromSelector = useMemo(
-  selector => classNameParser.transformSync(selector),
-  selector => selector
+  (selector) => classNameParser.transformSync(selector),
+  (selector) => selector
 )
 
 export default function generateVariantFunction(generator, options = {}) {
@@ -23,13 +23,13 @@ export default function generateVariantFunction(generator, options = {}) {
           generator({
             container: cloned,
             separator: config.separator,
-            modifySelectors: modifierFunction => {
-              cloned.each(rule => {
+            modifySelectors: (modifierFunction) => {
+              cloned.each((rule) => {
                 if (rule.type !== 'rule') {
                   return
                 }
 
-                rule.selectors = rule.selectors.map(selector => {
+                rule.selectors = rule.selectors.map((selector) => {
                   return modifierFunction({
                     get className() {
                       return getClassNameFromSelector(selector)

--- a/src/util/getAllConfigs.js
+++ b/src/util/getAllConfigs.js
@@ -20,7 +20,7 @@ export default function getAllConfigs(config) {
     additionalBreakpoint,
   }
 
-  Object.keys(features).forEach(feature => {
+  Object.keys(features).forEach((feature) => {
     if (flagEnabled(config, feature)) {
       configs.unshift(features[feature])
     }

--- a/src/util/log.js
+++ b/src/util/log.js
@@ -3,19 +3,19 @@ import chalk from 'chalk'
 export default {
   info(messages) {
     console.warn('')
-    messages.forEach(message => {
+    messages.forEach((message) => {
       console.warn(chalk.bold.cyan('info'), '-', message)
     })
   },
   warn(messages) {
     console.warn('')
-    messages.forEach(message => {
+    messages.forEach((message) => {
       console.warn(chalk.bold.yellow('warn'), '-', message)
     })
   },
   risk(messages) {
     console.warn('')
-    messages.forEach(message => {
+    messages.forEach((message) => {
       console.warn(chalk.bold.magenta('risk'), '-', message)
     })
   },

--- a/src/util/parseObjectStyles.js
+++ b/src/util/parseObjectStyles.js
@@ -8,7 +8,7 @@ export default function parseObjectStyles(styles) {
     return parseObjectStyles([styles])
   }
 
-  return _.flatMap(styles, style => {
+  return _.flatMap(styles, (style) => {
     return postcss([
       postcssNested({
         bubble: ['screen'],

--- a/src/util/prefixSelector.js
+++ b/src/util/prefixSelector.js
@@ -4,9 +4,9 @@ import tap from 'lodash/tap'
 export default function(prefix, selector) {
   const getPrefix = typeof prefix === 'function' ? prefix : () => prefix
 
-  return parser(selectors => {
-    selectors.walkClasses(classSelector => {
-      tap(classSelector.value, baseClass => {
+  return parser((selectors) => {
+    selectors.walkClasses((classSelector) => {
+      tap(classSelector.value, (baseClass) => {
         classSelector.value = `${getPrefix('.' + baseClass)}${baseClass}`
       })
     })

--- a/src/util/processPlugins.js
+++ b/src/util/processPlugins.js
@@ -15,7 +15,7 @@ function parseStyles(styles) {
     return parseStyles([styles])
   }
 
-  return _.flatMap(styles, style => (style instanceof Node ? style : parseObjectStyles(style)))
+  return _.flatMap(styles, (style) => (style instanceof Node ? style : parseObjectStyles(style)))
 }
 
 function wrapWithLayer(rules, layer) {
@@ -37,14 +37,14 @@ export default function(plugins, config) {
   const pluginUtilities = []
   const pluginVariantGenerators = {}
 
-  const applyConfiguredPrefix = selector => {
+  const applyConfiguredPrefix = (selector) => {
     return prefixSelector(config.prefix, selector)
   }
 
   const getConfigValue = (path, defaultValue) => (path ? _.get(config, path, defaultValue) : config)
   const browserslistTarget = browserslist().includes('ie 11') ? 'ie11' : 'relaxed'
 
-  plugins.forEach(plugin => {
+  plugins.forEach((plugin) => {
     if (plugin.__isOptionsFunction) {
       plugin = plugin()
     }
@@ -55,7 +55,7 @@ export default function(plugins, config) {
       postcss,
       config: getConfigValue,
       theme: (path, defaultValue) => getConfigValue(`theme.${path}`, defaultValue),
-      corePlugins: path => {
+      corePlugins: (path) => {
         if (Array.isArray(config.corePlugins)) {
           return config.corePlugins.includes(path)
         }
@@ -69,7 +69,7 @@ export default function(plugins, config) {
 
         return getConfigValue(`variants.${path}`, defaultValue)
       },
-      target: path => {
+      target: (path) => {
         if (_.isString(config.target)) {
           return config.target === 'browserslist' ? browserslistTarget : config.target
         }
@@ -91,7 +91,7 @@ export default function(plugins, config) {
 
         const styles = postcss.root({ nodes: parseStyles(utilities) })
 
-        styles.walkRules(rule => {
+        styles.walkRules((rule) => {
           if (options.respectPrefix && !isKeyframeRule(rule)) {
             rule.selector = applyConfiguredPrefix(rule.selector)
           }
@@ -117,7 +117,7 @@ export default function(plugins, config) {
 
         const styles = postcss.root({ nodes: parseStyles(components) })
 
-        styles.walkRules(rule => {
+        styles.walkRules((rule) => {
           if (options.respectPrefix && !isKeyframeRule(rule)) {
             rule.selector = applyConfiguredPrefix(rule.selector)
           }
@@ -127,7 +127,7 @@ export default function(plugins, config) {
           wrapWithLayer(wrapWithVariants(styles.nodes, options.variants), 'components')
         )
       },
-      addBase: baseStyles => {
+      addBase: (baseStyles) => {
         pluginBaseStyles.push(wrapWithLayer(parseStyles(baseStyles), 'base'))
       },
       addVariant: (name, generator, options = {}) => {

--- a/src/util/resolveConfig.js
+++ b/src/util/resolveConfig.js
@@ -11,7 +11,7 @@ import negateValue from './negateValue'
 const configUtils = {
   negative(scale) {
     return Object.keys(scale)
-      .filter(key => scale[key] !== '0')
+      .filter((key) => scale[key] !== '0')
       .reduce(
         (negativeScale, key) => ({
           ...negativeScale,
@@ -22,7 +22,7 @@ const configUtils = {
   },
   breakpoints(screens) {
     return Object.keys(screens)
-      .filter(key => typeof screens[key] === 'string')
+      .filter((key) => typeof screens[key] === 'string')
       .reduce(
         (breakpoints, key) => ({
           ...breakpoints,
@@ -77,7 +77,7 @@ function mergeExtensions({ extend, ...theme }) {
 
     return (resolveThemePath, utils) => ({
       ...value(themeValue, resolveThemePath, utils),
-      ...Object.assign({}, ...extensions.map(e => value(e, resolveThemePath, utils))),
+      ...Object.assign({}, ...extensions.map((e) => value(e, resolveThemePath, utils))),
     })
   })
 }
@@ -108,7 +108,7 @@ function resolveFunctionKeys(object) {
 function extractPluginConfigs(configs) {
   let allConfigs = []
 
-  configs.forEach(config => {
+  configs.forEach((config) => {
     allConfigs = [...allConfigs, config]
 
     const plugins = get(config, 'plugins', [])
@@ -117,7 +117,7 @@ function extractPluginConfigs(configs) {
       return
     }
 
-    plugins.forEach(plugin => {
+    plugins.forEach((plugin) => {
       if (plugin.__isOptionsFunction) {
         plugin = plugin()
       }
@@ -175,7 +175,7 @@ function resolveVariants([firstConfig, ...variantConfigs]) {
             ]
           },
           without(toRemove, existingPluginVariants = get(resolved, plugin, [])) {
-            return existingPluginVariants.filter(v => !toRemove.includes(v))
+            return existingPluginVariants.filter((v) => !toRemove.includes(v))
           },
         })
       } else {
@@ -193,9 +193,9 @@ export default function resolveConfig(configs) {
   return defaults(
     {
       theme: resolveFunctionKeys(
-        mergeExtensions(mergeThemes(map(allConfigs, t => get(t, 'theme', {}))))
+        mergeExtensions(mergeThemes(map(allConfigs, (t) => get(t, 'theme', {}))))
       ),
-      variants: resolveVariants(allConfigs.map(c => c.variants)),
+      variants: resolveVariants(allConfigs.map((c) => c.variants)),
     },
     ...allConfigs
   )

--- a/src/util/usesCustomProperties.js
+++ b/src/util/usesCustomProperties.js
@@ -3,7 +3,7 @@ import valueParser from 'postcss-value-parser'
 export default function usesCustomProperties(value) {
   let foundCustomProperty = false
 
-  valueParser(value).walk(node => {
+  valueParser(value).walk((node) => {
     if (node.type === 'function' && node.value === 'var') {
       foundCustomProperty = true
     }


### PR DESCRIPTION
I am trying to contribute to this project but when I checked out this project and worked through the contributing guidelines I noticed that `npm run style` gives around 300+ linting errors, such as:

```
/Users/weyert/Development/Projects/Opensource/tailwindcss/src/util/resolveConfig.js
   14:15  error  Replace `key` with `(key)`        prettier/prettier
   25:15  error  Replace `key` with `(key)`        prettier/prettier
   80:46  error  Replace `e` with `(e)`            prettier/prettier
  111:19  error  Replace `config` with `(config)`  prettier/prettier
  120:21  error  Replace `plugin` with `(plugin)`  prettier/prettier
  178:50  error  Replace `v` with `(v)`            prettier/prettier
  196:53  error  Replace `t` with `(t)`            prettier/prettier
  198:48  error  Replace `c` with `(c)`            prettier/prettier

/Users/weyert/Development/Projects/Opensource/tailwindcss/src/util/usesCustomProperties.js
  6:27  error  Replace `node` with `(node)`  prettier/prettier

:heavy_multiplication_x: 371 problems (371 errors, 0 warnings)
```

This PR is resolving these problems