### PR TITLE
Support disabling dark mode globally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make `outline` configurable, `outline-none` more accessible by default, and add `outline-black` and `outline-white` ([#2460](https://github.com/tailwindlabs/tailwindcss/pull/2460))
 - Add additional small `rotate` and `skew` values ([#2528](https://github.com/tailwindlabs/tailwindcss/pull/2528))
 - Add `xl`, `2xl`, and `3xl` border radius values ([#2529](https://github.com/tailwindlabs/tailwindcss/pull/2529))
+- Support disabling dark mode variants globally ([#2530](https://github.com/tailwindlabs/tailwindcss/pull/2530))
 
 ## [1.8.12] - 2020-10-07
 

--- a/__tests__/darkMode.test.js
+++ b/__tests__/darkMode.test.js
@@ -143,6 +143,29 @@ test('dark mode variants can be generated using the class strategy', () => {
   })
 })
 
+test('dark mode variants can be disabled', () => {
+  const input = `
+    @variants dark {
+      .text-red {
+        color: red;
+      }
+    }
+  `
+
+  const expected = `
+    .text-red {
+      color: red;
+    }
+  `
+
+  expect.assertions(2)
+
+  return run(input, { dark: false }).then(result => {
+    expect(result.css).toMatchCss(expected)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('dark mode variants stack with other variants', () => {
   const input = `
     @variants responsive, dark, hover, focus {

--- a/src/flagged/darkModeVariantPlugin.js
+++ b/src/flagged/darkModeVariantPlugin.js
@@ -4,6 +4,10 @@ export default function({ addVariant, config, postcss, prefix }) {
   addVariant(
     'dark',
     ({ container, separator, modifySelectors }) => {
+      if (config('dark') === false) {
+        return postcss.root()
+      }
+
       if (config('dark') === 'media') {
         const modified = modifySelectors(({ selector }) => {
           return buildSelectorVariant(selector, 'dark', separator, message => {


### PR DESCRIPTION
This PR adds support setting `dark` to `false` in your config file to prevent dark mode variants from being generated.

Normally I would say just disable it individually for all of the core plugins where you have it enabled, but since we are going to enable it out of the box and it adds considerable file size and we already have a global config option for it, it seemed like a useful thing to support for people who don't care about dark mode and want their builds to purge a bit faster.