### PR TITLE
fix: rename dark to darkMode in error log

### DIFF
--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -61,7 +61,7 @@ const defaultVariantGenerators = (config) => ({
         return modified
       }
 
-      throw new Error("The `dark` config option must be either 'media' or 'class'.")
+      throw new Error("The `darkMode` config option must be either 'media' or 'class'.")
     },
     { unstable_stack: true }
   ),


### PR DESCRIPTION
This key was renamed in https://github.com/tailwindlabs/tailwindcss/pull/2631
