### PR TITLE
build: ensure eslint is not enforcing the current formatting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,8 @@
         "useTabs": false,
         "trailingComma": "es5",
         "bracketSpacing": true,
-        "parser": "flow"
+        "parser": "flow",
+        "arrowParens": "avoid"
       }
     ]
   }

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /node_modules
 /lib
 /example
+tailwind.config.js
 index.html
 package-lock.json
 yarn-error.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Scaffold new `tailwind.config.js` files with available `future` flags commented out ([#2379](https://github.com/tailwindlabs/tailwindcss/pull/2379))
 - Don't escape keyframe values ([#2432](https://github.com/tailwindlabs/tailwindcss/pull/2432))
-- Add experimental `2xl` breakpoint ([#2468](https://github.com/tailwindlabs/tailwindcss/pull/2471))
+- Add experimental `2xl` breakpoint ([#2468](https://github.com/tailwindlabs/tailwindcss/pull/2468))
 - Add `col-span-full` and `row-span-full` ([#2471](https://github.com/tailwindlabs/tailwindcss/pull/2471))
 - Promote `defaultLineHeights` and `standardFontWeights` from experimental to future
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't escape keyframe values ([#2432](https://github.com/tailwindlabs/tailwindcss/pull/2432))
 - Add experimental `2xl` breakpoint ([#2468](https://github.com/tailwindlabs/tailwindcss/pull/2471))
 - Add `col-span-full` and `row-span-full` ([#2471](https://github.com/tailwindlabs/tailwindcss/pull/2471))
+- Promote `defaultLineHeights` and `standardFontWeights` from experimental to future
 
 ## [1.8.10] - 2020-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `col-span-full` and `row-span-full` ([#2471](https://github.com/tailwindlabs/tailwindcss/pull/2471))
 - Promote `defaultLineHeights` and `standardFontWeights` from experimental to future
 
+## [1.8.11] - 2020-10-06
+
+- Make `tailwindcss.plugin` work in ESM environments for reasons
+
 ## [1.8.10] - 2020-09-14
 
 ### Fixed
@@ -930,7 +934,8 @@ No release notes
 
 - Everything!
 
-[unreleased]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.10...HEAD
+[unreleased]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.11...HEAD
+[1.8.11]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.10...v1.8.11
 [1.8.10]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.9...v1.8.10
 [1.8.9]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.8...v1.8.9
 [1.8.8]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.7...v1.8.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -927,7 +927,7 @@ No release notes
 - Everything!
 
 [unreleased]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.10...HEAD
-[1.8.9]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.9...v1.8.10
+[1.8.10]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.9...v1.8.10
 [1.8.9]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.8...v1.8.9
 [1.8.8]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.7...v1.8.8
 [1.8.7]: https://github.com/tailwindlabs/tailwindcss/compare/v1.8.6...v1.8.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+- Don't escape keyframe values ([#2432](https://github.com/tailwindlabs/tailwindcss/pull/2432))
 
 ## [1.8.10] - 2020-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Scaffold new `tailwind.config.js` files with available `future` flags commented out ([#2379](https://github.com/tailwindlabs/tailwindcss/pull/2379))
 - Don't escape keyframe values ([#2432](https://github.com/tailwindlabs/tailwindcss/pull/2432))
+- Add experimental `2xl` breakpoint ([#2468](https://github.com/tailwindlabs/tailwindcss/pull/2471))
+- Add `col-span-full` and `row-span-full` ([#2471](https://github.com/tailwindlabs/tailwindcss/pull/2471))
 
 ## [1.8.10] - 2020-09-14
 

--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -4,12 +4,11 @@ import cli from '../src/cli/main'
 import * as constants from '../src/constants'
 import * as utils from '../src/cli/utils'
 import runInTempDirectory from '../jest/runInTempDirectory'
+import featureFlags from '../src/featureFlags'
 
 describe('cli', () => {
   const inputCssPath = path.resolve(__dirname, 'fixtures/tailwind-input.css')
   const customConfigPath = path.resolve(__dirname, 'fixtures/custom-config.js')
-  const defaultConfigFixture = utils.readFile(constants.defaultConfigStubFile)
-  const simpleConfigFixture = utils.readFile(constants.simpleConfigStubFile)
   const defaultPostCssConfigFixture = utils.readFile(constants.defaultPostCssConfigStubFile)
 
   beforeEach(() => {
@@ -21,7 +20,7 @@ describe('cli', () => {
     it('creates a Tailwind config file', () => {
       return runInTempDirectory(() => {
         return cli(['init']).then(() => {
-          expect(utils.readFile(constants.defaultConfigFile)).toEqual(simpleConfigFixture)
+          expect(utils.exists(constants.defaultConfigFile)).toEqual(true)
         })
       })
     })
@@ -29,7 +28,7 @@ describe('cli', () => {
     it('creates a Tailwind config file and a postcss.config.js file', () => {
       return runInTempDirectory(() => {
         return cli(['init', '-p']).then(() => {
-          expect(utils.readFile(constants.defaultConfigFile)).toEqual(simpleConfigFixture)
+          expect(utils.exists(constants.defaultConfigFile)).toEqual(true)
           expect(utils.readFile(constants.defaultPostCssConfigFile)).toEqual(
             defaultPostCssConfigFixture
           )
@@ -40,7 +39,7 @@ describe('cli', () => {
     it('creates a full Tailwind config file', () => {
       return runInTempDirectory(() => {
         return cli(['init', '--full']).then(() => {
-          expect(utils.readFile(constants.defaultConfigFile)).toEqual(defaultConfigFixture)
+          expect(utils.exists(constants.defaultConfigFile)).toEqual(true)
         })
       })
     })
@@ -92,6 +91,16 @@ describe('cli', () => {
     it('compiles CSS file without autoprefixer', () => {
       return cli(['build', inputCssPath, '--no-autoprefixer']).then(() => {
         expect(process.stdout.write.mock.calls[0][0]).not.toContain('-ms-input-placeholder')
+      })
+    })
+
+    it('creates a Tailwind config file with future flags', () => {
+      return runInTempDirectory(() => {
+        return cli(['init']).then(() => {
+          featureFlags.future.forEach(flag => {
+            expect(utils.readFile(constants.defaultConfigFile)).toContain(`${flag}: true`)
+          })
+        })
       })
     })
   })

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -16726,6 +16726,10 @@ video {
   grid-column: span 12 / span 12 !important;
 }
 
+.col-span-full {
+  grid-column: 1 / -1 !important;
+}
+
 .col-start-1 {
   grid-column-start: 1 !important;
 }
@@ -16892,6 +16896,10 @@ video {
 
 .row-span-6 {
   grid-row: span 6 / span 6 !important;
+}
+
+.row-span-full {
+  grid-row: 1 / -1 !important;
 }
 
 .row-start-1 {
@@ -34949,6 +34957,10 @@ video {
     grid-column: span 12 / span 12 !important;
   }
 
+  .sm\:col-span-full {
+    grid-column: 1 / -1 !important;
+  }
+
   .sm\:col-start-1 {
     grid-column-start: 1 !important;
   }
@@ -35115,6 +35127,10 @@ video {
 
   .sm\:row-span-6 {
     grid-row: span 6 / span 6 !important;
+  }
+
+  .sm\:row-span-full {
+    grid-row: 1 / -1 !important;
   }
 
   .sm\:row-start-1 {
@@ -53142,6 +53158,10 @@ video {
     grid-column: span 12 / span 12 !important;
   }
 
+  .md\:col-span-full {
+    grid-column: 1 / -1 !important;
+  }
+
   .md\:col-start-1 {
     grid-column-start: 1 !important;
   }
@@ -53308,6 +53328,10 @@ video {
 
   .md\:row-span-6 {
     grid-row: span 6 / span 6 !important;
+  }
+
+  .md\:row-span-full {
+    grid-row: 1 / -1 !important;
   }
 
   .md\:row-start-1 {
@@ -71335,6 +71359,10 @@ video {
     grid-column: span 12 / span 12 !important;
   }
 
+  .lg\:col-span-full {
+    grid-column: 1 / -1 !important;
+  }
+
   .lg\:col-start-1 {
     grid-column-start: 1 !important;
   }
@@ -71501,6 +71529,10 @@ video {
 
   .lg\:row-span-6 {
     grid-row: span 6 / span 6 !important;
+  }
+
+  .lg\:row-span-full {
+    grid-row: 1 / -1 !important;
   }
 
   .lg\:row-start-1 {
@@ -89528,6 +89560,10 @@ video {
     grid-column: span 12 / span 12 !important;
   }
 
+  .xl\:col-span-full {
+    grid-column: 1 / -1 !important;
+  }
+
   .xl\:col-start-1 {
     grid-column-start: 1 !important;
   }
@@ -89694,6 +89730,10 @@ video {
 
   .xl\:row-span-6 {
     grid-row: span 6 / span 6 !important;
+  }
+
+  .xl\:row-span-full {
+    grid-row: 1 / -1 !important;
   }
 
   .xl\:row-start-1 {

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -14278,6 +14278,10 @@ video {
   grid-column: span 12 / span 12;
 }
 
+.col-span-full {
+  grid-column: 1 / -1;
+}
+
 .col-start-1 {
   grid-column-start: 1;
 }
@@ -14444,6 +14448,10 @@ video {
 
 .row-span-6 {
   grid-row: span 6 / span 6;
+}
+
+.row-span-full {
+  grid-row: 1 / -1;
 }
 
 .row-start-1 {
@@ -30053,6 +30061,10 @@ video {
     grid-column: span 12 / span 12;
   }
 
+  .sm\:col-span-full {
+    grid-column: 1 / -1;
+  }
+
   .sm\:col-start-1 {
     grid-column-start: 1;
   }
@@ -30219,6 +30231,10 @@ video {
 
   .sm\:row-span-6 {
     grid-row: span 6 / span 6;
+  }
+
+  .sm\:row-span-full {
+    grid-row: 1 / -1;
   }
 
   .sm\:row-start-1 {
@@ -45798,6 +45814,10 @@ video {
     grid-column: span 12 / span 12;
   }
 
+  .md\:col-span-full {
+    grid-column: 1 / -1;
+  }
+
   .md\:col-start-1 {
     grid-column-start: 1;
   }
@@ -45964,6 +45984,10 @@ video {
 
   .md\:row-span-6 {
     grid-row: span 6 / span 6;
+  }
+
+  .md\:row-span-full {
+    grid-row: 1 / -1;
   }
 
   .md\:row-start-1 {
@@ -61543,6 +61567,10 @@ video {
     grid-column: span 12 / span 12;
   }
 
+  .lg\:col-span-full {
+    grid-column: 1 / -1;
+  }
+
   .lg\:col-start-1 {
     grid-column-start: 1;
   }
@@ -61709,6 +61737,10 @@ video {
 
   .lg\:row-span-6 {
     grid-row: span 6 / span 6;
+  }
+
+  .lg\:row-span-full {
+    grid-row: 1 / -1;
   }
 
   .lg\:row-start-1 {
@@ -77288,6 +77320,10 @@ video {
     grid-column: span 12 / span 12;
   }
 
+  .xl\:col-span-full {
+    grid-column: 1 / -1;
+  }
+
   .xl\:col-start-1 {
     grid-column-start: 1;
   }
@@ -77454,6 +77490,10 @@ video {
 
   .xl\:row-span-6 {
     grid-row: span 6 / span 6;
+  }
+
+  .xl\:row-span-full {
+    grid-row: 1 / -1;
   }
 
   .xl\:row-start-1 {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -16726,6 +16726,10 @@ video {
   grid-column: span 12 / span 12;
 }
 
+.col-span-full {
+  grid-column: 1 / -1;
+}
+
 .col-start-1 {
   grid-column-start: 1;
 }
@@ -16892,6 +16896,10 @@ video {
 
 .row-span-6 {
   grid-row: span 6 / span 6;
+}
+
+.row-span-full {
+  grid-row: 1 / -1;
 }
 
 .row-start-1 {
@@ -34949,6 +34957,10 @@ video {
     grid-column: span 12 / span 12;
   }
 
+  .sm\:col-span-full {
+    grid-column: 1 / -1;
+  }
+
   .sm\:col-start-1 {
     grid-column-start: 1;
   }
@@ -35115,6 +35127,10 @@ video {
 
   .sm\:row-span-6 {
     grid-row: span 6 / span 6;
+  }
+
+  .sm\:row-span-full {
+    grid-row: 1 / -1;
   }
 
   .sm\:row-start-1 {
@@ -53142,6 +53158,10 @@ video {
     grid-column: span 12 / span 12;
   }
 
+  .md\:col-span-full {
+    grid-column: 1 / -1;
+  }
+
   .md\:col-start-1 {
     grid-column-start: 1;
   }
@@ -53308,6 +53328,10 @@ video {
 
   .md\:row-span-6 {
     grid-row: span 6 / span 6;
+  }
+
+  .md\:row-span-full {
+    grid-row: 1 / -1;
   }
 
   .md\:row-start-1 {
@@ -71335,6 +71359,10 @@ video {
     grid-column: span 12 / span 12;
   }
 
+  .lg\:col-span-full {
+    grid-column: 1 / -1;
+  }
+
   .lg\:col-start-1 {
     grid-column-start: 1;
   }
@@ -71501,6 +71529,10 @@ video {
 
   .lg\:row-span-6 {
     grid-row: span 6 / span 6;
+  }
+
+  .lg\:row-span-full {
+    grid-row: 1 / -1;
   }
 
   .lg\:row-start-1 {
@@ -89528,6 +89560,10 @@ video {
     grid-column: span 12 / span 12;
   }
 
+  .xl\:col-span-full {
+    grid-column: 1 / -1;
+  }
+
   .xl\:col-start-1 {
     grid-column-start: 1;
   }
@@ -89694,6 +89730,10 @@ video {
 
   .xl\:row-span-6 {
     grid-row: span 6 / span 6;
+  }
+
+  .xl\:row-span-full {
+    grid-row: 1 / -1;
   }
 
   .xl\:row-start-1 {

--- a/__tests__/processPlugins.test.js
+++ b/__tests__/processPlugins.test.js
@@ -2003,3 +2003,50 @@ test('plugins can extend variants', () => {
       expect(result.css).toMatchCss(expected)
     })
 })
+
+test('keyframes are not escaped', () => {
+  const { components, utilities } = processPlugins(
+    [
+      function({ addUtilities, addComponents }) {
+        addComponents({
+          '@keyframes foo': {
+            '25.001%': {
+              color: 'black',
+            },
+          },
+        })
+        addUtilities({
+          '@keyframes bar': {
+            '75.001%': {
+              color: 'white',
+            },
+          },
+        })
+      },
+    ],
+    makeConfig()
+  )
+
+  expect(css(components)).toMatchCss(`
+    @layer components {
+      @variants {
+        @keyframes foo {
+          25.001% {
+            color: black
+          }
+        }
+      }
+    }
+  `)
+  expect(css(utilities)).toMatchCss(`
+    @layer utilities {
+      @variants {
+        @keyframes bar {
+          75.001% {
+            color: white
+          }
+        }
+      }
+    }
+  `)
+})

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -35,15 +35,26 @@ export function run(cliParams, cliOptions) {
   return new Promise(resolve => {
     utils.header()
 
-    const full = cliOptions.full
     const file = cliParams[0] || constants.defaultConfigFile
     const simplePath = utils.getSimplePath(file)
 
     utils.exists(file) && utils.die(colors.file(simplePath), 'already exists.')
 
-    const stubFile = full ? constants.defaultConfigStubFile : constants.simpleConfigStubFile
+    const stubFile = cliOptions.full
+      ? constants.defaultConfigStubFile
+      : constants.simpleConfigStubFile
 
-    utils.copyFile(stubFile, file)
+    const config = require(stubFile)
+    const { future: flags } = require('../../featureFlags').default
+
+    flags.forEach(flag => {
+      config.future[`// ${flag}`] = true
+    })
+
+    utils.writeFile(
+      file,
+      `module.exports = ${JSON.stringify(config, null, 2).replace(/"([^-_\d"]+)":/g, '$1:')}\n`
+    )
 
     utils.log()
     utils.log(emoji.yes, 'Created Tailwind config file:', colors.file(simplePath))

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -3,15 +3,18 @@ import chalk from 'chalk'
 import log from './util/log'
 
 const featureFlags = {
-  future: ['removeDeprecatedGapUtilities', 'purgeLayersByDefault'],
+  future: [
+    'removeDeprecatedGapUtilities',
+    'purgeLayersByDefault',
+    'defaultLineHeights',
+    'standardFontWeights',
+  ],
   experimental: [
     'uniformColorPalette',
     'extendedSpacingScale',
-    'defaultLineHeights',
     'extendedFontSizeScale',
     'applyComplexClasses',
     'darkModeVariant',
-    'standardFontWeights',
     'additionalBreakpoint',
   ],
 }

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -12,6 +12,7 @@ const featureFlags = {
     'applyComplexClasses',
     'darkModeVariant',
     'standardFontWeights',
+    'additionalBreakpoint',
   ],
 }
 

--- a/src/flagged/additionalBreakpoint.js
+++ b/src/flagged/additionalBreakpoint.js
@@ -1,0 +1,11 @@
+export default {
+  theme: {
+    screens: {
+      sm: '640px',
+      md: '768px',
+      lg: '1024px',
+      xl: '1280px',
+      '2xl': '1536px',
+    },
+  },
+}

--- a/src/util/getAllConfigs.js
+++ b/src/util/getAllConfigs.js
@@ -6,33 +6,25 @@ import defaultLineHeights from '../flagged/defaultLineHeights.js'
 import extendedFontSizeScale from '../flagged/extendedFontSizeScale.js'
 import darkModeVariant from '../flagged/darkModeVariant.js'
 import standardFontWeights from '../flagged/standardFontWeights'
+import additionalBreakpoint from '../flagged/additionalBreakpoint'
 
 export default function getAllConfigs(config) {
   const configs = [defaultConfig]
-
-  if (flagEnabled(config, 'uniformColorPalette')) {
-    configs.unshift(uniformColorPalette)
+  const features = {
+    uniformColorPalette,
+    extendedSpacingScale,
+    defaultLineHeights,
+    extendedFontSizeScale,
+    standardFontWeights,
+    darkModeVariant,
+    additionalBreakpoint,
   }
 
-  if (flagEnabled(config, 'extendedSpacingScale')) {
-    configs.unshift(extendedSpacingScale)
-  }
-
-  if (flagEnabled(config, 'defaultLineHeights')) {
-    configs.unshift(defaultLineHeights)
-  }
-
-  if (flagEnabled(config, 'extendedFontSizeScale')) {
-    configs.unshift(extendedFontSizeScale)
-  }
-
-  if (flagEnabled(config, 'standardFontWeights')) {
-    configs.unshift(standardFontWeights)
-  }
-
-  if (flagEnabled(config, 'darkModeVariant')) {
-    configs.unshift(darkModeVariant)
-  }
+  Object.keys(features).forEach(feature => {
+    if (flagEnabled(config, feature)) {
+      configs.unshift(features[feature])
+    }
+  })
 
   return [config, ...configs]
 }

--- a/src/util/processPlugins.js
+++ b/src/util/processPlugins.js
@@ -27,6 +27,10 @@ function wrapWithLayer(rules, layer) {
     .append(cloneNodes(Array.isArray(rules) ? rules : [rules]))
 }
 
+function isKeyframeRule(rule) {
+  return rule.parent && rule.parent.type === 'atrule' && /keyframes$/.test(rule.parent.name)
+}
+
 export default function(plugins, config) {
   const pluginBaseStyles = []
   const pluginComponents = []
@@ -88,7 +92,7 @@ export default function(plugins, config) {
         const styles = postcss.root({ nodes: parseStyles(utilities) })
 
         styles.walkRules(rule => {
-          if (options.respectPrefix) {
+          if (options.respectPrefix && !isKeyframeRule(rule)) {
             rule.selector = applyConfiguredPrefix(rule.selector)
           }
 
@@ -114,7 +118,7 @@ export default function(plugins, config) {
         const styles = postcss.root({ nodes: parseStyles(components) })
 
         styles.walkRules(rule => {
-          if (options.respectPrefix) {
+          if (options.respectPrefix && !isKeyframeRule(rule)) {
             rule.selector = applyConfiguredPrefix(rule.selector)
           }
         })

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -1,8 +1,5 @@
 module.exports = {
-  future: {
-    // removeDeprecatedGapUtilities: true,
-    // purgeLayersByDefault: true,
-  },
+  future: {},
   purge: [],
   target: 'relaxed',
   prefix: '',

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -480,6 +480,7 @@ module.exports = {
       'span-10': 'span 10 / span 10',
       'span-11': 'span 11 / span 11',
       'span-12': 'span 12 / span 12',
+      'span-full': '1 / -1',
     },
     gridColumnStart: {
       auto: 'auto',
@@ -530,6 +531,7 @@ module.exports = {
       'span-4': 'span 4 / span 4',
       'span-5': 'span 5 / span 5',
       'span-6': 'span 6 / span 6',
+      'span-full': '1 / -1',
     },
     gridRowStart: {
       auto: 'auto',

--- a/stubs/simpleConfig.stub.js
+++ b/stubs/simpleConfig.stub.js
@@ -1,8 +1,5 @@
 module.exports = {
-  future: {
-    // removeDeprecatedGapUtilities: true,
-    // purgeLayersByDefault: true,
-  },
+  future: {},
   purge: [],
   theme: {
     extend: {},


### PR DESCRIPTION
This pull request attempts to correct the Prettier configuration defined in the `eslint`-config which appears not to match the formatting of the files which cause false linting errors.

See also: #2504 