### PR TITLE
Merge plugins when resolving config

### DIFF
--- a/__tests__/resolveConfig.test.js
+++ b/__tests__/resolveConfig.test.js
@@ -1856,3 +1856,33 @@ test('core plugin configurations stack', () => {
     corePlugins: ['float', 'padding', 'margin'],
   })
 })
+
+test('plugins are merged', () => {
+  const userConfig = {
+    plugins: ['3'],
+  }
+
+  const otherConfig = {
+    plugins: ['2'],
+  }
+
+  const defaultConfig = {
+    plugins: ['1'],
+    prefix: '',
+    important: false,
+    separator: ':',
+    theme: {},
+    variants: {},
+  }
+
+  const result = resolveConfig([userConfig, otherConfig, defaultConfig])
+
+  expect(result).toMatchObject({
+    prefix: '',
+    important: false,
+    separator: ':',
+    theme: {},
+    variants: {},
+    plugins: ['1', '2', '3'],
+  })
+})

--- a/src/util/resolveConfig.js
+++ b/src/util/resolveConfig.js
@@ -200,6 +200,14 @@ function resolveCorePlugins(corePluginConfigs) {
   return result
 }
 
+function resolvePluginLists(pluginLists) {
+  const result = [...pluginLists].reverse().reduce((resolved, pluginList) => {
+    return [...resolved, ...pluginList]
+  }, [])
+
+  return result
+}
+
 export default function resolveConfig(configs) {
   const allConfigs = extractPluginConfigs(configs)
 
@@ -210,6 +218,7 @@ export default function resolveConfig(configs) {
       ),
       variants: resolveVariants(allConfigs.map(c => c.variants)),
       corePlugins: resolveCorePlugins(allConfigs.map(c => c.corePlugins)),
+      plugins: resolvePluginLists(configs.map(c => get(c, 'plugins', []))),
     },
     ...allConfigs
   )


### PR DESCRIPTION
This PR fixes what I would consider to be a bug where if you are using the new `presets` option and your preset contains plugins, those plugins are overridden by the user's config, effectively making those plugins ignored.

I think if someone has put plugins into their base config, those plugins should be included even if the user has `plugins: []` in their config.