### PR TITLE
added white-space to wordBreak options

### DIFF
--- a/__tests__/fixtures/tailwind-output-ie11.css
+++ b/__tests__/fixtures/tailwind-output-ie11.css
@@ -9014,14 +9014,17 @@ video {
 .break-normal {
   overflow-wrap: normal;
   word-break: normal;
+  white-space: normal;
 }
 
 .break-words {
   overflow-wrap: break-word;
+  white-space: normal;
 }
 
 .break-all {
   word-break: break-all;
+  white-space: normal;
 }
 
 .truncate {
@@ -19484,14 +19487,17 @@ video {
   .sm\:break-normal {
     overflow-wrap: normal;
     word-break: normal;
+    white-space: normal;
   }
 
   .sm\:break-words {
     overflow-wrap: break-word;
+    white-space: normal;
   }
 
   .sm\:break-all {
     word-break: break-all;
+    white-space: normal;
   }
 
   .sm\:truncate {
@@ -29924,14 +29930,17 @@ video {
   .md\:break-normal {
     overflow-wrap: normal;
     word-break: normal;
+    white-space: normal;
   }
 
   .md\:break-words {
     overflow-wrap: break-word;
+    white-space: normal;
   }
 
   .md\:break-all {
     word-break: break-all;
+    white-space: normal;
   }
 
   .md\:truncate {
@@ -40364,14 +40373,17 @@ video {
   .lg\:break-normal {
     overflow-wrap: normal;
     word-break: normal;
+    white-space: normal;
   }
 
   .lg\:break-words {
     overflow-wrap: break-word;
+    white-space: normal;
   }
 
   .lg\:break-all {
     word-break: break-all;
+    white-space: normal;
   }
 
   .lg\:truncate {
@@ -50804,14 +50816,17 @@ video {
   .xl\:break-normal {
     overflow-wrap: normal;
     word-break: normal;
+    white-space: normal;
   }
 
   .xl\:break-words {
     overflow-wrap: break-word;
+    white-space: normal;
   }
 
   .xl\:break-all {
     word-break: break-all;
+    white-space: normal;
   }
 
   .xl\:truncate {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -15895,14 +15895,17 @@ video {
 .break-normal {
   overflow-wrap: normal !important;
   word-break: normal !important;
+  white-space: normal !important;
 }
 
 .break-words {
   overflow-wrap: break-word !important;
+  white-space: normal !important;
 }
 
 .break-all {
   word-break: break-all !important;
+  white-space: normal !important;
 }
 
 .truncate {
@@ -34126,14 +34129,17 @@ video {
   .sm\:break-normal {
     overflow-wrap: normal !important;
     word-break: normal !important;
+    white-space: normal !important;
   }
 
   .sm\:break-words {
     overflow-wrap: break-word !important;
+    white-space: normal !important;
   }
 
   .sm\:break-all {
     word-break: break-all !important;
+    white-space: normal !important;
   }
 
   .sm\:truncate {
@@ -52327,14 +52333,17 @@ video {
   .md\:break-normal {
     overflow-wrap: normal !important;
     word-break: normal !important;
+    white-space: normal !important;
   }
 
   .md\:break-words {
     overflow-wrap: break-word !important;
+    white-space: normal !important;
   }
 
   .md\:break-all {
     word-break: break-all !important;
+    white-space: normal !important;
   }
 
   .md\:truncate {
@@ -70528,14 +70537,17 @@ video {
   .lg\:break-normal {
     overflow-wrap: normal !important;
     word-break: normal !important;
+    white-space: normal !important;
   }
 
   .lg\:break-words {
     overflow-wrap: break-word !important;
+    white-space: normal !important;
   }
 
   .lg\:break-all {
     word-break: break-all !important;
+    white-space: normal !important;
   }
 
   .lg\:truncate {
@@ -88729,14 +88741,17 @@ video {
   .xl\:break-normal {
     overflow-wrap: normal !important;
     word-break: normal !important;
+    white-space: normal !important;
   }
 
   .xl\:break-words {
     overflow-wrap: break-word !important;
+    white-space: normal !important;
   }
 
   .xl\:break-all {
     word-break: break-all !important;
+    white-space: normal !important;
   }
 
   .xl\:truncate {

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -13447,14 +13447,17 @@ video {
 .break-normal {
   overflow-wrap: normal;
   word-break: normal;
+  white-space: normal;
 }
 
 .break-words {
   overflow-wrap: break-word;
+  white-space: normal;
 }
 
 .break-all {
   word-break: break-all;
+  white-space: normal;
 }
 
 .truncate {
@@ -29230,14 +29233,17 @@ video {
   .sm\:break-normal {
     overflow-wrap: normal;
     word-break: normal;
+    white-space: normal;
   }
 
   .sm\:break-words {
     overflow-wrap: break-word;
+    white-space: normal;
   }
 
   .sm\:break-all {
     word-break: break-all;
+    white-space: normal;
   }
 
   .sm\:truncate {
@@ -44983,14 +44989,17 @@ video {
   .md\:break-normal {
     overflow-wrap: normal;
     word-break: normal;
+    white-space: normal;
   }
 
   .md\:break-words {
     overflow-wrap: break-word;
+    white-space: normal;
   }
 
   .md\:break-all {
     word-break: break-all;
+    white-space: normal;
   }
 
   .md\:truncate {
@@ -60736,14 +60745,17 @@ video {
   .lg\:break-normal {
     overflow-wrap: normal;
     word-break: normal;
+    white-space: normal;
   }
 
   .lg\:break-words {
     overflow-wrap: break-word;
+    white-space: normal;
   }
 
   .lg\:break-all {
     word-break: break-all;
+    white-space: normal;
   }
 
   .lg\:truncate {
@@ -76489,14 +76501,17 @@ video {
   .xl\:break-normal {
     overflow-wrap: normal;
     word-break: normal;
+    white-space: normal;
   }
 
   .xl\:break-words {
     overflow-wrap: break-word;
+    white-space: normal;
   }
 
   .xl\:break-all {
     word-break: break-all;
+    white-space: normal;
   }
 
   .xl\:truncate {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -15895,14 +15895,17 @@ video {
 .break-normal {
   overflow-wrap: normal;
   word-break: normal;
+  white-space: normal;
 }
 
 .break-words {
   overflow-wrap: break-word;
+  white-space: normal;
 }
 
 .break-all {
   word-break: break-all;
+  white-space: normal;
 }
 
 .truncate {
@@ -34126,14 +34129,17 @@ video {
   .sm\:break-normal {
     overflow-wrap: normal;
     word-break: normal;
+    white-space: normal;
   }
 
   .sm\:break-words {
     overflow-wrap: break-word;
+    white-space: normal;
   }
 
   .sm\:break-all {
     word-break: break-all;
+    white-space: normal;
   }
 
   .sm\:truncate {
@@ -52327,14 +52333,17 @@ video {
   .md\:break-normal {
     overflow-wrap: normal;
     word-break: normal;
+    white-space: normal;
   }
 
   .md\:break-words {
     overflow-wrap: break-word;
+    white-space: normal;
   }
 
   .md\:break-all {
     word-break: break-all;
+    white-space: normal;
   }
 
   .md\:truncate {
@@ -70528,14 +70537,17 @@ video {
   .lg\:break-normal {
     overflow-wrap: normal;
     word-break: normal;
+    white-space: normal;
   }
 
   .lg\:break-words {
     overflow-wrap: break-word;
+    white-space: normal;
   }
 
   .lg\:break-all {
     word-break: break-all;
+    white-space: normal;
   }
 
   .lg\:truncate {
@@ -88729,14 +88741,17 @@ video {
   .xl\:break-normal {
     overflow-wrap: normal;
     word-break: normal;
+    white-space: normal;
   }
 
   .xl\:break-words {
     overflow-wrap: break-word;
+    white-space: normal;
   }
 
   .xl\:break-all {
     word-break: break-all;
+    white-space: normal;
   }
 
   .xl\:truncate {

--- a/src/plugins/wordBreak.js
+++ b/src/plugins/wordBreak.js
@@ -5,9 +5,10 @@ export default function() {
         '.break-normal': {
           'overflow-wrap': 'normal',
           'word-break': 'normal',
+          'white-space': 'normal',
         },
-        '.break-words': { 'overflow-wrap': 'break-word' },
-        '.break-all': { 'word-break': 'break-all' },
+        '.break-words': { 'overflow-wrap': 'break-word', 'white-space': 'normal' },
+        '.break-all': { 'word-break': 'break-all', 'white-space': 'normal' },
 
         '.truncate': {
           overflow: 'hidden',


### PR DESCRIPTION
Potential fix for issue https://github.com/tailwindlabs/tailwindcss/issues/2517

Bug in use 'truncate' combined 'break-words' #2517
