### PR TITLE
Add 65ch widths for better readability

### DIFF
--- a/__tests__/fixtures/tailwind-output-flagged.css
+++ b/__tests__/fixtures/tailwind-output-flagged.css
@@ -12141,6 +12141,10 @@ video {
   max-width: max-content;
 }
 
+.max-w-prose {
+  max-width: 65ch;
+}
+
 .max-w-screen-sm {
   max-width: 640px;
 }
@@ -35117,6 +35121,10 @@ video {
     max-width: max-content;
   }
 
+  .sm\:max-w-prose {
+    max-width: 65ch;
+  }
+
   .sm\:max-w-screen-sm {
     max-width: 640px;
   }
@@ -58061,6 +58069,10 @@ video {
 
   .md\:max-w-max {
     max-width: max-content;
+  }
+
+  .md\:max-w-prose {
+    max-width: 65ch;
   }
 
   .md\:max-w-screen-sm {
@@ -81009,6 +81021,10 @@ video {
     max-width: max-content;
   }
 
+  .lg\:max-w-prose {
+    max-width: 65ch;
+  }
+
   .lg\:max-w-screen-sm {
     max-width: 640px;
   }
@@ -103955,6 +103971,10 @@ video {
     max-width: max-content;
   }
 
+  .xl\:max-w-prose {
+    max-width: 65ch;
+  }
+
   .xl\:max-w-screen-sm {
     max-width: 640px;
   }
@@ -126899,6 +126919,10 @@ video {
 
   .\32xl\:max-w-max {
     max-width: max-content;
+  }
+
+  .\32xl\:max-w-prose {
+    max-width: 65ch;
   }
 
   .\32xl\:max-w-screen-sm {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -12141,6 +12141,10 @@ video {
   max-width: max-content !important;
 }
 
+.max-w-prose {
+  max-width: 65ch !important;
+}
+
 .max-w-screen-sm {
   max-width: 640px !important;
 }
@@ -35117,6 +35121,10 @@ video {
     max-width: max-content !important;
   }
 
+  .sm\:max-w-prose {
+    max-width: 65ch !important;
+  }
+
   .sm\:max-w-screen-sm {
     max-width: 640px !important;
   }
@@ -58061,6 +58069,10 @@ video {
 
   .md\:max-w-max {
     max-width: max-content !important;
+  }
+
+  .md\:max-w-prose {
+    max-width: 65ch !important;
   }
 
   .md\:max-w-screen-sm {
@@ -81009,6 +81021,10 @@ video {
     max-width: max-content !important;
   }
 
+  .lg\:max-w-prose {
+    max-width: 65ch !important;
+  }
+
   .lg\:max-w-screen-sm {
     max-width: 640px !important;
   }
@@ -103955,6 +103971,10 @@ video {
     max-width: max-content !important;
   }
 
+  .xl\:max-w-prose {
+    max-width: 65ch !important;
+  }
+
   .xl\:max-w-screen-sm {
     max-width: 640px !important;
   }
@@ -126899,6 +126919,10 @@ video {
 
   .\32xl\:max-w-max {
     max-width: max-content !important;
+  }
+
+  .\32xl\:max-w-prose {
+    max-width: 65ch !important;
   }
 
   .\32xl\:max-w-screen-sm {

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -11025,6 +11025,10 @@ video {
   max-width: max-content;
 }
 
+.max-w-prose {
+  max-width: 65ch;
+}
+
 .max-w-screen-sm {
   max-width: 640px;
 }
@@ -32141,6 +32145,10 @@ video {
     max-width: max-content;
   }
 
+  .sm\:max-w-prose {
+    max-width: 65ch;
+  }
+
   .sm\:max-w-screen-sm {
     max-width: 640px;
   }
@@ -53225,6 +53233,10 @@ video {
 
   .md\:max-w-max {
     max-width: max-content;
+  }
+
+  .md\:max-w-prose {
+    max-width: 65ch;
   }
 
   .md\:max-w-screen-sm {
@@ -74313,6 +74325,10 @@ video {
     max-width: max-content;
   }
 
+  .lg\:max-w-prose {
+    max-width: 65ch;
+  }
+
   .lg\:max-w-screen-sm {
     max-width: 640px;
   }
@@ -95399,6 +95415,10 @@ video {
     max-width: max-content;
   }
 
+  .xl\:max-w-prose {
+    max-width: 65ch;
+  }
+
   .xl\:max-w-screen-sm {
     max-width: 640px;
   }
@@ -116483,6 +116503,10 @@ video {
 
   .\32xl\:max-w-max {
     max-width: max-content;
+  }
+
+  .\32xl\:max-w-prose {
+    max-width: 65ch;
   }
 
   .\32xl\:max-w-screen-sm {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -12141,6 +12141,10 @@ video {
   max-width: max-content;
 }
 
+.max-w-prose {
+  max-width: 65ch;
+}
+
 .max-w-screen-sm {
   max-width: 640px;
 }
@@ -35117,6 +35121,10 @@ video {
     max-width: max-content;
   }
 
+  .sm\:max-w-prose {
+    max-width: 65ch;
+  }
+
   .sm\:max-w-screen-sm {
     max-width: 640px;
   }
@@ -58061,6 +58069,10 @@ video {
 
   .md\:max-w-max {
     max-width: max-content;
+  }
+
+  .md\:max-w-prose {
+    max-width: 65ch;
   }
 
   .md\:max-w-screen-sm {
@@ -81009,6 +81021,10 @@ video {
     max-width: max-content;
   }
 
+  .lg\:max-w-prose {
+    max-width: 65ch;
+  }
+
   .lg\:max-w-screen-sm {
     max-width: 640px;
   }
@@ -103955,6 +103971,10 @@ video {
     max-width: max-content;
   }
 
+  .xl\:max-w-prose {
+    max-width: 65ch;
+  }
+
   .xl\:max-w-screen-sm {
     max-width: 640px;
   }
@@ -126899,6 +126919,10 @@ video {
 
   .\32xl\:max-w-max {
     max-width: max-content;
+  }
+
+  .\32xl\:max-w-prose {
+    max-width: 65ch;
   }
 
   .\32xl\:max-w-screen-sm {

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -294,6 +294,7 @@ module.exports = {
       full: '100%',
       min: 'min-content',
       max: 'max-content',
+      prose: '65ch',
       ...breakpoints(theme('screens')),
     }),
     minHeight: {


### PR DESCRIPTION
This pull request is based on this discussion https://github.com/tailwindlabs/tailwindcss/discussions/2495

It introduces a new width of `65ch` intended to maximize readability. A 65 character line length is generally agreed to be the maximum readable width for text. Tailwind Typography already uses a 65ch max-width so this will make it easier to match that behaviour.

The new size has been implemented for both `width` and `maxWidth` as well as all responsive variants.

```html
<div class="w-read"></div>
<div class="max-w-read"></div>
<div class="lg:w-read"></div>
<div class="lg:max-w-read"></div>
```

Tests have been updated accordingly.

This will eventually require a documentation update in both the width and max-width pages. Most likely it would benefit from its own short section (after [screen width](https://github.com/tailwindlabs/tailwindcss.com/blob/master/src/pages/docs/width.mdx#screen-width)) in each explaining why 65ch is considered readable.