### PR TITLE
Remove `scrolling-touch/auto` utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed `target` feature and dropped any compatibility with IE 11 ([#2571](https://github.com/tailwindlabs/tailwindcss/pull/2571))
 - Switch `normalize.css` to `modern-normalize` ([#2572](https://github.com/tailwindlabs/tailwindcss/pull/2572))
+- Remove `scrolling-touch` and `scrolling-auto` utilities ([#2573](https://github.com/tailwindlabs/tailwindcss/pull/2573))
 
 ## [1.9.2]
 

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -11344,14 +11344,6 @@ video {
   overflow-y: scroll !important;
 }
 
-.scrolling-touch {
-  -webkit-overflow-scrolling: touch !important;
-}
-
-.scrolling-auto {
-  -webkit-overflow-scrolling: auto !important;
-}
-
 .overscroll-auto {
   overscroll-behavior: auto !important;
 }
@@ -28871,14 +28863,6 @@ video {
     overflow-y: scroll !important;
   }
 
-  .sm\:scrolling-touch {
-    -webkit-overflow-scrolling: touch !important;
-  }
-
-  .sm\:scrolling-auto {
-    -webkit-overflow-scrolling: auto !important;
-  }
-
   .sm\:overscroll-auto {
     overscroll-behavior: auto !important;
   }
@@ -46366,14 +46350,6 @@ video {
 
   .md\:overflow-y-scroll {
     overflow-y: scroll !important;
-  }
-
-  .md\:scrolling-touch {
-    -webkit-overflow-scrolling: touch !important;
-  }
-
-  .md\:scrolling-auto {
-    -webkit-overflow-scrolling: auto !important;
   }
 
   .md\:overscroll-auto {
@@ -63865,14 +63841,6 @@ video {
     overflow-y: scroll !important;
   }
 
-  .lg\:scrolling-touch {
-    -webkit-overflow-scrolling: touch !important;
-  }
-
-  .lg\:scrolling-auto {
-    -webkit-overflow-scrolling: auto !important;
-  }
-
   .lg\:overscroll-auto {
     overscroll-behavior: auto !important;
   }
@@ -81360,14 +81328,6 @@ video {
 
   .xl\:overflow-y-scroll {
     overflow-y: scroll !important;
-  }
-
-  .xl\:scrolling-touch {
-    -webkit-overflow-scrolling: touch !important;
-  }
-
-  .xl\:scrolling-auto {
-    -webkit-overflow-scrolling: auto !important;
   }
 
   .xl\:overscroll-auto {

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -10560,14 +10560,6 @@ video {
   overflow-y: scroll;
 }
 
-.scrolling-touch {
-  -webkit-overflow-scrolling: touch;
-}
-
-.scrolling-auto {
-  -webkit-overflow-scrolling: auto;
-}
-
 .overscroll-auto {
   overscroll-behavior: auto;
 }
@@ -26743,14 +26735,6 @@ video {
     overflow-y: scroll;
   }
 
-  .sm\:scrolling-touch {
-    -webkit-overflow-scrolling: touch;
-  }
-
-  .sm\:scrolling-auto {
-    -webkit-overflow-scrolling: auto;
-  }
-
   .sm\:overscroll-auto {
     overscroll-behavior: auto;
   }
@@ -42894,14 +42878,6 @@ video {
 
   .md\:overflow-y-scroll {
     overflow-y: scroll;
-  }
-
-  .md\:scrolling-touch {
-    -webkit-overflow-scrolling: touch;
-  }
-
-  .md\:scrolling-auto {
-    -webkit-overflow-scrolling: auto;
   }
 
   .md\:overscroll-auto {
@@ -59049,14 +59025,6 @@ video {
     overflow-y: scroll;
   }
 
-  .lg\:scrolling-touch {
-    -webkit-overflow-scrolling: touch;
-  }
-
-  .lg\:scrolling-auto {
-    -webkit-overflow-scrolling: auto;
-  }
-
   .lg\:overscroll-auto {
     overscroll-behavior: auto;
   }
@@ -75200,14 +75168,6 @@ video {
 
   .xl\:overflow-y-scroll {
     overflow-y: scroll;
-  }
-
-  .xl\:scrolling-touch {
-    -webkit-overflow-scrolling: touch;
-  }
-
-  .xl\:scrolling-auto {
-    -webkit-overflow-scrolling: auto;
   }
 
   .xl\:overscroll-auto {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -11344,14 +11344,6 @@ video {
   overflow-y: scroll;
 }
 
-.scrolling-touch {
-  -webkit-overflow-scrolling: touch;
-}
-
-.scrolling-auto {
-  -webkit-overflow-scrolling: auto;
-}
-
 .overscroll-auto {
   overscroll-behavior: auto;
 }
@@ -28871,14 +28863,6 @@ video {
     overflow-y: scroll;
   }
 
-  .sm\:scrolling-touch {
-    -webkit-overflow-scrolling: touch;
-  }
-
-  .sm\:scrolling-auto {
-    -webkit-overflow-scrolling: auto;
-  }
-
   .sm\:overscroll-auto {
     overscroll-behavior: auto;
   }
@@ -46366,14 +46350,6 @@ video {
 
   .md\:overflow-y-scroll {
     overflow-y: scroll;
-  }
-
-  .md\:scrolling-touch {
-    -webkit-overflow-scrolling: touch;
-  }
-
-  .md\:scrolling-auto {
-    -webkit-overflow-scrolling: auto;
   }
 
   .md\:overscroll-auto {
@@ -63865,14 +63841,6 @@ video {
     overflow-y: scroll;
   }
 
-  .lg\:scrolling-touch {
-    -webkit-overflow-scrolling: touch;
-  }
-
-  .lg\:scrolling-auto {
-    -webkit-overflow-scrolling: auto;
-  }
-
   .lg\:overscroll-auto {
     overscroll-behavior: auto;
   }
@@ -81360,14 +81328,6 @@ video {
 
   .xl\:overflow-y-scroll {
     overflow-y: scroll;
-  }
-
-  .xl\:scrolling-touch {
-    -webkit-overflow-scrolling: touch;
-  }
-
-  .xl\:scrolling-auto {
-    -webkit-overflow-scrolling: auto;
   }
 
   .xl\:overscroll-auto {

--- a/src/plugins/overflow.js
+++ b/src/plugins/overflow.js
@@ -14,8 +14,6 @@ export default function() {
         '.overflow-y-visible': { 'overflow-y': 'visible' },
         '.overflow-x-scroll': { 'overflow-x': 'scroll' },
         '.overflow-y-scroll': { 'overflow-y': 'scroll' },
-        '.scrolling-touch': { '-webkit-overflow-scrolling': 'touch' },
-        '.scrolling-auto': { '-webkit-overflow-scrolling': 'auto' },
       },
       variants('overflow')
     )


### PR DESCRIPTION
No longer supported by iOS as of iOS 13, and was always weird that they lived in the `overflow` plugin.