### PR TITLE
Extend and enhance Preflight styles

### DIFF
--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -299,6 +299,7 @@ summary {
 
 /**
  * Manually forked from SUIT CSS Base: https://github.com/suitcss/base
+ * Modern reset obtained from: https://github.com/kripod/css-homogenizer
  * A thin layer on top of normalize.css that provides a starting point more
  * suitable for web applications.
  */
@@ -307,20 +308,40 @@ summary {
  * Removes the default spacing and border for appropriate elements.
  */
 
-blockquote,
-dl,
-dd,
+p,
 h1,
 h2,
 h3,
 h4,
 h5,
 h6,
-hr,
+blockquote,
+dl,
+dd,
 figure,
-p,
-pre {
+pre,
+hr,
+fieldset,
+ol,
+ul,
+menu {
   margin: 0;
+}
+
+th,
+td,
+legend,
+fieldset,
+ol,
+ul,
+menu {
+  padding: 0;
+}
+
+hr,
+fieldset,
+iframe {
+  border: 0;
 }
 
 button {
@@ -338,16 +359,10 @@ button:focus {
   outline: 5px auto -webkit-focus-ring-color;
 }
 
-fieldset {
-  margin: 0;
-  padding: 0;
-}
-
 ol,
-ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+ul,
+menu {
+  list-style: none; /* list-style-type */
 }
 
 /**
@@ -359,11 +374,13 @@ ul {
  *    sans-serif font stack as a fallback) as a sane default.
  * 2. Use Tailwind's default "normal" line-height so the user isn't forced
  *    to override it to ensure consistency even when using the default theme.
+ * 3. Prevent overflow caused by long words when absolutely necessary.
  */
 
 html {
   font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; /* 1 */
   line-height: 1.5; /* 2 */
+  overflow-wrap: break-word; /* 3 */
 }
 
 /**
@@ -438,7 +455,12 @@ button,
 }
 
 table {
+  border-spacing: 0;
   border-collapse: collapse;
+}
+
+th {
+  text-align: inherit;
 }
 
 h1,
@@ -446,9 +468,10 @@ h2,
 h3,
 h4,
 h5,
-h6 {
-  font-size: inherit;
-  font-weight: inherit;
+h6,
+th,
+address {
+  font: inherit; /* font-size, font-weight, font-style */
 }
 
 /**

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -299,6 +299,7 @@ summary {
 
 /**
  * Manually forked from SUIT CSS Base: https://github.com/suitcss/base
+ * Modern reset obtained from: https://github.com/kripod/css-homogenizer
  * A thin layer on top of normalize.css that provides a starting point more
  * suitable for web applications.
  */
@@ -307,20 +308,40 @@ summary {
  * Removes the default spacing and border for appropriate elements.
  */
 
-blockquote,
-dl,
-dd,
+p,
 h1,
 h2,
 h3,
 h4,
 h5,
 h6,
-hr,
+blockquote,
+dl,
+dd,
 figure,
-p,
-pre {
+pre,
+hr,
+fieldset,
+ol,
+ul,
+menu {
   margin: 0;
+}
+
+th,
+td,
+legend,
+fieldset,
+ol,
+ul,
+menu {
+  padding: 0;
+}
+
+hr,
+fieldset,
+iframe {
+  border: 0;
 }
 
 button {
@@ -338,16 +359,10 @@ button:focus {
   outline: 5px auto -webkit-focus-ring-color;
 }
 
-fieldset {
-  margin: 0;
-  padding: 0;
-}
-
 ol,
-ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+ul,
+menu {
+  list-style: none; /* list-style-type */
 }
 
 /**
@@ -359,11 +374,13 @@ ul {
  *    sans-serif font stack as a fallback) as a sane default.
  * 2. Use Tailwind's default "normal" line-height so the user isn't forced
  *    to override it to ensure consistency even when using the default theme.
+ * 3. Prevent overflow caused by long words when absolutely necessary.
  */
 
 html {
   font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; /* 1 */
   line-height: 1.5; /* 2 */
+  overflow-wrap: break-word; /* 3 */
 }
 
 /**
@@ -438,7 +455,12 @@ button,
 }
 
 table {
+  border-spacing: 0;
   border-collapse: collapse;
+}
+
+th {
+  text-align: inherit;
 }
 
 h1,
@@ -446,9 +468,10 @@ h2,
 h3,
 h4,
 h5,
-h6 {
-  font-size: inherit;
-  font-weight: inherit;
+h6,
+th,
+address {
+  font: inherit; /* font-size, font-weight, font-style */
 }
 
 /**

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -299,6 +299,7 @@ summary {
 
 /**
  * Manually forked from SUIT CSS Base: https://github.com/suitcss/base
+ * Modern reset obtained from: https://github.com/kripod/css-homogenizer
  * A thin layer on top of normalize.css that provides a starting point more
  * suitable for web applications.
  */
@@ -307,20 +308,40 @@ summary {
  * Removes the default spacing and border for appropriate elements.
  */
 
-blockquote,
-dl,
-dd,
+p,
 h1,
 h2,
 h3,
 h4,
 h5,
 h6,
-hr,
+blockquote,
+dl,
+dd,
 figure,
-p,
-pre {
+pre,
+hr,
+fieldset,
+ol,
+ul,
+menu {
   margin: 0;
+}
+
+th,
+td,
+legend,
+fieldset,
+ol,
+ul,
+menu {
+  padding: 0;
+}
+
+hr,
+fieldset,
+iframe {
+  border: 0;
 }
 
 button {
@@ -338,16 +359,10 @@ button:focus {
   outline: 5px auto -webkit-focus-ring-color;
 }
 
-fieldset {
-  margin: 0;
-  padding: 0;
-}
-
 ol,
-ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+ul,
+menu {
+  list-style: none; /* list-style-type */
 }
 
 /**
@@ -359,11 +374,13 @@ ul {
  *    sans-serif font stack as a fallback) as a sane default.
  * 2. Use Tailwind's default "normal" line-height so the user isn't forced
  *    to override it to ensure consistency even when using the default theme.
+ * 3. Prevent overflow caused by long words when absolutely necessary.
  */
 
 html {
   font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"; /* 1 */
   line-height: 1.5; /* 2 */
+  overflow-wrap: break-word; /* 3 */
 }
 
 /**
@@ -438,7 +455,12 @@ button,
 }
 
 table {
+  border-spacing: 0;
   border-collapse: collapse;
+}
+
+th {
+  text-align: inherit;
 }
 
 h1,
@@ -446,9 +468,10 @@ h2,
 h3,
 h4,
 h5,
-h6 {
-  font-size: inherit;
-  font-weight: inherit;
+h6,
+th,
+address {
+  font: inherit; /* font-size, font-weight, font-style */
 }
 
 /**

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -1,5 +1,6 @@
 /**
  * Manually forked from SUIT CSS Base: https://github.com/suitcss/base
+ * Modern reset obtained from: https://github.com/kripod/css-homogenizer
  * A thin layer on top of normalize.css that provides a starting point more
  * suitable for web applications.
  */
@@ -8,20 +9,40 @@
  * Removes the default spacing and border for appropriate elements.
  */
 
-blockquote,
-dl,
-dd,
+p,
 h1,
 h2,
 h3,
 h4,
 h5,
 h6,
-hr,
+blockquote,
+dl,
+dd,
 figure,
-p,
-pre {
+pre,
+hr,
+fieldset,
+ol,
+ul,
+menu {
   margin: 0;
+}
+
+th,
+td,
+legend,
+fieldset,
+ol,
+ul,
+menu {
+  padding: 0;
+}
+
+hr,
+fieldset,
+iframe {
+  border: 0;
 }
 
 button {
@@ -39,16 +60,10 @@ button:focus {
   outline: 5px auto -webkit-focus-ring-color;
 }
 
-fieldset {
-  margin: 0;
-  padding: 0;
-}
-
 ol,
-ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+ul,
+menu {
+  list-style: none; /* list-style-type */
 }
 
 /**
@@ -60,11 +75,13 @@ ul {
  *    sans-serif font stack as a fallback) as a sane default.
  * 2. Use Tailwind's default "normal" line-height so the user isn't forced
  *    to override it to ensure consistency even when using the default theme.
+ * 3. Prevent overflow caused by long words when absolutely necessary.
  */
 
 html {
   font-family: theme('fontFamily.sans', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"); /* 1 */
   line-height: 1.5; /* 2 */
+  overflow-wrap: break-word; /* 3 */
 }
 
 /**
@@ -139,7 +156,12 @@ button,
 }
 
 table {
+  border-spacing: 0;
   border-collapse: collapse;
+}
+
+th {
+  text-align: inherit;
 }
 
 h1,
@@ -147,9 +169,10 @@ h2,
 h3,
 h4,
 h5,
-h6 {
-  font-size: inherit;
-  font-weight: inherit;
+h6,
+th,
+address {
+  font: inherit; /* font-size, font-weight, font-style */
 }
 
 /**


### PR DESCRIPTION
_(This PR is a reiteration of #2417)_

---

Most of the following changes were inspired by [css-homogenizer](https://github.com/kripod/css-homogenizer):

- Reset styles are now more extensive:
  - `menu` margins are nullified.
  - Paddings of `legend`, `th`, `td` and `menu` elements have been reset.
  - The border styling of `hr`, `fieldset` and `iframe` elements has been reset.
  - `border-spacing: 0`, instead of the `2px` default.
  - `th` and `address` elements are de-styled to only maintain their semantic meaning.
- A new opinionated rule has been added:
  - Prevent overflow caused by long words when absolutely necessary.