### PR TITLE
Move truncate to textOverflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `overflow-ellipsis` and `overflow-clip` utilities ([#1289](https://github.com/tailwindlabs/tailwindcss/pull/1289))
+- Move `truncate` class to `textOverflow` core plugin ([#2562](https://github.com/tailwindlabs/tailwindcss/pull/2562))
 
 ## [1.9.2]
 

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -8,6 +8,7 @@ const featureFlags = {
     'purgeLayersByDefault',
     'defaultLineHeights',
     'standardFontWeights',
+    'moveTruncateToTextOverflow',
   ],
   experimental: [
     'uniformColorPalette',

--- a/src/plugins/textOverflow.js
+++ b/src/plugins/textOverflow.js
@@ -1,7 +1,18 @@
+import { flagEnabled } from '../featureFlags'
+
 export default function() {
-  return function({ addUtilities, variants }) {
+  return function({ addUtilities, variants, config }) {
     addUtilities(
       {
+        ...(flagEnabled(config(), 'moveTruncateToTextOverflow')
+          ? {
+              '.truncate': {
+                overflow: 'hidden',
+                'text-overflow': 'ellipsis',
+                'white-space': 'nowrap',
+              },
+            }
+          : {}),
         '.overflow-ellipsis': { 'text-overflow': 'ellipsis' },
         '.overflow-clip': { 'text-overflow': 'clip' },
       },

--- a/src/plugins/wordBreak.js
+++ b/src/plugins/wordBreak.js
@@ -1,5 +1,7 @@
+import { flagEnabled } from '../featureFlags'
+
 export default function() {
-  return function({ addUtilities, variants }) {
+  return function({ addUtilities, variants, config }) {
     addUtilities(
       {
         '.break-normal': {
@@ -15,11 +17,15 @@ export default function() {
         },
         '.break-all': { 'word-break': 'break-all' },
 
-        '.truncate': {
-          overflow: 'hidden',
-          'text-overflow': 'ellipsis',
-          'white-space': 'nowrap',
-        },
+        ...(!flagEnabled(config(), 'moveTruncateToTextOverflow')
+          ? {
+              '.truncate': {
+                overflow: 'hidden',
+                'text-overflow': 'ellipsis',
+                'white-space': 'nowrap',
+              },
+            }
+          : {}),
       },
       variants('wordBreak')
     )


### PR DESCRIPTION
This PR moves the `truncate` utility into the new `textOverflow` core plugin since that just makes way more sense and doesn't really affect anyone in any meaningful way. Technically a breaking change so it's behind a `moveTruncateToTextOverflow` flag for now.