### PR TITLE
Change special keyword 'default' to 'DEFAULT', make negative prefixes work across all plugins

### DIFF
--- a/__tests__/containerPlugin.test.js
+++ b/__tests__/containerPlugin.test.js
@@ -217,7 +217,7 @@ test('responsive horizontal padding can be included by default', () => {
         },
         container: {
           padding: {
-            default: '1rem',
+            DEFAULT: '1rem',
             sm: '2rem',
             lg: '4rem',
             xl: '5rem',

--- a/__tests__/flattenColorPalette.test.js
+++ b/__tests__/flattenColorPalette.test.js
@@ -8,7 +8,7 @@ test('it flattens nested color objects', () => {
         25: 'rgba(255,255,255,.25)',
         50: 'rgba(255,255,255,.5)',
         75: 'rgba(255,255,255,.75)',
-        default: '#fff',
+        DEFAULT: '#fff',
       },
       red: {
         1: 'rgb(33,0,0)',

--- a/__tests__/plugins/boxShadow.test.js
+++ b/__tests__/plugins/boxShadow.test.js
@@ -2,13 +2,13 @@ import _ from 'lodash'
 import escapeClassName from '../../src/util/escapeClassName'
 import plugin from '../../src/plugins/boxShadow'
 
-test('box shadow can use default keyword and negative prefix syntax', () => {
+test('box shadow can use DEFAULT keyword and negative prefix syntax', () => {
   const addedUtilities = []
 
   const config = {
     theme: {
       boxShadow: {
-        default: '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
+        DEFAULT: '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
         md: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
         '-': 'inset 0 2px 4px 0 rgba(0, 0, 0, 0.06)',
         '-md': '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',

--- a/__tests__/plugins/divideWidth.test.js
+++ b/__tests__/plugins/divideWidth.test.js
@@ -5,7 +5,7 @@ test('generating divide width utilities', () => {
   const config = {
     theme: {
       divideWidth: {
-        default: '1px',
+        DEFAULT: '1px',
         '0': '0',
         '2': '2px',
         '4': '4px',

--- a/__tests__/plugins/letterSpacing.test.js
+++ b/__tests__/plugins/letterSpacing.test.js
@@ -41,10 +41,12 @@ test('letter spacing can use negative prefix syntax', () => {
 
   expect(addedUtilities).toEqual([
     {
-      utilities: {
-        '.-tracking-1': { 'letter-spacing': '-0.025em' },
-        '.tracking-1': { 'letter-spacing': '0.025em' },
-      },
+      utilities: [
+        {
+          '.-tracking-1': { letterSpacing: '-0.025em' },
+          '.tracking-1': { letterSpacing: '0.025em' },
+        },
+      ],
       variants: ['responsive'],
     },
   ])

--- a/__tests__/plugins/zIndex.test.js
+++ b/__tests__/plugins/zIndex.test.js
@@ -43,12 +43,14 @@ test('z index can use negative prefix syntax', () => {
 
   expect(addedUtilities).toEqual([
     {
-      utilities: {
-        '.-z-20': { 'z-index': '-20' },
-        '.-z-10': { 'z-index': '-10' },
-        '.z-10': { 'z-index': '10' },
-        '.z-20': { 'z-index': '20' },
-      },
+      utilities: [
+        {
+          '.-z-20': { zIndex: '-20' },
+          '.-z-10': { zIndex: '-10' },
+          '.z-10': { zIndex: '10' },
+          '.z-20': { zIndex: '20' },
+        },
+      ],
       variants: ['responsive'],
     },
   ])

--- a/__tests__/sanity.test.js
+++ b/__tests__/sanity.test.js
@@ -4,7 +4,7 @@ import postcss from 'postcss'
 import tailwind from '../src/index'
 import config from '../stubs/defaultConfig.stub.js'
 
-it('generates the right CSS', () => {
+it('generates the right CSS using the default settings', () => {
   const inputPath = path.resolve(`${__dirname}/fixtures/tailwind-input.css`)
   const input = fs.readFileSync(inputPath, 'utf8')
 

--- a/__tests__/variantsAtRule.test.js
+++ b/__tests__/variantsAtRule.test.js
@@ -648,7 +648,7 @@ test('the built-in variant pseudo-selectors are appended before any pseudo-eleme
 
 test('the default variant can be generated in a specified position', () => {
   const input = `
-    @variants focus, active, default, hover {
+    @variants focus, active, DEFAULT, hover {
       .banana { color: yellow; }
       .chocolate { color: brown; }
     }

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -19,11 +19,11 @@ function generatePseudoClassVariant(pseudoClass, selectorPrefix = pseudoClass) {
 }
 
 function ensureIncludesDefault(variants) {
-  return variants.includes('default') ? variants : ['default', ...variants]
+  return variants.includes('DEFAULT') ? variants : ['DEFAULT', ...variants]
 }
 
 const defaultVariantGenerators = config => ({
-  default: generateVariantFunction(() => {}),
+  DEFAULT: generateVariantFunction(() => {}),
   'motion-safe': generateVariantFunction(
     ({ container, separator, modifySelectors }) => {
       const modified = modifySelectors(({ selector }) => {

--- a/src/plugins/animation.js
+++ b/src/plugins/animation.js
@@ -1,7 +1,8 @@
 import _ from 'lodash'
+import nameClass from '../util/nameClass'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     const keyframesConfig = theme('keyframes')
     const keyframesStyles = _.fromPairs(
       _.toPairs(keyframesConfig).map(([name, keyframes]) => {
@@ -14,7 +15,7 @@ export default function() {
     const utilities = _.fromPairs(
       _.toPairs(animationConfig).map(([suffix, animation]) => {
         return [
-          `.${e(`animate-${suffix}`)}`,
+          nameClass('animate', suffix),
           {
             animation,
           },

--- a/src/plugins/backgroundColor.js
+++ b/src/plugins/backgroundColor.js
@@ -5,7 +5,7 @@ import toColorValue from '../util/toColorValue'
 import nameClass from '../util/nameClass'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants, corePlugins }) {
+  return function({ addUtilities, theme, variants, corePlugins }) {
     const colors = flattenColorPalette(theme('backgroundColor'))
 
     const getProperties = value => {

--- a/src/plugins/backgroundColor.js
+++ b/src/plugins/backgroundColor.js
@@ -2,6 +2,7 @@ import _ from 'lodash'
 import flattenColorPalette from '../util/flattenColorPalette'
 import withAlphaVariable from '../util/withAlphaVariable'
 import toColorValue from '../util/toColorValue'
+import nameClass from '../util/nameClass'
 
 export default function() {
   return function({ addUtilities, e, theme, variants, corePlugins }) {
@@ -21,7 +22,7 @@ export default function() {
 
     const utilities = _.fromPairs(
       _.map(colors, (value, modifier) => {
-        return [`.${e(`bg-${modifier}`)}`, getProperties(value)]
+        return [nameClass('bg', modifier), getProperties(value)]
       })
     )
 

--- a/src/plugins/backgroundImage.js
+++ b/src/plugins/backgroundImage.js
@@ -1,11 +1,12 @@
 import _ from 'lodash'
+import nameClass from '../util/nameClass'
 
 export default function() {
   return function({ addUtilities, e, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('backgroundImage'), (value, modifier) => {
         return [
-          `.${e(`bg-${modifier}`)}`,
+          nameClass('bg', modifier),
           {
             'background-image': value,
           },

--- a/src/plugins/backgroundImage.js
+++ b/src/plugins/backgroundImage.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import nameClass from '../util/nameClass'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('backgroundImage'), (value, modifier) => {
         return [

--- a/src/plugins/backgroundPosition.js
+++ b/src/plugins/backgroundPosition.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import nameClass from '../util/nameClass'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('backgroundPosition'), (value, modifier) => {
         return [

--- a/src/plugins/backgroundPosition.js
+++ b/src/plugins/backgroundPosition.js
@@ -1,11 +1,12 @@
 import _ from 'lodash'
+import nameClass from '../util/nameClass'
 
 export default function() {
   return function({ addUtilities, e, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('backgroundPosition'), (value, modifier) => {
         return [
-          `.${e(`bg-${modifier}`)}`,
+          nameClass('bg', modifier),
           {
             'background-position': value,
           },

--- a/src/plugins/backgroundSize.js
+++ b/src/plugins/backgroundSize.js
@@ -1,11 +1,12 @@
 import _ from 'lodash'
+import nameClass from '../util/nameClass'
 
 export default function() {
   return function({ addUtilities, e, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('backgroundSize'), (value, modifier) => {
         return [
-          `.${e(`bg-${modifier}`)}`,
+          nameClass('bg', modifier),
           {
             'background-size': value,
           },

--- a/src/plugins/backgroundSize.js
+++ b/src/plugins/backgroundSize.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import nameClass from '../util/nameClass'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('backgroundSize'), (value, modifier) => {
         return [

--- a/src/plugins/borderColor.js
+++ b/src/plugins/borderColor.js
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import flattenColorPalette from '../util/flattenColorPalette'
+import nameClass from '../util/nameClass'
 import toColorValue from '../util/toColorValue'
 import withAlphaVariable from '../util/withAlphaVariable'
 
@@ -21,7 +22,7 @@ export default function() {
 
     const utilities = _.fromPairs(
       _.map(_.omit(colors, 'DEFAULT'), (value, modifier) => {
-        return [`.${e(`border-${modifier}`)}`, getProperties(value)]
+        return [nameClass('border', modifier), getProperties(value)]
       })
     )
 

--- a/src/plugins/borderColor.js
+++ b/src/plugins/borderColor.js
@@ -20,7 +20,7 @@ export default function() {
     }
 
     const utilities = _.fromPairs(
-      _.map(_.omit(colors, 'default'), (value, modifier) => {
+      _.map(_.omit(colors, 'DEFAULT'), (value, modifier) => {
         return [`.${e(`border-${modifier}`)}`, getProperties(value)]
       })
     )

--- a/src/plugins/borderColor.js
+++ b/src/plugins/borderColor.js
@@ -5,7 +5,7 @@ import toColorValue from '../util/toColorValue'
 import withAlphaVariable from '../util/withAlphaVariable'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants, corePlugins }) {
+  return function({ addUtilities, theme, variants, corePlugins }) {
     const colors = flattenColorPalette(theme('borderColor'))
 
     const getProperties = value => {

--- a/src/plugins/borderRadius.js
+++ b/src/plugins/borderRadius.js
@@ -1,40 +1,41 @@
 import _ from 'lodash'
+import nameClass from '../util/nameClass'
 
 export default function() {
   return function({ addUtilities, e, theme, variants }) {
     const generators = [
       (value, modifier) => ({
-        [`.${e(`rounded${modifier}`)}`]: { borderRadius: `${value}` },
+        [nameClass('rounded', modifier)]: { borderRadius: `${value}` },
       }),
       (value, modifier) => ({
-        [`.${e(`rounded-t${modifier}`)}`]: {
+        [nameClass('rounded-t', modifier)]: {
           borderTopLeftRadius: `${value}`,
           borderTopRightRadius: `${value}`,
         },
-        [`.${e(`rounded-r${modifier}`)}`]: {
+        [nameClass('rounded-r', modifier)]: {
           borderTopRightRadius: `${value}`,
           borderBottomRightRadius: `${value}`,
         },
-        [`.${e(`rounded-b${modifier}`)}`]: {
+        [nameClass('rounded-b', modifier)]: {
           borderBottomRightRadius: `${value}`,
           borderBottomLeftRadius: `${value}`,
         },
-        [`.${e(`rounded-l${modifier}`)}`]: {
+        [nameClass('rounded-l', modifier)]: {
           borderTopLeftRadius: `${value}`,
           borderBottomLeftRadius: `${value}`,
         },
       }),
       (value, modifier) => ({
-        [`.${e(`rounded-tl${modifier}`)}`]: { borderTopLeftRadius: `${value}` },
-        [`.${e(`rounded-tr${modifier}`)}`]: { borderTopRightRadius: `${value}` },
-        [`.${e(`rounded-br${modifier}`)}`]: { borderBottomRightRadius: `${value}` },
-        [`.${e(`rounded-bl${modifier}`)}`]: { borderBottomLeftRadius: `${value}` },
+        [nameClass('rounded-tl', modifier)]: { borderTopLeftRadius: `${value}` },
+        [nameClass('rounded-tr', modifier)]: { borderTopRightRadius: `${value}` },
+        [nameClass('rounded-br', modifier)]: { borderBottomRightRadius: `${value}` },
+        [nameClass('rounded-bl', modifier)]: { borderBottomLeftRadius: `${value}` },
       }),
     ]
 
     const utilities = _.flatMap(generators, generator => {
       return _.flatMap(theme('borderRadius'), (value, modifier) => {
-        return generator(value, modifier === 'DEFAULT' ? '' : `-${modifier}`)
+        return generator(value, modifier)
       })
     })
 

--- a/src/plugins/borderRadius.js
+++ b/src/plugins/borderRadius.js
@@ -34,7 +34,7 @@ export default function() {
 
     const utilities = _.flatMap(generators, generator => {
       return _.flatMap(theme('borderRadius'), (value, modifier) => {
-        return generator(value, modifier === 'default' ? '' : `-${modifier}`)
+        return generator(value, modifier === 'DEFAULT' ? '' : `-${modifier}`)
       })
     })
 

--- a/src/plugins/borderRadius.js
+++ b/src/plugins/borderRadius.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import nameClass from '../util/nameClass'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     const generators = [
       (value, modifier) => ({
         [nameClass('rounded', modifier)]: { borderRadius: `${value}` },

--- a/src/plugins/borderWidth.js
+++ b/src/plugins/borderWidth.js
@@ -16,7 +16,7 @@ export default function() {
 
     const utilities = _.flatMap(generators, generator => {
       return _.flatMap(theme('borderWidth'), (value, modifier) => {
-        return generator(value, modifier === 'default' ? '' : `-${modifier}`)
+        return generator(value, modifier === 'DEFAULT' ? '' : `-${modifier}`)
       })
     })
 

--- a/src/plugins/borderWidth.js
+++ b/src/plugins/borderWidth.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import nameClass from '../util/nameClass'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     const generators = [
       (value, modifier) => ({
         [nameClass('border', modifier)]: { borderWidth: `${value}` },

--- a/src/plugins/borderWidth.js
+++ b/src/plugins/borderWidth.js
@@ -1,22 +1,23 @@
 import _ from 'lodash'
+import nameClass from '../util/nameClass'
 
 export default function() {
   return function({ addUtilities, e, theme, variants }) {
     const generators = [
       (value, modifier) => ({
-        [`.${e(`border${modifier}`)}`]: { borderWidth: `${value}` },
+        [nameClass('border', modifier)]: { borderWidth: `${value}` },
       }),
       (value, modifier) => ({
-        [`.${e(`border-t${modifier}`)}`]: { borderTopWidth: `${value}` },
-        [`.${e(`border-r${modifier}`)}`]: { borderRightWidth: `${value}` },
-        [`.${e(`border-b${modifier}`)}`]: { borderBottomWidth: `${value}` },
-        [`.${e(`border-l${modifier}`)}`]: { borderLeftWidth: `${value}` },
+        [nameClass('border-t', modifier)]: { borderTopWidth: `${value}` },
+        [nameClass('border-r', modifier)]: { borderRightWidth: `${value}` },
+        [nameClass('border-b', modifier)]: { borderBottomWidth: `${value}` },
+        [nameClass('border-l', modifier)]: { borderLeftWidth: `${value}` },
       }),
     ]
 
     const utilities = _.flatMap(generators, generator => {
       return _.flatMap(theme('borderWidth'), (value, modifier) => {
-        return generator(value, modifier === 'DEFAULT' ? '' : `-${modifier}`)
+        return generator(value, modifier)
       })
     })
 

--- a/src/plugins/boxShadow.js
+++ b/src/plugins/boxShadow.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import nameClass from '../util/nameClass'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('boxShadow'), (value, modifier) => {
         return [

--- a/src/plugins/boxShadow.js
+++ b/src/plugins/boxShadow.js
@@ -6,7 +6,7 @@ export default function() {
     const utilities = _.fromPairs(
       _.map(theme('boxShadow'), (value, modifier) => {
         const className =
-          modifier === 'default' ? 'shadow' : `${e(prefixNegativeModifiers('shadow', modifier))}`
+          modifier === 'DEFAULT' ? 'shadow' : `${e(prefixNegativeModifiers('shadow', modifier))}`
         return [
           `.${className}`,
           {

--- a/src/plugins/boxShadow.js
+++ b/src/plugins/boxShadow.js
@@ -1,14 +1,12 @@
 import _ from 'lodash'
-import prefixNegativeModifiers from '../util/prefixNegativeModifiers'
+import nameClass from '../util/nameClass'
 
 export default function() {
   return function({ addUtilities, e, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('boxShadow'), (value, modifier) => {
-        const className =
-          modifier === 'DEFAULT' ? 'shadow' : `${e(prefixNegativeModifiers('shadow', modifier))}`
         return [
-          `.${className}`,
+          nameClass('shadow', modifier),
           {
             'box-shadow': value,
           },

--- a/src/plugins/container.js
+++ b/src/plugins/container.js
@@ -30,7 +30,7 @@ function mapMinWidthsToPadding(minWidths, screens, paddings) {
   if (!_.isObject(paddings)) {
     return [
       {
-        screen: 'default',
+        screen: 'DEFAULT',
         minWidth: 0,
         padding: paddings,
       },
@@ -39,11 +39,11 @@ function mapMinWidthsToPadding(minWidths, screens, paddings) {
 
   const mapping = []
 
-  if (paddings.default) {
+  if (paddings.DEFAULT) {
     mapping.push({
-      screen: 'default',
+      screen: 'DEFAULT',
       minWidth: 0,
-      padding: paddings.default,
+      padding: paddings.DEFAULT,
     })
   }
 

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -99,7 +99,7 @@ html {
   box-sizing: border-box; /* 1 */
   border-width: 0; /* 2 */
   border-style: solid; /* 2 */
-  border-color: theme('borderColor.default', currentColor); /* 2 */
+  border-color: theme('borderColor.DEFAULT', currentColor); /* 2 */
 }
 
 /*

--- a/src/plugins/cursor.js
+++ b/src/plugins/cursor.js
@@ -1,11 +1,12 @@
 import _ from 'lodash'
+import nameClass from '../util/nameClass'
 
 export default function() {
   return function({ addUtilities, e, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('cursor'), (value, modifier) => {
         return [
-          `.${e(`cursor-${modifier}`)}`,
+          nameClass('cursor', modifier),
           {
             cursor: value,
           },

--- a/src/plugins/cursor.js
+++ b/src/plugins/cursor.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import nameClass from '../util/nameClass'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('cursor'), (value, modifier) => {
         return [

--- a/src/plugins/divideColor.js
+++ b/src/plugins/divideColor.js
@@ -20,7 +20,7 @@ export default function() {
     }
 
     const utilities = _.fromPairs(
-      _.map(_.omit(colors, 'default'), (value, modifier) => {
+      _.map(_.omit(colors, 'DEFAULT'), (value, modifier) => {
         return [
           `.${e(`divide-${modifier}`)} > :not(template) ~ :not(template)`,
           getProperties(value),

--- a/src/plugins/divideColor.js
+++ b/src/plugins/divideColor.js
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import flattenColorPalette from '../util/flattenColorPalette'
+import nameClass from '../util/nameClass'
 import toColorValue from '../util/toColorValue'
 import withAlphaVariable from '../util/withAlphaVariable'
 
@@ -22,7 +23,7 @@ export default function() {
     const utilities = _.fromPairs(
       _.map(_.omit(colors, 'DEFAULT'), (value, modifier) => {
         return [
-          `.${e(`divide-${modifier}`)} > :not(template) ~ :not(template)`,
+          `${nameClass('divide', modifier)} > :not(template) ~ :not(template)`,
           getProperties(value),
         ]
       })

--- a/src/plugins/divideColor.js
+++ b/src/plugins/divideColor.js
@@ -5,7 +5,7 @@ import toColorValue from '../util/toColorValue'
 import withAlphaVariable from '../util/withAlphaVariable'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants, corePlugins }) {
+  return function({ addUtilities, theme, variants, corePlugins }) {
     const colors = flattenColorPalette(theme('divideColor'))
 
     const getProperties = value => {

--- a/src/plugins/divideOpacity.js
+++ b/src/plugins/divideOpacity.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import nameClass from '../util/nameClass'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('divideOpacity'), (value, modifier) => {
         return [

--- a/src/plugins/divideOpacity.js
+++ b/src/plugins/divideOpacity.js
@@ -1,11 +1,12 @@
 import _ from 'lodash'
+import nameClass from '../util/nameClass'
 
 export default function() {
   return function({ addUtilities, e, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('divideOpacity'), (value, modifier) => {
         return [
-          `.${e(`divide-opacity-${modifier}`)} > :not(template) ~ :not(template)`,
+          `${nameClass('divide-opacity', modifier)} > :not(template) ~ :not(template)`,
           {
             '--divide-opacity': value,
           },

--- a/src/plugins/divideWidth.js
+++ b/src/plugins/divideWidth.js
@@ -1,17 +1,18 @@
 import _ from 'lodash'
+import nameClass from '../util/nameClass'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     const generators = [
       (size, modifier) => ({
-        [`.${e(`divide-y${modifier}`)} > :not(template) ~ :not(template)`]: {
+        [`${nameClass('divide-y', modifier)} > :not(template) ~ :not(template)`]: {
           '--divide-y-reverse': '0',
           'border-top-width': `calc(${
             size === '0' ? '0px' : size
           } * calc(1 - var(--divide-y-reverse)))`,
           'border-bottom-width': `calc(${size === '0' ? '0px' : size} * var(--divide-y-reverse))`,
         },
-        [`.${e(`divide-x${modifier}`)} > :not(template) ~ :not(template)`]: {
+        [`${nameClass('divide-x', modifier)} > :not(template) ~ :not(template)`]: {
           '--divide-x-reverse': '0',
           'border-right-width': `calc(${size === '0' ? '0px' : size} * var(--divide-x-reverse))`,
           'border-left-width': `calc(${
@@ -24,7 +25,7 @@ export default function() {
     const utilities = _.flatMap(generators, generator => {
       return [
         ..._.flatMap(theme('divideWidth'), (value, modifier) => {
-          return generator(value, modifier === 'DEFAULT' ? '' : `-${modifier}`)
+          return generator(value, modifier)
         }),
         {
           '.divide-y-reverse > :not(template) ~ :not(template)': {

--- a/src/plugins/divideWidth.js
+++ b/src/plugins/divideWidth.js
@@ -24,7 +24,7 @@ export default function() {
     const utilities = _.flatMap(generators, generator => {
       return [
         ..._.flatMap(theme('divideWidth'), (value, modifier) => {
-          return generator(value, modifier === 'default' ? '' : `-${modifier}`)
+          return generator(value, modifier === 'DEFAULT' ? '' : `-${modifier}`)
         }),
         {
           '.divide-y-reverse > :not(template) ~ :not(template)': {

--- a/src/plugins/fill.js
+++ b/src/plugins/fill.js
@@ -4,7 +4,7 @@ import nameClass from '../util/nameClass'
 import toColorValue from '../util/toColorValue'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     const colors = flattenColorPalette(theme('fill'))
 
     const utilities = _.fromPairs(

--- a/src/plugins/fill.js
+++ b/src/plugins/fill.js
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import flattenColorPalette from '../util/flattenColorPalette'
+import nameClass from '../util/nameClass'
 import toColorValue from '../util/toColorValue'
 
 export default function() {
@@ -8,7 +9,7 @@ export default function() {
 
     const utilities = _.fromPairs(
       _.map(colors, (value, modifier) => {
-        return [`.${e(`fill-${modifier}`)}`, { fill: toColorValue(value) }]
+        return [nameClass('fill', modifier), { fill: toColorValue(value) }]
       })
     )
 

--- a/src/plugins/flex.js
+++ b/src/plugins/flex.js
@@ -1,11 +1,12 @@
 import _ from 'lodash'
+import nameClass from '../util/nameClass'
 
 export default function() {
   return function({ addUtilities, e, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('flex'), (value, modifier) => {
         return [
-          `.${e(`flex-${modifier}`)}`,
+          nameClass('flex', modifier),
           {
             flex: value,
           },

--- a/src/plugins/flex.js
+++ b/src/plugins/flex.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import nameClass from '../util/nameClass'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('flex'), (value, modifier) => {
         return [

--- a/src/plugins/flexGrow.js
+++ b/src/plugins/flexGrow.js
@@ -5,7 +5,7 @@ export default function() {
     addUtilities(
       _.fromPairs(
         _.map(theme('flexGrow'), (value, modifier) => {
-          const className = modifier === 'default' ? 'flex-grow' : `flex-grow-${modifier}`
+          const className = modifier === 'DEFAULT' ? 'flex-grow' : `flex-grow-${modifier}`
           return [
             `.${e(className)}`,
             {

--- a/src/plugins/flexGrow.js
+++ b/src/plugins/flexGrow.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import nameClass from '../util/nameClass'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     addUtilities(
       _.fromPairs(
         _.map(theme('flexGrow'), (value, modifier) => {

--- a/src/plugins/flexGrow.js
+++ b/src/plugins/flexGrow.js
@@ -1,13 +1,13 @@
 import _ from 'lodash'
+import nameClass from '../util/nameClass'
 
 export default function() {
   return function({ addUtilities, e, theme, variants }) {
     addUtilities(
       _.fromPairs(
         _.map(theme('flexGrow'), (value, modifier) => {
-          const className = modifier === 'DEFAULT' ? 'flex-grow' : `flex-grow-${modifier}`
           return [
-            `.${e(className)}`,
+            nameClass('flex-grow', modifier),
             {
               'flex-grow': value,
             },

--- a/src/plugins/flexShrink.js
+++ b/src/plugins/flexShrink.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import nameClass from '../util/nameClass'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     addUtilities(
       _.fromPairs(
         _.map(theme('flexShrink'), (value, modifier) => {

--- a/src/plugins/flexShrink.js
+++ b/src/plugins/flexShrink.js
@@ -5,7 +5,7 @@ export default function() {
     addUtilities(
       _.fromPairs(
         _.map(theme('flexShrink'), (value, modifier) => {
-          const className = modifier === 'default' ? 'flex-shrink' : `flex-shrink-${modifier}`
+          const className = modifier === 'DEFAULT' ? 'flex-shrink' : `flex-shrink-${modifier}`
           return [
             `.${e(className)}`,
             {

--- a/src/plugins/flexShrink.js
+++ b/src/plugins/flexShrink.js
@@ -1,13 +1,13 @@
 import _ from 'lodash'
+import nameClass from '../util/nameClass'
 
 export default function() {
   return function({ addUtilities, e, theme, variants }) {
     addUtilities(
       _.fromPairs(
         _.map(theme('flexShrink'), (value, modifier) => {
-          const className = modifier === 'DEFAULT' ? 'flex-shrink' : `flex-shrink-${modifier}`
           return [
-            `.${e(className)}`,
+            nameClass('flex-shrink', modifier),
             {
               'flex-shrink': value,
             },

--- a/src/plugins/fontFamily.js
+++ b/src/plugins/fontFamily.js
@@ -1,18 +1,13 @@
-import _ from 'lodash'
+import createUtilityPlugin from '../util/createUtilityPlugin'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('fontFamily'), (value, modifier) => {
-        return [
-          `.${e(`font-${modifier}`)}`,
-          {
-            'font-family': Array.isArray(value) ? value.join(', ') : value,
-          },
-        ]
-      })
-    )
-
-    addUtilities(utilities, variants('fontFamily'))
-  }
+  return createUtilityPlugin('fontFamily', [
+    [
+      'font',
+      ['fontFamily'],
+      value => {
+        return Array.isArray(value) ? value.join(', ') : value
+      },
+    ],
+  ])
 }

--- a/src/plugins/fontSize.js
+++ b/src/plugins/fontSize.js
@@ -1,4 +1,5 @@
 import _ from 'lodash'
+import nameClass from '../util/nameClass'
 
 export default function() {
   return function({ addUtilities, e, theme, variants }) {
@@ -12,7 +13,7 @@ export default function() {
             }
 
         return [
-          `.${e(`text-${modifier}`)}`,
+          nameClass('text', modifier),
           {
             'font-size': fontSize,
             ...(lineHeight === undefined

--- a/src/plugins/fontSize.js
+++ b/src/plugins/fontSize.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import nameClass from '../util/nameClass'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('fontSize'), (value, modifier) => {
         const [fontSize, options] = Array.isArray(value) ? value : [value]

--- a/src/plugins/fontWeight.js
+++ b/src/plugins/fontWeight.js
@@ -1,18 +1,5 @@
-import _ from 'lodash'
+import createUtilityPlugin from '../util/createUtilityPlugin'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('fontWeight'), (value, modifier) => {
-        return [
-          `.${e(`font-${modifier}`)}`,
-          {
-            'font-weight': value,
-          },
-        ]
-      })
-    )
-
-    addUtilities(utilities, variants('fontWeight'))
-  }
+  return createUtilityPlugin('fontWeight', [['font', ['fontWeight']]])
 }

--- a/src/plugins/gradientColorStops.js
+++ b/src/plugins/gradientColorStops.js
@@ -5,7 +5,7 @@ import toColorValue from '../util/toColorValue'
 import { toRgba } from '../util/withAlphaVariable'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     const colors = flattenColorPalette(theme('gradientColorStops'))
 
     const utilities = _(colors)

--- a/src/plugins/gradientColorStops.js
+++ b/src/plugins/gradientColorStops.js
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import flattenColorPalette from '../util/flattenColorPalette'
+import nameClass from '../util/nameClass'
 import toColorValue from '../util/toColorValue'
 import { toRgba } from '../util/withAlphaVariable'
 
@@ -24,21 +25,21 @@ export default function() {
 
         return [
           [
-            `.${e(`from-${modifier}`)}`,
+            nameClass('from', modifier),
             {
               '--gradient-from-color': toColorValue(value, 'from'),
               '--gradient-color-stops': `var(--gradient-from-color), var(--gradient-to-color, ${transparentTo})`,
             },
           ],
           [
-            `.${e(`via-${modifier}`)}`,
+            nameClass('via', modifier),
             {
               '--gradient-via-color': toColorValue(value, 'via'),
               '--gradient-color-stops': `var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, ${transparentTo})`,
             },
           ],
           [
-            `.${e(`to-${modifier}`)}`,
+            nameClass('to', modifier),
             {
               '--gradient-to-color': toColorValue(value, 'to'),
             },

--- a/src/plugins/height.js
+++ b/src/plugins/height.js
@@ -1,18 +1,5 @@
-import _ from 'lodash'
+import createUtilityPlugin from '../util/createUtilityPlugin'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('height'), (value, modifier) => {
-        return [
-          `.${e(`h-${modifier}`)}`,
-          {
-            height: value,
-          },
-        ]
-      })
-    )
-
-    addUtilities(utilities, variants('height'))
-  }
+  return createUtilityPlugin('height', [['h', ['height']]])
 }

--- a/src/plugins/inset.js
+++ b/src/plugins/inset.js
@@ -1,11 +1,11 @@
 import _ from 'lodash'
-import prefixNegativeModifiers from '../util/prefixNegativeModifiers'
+import nameClass from '../util/nameClass'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     const generators = [
       (size, modifier) => ({
-        [`.${e(prefixNegativeModifiers('inset', modifier))}`]: {
+        [nameClass('inset', modifier)]: {
           top: `${size}`,
           right: `${size}`,
           bottom: `${size}`,
@@ -13,20 +13,20 @@ export default function() {
         },
       }),
       (size, modifier) => ({
-        [`.${e(prefixNegativeModifiers('inset-y', modifier))}`]: {
+        [nameClass('inset-y', modifier)]: {
           top: `${size}`,
           bottom: `${size}`,
         },
-        [`.${e(prefixNegativeModifiers('inset-x', modifier))}`]: {
+        [nameClass('inset-x', modifier)]: {
           right: `${size}`,
           left: `${size}`,
         },
       }),
       (size, modifier) => ({
-        [`.${e(prefixNegativeModifiers('top', modifier))}`]: { top: `${size}` },
-        [`.${e(prefixNegativeModifiers('right', modifier))}`]: { right: `${size}` },
-        [`.${e(prefixNegativeModifiers('bottom', modifier))}`]: { bottom: `${size}` },
-        [`.${e(prefixNegativeModifiers('left', modifier))}`]: { left: `${size}` },
+        [nameClass('top', modifier)]: { top: `${size}` },
+        [nameClass('right', modifier)]: { right: `${size}` },
+        [nameClass('bottom', modifier)]: { bottom: `${size}` },
+        [nameClass('left', modifier)]: { left: `${size}` },
       }),
     ]
 

--- a/src/plugins/letterSpacing.js
+++ b/src/plugins/letterSpacing.js
@@ -1,19 +1,5 @@
-import _ from 'lodash'
-import prefixNegativeModifiers from '../util/prefixNegativeModifiers'
+import createUtilityPlugin from '../util/createUtilityPlugin'
 
 export default function() {
-  return function({ addUtilities, theme, variants, e }) {
-    const utilities = _.fromPairs(
-      _.map(theme('letterSpacing'), (value, modifier) => {
-        return [
-          `.${e(prefixNegativeModifiers('tracking', modifier))}`,
-          {
-            'letter-spacing': value,
-          },
-        ]
-      })
-    )
-
-    addUtilities(utilities, variants('letterSpacing'))
-  }
+  return createUtilityPlugin('letterSpacing', [['tracking', ['letterSpacing']]])
 }

--- a/src/plugins/lineHeight.js
+++ b/src/plugins/lineHeight.js
@@ -1,18 +1,5 @@
-import _ from 'lodash'
+import createUtilityPlugin from '../util/createUtilityPlugin'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('lineHeight'), (value, modifier) => {
-        return [
-          `.${e(`leading-${modifier}`)}`,
-          {
-            'line-height': value,
-          },
-        ]
-      })
-    )
-
-    addUtilities(utilities, variants('lineHeight'))
-  }
+  return createUtilityPlugin('lineHeight', [['leading', ['lineHeight']]])
 }

--- a/src/plugins/listStyleType.js
+++ b/src/plugins/listStyleType.js
@@ -1,18 +1,5 @@
-import _ from 'lodash'
+import createUtilityPlugin from '../util/createUtilityPlugin'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('listStyleType'), (value, modifier) => {
-        return [
-          `.${e(`list-${modifier}`)}`,
-          {
-            'list-style-type': value,
-          },
-        ]
-      })
-    )
-
-    addUtilities(utilities, variants('listStyleType'))
-  }
+  return createUtilityPlugin('listStyleType', [['list', ['listStyleType']]])
 }

--- a/src/plugins/margin.js
+++ b/src/plugins/margin.js
@@ -1,27 +1,27 @@
 import _ from 'lodash'
-import prefixNegativeModifiers from '../util/prefixNegativeModifiers'
+import nameClass from '../util/nameClass'
 
 export default function() {
   return function({ addUtilities, e, theme, variants }) {
     const generators = [
       (size, modifier) => ({
-        [`.${e(prefixNegativeModifiers('m', modifier))}`]: { margin: `${size}` },
+        [nameClass('m', modifier)]: { margin: `${size}` },
       }),
       (size, modifier) => ({
-        [`.${e(prefixNegativeModifiers('my', modifier))}`]: {
+        [nameClass('my', modifier)]: {
           'margin-top': `${size}`,
           'margin-bottom': `${size}`,
         },
-        [`.${e(prefixNegativeModifiers('mx', modifier))}`]: {
+        [nameClass('mx', modifier)]: {
           'margin-left': `${size}`,
           'margin-right': `${size}`,
         },
       }),
       (size, modifier) => ({
-        [`.${e(prefixNegativeModifiers('mt', modifier))}`]: { 'margin-top': `${size}` },
-        [`.${e(prefixNegativeModifiers('mr', modifier))}`]: { 'margin-right': `${size}` },
-        [`.${e(prefixNegativeModifiers('mb', modifier))}`]: { 'margin-bottom': `${size}` },
-        [`.${e(prefixNegativeModifiers('ml', modifier))}`]: { 'margin-left': `${size}` },
+        [nameClass('mt', modifier)]: { 'margin-top': `${size}` },
+        [nameClass('mr', modifier)]: { 'margin-right': `${size}` },
+        [nameClass('mb', modifier)]: { 'margin-bottom': `${size}` },
+        [nameClass('ml', modifier)]: { 'margin-left': `${size}` },
       }),
     ]
 

--- a/src/plugins/margin.js
+++ b/src/plugins/margin.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import nameClass from '../util/nameClass'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     const generators = [
       (size, modifier) => ({
         [nameClass('m', modifier)]: { margin: `${size}` },

--- a/src/plugins/maxHeight.js
+++ b/src/plugins/maxHeight.js
@@ -1,18 +1,5 @@
-import _ from 'lodash'
+import createUtilityPlugin from '../util/createUtilityPlugin'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('maxHeight'), (value, modifier) => {
-        return [
-          `.${e(`max-h-${modifier}`)}`,
-          {
-            'max-height': value,
-          },
-        ]
-      })
-    )
-
-    addUtilities(utilities, variants('maxHeight'))
-  }
+  return createUtilityPlugin('maxHeight', [['max-h', ['maxHeight']]])
 }

--- a/src/plugins/maxWidth.js
+++ b/src/plugins/maxWidth.js
@@ -1,18 +1,5 @@
-import _ from 'lodash'
+import createUtilityPlugin from '../util/createUtilityPlugin'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('maxWidth'), (value, modifier) => {
-        return [
-          `.${e(`max-w-${modifier}`)}`,
-          {
-            'max-width': value,
-          },
-        ]
-      })
-    )
-
-    addUtilities(utilities, variants('maxWidth'))
-  }
+  return createUtilityPlugin('maxWidth', [['max-w', ['maxWidth']]])
 }

--- a/src/plugins/minHeight.js
+++ b/src/plugins/minHeight.js
@@ -1,18 +1,5 @@
-import _ from 'lodash'
+import createUtilityPlugin from '../util/createUtilityPlugin'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('minHeight'), (value, modifier) => {
-        return [
-          `.${e(`min-h-${modifier}`)}`,
-          {
-            'min-height': value,
-          },
-        ]
-      })
-    )
-
-    addUtilities(utilities, variants('minHeight'))
-  }
+  return createUtilityPlugin('minHeight', [['min-h', ['minHeight']]])
 }

--- a/src/plugins/minWidth.js
+++ b/src/plugins/minWidth.js
@@ -1,18 +1,5 @@
-import _ from 'lodash'
+import createUtilityPlugin from '../util/createUtilityPlugin'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('minWidth'), (value, modifier) => {
-        return [
-          `.${e(`min-w-${modifier}`)}`,
-          {
-            'min-width': value,
-          },
-        ]
-      })
-    )
-
-    addUtilities(utilities, variants('minWidth'))
-  }
+  return createUtilityPlugin('minWidth', [['min-w', ['minWidth']]])
 }

--- a/src/plugins/objectPosition.js
+++ b/src/plugins/objectPosition.js
@@ -1,18 +1,5 @@
-import _ from 'lodash'
+import createUtilityPlugin from '../util/createUtilityPlugin'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('objectPosition'), (value, modifier) => {
-        return [
-          `.${e(`object-${modifier}`)}`,
-          {
-            'object-position': value,
-          },
-        ]
-      })
-    )
-
-    addUtilities(utilities, variants('objectPosition'))
-  }
+  return createUtilityPlugin('objectPosition', [['object', ['objectPosition']]])
 }

--- a/src/plugins/opacity.js
+++ b/src/plugins/opacity.js
@@ -1,18 +1,5 @@
-import _ from 'lodash'
+import createUtilityPlugin from '../util/createUtilityPlugin'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('opacity'), (value, modifier) => {
-        return [
-          `.${e(`opacity-${modifier}`)}`,
-          {
-            opacity: value,
-          },
-        ]
-      })
-    )
-
-    addUtilities(utilities, variants('opacity'))
-  }
+  return createUtilityPlugin('opacity', [['opacity', ['opacity']]])
 }

--- a/src/plugins/order.js
+++ b/src/plugins/order.js
@@ -1,18 +1,5 @@
-import _ from 'lodash'
+import createUtilityPlugin from '../util/createUtilityPlugin'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('order'), (value, modifier) => {
-        return [
-          `.${e(`order-${modifier}`)}`,
-          {
-            order: value,
-          },
-        ]
-      })
-    )
-
-    addUtilities(utilities, variants('order'))
-  }
+  return createUtilityPlugin('order', [['order', ['order']]])
 }

--- a/src/plugins/outline.js
+++ b/src/plugins/outline.js
@@ -1,4 +1,5 @@
 import _ from 'lodash'
+import nameClass from '../util/nameClass'
 
 export default function() {
   return function({ addUtilities, e, theme, variants }) {
@@ -7,7 +8,7 @@ export default function() {
         const [outline, outlineOffset = '0'] = Array.isArray(value) ? value : [value]
 
         return [
-          `.${e(`outline-${modifier}`)}`,
+          nameClass('outline', modifier),
           {
             outline,
             outlineOffset,

--- a/src/plugins/outline.js
+++ b/src/plugins/outline.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import nameClass from '../util/nameClass'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('outline'), (value, modifier) => {
         const [outline, outlineOffset = '0'] = Array.isArray(value) ? value : [value]

--- a/src/plugins/padding.js
+++ b/src/plugins/padding.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import nameClass from '../util/nameClass'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     const generators = [
       (size, modifier) => ({
         [nameClass('p', modifier)]: { padding: `${size}` },

--- a/src/plugins/padding.js
+++ b/src/plugins/padding.js
@@ -1,20 +1,21 @@
 import _ from 'lodash'
+import nameClass from '../util/nameClass'
 
 export default function() {
   return function({ addUtilities, e, theme, variants }) {
     const generators = [
       (size, modifier) => ({
-        [`.${e(`p-${modifier}`)}`]: { padding: `${size}` },
+        [nameClass('p', modifier)]: { padding: `${size}` },
       }),
       (size, modifier) => ({
-        [`.${e(`py-${modifier}`)}`]: { 'padding-top': `${size}`, 'padding-bottom': `${size}` },
-        [`.${e(`px-${modifier}`)}`]: { 'padding-left': `${size}`, 'padding-right': `${size}` },
+        [nameClass('py', modifier)]: { 'padding-top': `${size}`, 'padding-bottom': `${size}` },
+        [nameClass('px', modifier)]: { 'padding-left': `${size}`, 'padding-right': `${size}` },
       }),
       (size, modifier) => ({
-        [`.${e(`pt-${modifier}`)}`]: { 'padding-top': `${size}` },
-        [`.${e(`pr-${modifier}`)}`]: { 'padding-right': `${size}` },
-        [`.${e(`pb-${modifier}`)}`]: { 'padding-bottom': `${size}` },
-        [`.${e(`pl-${modifier}`)}`]: { 'padding-left': `${size}` },
+        [nameClass('pt', modifier)]: { 'padding-top': `${size}` },
+        [nameClass('pr', modifier)]: { 'padding-right': `${size}` },
+        [nameClass('pb', modifier)]: { 'padding-bottom': `${size}` },
+        [nameClass('pl', modifier)]: { 'padding-left': `${size}` },
       }),
     ]
 

--- a/src/plugins/placeholderColor.js
+++ b/src/plugins/placeholderColor.js
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import flattenColorPalette from '../util/flattenColorPalette'
+import nameClass from '../util/nameClass'
 import toColorValue from '../util/toColorValue'
 import withAlphaVariable from '../util/withAlphaVariable'
 
@@ -21,7 +22,7 @@ export default function() {
 
     const utilities = _.fromPairs(
       _.map(colors, (value, modifier) => {
-        return [`.${e(`placeholder-${modifier}`)}::placeholder`, getProperties(value)]
+        return [`${nameClass('placeholder', modifier)}::placeholder`, getProperties(value)]
       })
     )
 

--- a/src/plugins/placeholderColor.js
+++ b/src/plugins/placeholderColor.js
@@ -5,7 +5,7 @@ import toColorValue from '../util/toColorValue'
 import withAlphaVariable from '../util/withAlphaVariable'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants, corePlugins }) {
+  return function({ addUtilities, theme, variants, corePlugins }) {
     const colors = flattenColorPalette(theme('placeholderColor'))
 
     const getProperties = value => {

--- a/src/plugins/placeholderOpacity.js
+++ b/src/plugins/placeholderOpacity.js
@@ -1,11 +1,12 @@
 import _ from 'lodash'
+import nameClass from '../util/nameClass'
 
 export default function() {
   return function({ addUtilities, e, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('placeholderOpacity'), (value, modifier) => {
         return [
-          `.${e(`placeholder-opacity-${modifier}`)}::placeholder`,
+          `${nameClass('placeholder-opacity', modifier)}::placeholder`,
           {
             '--placeholder-opacity': value,
           },

--- a/src/plugins/placeholderOpacity.js
+++ b/src/plugins/placeholderOpacity.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import nameClass from '../util/nameClass'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     const utilities = _.fromPairs(
       _.map(theme('placeholderOpacity'), (value, modifier) => {
         return [

--- a/src/plugins/space.js
+++ b/src/plugins/space.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import nameClass from '../util/nameClass'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     const generators = [
       (size, modifier) => ({
         [`${nameClass('space-y', modifier)} > :not(template) ~ :not(template)`]: {

--- a/src/plugins/space.js
+++ b/src/plugins/space.js
@@ -1,16 +1,16 @@
 import _ from 'lodash'
-import prefixNegativeModifiers from '../util/prefixNegativeModifiers'
+import nameClass from '../util/nameClass'
 
 export default function() {
   return function({ addUtilities, e, theme, variants }) {
     const generators = [
       (size, modifier) => ({
-        [`.${e(prefixNegativeModifiers('space-y', modifier))} > :not(template) ~ :not(template)`]: {
+        [`${nameClass('space-y', modifier)} > :not(template) ~ :not(template)`]: {
           '--space-y-reverse': '0',
           'margin-top': `calc(${size === '0' ? '0px' : size} * calc(1 - var(--space-y-reverse)))`,
           'margin-bottom': `calc(${size === '0' ? '0px' : size} * var(--space-y-reverse))`,
         },
-        [`.${e(prefixNegativeModifiers('space-x', modifier))} > :not(template) ~ :not(template)`]: {
+        [`${nameClass('space-x', modifier)} > :not(template) ~ :not(template)`]: {
           '--space-x-reverse': '0',
           'margin-right': `calc(${size === '0' ? '0px' : size} * var(--space-x-reverse))`,
           'margin-left': `calc(${size === '0' ? '0px' : size} * calc(1 - var(--space-x-reverse)))`,

--- a/src/plugins/stroke.js
+++ b/src/plugins/stroke.js
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import flattenColorPalette from '../util/flattenColorPalette'
+import nameClass from '../util/nameClass'
 import toColorValue from '../util/toColorValue'
 
 export default function() {
@@ -8,7 +9,7 @@ export default function() {
 
     const utilities = _.fromPairs(
       _.map(colors, (value, modifier) => {
-        return [`.${e(`stroke-${modifier}`)}`, { stroke: toColorValue(value) }]
+        return [nameClass('stroke', modifier), { stroke: toColorValue(value) }]
       })
     )
 

--- a/src/plugins/stroke.js
+++ b/src/plugins/stroke.js
@@ -4,7 +4,7 @@ import nameClass from '../util/nameClass'
 import toColorValue from '../util/toColorValue'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
+  return function({ addUtilities, theme, variants }) {
     const colors = flattenColorPalette(theme('stroke'))
 
     const utilities = _.fromPairs(

--- a/src/plugins/strokeWidth.js
+++ b/src/plugins/strokeWidth.js
@@ -1,18 +1,5 @@
-import _ from 'lodash'
+import createUtilityPlugin from '../util/createUtilityPlugin'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('strokeWidth'), (value, modifier) => {
-        return [
-          `.${e(`stroke-${modifier}`)}`,
-          {
-            strokeWidth: value,
-          },
-        ]
-      })
-    )
-
-    addUtilities(utilities, variants('strokeWidth'))
-  }
+  return createUtilityPlugin('strokeWidth', [['stroke', ['strokeWidth']]])
 }

--- a/src/plugins/textColor.js
+++ b/src/plugins/textColor.js
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import flattenColorPalette from '../util/flattenColorPalette'
+import nameClass from '../util/nameClass'
 import toColorValue from '../util/toColorValue'
 import withAlphaVariable from '../util/withAlphaVariable'
 
@@ -21,7 +22,7 @@ export default function() {
 
     const utilities = _.fromPairs(
       _.map(colors, (value, modifier) => {
-        return [`.${e(`text-${modifier}`)}`, getProperties(value)]
+        return [nameClass('text', modifier), getProperties(value)]
       })
     )
 

--- a/src/plugins/textColor.js
+++ b/src/plugins/textColor.js
@@ -5,7 +5,7 @@ import toColorValue from '../util/toColorValue'
 import withAlphaVariable from '../util/withAlphaVariable'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants, corePlugins }) {
+  return function({ addUtilities, theme, variants, corePlugins }) {
     const colors = flattenColorPalette(theme('textColor'))
 
     const getProperties = value => {

--- a/src/plugins/width.js
+++ b/src/plugins/width.js
@@ -1,18 +1,5 @@
-import _ from 'lodash'
+import createUtilityPlugin from '../util/createUtilityPlugin'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('width'), (value, modifier) => {
-        return [
-          `.${e(`w-${modifier}`)}`,
-          {
-            width: value,
-          },
-        ]
-      })
-    )
-
-    addUtilities(utilities, variants('width'))
-  }
+  return createUtilityPlugin('width', [['w', ['width']]])
 }

--- a/src/plugins/zIndex.js
+++ b/src/plugins/zIndex.js
@@ -1,19 +1,5 @@
-import _ from 'lodash'
-import prefixNegativeModifiers from '../util/prefixNegativeModifiers'
+import createUtilityPlugin from '../util/createUtilityPlugin'
 
 export default function() {
-  return function({ addUtilities, e, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('zIndex'), (value, modifier) => {
-        return [
-          `.${e(prefixNegativeModifiers('z', modifier))}`,
-          {
-            'z-index': value,
-          },
-        ]
-      })
-    )
-
-    addUtilities(utilities, variants('zIndex'))
-  }
+  return createUtilityPlugin('zIndex', [['z', ['zIndex']]])
 }

--- a/src/util/createUtilityPlugin.js
+++ b/src/util/createUtilityPlugin.js
@@ -2,27 +2,16 @@ import identity from 'lodash/identity'
 import fromPairs from 'lodash/fromPairs'
 import toPairs from 'lodash/toPairs'
 import castArray from 'lodash/castArray'
-
-function className(classPrefix, key) {
-  if (key === 'DEFAULT') {
-    return classPrefix
-  }
-
-  if (key.startsWith('-')) {
-    return `-${classPrefix}${key}`
-  }
-
-  return `${classPrefix}-${key}`
-}
+import nameClass from './nameClass'
 
 export default function createUtilityPlugin(themeKey, utilityVariations) {
-  return function({ e, addUtilities, variants, theme }) {
+  return function({ addUtilities, variants, theme }) {
     const utilities = utilityVariations.map(
       ([classPrefix, properties, transformValue = identity]) => {
         return fromPairs(
           toPairs(theme(themeKey)).map(([key, value]) => {
             return [
-              `.${e(className(classPrefix, key))}`,
+              nameClass(classPrefix, key),
               fromPairs(castArray(properties).map(property => [property, transformValue(value)])),
             ]
           })

--- a/src/util/createUtilityPlugin.js
+++ b/src/util/createUtilityPlugin.js
@@ -4,7 +4,7 @@ import toPairs from 'lodash/toPairs'
 import castArray from 'lodash/castArray'
 
 function className(classPrefix, key) {
-  if (key === 'default') {
+  if (key === 'DEFAULT') {
     return classPrefix
   }
 

--- a/src/util/flattenColorPalette.js
+++ b/src/util/flattenColorPalette.js
@@ -8,7 +8,7 @@ export default function flattenColorPalette(colors) {
       }
 
       return _.map(color, (value, key) => {
-        const suffix = key === 'default' ? '' : `-${key}`
+        const suffix = key === 'DEFAULT' ? '' : `-${key}`
         return [`${name}${suffix}`, value]
       })
     })

--- a/src/util/nameClass.js
+++ b/src/util/nameClass.js
@@ -1,0 +1,21 @@
+import escapeClassName from './escapeClassName'
+
+function asClass(name) {
+  return `.${escapeClassName(name)}`
+}
+
+export default function nameClass(classPrefix, key) {
+  if (key === 'DEFAULT') {
+    return asClass(classPrefix)
+  }
+
+  if (key === '-') {
+    return asClass(`-${classPrefix}`)
+  }
+
+  if (key.startsWith('-')) {
+    return asClass(`-${classPrefix}${key}`)
+  }
+
+  return asClass(`${classPrefix}-${key}`)
+}

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -182,13 +182,13 @@ module.exports = {
     },
     borderColor: theme => ({
       ...theme('colors'),
-      default: theme('colors.gray.300', 'currentColor'),
+      DEFAULT: theme('colors.gray.300', 'currentColor'),
     }),
     borderOpacity: theme => theme('opacity'),
     borderRadius: {
       none: '0',
       sm: '0.125rem',
-      default: '0.25rem',
+      DEFAULT: '0.25rem',
       md: '0.375rem',
       lg: '0.5rem',
       xl: '0.75rem',
@@ -197,7 +197,7 @@ module.exports = {
       full: '9999px',
     },
     borderWidth: {
-      default: '1px',
+      DEFAULT: '1px',
       '0': '0',
       '2': '2px',
       '4': '4px',
@@ -206,7 +206,7 @@ module.exports = {
     boxShadow: {
       xs: '0 0 0 1px rgba(0, 0, 0, 0.05)',
       sm: '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
-      default: '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
+      DEFAULT: '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
       md: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',
       lg: '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
       xl: '0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)',
@@ -239,11 +239,11 @@ module.exports = {
     },
     flexGrow: {
       '0': '0',
-      default: '1',
+      DEFAULT: '1',
     },
     flexShrink: {
       '0': '0',
-      default: '1',
+      DEFAULT: '1',
     },
     fontFamily: {
       sans: [
@@ -638,7 +638,7 @@ module.exports = {
     transitionProperty: {
       none: 'none',
       all: 'all',
-      default: 'background-color, border-color, color, fill, stroke, opacity, box-shadow, transform',
+      DEFAULT: 'background-color, border-color, color, fill, stroke, opacity, box-shadow, transform',
       colors: 'background-color, border-color, color, fill, stroke',
       opacity: 'opacity',
       shadow: 'box-shadow',


### PR DESCRIPTION
This PR aims to simplify how utility class names are generated in Tailwind in order to make things much more consistent and predictable.

This is a breaking change and slated for v2.0.

---

Currently in Tailwind, several core plugins support a special `default` key in the config which tells Tailwind to generate a utility with _no_ suffix:

```js
module.exports = {
  theme: {
    boxShadow: {
      default: '0 0 5px black'
      // Generates `shadow`, not `shadow-default`
    }
  }
}
```

This is useful but confusing, because many other plugins _don't_ support this, for example:

```js
module.exports = {
  theme: {
    cursor: {
      default: 'default'
      // Generates `cursor-default`, not `cursor`
    }
  }
}
```

Similarly, many plugins support generating classes that are prefixed with `-` by adding `-` to the beginning of the key name:

```js
module.exports = {
  theme: {
    margin: {
      '-5': '-5px'
      // Generates `-m-5`, not `m--5`
    }
  }
}
```

...but others don't:

```js
module.exports = {
  theme: {
     backgroundPosition: {
      '-top-10': 'top -10px',
      // Generates `bg--top-10`, not `-bg-top-10`
    }
  }
}
```

This is confusing and makes the codebase complicated. The problem is, for some plugins we really do need to be able to include "default" in the utility name, like `cursor-default`.

So this PR replaces all usage of the lowercase `default` with the uppercase `DEFAULT`. The uppercase `DEFAULT` always means "with no suffix", and lowercase is just a regular string with no special meaning.

```diff
  module.exports = {
    theme: {
      boxShadow: {
-       default: '0 0 5px black'
+       DEFAULT: '0 0 5px black'
      }
    }
  }
```

This PR also makes things consistent so that `DEFAULT` can be used _anywhere for any plugin_, and so can the `-` prefix. This lets you make really stupid classes like `-font-sans` but that's your decision.

I've also updated the use of "default" in variants. We allow you to control the position of the default variant by adding "default" to your variants list:

```js
// Old syntax
module.exports = {
  variants: {
     backgroundPosition: ['hover', 'default', 'focus']
  }
}
```

This has been replaced with `DEFAULT` as well, so that things are consistent.

```js
// New syntax
module.exports = {
  variants: {
     backgroundPosition: ['hover', 'DEFAULT', 'focus']
  }
}
```

The last place this has been updated is when customizing the per-screen-size padding of the container:

```js
module.exports = {
  theme: {
    container: {
      padding: {
        DEFAULT: '1rem',
        sm: '2rem',
        lg: '4rem',
        xl: '5rem',
      },
    },
  }
}
```

Updating for this change isn't too painful (just replace `default` with `DEFAULT` everywhere in your config where you want no suffix, and stuff like `theme('borderRadius.default')` with `theme('borderRadius.DEFAULT')` in your CSS) but is slightly annoying admittedly. I'm sorry.