### PR TITLE
Rename max-content and min-content to max and min in experimental spacing scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `xl`, `2xl`, and `3xl` border radius values ([#2529](https://github.com/tailwindlabs/tailwindcss/pull/2529))
 - Support disabling dark mode variants globally ([#2530](https://github.com/tailwindlabs/tailwindcss/pull/2530))
 - Add new utilities for `grid-auto-columns` and `grid-auto-rows` ([#2531](https://github.com/tailwindlabs/tailwindcss/pull/2531))
+- Rename `{u}-max-content` and `{u}-min-content` utilities to `{u}-max` and `{u}-min` in experimental extended spacing scale ([#2532](https://github.com/tailwindlabs/tailwindcss/pull/2532))
 
 ## [1.8.12] - 2020-10-07
 

--- a/src/flagged/extendedSpacingScale.js
+++ b/src/flagged/extendedSpacingScale.js
@@ -74,15 +74,15 @@ export default {
     minWidth: {
       '0': '0',
       full: '100%',
-      'min-content': 'min-content',
-      'max-content': 'max-content',
+      min: 'min-content',
+      max: 'max-content',
     },
     width: theme => ({
       auto: 'auto',
       ...theme('spacing'),
       screen: '100vw',
-      'min-content': 'min-content',
-      'max-content': 'max-content',
+      min: 'min-content',
+      max: 'max-content',
     }),
     maxWidth: (theme, { breakpoints }) => ({
       none: 'none',
@@ -99,8 +99,8 @@ export default {
       '6xl': '72rem',
       '7xl': '80rem',
       full: '100%',
-      'min-content': 'min-content',
-      'max-content': 'max-content',
+      min: 'min-content',
+      max: 'max-content',
       ...breakpoints(theme('screens')),
     }),
     maxHeight: theme => ({


### PR DESCRIPTION
This PR renames the `max-content` and `min-content` utilities under `width`, `minWidth`, and `maxWidth` to just `max` and `min` respectively to be more consistent with the new `auto-cols/rows-max/min` utilities. We'll have to remember to update this stuff in the Tailwind UI templates when Tailwind 2.0 is released.