### PR TITLE
add the relative font weights

### DIFF
--- a/src/flagged/standardFontWeights.js
+++ b/src/flagged/standardFontWeights.js
@@ -10,6 +10,8 @@ export default {
       bold: '700',
       extrabold: '800',
       black: '900',
+      lighter: 'lighter',
+      bolder: 'bolder',
     },
   },
 }


### PR DESCRIPTION
`lighter` and `bolder` are relative font weights that reference the parent element.

https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight