### PR TITLE
Use [hidden] instead of template in space/divide utilities

### DIFF
--- a/__tests__/fixtures/tailwind-output-flagged.css
+++ b/__tests__/fixtures/tailwind-output-flagged.css
@@ -560,1323 +560,1323 @@ video {
   }
 }
 
-.space-y-0 > :not(template) ~ :not(template) {
+.space-y-0 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0px * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0px * var(--space-y-reverse));
 }
 
-.space-x-0 > :not(template) ~ :not(template) {
+.space-x-0 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0px * var(--space-x-reverse));
   margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-1 > :not(template) ~ :not(template) {
+.space-y-1 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0.25rem * var(--space-y-reverse));
 }
 
-.space-x-1 > :not(template) ~ :not(template) {
+.space-x-1 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0.25rem * var(--space-x-reverse));
   margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-2 > :not(template) ~ :not(template) {
+.space-y-2 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0.5rem * var(--space-y-reverse));
 }
 
-.space-x-2 > :not(template) ~ :not(template) {
+.space-x-2 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0.5rem * var(--space-x-reverse));
   margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-3 > :not(template) ~ :not(template) {
+.space-y-3 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0.75rem * var(--space-y-reverse));
 }
 
-.space-x-3 > :not(template) ~ :not(template) {
+.space-x-3 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0.75rem * var(--space-x-reverse));
   margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-4 > :not(template) ~ :not(template) {
+.space-y-4 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(1rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(1rem * var(--space-y-reverse));
 }
 
-.space-x-4 > :not(template) ~ :not(template) {
+.space-x-4 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(1rem * var(--space-x-reverse));
   margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-5 > :not(template) ~ :not(template) {
+.space-y-5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(1.25rem * var(--space-y-reverse));
 }
 
-.space-x-5 > :not(template) ~ :not(template) {
+.space-x-5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(1.25rem * var(--space-x-reverse));
   margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-6 > :not(template) ~ :not(template) {
+.space-y-6 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(1.5rem * var(--space-y-reverse));
 }
 
-.space-x-6 > :not(template) ~ :not(template) {
+.space-x-6 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(1.5rem * var(--space-x-reverse));
   margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-7 > :not(template) ~ :not(template) {
+.space-y-7 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(1.75rem * var(--space-y-reverse));
 }
 
-.space-x-7 > :not(template) ~ :not(template) {
+.space-x-7 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(1.75rem * var(--space-x-reverse));
   margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-8 > :not(template) ~ :not(template) {
+.space-y-8 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(2rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(2rem * var(--space-y-reverse));
 }
 
-.space-x-8 > :not(template) ~ :not(template) {
+.space-x-8 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(2rem * var(--space-x-reverse));
   margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-9 > :not(template) ~ :not(template) {
+.space-y-9 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(2.25rem * var(--space-y-reverse));
 }
 
-.space-x-9 > :not(template) ~ :not(template) {
+.space-x-9 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(2.25rem * var(--space-x-reverse));
   margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-10 > :not(template) ~ :not(template) {
+.space-y-10 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(2.5rem * var(--space-y-reverse));
 }
 
-.space-x-10 > :not(template) ~ :not(template) {
+.space-x-10 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(2.5rem * var(--space-x-reverse));
   margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-12 > :not(template) ~ :not(template) {
+.space-y-12 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(3rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(3rem * var(--space-y-reverse));
 }
 
-.space-x-12 > :not(template) ~ :not(template) {
+.space-x-12 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(3rem * var(--space-x-reverse));
   margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-14 > :not(template) ~ :not(template) {
+.space-y-14 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(3.5rem * var(--space-y-reverse));
 }
 
-.space-x-14 > :not(template) ~ :not(template) {
+.space-x-14 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(3.5rem * var(--space-x-reverse));
   margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-16 > :not(template) ~ :not(template) {
+.space-y-16 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(4rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(4rem * var(--space-y-reverse));
 }
 
-.space-x-16 > :not(template) ~ :not(template) {
+.space-x-16 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(4rem * var(--space-x-reverse));
   margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-20 > :not(template) ~ :not(template) {
+.space-y-20 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(5rem * var(--space-y-reverse));
 }
 
-.space-x-20 > :not(template) ~ :not(template) {
+.space-x-20 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(5rem * var(--space-x-reverse));
   margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-24 > :not(template) ~ :not(template) {
+.space-y-24 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(6rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(6rem * var(--space-y-reverse));
 }
 
-.space-x-24 > :not(template) ~ :not(template) {
+.space-x-24 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(6rem * var(--space-x-reverse));
   margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-28 > :not(template) ~ :not(template) {
+.space-y-28 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(7rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(7rem * var(--space-y-reverse));
 }
 
-.space-x-28 > :not(template) ~ :not(template) {
+.space-x-28 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(7rem * var(--space-x-reverse));
   margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-32 > :not(template) ~ :not(template) {
+.space-y-32 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(8rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(8rem * var(--space-y-reverse));
 }
 
-.space-x-32 > :not(template) ~ :not(template) {
+.space-x-32 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(8rem * var(--space-x-reverse));
   margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-36 > :not(template) ~ :not(template) {
+.space-y-36 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(9rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(9rem * var(--space-y-reverse));
 }
 
-.space-x-36 > :not(template) ~ :not(template) {
+.space-x-36 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(9rem * var(--space-x-reverse));
   margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-40 > :not(template) ~ :not(template) {
+.space-y-40 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(10rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(10rem * var(--space-y-reverse));
 }
 
-.space-x-40 > :not(template) ~ :not(template) {
+.space-x-40 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(10rem * var(--space-x-reverse));
   margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-44 > :not(template) ~ :not(template) {
+.space-y-44 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(11rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(11rem * var(--space-y-reverse));
 }
 
-.space-x-44 > :not(template) ~ :not(template) {
+.space-x-44 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(11rem * var(--space-x-reverse));
   margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-48 > :not(template) ~ :not(template) {
+.space-y-48 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(12rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(12rem * var(--space-y-reverse));
 }
 
-.space-x-48 > :not(template) ~ :not(template) {
+.space-x-48 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(12rem * var(--space-x-reverse));
   margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-52 > :not(template) ~ :not(template) {
+.space-y-52 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(13rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(13rem * var(--space-y-reverse));
 }
 
-.space-x-52 > :not(template) ~ :not(template) {
+.space-x-52 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(13rem * var(--space-x-reverse));
   margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-56 > :not(template) ~ :not(template) {
+.space-y-56 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(14rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(14rem * var(--space-y-reverse));
 }
 
-.space-x-56 > :not(template) ~ :not(template) {
+.space-x-56 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(14rem * var(--space-x-reverse));
   margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-60 > :not(template) ~ :not(template) {
+.space-y-60 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(15rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(15rem * var(--space-y-reverse));
 }
 
-.space-x-60 > :not(template) ~ :not(template) {
+.space-x-60 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(15rem * var(--space-x-reverse));
   margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-64 > :not(template) ~ :not(template) {
+.space-y-64 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(16rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(16rem * var(--space-y-reverse));
 }
 
-.space-x-64 > :not(template) ~ :not(template) {
+.space-x-64 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(16rem * var(--space-x-reverse));
   margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-72 > :not(template) ~ :not(template) {
+.space-y-72 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(18rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(18rem * var(--space-y-reverse));
 }
 
-.space-x-72 > :not(template) ~ :not(template) {
+.space-x-72 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(18rem * var(--space-x-reverse));
   margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-80 > :not(template) ~ :not(template) {
+.space-y-80 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(20rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(20rem * var(--space-y-reverse));
 }
 
-.space-x-80 > :not(template) ~ :not(template) {
+.space-x-80 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(20rem * var(--space-x-reverse));
   margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-96 > :not(template) ~ :not(template) {
+.space-y-96 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(24rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(24rem * var(--space-y-reverse));
 }
 
-.space-x-96 > :not(template) ~ :not(template) {
+.space-x-96 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(24rem * var(--space-x-reverse));
   margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-px > :not(template) ~ :not(template) {
+.space-y-px > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(1px * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(1px * var(--space-y-reverse));
 }
 
-.space-x-px > :not(template) ~ :not(template) {
+.space-x-px > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(1px * var(--space-x-reverse));
   margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-0\.5 > :not(template) ~ :not(template) {
+.space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0.125rem * var(--space-y-reverse));
 }
 
-.space-x-0\.5 > :not(template) ~ :not(template) {
+.space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0.125rem * var(--space-x-reverse));
   margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-1\.5 > :not(template) ~ :not(template) {
+.space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0.375rem * var(--space-y-reverse));
 }
 
-.space-x-1\.5 > :not(template) ~ :not(template) {
+.space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0.375rem * var(--space-x-reverse));
   margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-2\.5 > :not(template) ~ :not(template) {
+.space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0.625rem * var(--space-y-reverse));
 }
 
-.space-x-2\.5 > :not(template) ~ :not(template) {
+.space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0.625rem * var(--space-x-reverse));
   margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-3\.5 > :not(template) ~ :not(template) {
+.space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0.875rem * var(--space-y-reverse));
 }
 
-.space-x-3\.5 > :not(template) ~ :not(template) {
+.space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0.875rem * var(--space-x-reverse));
   margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-1 > :not(template) ~ :not(template) {
+.-space-y-1 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-0.25rem * var(--space-y-reverse));
 }
 
-.-space-x-1 > :not(template) ~ :not(template) {
+.-space-x-1 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
   margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-2 > :not(template) ~ :not(template) {
+.-space-y-2 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-0.5rem * var(--space-y-reverse));
 }
 
-.-space-x-2 > :not(template) ~ :not(template) {
+.-space-x-2 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
   margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-3 > :not(template) ~ :not(template) {
+.-space-y-3 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-0.75rem * var(--space-y-reverse));
 }
 
-.-space-x-3 > :not(template) ~ :not(template) {
+.-space-x-3 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
   margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-4 > :not(template) ~ :not(template) {
+.-space-y-4 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-1rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-1rem * var(--space-y-reverse));
 }
 
-.-space-x-4 > :not(template) ~ :not(template) {
+.-space-x-4 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-1rem * var(--space-x-reverse));
   margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-5 > :not(template) ~ :not(template) {
+.-space-y-5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-1.25rem * var(--space-y-reverse));
 }
 
-.-space-x-5 > :not(template) ~ :not(template) {
+.-space-x-5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
   margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-6 > :not(template) ~ :not(template) {
+.-space-y-6 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-1.5rem * var(--space-y-reverse));
 }
 
-.-space-x-6 > :not(template) ~ :not(template) {
+.-space-x-6 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
   margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-7 > :not(template) ~ :not(template) {
+.-space-y-7 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-1.75rem * var(--space-y-reverse));
 }
 
-.-space-x-7 > :not(template) ~ :not(template) {
+.-space-x-7 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
   margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-8 > :not(template) ~ :not(template) {
+.-space-y-8 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-2rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-2rem * var(--space-y-reverse));
 }
 
-.-space-x-8 > :not(template) ~ :not(template) {
+.-space-x-8 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-2rem * var(--space-x-reverse));
   margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-9 > :not(template) ~ :not(template) {
+.-space-y-9 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-2.25rem * var(--space-y-reverse));
 }
 
-.-space-x-9 > :not(template) ~ :not(template) {
+.-space-x-9 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
   margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-10 > :not(template) ~ :not(template) {
+.-space-y-10 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-2.5rem * var(--space-y-reverse));
 }
 
-.-space-x-10 > :not(template) ~ :not(template) {
+.-space-x-10 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
   margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-12 > :not(template) ~ :not(template) {
+.-space-y-12 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-3rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-3rem * var(--space-y-reverse));
 }
 
-.-space-x-12 > :not(template) ~ :not(template) {
+.-space-x-12 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-3rem * var(--space-x-reverse));
   margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-14 > :not(template) ~ :not(template) {
+.-space-y-14 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-3.5rem * var(--space-y-reverse));
 }
 
-.-space-x-14 > :not(template) ~ :not(template) {
+.-space-x-14 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
   margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-16 > :not(template) ~ :not(template) {
+.-space-y-16 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-4rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-4rem * var(--space-y-reverse));
 }
 
-.-space-x-16 > :not(template) ~ :not(template) {
+.-space-x-16 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-4rem * var(--space-x-reverse));
   margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-20 > :not(template) ~ :not(template) {
+.-space-y-20 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-5rem * var(--space-y-reverse));
 }
 
-.-space-x-20 > :not(template) ~ :not(template) {
+.-space-x-20 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-5rem * var(--space-x-reverse));
   margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-24 > :not(template) ~ :not(template) {
+.-space-y-24 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-6rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-6rem * var(--space-y-reverse));
 }
 
-.-space-x-24 > :not(template) ~ :not(template) {
+.-space-x-24 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-6rem * var(--space-x-reverse));
   margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-28 > :not(template) ~ :not(template) {
+.-space-y-28 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-7rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-7rem * var(--space-y-reverse));
 }
 
-.-space-x-28 > :not(template) ~ :not(template) {
+.-space-x-28 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-7rem * var(--space-x-reverse));
   margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-32 > :not(template) ~ :not(template) {
+.-space-y-32 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-8rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-8rem * var(--space-y-reverse));
 }
 
-.-space-x-32 > :not(template) ~ :not(template) {
+.-space-x-32 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-8rem * var(--space-x-reverse));
   margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-36 > :not(template) ~ :not(template) {
+.-space-y-36 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-9rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-9rem * var(--space-y-reverse));
 }
 
-.-space-x-36 > :not(template) ~ :not(template) {
+.-space-x-36 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-9rem * var(--space-x-reverse));
   margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-40 > :not(template) ~ :not(template) {
+.-space-y-40 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-10rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-10rem * var(--space-y-reverse));
 }
 
-.-space-x-40 > :not(template) ~ :not(template) {
+.-space-x-40 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-10rem * var(--space-x-reverse));
   margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-44 > :not(template) ~ :not(template) {
+.-space-y-44 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-11rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-11rem * var(--space-y-reverse));
 }
 
-.-space-x-44 > :not(template) ~ :not(template) {
+.-space-x-44 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-11rem * var(--space-x-reverse));
   margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-48 > :not(template) ~ :not(template) {
+.-space-y-48 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-12rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-12rem * var(--space-y-reverse));
 }
 
-.-space-x-48 > :not(template) ~ :not(template) {
+.-space-x-48 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-12rem * var(--space-x-reverse));
   margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-52 > :not(template) ~ :not(template) {
+.-space-y-52 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-13rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-13rem * var(--space-y-reverse));
 }
 
-.-space-x-52 > :not(template) ~ :not(template) {
+.-space-x-52 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-13rem * var(--space-x-reverse));
   margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-56 > :not(template) ~ :not(template) {
+.-space-y-56 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-14rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-14rem * var(--space-y-reverse));
 }
 
-.-space-x-56 > :not(template) ~ :not(template) {
+.-space-x-56 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-14rem * var(--space-x-reverse));
   margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-60 > :not(template) ~ :not(template) {
+.-space-y-60 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-15rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-15rem * var(--space-y-reverse));
 }
 
-.-space-x-60 > :not(template) ~ :not(template) {
+.-space-x-60 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-15rem * var(--space-x-reverse));
   margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-64 > :not(template) ~ :not(template) {
+.-space-y-64 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-16rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-16rem * var(--space-y-reverse));
 }
 
-.-space-x-64 > :not(template) ~ :not(template) {
+.-space-x-64 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-16rem * var(--space-x-reverse));
   margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-72 > :not(template) ~ :not(template) {
+.-space-y-72 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-18rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-18rem * var(--space-y-reverse));
 }
 
-.-space-x-72 > :not(template) ~ :not(template) {
+.-space-x-72 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-18rem * var(--space-x-reverse));
   margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-80 > :not(template) ~ :not(template) {
+.-space-y-80 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-20rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-20rem * var(--space-y-reverse));
 }
 
-.-space-x-80 > :not(template) ~ :not(template) {
+.-space-x-80 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-20rem * var(--space-x-reverse));
   margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-96 > :not(template) ~ :not(template) {
+.-space-y-96 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-24rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-24rem * var(--space-y-reverse));
 }
 
-.-space-x-96 > :not(template) ~ :not(template) {
+.-space-x-96 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-24rem * var(--space-x-reverse));
   margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-px > :not(template) ~ :not(template) {
+.-space-y-px > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-1px * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-1px * var(--space-y-reverse));
 }
 
-.-space-x-px > :not(template) ~ :not(template) {
+.-space-x-px > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-1px * var(--space-x-reverse));
   margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-0\.5 > :not(template) ~ :not(template) {
+.-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-0.125rem * var(--space-y-reverse));
 }
 
-.-space-x-0\.5 > :not(template) ~ :not(template) {
+.-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
   margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-1\.5 > :not(template) ~ :not(template) {
+.-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-0.375rem * var(--space-y-reverse));
 }
 
-.-space-x-1\.5 > :not(template) ~ :not(template) {
+.-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
   margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-2\.5 > :not(template) ~ :not(template) {
+.-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-0.625rem * var(--space-y-reverse));
 }
 
-.-space-x-2\.5 > :not(template) ~ :not(template) {
+.-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
   margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-3\.5 > :not(template) ~ :not(template) {
+.-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-0.875rem * var(--space-y-reverse));
 }
 
-.-space-x-3\.5 > :not(template) ~ :not(template) {
+.-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
   margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-reverse > :not(template) ~ :not(template) {
+.space-y-reverse > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 1;
 }
 
-.space-x-reverse > :not(template) ~ :not(template) {
+.space-x-reverse > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 1;
 }
 
-.divide-y-0 > :not(template) ~ :not(template) {
+.divide-y-0 > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 0;
   border-top-width: calc(0px * calc(1 - var(--divide-y-reverse)));
   border-bottom-width: calc(0px * var(--divide-y-reverse));
 }
 
-.divide-x-0 > :not(template) ~ :not(template) {
+.divide-x-0 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
   border-inline-end-width: calc(0px * var(--divide-x-reverse));
   border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
 }
 
-.divide-y-2 > :not(template) ~ :not(template) {
+.divide-y-2 > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 0;
   border-top-width: calc(2px * calc(1 - var(--divide-y-reverse)));
   border-bottom-width: calc(2px * var(--divide-y-reverse));
 }
 
-.divide-x-2 > :not(template) ~ :not(template) {
+.divide-x-2 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
   border-inline-end-width: calc(2px * var(--divide-x-reverse));
   border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
 }
 
-.divide-y-4 > :not(template) ~ :not(template) {
+.divide-y-4 > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 0;
   border-top-width: calc(4px * calc(1 - var(--divide-y-reverse)));
   border-bottom-width: calc(4px * var(--divide-y-reverse));
 }
 
-.divide-x-4 > :not(template) ~ :not(template) {
+.divide-x-4 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
   border-inline-end-width: calc(4px * var(--divide-x-reverse));
   border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
 }
 
-.divide-y-8 > :not(template) ~ :not(template) {
+.divide-y-8 > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 0;
   border-top-width: calc(8px * calc(1 - var(--divide-y-reverse)));
   border-bottom-width: calc(8px * var(--divide-y-reverse));
 }
 
-.divide-x-8 > :not(template) ~ :not(template) {
+.divide-x-8 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
   border-inline-end-width: calc(8px * var(--divide-x-reverse));
   border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
 }
 
-.divide-y > :not(template) ~ :not(template) {
+.divide-y > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 0;
   border-top-width: calc(1px * calc(1 - var(--divide-y-reverse)));
   border-bottom-width: calc(1px * var(--divide-y-reverse));
 }
 
-.divide-x > :not(template) ~ :not(template) {
+.divide-x > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
   border-inline-end-width: calc(1px * var(--divide-x-reverse));
   border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
 }
 
-.divide-y-reverse > :not(template) ~ :not(template) {
+.divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 1;
 }
 
-.divide-x-reverse > :not(template) ~ :not(template) {
+.divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 1;
 }
 
-.divide-transparent > :not(template) ~ :not(template) {
+.divide-transparent > :not([hidden]) ~ :not([hidden]) {
   border-color: transparent;
 }
 
-.divide-current > :not(template) ~ :not(template) {
+.divide-current > :not([hidden]) ~ :not([hidden]) {
   border-color: currentColor;
 }
 
-.divide-black > :not(template) ~ :not(template) {
+.divide-black > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(0, 0, 0, var(--divide-opacity));
 }
 
-.divide-white > :not(template) ~ :not(template) {
+.divide-white > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(255, 255, 255, var(--divide-opacity));
 }
 
-.divide-gray-50 > :not(template) ~ :not(template) {
+.divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(250, 250, 250, var(--divide-opacity));
 }
 
-.divide-gray-100 > :not(template) ~ :not(template) {
+.divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(244, 244, 245, var(--divide-opacity));
 }
 
-.divide-gray-200 > :not(template) ~ :not(template) {
+.divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(228, 228, 231, var(--divide-opacity));
 }
 
-.divide-gray-300 > :not(template) ~ :not(template) {
+.divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(212, 212, 216, var(--divide-opacity));
 }
 
-.divide-gray-400 > :not(template) ~ :not(template) {
+.divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(161, 161, 170, var(--divide-opacity));
 }
 
-.divide-gray-500 > :not(template) ~ :not(template) {
+.divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(113, 113, 122, var(--divide-opacity));
 }
 
-.divide-gray-600 > :not(template) ~ :not(template) {
+.divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(82, 82, 91, var(--divide-opacity));
 }
 
-.divide-gray-700 > :not(template) ~ :not(template) {
+.divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(63, 63, 70, var(--divide-opacity));
 }
 
-.divide-gray-800 > :not(template) ~ :not(template) {
+.divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(39, 39, 42, var(--divide-opacity));
 }
 
-.divide-gray-900 > :not(template) ~ :not(template) {
+.divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(24, 24, 27, var(--divide-opacity));
 }
 
-.divide-red-50 > :not(template) ~ :not(template) {
+.divide-red-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(254, 242, 242, var(--divide-opacity));
 }
 
-.divide-red-100 > :not(template) ~ :not(template) {
+.divide-red-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(254, 226, 226, var(--divide-opacity));
 }
 
-.divide-red-200 > :not(template) ~ :not(template) {
+.divide-red-200 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(254, 202, 202, var(--divide-opacity));
 }
 
-.divide-red-300 > :not(template) ~ :not(template) {
+.divide-red-300 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(252, 165, 165, var(--divide-opacity));
 }
 
-.divide-red-400 > :not(template) ~ :not(template) {
+.divide-red-400 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(248, 113, 113, var(--divide-opacity));
 }
 
-.divide-red-500 > :not(template) ~ :not(template) {
+.divide-red-500 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(239, 68, 68, var(--divide-opacity));
 }
 
-.divide-red-600 > :not(template) ~ :not(template) {
+.divide-red-600 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(220, 38, 38, var(--divide-opacity));
 }
 
-.divide-red-700 > :not(template) ~ :not(template) {
+.divide-red-700 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(185, 28, 28, var(--divide-opacity));
 }
 
-.divide-red-800 > :not(template) ~ :not(template) {
+.divide-red-800 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(153, 27, 27, var(--divide-opacity));
 }
 
-.divide-red-900 > :not(template) ~ :not(template) {
+.divide-red-900 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(127, 29, 29, var(--divide-opacity));
 }
 
-.divide-yellow-50 > :not(template) ~ :not(template) {
+.divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(255, 251, 235, var(--divide-opacity));
 }
 
-.divide-yellow-100 > :not(template) ~ :not(template) {
+.divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(254, 243, 199, var(--divide-opacity));
 }
 
-.divide-yellow-200 > :not(template) ~ :not(template) {
+.divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(253, 230, 138, var(--divide-opacity));
 }
 
-.divide-yellow-300 > :not(template) ~ :not(template) {
+.divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(252, 211, 77, var(--divide-opacity));
 }
 
-.divide-yellow-400 > :not(template) ~ :not(template) {
+.divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(251, 191, 36, var(--divide-opacity));
 }
 
-.divide-yellow-500 > :not(template) ~ :not(template) {
+.divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(245, 158, 11, var(--divide-opacity));
 }
 
-.divide-yellow-600 > :not(template) ~ :not(template) {
+.divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(217, 119, 6, var(--divide-opacity));
 }
 
-.divide-yellow-700 > :not(template) ~ :not(template) {
+.divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(180, 83, 9, var(--divide-opacity));
 }
 
-.divide-yellow-800 > :not(template) ~ :not(template) {
+.divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(146, 64, 14, var(--divide-opacity));
 }
 
-.divide-yellow-900 > :not(template) ~ :not(template) {
+.divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(120, 53, 15, var(--divide-opacity));
 }
 
-.divide-green-50 > :not(template) ~ :not(template) {
+.divide-green-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(236, 253, 245, var(--divide-opacity));
 }
 
-.divide-green-100 > :not(template) ~ :not(template) {
+.divide-green-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(209, 250, 229, var(--divide-opacity));
 }
 
-.divide-green-200 > :not(template) ~ :not(template) {
+.divide-green-200 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(167, 243, 208, var(--divide-opacity));
 }
 
-.divide-green-300 > :not(template) ~ :not(template) {
+.divide-green-300 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(110, 231, 183, var(--divide-opacity));
 }
 
-.divide-green-400 > :not(template) ~ :not(template) {
+.divide-green-400 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(52, 211, 153, var(--divide-opacity));
 }
 
-.divide-green-500 > :not(template) ~ :not(template) {
+.divide-green-500 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(16, 185, 129, var(--divide-opacity));
 }
 
-.divide-green-600 > :not(template) ~ :not(template) {
+.divide-green-600 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(5, 150, 105, var(--divide-opacity));
 }
 
-.divide-green-700 > :not(template) ~ :not(template) {
+.divide-green-700 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(4, 120, 87, var(--divide-opacity));
 }
 
-.divide-green-800 > :not(template) ~ :not(template) {
+.divide-green-800 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(6, 95, 70, var(--divide-opacity));
 }
 
-.divide-green-900 > :not(template) ~ :not(template) {
+.divide-green-900 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(6, 78, 59, var(--divide-opacity));
 }
 
-.divide-blue-50 > :not(template) ~ :not(template) {
+.divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(239, 246, 255, var(--divide-opacity));
 }
 
-.divide-blue-100 > :not(template) ~ :not(template) {
+.divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(219, 234, 254, var(--divide-opacity));
 }
 
-.divide-blue-200 > :not(template) ~ :not(template) {
+.divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(191, 219, 254, var(--divide-opacity));
 }
 
-.divide-blue-300 > :not(template) ~ :not(template) {
+.divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(147, 197, 253, var(--divide-opacity));
 }
 
-.divide-blue-400 > :not(template) ~ :not(template) {
+.divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(96, 165, 250, var(--divide-opacity));
 }
 
-.divide-blue-500 > :not(template) ~ :not(template) {
+.divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(59, 130, 246, var(--divide-opacity));
 }
 
-.divide-blue-600 > :not(template) ~ :not(template) {
+.divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(37, 99, 235, var(--divide-opacity));
 }
 
-.divide-blue-700 > :not(template) ~ :not(template) {
+.divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(29, 78, 216, var(--divide-opacity));
 }
 
-.divide-blue-800 > :not(template) ~ :not(template) {
+.divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(30, 64, 175, var(--divide-opacity));
 }
 
-.divide-blue-900 > :not(template) ~ :not(template) {
+.divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(30, 58, 138, var(--divide-opacity));
 }
 
-.divide-purple-50 > :not(template) ~ :not(template) {
+.divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(245, 243, 255, var(--divide-opacity));
 }
 
-.divide-purple-100 > :not(template) ~ :not(template) {
+.divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(237, 233, 254, var(--divide-opacity));
 }
 
-.divide-purple-200 > :not(template) ~ :not(template) {
+.divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(221, 214, 254, var(--divide-opacity));
 }
 
-.divide-purple-300 > :not(template) ~ :not(template) {
+.divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(196, 181, 253, var(--divide-opacity));
 }
 
-.divide-purple-400 > :not(template) ~ :not(template) {
+.divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(167, 139, 250, var(--divide-opacity));
 }
 
-.divide-purple-500 > :not(template) ~ :not(template) {
+.divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(139, 92, 246, var(--divide-opacity));
 }
 
-.divide-purple-600 > :not(template) ~ :not(template) {
+.divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(124, 58, 237, var(--divide-opacity));
 }
 
-.divide-purple-700 > :not(template) ~ :not(template) {
+.divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(109, 40, 217, var(--divide-opacity));
 }
 
-.divide-purple-800 > :not(template) ~ :not(template) {
+.divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(91, 33, 182, var(--divide-opacity));
 }
 
-.divide-purple-900 > :not(template) ~ :not(template) {
+.divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(76, 29, 149, var(--divide-opacity));
 }
 
-.divide-pink-50 > :not(template) ~ :not(template) {
+.divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(253, 242, 248, var(--divide-opacity));
 }
 
-.divide-pink-100 > :not(template) ~ :not(template) {
+.divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(252, 231, 243, var(--divide-opacity));
 }
 
-.divide-pink-200 > :not(template) ~ :not(template) {
+.divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(251, 207, 232, var(--divide-opacity));
 }
 
-.divide-pink-300 > :not(template) ~ :not(template) {
+.divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(249, 168, 212, var(--divide-opacity));
 }
 
-.divide-pink-400 > :not(template) ~ :not(template) {
+.divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(244, 114, 182, var(--divide-opacity));
 }
 
-.divide-pink-500 > :not(template) ~ :not(template) {
+.divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(236, 72, 153, var(--divide-opacity));
 }
 
-.divide-pink-600 > :not(template) ~ :not(template) {
+.divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(219, 39, 119, var(--divide-opacity));
 }
 
-.divide-pink-700 > :not(template) ~ :not(template) {
+.divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(190, 24, 93, var(--divide-opacity));
 }
 
-.divide-pink-800 > :not(template) ~ :not(template) {
+.divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(157, 23, 77, var(--divide-opacity));
 }
 
-.divide-pink-900 > :not(template) ~ :not(template) {
+.divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(131, 24, 67, var(--divide-opacity));
 }
 
-.divide-solid > :not(template) ~ :not(template) {
+.divide-solid > :not([hidden]) ~ :not([hidden]) {
   border-style: solid;
 }
 
-.divide-dashed > :not(template) ~ :not(template) {
+.divide-dashed > :not([hidden]) ~ :not([hidden]) {
   border-style: dashed;
 }
 
-.divide-dotted > :not(template) ~ :not(template) {
+.divide-dotted > :not([hidden]) ~ :not([hidden]) {
   border-style: dotted;
 }
 
-.divide-double > :not(template) ~ :not(template) {
+.divide-double > :not([hidden]) ~ :not([hidden]) {
   border-style: double;
 }
 
-.divide-none > :not(template) ~ :not(template) {
+.divide-none > :not([hidden]) ~ :not([hidden]) {
   border-style: none;
 }
 
-.divide-opacity-0 > :not(template) ~ :not(template) {
+.divide-opacity-0 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0;
 }
 
-.divide-opacity-10 > :not(template) ~ :not(template) {
+.divide-opacity-10 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.1;
 }
 
-.divide-opacity-20 > :not(template) ~ :not(template) {
+.divide-opacity-20 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.2;
 }
 
-.divide-opacity-25 > :not(template) ~ :not(template) {
+.divide-opacity-25 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.25;
 }
 
-.divide-opacity-30 > :not(template) ~ :not(template) {
+.divide-opacity-30 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.3;
 }
 
-.divide-opacity-40 > :not(template) ~ :not(template) {
+.divide-opacity-40 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.4;
 }
 
-.divide-opacity-50 > :not(template) ~ :not(template) {
+.divide-opacity-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.5;
 }
 
-.divide-opacity-60 > :not(template) ~ :not(template) {
+.divide-opacity-60 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.6;
 }
 
-.divide-opacity-70 > :not(template) ~ :not(template) {
+.divide-opacity-70 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.7;
 }
 
-.divide-opacity-75 > :not(template) ~ :not(template) {
+.divide-opacity-75 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.75;
 }
 
-.divide-opacity-80 > :not(template) ~ :not(template) {
+.divide-opacity-80 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.8;
 }
 
-.divide-opacity-90 > :not(template) ~ :not(template) {
+.divide-opacity-90 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.9;
 }
 
-.divide-opacity-100 > :not(template) ~ :not(template) {
+.divide-opacity-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
 }
 
@@ -23536,1323 +23536,1323 @@ video {
     }
   }
 
-  .sm\:space-y-0 > :not(template) ~ :not(template) {
+  .sm\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0px * var(--space-y-reverse));
   }
 
-  .sm\:space-x-0 > :not(template) ~ :not(template) {
+  .sm\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0px * var(--space-x-reverse));
     margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-1 > :not(template) ~ :not(template) {
+  .sm\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.25rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-1 > :not(template) ~ :not(template) {
+  .sm\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-2 > :not(template) ~ :not(template) {
+  .sm\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.5rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-2 > :not(template) ~ :not(template) {
+  .sm\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-3 > :not(template) ~ :not(template) {
+  .sm\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.75rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-3 > :not(template) ~ :not(template) {
+  .sm\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-4 > :not(template) ~ :not(template) {
+  .sm\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-4 > :not(template) ~ :not(template) {
+  .sm\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1rem * var(--space-x-reverse));
     margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-5 > :not(template) ~ :not(template) {
+  .sm\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.25rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-5 > :not(template) ~ :not(template) {
+  .sm\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-6 > :not(template) ~ :not(template) {
+  .sm\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.5rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-6 > :not(template) ~ :not(template) {
+  .sm\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-7 > :not(template) ~ :not(template) {
+  .sm\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.75rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-7 > :not(template) ~ :not(template) {
+  .sm\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-8 > :not(template) ~ :not(template) {
+  .sm\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-8 > :not(template) ~ :not(template) {
+  .sm\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2rem * var(--space-x-reverse));
     margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-9 > :not(template) ~ :not(template) {
+  .sm\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.25rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-9 > :not(template) ~ :not(template) {
+  .sm\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-10 > :not(template) ~ :not(template) {
+  .sm\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.5rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-10 > :not(template) ~ :not(template) {
+  .sm\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-12 > :not(template) ~ :not(template) {
+  .sm\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-12 > :not(template) ~ :not(template) {
+  .sm\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3rem * var(--space-x-reverse));
     margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-14 > :not(template) ~ :not(template) {
+  .sm\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3.5rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-14 > :not(template) ~ :not(template) {
+  .sm\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-16 > :not(template) ~ :not(template) {
+  .sm\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(4rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-16 > :not(template) ~ :not(template) {
+  .sm\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(4rem * var(--space-x-reverse));
     margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-20 > :not(template) ~ :not(template) {
+  .sm\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(5rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-20 > :not(template) ~ :not(template) {
+  .sm\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(5rem * var(--space-x-reverse));
     margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-24 > :not(template) ~ :not(template) {
+  .sm\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(6rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-24 > :not(template) ~ :not(template) {
+  .sm\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(6rem * var(--space-x-reverse));
     margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-28 > :not(template) ~ :not(template) {
+  .sm\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(7rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-28 > :not(template) ~ :not(template) {
+  .sm\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(7rem * var(--space-x-reverse));
     margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-32 > :not(template) ~ :not(template) {
+  .sm\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(8rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-32 > :not(template) ~ :not(template) {
+  .sm\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(8rem * var(--space-x-reverse));
     margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-36 > :not(template) ~ :not(template) {
+  .sm\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(9rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-36 > :not(template) ~ :not(template) {
+  .sm\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(9rem * var(--space-x-reverse));
     margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-40 > :not(template) ~ :not(template) {
+  .sm\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(10rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-40 > :not(template) ~ :not(template) {
+  .sm\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(10rem * var(--space-x-reverse));
     margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-44 > :not(template) ~ :not(template) {
+  .sm\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(11rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-44 > :not(template) ~ :not(template) {
+  .sm\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(11rem * var(--space-x-reverse));
     margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-48 > :not(template) ~ :not(template) {
+  .sm\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(12rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-48 > :not(template) ~ :not(template) {
+  .sm\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(12rem * var(--space-x-reverse));
     margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-52 > :not(template) ~ :not(template) {
+  .sm\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(13rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-52 > :not(template) ~ :not(template) {
+  .sm\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(13rem * var(--space-x-reverse));
     margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-56 > :not(template) ~ :not(template) {
+  .sm\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(14rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-56 > :not(template) ~ :not(template) {
+  .sm\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(14rem * var(--space-x-reverse));
     margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-60 > :not(template) ~ :not(template) {
+  .sm\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(15rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-60 > :not(template) ~ :not(template) {
+  .sm\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(15rem * var(--space-x-reverse));
     margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-64 > :not(template) ~ :not(template) {
+  .sm\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(16rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-64 > :not(template) ~ :not(template) {
+  .sm\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(16rem * var(--space-x-reverse));
     margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-72 > :not(template) ~ :not(template) {
+  .sm\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(18rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-72 > :not(template) ~ :not(template) {
+  .sm\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(18rem * var(--space-x-reverse));
     margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-80 > :not(template) ~ :not(template) {
+  .sm\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(20rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-80 > :not(template) ~ :not(template) {
+  .sm\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(20rem * var(--space-x-reverse));
     margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-96 > :not(template) ~ :not(template) {
+  .sm\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(24rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-96 > :not(template) ~ :not(template) {
+  .sm\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(24rem * var(--space-x-reverse));
     margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-px > :not(template) ~ :not(template) {
+  .sm\:space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1px * var(--space-y-reverse));
   }
 
-  .sm\:space-x-px > :not(template) ~ :not(template) {
+  .sm\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1px * var(--space-x-reverse));
     margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-0\.5 > :not(template) ~ :not(template) {
+  .sm\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.125rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-0\.5 > :not(template) ~ :not(template) {
+  .sm\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-1\.5 > :not(template) ~ :not(template) {
+  .sm\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.375rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-1\.5 > :not(template) ~ :not(template) {
+  .sm\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-2\.5 > :not(template) ~ :not(template) {
+  .sm\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.625rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-2\.5 > :not(template) ~ :not(template) {
+  .sm\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-3\.5 > :not(template) ~ :not(template) {
+  .sm\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.875rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-3\.5 > :not(template) ~ :not(template) {
+  .sm\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-1 > :not(template) ~ :not(template) {
+  .sm\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.25rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-1 > :not(template) ~ :not(template) {
+  .sm\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-2 > :not(template) ~ :not(template) {
+  .sm\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.5rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-2 > :not(template) ~ :not(template) {
+  .sm\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-3 > :not(template) ~ :not(template) {
+  .sm\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.75rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-3 > :not(template) ~ :not(template) {
+  .sm\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-4 > :not(template) ~ :not(template) {
+  .sm\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-4 > :not(template) ~ :not(template) {
+  .sm\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1rem * var(--space-x-reverse));
     margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-5 > :not(template) ~ :not(template) {
+  .sm\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.25rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-5 > :not(template) ~ :not(template) {
+  .sm\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-6 > :not(template) ~ :not(template) {
+  .sm\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.5rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-6 > :not(template) ~ :not(template) {
+  .sm\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-7 > :not(template) ~ :not(template) {
+  .sm\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.75rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-7 > :not(template) ~ :not(template) {
+  .sm\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-8 > :not(template) ~ :not(template) {
+  .sm\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-8 > :not(template) ~ :not(template) {
+  .sm\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2rem * var(--space-x-reverse));
     margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-9 > :not(template) ~ :not(template) {
+  .sm\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.25rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-9 > :not(template) ~ :not(template) {
+  .sm\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-10 > :not(template) ~ :not(template) {
+  .sm\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.5rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-10 > :not(template) ~ :not(template) {
+  .sm\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-12 > :not(template) ~ :not(template) {
+  .sm\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-12 > :not(template) ~ :not(template) {
+  .sm\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3rem * var(--space-x-reverse));
     margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-14 > :not(template) ~ :not(template) {
+  .sm\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3.5rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-14 > :not(template) ~ :not(template) {
+  .sm\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-16 > :not(template) ~ :not(template) {
+  .sm\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-4rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-16 > :not(template) ~ :not(template) {
+  .sm\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-4rem * var(--space-x-reverse));
     margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-20 > :not(template) ~ :not(template) {
+  .sm\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-5rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-20 > :not(template) ~ :not(template) {
+  .sm\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-5rem * var(--space-x-reverse));
     margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-24 > :not(template) ~ :not(template) {
+  .sm\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-6rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-24 > :not(template) ~ :not(template) {
+  .sm\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-6rem * var(--space-x-reverse));
     margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-28 > :not(template) ~ :not(template) {
+  .sm\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-7rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-28 > :not(template) ~ :not(template) {
+  .sm\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-7rem * var(--space-x-reverse));
     margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-32 > :not(template) ~ :not(template) {
+  .sm\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-8rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-32 > :not(template) ~ :not(template) {
+  .sm\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-8rem * var(--space-x-reverse));
     margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-36 > :not(template) ~ :not(template) {
+  .sm\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-9rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-36 > :not(template) ~ :not(template) {
+  .sm\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-9rem * var(--space-x-reverse));
     margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-40 > :not(template) ~ :not(template) {
+  .sm\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-10rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-40 > :not(template) ~ :not(template) {
+  .sm\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-10rem * var(--space-x-reverse));
     margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-44 > :not(template) ~ :not(template) {
+  .sm\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-11rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-44 > :not(template) ~ :not(template) {
+  .sm\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-11rem * var(--space-x-reverse));
     margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-48 > :not(template) ~ :not(template) {
+  .sm\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-12rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-48 > :not(template) ~ :not(template) {
+  .sm\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-12rem * var(--space-x-reverse));
     margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-52 > :not(template) ~ :not(template) {
+  .sm\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-13rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-52 > :not(template) ~ :not(template) {
+  .sm\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-13rem * var(--space-x-reverse));
     margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-56 > :not(template) ~ :not(template) {
+  .sm\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-14rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-56 > :not(template) ~ :not(template) {
+  .sm\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-14rem * var(--space-x-reverse));
     margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-60 > :not(template) ~ :not(template) {
+  .sm\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-15rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-60 > :not(template) ~ :not(template) {
+  .sm\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-15rem * var(--space-x-reverse));
     margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-64 > :not(template) ~ :not(template) {
+  .sm\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-16rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-64 > :not(template) ~ :not(template) {
+  .sm\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-16rem * var(--space-x-reverse));
     margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-72 > :not(template) ~ :not(template) {
+  .sm\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-18rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-72 > :not(template) ~ :not(template) {
+  .sm\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-18rem * var(--space-x-reverse));
     margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-80 > :not(template) ~ :not(template) {
+  .sm\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-20rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-80 > :not(template) ~ :not(template) {
+  .sm\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-20rem * var(--space-x-reverse));
     margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-96 > :not(template) ~ :not(template) {
+  .sm\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-24rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-96 > :not(template) ~ :not(template) {
+  .sm\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-24rem * var(--space-x-reverse));
     margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-px > :not(template) ~ :not(template) {
+  .sm\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1px * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-px > :not(template) ~ :not(template) {
+  .sm\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1px * var(--space-x-reverse));
     margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-0\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.125rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-0\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-1\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.375rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-1\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-2\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.625rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-2\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-3\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.875rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-3\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-reverse > :not(template) ~ :not(template) {
+  .sm\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 1;
   }
 
-  .sm\:space-x-reverse > :not(template) ~ :not(template) {
+  .sm\:space-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 1;
   }
 
-  .sm\:divide-y-0 > :not(template) ~ :not(template) {
+  .sm\:divide-y-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(0px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(0px * var(--divide-y-reverse));
   }
 
-  .sm\:divide-x-0 > :not(template) ~ :not(template) {
+  .sm\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(0px * var(--divide-x-reverse));
     border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .sm\:divide-y-2 > :not(template) ~ :not(template) {
+  .sm\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(2px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(2px * var(--divide-y-reverse));
   }
 
-  .sm\:divide-x-2 > :not(template) ~ :not(template) {
+  .sm\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(2px * var(--divide-x-reverse));
     border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .sm\:divide-y-4 > :not(template) ~ :not(template) {
+  .sm\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(4px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(4px * var(--divide-y-reverse));
   }
 
-  .sm\:divide-x-4 > :not(template) ~ :not(template) {
+  .sm\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(4px * var(--divide-x-reverse));
     border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .sm\:divide-y-8 > :not(template) ~ :not(template) {
+  .sm\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(8px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(8px * var(--divide-y-reverse));
   }
 
-  .sm\:divide-x-8 > :not(template) ~ :not(template) {
+  .sm\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(8px * var(--divide-x-reverse));
     border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .sm\:divide-y > :not(template) ~ :not(template) {
+  .sm\:divide-y > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(1px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(1px * var(--divide-y-reverse));
   }
 
-  .sm\:divide-x > :not(template) ~ :not(template) {
+  .sm\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(1px * var(--divide-x-reverse));
     border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .sm\:divide-y-reverse > :not(template) ~ :not(template) {
+  .sm\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 1;
   }
 
-  .sm\:divide-x-reverse > :not(template) ~ :not(template) {
+  .sm\:divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 1;
   }
 
-  .sm\:divide-transparent > :not(template) ~ :not(template) {
+  .sm\:divide-transparent > :not([hidden]) ~ :not([hidden]) {
     border-color: transparent;
   }
 
-  .sm\:divide-current > :not(template) ~ :not(template) {
+  .sm\:divide-current > :not([hidden]) ~ :not([hidden]) {
     border-color: currentColor;
   }
 
-  .sm\:divide-black > :not(template) ~ :not(template) {
+  .sm\:divide-black > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(0, 0, 0, var(--divide-opacity));
   }
 
-  .sm\:divide-white > :not(template) ~ :not(template) {
+  .sm\:divide-white > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(255, 255, 255, var(--divide-opacity));
   }
 
-  .sm\:divide-gray-50 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(250, 250, 250, var(--divide-opacity));
   }
 
-  .sm\:divide-gray-100 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(244, 244, 245, var(--divide-opacity));
   }
 
-  .sm\:divide-gray-200 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(228, 228, 231, var(--divide-opacity));
   }
 
-  .sm\:divide-gray-300 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(212, 212, 216, var(--divide-opacity));
   }
 
-  .sm\:divide-gray-400 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(161, 161, 170, var(--divide-opacity));
   }
 
-  .sm\:divide-gray-500 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(113, 113, 122, var(--divide-opacity));
   }
 
-  .sm\:divide-gray-600 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(82, 82, 91, var(--divide-opacity));
   }
 
-  .sm\:divide-gray-700 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(63, 63, 70, var(--divide-opacity));
   }
 
-  .sm\:divide-gray-800 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(39, 39, 42, var(--divide-opacity));
   }
 
-  .sm\:divide-gray-900 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(24, 24, 27, var(--divide-opacity));
   }
 
-  .sm\:divide-red-50 > :not(template) ~ :not(template) {
+  .sm\:divide-red-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 242, 242, var(--divide-opacity));
   }
 
-  .sm\:divide-red-100 > :not(template) ~ :not(template) {
+  .sm\:divide-red-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 226, 226, var(--divide-opacity));
   }
 
-  .sm\:divide-red-200 > :not(template) ~ :not(template) {
+  .sm\:divide-red-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 202, 202, var(--divide-opacity));
   }
 
-  .sm\:divide-red-300 > :not(template) ~ :not(template) {
+  .sm\:divide-red-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 165, 165, var(--divide-opacity));
   }
 
-  .sm\:divide-red-400 > :not(template) ~ :not(template) {
+  .sm\:divide-red-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(248, 113, 113, var(--divide-opacity));
   }
 
-  .sm\:divide-red-500 > :not(template) ~ :not(template) {
+  .sm\:divide-red-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(239, 68, 68, var(--divide-opacity));
   }
 
-  .sm\:divide-red-600 > :not(template) ~ :not(template) {
+  .sm\:divide-red-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(220, 38, 38, var(--divide-opacity));
   }
 
-  .sm\:divide-red-700 > :not(template) ~ :not(template) {
+  .sm\:divide-red-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(185, 28, 28, var(--divide-opacity));
   }
 
-  .sm\:divide-red-800 > :not(template) ~ :not(template) {
+  .sm\:divide-red-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(153, 27, 27, var(--divide-opacity));
   }
 
-  .sm\:divide-red-900 > :not(template) ~ :not(template) {
+  .sm\:divide-red-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(127, 29, 29, var(--divide-opacity));
   }
 
-  .sm\:divide-yellow-50 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(255, 251, 235, var(--divide-opacity));
   }
 
-  .sm\:divide-yellow-100 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 243, 199, var(--divide-opacity));
   }
 
-  .sm\:divide-yellow-200 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(253, 230, 138, var(--divide-opacity));
   }
 
-  .sm\:divide-yellow-300 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 211, 77, var(--divide-opacity));
   }
 
-  .sm\:divide-yellow-400 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(251, 191, 36, var(--divide-opacity));
   }
 
-  .sm\:divide-yellow-500 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(245, 158, 11, var(--divide-opacity));
   }
 
-  .sm\:divide-yellow-600 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(217, 119, 6, var(--divide-opacity));
   }
 
-  .sm\:divide-yellow-700 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(180, 83, 9, var(--divide-opacity));
   }
 
-  .sm\:divide-yellow-800 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(146, 64, 14, var(--divide-opacity));
   }
 
-  .sm\:divide-yellow-900 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(120, 53, 15, var(--divide-opacity));
   }
 
-  .sm\:divide-green-50 > :not(template) ~ :not(template) {
+  .sm\:divide-green-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(236, 253, 245, var(--divide-opacity));
   }
 
-  .sm\:divide-green-100 > :not(template) ~ :not(template) {
+  .sm\:divide-green-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(209, 250, 229, var(--divide-opacity));
   }
 
-  .sm\:divide-green-200 > :not(template) ~ :not(template) {
+  .sm\:divide-green-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(167, 243, 208, var(--divide-opacity));
   }
 
-  .sm\:divide-green-300 > :not(template) ~ :not(template) {
+  .sm\:divide-green-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(110, 231, 183, var(--divide-opacity));
   }
 
-  .sm\:divide-green-400 > :not(template) ~ :not(template) {
+  .sm\:divide-green-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(52, 211, 153, var(--divide-opacity));
   }
 
-  .sm\:divide-green-500 > :not(template) ~ :not(template) {
+  .sm\:divide-green-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(16, 185, 129, var(--divide-opacity));
   }
 
-  .sm\:divide-green-600 > :not(template) ~ :not(template) {
+  .sm\:divide-green-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(5, 150, 105, var(--divide-opacity));
   }
 
-  .sm\:divide-green-700 > :not(template) ~ :not(template) {
+  .sm\:divide-green-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(4, 120, 87, var(--divide-opacity));
   }
 
-  .sm\:divide-green-800 > :not(template) ~ :not(template) {
+  .sm\:divide-green-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(6, 95, 70, var(--divide-opacity));
   }
 
-  .sm\:divide-green-900 > :not(template) ~ :not(template) {
+  .sm\:divide-green-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(6, 78, 59, var(--divide-opacity));
   }
 
-  .sm\:divide-blue-50 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(239, 246, 255, var(--divide-opacity));
   }
 
-  .sm\:divide-blue-100 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(219, 234, 254, var(--divide-opacity));
   }
 
-  .sm\:divide-blue-200 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(191, 219, 254, var(--divide-opacity));
   }
 
-  .sm\:divide-blue-300 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(147, 197, 253, var(--divide-opacity));
   }
 
-  .sm\:divide-blue-400 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(96, 165, 250, var(--divide-opacity));
   }
 
-  .sm\:divide-blue-500 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(59, 130, 246, var(--divide-opacity));
   }
 
-  .sm\:divide-blue-600 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(37, 99, 235, var(--divide-opacity));
   }
 
-  .sm\:divide-blue-700 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(29, 78, 216, var(--divide-opacity));
   }
 
-  .sm\:divide-blue-800 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(30, 64, 175, var(--divide-opacity));
   }
 
-  .sm\:divide-blue-900 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(30, 58, 138, var(--divide-opacity));
   }
 
-  .sm\:divide-purple-50 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(245, 243, 255, var(--divide-opacity));
   }
 
-  .sm\:divide-purple-100 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(237, 233, 254, var(--divide-opacity));
   }
 
-  .sm\:divide-purple-200 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(221, 214, 254, var(--divide-opacity));
   }
 
-  .sm\:divide-purple-300 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(196, 181, 253, var(--divide-opacity));
   }
 
-  .sm\:divide-purple-400 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(167, 139, 250, var(--divide-opacity));
   }
 
-  .sm\:divide-purple-500 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(139, 92, 246, var(--divide-opacity));
   }
 
-  .sm\:divide-purple-600 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(124, 58, 237, var(--divide-opacity));
   }
 
-  .sm\:divide-purple-700 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(109, 40, 217, var(--divide-opacity));
   }
 
-  .sm\:divide-purple-800 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(91, 33, 182, var(--divide-opacity));
   }
 
-  .sm\:divide-purple-900 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(76, 29, 149, var(--divide-opacity));
   }
 
-  .sm\:divide-pink-50 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(253, 242, 248, var(--divide-opacity));
   }
 
-  .sm\:divide-pink-100 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 231, 243, var(--divide-opacity));
   }
 
-  .sm\:divide-pink-200 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(251, 207, 232, var(--divide-opacity));
   }
 
-  .sm\:divide-pink-300 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(249, 168, 212, var(--divide-opacity));
   }
 
-  .sm\:divide-pink-400 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(244, 114, 182, var(--divide-opacity));
   }
 
-  .sm\:divide-pink-500 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(236, 72, 153, var(--divide-opacity));
   }
 
-  .sm\:divide-pink-600 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(219, 39, 119, var(--divide-opacity));
   }
 
-  .sm\:divide-pink-700 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(190, 24, 93, var(--divide-opacity));
   }
 
-  .sm\:divide-pink-800 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(157, 23, 77, var(--divide-opacity));
   }
 
-  .sm\:divide-pink-900 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(131, 24, 67, var(--divide-opacity));
   }
 
-  .sm\:divide-solid > :not(template) ~ :not(template) {
+  .sm\:divide-solid > :not([hidden]) ~ :not([hidden]) {
     border-style: solid;
   }
 
-  .sm\:divide-dashed > :not(template) ~ :not(template) {
+  .sm\:divide-dashed > :not([hidden]) ~ :not([hidden]) {
     border-style: dashed;
   }
 
-  .sm\:divide-dotted > :not(template) ~ :not(template) {
+  .sm\:divide-dotted > :not([hidden]) ~ :not([hidden]) {
     border-style: dotted;
   }
 
-  .sm\:divide-double > :not(template) ~ :not(template) {
+  .sm\:divide-double > :not([hidden]) ~ :not([hidden]) {
     border-style: double;
   }
 
-  .sm\:divide-none > :not(template) ~ :not(template) {
+  .sm\:divide-none > :not([hidden]) ~ :not([hidden]) {
     border-style: none;
   }
 
-  .sm\:divide-opacity-0 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0;
   }
 
-  .sm\:divide-opacity-10 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-10 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.1;
   }
 
-  .sm\:divide-opacity-20 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-20 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.2;
   }
 
-  .sm\:divide-opacity-25 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-25 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.25;
   }
 
-  .sm\:divide-opacity-30 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-30 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.3;
   }
 
-  .sm\:divide-opacity-40 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-40 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.4;
   }
 
-  .sm\:divide-opacity-50 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.5;
   }
 
-  .sm\:divide-opacity-60 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-60 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.6;
   }
 
-  .sm\:divide-opacity-70 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-70 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.7;
   }
 
-  .sm\:divide-opacity-75 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-75 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.75;
   }
 
-  .sm\:divide-opacity-80 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-80 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.8;
   }
 
-  .sm\:divide-opacity-90 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-90 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.9;
   }
 
-  .sm\:divide-opacity-100 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
   }
 
@@ -46482,1323 +46482,1323 @@ video {
     }
   }
 
-  .md\:space-y-0 > :not(template) ~ :not(template) {
+  .md\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0px * var(--space-y-reverse));
   }
 
-  .md\:space-x-0 > :not(template) ~ :not(template) {
+  .md\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0px * var(--space-x-reverse));
     margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-1 > :not(template) ~ :not(template) {
+  .md\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.25rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-1 > :not(template) ~ :not(template) {
+  .md\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-2 > :not(template) ~ :not(template) {
+  .md\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.5rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-2 > :not(template) ~ :not(template) {
+  .md\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-3 > :not(template) ~ :not(template) {
+  .md\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.75rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-3 > :not(template) ~ :not(template) {
+  .md\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-4 > :not(template) ~ :not(template) {
+  .md\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-4 > :not(template) ~ :not(template) {
+  .md\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1rem * var(--space-x-reverse));
     margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-5 > :not(template) ~ :not(template) {
+  .md\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.25rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-5 > :not(template) ~ :not(template) {
+  .md\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-6 > :not(template) ~ :not(template) {
+  .md\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.5rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-6 > :not(template) ~ :not(template) {
+  .md\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-7 > :not(template) ~ :not(template) {
+  .md\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.75rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-7 > :not(template) ~ :not(template) {
+  .md\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-8 > :not(template) ~ :not(template) {
+  .md\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-8 > :not(template) ~ :not(template) {
+  .md\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2rem * var(--space-x-reverse));
     margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-9 > :not(template) ~ :not(template) {
+  .md\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.25rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-9 > :not(template) ~ :not(template) {
+  .md\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-10 > :not(template) ~ :not(template) {
+  .md\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.5rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-10 > :not(template) ~ :not(template) {
+  .md\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-12 > :not(template) ~ :not(template) {
+  .md\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-12 > :not(template) ~ :not(template) {
+  .md\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3rem * var(--space-x-reverse));
     margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-14 > :not(template) ~ :not(template) {
+  .md\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3.5rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-14 > :not(template) ~ :not(template) {
+  .md\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-16 > :not(template) ~ :not(template) {
+  .md\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(4rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-16 > :not(template) ~ :not(template) {
+  .md\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(4rem * var(--space-x-reverse));
     margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-20 > :not(template) ~ :not(template) {
+  .md\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(5rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-20 > :not(template) ~ :not(template) {
+  .md\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(5rem * var(--space-x-reverse));
     margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-24 > :not(template) ~ :not(template) {
+  .md\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(6rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-24 > :not(template) ~ :not(template) {
+  .md\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(6rem * var(--space-x-reverse));
     margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-28 > :not(template) ~ :not(template) {
+  .md\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(7rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-28 > :not(template) ~ :not(template) {
+  .md\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(7rem * var(--space-x-reverse));
     margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-32 > :not(template) ~ :not(template) {
+  .md\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(8rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-32 > :not(template) ~ :not(template) {
+  .md\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(8rem * var(--space-x-reverse));
     margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-36 > :not(template) ~ :not(template) {
+  .md\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(9rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-36 > :not(template) ~ :not(template) {
+  .md\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(9rem * var(--space-x-reverse));
     margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-40 > :not(template) ~ :not(template) {
+  .md\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(10rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-40 > :not(template) ~ :not(template) {
+  .md\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(10rem * var(--space-x-reverse));
     margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-44 > :not(template) ~ :not(template) {
+  .md\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(11rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-44 > :not(template) ~ :not(template) {
+  .md\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(11rem * var(--space-x-reverse));
     margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-48 > :not(template) ~ :not(template) {
+  .md\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(12rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-48 > :not(template) ~ :not(template) {
+  .md\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(12rem * var(--space-x-reverse));
     margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-52 > :not(template) ~ :not(template) {
+  .md\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(13rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-52 > :not(template) ~ :not(template) {
+  .md\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(13rem * var(--space-x-reverse));
     margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-56 > :not(template) ~ :not(template) {
+  .md\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(14rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-56 > :not(template) ~ :not(template) {
+  .md\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(14rem * var(--space-x-reverse));
     margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-60 > :not(template) ~ :not(template) {
+  .md\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(15rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-60 > :not(template) ~ :not(template) {
+  .md\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(15rem * var(--space-x-reverse));
     margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-64 > :not(template) ~ :not(template) {
+  .md\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(16rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-64 > :not(template) ~ :not(template) {
+  .md\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(16rem * var(--space-x-reverse));
     margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-72 > :not(template) ~ :not(template) {
+  .md\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(18rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-72 > :not(template) ~ :not(template) {
+  .md\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(18rem * var(--space-x-reverse));
     margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-80 > :not(template) ~ :not(template) {
+  .md\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(20rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-80 > :not(template) ~ :not(template) {
+  .md\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(20rem * var(--space-x-reverse));
     margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-96 > :not(template) ~ :not(template) {
+  .md\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(24rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-96 > :not(template) ~ :not(template) {
+  .md\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(24rem * var(--space-x-reverse));
     margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-px > :not(template) ~ :not(template) {
+  .md\:space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1px * var(--space-y-reverse));
   }
 
-  .md\:space-x-px > :not(template) ~ :not(template) {
+  .md\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1px * var(--space-x-reverse));
     margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-0\.5 > :not(template) ~ :not(template) {
+  .md\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.125rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-0\.5 > :not(template) ~ :not(template) {
+  .md\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-1\.5 > :not(template) ~ :not(template) {
+  .md\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.375rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-1\.5 > :not(template) ~ :not(template) {
+  .md\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-2\.5 > :not(template) ~ :not(template) {
+  .md\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.625rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-2\.5 > :not(template) ~ :not(template) {
+  .md\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-3\.5 > :not(template) ~ :not(template) {
+  .md\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.875rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-3\.5 > :not(template) ~ :not(template) {
+  .md\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-1 > :not(template) ~ :not(template) {
+  .md\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.25rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-1 > :not(template) ~ :not(template) {
+  .md\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-2 > :not(template) ~ :not(template) {
+  .md\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.5rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-2 > :not(template) ~ :not(template) {
+  .md\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-3 > :not(template) ~ :not(template) {
+  .md\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.75rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-3 > :not(template) ~ :not(template) {
+  .md\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-4 > :not(template) ~ :not(template) {
+  .md\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-4 > :not(template) ~ :not(template) {
+  .md\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1rem * var(--space-x-reverse));
     margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-5 > :not(template) ~ :not(template) {
+  .md\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.25rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-5 > :not(template) ~ :not(template) {
+  .md\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-6 > :not(template) ~ :not(template) {
+  .md\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.5rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-6 > :not(template) ~ :not(template) {
+  .md\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-7 > :not(template) ~ :not(template) {
+  .md\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.75rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-7 > :not(template) ~ :not(template) {
+  .md\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-8 > :not(template) ~ :not(template) {
+  .md\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-8 > :not(template) ~ :not(template) {
+  .md\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2rem * var(--space-x-reverse));
     margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-9 > :not(template) ~ :not(template) {
+  .md\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.25rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-9 > :not(template) ~ :not(template) {
+  .md\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-10 > :not(template) ~ :not(template) {
+  .md\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.5rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-10 > :not(template) ~ :not(template) {
+  .md\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-12 > :not(template) ~ :not(template) {
+  .md\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-12 > :not(template) ~ :not(template) {
+  .md\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3rem * var(--space-x-reverse));
     margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-14 > :not(template) ~ :not(template) {
+  .md\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3.5rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-14 > :not(template) ~ :not(template) {
+  .md\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-16 > :not(template) ~ :not(template) {
+  .md\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-4rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-16 > :not(template) ~ :not(template) {
+  .md\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-4rem * var(--space-x-reverse));
     margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-20 > :not(template) ~ :not(template) {
+  .md\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-5rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-20 > :not(template) ~ :not(template) {
+  .md\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-5rem * var(--space-x-reverse));
     margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-24 > :not(template) ~ :not(template) {
+  .md\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-6rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-24 > :not(template) ~ :not(template) {
+  .md\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-6rem * var(--space-x-reverse));
     margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-28 > :not(template) ~ :not(template) {
+  .md\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-7rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-28 > :not(template) ~ :not(template) {
+  .md\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-7rem * var(--space-x-reverse));
     margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-32 > :not(template) ~ :not(template) {
+  .md\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-8rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-32 > :not(template) ~ :not(template) {
+  .md\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-8rem * var(--space-x-reverse));
     margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-36 > :not(template) ~ :not(template) {
+  .md\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-9rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-36 > :not(template) ~ :not(template) {
+  .md\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-9rem * var(--space-x-reverse));
     margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-40 > :not(template) ~ :not(template) {
+  .md\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-10rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-40 > :not(template) ~ :not(template) {
+  .md\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-10rem * var(--space-x-reverse));
     margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-44 > :not(template) ~ :not(template) {
+  .md\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-11rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-44 > :not(template) ~ :not(template) {
+  .md\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-11rem * var(--space-x-reverse));
     margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-48 > :not(template) ~ :not(template) {
+  .md\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-12rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-48 > :not(template) ~ :not(template) {
+  .md\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-12rem * var(--space-x-reverse));
     margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-52 > :not(template) ~ :not(template) {
+  .md\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-13rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-52 > :not(template) ~ :not(template) {
+  .md\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-13rem * var(--space-x-reverse));
     margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-56 > :not(template) ~ :not(template) {
+  .md\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-14rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-56 > :not(template) ~ :not(template) {
+  .md\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-14rem * var(--space-x-reverse));
     margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-60 > :not(template) ~ :not(template) {
+  .md\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-15rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-60 > :not(template) ~ :not(template) {
+  .md\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-15rem * var(--space-x-reverse));
     margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-64 > :not(template) ~ :not(template) {
+  .md\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-16rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-64 > :not(template) ~ :not(template) {
+  .md\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-16rem * var(--space-x-reverse));
     margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-72 > :not(template) ~ :not(template) {
+  .md\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-18rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-72 > :not(template) ~ :not(template) {
+  .md\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-18rem * var(--space-x-reverse));
     margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-80 > :not(template) ~ :not(template) {
+  .md\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-20rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-80 > :not(template) ~ :not(template) {
+  .md\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-20rem * var(--space-x-reverse));
     margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-96 > :not(template) ~ :not(template) {
+  .md\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-24rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-96 > :not(template) ~ :not(template) {
+  .md\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-24rem * var(--space-x-reverse));
     margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-px > :not(template) ~ :not(template) {
+  .md\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1px * var(--space-y-reverse));
   }
 
-  .md\:-space-x-px > :not(template) ~ :not(template) {
+  .md\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1px * var(--space-x-reverse));
     margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-0\.5 > :not(template) ~ :not(template) {
+  .md\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.125rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-0\.5 > :not(template) ~ :not(template) {
+  .md\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-1\.5 > :not(template) ~ :not(template) {
+  .md\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.375rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-1\.5 > :not(template) ~ :not(template) {
+  .md\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-2\.5 > :not(template) ~ :not(template) {
+  .md\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.625rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-2\.5 > :not(template) ~ :not(template) {
+  .md\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-3\.5 > :not(template) ~ :not(template) {
+  .md\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.875rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-3\.5 > :not(template) ~ :not(template) {
+  .md\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-reverse > :not(template) ~ :not(template) {
+  .md\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 1;
   }
 
-  .md\:space-x-reverse > :not(template) ~ :not(template) {
+  .md\:space-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 1;
   }
 
-  .md\:divide-y-0 > :not(template) ~ :not(template) {
+  .md\:divide-y-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(0px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(0px * var(--divide-y-reverse));
   }
 
-  .md\:divide-x-0 > :not(template) ~ :not(template) {
+  .md\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(0px * var(--divide-x-reverse));
     border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .md\:divide-y-2 > :not(template) ~ :not(template) {
+  .md\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(2px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(2px * var(--divide-y-reverse));
   }
 
-  .md\:divide-x-2 > :not(template) ~ :not(template) {
+  .md\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(2px * var(--divide-x-reverse));
     border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .md\:divide-y-4 > :not(template) ~ :not(template) {
+  .md\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(4px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(4px * var(--divide-y-reverse));
   }
 
-  .md\:divide-x-4 > :not(template) ~ :not(template) {
+  .md\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(4px * var(--divide-x-reverse));
     border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .md\:divide-y-8 > :not(template) ~ :not(template) {
+  .md\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(8px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(8px * var(--divide-y-reverse));
   }
 
-  .md\:divide-x-8 > :not(template) ~ :not(template) {
+  .md\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(8px * var(--divide-x-reverse));
     border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .md\:divide-y > :not(template) ~ :not(template) {
+  .md\:divide-y > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(1px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(1px * var(--divide-y-reverse));
   }
 
-  .md\:divide-x > :not(template) ~ :not(template) {
+  .md\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(1px * var(--divide-x-reverse));
     border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .md\:divide-y-reverse > :not(template) ~ :not(template) {
+  .md\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 1;
   }
 
-  .md\:divide-x-reverse > :not(template) ~ :not(template) {
+  .md\:divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 1;
   }
 
-  .md\:divide-transparent > :not(template) ~ :not(template) {
+  .md\:divide-transparent > :not([hidden]) ~ :not([hidden]) {
     border-color: transparent;
   }
 
-  .md\:divide-current > :not(template) ~ :not(template) {
+  .md\:divide-current > :not([hidden]) ~ :not([hidden]) {
     border-color: currentColor;
   }
 
-  .md\:divide-black > :not(template) ~ :not(template) {
+  .md\:divide-black > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(0, 0, 0, var(--divide-opacity));
   }
 
-  .md\:divide-white > :not(template) ~ :not(template) {
+  .md\:divide-white > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(255, 255, 255, var(--divide-opacity));
   }
 
-  .md\:divide-gray-50 > :not(template) ~ :not(template) {
+  .md\:divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(250, 250, 250, var(--divide-opacity));
   }
 
-  .md\:divide-gray-100 > :not(template) ~ :not(template) {
+  .md\:divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(244, 244, 245, var(--divide-opacity));
   }
 
-  .md\:divide-gray-200 > :not(template) ~ :not(template) {
+  .md\:divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(228, 228, 231, var(--divide-opacity));
   }
 
-  .md\:divide-gray-300 > :not(template) ~ :not(template) {
+  .md\:divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(212, 212, 216, var(--divide-opacity));
   }
 
-  .md\:divide-gray-400 > :not(template) ~ :not(template) {
+  .md\:divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(161, 161, 170, var(--divide-opacity));
   }
 
-  .md\:divide-gray-500 > :not(template) ~ :not(template) {
+  .md\:divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(113, 113, 122, var(--divide-opacity));
   }
 
-  .md\:divide-gray-600 > :not(template) ~ :not(template) {
+  .md\:divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(82, 82, 91, var(--divide-opacity));
   }
 
-  .md\:divide-gray-700 > :not(template) ~ :not(template) {
+  .md\:divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(63, 63, 70, var(--divide-opacity));
   }
 
-  .md\:divide-gray-800 > :not(template) ~ :not(template) {
+  .md\:divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(39, 39, 42, var(--divide-opacity));
   }
 
-  .md\:divide-gray-900 > :not(template) ~ :not(template) {
+  .md\:divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(24, 24, 27, var(--divide-opacity));
   }
 
-  .md\:divide-red-50 > :not(template) ~ :not(template) {
+  .md\:divide-red-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 242, 242, var(--divide-opacity));
   }
 
-  .md\:divide-red-100 > :not(template) ~ :not(template) {
+  .md\:divide-red-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 226, 226, var(--divide-opacity));
   }
 
-  .md\:divide-red-200 > :not(template) ~ :not(template) {
+  .md\:divide-red-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 202, 202, var(--divide-opacity));
   }
 
-  .md\:divide-red-300 > :not(template) ~ :not(template) {
+  .md\:divide-red-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 165, 165, var(--divide-opacity));
   }
 
-  .md\:divide-red-400 > :not(template) ~ :not(template) {
+  .md\:divide-red-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(248, 113, 113, var(--divide-opacity));
   }
 
-  .md\:divide-red-500 > :not(template) ~ :not(template) {
+  .md\:divide-red-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(239, 68, 68, var(--divide-opacity));
   }
 
-  .md\:divide-red-600 > :not(template) ~ :not(template) {
+  .md\:divide-red-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(220, 38, 38, var(--divide-opacity));
   }
 
-  .md\:divide-red-700 > :not(template) ~ :not(template) {
+  .md\:divide-red-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(185, 28, 28, var(--divide-opacity));
   }
 
-  .md\:divide-red-800 > :not(template) ~ :not(template) {
+  .md\:divide-red-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(153, 27, 27, var(--divide-opacity));
   }
 
-  .md\:divide-red-900 > :not(template) ~ :not(template) {
+  .md\:divide-red-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(127, 29, 29, var(--divide-opacity));
   }
 
-  .md\:divide-yellow-50 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(255, 251, 235, var(--divide-opacity));
   }
 
-  .md\:divide-yellow-100 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 243, 199, var(--divide-opacity));
   }
 
-  .md\:divide-yellow-200 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(253, 230, 138, var(--divide-opacity));
   }
 
-  .md\:divide-yellow-300 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 211, 77, var(--divide-opacity));
   }
 
-  .md\:divide-yellow-400 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(251, 191, 36, var(--divide-opacity));
   }
 
-  .md\:divide-yellow-500 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(245, 158, 11, var(--divide-opacity));
   }
 
-  .md\:divide-yellow-600 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(217, 119, 6, var(--divide-opacity));
   }
 
-  .md\:divide-yellow-700 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(180, 83, 9, var(--divide-opacity));
   }
 
-  .md\:divide-yellow-800 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(146, 64, 14, var(--divide-opacity));
   }
 
-  .md\:divide-yellow-900 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(120, 53, 15, var(--divide-opacity));
   }
 
-  .md\:divide-green-50 > :not(template) ~ :not(template) {
+  .md\:divide-green-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(236, 253, 245, var(--divide-opacity));
   }
 
-  .md\:divide-green-100 > :not(template) ~ :not(template) {
+  .md\:divide-green-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(209, 250, 229, var(--divide-opacity));
   }
 
-  .md\:divide-green-200 > :not(template) ~ :not(template) {
+  .md\:divide-green-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(167, 243, 208, var(--divide-opacity));
   }
 
-  .md\:divide-green-300 > :not(template) ~ :not(template) {
+  .md\:divide-green-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(110, 231, 183, var(--divide-opacity));
   }
 
-  .md\:divide-green-400 > :not(template) ~ :not(template) {
+  .md\:divide-green-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(52, 211, 153, var(--divide-opacity));
   }
 
-  .md\:divide-green-500 > :not(template) ~ :not(template) {
+  .md\:divide-green-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(16, 185, 129, var(--divide-opacity));
   }
 
-  .md\:divide-green-600 > :not(template) ~ :not(template) {
+  .md\:divide-green-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(5, 150, 105, var(--divide-opacity));
   }
 
-  .md\:divide-green-700 > :not(template) ~ :not(template) {
+  .md\:divide-green-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(4, 120, 87, var(--divide-opacity));
   }
 
-  .md\:divide-green-800 > :not(template) ~ :not(template) {
+  .md\:divide-green-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(6, 95, 70, var(--divide-opacity));
   }
 
-  .md\:divide-green-900 > :not(template) ~ :not(template) {
+  .md\:divide-green-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(6, 78, 59, var(--divide-opacity));
   }
 
-  .md\:divide-blue-50 > :not(template) ~ :not(template) {
+  .md\:divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(239, 246, 255, var(--divide-opacity));
   }
 
-  .md\:divide-blue-100 > :not(template) ~ :not(template) {
+  .md\:divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(219, 234, 254, var(--divide-opacity));
   }
 
-  .md\:divide-blue-200 > :not(template) ~ :not(template) {
+  .md\:divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(191, 219, 254, var(--divide-opacity));
   }
 
-  .md\:divide-blue-300 > :not(template) ~ :not(template) {
+  .md\:divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(147, 197, 253, var(--divide-opacity));
   }
 
-  .md\:divide-blue-400 > :not(template) ~ :not(template) {
+  .md\:divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(96, 165, 250, var(--divide-opacity));
   }
 
-  .md\:divide-blue-500 > :not(template) ~ :not(template) {
+  .md\:divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(59, 130, 246, var(--divide-opacity));
   }
 
-  .md\:divide-blue-600 > :not(template) ~ :not(template) {
+  .md\:divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(37, 99, 235, var(--divide-opacity));
   }
 
-  .md\:divide-blue-700 > :not(template) ~ :not(template) {
+  .md\:divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(29, 78, 216, var(--divide-opacity));
   }
 
-  .md\:divide-blue-800 > :not(template) ~ :not(template) {
+  .md\:divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(30, 64, 175, var(--divide-opacity));
   }
 
-  .md\:divide-blue-900 > :not(template) ~ :not(template) {
+  .md\:divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(30, 58, 138, var(--divide-opacity));
   }
 
-  .md\:divide-purple-50 > :not(template) ~ :not(template) {
+  .md\:divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(245, 243, 255, var(--divide-opacity));
   }
 
-  .md\:divide-purple-100 > :not(template) ~ :not(template) {
+  .md\:divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(237, 233, 254, var(--divide-opacity));
   }
 
-  .md\:divide-purple-200 > :not(template) ~ :not(template) {
+  .md\:divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(221, 214, 254, var(--divide-opacity));
   }
 
-  .md\:divide-purple-300 > :not(template) ~ :not(template) {
+  .md\:divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(196, 181, 253, var(--divide-opacity));
   }
 
-  .md\:divide-purple-400 > :not(template) ~ :not(template) {
+  .md\:divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(167, 139, 250, var(--divide-opacity));
   }
 
-  .md\:divide-purple-500 > :not(template) ~ :not(template) {
+  .md\:divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(139, 92, 246, var(--divide-opacity));
   }
 
-  .md\:divide-purple-600 > :not(template) ~ :not(template) {
+  .md\:divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(124, 58, 237, var(--divide-opacity));
   }
 
-  .md\:divide-purple-700 > :not(template) ~ :not(template) {
+  .md\:divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(109, 40, 217, var(--divide-opacity));
   }
 
-  .md\:divide-purple-800 > :not(template) ~ :not(template) {
+  .md\:divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(91, 33, 182, var(--divide-opacity));
   }
 
-  .md\:divide-purple-900 > :not(template) ~ :not(template) {
+  .md\:divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(76, 29, 149, var(--divide-opacity));
   }
 
-  .md\:divide-pink-50 > :not(template) ~ :not(template) {
+  .md\:divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(253, 242, 248, var(--divide-opacity));
   }
 
-  .md\:divide-pink-100 > :not(template) ~ :not(template) {
+  .md\:divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 231, 243, var(--divide-opacity));
   }
 
-  .md\:divide-pink-200 > :not(template) ~ :not(template) {
+  .md\:divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(251, 207, 232, var(--divide-opacity));
   }
 
-  .md\:divide-pink-300 > :not(template) ~ :not(template) {
+  .md\:divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(249, 168, 212, var(--divide-opacity));
   }
 
-  .md\:divide-pink-400 > :not(template) ~ :not(template) {
+  .md\:divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(244, 114, 182, var(--divide-opacity));
   }
 
-  .md\:divide-pink-500 > :not(template) ~ :not(template) {
+  .md\:divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(236, 72, 153, var(--divide-opacity));
   }
 
-  .md\:divide-pink-600 > :not(template) ~ :not(template) {
+  .md\:divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(219, 39, 119, var(--divide-opacity));
   }
 
-  .md\:divide-pink-700 > :not(template) ~ :not(template) {
+  .md\:divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(190, 24, 93, var(--divide-opacity));
   }
 
-  .md\:divide-pink-800 > :not(template) ~ :not(template) {
+  .md\:divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(157, 23, 77, var(--divide-opacity));
   }
 
-  .md\:divide-pink-900 > :not(template) ~ :not(template) {
+  .md\:divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(131, 24, 67, var(--divide-opacity));
   }
 
-  .md\:divide-solid > :not(template) ~ :not(template) {
+  .md\:divide-solid > :not([hidden]) ~ :not([hidden]) {
     border-style: solid;
   }
 
-  .md\:divide-dashed > :not(template) ~ :not(template) {
+  .md\:divide-dashed > :not([hidden]) ~ :not([hidden]) {
     border-style: dashed;
   }
 
-  .md\:divide-dotted > :not(template) ~ :not(template) {
+  .md\:divide-dotted > :not([hidden]) ~ :not([hidden]) {
     border-style: dotted;
   }
 
-  .md\:divide-double > :not(template) ~ :not(template) {
+  .md\:divide-double > :not([hidden]) ~ :not([hidden]) {
     border-style: double;
   }
 
-  .md\:divide-none > :not(template) ~ :not(template) {
+  .md\:divide-none > :not([hidden]) ~ :not([hidden]) {
     border-style: none;
   }
 
-  .md\:divide-opacity-0 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0;
   }
 
-  .md\:divide-opacity-10 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-10 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.1;
   }
 
-  .md\:divide-opacity-20 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-20 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.2;
   }
 
-  .md\:divide-opacity-25 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-25 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.25;
   }
 
-  .md\:divide-opacity-30 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-30 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.3;
   }
 
-  .md\:divide-opacity-40 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-40 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.4;
   }
 
-  .md\:divide-opacity-50 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.5;
   }
 
-  .md\:divide-opacity-60 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-60 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.6;
   }
 
-  .md\:divide-opacity-70 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-70 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.7;
   }
 
-  .md\:divide-opacity-75 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-75 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.75;
   }
 
-  .md\:divide-opacity-80 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-80 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.8;
   }
 
-  .md\:divide-opacity-90 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-90 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.9;
   }
 
-  .md\:divide-opacity-100 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
   }
 
@@ -69428,1323 +69428,1323 @@ video {
     }
   }
 
-  .lg\:space-y-0 > :not(template) ~ :not(template) {
+  .lg\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0px * var(--space-y-reverse));
   }
 
-  .lg\:space-x-0 > :not(template) ~ :not(template) {
+  .lg\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0px * var(--space-x-reverse));
     margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-1 > :not(template) ~ :not(template) {
+  .lg\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.25rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-1 > :not(template) ~ :not(template) {
+  .lg\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-2 > :not(template) ~ :not(template) {
+  .lg\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.5rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-2 > :not(template) ~ :not(template) {
+  .lg\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-3 > :not(template) ~ :not(template) {
+  .lg\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.75rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-3 > :not(template) ~ :not(template) {
+  .lg\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-4 > :not(template) ~ :not(template) {
+  .lg\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-4 > :not(template) ~ :not(template) {
+  .lg\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1rem * var(--space-x-reverse));
     margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-5 > :not(template) ~ :not(template) {
+  .lg\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.25rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-5 > :not(template) ~ :not(template) {
+  .lg\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-6 > :not(template) ~ :not(template) {
+  .lg\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.5rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-6 > :not(template) ~ :not(template) {
+  .lg\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-7 > :not(template) ~ :not(template) {
+  .lg\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.75rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-7 > :not(template) ~ :not(template) {
+  .lg\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-8 > :not(template) ~ :not(template) {
+  .lg\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-8 > :not(template) ~ :not(template) {
+  .lg\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2rem * var(--space-x-reverse));
     margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-9 > :not(template) ~ :not(template) {
+  .lg\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.25rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-9 > :not(template) ~ :not(template) {
+  .lg\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-10 > :not(template) ~ :not(template) {
+  .lg\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.5rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-10 > :not(template) ~ :not(template) {
+  .lg\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-12 > :not(template) ~ :not(template) {
+  .lg\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-12 > :not(template) ~ :not(template) {
+  .lg\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3rem * var(--space-x-reverse));
     margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-14 > :not(template) ~ :not(template) {
+  .lg\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3.5rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-14 > :not(template) ~ :not(template) {
+  .lg\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-16 > :not(template) ~ :not(template) {
+  .lg\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(4rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-16 > :not(template) ~ :not(template) {
+  .lg\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(4rem * var(--space-x-reverse));
     margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-20 > :not(template) ~ :not(template) {
+  .lg\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(5rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-20 > :not(template) ~ :not(template) {
+  .lg\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(5rem * var(--space-x-reverse));
     margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-24 > :not(template) ~ :not(template) {
+  .lg\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(6rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-24 > :not(template) ~ :not(template) {
+  .lg\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(6rem * var(--space-x-reverse));
     margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-28 > :not(template) ~ :not(template) {
+  .lg\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(7rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-28 > :not(template) ~ :not(template) {
+  .lg\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(7rem * var(--space-x-reverse));
     margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-32 > :not(template) ~ :not(template) {
+  .lg\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(8rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-32 > :not(template) ~ :not(template) {
+  .lg\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(8rem * var(--space-x-reverse));
     margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-36 > :not(template) ~ :not(template) {
+  .lg\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(9rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-36 > :not(template) ~ :not(template) {
+  .lg\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(9rem * var(--space-x-reverse));
     margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-40 > :not(template) ~ :not(template) {
+  .lg\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(10rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-40 > :not(template) ~ :not(template) {
+  .lg\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(10rem * var(--space-x-reverse));
     margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-44 > :not(template) ~ :not(template) {
+  .lg\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(11rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-44 > :not(template) ~ :not(template) {
+  .lg\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(11rem * var(--space-x-reverse));
     margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-48 > :not(template) ~ :not(template) {
+  .lg\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(12rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-48 > :not(template) ~ :not(template) {
+  .lg\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(12rem * var(--space-x-reverse));
     margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-52 > :not(template) ~ :not(template) {
+  .lg\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(13rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-52 > :not(template) ~ :not(template) {
+  .lg\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(13rem * var(--space-x-reverse));
     margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-56 > :not(template) ~ :not(template) {
+  .lg\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(14rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-56 > :not(template) ~ :not(template) {
+  .lg\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(14rem * var(--space-x-reverse));
     margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-60 > :not(template) ~ :not(template) {
+  .lg\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(15rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-60 > :not(template) ~ :not(template) {
+  .lg\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(15rem * var(--space-x-reverse));
     margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-64 > :not(template) ~ :not(template) {
+  .lg\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(16rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-64 > :not(template) ~ :not(template) {
+  .lg\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(16rem * var(--space-x-reverse));
     margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-72 > :not(template) ~ :not(template) {
+  .lg\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(18rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-72 > :not(template) ~ :not(template) {
+  .lg\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(18rem * var(--space-x-reverse));
     margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-80 > :not(template) ~ :not(template) {
+  .lg\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(20rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-80 > :not(template) ~ :not(template) {
+  .lg\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(20rem * var(--space-x-reverse));
     margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-96 > :not(template) ~ :not(template) {
+  .lg\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(24rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-96 > :not(template) ~ :not(template) {
+  .lg\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(24rem * var(--space-x-reverse));
     margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-px > :not(template) ~ :not(template) {
+  .lg\:space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1px * var(--space-y-reverse));
   }
 
-  .lg\:space-x-px > :not(template) ~ :not(template) {
+  .lg\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1px * var(--space-x-reverse));
     margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-0\.5 > :not(template) ~ :not(template) {
+  .lg\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.125rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-0\.5 > :not(template) ~ :not(template) {
+  .lg\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-1\.5 > :not(template) ~ :not(template) {
+  .lg\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.375rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-1\.5 > :not(template) ~ :not(template) {
+  .lg\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-2\.5 > :not(template) ~ :not(template) {
+  .lg\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.625rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-2\.5 > :not(template) ~ :not(template) {
+  .lg\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-3\.5 > :not(template) ~ :not(template) {
+  .lg\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.875rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-3\.5 > :not(template) ~ :not(template) {
+  .lg\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-1 > :not(template) ~ :not(template) {
+  .lg\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.25rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-1 > :not(template) ~ :not(template) {
+  .lg\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-2 > :not(template) ~ :not(template) {
+  .lg\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.5rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-2 > :not(template) ~ :not(template) {
+  .lg\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-3 > :not(template) ~ :not(template) {
+  .lg\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.75rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-3 > :not(template) ~ :not(template) {
+  .lg\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-4 > :not(template) ~ :not(template) {
+  .lg\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-4 > :not(template) ~ :not(template) {
+  .lg\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1rem * var(--space-x-reverse));
     margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-5 > :not(template) ~ :not(template) {
+  .lg\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.25rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-5 > :not(template) ~ :not(template) {
+  .lg\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-6 > :not(template) ~ :not(template) {
+  .lg\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.5rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-6 > :not(template) ~ :not(template) {
+  .lg\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-7 > :not(template) ~ :not(template) {
+  .lg\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.75rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-7 > :not(template) ~ :not(template) {
+  .lg\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-8 > :not(template) ~ :not(template) {
+  .lg\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-8 > :not(template) ~ :not(template) {
+  .lg\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2rem * var(--space-x-reverse));
     margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-9 > :not(template) ~ :not(template) {
+  .lg\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.25rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-9 > :not(template) ~ :not(template) {
+  .lg\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-10 > :not(template) ~ :not(template) {
+  .lg\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.5rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-10 > :not(template) ~ :not(template) {
+  .lg\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-12 > :not(template) ~ :not(template) {
+  .lg\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-12 > :not(template) ~ :not(template) {
+  .lg\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3rem * var(--space-x-reverse));
     margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-14 > :not(template) ~ :not(template) {
+  .lg\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3.5rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-14 > :not(template) ~ :not(template) {
+  .lg\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-16 > :not(template) ~ :not(template) {
+  .lg\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-4rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-16 > :not(template) ~ :not(template) {
+  .lg\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-4rem * var(--space-x-reverse));
     margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-20 > :not(template) ~ :not(template) {
+  .lg\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-5rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-20 > :not(template) ~ :not(template) {
+  .lg\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-5rem * var(--space-x-reverse));
     margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-24 > :not(template) ~ :not(template) {
+  .lg\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-6rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-24 > :not(template) ~ :not(template) {
+  .lg\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-6rem * var(--space-x-reverse));
     margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-28 > :not(template) ~ :not(template) {
+  .lg\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-7rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-28 > :not(template) ~ :not(template) {
+  .lg\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-7rem * var(--space-x-reverse));
     margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-32 > :not(template) ~ :not(template) {
+  .lg\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-8rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-32 > :not(template) ~ :not(template) {
+  .lg\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-8rem * var(--space-x-reverse));
     margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-36 > :not(template) ~ :not(template) {
+  .lg\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-9rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-36 > :not(template) ~ :not(template) {
+  .lg\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-9rem * var(--space-x-reverse));
     margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-40 > :not(template) ~ :not(template) {
+  .lg\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-10rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-40 > :not(template) ~ :not(template) {
+  .lg\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-10rem * var(--space-x-reverse));
     margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-44 > :not(template) ~ :not(template) {
+  .lg\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-11rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-44 > :not(template) ~ :not(template) {
+  .lg\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-11rem * var(--space-x-reverse));
     margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-48 > :not(template) ~ :not(template) {
+  .lg\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-12rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-48 > :not(template) ~ :not(template) {
+  .lg\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-12rem * var(--space-x-reverse));
     margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-52 > :not(template) ~ :not(template) {
+  .lg\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-13rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-52 > :not(template) ~ :not(template) {
+  .lg\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-13rem * var(--space-x-reverse));
     margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-56 > :not(template) ~ :not(template) {
+  .lg\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-14rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-56 > :not(template) ~ :not(template) {
+  .lg\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-14rem * var(--space-x-reverse));
     margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-60 > :not(template) ~ :not(template) {
+  .lg\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-15rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-60 > :not(template) ~ :not(template) {
+  .lg\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-15rem * var(--space-x-reverse));
     margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-64 > :not(template) ~ :not(template) {
+  .lg\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-16rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-64 > :not(template) ~ :not(template) {
+  .lg\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-16rem * var(--space-x-reverse));
     margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-72 > :not(template) ~ :not(template) {
+  .lg\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-18rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-72 > :not(template) ~ :not(template) {
+  .lg\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-18rem * var(--space-x-reverse));
     margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-80 > :not(template) ~ :not(template) {
+  .lg\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-20rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-80 > :not(template) ~ :not(template) {
+  .lg\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-20rem * var(--space-x-reverse));
     margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-96 > :not(template) ~ :not(template) {
+  .lg\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-24rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-96 > :not(template) ~ :not(template) {
+  .lg\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-24rem * var(--space-x-reverse));
     margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-px > :not(template) ~ :not(template) {
+  .lg\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1px * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-px > :not(template) ~ :not(template) {
+  .lg\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1px * var(--space-x-reverse));
     margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-0\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.125rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-0\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-1\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.375rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-1\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-2\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.625rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-2\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-3\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.875rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-3\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-reverse > :not(template) ~ :not(template) {
+  .lg\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 1;
   }
 
-  .lg\:space-x-reverse > :not(template) ~ :not(template) {
+  .lg\:space-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 1;
   }
 
-  .lg\:divide-y-0 > :not(template) ~ :not(template) {
+  .lg\:divide-y-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(0px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(0px * var(--divide-y-reverse));
   }
 
-  .lg\:divide-x-0 > :not(template) ~ :not(template) {
+  .lg\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(0px * var(--divide-x-reverse));
     border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .lg\:divide-y-2 > :not(template) ~ :not(template) {
+  .lg\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(2px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(2px * var(--divide-y-reverse));
   }
 
-  .lg\:divide-x-2 > :not(template) ~ :not(template) {
+  .lg\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(2px * var(--divide-x-reverse));
     border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .lg\:divide-y-4 > :not(template) ~ :not(template) {
+  .lg\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(4px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(4px * var(--divide-y-reverse));
   }
 
-  .lg\:divide-x-4 > :not(template) ~ :not(template) {
+  .lg\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(4px * var(--divide-x-reverse));
     border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .lg\:divide-y-8 > :not(template) ~ :not(template) {
+  .lg\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(8px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(8px * var(--divide-y-reverse));
   }
 
-  .lg\:divide-x-8 > :not(template) ~ :not(template) {
+  .lg\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(8px * var(--divide-x-reverse));
     border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .lg\:divide-y > :not(template) ~ :not(template) {
+  .lg\:divide-y > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(1px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(1px * var(--divide-y-reverse));
   }
 
-  .lg\:divide-x > :not(template) ~ :not(template) {
+  .lg\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(1px * var(--divide-x-reverse));
     border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .lg\:divide-y-reverse > :not(template) ~ :not(template) {
+  .lg\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 1;
   }
 
-  .lg\:divide-x-reverse > :not(template) ~ :not(template) {
+  .lg\:divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 1;
   }
 
-  .lg\:divide-transparent > :not(template) ~ :not(template) {
+  .lg\:divide-transparent > :not([hidden]) ~ :not([hidden]) {
     border-color: transparent;
   }
 
-  .lg\:divide-current > :not(template) ~ :not(template) {
+  .lg\:divide-current > :not([hidden]) ~ :not([hidden]) {
     border-color: currentColor;
   }
 
-  .lg\:divide-black > :not(template) ~ :not(template) {
+  .lg\:divide-black > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(0, 0, 0, var(--divide-opacity));
   }
 
-  .lg\:divide-white > :not(template) ~ :not(template) {
+  .lg\:divide-white > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(255, 255, 255, var(--divide-opacity));
   }
 
-  .lg\:divide-gray-50 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(250, 250, 250, var(--divide-opacity));
   }
 
-  .lg\:divide-gray-100 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(244, 244, 245, var(--divide-opacity));
   }
 
-  .lg\:divide-gray-200 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(228, 228, 231, var(--divide-opacity));
   }
 
-  .lg\:divide-gray-300 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(212, 212, 216, var(--divide-opacity));
   }
 
-  .lg\:divide-gray-400 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(161, 161, 170, var(--divide-opacity));
   }
 
-  .lg\:divide-gray-500 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(113, 113, 122, var(--divide-opacity));
   }
 
-  .lg\:divide-gray-600 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(82, 82, 91, var(--divide-opacity));
   }
 
-  .lg\:divide-gray-700 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(63, 63, 70, var(--divide-opacity));
   }
 
-  .lg\:divide-gray-800 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(39, 39, 42, var(--divide-opacity));
   }
 
-  .lg\:divide-gray-900 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(24, 24, 27, var(--divide-opacity));
   }
 
-  .lg\:divide-red-50 > :not(template) ~ :not(template) {
+  .lg\:divide-red-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 242, 242, var(--divide-opacity));
   }
 
-  .lg\:divide-red-100 > :not(template) ~ :not(template) {
+  .lg\:divide-red-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 226, 226, var(--divide-opacity));
   }
 
-  .lg\:divide-red-200 > :not(template) ~ :not(template) {
+  .lg\:divide-red-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 202, 202, var(--divide-opacity));
   }
 
-  .lg\:divide-red-300 > :not(template) ~ :not(template) {
+  .lg\:divide-red-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 165, 165, var(--divide-opacity));
   }
 
-  .lg\:divide-red-400 > :not(template) ~ :not(template) {
+  .lg\:divide-red-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(248, 113, 113, var(--divide-opacity));
   }
 
-  .lg\:divide-red-500 > :not(template) ~ :not(template) {
+  .lg\:divide-red-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(239, 68, 68, var(--divide-opacity));
   }
 
-  .lg\:divide-red-600 > :not(template) ~ :not(template) {
+  .lg\:divide-red-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(220, 38, 38, var(--divide-opacity));
   }
 
-  .lg\:divide-red-700 > :not(template) ~ :not(template) {
+  .lg\:divide-red-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(185, 28, 28, var(--divide-opacity));
   }
 
-  .lg\:divide-red-800 > :not(template) ~ :not(template) {
+  .lg\:divide-red-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(153, 27, 27, var(--divide-opacity));
   }
 
-  .lg\:divide-red-900 > :not(template) ~ :not(template) {
+  .lg\:divide-red-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(127, 29, 29, var(--divide-opacity));
   }
 
-  .lg\:divide-yellow-50 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(255, 251, 235, var(--divide-opacity));
   }
 
-  .lg\:divide-yellow-100 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 243, 199, var(--divide-opacity));
   }
 
-  .lg\:divide-yellow-200 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(253, 230, 138, var(--divide-opacity));
   }
 
-  .lg\:divide-yellow-300 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 211, 77, var(--divide-opacity));
   }
 
-  .lg\:divide-yellow-400 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(251, 191, 36, var(--divide-opacity));
   }
 
-  .lg\:divide-yellow-500 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(245, 158, 11, var(--divide-opacity));
   }
 
-  .lg\:divide-yellow-600 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(217, 119, 6, var(--divide-opacity));
   }
 
-  .lg\:divide-yellow-700 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(180, 83, 9, var(--divide-opacity));
   }
 
-  .lg\:divide-yellow-800 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(146, 64, 14, var(--divide-opacity));
   }
 
-  .lg\:divide-yellow-900 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(120, 53, 15, var(--divide-opacity));
   }
 
-  .lg\:divide-green-50 > :not(template) ~ :not(template) {
+  .lg\:divide-green-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(236, 253, 245, var(--divide-opacity));
   }
 
-  .lg\:divide-green-100 > :not(template) ~ :not(template) {
+  .lg\:divide-green-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(209, 250, 229, var(--divide-opacity));
   }
 
-  .lg\:divide-green-200 > :not(template) ~ :not(template) {
+  .lg\:divide-green-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(167, 243, 208, var(--divide-opacity));
   }
 
-  .lg\:divide-green-300 > :not(template) ~ :not(template) {
+  .lg\:divide-green-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(110, 231, 183, var(--divide-opacity));
   }
 
-  .lg\:divide-green-400 > :not(template) ~ :not(template) {
+  .lg\:divide-green-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(52, 211, 153, var(--divide-opacity));
   }
 
-  .lg\:divide-green-500 > :not(template) ~ :not(template) {
+  .lg\:divide-green-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(16, 185, 129, var(--divide-opacity));
   }
 
-  .lg\:divide-green-600 > :not(template) ~ :not(template) {
+  .lg\:divide-green-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(5, 150, 105, var(--divide-opacity));
   }
 
-  .lg\:divide-green-700 > :not(template) ~ :not(template) {
+  .lg\:divide-green-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(4, 120, 87, var(--divide-opacity));
   }
 
-  .lg\:divide-green-800 > :not(template) ~ :not(template) {
+  .lg\:divide-green-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(6, 95, 70, var(--divide-opacity));
   }
 
-  .lg\:divide-green-900 > :not(template) ~ :not(template) {
+  .lg\:divide-green-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(6, 78, 59, var(--divide-opacity));
   }
 
-  .lg\:divide-blue-50 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(239, 246, 255, var(--divide-opacity));
   }
 
-  .lg\:divide-blue-100 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(219, 234, 254, var(--divide-opacity));
   }
 
-  .lg\:divide-blue-200 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(191, 219, 254, var(--divide-opacity));
   }
 
-  .lg\:divide-blue-300 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(147, 197, 253, var(--divide-opacity));
   }
 
-  .lg\:divide-blue-400 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(96, 165, 250, var(--divide-opacity));
   }
 
-  .lg\:divide-blue-500 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(59, 130, 246, var(--divide-opacity));
   }
 
-  .lg\:divide-blue-600 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(37, 99, 235, var(--divide-opacity));
   }
 
-  .lg\:divide-blue-700 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(29, 78, 216, var(--divide-opacity));
   }
 
-  .lg\:divide-blue-800 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(30, 64, 175, var(--divide-opacity));
   }
 
-  .lg\:divide-blue-900 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(30, 58, 138, var(--divide-opacity));
   }
 
-  .lg\:divide-purple-50 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(245, 243, 255, var(--divide-opacity));
   }
 
-  .lg\:divide-purple-100 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(237, 233, 254, var(--divide-opacity));
   }
 
-  .lg\:divide-purple-200 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(221, 214, 254, var(--divide-opacity));
   }
 
-  .lg\:divide-purple-300 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(196, 181, 253, var(--divide-opacity));
   }
 
-  .lg\:divide-purple-400 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(167, 139, 250, var(--divide-opacity));
   }
 
-  .lg\:divide-purple-500 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(139, 92, 246, var(--divide-opacity));
   }
 
-  .lg\:divide-purple-600 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(124, 58, 237, var(--divide-opacity));
   }
 
-  .lg\:divide-purple-700 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(109, 40, 217, var(--divide-opacity));
   }
 
-  .lg\:divide-purple-800 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(91, 33, 182, var(--divide-opacity));
   }
 
-  .lg\:divide-purple-900 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(76, 29, 149, var(--divide-opacity));
   }
 
-  .lg\:divide-pink-50 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(253, 242, 248, var(--divide-opacity));
   }
 
-  .lg\:divide-pink-100 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 231, 243, var(--divide-opacity));
   }
 
-  .lg\:divide-pink-200 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(251, 207, 232, var(--divide-opacity));
   }
 
-  .lg\:divide-pink-300 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(249, 168, 212, var(--divide-opacity));
   }
 
-  .lg\:divide-pink-400 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(244, 114, 182, var(--divide-opacity));
   }
 
-  .lg\:divide-pink-500 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(236, 72, 153, var(--divide-opacity));
   }
 
-  .lg\:divide-pink-600 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(219, 39, 119, var(--divide-opacity));
   }
 
-  .lg\:divide-pink-700 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(190, 24, 93, var(--divide-opacity));
   }
 
-  .lg\:divide-pink-800 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(157, 23, 77, var(--divide-opacity));
   }
 
-  .lg\:divide-pink-900 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(131, 24, 67, var(--divide-opacity));
   }
 
-  .lg\:divide-solid > :not(template) ~ :not(template) {
+  .lg\:divide-solid > :not([hidden]) ~ :not([hidden]) {
     border-style: solid;
   }
 
-  .lg\:divide-dashed > :not(template) ~ :not(template) {
+  .lg\:divide-dashed > :not([hidden]) ~ :not([hidden]) {
     border-style: dashed;
   }
 
-  .lg\:divide-dotted > :not(template) ~ :not(template) {
+  .lg\:divide-dotted > :not([hidden]) ~ :not([hidden]) {
     border-style: dotted;
   }
 
-  .lg\:divide-double > :not(template) ~ :not(template) {
+  .lg\:divide-double > :not([hidden]) ~ :not([hidden]) {
     border-style: double;
   }
 
-  .lg\:divide-none > :not(template) ~ :not(template) {
+  .lg\:divide-none > :not([hidden]) ~ :not([hidden]) {
     border-style: none;
   }
 
-  .lg\:divide-opacity-0 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0;
   }
 
-  .lg\:divide-opacity-10 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-10 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.1;
   }
 
-  .lg\:divide-opacity-20 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-20 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.2;
   }
 
-  .lg\:divide-opacity-25 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-25 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.25;
   }
 
-  .lg\:divide-opacity-30 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-30 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.3;
   }
 
-  .lg\:divide-opacity-40 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-40 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.4;
   }
 
-  .lg\:divide-opacity-50 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.5;
   }
 
-  .lg\:divide-opacity-60 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-60 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.6;
   }
 
-  .lg\:divide-opacity-70 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-70 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.7;
   }
 
-  .lg\:divide-opacity-75 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-75 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.75;
   }
 
-  .lg\:divide-opacity-80 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-80 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.8;
   }
 
-  .lg\:divide-opacity-90 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-90 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.9;
   }
 
-  .lg\:divide-opacity-100 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
   }
 
@@ -92374,1323 +92374,1323 @@ video {
     }
   }
 
-  .xl\:space-y-0 > :not(template) ~ :not(template) {
+  .xl\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0px * var(--space-y-reverse));
   }
 
-  .xl\:space-x-0 > :not(template) ~ :not(template) {
+  .xl\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0px * var(--space-x-reverse));
     margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-1 > :not(template) ~ :not(template) {
+  .xl\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.25rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-1 > :not(template) ~ :not(template) {
+  .xl\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-2 > :not(template) ~ :not(template) {
+  .xl\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.5rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-2 > :not(template) ~ :not(template) {
+  .xl\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-3 > :not(template) ~ :not(template) {
+  .xl\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.75rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-3 > :not(template) ~ :not(template) {
+  .xl\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-4 > :not(template) ~ :not(template) {
+  .xl\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-4 > :not(template) ~ :not(template) {
+  .xl\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1rem * var(--space-x-reverse));
     margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-5 > :not(template) ~ :not(template) {
+  .xl\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.25rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-5 > :not(template) ~ :not(template) {
+  .xl\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-6 > :not(template) ~ :not(template) {
+  .xl\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.5rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-6 > :not(template) ~ :not(template) {
+  .xl\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-7 > :not(template) ~ :not(template) {
+  .xl\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.75rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-7 > :not(template) ~ :not(template) {
+  .xl\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-8 > :not(template) ~ :not(template) {
+  .xl\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-8 > :not(template) ~ :not(template) {
+  .xl\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2rem * var(--space-x-reverse));
     margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-9 > :not(template) ~ :not(template) {
+  .xl\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.25rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-9 > :not(template) ~ :not(template) {
+  .xl\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-10 > :not(template) ~ :not(template) {
+  .xl\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.5rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-10 > :not(template) ~ :not(template) {
+  .xl\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-12 > :not(template) ~ :not(template) {
+  .xl\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-12 > :not(template) ~ :not(template) {
+  .xl\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3rem * var(--space-x-reverse));
     margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-14 > :not(template) ~ :not(template) {
+  .xl\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3.5rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-14 > :not(template) ~ :not(template) {
+  .xl\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-16 > :not(template) ~ :not(template) {
+  .xl\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(4rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-16 > :not(template) ~ :not(template) {
+  .xl\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(4rem * var(--space-x-reverse));
     margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-20 > :not(template) ~ :not(template) {
+  .xl\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(5rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-20 > :not(template) ~ :not(template) {
+  .xl\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(5rem * var(--space-x-reverse));
     margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-24 > :not(template) ~ :not(template) {
+  .xl\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(6rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-24 > :not(template) ~ :not(template) {
+  .xl\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(6rem * var(--space-x-reverse));
     margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-28 > :not(template) ~ :not(template) {
+  .xl\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(7rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-28 > :not(template) ~ :not(template) {
+  .xl\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(7rem * var(--space-x-reverse));
     margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-32 > :not(template) ~ :not(template) {
+  .xl\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(8rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-32 > :not(template) ~ :not(template) {
+  .xl\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(8rem * var(--space-x-reverse));
     margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-36 > :not(template) ~ :not(template) {
+  .xl\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(9rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-36 > :not(template) ~ :not(template) {
+  .xl\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(9rem * var(--space-x-reverse));
     margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-40 > :not(template) ~ :not(template) {
+  .xl\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(10rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-40 > :not(template) ~ :not(template) {
+  .xl\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(10rem * var(--space-x-reverse));
     margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-44 > :not(template) ~ :not(template) {
+  .xl\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(11rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-44 > :not(template) ~ :not(template) {
+  .xl\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(11rem * var(--space-x-reverse));
     margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-48 > :not(template) ~ :not(template) {
+  .xl\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(12rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-48 > :not(template) ~ :not(template) {
+  .xl\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(12rem * var(--space-x-reverse));
     margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-52 > :not(template) ~ :not(template) {
+  .xl\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(13rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-52 > :not(template) ~ :not(template) {
+  .xl\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(13rem * var(--space-x-reverse));
     margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-56 > :not(template) ~ :not(template) {
+  .xl\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(14rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-56 > :not(template) ~ :not(template) {
+  .xl\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(14rem * var(--space-x-reverse));
     margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-60 > :not(template) ~ :not(template) {
+  .xl\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(15rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-60 > :not(template) ~ :not(template) {
+  .xl\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(15rem * var(--space-x-reverse));
     margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-64 > :not(template) ~ :not(template) {
+  .xl\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(16rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-64 > :not(template) ~ :not(template) {
+  .xl\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(16rem * var(--space-x-reverse));
     margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-72 > :not(template) ~ :not(template) {
+  .xl\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(18rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-72 > :not(template) ~ :not(template) {
+  .xl\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(18rem * var(--space-x-reverse));
     margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-80 > :not(template) ~ :not(template) {
+  .xl\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(20rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-80 > :not(template) ~ :not(template) {
+  .xl\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(20rem * var(--space-x-reverse));
     margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-96 > :not(template) ~ :not(template) {
+  .xl\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(24rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-96 > :not(template) ~ :not(template) {
+  .xl\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(24rem * var(--space-x-reverse));
     margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-px > :not(template) ~ :not(template) {
+  .xl\:space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1px * var(--space-y-reverse));
   }
 
-  .xl\:space-x-px > :not(template) ~ :not(template) {
+  .xl\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1px * var(--space-x-reverse));
     margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-0\.5 > :not(template) ~ :not(template) {
+  .xl\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.125rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-0\.5 > :not(template) ~ :not(template) {
+  .xl\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-1\.5 > :not(template) ~ :not(template) {
+  .xl\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.375rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-1\.5 > :not(template) ~ :not(template) {
+  .xl\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-2\.5 > :not(template) ~ :not(template) {
+  .xl\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.625rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-2\.5 > :not(template) ~ :not(template) {
+  .xl\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-3\.5 > :not(template) ~ :not(template) {
+  .xl\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.875rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-3\.5 > :not(template) ~ :not(template) {
+  .xl\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-1 > :not(template) ~ :not(template) {
+  .xl\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.25rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-1 > :not(template) ~ :not(template) {
+  .xl\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-2 > :not(template) ~ :not(template) {
+  .xl\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.5rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-2 > :not(template) ~ :not(template) {
+  .xl\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-3 > :not(template) ~ :not(template) {
+  .xl\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.75rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-3 > :not(template) ~ :not(template) {
+  .xl\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-4 > :not(template) ~ :not(template) {
+  .xl\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-4 > :not(template) ~ :not(template) {
+  .xl\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1rem * var(--space-x-reverse));
     margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-5 > :not(template) ~ :not(template) {
+  .xl\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.25rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-5 > :not(template) ~ :not(template) {
+  .xl\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-6 > :not(template) ~ :not(template) {
+  .xl\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.5rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-6 > :not(template) ~ :not(template) {
+  .xl\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-7 > :not(template) ~ :not(template) {
+  .xl\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.75rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-7 > :not(template) ~ :not(template) {
+  .xl\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-8 > :not(template) ~ :not(template) {
+  .xl\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-8 > :not(template) ~ :not(template) {
+  .xl\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2rem * var(--space-x-reverse));
     margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-9 > :not(template) ~ :not(template) {
+  .xl\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.25rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-9 > :not(template) ~ :not(template) {
+  .xl\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-10 > :not(template) ~ :not(template) {
+  .xl\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.5rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-10 > :not(template) ~ :not(template) {
+  .xl\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-12 > :not(template) ~ :not(template) {
+  .xl\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-12 > :not(template) ~ :not(template) {
+  .xl\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3rem * var(--space-x-reverse));
     margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-14 > :not(template) ~ :not(template) {
+  .xl\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3.5rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-14 > :not(template) ~ :not(template) {
+  .xl\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-16 > :not(template) ~ :not(template) {
+  .xl\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-4rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-16 > :not(template) ~ :not(template) {
+  .xl\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-4rem * var(--space-x-reverse));
     margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-20 > :not(template) ~ :not(template) {
+  .xl\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-5rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-20 > :not(template) ~ :not(template) {
+  .xl\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-5rem * var(--space-x-reverse));
     margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-24 > :not(template) ~ :not(template) {
+  .xl\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-6rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-24 > :not(template) ~ :not(template) {
+  .xl\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-6rem * var(--space-x-reverse));
     margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-28 > :not(template) ~ :not(template) {
+  .xl\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-7rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-28 > :not(template) ~ :not(template) {
+  .xl\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-7rem * var(--space-x-reverse));
     margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-32 > :not(template) ~ :not(template) {
+  .xl\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-8rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-32 > :not(template) ~ :not(template) {
+  .xl\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-8rem * var(--space-x-reverse));
     margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-36 > :not(template) ~ :not(template) {
+  .xl\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-9rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-36 > :not(template) ~ :not(template) {
+  .xl\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-9rem * var(--space-x-reverse));
     margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-40 > :not(template) ~ :not(template) {
+  .xl\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-10rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-40 > :not(template) ~ :not(template) {
+  .xl\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-10rem * var(--space-x-reverse));
     margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-44 > :not(template) ~ :not(template) {
+  .xl\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-11rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-44 > :not(template) ~ :not(template) {
+  .xl\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-11rem * var(--space-x-reverse));
     margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-48 > :not(template) ~ :not(template) {
+  .xl\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-12rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-48 > :not(template) ~ :not(template) {
+  .xl\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-12rem * var(--space-x-reverse));
     margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-52 > :not(template) ~ :not(template) {
+  .xl\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-13rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-52 > :not(template) ~ :not(template) {
+  .xl\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-13rem * var(--space-x-reverse));
     margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-56 > :not(template) ~ :not(template) {
+  .xl\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-14rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-56 > :not(template) ~ :not(template) {
+  .xl\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-14rem * var(--space-x-reverse));
     margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-60 > :not(template) ~ :not(template) {
+  .xl\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-15rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-60 > :not(template) ~ :not(template) {
+  .xl\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-15rem * var(--space-x-reverse));
     margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-64 > :not(template) ~ :not(template) {
+  .xl\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-16rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-64 > :not(template) ~ :not(template) {
+  .xl\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-16rem * var(--space-x-reverse));
     margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-72 > :not(template) ~ :not(template) {
+  .xl\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-18rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-72 > :not(template) ~ :not(template) {
+  .xl\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-18rem * var(--space-x-reverse));
     margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-80 > :not(template) ~ :not(template) {
+  .xl\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-20rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-80 > :not(template) ~ :not(template) {
+  .xl\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-20rem * var(--space-x-reverse));
     margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-96 > :not(template) ~ :not(template) {
+  .xl\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-24rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-96 > :not(template) ~ :not(template) {
+  .xl\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-24rem * var(--space-x-reverse));
     margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-px > :not(template) ~ :not(template) {
+  .xl\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1px * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-px > :not(template) ~ :not(template) {
+  .xl\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1px * var(--space-x-reverse));
     margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-0\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.125rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-0\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-1\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.375rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-1\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-2\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.625rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-2\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-3\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.875rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-3\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-reverse > :not(template) ~ :not(template) {
+  .xl\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 1;
   }
 
-  .xl\:space-x-reverse > :not(template) ~ :not(template) {
+  .xl\:space-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 1;
   }
 
-  .xl\:divide-y-0 > :not(template) ~ :not(template) {
+  .xl\:divide-y-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(0px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(0px * var(--divide-y-reverse));
   }
 
-  .xl\:divide-x-0 > :not(template) ~ :not(template) {
+  .xl\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(0px * var(--divide-x-reverse));
     border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .xl\:divide-y-2 > :not(template) ~ :not(template) {
+  .xl\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(2px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(2px * var(--divide-y-reverse));
   }
 
-  .xl\:divide-x-2 > :not(template) ~ :not(template) {
+  .xl\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(2px * var(--divide-x-reverse));
     border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .xl\:divide-y-4 > :not(template) ~ :not(template) {
+  .xl\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(4px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(4px * var(--divide-y-reverse));
   }
 
-  .xl\:divide-x-4 > :not(template) ~ :not(template) {
+  .xl\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(4px * var(--divide-x-reverse));
     border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .xl\:divide-y-8 > :not(template) ~ :not(template) {
+  .xl\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(8px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(8px * var(--divide-y-reverse));
   }
 
-  .xl\:divide-x-8 > :not(template) ~ :not(template) {
+  .xl\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(8px * var(--divide-x-reverse));
     border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .xl\:divide-y > :not(template) ~ :not(template) {
+  .xl\:divide-y > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(1px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(1px * var(--divide-y-reverse));
   }
 
-  .xl\:divide-x > :not(template) ~ :not(template) {
+  .xl\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(1px * var(--divide-x-reverse));
     border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .xl\:divide-y-reverse > :not(template) ~ :not(template) {
+  .xl\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 1;
   }
 
-  .xl\:divide-x-reverse > :not(template) ~ :not(template) {
+  .xl\:divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 1;
   }
 
-  .xl\:divide-transparent > :not(template) ~ :not(template) {
+  .xl\:divide-transparent > :not([hidden]) ~ :not([hidden]) {
     border-color: transparent;
   }
 
-  .xl\:divide-current > :not(template) ~ :not(template) {
+  .xl\:divide-current > :not([hidden]) ~ :not([hidden]) {
     border-color: currentColor;
   }
 
-  .xl\:divide-black > :not(template) ~ :not(template) {
+  .xl\:divide-black > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(0, 0, 0, var(--divide-opacity));
   }
 
-  .xl\:divide-white > :not(template) ~ :not(template) {
+  .xl\:divide-white > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(255, 255, 255, var(--divide-opacity));
   }
 
-  .xl\:divide-gray-50 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(250, 250, 250, var(--divide-opacity));
   }
 
-  .xl\:divide-gray-100 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(244, 244, 245, var(--divide-opacity));
   }
 
-  .xl\:divide-gray-200 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(228, 228, 231, var(--divide-opacity));
   }
 
-  .xl\:divide-gray-300 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(212, 212, 216, var(--divide-opacity));
   }
 
-  .xl\:divide-gray-400 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(161, 161, 170, var(--divide-opacity));
   }
 
-  .xl\:divide-gray-500 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(113, 113, 122, var(--divide-opacity));
   }
 
-  .xl\:divide-gray-600 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(82, 82, 91, var(--divide-opacity));
   }
 
-  .xl\:divide-gray-700 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(63, 63, 70, var(--divide-opacity));
   }
 
-  .xl\:divide-gray-800 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(39, 39, 42, var(--divide-opacity));
   }
 
-  .xl\:divide-gray-900 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(24, 24, 27, var(--divide-opacity));
   }
 
-  .xl\:divide-red-50 > :not(template) ~ :not(template) {
+  .xl\:divide-red-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 242, 242, var(--divide-opacity));
   }
 
-  .xl\:divide-red-100 > :not(template) ~ :not(template) {
+  .xl\:divide-red-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 226, 226, var(--divide-opacity));
   }
 
-  .xl\:divide-red-200 > :not(template) ~ :not(template) {
+  .xl\:divide-red-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 202, 202, var(--divide-opacity));
   }
 
-  .xl\:divide-red-300 > :not(template) ~ :not(template) {
+  .xl\:divide-red-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 165, 165, var(--divide-opacity));
   }
 
-  .xl\:divide-red-400 > :not(template) ~ :not(template) {
+  .xl\:divide-red-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(248, 113, 113, var(--divide-opacity));
   }
 
-  .xl\:divide-red-500 > :not(template) ~ :not(template) {
+  .xl\:divide-red-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(239, 68, 68, var(--divide-opacity));
   }
 
-  .xl\:divide-red-600 > :not(template) ~ :not(template) {
+  .xl\:divide-red-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(220, 38, 38, var(--divide-opacity));
   }
 
-  .xl\:divide-red-700 > :not(template) ~ :not(template) {
+  .xl\:divide-red-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(185, 28, 28, var(--divide-opacity));
   }
 
-  .xl\:divide-red-800 > :not(template) ~ :not(template) {
+  .xl\:divide-red-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(153, 27, 27, var(--divide-opacity));
   }
 
-  .xl\:divide-red-900 > :not(template) ~ :not(template) {
+  .xl\:divide-red-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(127, 29, 29, var(--divide-opacity));
   }
 
-  .xl\:divide-yellow-50 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(255, 251, 235, var(--divide-opacity));
   }
 
-  .xl\:divide-yellow-100 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 243, 199, var(--divide-opacity));
   }
 
-  .xl\:divide-yellow-200 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(253, 230, 138, var(--divide-opacity));
   }
 
-  .xl\:divide-yellow-300 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 211, 77, var(--divide-opacity));
   }
 
-  .xl\:divide-yellow-400 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(251, 191, 36, var(--divide-opacity));
   }
 
-  .xl\:divide-yellow-500 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(245, 158, 11, var(--divide-opacity));
   }
 
-  .xl\:divide-yellow-600 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(217, 119, 6, var(--divide-opacity));
   }
 
-  .xl\:divide-yellow-700 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(180, 83, 9, var(--divide-opacity));
   }
 
-  .xl\:divide-yellow-800 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(146, 64, 14, var(--divide-opacity));
   }
 
-  .xl\:divide-yellow-900 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(120, 53, 15, var(--divide-opacity));
   }
 
-  .xl\:divide-green-50 > :not(template) ~ :not(template) {
+  .xl\:divide-green-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(236, 253, 245, var(--divide-opacity));
   }
 
-  .xl\:divide-green-100 > :not(template) ~ :not(template) {
+  .xl\:divide-green-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(209, 250, 229, var(--divide-opacity));
   }
 
-  .xl\:divide-green-200 > :not(template) ~ :not(template) {
+  .xl\:divide-green-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(167, 243, 208, var(--divide-opacity));
   }
 
-  .xl\:divide-green-300 > :not(template) ~ :not(template) {
+  .xl\:divide-green-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(110, 231, 183, var(--divide-opacity));
   }
 
-  .xl\:divide-green-400 > :not(template) ~ :not(template) {
+  .xl\:divide-green-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(52, 211, 153, var(--divide-opacity));
   }
 
-  .xl\:divide-green-500 > :not(template) ~ :not(template) {
+  .xl\:divide-green-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(16, 185, 129, var(--divide-opacity));
   }
 
-  .xl\:divide-green-600 > :not(template) ~ :not(template) {
+  .xl\:divide-green-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(5, 150, 105, var(--divide-opacity));
   }
 
-  .xl\:divide-green-700 > :not(template) ~ :not(template) {
+  .xl\:divide-green-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(4, 120, 87, var(--divide-opacity));
   }
 
-  .xl\:divide-green-800 > :not(template) ~ :not(template) {
+  .xl\:divide-green-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(6, 95, 70, var(--divide-opacity));
   }
 
-  .xl\:divide-green-900 > :not(template) ~ :not(template) {
+  .xl\:divide-green-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(6, 78, 59, var(--divide-opacity));
   }
 
-  .xl\:divide-blue-50 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(239, 246, 255, var(--divide-opacity));
   }
 
-  .xl\:divide-blue-100 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(219, 234, 254, var(--divide-opacity));
   }
 
-  .xl\:divide-blue-200 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(191, 219, 254, var(--divide-opacity));
   }
 
-  .xl\:divide-blue-300 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(147, 197, 253, var(--divide-opacity));
   }
 
-  .xl\:divide-blue-400 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(96, 165, 250, var(--divide-opacity));
   }
 
-  .xl\:divide-blue-500 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(59, 130, 246, var(--divide-opacity));
   }
 
-  .xl\:divide-blue-600 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(37, 99, 235, var(--divide-opacity));
   }
 
-  .xl\:divide-blue-700 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(29, 78, 216, var(--divide-opacity));
   }
 
-  .xl\:divide-blue-800 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(30, 64, 175, var(--divide-opacity));
   }
 
-  .xl\:divide-blue-900 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(30, 58, 138, var(--divide-opacity));
   }
 
-  .xl\:divide-purple-50 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(245, 243, 255, var(--divide-opacity));
   }
 
-  .xl\:divide-purple-100 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(237, 233, 254, var(--divide-opacity));
   }
 
-  .xl\:divide-purple-200 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(221, 214, 254, var(--divide-opacity));
   }
 
-  .xl\:divide-purple-300 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(196, 181, 253, var(--divide-opacity));
   }
 
-  .xl\:divide-purple-400 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(167, 139, 250, var(--divide-opacity));
   }
 
-  .xl\:divide-purple-500 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(139, 92, 246, var(--divide-opacity));
   }
 
-  .xl\:divide-purple-600 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(124, 58, 237, var(--divide-opacity));
   }
 
-  .xl\:divide-purple-700 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(109, 40, 217, var(--divide-opacity));
   }
 
-  .xl\:divide-purple-800 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(91, 33, 182, var(--divide-opacity));
   }
 
-  .xl\:divide-purple-900 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(76, 29, 149, var(--divide-opacity));
   }
 
-  .xl\:divide-pink-50 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(253, 242, 248, var(--divide-opacity));
   }
 
-  .xl\:divide-pink-100 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 231, 243, var(--divide-opacity));
   }
 
-  .xl\:divide-pink-200 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(251, 207, 232, var(--divide-opacity));
   }
 
-  .xl\:divide-pink-300 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(249, 168, 212, var(--divide-opacity));
   }
 
-  .xl\:divide-pink-400 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(244, 114, 182, var(--divide-opacity));
   }
 
-  .xl\:divide-pink-500 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(236, 72, 153, var(--divide-opacity));
   }
 
-  .xl\:divide-pink-600 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(219, 39, 119, var(--divide-opacity));
   }
 
-  .xl\:divide-pink-700 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(190, 24, 93, var(--divide-opacity));
   }
 
-  .xl\:divide-pink-800 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(157, 23, 77, var(--divide-opacity));
   }
 
-  .xl\:divide-pink-900 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(131, 24, 67, var(--divide-opacity));
   }
 
-  .xl\:divide-solid > :not(template) ~ :not(template) {
+  .xl\:divide-solid > :not([hidden]) ~ :not([hidden]) {
     border-style: solid;
   }
 
-  .xl\:divide-dashed > :not(template) ~ :not(template) {
+  .xl\:divide-dashed > :not([hidden]) ~ :not([hidden]) {
     border-style: dashed;
   }
 
-  .xl\:divide-dotted > :not(template) ~ :not(template) {
+  .xl\:divide-dotted > :not([hidden]) ~ :not([hidden]) {
     border-style: dotted;
   }
 
-  .xl\:divide-double > :not(template) ~ :not(template) {
+  .xl\:divide-double > :not([hidden]) ~ :not([hidden]) {
     border-style: double;
   }
 
-  .xl\:divide-none > :not(template) ~ :not(template) {
+  .xl\:divide-none > :not([hidden]) ~ :not([hidden]) {
     border-style: none;
   }
 
-  .xl\:divide-opacity-0 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0;
   }
 
-  .xl\:divide-opacity-10 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-10 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.1;
   }
 
-  .xl\:divide-opacity-20 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-20 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.2;
   }
 
-  .xl\:divide-opacity-25 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-25 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.25;
   }
 
-  .xl\:divide-opacity-30 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-30 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.3;
   }
 
-  .xl\:divide-opacity-40 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-40 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.4;
   }
 
-  .xl\:divide-opacity-50 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.5;
   }
 
-  .xl\:divide-opacity-60 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-60 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.6;
   }
 
-  .xl\:divide-opacity-70 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-70 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.7;
   }
 
-  .xl\:divide-opacity-75 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-75 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.75;
   }
 
-  .xl\:divide-opacity-80 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-80 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.8;
   }
 
-  .xl\:divide-opacity-90 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-90 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.9;
   }
 
-  .xl\:divide-opacity-100 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
   }
 
@@ -115320,1323 +115320,1323 @@ video {
     }
   }
 
-  .\32xl\:space-y-0 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0px * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-0 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0px * var(--space-x-reverse));
     margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-1 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.25rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-1 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-2 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-2 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-3 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.75rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-3 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-4 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-4 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1rem * var(--space-x-reverse));
     margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-5 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.25rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-5 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-6 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-6 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-7 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.75rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-7 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-8 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-8 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2rem * var(--space-x-reverse));
     margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-9 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.25rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-9 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-10 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-10 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-12 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-12 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3rem * var(--space-x-reverse));
     margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-14 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-14 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-16 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(4rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-16 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(4rem * var(--space-x-reverse));
     margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-20 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-20 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(5rem * var(--space-x-reverse));
     margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-24 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(6rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-24 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(6rem * var(--space-x-reverse));
     margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-28 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(7rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-28 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(7rem * var(--space-x-reverse));
     margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-32 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(8rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-32 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(8rem * var(--space-x-reverse));
     margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-36 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(9rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-36 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(9rem * var(--space-x-reverse));
     margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-40 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(10rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-40 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(10rem * var(--space-x-reverse));
     margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-44 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(11rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-44 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(11rem * var(--space-x-reverse));
     margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-48 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(12rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-48 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(12rem * var(--space-x-reverse));
     margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-52 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(13rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-52 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(13rem * var(--space-x-reverse));
     margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-56 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(14rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-56 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(14rem * var(--space-x-reverse));
     margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-60 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(15rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-60 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(15rem * var(--space-x-reverse));
     margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-64 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(16rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-64 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(16rem * var(--space-x-reverse));
     margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-72 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(18rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-72 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(18rem * var(--space-x-reverse));
     margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-80 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(20rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-80 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(20rem * var(--space-x-reverse));
     margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-96 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(24rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-96 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(24rem * var(--space-x-reverse));
     margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-px > :not(template) ~ :not(template) {
+  .\32xl\:space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1px * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-px > :not(template) ~ :not(template) {
+  .\32xl\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1px * var(--space-x-reverse));
     margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-0\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.125rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-0\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-1\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.375rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-1\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-2\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.625rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-2\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-3\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.875rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-3\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-1 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.25rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-1 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-2 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-2 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-3 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.75rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-3 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-4 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-4 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1rem * var(--space-x-reverse));
     margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.25rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-6 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-6 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-7 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.75rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-7 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-8 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-8 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2rem * var(--space-x-reverse));
     margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-9 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.25rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-9 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-10 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-10 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-12 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-12 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3rem * var(--space-x-reverse));
     margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-14 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-14 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-16 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-4rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-16 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-4rem * var(--space-x-reverse));
     margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-20 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-20 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-5rem * var(--space-x-reverse));
     margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-24 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-6rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-24 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-6rem * var(--space-x-reverse));
     margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-28 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-7rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-28 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-7rem * var(--space-x-reverse));
     margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-32 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-8rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-32 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-8rem * var(--space-x-reverse));
     margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-36 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-9rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-36 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-9rem * var(--space-x-reverse));
     margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-40 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-10rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-40 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-10rem * var(--space-x-reverse));
     margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-44 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-11rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-44 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-11rem * var(--space-x-reverse));
     margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-48 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-12rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-48 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-12rem * var(--space-x-reverse));
     margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-52 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-13rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-52 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-13rem * var(--space-x-reverse));
     margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-56 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-14rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-56 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-14rem * var(--space-x-reverse));
     margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-60 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-15rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-60 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-15rem * var(--space-x-reverse));
     margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-64 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-16rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-64 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-16rem * var(--space-x-reverse));
     margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-72 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-18rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-72 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-18rem * var(--space-x-reverse));
     margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-80 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-20rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-80 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-20rem * var(--space-x-reverse));
     margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-96 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-24rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-96 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-24rem * var(--space-x-reverse));
     margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-px > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1px * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-px > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1px * var(--space-x-reverse));
     margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-0\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.125rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-0\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-1\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.375rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-1\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-2\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.625rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-2\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-3\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.875rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-3\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-reverse > :not(template) ~ :not(template) {
+  .\32xl\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 1;
   }
 
-  .\32xl\:space-x-reverse > :not(template) ~ :not(template) {
+  .\32xl\:space-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 1;
   }
 
-  .\32xl\:divide-y-0 > :not(template) ~ :not(template) {
+  .\32xl\:divide-y-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(0px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(0px * var(--divide-y-reverse));
   }
 
-  .\32xl\:divide-x-0 > :not(template) ~ :not(template) {
+  .\32xl\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(0px * var(--divide-x-reverse));
     border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .\32xl\:divide-y-2 > :not(template) ~ :not(template) {
+  .\32xl\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(2px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(2px * var(--divide-y-reverse));
   }
 
-  .\32xl\:divide-x-2 > :not(template) ~ :not(template) {
+  .\32xl\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(2px * var(--divide-x-reverse));
     border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .\32xl\:divide-y-4 > :not(template) ~ :not(template) {
+  .\32xl\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(4px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(4px * var(--divide-y-reverse));
   }
 
-  .\32xl\:divide-x-4 > :not(template) ~ :not(template) {
+  .\32xl\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(4px * var(--divide-x-reverse));
     border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .\32xl\:divide-y-8 > :not(template) ~ :not(template) {
+  .\32xl\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(8px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(8px * var(--divide-y-reverse));
   }
 
-  .\32xl\:divide-x-8 > :not(template) ~ :not(template) {
+  .\32xl\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(8px * var(--divide-x-reverse));
     border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .\32xl\:divide-y > :not(template) ~ :not(template) {
+  .\32xl\:divide-y > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(1px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(1px * var(--divide-y-reverse));
   }
 
-  .\32xl\:divide-x > :not(template) ~ :not(template) {
+  .\32xl\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(1px * var(--divide-x-reverse));
     border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .\32xl\:divide-y-reverse > :not(template) ~ :not(template) {
+  .\32xl\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 1;
   }
 
-  .\32xl\:divide-x-reverse > :not(template) ~ :not(template) {
+  .\32xl\:divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 1;
   }
 
-  .\32xl\:divide-transparent > :not(template) ~ :not(template) {
+  .\32xl\:divide-transparent > :not([hidden]) ~ :not([hidden]) {
     border-color: transparent;
   }
 
-  .\32xl\:divide-current > :not(template) ~ :not(template) {
+  .\32xl\:divide-current > :not([hidden]) ~ :not([hidden]) {
     border-color: currentColor;
   }
 
-  .\32xl\:divide-black > :not(template) ~ :not(template) {
+  .\32xl\:divide-black > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(0, 0, 0, var(--divide-opacity));
   }
 
-  .\32xl\:divide-white > :not(template) ~ :not(template) {
+  .\32xl\:divide-white > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(255, 255, 255, var(--divide-opacity));
   }
 
-  .\32xl\:divide-gray-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(250, 250, 250, var(--divide-opacity));
   }
 
-  .\32xl\:divide-gray-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(244, 244, 245, var(--divide-opacity));
   }
 
-  .\32xl\:divide-gray-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(228, 228, 231, var(--divide-opacity));
   }
 
-  .\32xl\:divide-gray-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(212, 212, 216, var(--divide-opacity));
   }
 
-  .\32xl\:divide-gray-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(161, 161, 170, var(--divide-opacity));
   }
 
-  .\32xl\:divide-gray-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(113, 113, 122, var(--divide-opacity));
   }
 
-  .\32xl\:divide-gray-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(82, 82, 91, var(--divide-opacity));
   }
 
-  .\32xl\:divide-gray-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(63, 63, 70, var(--divide-opacity));
   }
 
-  .\32xl\:divide-gray-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(39, 39, 42, var(--divide-opacity));
   }
 
-  .\32xl\:divide-gray-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(24, 24, 27, var(--divide-opacity));
   }
 
-  .\32xl\:divide-red-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 242, 242, var(--divide-opacity));
   }
 
-  .\32xl\:divide-red-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 226, 226, var(--divide-opacity));
   }
 
-  .\32xl\:divide-red-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 202, 202, var(--divide-opacity));
   }
 
-  .\32xl\:divide-red-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 165, 165, var(--divide-opacity));
   }
 
-  .\32xl\:divide-red-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(248, 113, 113, var(--divide-opacity));
   }
 
-  .\32xl\:divide-red-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(239, 68, 68, var(--divide-opacity));
   }
 
-  .\32xl\:divide-red-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(220, 38, 38, var(--divide-opacity));
   }
 
-  .\32xl\:divide-red-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(185, 28, 28, var(--divide-opacity));
   }
 
-  .\32xl\:divide-red-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(153, 27, 27, var(--divide-opacity));
   }
 
-  .\32xl\:divide-red-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(127, 29, 29, var(--divide-opacity));
   }
 
-  .\32xl\:divide-yellow-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(255, 251, 235, var(--divide-opacity));
   }
 
-  .\32xl\:divide-yellow-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 243, 199, var(--divide-opacity));
   }
 
-  .\32xl\:divide-yellow-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(253, 230, 138, var(--divide-opacity));
   }
 
-  .\32xl\:divide-yellow-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 211, 77, var(--divide-opacity));
   }
 
-  .\32xl\:divide-yellow-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(251, 191, 36, var(--divide-opacity));
   }
 
-  .\32xl\:divide-yellow-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(245, 158, 11, var(--divide-opacity));
   }
 
-  .\32xl\:divide-yellow-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(217, 119, 6, var(--divide-opacity));
   }
 
-  .\32xl\:divide-yellow-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(180, 83, 9, var(--divide-opacity));
   }
 
-  .\32xl\:divide-yellow-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(146, 64, 14, var(--divide-opacity));
   }
 
-  .\32xl\:divide-yellow-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(120, 53, 15, var(--divide-opacity));
   }
 
-  .\32xl\:divide-green-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(236, 253, 245, var(--divide-opacity));
   }
 
-  .\32xl\:divide-green-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(209, 250, 229, var(--divide-opacity));
   }
 
-  .\32xl\:divide-green-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(167, 243, 208, var(--divide-opacity));
   }
 
-  .\32xl\:divide-green-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(110, 231, 183, var(--divide-opacity));
   }
 
-  .\32xl\:divide-green-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(52, 211, 153, var(--divide-opacity));
   }
 
-  .\32xl\:divide-green-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(16, 185, 129, var(--divide-opacity));
   }
 
-  .\32xl\:divide-green-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(5, 150, 105, var(--divide-opacity));
   }
 
-  .\32xl\:divide-green-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(4, 120, 87, var(--divide-opacity));
   }
 
-  .\32xl\:divide-green-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(6, 95, 70, var(--divide-opacity));
   }
 
-  .\32xl\:divide-green-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(6, 78, 59, var(--divide-opacity));
   }
 
-  .\32xl\:divide-blue-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(239, 246, 255, var(--divide-opacity));
   }
 
-  .\32xl\:divide-blue-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(219, 234, 254, var(--divide-opacity));
   }
 
-  .\32xl\:divide-blue-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(191, 219, 254, var(--divide-opacity));
   }
 
-  .\32xl\:divide-blue-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(147, 197, 253, var(--divide-opacity));
   }
 
-  .\32xl\:divide-blue-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(96, 165, 250, var(--divide-opacity));
   }
 
-  .\32xl\:divide-blue-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(59, 130, 246, var(--divide-opacity));
   }
 
-  .\32xl\:divide-blue-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(37, 99, 235, var(--divide-opacity));
   }
 
-  .\32xl\:divide-blue-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(29, 78, 216, var(--divide-opacity));
   }
 
-  .\32xl\:divide-blue-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(30, 64, 175, var(--divide-opacity));
   }
 
-  .\32xl\:divide-blue-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(30, 58, 138, var(--divide-opacity));
   }
 
-  .\32xl\:divide-purple-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(245, 243, 255, var(--divide-opacity));
   }
 
-  .\32xl\:divide-purple-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(237, 233, 254, var(--divide-opacity));
   }
 
-  .\32xl\:divide-purple-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(221, 214, 254, var(--divide-opacity));
   }
 
-  .\32xl\:divide-purple-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(196, 181, 253, var(--divide-opacity));
   }
 
-  .\32xl\:divide-purple-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(167, 139, 250, var(--divide-opacity));
   }
 
-  .\32xl\:divide-purple-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(139, 92, 246, var(--divide-opacity));
   }
 
-  .\32xl\:divide-purple-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(124, 58, 237, var(--divide-opacity));
   }
 
-  .\32xl\:divide-purple-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(109, 40, 217, var(--divide-opacity));
   }
 
-  .\32xl\:divide-purple-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(91, 33, 182, var(--divide-opacity));
   }
 
-  .\32xl\:divide-purple-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(76, 29, 149, var(--divide-opacity));
   }
 
-  .\32xl\:divide-pink-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(253, 242, 248, var(--divide-opacity));
   }
 
-  .\32xl\:divide-pink-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 231, 243, var(--divide-opacity));
   }
 
-  .\32xl\:divide-pink-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(251, 207, 232, var(--divide-opacity));
   }
 
-  .\32xl\:divide-pink-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(249, 168, 212, var(--divide-opacity));
   }
 
-  .\32xl\:divide-pink-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(244, 114, 182, var(--divide-opacity));
   }
 
-  .\32xl\:divide-pink-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(236, 72, 153, var(--divide-opacity));
   }
 
-  .\32xl\:divide-pink-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(219, 39, 119, var(--divide-opacity));
   }
 
-  .\32xl\:divide-pink-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(190, 24, 93, var(--divide-opacity));
   }
 
-  .\32xl\:divide-pink-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(157, 23, 77, var(--divide-opacity));
   }
 
-  .\32xl\:divide-pink-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(131, 24, 67, var(--divide-opacity));
   }
 
-  .\32xl\:divide-solid > :not(template) ~ :not(template) {
+  .\32xl\:divide-solid > :not([hidden]) ~ :not([hidden]) {
     border-style: solid;
   }
 
-  .\32xl\:divide-dashed > :not(template) ~ :not(template) {
+  .\32xl\:divide-dashed > :not([hidden]) ~ :not([hidden]) {
     border-style: dashed;
   }
 
-  .\32xl\:divide-dotted > :not(template) ~ :not(template) {
+  .\32xl\:divide-dotted > :not([hidden]) ~ :not([hidden]) {
     border-style: dotted;
   }
 
-  .\32xl\:divide-double > :not(template) ~ :not(template) {
+  .\32xl\:divide-double > :not([hidden]) ~ :not([hidden]) {
     border-style: double;
   }
 
-  .\32xl\:divide-none > :not(template) ~ :not(template) {
+  .\32xl\:divide-none > :not([hidden]) ~ :not([hidden]) {
     border-style: none;
   }
 
-  .\32xl\:divide-opacity-0 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0;
   }
 
-  .\32xl\:divide-opacity-10 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-10 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.1;
   }
 
-  .\32xl\:divide-opacity-20 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-20 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.2;
   }
 
-  .\32xl\:divide-opacity-25 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-25 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.25;
   }
 
-  .\32xl\:divide-opacity-30 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-30 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.3;
   }
 
-  .\32xl\:divide-opacity-40 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-40 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.4;
   }
 
-  .\32xl\:divide-opacity-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.5;
   }
 
-  .\32xl\:divide-opacity-60 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-60 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.6;
   }
 
-  .\32xl\:divide-opacity-70 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-70 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.7;
   }
 
-  .\32xl\:divide-opacity-75 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-75 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.75;
   }
 
-  .\32xl\:divide-opacity-80 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-80 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.8;
   }
 
-  .\32xl\:divide-opacity-90 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-90 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.9;
   }
 
-  .\32xl\:divide-opacity-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
   }
 

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -560,1323 +560,1323 @@ video {
   }
 }
 
-.space-y-0 > :not(template) ~ :not(template) {
+.space-y-0 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(0px * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(0px * var(--space-y-reverse)) !important;
 }
 
-.space-x-0 > :not(template) ~ :not(template) {
+.space-x-0 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(0px * var(--space-x-reverse)) !important;
   margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-1 > :not(template) ~ :not(template) {
+.space-y-1 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(0.25rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-1 > :not(template) ~ :not(template) {
+.space-x-1 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(0.25rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-2 > :not(template) ~ :not(template) {
+.space-y-2 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(0.5rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-2 > :not(template) ~ :not(template) {
+.space-x-2 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(0.5rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-3 > :not(template) ~ :not(template) {
+.space-y-3 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(0.75rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-3 > :not(template) ~ :not(template) {
+.space-x-3 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(0.75rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-4 > :not(template) ~ :not(template) {
+.space-y-4 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(1rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(1rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-4 > :not(template) ~ :not(template) {
+.space-x-4 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(1rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-5 > :not(template) ~ :not(template) {
+.space-y-5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(1.25rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-5 > :not(template) ~ :not(template) {
+.space-x-5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(1.25rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-6 > :not(template) ~ :not(template) {
+.space-y-6 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(1.5rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-6 > :not(template) ~ :not(template) {
+.space-x-6 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(1.5rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-7 > :not(template) ~ :not(template) {
+.space-y-7 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(1.75rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-7 > :not(template) ~ :not(template) {
+.space-x-7 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(1.75rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-8 > :not(template) ~ :not(template) {
+.space-y-8 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(2rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(2rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-8 > :not(template) ~ :not(template) {
+.space-x-8 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(2rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-9 > :not(template) ~ :not(template) {
+.space-y-9 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(2.25rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-9 > :not(template) ~ :not(template) {
+.space-x-9 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(2.25rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-10 > :not(template) ~ :not(template) {
+.space-y-10 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(2.5rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-10 > :not(template) ~ :not(template) {
+.space-x-10 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(2.5rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-12 > :not(template) ~ :not(template) {
+.space-y-12 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(3rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(3rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-12 > :not(template) ~ :not(template) {
+.space-x-12 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(3rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-14 > :not(template) ~ :not(template) {
+.space-y-14 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(3.5rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-14 > :not(template) ~ :not(template) {
+.space-x-14 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(3.5rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-16 > :not(template) ~ :not(template) {
+.space-y-16 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(4rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(4rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-16 > :not(template) ~ :not(template) {
+.space-x-16 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(4rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-20 > :not(template) ~ :not(template) {
+.space-y-20 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(5rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(5rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-20 > :not(template) ~ :not(template) {
+.space-x-20 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(5rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-24 > :not(template) ~ :not(template) {
+.space-y-24 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(6rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(6rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-24 > :not(template) ~ :not(template) {
+.space-x-24 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(6rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-28 > :not(template) ~ :not(template) {
+.space-y-28 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(7rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(7rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-28 > :not(template) ~ :not(template) {
+.space-x-28 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(7rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-32 > :not(template) ~ :not(template) {
+.space-y-32 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(8rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(8rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-32 > :not(template) ~ :not(template) {
+.space-x-32 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(8rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-36 > :not(template) ~ :not(template) {
+.space-y-36 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(9rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(9rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-36 > :not(template) ~ :not(template) {
+.space-x-36 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(9rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-40 > :not(template) ~ :not(template) {
+.space-y-40 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(10rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(10rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-40 > :not(template) ~ :not(template) {
+.space-x-40 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(10rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-44 > :not(template) ~ :not(template) {
+.space-y-44 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(11rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(11rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-44 > :not(template) ~ :not(template) {
+.space-x-44 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(11rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-48 > :not(template) ~ :not(template) {
+.space-y-48 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(12rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(12rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-48 > :not(template) ~ :not(template) {
+.space-x-48 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(12rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-52 > :not(template) ~ :not(template) {
+.space-y-52 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(13rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(13rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-52 > :not(template) ~ :not(template) {
+.space-x-52 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(13rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-56 > :not(template) ~ :not(template) {
+.space-y-56 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(14rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(14rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-56 > :not(template) ~ :not(template) {
+.space-x-56 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(14rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-60 > :not(template) ~ :not(template) {
+.space-y-60 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(15rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(15rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-60 > :not(template) ~ :not(template) {
+.space-x-60 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(15rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-64 > :not(template) ~ :not(template) {
+.space-y-64 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(16rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(16rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-64 > :not(template) ~ :not(template) {
+.space-x-64 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(16rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-72 > :not(template) ~ :not(template) {
+.space-y-72 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(18rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(18rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-72 > :not(template) ~ :not(template) {
+.space-x-72 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(18rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-80 > :not(template) ~ :not(template) {
+.space-y-80 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(20rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(20rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-80 > :not(template) ~ :not(template) {
+.space-x-80 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(20rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-96 > :not(template) ~ :not(template) {
+.space-y-96 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(24rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(24rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-96 > :not(template) ~ :not(template) {
+.space-x-96 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(24rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-px > :not(template) ~ :not(template) {
+.space-y-px > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(1px * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(1px * var(--space-y-reverse)) !important;
 }
 
-.space-x-px > :not(template) ~ :not(template) {
+.space-x-px > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(1px * var(--space-x-reverse)) !important;
   margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-0\.5 > :not(template) ~ :not(template) {
+.space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(0.125rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-0\.5 > :not(template) ~ :not(template) {
+.space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(0.125rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-1\.5 > :not(template) ~ :not(template) {
+.space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(0.375rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-1\.5 > :not(template) ~ :not(template) {
+.space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(0.375rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-2\.5 > :not(template) ~ :not(template) {
+.space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(0.625rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-2\.5 > :not(template) ~ :not(template) {
+.space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(0.625rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-3\.5 > :not(template) ~ :not(template) {
+.space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(0.875rem * var(--space-y-reverse)) !important;
 }
 
-.space-x-3\.5 > :not(template) ~ :not(template) {
+.space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(0.875rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-1 > :not(template) ~ :not(template) {
+.-space-y-1 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-0.25rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-1 > :not(template) ~ :not(template) {
+.-space-x-1 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-0.25rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-2 > :not(template) ~ :not(template) {
+.-space-y-2 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-0.5rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-2 > :not(template) ~ :not(template) {
+.-space-x-2 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-0.5rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-3 > :not(template) ~ :not(template) {
+.-space-y-3 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-0.75rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-3 > :not(template) ~ :not(template) {
+.-space-x-3 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-0.75rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-4 > :not(template) ~ :not(template) {
+.-space-y-4 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-1rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-1rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-4 > :not(template) ~ :not(template) {
+.-space-x-4 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-1rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-5 > :not(template) ~ :not(template) {
+.-space-y-5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-1.25rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-5 > :not(template) ~ :not(template) {
+.-space-x-5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-1.25rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-6 > :not(template) ~ :not(template) {
+.-space-y-6 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-1.5rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-6 > :not(template) ~ :not(template) {
+.-space-x-6 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-1.5rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-7 > :not(template) ~ :not(template) {
+.-space-y-7 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-1.75rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-7 > :not(template) ~ :not(template) {
+.-space-x-7 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-1.75rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-8 > :not(template) ~ :not(template) {
+.-space-y-8 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-2rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-2rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-8 > :not(template) ~ :not(template) {
+.-space-x-8 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-2rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-9 > :not(template) ~ :not(template) {
+.-space-y-9 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-2.25rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-9 > :not(template) ~ :not(template) {
+.-space-x-9 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-2.25rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-10 > :not(template) ~ :not(template) {
+.-space-y-10 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-2.5rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-10 > :not(template) ~ :not(template) {
+.-space-x-10 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-2.5rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-12 > :not(template) ~ :not(template) {
+.-space-y-12 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-3rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-3rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-12 > :not(template) ~ :not(template) {
+.-space-x-12 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-3rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-14 > :not(template) ~ :not(template) {
+.-space-y-14 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-3.5rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-14 > :not(template) ~ :not(template) {
+.-space-x-14 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-3.5rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-16 > :not(template) ~ :not(template) {
+.-space-y-16 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-4rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-4rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-16 > :not(template) ~ :not(template) {
+.-space-x-16 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-4rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-20 > :not(template) ~ :not(template) {
+.-space-y-20 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-5rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-5rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-20 > :not(template) ~ :not(template) {
+.-space-x-20 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-5rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-24 > :not(template) ~ :not(template) {
+.-space-y-24 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-6rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-6rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-24 > :not(template) ~ :not(template) {
+.-space-x-24 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-6rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-28 > :not(template) ~ :not(template) {
+.-space-y-28 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-7rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-7rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-28 > :not(template) ~ :not(template) {
+.-space-x-28 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-7rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-32 > :not(template) ~ :not(template) {
+.-space-y-32 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-8rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-8rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-32 > :not(template) ~ :not(template) {
+.-space-x-32 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-8rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-36 > :not(template) ~ :not(template) {
+.-space-y-36 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-9rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-9rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-36 > :not(template) ~ :not(template) {
+.-space-x-36 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-9rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-40 > :not(template) ~ :not(template) {
+.-space-y-40 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-10rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-10rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-40 > :not(template) ~ :not(template) {
+.-space-x-40 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-10rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-44 > :not(template) ~ :not(template) {
+.-space-y-44 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-11rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-11rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-44 > :not(template) ~ :not(template) {
+.-space-x-44 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-11rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-48 > :not(template) ~ :not(template) {
+.-space-y-48 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-12rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-12rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-48 > :not(template) ~ :not(template) {
+.-space-x-48 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-12rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-52 > :not(template) ~ :not(template) {
+.-space-y-52 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-13rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-13rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-52 > :not(template) ~ :not(template) {
+.-space-x-52 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-13rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-56 > :not(template) ~ :not(template) {
+.-space-y-56 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-14rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-14rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-56 > :not(template) ~ :not(template) {
+.-space-x-56 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-14rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-60 > :not(template) ~ :not(template) {
+.-space-y-60 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-15rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-15rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-60 > :not(template) ~ :not(template) {
+.-space-x-60 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-15rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-64 > :not(template) ~ :not(template) {
+.-space-y-64 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-16rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-16rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-64 > :not(template) ~ :not(template) {
+.-space-x-64 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-16rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-72 > :not(template) ~ :not(template) {
+.-space-y-72 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-18rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-18rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-72 > :not(template) ~ :not(template) {
+.-space-x-72 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-18rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-80 > :not(template) ~ :not(template) {
+.-space-y-80 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-20rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-20rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-80 > :not(template) ~ :not(template) {
+.-space-x-80 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-20rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-96 > :not(template) ~ :not(template) {
+.-space-y-96 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-24rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-24rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-96 > :not(template) ~ :not(template) {
+.-space-x-96 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-24rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-px > :not(template) ~ :not(template) {
+.-space-y-px > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-1px * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-1px * var(--space-y-reverse)) !important;
 }
 
-.-space-x-px > :not(template) ~ :not(template) {
+.-space-x-px > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-1px * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-0\.5 > :not(template) ~ :not(template) {
+.-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-0.125rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-0\.5 > :not(template) ~ :not(template) {
+.-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-0.125rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-1\.5 > :not(template) ~ :not(template) {
+.-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-0.375rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-1\.5 > :not(template) ~ :not(template) {
+.-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-0.375rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-2\.5 > :not(template) ~ :not(template) {
+.-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-0.625rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-2\.5 > :not(template) ~ :not(template) {
+.-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-0.625rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.-space-y-3\.5 > :not(template) ~ :not(template) {
+.-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0 !important;
   margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse))) !important;
   margin-bottom: calc(-0.875rem * var(--space-y-reverse)) !important;
 }
 
-.-space-x-3\.5 > :not(template) ~ :not(template) {
+.-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
   margin-inline-end: calc(-0.875rem * var(--space-x-reverse)) !important;
   margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
-.space-y-reverse > :not(template) ~ :not(template) {
+.space-y-reverse > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 1 !important;
 }
 
-.space-x-reverse > :not(template) ~ :not(template) {
+.space-x-reverse > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 1 !important;
 }
 
-.divide-y-0 > :not(template) ~ :not(template) {
+.divide-y-0 > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 0 !important;
   border-top-width: calc(0px * calc(1 - var(--divide-y-reverse))) !important;
   border-bottom-width: calc(0px * var(--divide-y-reverse)) !important;
 }
 
-.divide-x-0 > :not(template) ~ :not(template) {
+.divide-x-0 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0 !important;
   border-inline-end-width: calc(0px * var(--divide-x-reverse)) !important;
   border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse))) !important;
 }
 
-.divide-y-2 > :not(template) ~ :not(template) {
+.divide-y-2 > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 0 !important;
   border-top-width: calc(2px * calc(1 - var(--divide-y-reverse))) !important;
   border-bottom-width: calc(2px * var(--divide-y-reverse)) !important;
 }
 
-.divide-x-2 > :not(template) ~ :not(template) {
+.divide-x-2 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0 !important;
   border-inline-end-width: calc(2px * var(--divide-x-reverse)) !important;
   border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse))) !important;
 }
 
-.divide-y-4 > :not(template) ~ :not(template) {
+.divide-y-4 > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 0 !important;
   border-top-width: calc(4px * calc(1 - var(--divide-y-reverse))) !important;
   border-bottom-width: calc(4px * var(--divide-y-reverse)) !important;
 }
 
-.divide-x-4 > :not(template) ~ :not(template) {
+.divide-x-4 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0 !important;
   border-inline-end-width: calc(4px * var(--divide-x-reverse)) !important;
   border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse))) !important;
 }
 
-.divide-y-8 > :not(template) ~ :not(template) {
+.divide-y-8 > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 0 !important;
   border-top-width: calc(8px * calc(1 - var(--divide-y-reverse))) !important;
   border-bottom-width: calc(8px * var(--divide-y-reverse)) !important;
 }
 
-.divide-x-8 > :not(template) ~ :not(template) {
+.divide-x-8 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0 !important;
   border-inline-end-width: calc(8px * var(--divide-x-reverse)) !important;
   border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse))) !important;
 }
 
-.divide-y > :not(template) ~ :not(template) {
+.divide-y > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 0 !important;
   border-top-width: calc(1px * calc(1 - var(--divide-y-reverse))) !important;
   border-bottom-width: calc(1px * var(--divide-y-reverse)) !important;
 }
 
-.divide-x > :not(template) ~ :not(template) {
+.divide-x > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0 !important;
   border-inline-end-width: calc(1px * var(--divide-x-reverse)) !important;
   border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse))) !important;
 }
 
-.divide-y-reverse > :not(template) ~ :not(template) {
+.divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 1 !important;
 }
 
-.divide-x-reverse > :not(template) ~ :not(template) {
+.divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 1 !important;
 }
 
-.divide-transparent > :not(template) ~ :not(template) {
+.divide-transparent > :not([hidden]) ~ :not([hidden]) {
   border-color: transparent !important;
 }
 
-.divide-current > :not(template) ~ :not(template) {
+.divide-current > :not([hidden]) ~ :not([hidden]) {
   border-color: currentColor !important;
 }
 
-.divide-black > :not(template) ~ :not(template) {
+.divide-black > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(0, 0, 0, var(--divide-opacity)) !important;
 }
 
-.divide-white > :not(template) ~ :not(template) {
+.divide-white > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(255, 255, 255, var(--divide-opacity)) !important;
 }
 
-.divide-gray-50 > :not(template) ~ :not(template) {
+.divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(250, 250, 250, var(--divide-opacity)) !important;
 }
 
-.divide-gray-100 > :not(template) ~ :not(template) {
+.divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(244, 244, 245, var(--divide-opacity)) !important;
 }
 
-.divide-gray-200 > :not(template) ~ :not(template) {
+.divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(228, 228, 231, var(--divide-opacity)) !important;
 }
 
-.divide-gray-300 > :not(template) ~ :not(template) {
+.divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(212, 212, 216, var(--divide-opacity)) !important;
 }
 
-.divide-gray-400 > :not(template) ~ :not(template) {
+.divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(161, 161, 170, var(--divide-opacity)) !important;
 }
 
-.divide-gray-500 > :not(template) ~ :not(template) {
+.divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(113, 113, 122, var(--divide-opacity)) !important;
 }
 
-.divide-gray-600 > :not(template) ~ :not(template) {
+.divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(82, 82, 91, var(--divide-opacity)) !important;
 }
 
-.divide-gray-700 > :not(template) ~ :not(template) {
+.divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(63, 63, 70, var(--divide-opacity)) !important;
 }
 
-.divide-gray-800 > :not(template) ~ :not(template) {
+.divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(39, 39, 42, var(--divide-opacity)) !important;
 }
 
-.divide-gray-900 > :not(template) ~ :not(template) {
+.divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(24, 24, 27, var(--divide-opacity)) !important;
 }
 
-.divide-red-50 > :not(template) ~ :not(template) {
+.divide-red-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(254, 242, 242, var(--divide-opacity)) !important;
 }
 
-.divide-red-100 > :not(template) ~ :not(template) {
+.divide-red-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(254, 226, 226, var(--divide-opacity)) !important;
 }
 
-.divide-red-200 > :not(template) ~ :not(template) {
+.divide-red-200 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(254, 202, 202, var(--divide-opacity)) !important;
 }
 
-.divide-red-300 > :not(template) ~ :not(template) {
+.divide-red-300 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(252, 165, 165, var(--divide-opacity)) !important;
 }
 
-.divide-red-400 > :not(template) ~ :not(template) {
+.divide-red-400 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(248, 113, 113, var(--divide-opacity)) !important;
 }
 
-.divide-red-500 > :not(template) ~ :not(template) {
+.divide-red-500 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(239, 68, 68, var(--divide-opacity)) !important;
 }
 
-.divide-red-600 > :not(template) ~ :not(template) {
+.divide-red-600 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(220, 38, 38, var(--divide-opacity)) !important;
 }
 
-.divide-red-700 > :not(template) ~ :not(template) {
+.divide-red-700 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(185, 28, 28, var(--divide-opacity)) !important;
 }
 
-.divide-red-800 > :not(template) ~ :not(template) {
+.divide-red-800 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(153, 27, 27, var(--divide-opacity)) !important;
 }
 
-.divide-red-900 > :not(template) ~ :not(template) {
+.divide-red-900 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(127, 29, 29, var(--divide-opacity)) !important;
 }
 
-.divide-yellow-50 > :not(template) ~ :not(template) {
+.divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(255, 251, 235, var(--divide-opacity)) !important;
 }
 
-.divide-yellow-100 > :not(template) ~ :not(template) {
+.divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(254, 243, 199, var(--divide-opacity)) !important;
 }
 
-.divide-yellow-200 > :not(template) ~ :not(template) {
+.divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(253, 230, 138, var(--divide-opacity)) !important;
 }
 
-.divide-yellow-300 > :not(template) ~ :not(template) {
+.divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(252, 211, 77, var(--divide-opacity)) !important;
 }
 
-.divide-yellow-400 > :not(template) ~ :not(template) {
+.divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(251, 191, 36, var(--divide-opacity)) !important;
 }
 
-.divide-yellow-500 > :not(template) ~ :not(template) {
+.divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(245, 158, 11, var(--divide-opacity)) !important;
 }
 
-.divide-yellow-600 > :not(template) ~ :not(template) {
+.divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(217, 119, 6, var(--divide-opacity)) !important;
 }
 
-.divide-yellow-700 > :not(template) ~ :not(template) {
+.divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(180, 83, 9, var(--divide-opacity)) !important;
 }
 
-.divide-yellow-800 > :not(template) ~ :not(template) {
+.divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(146, 64, 14, var(--divide-opacity)) !important;
 }
 
-.divide-yellow-900 > :not(template) ~ :not(template) {
+.divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(120, 53, 15, var(--divide-opacity)) !important;
 }
 
-.divide-green-50 > :not(template) ~ :not(template) {
+.divide-green-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(236, 253, 245, var(--divide-opacity)) !important;
 }
 
-.divide-green-100 > :not(template) ~ :not(template) {
+.divide-green-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(209, 250, 229, var(--divide-opacity)) !important;
 }
 
-.divide-green-200 > :not(template) ~ :not(template) {
+.divide-green-200 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(167, 243, 208, var(--divide-opacity)) !important;
 }
 
-.divide-green-300 > :not(template) ~ :not(template) {
+.divide-green-300 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(110, 231, 183, var(--divide-opacity)) !important;
 }
 
-.divide-green-400 > :not(template) ~ :not(template) {
+.divide-green-400 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(52, 211, 153, var(--divide-opacity)) !important;
 }
 
-.divide-green-500 > :not(template) ~ :not(template) {
+.divide-green-500 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(16, 185, 129, var(--divide-opacity)) !important;
 }
 
-.divide-green-600 > :not(template) ~ :not(template) {
+.divide-green-600 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(5, 150, 105, var(--divide-opacity)) !important;
 }
 
-.divide-green-700 > :not(template) ~ :not(template) {
+.divide-green-700 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(4, 120, 87, var(--divide-opacity)) !important;
 }
 
-.divide-green-800 > :not(template) ~ :not(template) {
+.divide-green-800 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(6, 95, 70, var(--divide-opacity)) !important;
 }
 
-.divide-green-900 > :not(template) ~ :not(template) {
+.divide-green-900 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(6, 78, 59, var(--divide-opacity)) !important;
 }
 
-.divide-blue-50 > :not(template) ~ :not(template) {
+.divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(239, 246, 255, var(--divide-opacity)) !important;
 }
 
-.divide-blue-100 > :not(template) ~ :not(template) {
+.divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(219, 234, 254, var(--divide-opacity)) !important;
 }
 
-.divide-blue-200 > :not(template) ~ :not(template) {
+.divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(191, 219, 254, var(--divide-opacity)) !important;
 }
 
-.divide-blue-300 > :not(template) ~ :not(template) {
+.divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(147, 197, 253, var(--divide-opacity)) !important;
 }
 
-.divide-blue-400 > :not(template) ~ :not(template) {
+.divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(96, 165, 250, var(--divide-opacity)) !important;
 }
 
-.divide-blue-500 > :not(template) ~ :not(template) {
+.divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(59, 130, 246, var(--divide-opacity)) !important;
 }
 
-.divide-blue-600 > :not(template) ~ :not(template) {
+.divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(37, 99, 235, var(--divide-opacity)) !important;
 }
 
-.divide-blue-700 > :not(template) ~ :not(template) {
+.divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(29, 78, 216, var(--divide-opacity)) !important;
 }
 
-.divide-blue-800 > :not(template) ~ :not(template) {
+.divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(30, 64, 175, var(--divide-opacity)) !important;
 }
 
-.divide-blue-900 > :not(template) ~ :not(template) {
+.divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(30, 58, 138, var(--divide-opacity)) !important;
 }
 
-.divide-purple-50 > :not(template) ~ :not(template) {
+.divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(245, 243, 255, var(--divide-opacity)) !important;
 }
 
-.divide-purple-100 > :not(template) ~ :not(template) {
+.divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(237, 233, 254, var(--divide-opacity)) !important;
 }
 
-.divide-purple-200 > :not(template) ~ :not(template) {
+.divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(221, 214, 254, var(--divide-opacity)) !important;
 }
 
-.divide-purple-300 > :not(template) ~ :not(template) {
+.divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(196, 181, 253, var(--divide-opacity)) !important;
 }
 
-.divide-purple-400 > :not(template) ~ :not(template) {
+.divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(167, 139, 250, var(--divide-opacity)) !important;
 }
 
-.divide-purple-500 > :not(template) ~ :not(template) {
+.divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(139, 92, 246, var(--divide-opacity)) !important;
 }
 
-.divide-purple-600 > :not(template) ~ :not(template) {
+.divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(124, 58, 237, var(--divide-opacity)) !important;
 }
 
-.divide-purple-700 > :not(template) ~ :not(template) {
+.divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(109, 40, 217, var(--divide-opacity)) !important;
 }
 
-.divide-purple-800 > :not(template) ~ :not(template) {
+.divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(91, 33, 182, var(--divide-opacity)) !important;
 }
 
-.divide-purple-900 > :not(template) ~ :not(template) {
+.divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(76, 29, 149, var(--divide-opacity)) !important;
 }
 
-.divide-pink-50 > :not(template) ~ :not(template) {
+.divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(253, 242, 248, var(--divide-opacity)) !important;
 }
 
-.divide-pink-100 > :not(template) ~ :not(template) {
+.divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(252, 231, 243, var(--divide-opacity)) !important;
 }
 
-.divide-pink-200 > :not(template) ~ :not(template) {
+.divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(251, 207, 232, var(--divide-opacity)) !important;
 }
 
-.divide-pink-300 > :not(template) ~ :not(template) {
+.divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(249, 168, 212, var(--divide-opacity)) !important;
 }
 
-.divide-pink-400 > :not(template) ~ :not(template) {
+.divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(244, 114, 182, var(--divide-opacity)) !important;
 }
 
-.divide-pink-500 > :not(template) ~ :not(template) {
+.divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(236, 72, 153, var(--divide-opacity)) !important;
 }
 
-.divide-pink-600 > :not(template) ~ :not(template) {
+.divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(219, 39, 119, var(--divide-opacity)) !important;
 }
 
-.divide-pink-700 > :not(template) ~ :not(template) {
+.divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(190, 24, 93, var(--divide-opacity)) !important;
 }
 
-.divide-pink-800 > :not(template) ~ :not(template) {
+.divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(157, 23, 77, var(--divide-opacity)) !important;
 }
 
-.divide-pink-900 > :not(template) ~ :not(template) {
+.divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
   border-color: rgba(131, 24, 67, var(--divide-opacity)) !important;
 }
 
-.divide-solid > :not(template) ~ :not(template) {
+.divide-solid > :not([hidden]) ~ :not([hidden]) {
   border-style: solid !important;
 }
 
-.divide-dashed > :not(template) ~ :not(template) {
+.divide-dashed > :not([hidden]) ~ :not([hidden]) {
   border-style: dashed !important;
 }
 
-.divide-dotted > :not(template) ~ :not(template) {
+.divide-dotted > :not([hidden]) ~ :not([hidden]) {
   border-style: dotted !important;
 }
 
-.divide-double > :not(template) ~ :not(template) {
+.divide-double > :not([hidden]) ~ :not([hidden]) {
   border-style: double !important;
 }
 
-.divide-none > :not(template) ~ :not(template) {
+.divide-none > :not([hidden]) ~ :not([hidden]) {
   border-style: none !important;
 }
 
-.divide-opacity-0 > :not(template) ~ :not(template) {
+.divide-opacity-0 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0 !important;
 }
 
-.divide-opacity-10 > :not(template) ~ :not(template) {
+.divide-opacity-10 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.1 !important;
 }
 
-.divide-opacity-20 > :not(template) ~ :not(template) {
+.divide-opacity-20 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.2 !important;
 }
 
-.divide-opacity-25 > :not(template) ~ :not(template) {
+.divide-opacity-25 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.25 !important;
 }
 
-.divide-opacity-30 > :not(template) ~ :not(template) {
+.divide-opacity-30 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.3 !important;
 }
 
-.divide-opacity-40 > :not(template) ~ :not(template) {
+.divide-opacity-40 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.4 !important;
 }
 
-.divide-opacity-50 > :not(template) ~ :not(template) {
+.divide-opacity-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.5 !important;
 }
 
-.divide-opacity-60 > :not(template) ~ :not(template) {
+.divide-opacity-60 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.6 !important;
 }
 
-.divide-opacity-70 > :not(template) ~ :not(template) {
+.divide-opacity-70 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.7 !important;
 }
 
-.divide-opacity-75 > :not(template) ~ :not(template) {
+.divide-opacity-75 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.75 !important;
 }
 
-.divide-opacity-80 > :not(template) ~ :not(template) {
+.divide-opacity-80 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.8 !important;
 }
 
-.divide-opacity-90 > :not(template) ~ :not(template) {
+.divide-opacity-90 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.9 !important;
 }
 
-.divide-opacity-100 > :not(template) ~ :not(template) {
+.divide-opacity-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1 !important;
 }
 
@@ -23536,1323 +23536,1323 @@ video {
     }
   }
 
-  .sm\:space-y-0 > :not(template) ~ :not(template) {
+  .sm\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0px * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0px * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-0 > :not(template) ~ :not(template) {
+  .sm\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0px * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-1 > :not(template) ~ :not(template) {
+  .sm\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.25rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-1 > :not(template) ~ :not(template) {
+  .sm\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-2 > :not(template) ~ :not(template) {
+  .sm\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.5rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-2 > :not(template) ~ :not(template) {
+  .sm\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-3 > :not(template) ~ :not(template) {
+  .sm\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.75rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-3 > :not(template) ~ :not(template) {
+  .sm\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.75rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-4 > :not(template) ~ :not(template) {
+  .sm\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-4 > :not(template) ~ :not(template) {
+  .sm\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-5 > :not(template) ~ :not(template) {
+  .sm\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1.25rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-5 > :not(template) ~ :not(template) {
+  .sm\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-6 > :not(template) ~ :not(template) {
+  .sm\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1.5rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-6 > :not(template) ~ :not(template) {
+  .sm\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-7 > :not(template) ~ :not(template) {
+  .sm\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1.75rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-7 > :not(template) ~ :not(template) {
+  .sm\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1.75rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-8 > :not(template) ~ :not(template) {
+  .sm\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(2rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(2rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-8 > :not(template) ~ :not(template) {
+  .sm\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(2rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-9 > :not(template) ~ :not(template) {
+  .sm\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(2.25rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-9 > :not(template) ~ :not(template) {
+  .sm\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(2.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-10 > :not(template) ~ :not(template) {
+  .sm\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(2.5rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-10 > :not(template) ~ :not(template) {
+  .sm\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(2.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-12 > :not(template) ~ :not(template) {
+  .sm\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(3rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(3rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-12 > :not(template) ~ :not(template) {
+  .sm\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(3rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-14 > :not(template) ~ :not(template) {
+  .sm\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(3.5rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-14 > :not(template) ~ :not(template) {
+  .sm\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(3.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-16 > :not(template) ~ :not(template) {
+  .sm\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(4rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(4rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-16 > :not(template) ~ :not(template) {
+  .sm\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(4rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-20 > :not(template) ~ :not(template) {
+  .sm\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(5rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-20 > :not(template) ~ :not(template) {
+  .sm\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-24 > :not(template) ~ :not(template) {
+  .sm\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(6rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(6rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-24 > :not(template) ~ :not(template) {
+  .sm\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(6rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-28 > :not(template) ~ :not(template) {
+  .sm\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(7rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(7rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-28 > :not(template) ~ :not(template) {
+  .sm\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(7rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-32 > :not(template) ~ :not(template) {
+  .sm\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(8rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(8rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-32 > :not(template) ~ :not(template) {
+  .sm\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(8rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-36 > :not(template) ~ :not(template) {
+  .sm\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(9rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(9rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-36 > :not(template) ~ :not(template) {
+  .sm\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(9rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-40 > :not(template) ~ :not(template) {
+  .sm\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(10rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(10rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-40 > :not(template) ~ :not(template) {
+  .sm\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(10rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-44 > :not(template) ~ :not(template) {
+  .sm\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(11rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(11rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-44 > :not(template) ~ :not(template) {
+  .sm\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(11rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-48 > :not(template) ~ :not(template) {
+  .sm\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(12rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(12rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-48 > :not(template) ~ :not(template) {
+  .sm\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(12rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-52 > :not(template) ~ :not(template) {
+  .sm\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(13rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(13rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-52 > :not(template) ~ :not(template) {
+  .sm\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(13rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-56 > :not(template) ~ :not(template) {
+  .sm\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(14rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(14rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-56 > :not(template) ~ :not(template) {
+  .sm\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(14rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-60 > :not(template) ~ :not(template) {
+  .sm\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(15rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(15rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-60 > :not(template) ~ :not(template) {
+  .sm\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(15rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-64 > :not(template) ~ :not(template) {
+  .sm\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(16rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(16rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-64 > :not(template) ~ :not(template) {
+  .sm\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(16rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-72 > :not(template) ~ :not(template) {
+  .sm\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(18rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(18rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-72 > :not(template) ~ :not(template) {
+  .sm\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(18rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-80 > :not(template) ~ :not(template) {
+  .sm\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(20rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(20rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-80 > :not(template) ~ :not(template) {
+  .sm\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(20rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-96 > :not(template) ~ :not(template) {
+  .sm\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(24rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(24rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-96 > :not(template) ~ :not(template) {
+  .sm\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(24rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-px > :not(template) ~ :not(template) {
+  .sm\:space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1px * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1px * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-px > :not(template) ~ :not(template) {
+  .sm\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1px * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-0\.5 > :not(template) ~ :not(template) {
+  .sm\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.125rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-0\.5 > :not(template) ~ :not(template) {
+  .sm\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.125rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-1\.5 > :not(template) ~ :not(template) {
+  .sm\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.375rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-1\.5 > :not(template) ~ :not(template) {
+  .sm\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.375rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-2\.5 > :not(template) ~ :not(template) {
+  .sm\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.625rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-2\.5 > :not(template) ~ :not(template) {
+  .sm\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.625rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-3\.5 > :not(template) ~ :not(template) {
+  .sm\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.875rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:space-x-3\.5 > :not(template) ~ :not(template) {
+  .sm\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.875rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-1 > :not(template) ~ :not(template) {
+  .sm\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.25rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-1 > :not(template) ~ :not(template) {
+  .sm\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-2 > :not(template) ~ :not(template) {
+  .sm\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.5rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-2 > :not(template) ~ :not(template) {
+  .sm\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-3 > :not(template) ~ :not(template) {
+  .sm\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.75rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-3 > :not(template) ~ :not(template) {
+  .sm\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.75rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-4 > :not(template) ~ :not(template) {
+  .sm\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-4 > :not(template) ~ :not(template) {
+  .sm\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-5 > :not(template) ~ :not(template) {
+  .sm\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1.25rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-5 > :not(template) ~ :not(template) {
+  .sm\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-6 > :not(template) ~ :not(template) {
+  .sm\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1.5rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-6 > :not(template) ~ :not(template) {
+  .sm\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-7 > :not(template) ~ :not(template) {
+  .sm\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1.75rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-7 > :not(template) ~ :not(template) {
+  .sm\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1.75rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-8 > :not(template) ~ :not(template) {
+  .sm\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-2rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-2rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-8 > :not(template) ~ :not(template) {
+  .sm\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-2rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-9 > :not(template) ~ :not(template) {
+  .sm\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-2.25rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-9 > :not(template) ~ :not(template) {
+  .sm\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-2.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-10 > :not(template) ~ :not(template) {
+  .sm\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-2.5rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-10 > :not(template) ~ :not(template) {
+  .sm\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-2.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-12 > :not(template) ~ :not(template) {
+  .sm\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-3rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-3rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-12 > :not(template) ~ :not(template) {
+  .sm\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-3rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-14 > :not(template) ~ :not(template) {
+  .sm\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-3.5rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-14 > :not(template) ~ :not(template) {
+  .sm\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-3.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-16 > :not(template) ~ :not(template) {
+  .sm\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-4rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-4rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-16 > :not(template) ~ :not(template) {
+  .sm\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-4rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-20 > :not(template) ~ :not(template) {
+  .sm\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-5rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-20 > :not(template) ~ :not(template) {
+  .sm\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-24 > :not(template) ~ :not(template) {
+  .sm\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-6rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-6rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-24 > :not(template) ~ :not(template) {
+  .sm\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-6rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-28 > :not(template) ~ :not(template) {
+  .sm\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-7rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-7rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-28 > :not(template) ~ :not(template) {
+  .sm\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-7rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-32 > :not(template) ~ :not(template) {
+  .sm\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-8rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-8rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-32 > :not(template) ~ :not(template) {
+  .sm\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-8rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-36 > :not(template) ~ :not(template) {
+  .sm\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-9rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-9rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-36 > :not(template) ~ :not(template) {
+  .sm\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-9rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-40 > :not(template) ~ :not(template) {
+  .sm\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-10rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-10rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-40 > :not(template) ~ :not(template) {
+  .sm\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-10rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-44 > :not(template) ~ :not(template) {
+  .sm\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-11rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-11rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-44 > :not(template) ~ :not(template) {
+  .sm\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-11rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-48 > :not(template) ~ :not(template) {
+  .sm\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-12rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-12rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-48 > :not(template) ~ :not(template) {
+  .sm\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-12rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-52 > :not(template) ~ :not(template) {
+  .sm\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-13rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-13rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-52 > :not(template) ~ :not(template) {
+  .sm\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-13rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-56 > :not(template) ~ :not(template) {
+  .sm\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-14rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-14rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-56 > :not(template) ~ :not(template) {
+  .sm\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-14rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-60 > :not(template) ~ :not(template) {
+  .sm\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-15rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-15rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-60 > :not(template) ~ :not(template) {
+  .sm\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-15rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-64 > :not(template) ~ :not(template) {
+  .sm\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-16rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-16rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-64 > :not(template) ~ :not(template) {
+  .sm\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-16rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-72 > :not(template) ~ :not(template) {
+  .sm\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-18rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-18rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-72 > :not(template) ~ :not(template) {
+  .sm\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-18rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-80 > :not(template) ~ :not(template) {
+  .sm\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-20rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-20rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-80 > :not(template) ~ :not(template) {
+  .sm\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-20rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-96 > :not(template) ~ :not(template) {
+  .sm\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-24rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-24rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-96 > :not(template) ~ :not(template) {
+  .sm\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-24rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-px > :not(template) ~ :not(template) {
+  .sm\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1px * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1px * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-px > :not(template) ~ :not(template) {
+  .sm\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1px * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-0\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.125rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-0\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.125rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-1\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.375rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-1\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.375rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-2\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.625rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-2\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.625rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:-space-y-3\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.875rem * var(--space-y-reverse)) !important;
   }
 
-  .sm\:-space-x-3\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.875rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .sm\:space-y-reverse > :not(template) ~ :not(template) {
+  .sm\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 1 !important;
   }
 
-  .sm\:space-x-reverse > :not(template) ~ :not(template) {
+  .sm\:space-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 1 !important;
   }
 
-  .sm\:divide-y-0 > :not(template) ~ :not(template) {
+  .sm\:divide-y-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(0px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(0px * var(--divide-y-reverse)) !important;
   }
 
-  .sm\:divide-x-0 > :not(template) ~ :not(template) {
+  .sm\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(0px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .sm\:divide-y-2 > :not(template) ~ :not(template) {
+  .sm\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(2px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(2px * var(--divide-y-reverse)) !important;
   }
 
-  .sm\:divide-x-2 > :not(template) ~ :not(template) {
+  .sm\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(2px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .sm\:divide-y-4 > :not(template) ~ :not(template) {
+  .sm\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(4px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(4px * var(--divide-y-reverse)) !important;
   }
 
-  .sm\:divide-x-4 > :not(template) ~ :not(template) {
+  .sm\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(4px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .sm\:divide-y-8 > :not(template) ~ :not(template) {
+  .sm\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(8px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(8px * var(--divide-y-reverse)) !important;
   }
 
-  .sm\:divide-x-8 > :not(template) ~ :not(template) {
+  .sm\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(8px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .sm\:divide-y > :not(template) ~ :not(template) {
+  .sm\:divide-y > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(1px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(1px * var(--divide-y-reverse)) !important;
   }
 
-  .sm\:divide-x > :not(template) ~ :not(template) {
+  .sm\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(1px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .sm\:divide-y-reverse > :not(template) ~ :not(template) {
+  .sm\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 1 !important;
   }
 
-  .sm\:divide-x-reverse > :not(template) ~ :not(template) {
+  .sm\:divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 1 !important;
   }
 
-  .sm\:divide-transparent > :not(template) ~ :not(template) {
+  .sm\:divide-transparent > :not([hidden]) ~ :not([hidden]) {
     border-color: transparent !important;
   }
 
-  .sm\:divide-current > :not(template) ~ :not(template) {
+  .sm\:divide-current > :not([hidden]) ~ :not([hidden]) {
     border-color: currentColor !important;
   }
 
-  .sm\:divide-black > :not(template) ~ :not(template) {
+  .sm\:divide-black > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(0, 0, 0, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-white > :not(template) ~ :not(template) {
+  .sm\:divide-white > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(255, 255, 255, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-gray-50 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(250, 250, 250, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-gray-100 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(244, 244, 245, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-gray-200 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(228, 228, 231, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-gray-300 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(212, 212, 216, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-gray-400 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(161, 161, 170, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-gray-500 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(113, 113, 122, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-gray-600 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(82, 82, 91, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-gray-700 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(63, 63, 70, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-gray-800 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(39, 39, 42, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-gray-900 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(24, 24, 27, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-red-50 > :not(template) ~ :not(template) {
+  .sm\:divide-red-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(254, 242, 242, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-red-100 > :not(template) ~ :not(template) {
+  .sm\:divide-red-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(254, 226, 226, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-red-200 > :not(template) ~ :not(template) {
+  .sm\:divide-red-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(254, 202, 202, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-red-300 > :not(template) ~ :not(template) {
+  .sm\:divide-red-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(252, 165, 165, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-red-400 > :not(template) ~ :not(template) {
+  .sm\:divide-red-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(248, 113, 113, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-red-500 > :not(template) ~ :not(template) {
+  .sm\:divide-red-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(239, 68, 68, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-red-600 > :not(template) ~ :not(template) {
+  .sm\:divide-red-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(220, 38, 38, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-red-700 > :not(template) ~ :not(template) {
+  .sm\:divide-red-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(185, 28, 28, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-red-800 > :not(template) ~ :not(template) {
+  .sm\:divide-red-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(153, 27, 27, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-red-900 > :not(template) ~ :not(template) {
+  .sm\:divide-red-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(127, 29, 29, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-yellow-50 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(255, 251, 235, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-yellow-100 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(254, 243, 199, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-yellow-200 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(253, 230, 138, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-yellow-300 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(252, 211, 77, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-yellow-400 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(251, 191, 36, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-yellow-500 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(245, 158, 11, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-yellow-600 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(217, 119, 6, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-yellow-700 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(180, 83, 9, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-yellow-800 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(146, 64, 14, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-yellow-900 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(120, 53, 15, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-green-50 > :not(template) ~ :not(template) {
+  .sm\:divide-green-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(236, 253, 245, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-green-100 > :not(template) ~ :not(template) {
+  .sm\:divide-green-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(209, 250, 229, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-green-200 > :not(template) ~ :not(template) {
+  .sm\:divide-green-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(167, 243, 208, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-green-300 > :not(template) ~ :not(template) {
+  .sm\:divide-green-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(110, 231, 183, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-green-400 > :not(template) ~ :not(template) {
+  .sm\:divide-green-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(52, 211, 153, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-green-500 > :not(template) ~ :not(template) {
+  .sm\:divide-green-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(16, 185, 129, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-green-600 > :not(template) ~ :not(template) {
+  .sm\:divide-green-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(5, 150, 105, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-green-700 > :not(template) ~ :not(template) {
+  .sm\:divide-green-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(4, 120, 87, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-green-800 > :not(template) ~ :not(template) {
+  .sm\:divide-green-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(6, 95, 70, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-green-900 > :not(template) ~ :not(template) {
+  .sm\:divide-green-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(6, 78, 59, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-blue-50 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(239, 246, 255, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-blue-100 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(219, 234, 254, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-blue-200 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(191, 219, 254, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-blue-300 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(147, 197, 253, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-blue-400 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(96, 165, 250, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-blue-500 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(59, 130, 246, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-blue-600 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(37, 99, 235, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-blue-700 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(29, 78, 216, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-blue-800 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(30, 64, 175, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-blue-900 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(30, 58, 138, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-purple-50 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(245, 243, 255, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-purple-100 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(237, 233, 254, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-purple-200 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(221, 214, 254, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-purple-300 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(196, 181, 253, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-purple-400 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(167, 139, 250, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-purple-500 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(139, 92, 246, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-purple-600 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(124, 58, 237, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-purple-700 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(109, 40, 217, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-purple-800 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(91, 33, 182, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-purple-900 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(76, 29, 149, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-pink-50 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(253, 242, 248, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-pink-100 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(252, 231, 243, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-pink-200 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(251, 207, 232, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-pink-300 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(249, 168, 212, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-pink-400 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(244, 114, 182, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-pink-500 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(236, 72, 153, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-pink-600 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(219, 39, 119, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-pink-700 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(190, 24, 93, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-pink-800 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(157, 23, 77, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-pink-900 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(131, 24, 67, var(--divide-opacity)) !important;
   }
 
-  .sm\:divide-solid > :not(template) ~ :not(template) {
+  .sm\:divide-solid > :not([hidden]) ~ :not([hidden]) {
     border-style: solid !important;
   }
 
-  .sm\:divide-dashed > :not(template) ~ :not(template) {
+  .sm\:divide-dashed > :not([hidden]) ~ :not([hidden]) {
     border-style: dashed !important;
   }
 
-  .sm\:divide-dotted > :not(template) ~ :not(template) {
+  .sm\:divide-dotted > :not([hidden]) ~ :not([hidden]) {
     border-style: dotted !important;
   }
 
-  .sm\:divide-double > :not(template) ~ :not(template) {
+  .sm\:divide-double > :not([hidden]) ~ :not([hidden]) {
     border-style: double !important;
   }
 
-  .sm\:divide-none > :not(template) ~ :not(template) {
+  .sm\:divide-none > :not([hidden]) ~ :not([hidden]) {
     border-style: none !important;
   }
 
-  .sm\:divide-opacity-0 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0 !important;
   }
 
-  .sm\:divide-opacity-10 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-10 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.1 !important;
   }
 
-  .sm\:divide-opacity-20 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-20 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.2 !important;
   }
 
-  .sm\:divide-opacity-25 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-25 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.25 !important;
   }
 
-  .sm\:divide-opacity-30 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-30 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.3 !important;
   }
 
-  .sm\:divide-opacity-40 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-40 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.4 !important;
   }
 
-  .sm\:divide-opacity-50 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.5 !important;
   }
 
-  .sm\:divide-opacity-60 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-60 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.6 !important;
   }
 
-  .sm\:divide-opacity-70 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-70 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.7 !important;
   }
 
-  .sm\:divide-opacity-75 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-75 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.75 !important;
   }
 
-  .sm\:divide-opacity-80 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-80 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.8 !important;
   }
 
-  .sm\:divide-opacity-90 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-90 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.9 !important;
   }
 
-  .sm\:divide-opacity-100 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
   }
 
@@ -46482,1323 +46482,1323 @@ video {
     }
   }
 
-  .md\:space-y-0 > :not(template) ~ :not(template) {
+  .md\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0px * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0px * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-0 > :not(template) ~ :not(template) {
+  .md\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0px * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-1 > :not(template) ~ :not(template) {
+  .md\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.25rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-1 > :not(template) ~ :not(template) {
+  .md\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-2 > :not(template) ~ :not(template) {
+  .md\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.5rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-2 > :not(template) ~ :not(template) {
+  .md\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-3 > :not(template) ~ :not(template) {
+  .md\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.75rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-3 > :not(template) ~ :not(template) {
+  .md\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.75rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-4 > :not(template) ~ :not(template) {
+  .md\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-4 > :not(template) ~ :not(template) {
+  .md\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-5 > :not(template) ~ :not(template) {
+  .md\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1.25rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-5 > :not(template) ~ :not(template) {
+  .md\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-6 > :not(template) ~ :not(template) {
+  .md\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1.5rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-6 > :not(template) ~ :not(template) {
+  .md\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-7 > :not(template) ~ :not(template) {
+  .md\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1.75rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-7 > :not(template) ~ :not(template) {
+  .md\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1.75rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-8 > :not(template) ~ :not(template) {
+  .md\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(2rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(2rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-8 > :not(template) ~ :not(template) {
+  .md\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(2rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-9 > :not(template) ~ :not(template) {
+  .md\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(2.25rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-9 > :not(template) ~ :not(template) {
+  .md\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(2.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-10 > :not(template) ~ :not(template) {
+  .md\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(2.5rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-10 > :not(template) ~ :not(template) {
+  .md\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(2.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-12 > :not(template) ~ :not(template) {
+  .md\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(3rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(3rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-12 > :not(template) ~ :not(template) {
+  .md\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(3rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-14 > :not(template) ~ :not(template) {
+  .md\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(3.5rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-14 > :not(template) ~ :not(template) {
+  .md\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(3.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-16 > :not(template) ~ :not(template) {
+  .md\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(4rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(4rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-16 > :not(template) ~ :not(template) {
+  .md\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(4rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-20 > :not(template) ~ :not(template) {
+  .md\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(5rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-20 > :not(template) ~ :not(template) {
+  .md\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-24 > :not(template) ~ :not(template) {
+  .md\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(6rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(6rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-24 > :not(template) ~ :not(template) {
+  .md\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(6rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-28 > :not(template) ~ :not(template) {
+  .md\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(7rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(7rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-28 > :not(template) ~ :not(template) {
+  .md\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(7rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-32 > :not(template) ~ :not(template) {
+  .md\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(8rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(8rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-32 > :not(template) ~ :not(template) {
+  .md\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(8rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-36 > :not(template) ~ :not(template) {
+  .md\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(9rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(9rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-36 > :not(template) ~ :not(template) {
+  .md\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(9rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-40 > :not(template) ~ :not(template) {
+  .md\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(10rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(10rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-40 > :not(template) ~ :not(template) {
+  .md\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(10rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-44 > :not(template) ~ :not(template) {
+  .md\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(11rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(11rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-44 > :not(template) ~ :not(template) {
+  .md\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(11rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-48 > :not(template) ~ :not(template) {
+  .md\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(12rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(12rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-48 > :not(template) ~ :not(template) {
+  .md\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(12rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-52 > :not(template) ~ :not(template) {
+  .md\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(13rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(13rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-52 > :not(template) ~ :not(template) {
+  .md\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(13rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-56 > :not(template) ~ :not(template) {
+  .md\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(14rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(14rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-56 > :not(template) ~ :not(template) {
+  .md\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(14rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-60 > :not(template) ~ :not(template) {
+  .md\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(15rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(15rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-60 > :not(template) ~ :not(template) {
+  .md\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(15rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-64 > :not(template) ~ :not(template) {
+  .md\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(16rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(16rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-64 > :not(template) ~ :not(template) {
+  .md\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(16rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-72 > :not(template) ~ :not(template) {
+  .md\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(18rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(18rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-72 > :not(template) ~ :not(template) {
+  .md\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(18rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-80 > :not(template) ~ :not(template) {
+  .md\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(20rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(20rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-80 > :not(template) ~ :not(template) {
+  .md\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(20rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-96 > :not(template) ~ :not(template) {
+  .md\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(24rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(24rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-96 > :not(template) ~ :not(template) {
+  .md\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(24rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-px > :not(template) ~ :not(template) {
+  .md\:space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1px * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1px * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-px > :not(template) ~ :not(template) {
+  .md\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1px * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-0\.5 > :not(template) ~ :not(template) {
+  .md\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.125rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-0\.5 > :not(template) ~ :not(template) {
+  .md\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.125rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-1\.5 > :not(template) ~ :not(template) {
+  .md\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.375rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-1\.5 > :not(template) ~ :not(template) {
+  .md\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.375rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-2\.5 > :not(template) ~ :not(template) {
+  .md\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.625rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-2\.5 > :not(template) ~ :not(template) {
+  .md\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.625rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-3\.5 > :not(template) ~ :not(template) {
+  .md\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.875rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:space-x-3\.5 > :not(template) ~ :not(template) {
+  .md\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.875rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-1 > :not(template) ~ :not(template) {
+  .md\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.25rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-1 > :not(template) ~ :not(template) {
+  .md\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-2 > :not(template) ~ :not(template) {
+  .md\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.5rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-2 > :not(template) ~ :not(template) {
+  .md\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-3 > :not(template) ~ :not(template) {
+  .md\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.75rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-3 > :not(template) ~ :not(template) {
+  .md\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.75rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-4 > :not(template) ~ :not(template) {
+  .md\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-4 > :not(template) ~ :not(template) {
+  .md\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-5 > :not(template) ~ :not(template) {
+  .md\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1.25rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-5 > :not(template) ~ :not(template) {
+  .md\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-6 > :not(template) ~ :not(template) {
+  .md\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1.5rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-6 > :not(template) ~ :not(template) {
+  .md\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-7 > :not(template) ~ :not(template) {
+  .md\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1.75rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-7 > :not(template) ~ :not(template) {
+  .md\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1.75rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-8 > :not(template) ~ :not(template) {
+  .md\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-2rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-2rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-8 > :not(template) ~ :not(template) {
+  .md\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-2rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-9 > :not(template) ~ :not(template) {
+  .md\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-2.25rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-9 > :not(template) ~ :not(template) {
+  .md\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-2.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-10 > :not(template) ~ :not(template) {
+  .md\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-2.5rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-10 > :not(template) ~ :not(template) {
+  .md\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-2.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-12 > :not(template) ~ :not(template) {
+  .md\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-3rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-3rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-12 > :not(template) ~ :not(template) {
+  .md\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-3rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-14 > :not(template) ~ :not(template) {
+  .md\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-3.5rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-14 > :not(template) ~ :not(template) {
+  .md\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-3.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-16 > :not(template) ~ :not(template) {
+  .md\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-4rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-4rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-16 > :not(template) ~ :not(template) {
+  .md\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-4rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-20 > :not(template) ~ :not(template) {
+  .md\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-5rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-20 > :not(template) ~ :not(template) {
+  .md\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-24 > :not(template) ~ :not(template) {
+  .md\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-6rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-6rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-24 > :not(template) ~ :not(template) {
+  .md\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-6rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-28 > :not(template) ~ :not(template) {
+  .md\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-7rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-7rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-28 > :not(template) ~ :not(template) {
+  .md\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-7rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-32 > :not(template) ~ :not(template) {
+  .md\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-8rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-8rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-32 > :not(template) ~ :not(template) {
+  .md\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-8rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-36 > :not(template) ~ :not(template) {
+  .md\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-9rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-9rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-36 > :not(template) ~ :not(template) {
+  .md\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-9rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-40 > :not(template) ~ :not(template) {
+  .md\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-10rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-10rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-40 > :not(template) ~ :not(template) {
+  .md\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-10rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-44 > :not(template) ~ :not(template) {
+  .md\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-11rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-11rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-44 > :not(template) ~ :not(template) {
+  .md\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-11rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-48 > :not(template) ~ :not(template) {
+  .md\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-12rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-12rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-48 > :not(template) ~ :not(template) {
+  .md\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-12rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-52 > :not(template) ~ :not(template) {
+  .md\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-13rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-13rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-52 > :not(template) ~ :not(template) {
+  .md\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-13rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-56 > :not(template) ~ :not(template) {
+  .md\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-14rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-14rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-56 > :not(template) ~ :not(template) {
+  .md\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-14rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-60 > :not(template) ~ :not(template) {
+  .md\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-15rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-15rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-60 > :not(template) ~ :not(template) {
+  .md\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-15rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-64 > :not(template) ~ :not(template) {
+  .md\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-16rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-16rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-64 > :not(template) ~ :not(template) {
+  .md\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-16rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-72 > :not(template) ~ :not(template) {
+  .md\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-18rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-18rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-72 > :not(template) ~ :not(template) {
+  .md\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-18rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-80 > :not(template) ~ :not(template) {
+  .md\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-20rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-20rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-80 > :not(template) ~ :not(template) {
+  .md\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-20rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-96 > :not(template) ~ :not(template) {
+  .md\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-24rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-24rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-96 > :not(template) ~ :not(template) {
+  .md\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-24rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-px > :not(template) ~ :not(template) {
+  .md\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1px * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1px * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-px > :not(template) ~ :not(template) {
+  .md\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1px * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-0\.5 > :not(template) ~ :not(template) {
+  .md\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.125rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-0\.5 > :not(template) ~ :not(template) {
+  .md\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.125rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-1\.5 > :not(template) ~ :not(template) {
+  .md\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.375rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-1\.5 > :not(template) ~ :not(template) {
+  .md\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.375rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-2\.5 > :not(template) ~ :not(template) {
+  .md\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.625rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-2\.5 > :not(template) ~ :not(template) {
+  .md\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.625rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:-space-y-3\.5 > :not(template) ~ :not(template) {
+  .md\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.875rem * var(--space-y-reverse)) !important;
   }
 
-  .md\:-space-x-3\.5 > :not(template) ~ :not(template) {
+  .md\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.875rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .md\:space-y-reverse > :not(template) ~ :not(template) {
+  .md\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 1 !important;
   }
 
-  .md\:space-x-reverse > :not(template) ~ :not(template) {
+  .md\:space-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 1 !important;
   }
 
-  .md\:divide-y-0 > :not(template) ~ :not(template) {
+  .md\:divide-y-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(0px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(0px * var(--divide-y-reverse)) !important;
   }
 
-  .md\:divide-x-0 > :not(template) ~ :not(template) {
+  .md\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(0px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .md\:divide-y-2 > :not(template) ~ :not(template) {
+  .md\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(2px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(2px * var(--divide-y-reverse)) !important;
   }
 
-  .md\:divide-x-2 > :not(template) ~ :not(template) {
+  .md\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(2px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .md\:divide-y-4 > :not(template) ~ :not(template) {
+  .md\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(4px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(4px * var(--divide-y-reverse)) !important;
   }
 
-  .md\:divide-x-4 > :not(template) ~ :not(template) {
+  .md\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(4px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .md\:divide-y-8 > :not(template) ~ :not(template) {
+  .md\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(8px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(8px * var(--divide-y-reverse)) !important;
   }
 
-  .md\:divide-x-8 > :not(template) ~ :not(template) {
+  .md\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(8px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .md\:divide-y > :not(template) ~ :not(template) {
+  .md\:divide-y > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(1px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(1px * var(--divide-y-reverse)) !important;
   }
 
-  .md\:divide-x > :not(template) ~ :not(template) {
+  .md\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(1px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .md\:divide-y-reverse > :not(template) ~ :not(template) {
+  .md\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 1 !important;
   }
 
-  .md\:divide-x-reverse > :not(template) ~ :not(template) {
+  .md\:divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 1 !important;
   }
 
-  .md\:divide-transparent > :not(template) ~ :not(template) {
+  .md\:divide-transparent > :not([hidden]) ~ :not([hidden]) {
     border-color: transparent !important;
   }
 
-  .md\:divide-current > :not(template) ~ :not(template) {
+  .md\:divide-current > :not([hidden]) ~ :not([hidden]) {
     border-color: currentColor !important;
   }
 
-  .md\:divide-black > :not(template) ~ :not(template) {
+  .md\:divide-black > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(0, 0, 0, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-white > :not(template) ~ :not(template) {
+  .md\:divide-white > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(255, 255, 255, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-gray-50 > :not(template) ~ :not(template) {
+  .md\:divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(250, 250, 250, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-gray-100 > :not(template) ~ :not(template) {
+  .md\:divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(244, 244, 245, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-gray-200 > :not(template) ~ :not(template) {
+  .md\:divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(228, 228, 231, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-gray-300 > :not(template) ~ :not(template) {
+  .md\:divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(212, 212, 216, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-gray-400 > :not(template) ~ :not(template) {
+  .md\:divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(161, 161, 170, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-gray-500 > :not(template) ~ :not(template) {
+  .md\:divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(113, 113, 122, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-gray-600 > :not(template) ~ :not(template) {
+  .md\:divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(82, 82, 91, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-gray-700 > :not(template) ~ :not(template) {
+  .md\:divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(63, 63, 70, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-gray-800 > :not(template) ~ :not(template) {
+  .md\:divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(39, 39, 42, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-gray-900 > :not(template) ~ :not(template) {
+  .md\:divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(24, 24, 27, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-red-50 > :not(template) ~ :not(template) {
+  .md\:divide-red-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(254, 242, 242, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-red-100 > :not(template) ~ :not(template) {
+  .md\:divide-red-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(254, 226, 226, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-red-200 > :not(template) ~ :not(template) {
+  .md\:divide-red-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(254, 202, 202, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-red-300 > :not(template) ~ :not(template) {
+  .md\:divide-red-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(252, 165, 165, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-red-400 > :not(template) ~ :not(template) {
+  .md\:divide-red-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(248, 113, 113, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-red-500 > :not(template) ~ :not(template) {
+  .md\:divide-red-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(239, 68, 68, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-red-600 > :not(template) ~ :not(template) {
+  .md\:divide-red-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(220, 38, 38, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-red-700 > :not(template) ~ :not(template) {
+  .md\:divide-red-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(185, 28, 28, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-red-800 > :not(template) ~ :not(template) {
+  .md\:divide-red-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(153, 27, 27, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-red-900 > :not(template) ~ :not(template) {
+  .md\:divide-red-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(127, 29, 29, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-yellow-50 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(255, 251, 235, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-yellow-100 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(254, 243, 199, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-yellow-200 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(253, 230, 138, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-yellow-300 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(252, 211, 77, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-yellow-400 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(251, 191, 36, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-yellow-500 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(245, 158, 11, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-yellow-600 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(217, 119, 6, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-yellow-700 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(180, 83, 9, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-yellow-800 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(146, 64, 14, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-yellow-900 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(120, 53, 15, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-green-50 > :not(template) ~ :not(template) {
+  .md\:divide-green-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(236, 253, 245, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-green-100 > :not(template) ~ :not(template) {
+  .md\:divide-green-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(209, 250, 229, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-green-200 > :not(template) ~ :not(template) {
+  .md\:divide-green-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(167, 243, 208, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-green-300 > :not(template) ~ :not(template) {
+  .md\:divide-green-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(110, 231, 183, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-green-400 > :not(template) ~ :not(template) {
+  .md\:divide-green-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(52, 211, 153, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-green-500 > :not(template) ~ :not(template) {
+  .md\:divide-green-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(16, 185, 129, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-green-600 > :not(template) ~ :not(template) {
+  .md\:divide-green-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(5, 150, 105, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-green-700 > :not(template) ~ :not(template) {
+  .md\:divide-green-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(4, 120, 87, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-green-800 > :not(template) ~ :not(template) {
+  .md\:divide-green-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(6, 95, 70, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-green-900 > :not(template) ~ :not(template) {
+  .md\:divide-green-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(6, 78, 59, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-blue-50 > :not(template) ~ :not(template) {
+  .md\:divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(239, 246, 255, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-blue-100 > :not(template) ~ :not(template) {
+  .md\:divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(219, 234, 254, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-blue-200 > :not(template) ~ :not(template) {
+  .md\:divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(191, 219, 254, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-blue-300 > :not(template) ~ :not(template) {
+  .md\:divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(147, 197, 253, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-blue-400 > :not(template) ~ :not(template) {
+  .md\:divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(96, 165, 250, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-blue-500 > :not(template) ~ :not(template) {
+  .md\:divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(59, 130, 246, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-blue-600 > :not(template) ~ :not(template) {
+  .md\:divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(37, 99, 235, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-blue-700 > :not(template) ~ :not(template) {
+  .md\:divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(29, 78, 216, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-blue-800 > :not(template) ~ :not(template) {
+  .md\:divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(30, 64, 175, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-blue-900 > :not(template) ~ :not(template) {
+  .md\:divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(30, 58, 138, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-purple-50 > :not(template) ~ :not(template) {
+  .md\:divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(245, 243, 255, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-purple-100 > :not(template) ~ :not(template) {
+  .md\:divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(237, 233, 254, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-purple-200 > :not(template) ~ :not(template) {
+  .md\:divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(221, 214, 254, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-purple-300 > :not(template) ~ :not(template) {
+  .md\:divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(196, 181, 253, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-purple-400 > :not(template) ~ :not(template) {
+  .md\:divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(167, 139, 250, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-purple-500 > :not(template) ~ :not(template) {
+  .md\:divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(139, 92, 246, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-purple-600 > :not(template) ~ :not(template) {
+  .md\:divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(124, 58, 237, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-purple-700 > :not(template) ~ :not(template) {
+  .md\:divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(109, 40, 217, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-purple-800 > :not(template) ~ :not(template) {
+  .md\:divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(91, 33, 182, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-purple-900 > :not(template) ~ :not(template) {
+  .md\:divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(76, 29, 149, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-pink-50 > :not(template) ~ :not(template) {
+  .md\:divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(253, 242, 248, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-pink-100 > :not(template) ~ :not(template) {
+  .md\:divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(252, 231, 243, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-pink-200 > :not(template) ~ :not(template) {
+  .md\:divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(251, 207, 232, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-pink-300 > :not(template) ~ :not(template) {
+  .md\:divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(249, 168, 212, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-pink-400 > :not(template) ~ :not(template) {
+  .md\:divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(244, 114, 182, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-pink-500 > :not(template) ~ :not(template) {
+  .md\:divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(236, 72, 153, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-pink-600 > :not(template) ~ :not(template) {
+  .md\:divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(219, 39, 119, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-pink-700 > :not(template) ~ :not(template) {
+  .md\:divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(190, 24, 93, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-pink-800 > :not(template) ~ :not(template) {
+  .md\:divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(157, 23, 77, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-pink-900 > :not(template) ~ :not(template) {
+  .md\:divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(131, 24, 67, var(--divide-opacity)) !important;
   }
 
-  .md\:divide-solid > :not(template) ~ :not(template) {
+  .md\:divide-solid > :not([hidden]) ~ :not([hidden]) {
     border-style: solid !important;
   }
 
-  .md\:divide-dashed > :not(template) ~ :not(template) {
+  .md\:divide-dashed > :not([hidden]) ~ :not([hidden]) {
     border-style: dashed !important;
   }
 
-  .md\:divide-dotted > :not(template) ~ :not(template) {
+  .md\:divide-dotted > :not([hidden]) ~ :not([hidden]) {
     border-style: dotted !important;
   }
 
-  .md\:divide-double > :not(template) ~ :not(template) {
+  .md\:divide-double > :not([hidden]) ~ :not([hidden]) {
     border-style: double !important;
   }
 
-  .md\:divide-none > :not(template) ~ :not(template) {
+  .md\:divide-none > :not([hidden]) ~ :not([hidden]) {
     border-style: none !important;
   }
 
-  .md\:divide-opacity-0 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0 !important;
   }
 
-  .md\:divide-opacity-10 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-10 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.1 !important;
   }
 
-  .md\:divide-opacity-20 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-20 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.2 !important;
   }
 
-  .md\:divide-opacity-25 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-25 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.25 !important;
   }
 
-  .md\:divide-opacity-30 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-30 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.3 !important;
   }
 
-  .md\:divide-opacity-40 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-40 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.4 !important;
   }
 
-  .md\:divide-opacity-50 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.5 !important;
   }
 
-  .md\:divide-opacity-60 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-60 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.6 !important;
   }
 
-  .md\:divide-opacity-70 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-70 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.7 !important;
   }
 
-  .md\:divide-opacity-75 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-75 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.75 !important;
   }
 
-  .md\:divide-opacity-80 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-80 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.8 !important;
   }
 
-  .md\:divide-opacity-90 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-90 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.9 !important;
   }
 
-  .md\:divide-opacity-100 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
   }
 
@@ -69428,1323 +69428,1323 @@ video {
     }
   }
 
-  .lg\:space-y-0 > :not(template) ~ :not(template) {
+  .lg\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0px * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0px * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-0 > :not(template) ~ :not(template) {
+  .lg\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0px * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-1 > :not(template) ~ :not(template) {
+  .lg\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.25rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-1 > :not(template) ~ :not(template) {
+  .lg\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-2 > :not(template) ~ :not(template) {
+  .lg\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.5rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-2 > :not(template) ~ :not(template) {
+  .lg\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-3 > :not(template) ~ :not(template) {
+  .lg\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.75rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-3 > :not(template) ~ :not(template) {
+  .lg\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.75rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-4 > :not(template) ~ :not(template) {
+  .lg\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-4 > :not(template) ~ :not(template) {
+  .lg\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-5 > :not(template) ~ :not(template) {
+  .lg\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1.25rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-5 > :not(template) ~ :not(template) {
+  .lg\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-6 > :not(template) ~ :not(template) {
+  .lg\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1.5rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-6 > :not(template) ~ :not(template) {
+  .lg\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-7 > :not(template) ~ :not(template) {
+  .lg\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1.75rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-7 > :not(template) ~ :not(template) {
+  .lg\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1.75rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-8 > :not(template) ~ :not(template) {
+  .lg\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(2rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(2rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-8 > :not(template) ~ :not(template) {
+  .lg\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(2rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-9 > :not(template) ~ :not(template) {
+  .lg\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(2.25rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-9 > :not(template) ~ :not(template) {
+  .lg\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(2.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-10 > :not(template) ~ :not(template) {
+  .lg\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(2.5rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-10 > :not(template) ~ :not(template) {
+  .lg\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(2.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-12 > :not(template) ~ :not(template) {
+  .lg\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(3rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(3rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-12 > :not(template) ~ :not(template) {
+  .lg\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(3rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-14 > :not(template) ~ :not(template) {
+  .lg\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(3.5rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-14 > :not(template) ~ :not(template) {
+  .lg\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(3.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-16 > :not(template) ~ :not(template) {
+  .lg\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(4rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(4rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-16 > :not(template) ~ :not(template) {
+  .lg\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(4rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-20 > :not(template) ~ :not(template) {
+  .lg\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(5rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-20 > :not(template) ~ :not(template) {
+  .lg\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-24 > :not(template) ~ :not(template) {
+  .lg\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(6rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(6rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-24 > :not(template) ~ :not(template) {
+  .lg\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(6rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-28 > :not(template) ~ :not(template) {
+  .lg\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(7rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(7rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-28 > :not(template) ~ :not(template) {
+  .lg\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(7rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-32 > :not(template) ~ :not(template) {
+  .lg\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(8rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(8rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-32 > :not(template) ~ :not(template) {
+  .lg\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(8rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-36 > :not(template) ~ :not(template) {
+  .lg\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(9rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(9rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-36 > :not(template) ~ :not(template) {
+  .lg\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(9rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-40 > :not(template) ~ :not(template) {
+  .lg\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(10rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(10rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-40 > :not(template) ~ :not(template) {
+  .lg\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(10rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-44 > :not(template) ~ :not(template) {
+  .lg\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(11rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(11rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-44 > :not(template) ~ :not(template) {
+  .lg\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(11rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-48 > :not(template) ~ :not(template) {
+  .lg\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(12rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(12rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-48 > :not(template) ~ :not(template) {
+  .lg\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(12rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-52 > :not(template) ~ :not(template) {
+  .lg\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(13rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(13rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-52 > :not(template) ~ :not(template) {
+  .lg\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(13rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-56 > :not(template) ~ :not(template) {
+  .lg\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(14rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(14rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-56 > :not(template) ~ :not(template) {
+  .lg\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(14rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-60 > :not(template) ~ :not(template) {
+  .lg\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(15rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(15rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-60 > :not(template) ~ :not(template) {
+  .lg\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(15rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-64 > :not(template) ~ :not(template) {
+  .lg\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(16rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(16rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-64 > :not(template) ~ :not(template) {
+  .lg\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(16rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-72 > :not(template) ~ :not(template) {
+  .lg\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(18rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(18rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-72 > :not(template) ~ :not(template) {
+  .lg\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(18rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-80 > :not(template) ~ :not(template) {
+  .lg\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(20rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(20rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-80 > :not(template) ~ :not(template) {
+  .lg\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(20rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-96 > :not(template) ~ :not(template) {
+  .lg\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(24rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(24rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-96 > :not(template) ~ :not(template) {
+  .lg\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(24rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-px > :not(template) ~ :not(template) {
+  .lg\:space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1px * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1px * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-px > :not(template) ~ :not(template) {
+  .lg\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1px * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-0\.5 > :not(template) ~ :not(template) {
+  .lg\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.125rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-0\.5 > :not(template) ~ :not(template) {
+  .lg\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.125rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-1\.5 > :not(template) ~ :not(template) {
+  .lg\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.375rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-1\.5 > :not(template) ~ :not(template) {
+  .lg\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.375rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-2\.5 > :not(template) ~ :not(template) {
+  .lg\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.625rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-2\.5 > :not(template) ~ :not(template) {
+  .lg\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.625rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-3\.5 > :not(template) ~ :not(template) {
+  .lg\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.875rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:space-x-3\.5 > :not(template) ~ :not(template) {
+  .lg\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.875rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-1 > :not(template) ~ :not(template) {
+  .lg\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.25rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-1 > :not(template) ~ :not(template) {
+  .lg\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-2 > :not(template) ~ :not(template) {
+  .lg\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.5rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-2 > :not(template) ~ :not(template) {
+  .lg\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-3 > :not(template) ~ :not(template) {
+  .lg\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.75rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-3 > :not(template) ~ :not(template) {
+  .lg\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.75rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-4 > :not(template) ~ :not(template) {
+  .lg\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-4 > :not(template) ~ :not(template) {
+  .lg\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-5 > :not(template) ~ :not(template) {
+  .lg\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1.25rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-5 > :not(template) ~ :not(template) {
+  .lg\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-6 > :not(template) ~ :not(template) {
+  .lg\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1.5rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-6 > :not(template) ~ :not(template) {
+  .lg\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-7 > :not(template) ~ :not(template) {
+  .lg\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1.75rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-7 > :not(template) ~ :not(template) {
+  .lg\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1.75rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-8 > :not(template) ~ :not(template) {
+  .lg\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-2rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-2rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-8 > :not(template) ~ :not(template) {
+  .lg\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-2rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-9 > :not(template) ~ :not(template) {
+  .lg\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-2.25rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-9 > :not(template) ~ :not(template) {
+  .lg\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-2.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-10 > :not(template) ~ :not(template) {
+  .lg\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-2.5rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-10 > :not(template) ~ :not(template) {
+  .lg\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-2.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-12 > :not(template) ~ :not(template) {
+  .lg\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-3rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-3rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-12 > :not(template) ~ :not(template) {
+  .lg\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-3rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-14 > :not(template) ~ :not(template) {
+  .lg\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-3.5rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-14 > :not(template) ~ :not(template) {
+  .lg\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-3.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-16 > :not(template) ~ :not(template) {
+  .lg\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-4rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-4rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-16 > :not(template) ~ :not(template) {
+  .lg\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-4rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-20 > :not(template) ~ :not(template) {
+  .lg\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-5rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-20 > :not(template) ~ :not(template) {
+  .lg\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-24 > :not(template) ~ :not(template) {
+  .lg\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-6rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-6rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-24 > :not(template) ~ :not(template) {
+  .lg\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-6rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-28 > :not(template) ~ :not(template) {
+  .lg\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-7rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-7rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-28 > :not(template) ~ :not(template) {
+  .lg\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-7rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-32 > :not(template) ~ :not(template) {
+  .lg\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-8rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-8rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-32 > :not(template) ~ :not(template) {
+  .lg\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-8rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-36 > :not(template) ~ :not(template) {
+  .lg\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-9rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-9rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-36 > :not(template) ~ :not(template) {
+  .lg\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-9rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-40 > :not(template) ~ :not(template) {
+  .lg\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-10rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-10rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-40 > :not(template) ~ :not(template) {
+  .lg\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-10rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-44 > :not(template) ~ :not(template) {
+  .lg\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-11rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-11rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-44 > :not(template) ~ :not(template) {
+  .lg\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-11rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-48 > :not(template) ~ :not(template) {
+  .lg\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-12rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-12rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-48 > :not(template) ~ :not(template) {
+  .lg\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-12rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-52 > :not(template) ~ :not(template) {
+  .lg\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-13rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-13rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-52 > :not(template) ~ :not(template) {
+  .lg\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-13rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-56 > :not(template) ~ :not(template) {
+  .lg\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-14rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-14rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-56 > :not(template) ~ :not(template) {
+  .lg\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-14rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-60 > :not(template) ~ :not(template) {
+  .lg\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-15rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-15rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-60 > :not(template) ~ :not(template) {
+  .lg\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-15rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-64 > :not(template) ~ :not(template) {
+  .lg\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-16rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-16rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-64 > :not(template) ~ :not(template) {
+  .lg\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-16rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-72 > :not(template) ~ :not(template) {
+  .lg\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-18rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-18rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-72 > :not(template) ~ :not(template) {
+  .lg\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-18rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-80 > :not(template) ~ :not(template) {
+  .lg\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-20rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-20rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-80 > :not(template) ~ :not(template) {
+  .lg\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-20rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-96 > :not(template) ~ :not(template) {
+  .lg\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-24rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-24rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-96 > :not(template) ~ :not(template) {
+  .lg\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-24rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-px > :not(template) ~ :not(template) {
+  .lg\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1px * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1px * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-px > :not(template) ~ :not(template) {
+  .lg\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1px * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-0\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.125rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-0\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.125rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-1\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.375rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-1\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.375rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-2\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.625rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-2\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.625rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:-space-y-3\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.875rem * var(--space-y-reverse)) !important;
   }
 
-  .lg\:-space-x-3\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.875rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .lg\:space-y-reverse > :not(template) ~ :not(template) {
+  .lg\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 1 !important;
   }
 
-  .lg\:space-x-reverse > :not(template) ~ :not(template) {
+  .lg\:space-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 1 !important;
   }
 
-  .lg\:divide-y-0 > :not(template) ~ :not(template) {
+  .lg\:divide-y-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(0px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(0px * var(--divide-y-reverse)) !important;
   }
 
-  .lg\:divide-x-0 > :not(template) ~ :not(template) {
+  .lg\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(0px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .lg\:divide-y-2 > :not(template) ~ :not(template) {
+  .lg\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(2px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(2px * var(--divide-y-reverse)) !important;
   }
 
-  .lg\:divide-x-2 > :not(template) ~ :not(template) {
+  .lg\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(2px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .lg\:divide-y-4 > :not(template) ~ :not(template) {
+  .lg\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(4px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(4px * var(--divide-y-reverse)) !important;
   }
 
-  .lg\:divide-x-4 > :not(template) ~ :not(template) {
+  .lg\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(4px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .lg\:divide-y-8 > :not(template) ~ :not(template) {
+  .lg\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(8px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(8px * var(--divide-y-reverse)) !important;
   }
 
-  .lg\:divide-x-8 > :not(template) ~ :not(template) {
+  .lg\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(8px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .lg\:divide-y > :not(template) ~ :not(template) {
+  .lg\:divide-y > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(1px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(1px * var(--divide-y-reverse)) !important;
   }
 
-  .lg\:divide-x > :not(template) ~ :not(template) {
+  .lg\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(1px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .lg\:divide-y-reverse > :not(template) ~ :not(template) {
+  .lg\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 1 !important;
   }
 
-  .lg\:divide-x-reverse > :not(template) ~ :not(template) {
+  .lg\:divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 1 !important;
   }
 
-  .lg\:divide-transparent > :not(template) ~ :not(template) {
+  .lg\:divide-transparent > :not([hidden]) ~ :not([hidden]) {
     border-color: transparent !important;
   }
 
-  .lg\:divide-current > :not(template) ~ :not(template) {
+  .lg\:divide-current > :not([hidden]) ~ :not([hidden]) {
     border-color: currentColor !important;
   }
 
-  .lg\:divide-black > :not(template) ~ :not(template) {
+  .lg\:divide-black > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(0, 0, 0, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-white > :not(template) ~ :not(template) {
+  .lg\:divide-white > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(255, 255, 255, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-gray-50 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(250, 250, 250, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-gray-100 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(244, 244, 245, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-gray-200 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(228, 228, 231, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-gray-300 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(212, 212, 216, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-gray-400 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(161, 161, 170, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-gray-500 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(113, 113, 122, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-gray-600 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(82, 82, 91, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-gray-700 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(63, 63, 70, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-gray-800 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(39, 39, 42, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-gray-900 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(24, 24, 27, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-red-50 > :not(template) ~ :not(template) {
+  .lg\:divide-red-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(254, 242, 242, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-red-100 > :not(template) ~ :not(template) {
+  .lg\:divide-red-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(254, 226, 226, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-red-200 > :not(template) ~ :not(template) {
+  .lg\:divide-red-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(254, 202, 202, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-red-300 > :not(template) ~ :not(template) {
+  .lg\:divide-red-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(252, 165, 165, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-red-400 > :not(template) ~ :not(template) {
+  .lg\:divide-red-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(248, 113, 113, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-red-500 > :not(template) ~ :not(template) {
+  .lg\:divide-red-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(239, 68, 68, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-red-600 > :not(template) ~ :not(template) {
+  .lg\:divide-red-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(220, 38, 38, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-red-700 > :not(template) ~ :not(template) {
+  .lg\:divide-red-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(185, 28, 28, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-red-800 > :not(template) ~ :not(template) {
+  .lg\:divide-red-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(153, 27, 27, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-red-900 > :not(template) ~ :not(template) {
+  .lg\:divide-red-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(127, 29, 29, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-yellow-50 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(255, 251, 235, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-yellow-100 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(254, 243, 199, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-yellow-200 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(253, 230, 138, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-yellow-300 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(252, 211, 77, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-yellow-400 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(251, 191, 36, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-yellow-500 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(245, 158, 11, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-yellow-600 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(217, 119, 6, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-yellow-700 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(180, 83, 9, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-yellow-800 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(146, 64, 14, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-yellow-900 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(120, 53, 15, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-green-50 > :not(template) ~ :not(template) {
+  .lg\:divide-green-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(236, 253, 245, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-green-100 > :not(template) ~ :not(template) {
+  .lg\:divide-green-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(209, 250, 229, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-green-200 > :not(template) ~ :not(template) {
+  .lg\:divide-green-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(167, 243, 208, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-green-300 > :not(template) ~ :not(template) {
+  .lg\:divide-green-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(110, 231, 183, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-green-400 > :not(template) ~ :not(template) {
+  .lg\:divide-green-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(52, 211, 153, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-green-500 > :not(template) ~ :not(template) {
+  .lg\:divide-green-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(16, 185, 129, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-green-600 > :not(template) ~ :not(template) {
+  .lg\:divide-green-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(5, 150, 105, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-green-700 > :not(template) ~ :not(template) {
+  .lg\:divide-green-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(4, 120, 87, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-green-800 > :not(template) ~ :not(template) {
+  .lg\:divide-green-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(6, 95, 70, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-green-900 > :not(template) ~ :not(template) {
+  .lg\:divide-green-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(6, 78, 59, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-blue-50 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(239, 246, 255, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-blue-100 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(219, 234, 254, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-blue-200 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(191, 219, 254, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-blue-300 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(147, 197, 253, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-blue-400 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(96, 165, 250, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-blue-500 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(59, 130, 246, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-blue-600 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(37, 99, 235, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-blue-700 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(29, 78, 216, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-blue-800 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(30, 64, 175, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-blue-900 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(30, 58, 138, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-purple-50 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(245, 243, 255, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-purple-100 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(237, 233, 254, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-purple-200 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(221, 214, 254, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-purple-300 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(196, 181, 253, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-purple-400 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(167, 139, 250, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-purple-500 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(139, 92, 246, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-purple-600 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(124, 58, 237, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-purple-700 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(109, 40, 217, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-purple-800 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(91, 33, 182, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-purple-900 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(76, 29, 149, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-pink-50 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(253, 242, 248, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-pink-100 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(252, 231, 243, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-pink-200 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(251, 207, 232, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-pink-300 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(249, 168, 212, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-pink-400 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(244, 114, 182, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-pink-500 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(236, 72, 153, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-pink-600 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(219, 39, 119, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-pink-700 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(190, 24, 93, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-pink-800 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(157, 23, 77, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-pink-900 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(131, 24, 67, var(--divide-opacity)) !important;
   }
 
-  .lg\:divide-solid > :not(template) ~ :not(template) {
+  .lg\:divide-solid > :not([hidden]) ~ :not([hidden]) {
     border-style: solid !important;
   }
 
-  .lg\:divide-dashed > :not(template) ~ :not(template) {
+  .lg\:divide-dashed > :not([hidden]) ~ :not([hidden]) {
     border-style: dashed !important;
   }
 
-  .lg\:divide-dotted > :not(template) ~ :not(template) {
+  .lg\:divide-dotted > :not([hidden]) ~ :not([hidden]) {
     border-style: dotted !important;
   }
 
-  .lg\:divide-double > :not(template) ~ :not(template) {
+  .lg\:divide-double > :not([hidden]) ~ :not([hidden]) {
     border-style: double !important;
   }
 
-  .lg\:divide-none > :not(template) ~ :not(template) {
+  .lg\:divide-none > :not([hidden]) ~ :not([hidden]) {
     border-style: none !important;
   }
 
-  .lg\:divide-opacity-0 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0 !important;
   }
 
-  .lg\:divide-opacity-10 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-10 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.1 !important;
   }
 
-  .lg\:divide-opacity-20 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-20 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.2 !important;
   }
 
-  .lg\:divide-opacity-25 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-25 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.25 !important;
   }
 
-  .lg\:divide-opacity-30 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-30 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.3 !important;
   }
 
-  .lg\:divide-opacity-40 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-40 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.4 !important;
   }
 
-  .lg\:divide-opacity-50 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.5 !important;
   }
 
-  .lg\:divide-opacity-60 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-60 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.6 !important;
   }
 
-  .lg\:divide-opacity-70 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-70 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.7 !important;
   }
 
-  .lg\:divide-opacity-75 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-75 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.75 !important;
   }
 
-  .lg\:divide-opacity-80 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-80 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.8 !important;
   }
 
-  .lg\:divide-opacity-90 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-90 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.9 !important;
   }
 
-  .lg\:divide-opacity-100 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
   }
 
@@ -92374,1323 +92374,1323 @@ video {
     }
   }
 
-  .xl\:space-y-0 > :not(template) ~ :not(template) {
+  .xl\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0px * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0px * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-0 > :not(template) ~ :not(template) {
+  .xl\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0px * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-1 > :not(template) ~ :not(template) {
+  .xl\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.25rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-1 > :not(template) ~ :not(template) {
+  .xl\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-2 > :not(template) ~ :not(template) {
+  .xl\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.5rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-2 > :not(template) ~ :not(template) {
+  .xl\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-3 > :not(template) ~ :not(template) {
+  .xl\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.75rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-3 > :not(template) ~ :not(template) {
+  .xl\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.75rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-4 > :not(template) ~ :not(template) {
+  .xl\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-4 > :not(template) ~ :not(template) {
+  .xl\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-5 > :not(template) ~ :not(template) {
+  .xl\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1.25rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-5 > :not(template) ~ :not(template) {
+  .xl\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-6 > :not(template) ~ :not(template) {
+  .xl\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1.5rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-6 > :not(template) ~ :not(template) {
+  .xl\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-7 > :not(template) ~ :not(template) {
+  .xl\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1.75rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-7 > :not(template) ~ :not(template) {
+  .xl\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1.75rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-8 > :not(template) ~ :not(template) {
+  .xl\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(2rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(2rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-8 > :not(template) ~ :not(template) {
+  .xl\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(2rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-9 > :not(template) ~ :not(template) {
+  .xl\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(2.25rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-9 > :not(template) ~ :not(template) {
+  .xl\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(2.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-10 > :not(template) ~ :not(template) {
+  .xl\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(2.5rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-10 > :not(template) ~ :not(template) {
+  .xl\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(2.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-12 > :not(template) ~ :not(template) {
+  .xl\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(3rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(3rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-12 > :not(template) ~ :not(template) {
+  .xl\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(3rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-14 > :not(template) ~ :not(template) {
+  .xl\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(3.5rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-14 > :not(template) ~ :not(template) {
+  .xl\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(3.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-16 > :not(template) ~ :not(template) {
+  .xl\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(4rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(4rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-16 > :not(template) ~ :not(template) {
+  .xl\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(4rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-20 > :not(template) ~ :not(template) {
+  .xl\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(5rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-20 > :not(template) ~ :not(template) {
+  .xl\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-24 > :not(template) ~ :not(template) {
+  .xl\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(6rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(6rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-24 > :not(template) ~ :not(template) {
+  .xl\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(6rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-28 > :not(template) ~ :not(template) {
+  .xl\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(7rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(7rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-28 > :not(template) ~ :not(template) {
+  .xl\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(7rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-32 > :not(template) ~ :not(template) {
+  .xl\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(8rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(8rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-32 > :not(template) ~ :not(template) {
+  .xl\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(8rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-36 > :not(template) ~ :not(template) {
+  .xl\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(9rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(9rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-36 > :not(template) ~ :not(template) {
+  .xl\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(9rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-40 > :not(template) ~ :not(template) {
+  .xl\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(10rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(10rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-40 > :not(template) ~ :not(template) {
+  .xl\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(10rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-44 > :not(template) ~ :not(template) {
+  .xl\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(11rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(11rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-44 > :not(template) ~ :not(template) {
+  .xl\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(11rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-48 > :not(template) ~ :not(template) {
+  .xl\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(12rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(12rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-48 > :not(template) ~ :not(template) {
+  .xl\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(12rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-52 > :not(template) ~ :not(template) {
+  .xl\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(13rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(13rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-52 > :not(template) ~ :not(template) {
+  .xl\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(13rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-56 > :not(template) ~ :not(template) {
+  .xl\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(14rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(14rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-56 > :not(template) ~ :not(template) {
+  .xl\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(14rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-60 > :not(template) ~ :not(template) {
+  .xl\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(15rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(15rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-60 > :not(template) ~ :not(template) {
+  .xl\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(15rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-64 > :not(template) ~ :not(template) {
+  .xl\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(16rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(16rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-64 > :not(template) ~ :not(template) {
+  .xl\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(16rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-72 > :not(template) ~ :not(template) {
+  .xl\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(18rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(18rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-72 > :not(template) ~ :not(template) {
+  .xl\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(18rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-80 > :not(template) ~ :not(template) {
+  .xl\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(20rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(20rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-80 > :not(template) ~ :not(template) {
+  .xl\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(20rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-96 > :not(template) ~ :not(template) {
+  .xl\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(24rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(24rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-96 > :not(template) ~ :not(template) {
+  .xl\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(24rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-px > :not(template) ~ :not(template) {
+  .xl\:space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1px * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1px * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-px > :not(template) ~ :not(template) {
+  .xl\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1px * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-0\.5 > :not(template) ~ :not(template) {
+  .xl\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.125rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-0\.5 > :not(template) ~ :not(template) {
+  .xl\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.125rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-1\.5 > :not(template) ~ :not(template) {
+  .xl\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.375rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-1\.5 > :not(template) ~ :not(template) {
+  .xl\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.375rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-2\.5 > :not(template) ~ :not(template) {
+  .xl\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.625rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-2\.5 > :not(template) ~ :not(template) {
+  .xl\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.625rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-3\.5 > :not(template) ~ :not(template) {
+  .xl\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.875rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:space-x-3\.5 > :not(template) ~ :not(template) {
+  .xl\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.875rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-1 > :not(template) ~ :not(template) {
+  .xl\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.25rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-1 > :not(template) ~ :not(template) {
+  .xl\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-2 > :not(template) ~ :not(template) {
+  .xl\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.5rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-2 > :not(template) ~ :not(template) {
+  .xl\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-3 > :not(template) ~ :not(template) {
+  .xl\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.75rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-3 > :not(template) ~ :not(template) {
+  .xl\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.75rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-4 > :not(template) ~ :not(template) {
+  .xl\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-4 > :not(template) ~ :not(template) {
+  .xl\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-5 > :not(template) ~ :not(template) {
+  .xl\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1.25rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-5 > :not(template) ~ :not(template) {
+  .xl\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-6 > :not(template) ~ :not(template) {
+  .xl\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1.5rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-6 > :not(template) ~ :not(template) {
+  .xl\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-7 > :not(template) ~ :not(template) {
+  .xl\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1.75rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-7 > :not(template) ~ :not(template) {
+  .xl\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1.75rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-8 > :not(template) ~ :not(template) {
+  .xl\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-2rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-2rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-8 > :not(template) ~ :not(template) {
+  .xl\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-2rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-9 > :not(template) ~ :not(template) {
+  .xl\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-2.25rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-9 > :not(template) ~ :not(template) {
+  .xl\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-2.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-10 > :not(template) ~ :not(template) {
+  .xl\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-2.5rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-10 > :not(template) ~ :not(template) {
+  .xl\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-2.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-12 > :not(template) ~ :not(template) {
+  .xl\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-3rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-3rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-12 > :not(template) ~ :not(template) {
+  .xl\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-3rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-14 > :not(template) ~ :not(template) {
+  .xl\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-3.5rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-14 > :not(template) ~ :not(template) {
+  .xl\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-3.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-16 > :not(template) ~ :not(template) {
+  .xl\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-4rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-4rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-16 > :not(template) ~ :not(template) {
+  .xl\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-4rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-20 > :not(template) ~ :not(template) {
+  .xl\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-5rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-20 > :not(template) ~ :not(template) {
+  .xl\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-24 > :not(template) ~ :not(template) {
+  .xl\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-6rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-6rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-24 > :not(template) ~ :not(template) {
+  .xl\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-6rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-28 > :not(template) ~ :not(template) {
+  .xl\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-7rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-7rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-28 > :not(template) ~ :not(template) {
+  .xl\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-7rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-32 > :not(template) ~ :not(template) {
+  .xl\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-8rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-8rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-32 > :not(template) ~ :not(template) {
+  .xl\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-8rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-36 > :not(template) ~ :not(template) {
+  .xl\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-9rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-9rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-36 > :not(template) ~ :not(template) {
+  .xl\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-9rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-40 > :not(template) ~ :not(template) {
+  .xl\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-10rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-10rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-40 > :not(template) ~ :not(template) {
+  .xl\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-10rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-44 > :not(template) ~ :not(template) {
+  .xl\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-11rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-11rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-44 > :not(template) ~ :not(template) {
+  .xl\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-11rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-48 > :not(template) ~ :not(template) {
+  .xl\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-12rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-12rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-48 > :not(template) ~ :not(template) {
+  .xl\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-12rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-52 > :not(template) ~ :not(template) {
+  .xl\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-13rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-13rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-52 > :not(template) ~ :not(template) {
+  .xl\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-13rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-56 > :not(template) ~ :not(template) {
+  .xl\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-14rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-14rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-56 > :not(template) ~ :not(template) {
+  .xl\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-14rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-60 > :not(template) ~ :not(template) {
+  .xl\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-15rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-15rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-60 > :not(template) ~ :not(template) {
+  .xl\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-15rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-64 > :not(template) ~ :not(template) {
+  .xl\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-16rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-16rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-64 > :not(template) ~ :not(template) {
+  .xl\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-16rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-72 > :not(template) ~ :not(template) {
+  .xl\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-18rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-18rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-72 > :not(template) ~ :not(template) {
+  .xl\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-18rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-80 > :not(template) ~ :not(template) {
+  .xl\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-20rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-20rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-80 > :not(template) ~ :not(template) {
+  .xl\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-20rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-96 > :not(template) ~ :not(template) {
+  .xl\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-24rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-24rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-96 > :not(template) ~ :not(template) {
+  .xl\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-24rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-px > :not(template) ~ :not(template) {
+  .xl\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1px * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1px * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-px > :not(template) ~ :not(template) {
+  .xl\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1px * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-0\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.125rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-0\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.125rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-1\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.375rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-1\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.375rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-2\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.625rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-2\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.625rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:-space-y-3\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.875rem * var(--space-y-reverse)) !important;
   }
 
-  .xl\:-space-x-3\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.875rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .xl\:space-y-reverse > :not(template) ~ :not(template) {
+  .xl\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 1 !important;
   }
 
-  .xl\:space-x-reverse > :not(template) ~ :not(template) {
+  .xl\:space-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 1 !important;
   }
 
-  .xl\:divide-y-0 > :not(template) ~ :not(template) {
+  .xl\:divide-y-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(0px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(0px * var(--divide-y-reverse)) !important;
   }
 
-  .xl\:divide-x-0 > :not(template) ~ :not(template) {
+  .xl\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(0px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .xl\:divide-y-2 > :not(template) ~ :not(template) {
+  .xl\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(2px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(2px * var(--divide-y-reverse)) !important;
   }
 
-  .xl\:divide-x-2 > :not(template) ~ :not(template) {
+  .xl\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(2px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .xl\:divide-y-4 > :not(template) ~ :not(template) {
+  .xl\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(4px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(4px * var(--divide-y-reverse)) !important;
   }
 
-  .xl\:divide-x-4 > :not(template) ~ :not(template) {
+  .xl\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(4px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .xl\:divide-y-8 > :not(template) ~ :not(template) {
+  .xl\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(8px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(8px * var(--divide-y-reverse)) !important;
   }
 
-  .xl\:divide-x-8 > :not(template) ~ :not(template) {
+  .xl\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(8px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .xl\:divide-y > :not(template) ~ :not(template) {
+  .xl\:divide-y > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(1px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(1px * var(--divide-y-reverse)) !important;
   }
 
-  .xl\:divide-x > :not(template) ~ :not(template) {
+  .xl\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(1px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .xl\:divide-y-reverse > :not(template) ~ :not(template) {
+  .xl\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 1 !important;
   }
 
-  .xl\:divide-x-reverse > :not(template) ~ :not(template) {
+  .xl\:divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 1 !important;
   }
 
-  .xl\:divide-transparent > :not(template) ~ :not(template) {
+  .xl\:divide-transparent > :not([hidden]) ~ :not([hidden]) {
     border-color: transparent !important;
   }
 
-  .xl\:divide-current > :not(template) ~ :not(template) {
+  .xl\:divide-current > :not([hidden]) ~ :not([hidden]) {
     border-color: currentColor !important;
   }
 
-  .xl\:divide-black > :not(template) ~ :not(template) {
+  .xl\:divide-black > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(0, 0, 0, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-white > :not(template) ~ :not(template) {
+  .xl\:divide-white > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(255, 255, 255, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-gray-50 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(250, 250, 250, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-gray-100 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(244, 244, 245, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-gray-200 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(228, 228, 231, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-gray-300 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(212, 212, 216, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-gray-400 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(161, 161, 170, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-gray-500 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(113, 113, 122, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-gray-600 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(82, 82, 91, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-gray-700 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(63, 63, 70, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-gray-800 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(39, 39, 42, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-gray-900 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(24, 24, 27, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-red-50 > :not(template) ~ :not(template) {
+  .xl\:divide-red-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(254, 242, 242, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-red-100 > :not(template) ~ :not(template) {
+  .xl\:divide-red-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(254, 226, 226, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-red-200 > :not(template) ~ :not(template) {
+  .xl\:divide-red-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(254, 202, 202, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-red-300 > :not(template) ~ :not(template) {
+  .xl\:divide-red-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(252, 165, 165, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-red-400 > :not(template) ~ :not(template) {
+  .xl\:divide-red-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(248, 113, 113, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-red-500 > :not(template) ~ :not(template) {
+  .xl\:divide-red-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(239, 68, 68, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-red-600 > :not(template) ~ :not(template) {
+  .xl\:divide-red-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(220, 38, 38, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-red-700 > :not(template) ~ :not(template) {
+  .xl\:divide-red-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(185, 28, 28, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-red-800 > :not(template) ~ :not(template) {
+  .xl\:divide-red-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(153, 27, 27, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-red-900 > :not(template) ~ :not(template) {
+  .xl\:divide-red-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(127, 29, 29, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-yellow-50 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(255, 251, 235, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-yellow-100 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(254, 243, 199, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-yellow-200 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(253, 230, 138, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-yellow-300 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(252, 211, 77, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-yellow-400 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(251, 191, 36, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-yellow-500 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(245, 158, 11, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-yellow-600 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(217, 119, 6, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-yellow-700 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(180, 83, 9, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-yellow-800 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(146, 64, 14, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-yellow-900 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(120, 53, 15, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-green-50 > :not(template) ~ :not(template) {
+  .xl\:divide-green-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(236, 253, 245, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-green-100 > :not(template) ~ :not(template) {
+  .xl\:divide-green-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(209, 250, 229, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-green-200 > :not(template) ~ :not(template) {
+  .xl\:divide-green-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(167, 243, 208, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-green-300 > :not(template) ~ :not(template) {
+  .xl\:divide-green-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(110, 231, 183, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-green-400 > :not(template) ~ :not(template) {
+  .xl\:divide-green-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(52, 211, 153, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-green-500 > :not(template) ~ :not(template) {
+  .xl\:divide-green-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(16, 185, 129, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-green-600 > :not(template) ~ :not(template) {
+  .xl\:divide-green-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(5, 150, 105, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-green-700 > :not(template) ~ :not(template) {
+  .xl\:divide-green-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(4, 120, 87, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-green-800 > :not(template) ~ :not(template) {
+  .xl\:divide-green-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(6, 95, 70, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-green-900 > :not(template) ~ :not(template) {
+  .xl\:divide-green-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(6, 78, 59, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-blue-50 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(239, 246, 255, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-blue-100 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(219, 234, 254, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-blue-200 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(191, 219, 254, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-blue-300 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(147, 197, 253, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-blue-400 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(96, 165, 250, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-blue-500 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(59, 130, 246, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-blue-600 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(37, 99, 235, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-blue-700 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(29, 78, 216, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-blue-800 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(30, 64, 175, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-blue-900 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(30, 58, 138, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-purple-50 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(245, 243, 255, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-purple-100 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(237, 233, 254, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-purple-200 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(221, 214, 254, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-purple-300 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(196, 181, 253, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-purple-400 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(167, 139, 250, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-purple-500 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(139, 92, 246, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-purple-600 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(124, 58, 237, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-purple-700 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(109, 40, 217, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-purple-800 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(91, 33, 182, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-purple-900 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(76, 29, 149, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-pink-50 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(253, 242, 248, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-pink-100 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(252, 231, 243, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-pink-200 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(251, 207, 232, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-pink-300 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(249, 168, 212, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-pink-400 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(244, 114, 182, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-pink-500 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(236, 72, 153, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-pink-600 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(219, 39, 119, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-pink-700 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(190, 24, 93, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-pink-800 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(157, 23, 77, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-pink-900 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(131, 24, 67, var(--divide-opacity)) !important;
   }
 
-  .xl\:divide-solid > :not(template) ~ :not(template) {
+  .xl\:divide-solid > :not([hidden]) ~ :not([hidden]) {
     border-style: solid !important;
   }
 
-  .xl\:divide-dashed > :not(template) ~ :not(template) {
+  .xl\:divide-dashed > :not([hidden]) ~ :not([hidden]) {
     border-style: dashed !important;
   }
 
-  .xl\:divide-dotted > :not(template) ~ :not(template) {
+  .xl\:divide-dotted > :not([hidden]) ~ :not([hidden]) {
     border-style: dotted !important;
   }
 
-  .xl\:divide-double > :not(template) ~ :not(template) {
+  .xl\:divide-double > :not([hidden]) ~ :not([hidden]) {
     border-style: double !important;
   }
 
-  .xl\:divide-none > :not(template) ~ :not(template) {
+  .xl\:divide-none > :not([hidden]) ~ :not([hidden]) {
     border-style: none !important;
   }
 
-  .xl\:divide-opacity-0 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0 !important;
   }
 
-  .xl\:divide-opacity-10 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-10 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.1 !important;
   }
 
-  .xl\:divide-opacity-20 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-20 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.2 !important;
   }
 
-  .xl\:divide-opacity-25 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-25 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.25 !important;
   }
 
-  .xl\:divide-opacity-30 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-30 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.3 !important;
   }
 
-  .xl\:divide-opacity-40 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-40 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.4 !important;
   }
 
-  .xl\:divide-opacity-50 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.5 !important;
   }
 
-  .xl\:divide-opacity-60 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-60 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.6 !important;
   }
 
-  .xl\:divide-opacity-70 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-70 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.7 !important;
   }
 
-  .xl\:divide-opacity-75 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-75 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.75 !important;
   }
 
-  .xl\:divide-opacity-80 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-80 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.8 !important;
   }
 
-  .xl\:divide-opacity-90 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-90 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.9 !important;
   }
 
-  .xl\:divide-opacity-100 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
   }
 
@@ -115320,1323 +115320,1323 @@ video {
     }
   }
 
-  .\32xl\:space-y-0 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0px * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0px * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-0 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0px * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-1 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.25rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-1 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-2 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.5rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-2 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-3 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.75rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-3 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.75rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-4 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-4 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-5 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1.25rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-5 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-6 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1.5rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-6 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-7 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1.75rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-7 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1.75rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-8 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(2rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(2rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-8 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(2rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-9 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(2.25rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-9 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(2.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-10 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(2.5rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-10 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(2.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-12 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(3rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(3rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-12 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(3rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-14 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(3.5rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-14 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(3.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-16 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(4rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(4rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-16 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(4rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-20 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(5rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-20 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-24 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(6rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(6rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-24 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(6rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-28 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(7rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(7rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-28 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(7rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-32 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(8rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(8rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-32 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(8rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-36 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(9rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(9rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-36 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(9rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-40 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(10rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(10rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-40 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(10rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-44 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(11rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(11rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-44 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(11rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-48 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(12rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(12rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-48 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(12rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-52 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(13rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(13rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-52 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(13rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-56 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(14rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(14rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-56 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(14rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-60 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(15rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(15rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-60 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(15rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-64 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(16rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(16rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-64 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(16rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-72 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(18rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(18rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-72 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(18rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-80 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(20rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(20rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-80 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(20rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-96 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(24rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(24rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-96 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(24rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-px > :not(template) ~ :not(template) {
+  .\32xl\:space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(1px * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(1px * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-px > :not(template) ~ :not(template) {
+  .\32xl\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(1px * var(--space-x-reverse)) !important;
     margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-0\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.125rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-0\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.125rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-1\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.375rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-1\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.375rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-2\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.625rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-2\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.625rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-3\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(0.875rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:space-x-3\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(0.875rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-1 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.25rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-1 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-2 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.5rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-2 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-3 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.75rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-3 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.75rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-4 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-4 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1.25rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-6 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1.5rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-6 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-7 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1.75rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-7 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1.75rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-8 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-2rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-2rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-8 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-2rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-9 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-2.25rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-9 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-2.25rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-10 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-2.5rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-10 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-2.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-12 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-3rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-3rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-12 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-3rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-14 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-3.5rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-14 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-3.5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-16 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-4rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-4rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-16 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-4rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-20 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-5rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-5rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-20 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-5rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-24 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-6rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-6rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-24 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-6rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-28 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-7rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-7rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-28 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-7rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-32 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-8rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-8rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-32 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-8rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-36 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-9rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-9rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-36 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-9rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-40 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-10rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-10rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-40 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-10rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-44 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-11rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-11rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-44 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-11rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-48 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-12rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-12rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-48 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-12rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-52 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-13rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-13rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-52 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-13rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-56 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-14rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-14rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-56 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-14rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-60 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-15rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-15rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-60 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-15rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-64 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-16rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-16rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-64 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-16rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-72 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-18rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-18rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-72 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-18rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-80 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-20rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-20rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-80 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-20rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-96 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-24rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-24rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-96 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-24rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-px > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-1px * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-1px * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-px > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-1px * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-0\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.125rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-0\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.125rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-1\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.375rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-1\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.375rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-2\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.625rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-2\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.625rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:-space-y-3\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0 !important;
     margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse))) !important;
     margin-bottom: calc(-0.875rem * var(--space-y-reverse)) !important;
   }
 
-  .\32xl\:-space-x-3\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
     margin-inline-end: calc(-0.875rem * var(--space-x-reverse)) !important;
     margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
-  .\32xl\:space-y-reverse > :not(template) ~ :not(template) {
+  .\32xl\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 1 !important;
   }
 
-  .\32xl\:space-x-reverse > :not(template) ~ :not(template) {
+  .\32xl\:space-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 1 !important;
   }
 
-  .\32xl\:divide-y-0 > :not(template) ~ :not(template) {
+  .\32xl\:divide-y-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(0px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(0px * var(--divide-y-reverse)) !important;
   }
 
-  .\32xl\:divide-x-0 > :not(template) ~ :not(template) {
+  .\32xl\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(0px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .\32xl\:divide-y-2 > :not(template) ~ :not(template) {
+  .\32xl\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(2px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(2px * var(--divide-y-reverse)) !important;
   }
 
-  .\32xl\:divide-x-2 > :not(template) ~ :not(template) {
+  .\32xl\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(2px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .\32xl\:divide-y-4 > :not(template) ~ :not(template) {
+  .\32xl\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(4px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(4px * var(--divide-y-reverse)) !important;
   }
 
-  .\32xl\:divide-x-4 > :not(template) ~ :not(template) {
+  .\32xl\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(4px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .\32xl\:divide-y-8 > :not(template) ~ :not(template) {
+  .\32xl\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(8px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(8px * var(--divide-y-reverse)) !important;
   }
 
-  .\32xl\:divide-x-8 > :not(template) ~ :not(template) {
+  .\32xl\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(8px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .\32xl\:divide-y > :not(template) ~ :not(template) {
+  .\32xl\:divide-y > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0 !important;
     border-top-width: calc(1px * calc(1 - var(--divide-y-reverse))) !important;
     border-bottom-width: calc(1px * var(--divide-y-reverse)) !important;
   }
 
-  .\32xl\:divide-x > :not(template) ~ :not(template) {
+  .\32xl\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
     border-inline-end-width: calc(1px * var(--divide-x-reverse)) !important;
     border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
-  .\32xl\:divide-y-reverse > :not(template) ~ :not(template) {
+  .\32xl\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 1 !important;
   }
 
-  .\32xl\:divide-x-reverse > :not(template) ~ :not(template) {
+  .\32xl\:divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 1 !important;
   }
 
-  .\32xl\:divide-transparent > :not(template) ~ :not(template) {
+  .\32xl\:divide-transparent > :not([hidden]) ~ :not([hidden]) {
     border-color: transparent !important;
   }
 
-  .\32xl\:divide-current > :not(template) ~ :not(template) {
+  .\32xl\:divide-current > :not([hidden]) ~ :not([hidden]) {
     border-color: currentColor !important;
   }
 
-  .\32xl\:divide-black > :not(template) ~ :not(template) {
+  .\32xl\:divide-black > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(0, 0, 0, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-white > :not(template) ~ :not(template) {
+  .\32xl\:divide-white > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(255, 255, 255, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-gray-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(250, 250, 250, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-gray-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(244, 244, 245, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-gray-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(228, 228, 231, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-gray-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(212, 212, 216, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-gray-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(161, 161, 170, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-gray-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(113, 113, 122, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-gray-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(82, 82, 91, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-gray-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(63, 63, 70, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-gray-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(39, 39, 42, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-gray-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(24, 24, 27, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-red-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(254, 242, 242, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-red-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(254, 226, 226, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-red-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(254, 202, 202, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-red-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(252, 165, 165, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-red-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(248, 113, 113, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-red-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(239, 68, 68, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-red-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(220, 38, 38, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-red-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(185, 28, 28, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-red-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(153, 27, 27, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-red-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(127, 29, 29, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-yellow-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(255, 251, 235, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-yellow-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(254, 243, 199, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-yellow-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(253, 230, 138, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-yellow-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(252, 211, 77, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-yellow-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(251, 191, 36, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-yellow-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(245, 158, 11, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-yellow-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(217, 119, 6, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-yellow-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(180, 83, 9, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-yellow-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(146, 64, 14, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-yellow-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(120, 53, 15, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-green-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(236, 253, 245, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-green-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(209, 250, 229, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-green-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(167, 243, 208, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-green-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(110, 231, 183, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-green-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(52, 211, 153, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-green-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(16, 185, 129, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-green-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(5, 150, 105, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-green-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(4, 120, 87, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-green-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(6, 95, 70, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-green-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(6, 78, 59, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-blue-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(239, 246, 255, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-blue-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(219, 234, 254, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-blue-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(191, 219, 254, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-blue-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(147, 197, 253, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-blue-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(96, 165, 250, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-blue-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(59, 130, 246, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-blue-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(37, 99, 235, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-blue-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(29, 78, 216, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-blue-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(30, 64, 175, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-blue-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(30, 58, 138, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-purple-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(245, 243, 255, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-purple-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(237, 233, 254, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-purple-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(221, 214, 254, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-purple-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(196, 181, 253, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-purple-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(167, 139, 250, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-purple-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(139, 92, 246, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-purple-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(124, 58, 237, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-purple-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(109, 40, 217, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-purple-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(91, 33, 182, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-purple-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(76, 29, 149, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-pink-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(253, 242, 248, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-pink-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(252, 231, 243, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-pink-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(251, 207, 232, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-pink-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(249, 168, 212, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-pink-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(244, 114, 182, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-pink-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(236, 72, 153, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-pink-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(219, 39, 119, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-pink-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(190, 24, 93, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-pink-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(157, 23, 77, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-pink-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
     border-color: rgba(131, 24, 67, var(--divide-opacity)) !important;
   }
 
-  .\32xl\:divide-solid > :not(template) ~ :not(template) {
+  .\32xl\:divide-solid > :not([hidden]) ~ :not([hidden]) {
     border-style: solid !important;
   }
 
-  .\32xl\:divide-dashed > :not(template) ~ :not(template) {
+  .\32xl\:divide-dashed > :not([hidden]) ~ :not([hidden]) {
     border-style: dashed !important;
   }
 
-  .\32xl\:divide-dotted > :not(template) ~ :not(template) {
+  .\32xl\:divide-dotted > :not([hidden]) ~ :not([hidden]) {
     border-style: dotted !important;
   }
 
-  .\32xl\:divide-double > :not(template) ~ :not(template) {
+  .\32xl\:divide-double > :not([hidden]) ~ :not([hidden]) {
     border-style: double !important;
   }
 
-  .\32xl\:divide-none > :not(template) ~ :not(template) {
+  .\32xl\:divide-none > :not([hidden]) ~ :not([hidden]) {
     border-style: none !important;
   }
 
-  .\32xl\:divide-opacity-0 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0 !important;
   }
 
-  .\32xl\:divide-opacity-10 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-10 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.1 !important;
   }
 
-  .\32xl\:divide-opacity-20 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-20 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.2 !important;
   }
 
-  .\32xl\:divide-opacity-25 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-25 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.25 !important;
   }
 
-  .\32xl\:divide-opacity-30 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-30 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.3 !important;
   }
 
-  .\32xl\:divide-opacity-40 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-40 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.4 !important;
   }
 
-  .\32xl\:divide-opacity-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.5 !important;
   }
 
-  .\32xl\:divide-opacity-60 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-60 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.6 !important;
   }
 
-  .\32xl\:divide-opacity-70 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-70 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.7 !important;
   }
 
-  .\32xl\:divide-opacity-75 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-75 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.75 !important;
   }
 
-  .\32xl\:divide-opacity-80 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-80 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.8 !important;
   }
 
-  .\32xl\:divide-opacity-90 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-90 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.9 !important;
   }
 
-  .\32xl\:divide-opacity-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1 !important;
   }
 

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -560,1199 +560,1199 @@ video {
   }
 }
 
-.space-y-0 > :not(template) ~ :not(template) {
+.space-y-0 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0px * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0px * var(--space-y-reverse));
 }
 
-.space-x-0 > :not(template) ~ :not(template) {
+.space-x-0 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0px * var(--space-x-reverse));
   margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-1 > :not(template) ~ :not(template) {
+.space-y-1 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0.25rem * var(--space-y-reverse));
 }
 
-.space-x-1 > :not(template) ~ :not(template) {
+.space-x-1 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0.25rem * var(--space-x-reverse));
   margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-2 > :not(template) ~ :not(template) {
+.space-y-2 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0.5rem * var(--space-y-reverse));
 }
 
-.space-x-2 > :not(template) ~ :not(template) {
+.space-x-2 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0.5rem * var(--space-x-reverse));
   margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-3 > :not(template) ~ :not(template) {
+.space-y-3 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0.75rem * var(--space-y-reverse));
 }
 
-.space-x-3 > :not(template) ~ :not(template) {
+.space-x-3 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0.75rem * var(--space-x-reverse));
   margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-4 > :not(template) ~ :not(template) {
+.space-y-4 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(1rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(1rem * var(--space-y-reverse));
 }
 
-.space-x-4 > :not(template) ~ :not(template) {
+.space-x-4 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(1rem * var(--space-x-reverse));
   margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-5 > :not(template) ~ :not(template) {
+.space-y-5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(1.25rem * var(--space-y-reverse));
 }
 
-.space-x-5 > :not(template) ~ :not(template) {
+.space-x-5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(1.25rem * var(--space-x-reverse));
   margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-6 > :not(template) ~ :not(template) {
+.space-y-6 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(1.5rem * var(--space-y-reverse));
 }
 
-.space-x-6 > :not(template) ~ :not(template) {
+.space-x-6 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(1.5rem * var(--space-x-reverse));
   margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-7 > :not(template) ~ :not(template) {
+.space-y-7 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(1.75rem * var(--space-y-reverse));
 }
 
-.space-x-7 > :not(template) ~ :not(template) {
+.space-x-7 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(1.75rem * var(--space-x-reverse));
   margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-8 > :not(template) ~ :not(template) {
+.space-y-8 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(2rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(2rem * var(--space-y-reverse));
 }
 
-.space-x-8 > :not(template) ~ :not(template) {
+.space-x-8 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(2rem * var(--space-x-reverse));
   margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-9 > :not(template) ~ :not(template) {
+.space-y-9 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(2.25rem * var(--space-y-reverse));
 }
 
-.space-x-9 > :not(template) ~ :not(template) {
+.space-x-9 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(2.25rem * var(--space-x-reverse));
   margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-10 > :not(template) ~ :not(template) {
+.space-y-10 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(2.5rem * var(--space-y-reverse));
 }
 
-.space-x-10 > :not(template) ~ :not(template) {
+.space-x-10 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(2.5rem * var(--space-x-reverse));
   margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-12 > :not(template) ~ :not(template) {
+.space-y-12 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(3rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(3rem * var(--space-y-reverse));
 }
 
-.space-x-12 > :not(template) ~ :not(template) {
+.space-x-12 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(3rem * var(--space-x-reverse));
   margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-14 > :not(template) ~ :not(template) {
+.space-y-14 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(3.5rem * var(--space-y-reverse));
 }
 
-.space-x-14 > :not(template) ~ :not(template) {
+.space-x-14 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(3.5rem * var(--space-x-reverse));
   margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-16 > :not(template) ~ :not(template) {
+.space-y-16 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(4rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(4rem * var(--space-y-reverse));
 }
 
-.space-x-16 > :not(template) ~ :not(template) {
+.space-x-16 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(4rem * var(--space-x-reverse));
   margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-20 > :not(template) ~ :not(template) {
+.space-y-20 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(5rem * var(--space-y-reverse));
 }
 
-.space-x-20 > :not(template) ~ :not(template) {
+.space-x-20 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(5rem * var(--space-x-reverse));
   margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-24 > :not(template) ~ :not(template) {
+.space-y-24 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(6rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(6rem * var(--space-y-reverse));
 }
 
-.space-x-24 > :not(template) ~ :not(template) {
+.space-x-24 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(6rem * var(--space-x-reverse));
   margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-28 > :not(template) ~ :not(template) {
+.space-y-28 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(7rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(7rem * var(--space-y-reverse));
 }
 
-.space-x-28 > :not(template) ~ :not(template) {
+.space-x-28 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(7rem * var(--space-x-reverse));
   margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-32 > :not(template) ~ :not(template) {
+.space-y-32 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(8rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(8rem * var(--space-y-reverse));
 }
 
-.space-x-32 > :not(template) ~ :not(template) {
+.space-x-32 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(8rem * var(--space-x-reverse));
   margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-36 > :not(template) ~ :not(template) {
+.space-y-36 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(9rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(9rem * var(--space-y-reverse));
 }
 
-.space-x-36 > :not(template) ~ :not(template) {
+.space-x-36 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(9rem * var(--space-x-reverse));
   margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-40 > :not(template) ~ :not(template) {
+.space-y-40 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(10rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(10rem * var(--space-y-reverse));
 }
 
-.space-x-40 > :not(template) ~ :not(template) {
+.space-x-40 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(10rem * var(--space-x-reverse));
   margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-44 > :not(template) ~ :not(template) {
+.space-y-44 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(11rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(11rem * var(--space-y-reverse));
 }
 
-.space-x-44 > :not(template) ~ :not(template) {
+.space-x-44 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(11rem * var(--space-x-reverse));
   margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-48 > :not(template) ~ :not(template) {
+.space-y-48 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(12rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(12rem * var(--space-y-reverse));
 }
 
-.space-x-48 > :not(template) ~ :not(template) {
+.space-x-48 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(12rem * var(--space-x-reverse));
   margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-52 > :not(template) ~ :not(template) {
+.space-y-52 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(13rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(13rem * var(--space-y-reverse));
 }
 
-.space-x-52 > :not(template) ~ :not(template) {
+.space-x-52 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(13rem * var(--space-x-reverse));
   margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-56 > :not(template) ~ :not(template) {
+.space-y-56 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(14rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(14rem * var(--space-y-reverse));
 }
 
-.space-x-56 > :not(template) ~ :not(template) {
+.space-x-56 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(14rem * var(--space-x-reverse));
   margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-60 > :not(template) ~ :not(template) {
+.space-y-60 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(15rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(15rem * var(--space-y-reverse));
 }
 
-.space-x-60 > :not(template) ~ :not(template) {
+.space-x-60 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(15rem * var(--space-x-reverse));
   margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-64 > :not(template) ~ :not(template) {
+.space-y-64 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(16rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(16rem * var(--space-y-reverse));
 }
 
-.space-x-64 > :not(template) ~ :not(template) {
+.space-x-64 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(16rem * var(--space-x-reverse));
   margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-72 > :not(template) ~ :not(template) {
+.space-y-72 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(18rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(18rem * var(--space-y-reverse));
 }
 
-.space-x-72 > :not(template) ~ :not(template) {
+.space-x-72 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(18rem * var(--space-x-reverse));
   margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-80 > :not(template) ~ :not(template) {
+.space-y-80 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(20rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(20rem * var(--space-y-reverse));
 }
 
-.space-x-80 > :not(template) ~ :not(template) {
+.space-x-80 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(20rem * var(--space-x-reverse));
   margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-96 > :not(template) ~ :not(template) {
+.space-y-96 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(24rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(24rem * var(--space-y-reverse));
 }
 
-.space-x-96 > :not(template) ~ :not(template) {
+.space-x-96 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(24rem * var(--space-x-reverse));
   margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-px > :not(template) ~ :not(template) {
+.space-y-px > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(1px * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(1px * var(--space-y-reverse));
 }
 
-.space-x-px > :not(template) ~ :not(template) {
+.space-x-px > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(1px * var(--space-x-reverse));
   margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-0\.5 > :not(template) ~ :not(template) {
+.space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0.125rem * var(--space-y-reverse));
 }
 
-.space-x-0\.5 > :not(template) ~ :not(template) {
+.space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0.125rem * var(--space-x-reverse));
   margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-1\.5 > :not(template) ~ :not(template) {
+.space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0.375rem * var(--space-y-reverse));
 }
 
-.space-x-1\.5 > :not(template) ~ :not(template) {
+.space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0.375rem * var(--space-x-reverse));
   margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-2\.5 > :not(template) ~ :not(template) {
+.space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0.625rem * var(--space-y-reverse));
 }
 
-.space-x-2\.5 > :not(template) ~ :not(template) {
+.space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0.625rem * var(--space-x-reverse));
   margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-3\.5 > :not(template) ~ :not(template) {
+.space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0.875rem * var(--space-y-reverse));
 }
 
-.space-x-3\.5 > :not(template) ~ :not(template) {
+.space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0.875rem * var(--space-x-reverse));
   margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-1 > :not(template) ~ :not(template) {
+.-space-y-1 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-0.25rem * var(--space-y-reverse));
 }
 
-.-space-x-1 > :not(template) ~ :not(template) {
+.-space-x-1 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
   margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-2 > :not(template) ~ :not(template) {
+.-space-y-2 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-0.5rem * var(--space-y-reverse));
 }
 
-.-space-x-2 > :not(template) ~ :not(template) {
+.-space-x-2 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
   margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-3 > :not(template) ~ :not(template) {
+.-space-y-3 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-0.75rem * var(--space-y-reverse));
 }
 
-.-space-x-3 > :not(template) ~ :not(template) {
+.-space-x-3 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
   margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-4 > :not(template) ~ :not(template) {
+.-space-y-4 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-1rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-1rem * var(--space-y-reverse));
 }
 
-.-space-x-4 > :not(template) ~ :not(template) {
+.-space-x-4 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-1rem * var(--space-x-reverse));
   margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-5 > :not(template) ~ :not(template) {
+.-space-y-5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-1.25rem * var(--space-y-reverse));
 }
 
-.-space-x-5 > :not(template) ~ :not(template) {
+.-space-x-5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
   margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-6 > :not(template) ~ :not(template) {
+.-space-y-6 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-1.5rem * var(--space-y-reverse));
 }
 
-.-space-x-6 > :not(template) ~ :not(template) {
+.-space-x-6 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
   margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-7 > :not(template) ~ :not(template) {
+.-space-y-7 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-1.75rem * var(--space-y-reverse));
 }
 
-.-space-x-7 > :not(template) ~ :not(template) {
+.-space-x-7 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
   margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-8 > :not(template) ~ :not(template) {
+.-space-y-8 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-2rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-2rem * var(--space-y-reverse));
 }
 
-.-space-x-8 > :not(template) ~ :not(template) {
+.-space-x-8 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-2rem * var(--space-x-reverse));
   margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-9 > :not(template) ~ :not(template) {
+.-space-y-9 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-2.25rem * var(--space-y-reverse));
 }
 
-.-space-x-9 > :not(template) ~ :not(template) {
+.-space-x-9 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
   margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-10 > :not(template) ~ :not(template) {
+.-space-y-10 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-2.5rem * var(--space-y-reverse));
 }
 
-.-space-x-10 > :not(template) ~ :not(template) {
+.-space-x-10 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
   margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-12 > :not(template) ~ :not(template) {
+.-space-y-12 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-3rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-3rem * var(--space-y-reverse));
 }
 
-.-space-x-12 > :not(template) ~ :not(template) {
+.-space-x-12 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-3rem * var(--space-x-reverse));
   margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-14 > :not(template) ~ :not(template) {
+.-space-y-14 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-3.5rem * var(--space-y-reverse));
 }
 
-.-space-x-14 > :not(template) ~ :not(template) {
+.-space-x-14 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
   margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-16 > :not(template) ~ :not(template) {
+.-space-y-16 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-4rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-4rem * var(--space-y-reverse));
 }
 
-.-space-x-16 > :not(template) ~ :not(template) {
+.-space-x-16 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-4rem * var(--space-x-reverse));
   margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-20 > :not(template) ~ :not(template) {
+.-space-y-20 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-5rem * var(--space-y-reverse));
 }
 
-.-space-x-20 > :not(template) ~ :not(template) {
+.-space-x-20 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-5rem * var(--space-x-reverse));
   margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-24 > :not(template) ~ :not(template) {
+.-space-y-24 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-6rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-6rem * var(--space-y-reverse));
 }
 
-.-space-x-24 > :not(template) ~ :not(template) {
+.-space-x-24 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-6rem * var(--space-x-reverse));
   margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-28 > :not(template) ~ :not(template) {
+.-space-y-28 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-7rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-7rem * var(--space-y-reverse));
 }
 
-.-space-x-28 > :not(template) ~ :not(template) {
+.-space-x-28 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-7rem * var(--space-x-reverse));
   margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-32 > :not(template) ~ :not(template) {
+.-space-y-32 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-8rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-8rem * var(--space-y-reverse));
 }
 
-.-space-x-32 > :not(template) ~ :not(template) {
+.-space-x-32 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-8rem * var(--space-x-reverse));
   margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-36 > :not(template) ~ :not(template) {
+.-space-y-36 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-9rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-9rem * var(--space-y-reverse));
 }
 
-.-space-x-36 > :not(template) ~ :not(template) {
+.-space-x-36 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-9rem * var(--space-x-reverse));
   margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-40 > :not(template) ~ :not(template) {
+.-space-y-40 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-10rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-10rem * var(--space-y-reverse));
 }
 
-.-space-x-40 > :not(template) ~ :not(template) {
+.-space-x-40 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-10rem * var(--space-x-reverse));
   margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-44 > :not(template) ~ :not(template) {
+.-space-y-44 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-11rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-11rem * var(--space-y-reverse));
 }
 
-.-space-x-44 > :not(template) ~ :not(template) {
+.-space-x-44 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-11rem * var(--space-x-reverse));
   margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-48 > :not(template) ~ :not(template) {
+.-space-y-48 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-12rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-12rem * var(--space-y-reverse));
 }
 
-.-space-x-48 > :not(template) ~ :not(template) {
+.-space-x-48 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-12rem * var(--space-x-reverse));
   margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-52 > :not(template) ~ :not(template) {
+.-space-y-52 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-13rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-13rem * var(--space-y-reverse));
 }
 
-.-space-x-52 > :not(template) ~ :not(template) {
+.-space-x-52 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-13rem * var(--space-x-reverse));
   margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-56 > :not(template) ~ :not(template) {
+.-space-y-56 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-14rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-14rem * var(--space-y-reverse));
 }
 
-.-space-x-56 > :not(template) ~ :not(template) {
+.-space-x-56 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-14rem * var(--space-x-reverse));
   margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-60 > :not(template) ~ :not(template) {
+.-space-y-60 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-15rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-15rem * var(--space-y-reverse));
 }
 
-.-space-x-60 > :not(template) ~ :not(template) {
+.-space-x-60 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-15rem * var(--space-x-reverse));
   margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-64 > :not(template) ~ :not(template) {
+.-space-y-64 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-16rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-16rem * var(--space-y-reverse));
 }
 
-.-space-x-64 > :not(template) ~ :not(template) {
+.-space-x-64 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-16rem * var(--space-x-reverse));
   margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-72 > :not(template) ~ :not(template) {
+.-space-y-72 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-18rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-18rem * var(--space-y-reverse));
 }
 
-.-space-x-72 > :not(template) ~ :not(template) {
+.-space-x-72 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-18rem * var(--space-x-reverse));
   margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-80 > :not(template) ~ :not(template) {
+.-space-y-80 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-20rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-20rem * var(--space-y-reverse));
 }
 
-.-space-x-80 > :not(template) ~ :not(template) {
+.-space-x-80 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-20rem * var(--space-x-reverse));
   margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-96 > :not(template) ~ :not(template) {
+.-space-y-96 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-24rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-24rem * var(--space-y-reverse));
 }
 
-.-space-x-96 > :not(template) ~ :not(template) {
+.-space-x-96 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-24rem * var(--space-x-reverse));
   margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-px > :not(template) ~ :not(template) {
+.-space-y-px > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-1px * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-1px * var(--space-y-reverse));
 }
 
-.-space-x-px > :not(template) ~ :not(template) {
+.-space-x-px > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-1px * var(--space-x-reverse));
   margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-0\.5 > :not(template) ~ :not(template) {
+.-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-0.125rem * var(--space-y-reverse));
 }
 
-.-space-x-0\.5 > :not(template) ~ :not(template) {
+.-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
   margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-1\.5 > :not(template) ~ :not(template) {
+.-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-0.375rem * var(--space-y-reverse));
 }
 
-.-space-x-1\.5 > :not(template) ~ :not(template) {
+.-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
   margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-2\.5 > :not(template) ~ :not(template) {
+.-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-0.625rem * var(--space-y-reverse));
 }
 
-.-space-x-2\.5 > :not(template) ~ :not(template) {
+.-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
   margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-3\.5 > :not(template) ~ :not(template) {
+.-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-0.875rem * var(--space-y-reverse));
 }
 
-.-space-x-3\.5 > :not(template) ~ :not(template) {
+.-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
   margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-reverse > :not(template) ~ :not(template) {
+.space-y-reverse > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 1;
 }
 
-.space-x-reverse > :not(template) ~ :not(template) {
+.space-x-reverse > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 1;
 }
 
-.divide-y-0 > :not(template) ~ :not(template) {
+.divide-y-0 > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 0;
   border-top-width: calc(0px * calc(1 - var(--divide-y-reverse)));
   border-bottom-width: calc(0px * var(--divide-y-reverse));
 }
 
-.divide-x-0 > :not(template) ~ :not(template) {
+.divide-x-0 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
   border-inline-end-width: calc(0px * var(--divide-x-reverse));
   border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
 }
 
-.divide-y-2 > :not(template) ~ :not(template) {
+.divide-y-2 > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 0;
   border-top-width: calc(2px * calc(1 - var(--divide-y-reverse)));
   border-bottom-width: calc(2px * var(--divide-y-reverse));
 }
 
-.divide-x-2 > :not(template) ~ :not(template) {
+.divide-x-2 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
   border-inline-end-width: calc(2px * var(--divide-x-reverse));
   border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
 }
 
-.divide-y-4 > :not(template) ~ :not(template) {
+.divide-y-4 > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 0;
   border-top-width: calc(4px * calc(1 - var(--divide-y-reverse)));
   border-bottom-width: calc(4px * var(--divide-y-reverse));
 }
 
-.divide-x-4 > :not(template) ~ :not(template) {
+.divide-x-4 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
   border-inline-end-width: calc(4px * var(--divide-x-reverse));
   border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
 }
 
-.divide-y-8 > :not(template) ~ :not(template) {
+.divide-y-8 > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 0;
   border-top-width: calc(8px * calc(1 - var(--divide-y-reverse)));
   border-bottom-width: calc(8px * var(--divide-y-reverse));
 }
 
-.divide-x-8 > :not(template) ~ :not(template) {
+.divide-x-8 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
   border-inline-end-width: calc(8px * var(--divide-x-reverse));
   border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
 }
 
-.divide-y > :not(template) ~ :not(template) {
+.divide-y > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 0;
   border-top-width: calc(1px * calc(1 - var(--divide-y-reverse)));
   border-bottom-width: calc(1px * var(--divide-y-reverse));
 }
 
-.divide-x > :not(template) ~ :not(template) {
+.divide-x > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
   border-inline-end-width: calc(1px * var(--divide-x-reverse));
   border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
 }
 
-.divide-y-reverse > :not(template) ~ :not(template) {
+.divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 1;
 }
 
-.divide-x-reverse > :not(template) ~ :not(template) {
+.divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 1;
 }
 
-.divide-transparent > :not(template) ~ :not(template) {
+.divide-transparent > :not([hidden]) ~ :not([hidden]) {
   border-color: transparent;
 }
 
-.divide-current > :not(template) ~ :not(template) {
+.divide-current > :not([hidden]) ~ :not([hidden]) {
   border-color: currentColor;
 }
 
-.divide-black > :not(template) ~ :not(template) {
+.divide-black > :not([hidden]) ~ :not([hidden]) {
   border-color: #000;
 }
 
-.divide-white > :not(template) ~ :not(template) {
+.divide-white > :not([hidden]) ~ :not([hidden]) {
   border-color: #fff;
 }
 
-.divide-gray-50 > :not(template) ~ :not(template) {
+.divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
   border-color: #fafafa;
 }
 
-.divide-gray-100 > :not(template) ~ :not(template) {
+.divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
   border-color: #f4f4f5;
 }
 
-.divide-gray-200 > :not(template) ~ :not(template) {
+.divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
   border-color: #e4e4e7;
 }
 
-.divide-gray-300 > :not(template) ~ :not(template) {
+.divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
   border-color: #d4d4d8;
 }
 
-.divide-gray-400 > :not(template) ~ :not(template) {
+.divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
   border-color: #a1a1aa;
 }
 
-.divide-gray-500 > :not(template) ~ :not(template) {
+.divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
   border-color: #71717a;
 }
 
-.divide-gray-600 > :not(template) ~ :not(template) {
+.divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
   border-color: #52525b;
 }
 
-.divide-gray-700 > :not(template) ~ :not(template) {
+.divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
   border-color: #3f3f46;
 }
 
-.divide-gray-800 > :not(template) ~ :not(template) {
+.divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
   border-color: #27272a;
 }
 
-.divide-gray-900 > :not(template) ~ :not(template) {
+.divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
   border-color: #18181b;
 }
 
-.divide-red-50 > :not(template) ~ :not(template) {
+.divide-red-50 > :not([hidden]) ~ :not([hidden]) {
   border-color: #fef2f2;
 }
 
-.divide-red-100 > :not(template) ~ :not(template) {
+.divide-red-100 > :not([hidden]) ~ :not([hidden]) {
   border-color: #fee2e2;
 }
 
-.divide-red-200 > :not(template) ~ :not(template) {
+.divide-red-200 > :not([hidden]) ~ :not([hidden]) {
   border-color: #fecaca;
 }
 
-.divide-red-300 > :not(template) ~ :not(template) {
+.divide-red-300 > :not([hidden]) ~ :not([hidden]) {
   border-color: #fca5a5;
 }
 
-.divide-red-400 > :not(template) ~ :not(template) {
+.divide-red-400 > :not([hidden]) ~ :not([hidden]) {
   border-color: #f87171;
 }
 
-.divide-red-500 > :not(template) ~ :not(template) {
+.divide-red-500 > :not([hidden]) ~ :not([hidden]) {
   border-color: #ef4444;
 }
 
-.divide-red-600 > :not(template) ~ :not(template) {
+.divide-red-600 > :not([hidden]) ~ :not([hidden]) {
   border-color: #dc2626;
 }
 
-.divide-red-700 > :not(template) ~ :not(template) {
+.divide-red-700 > :not([hidden]) ~ :not([hidden]) {
   border-color: #b91c1c;
 }
 
-.divide-red-800 > :not(template) ~ :not(template) {
+.divide-red-800 > :not([hidden]) ~ :not([hidden]) {
   border-color: #991b1b;
 }
 
-.divide-red-900 > :not(template) ~ :not(template) {
+.divide-red-900 > :not([hidden]) ~ :not([hidden]) {
   border-color: #7f1d1d;
 }
 
-.divide-yellow-50 > :not(template) ~ :not(template) {
+.divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
   border-color: #fffbeb;
 }
 
-.divide-yellow-100 > :not(template) ~ :not(template) {
+.divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
   border-color: #fef3c7;
 }
 
-.divide-yellow-200 > :not(template) ~ :not(template) {
+.divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
   border-color: #fde68a;
 }
 
-.divide-yellow-300 > :not(template) ~ :not(template) {
+.divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
   border-color: #fcd34d;
 }
 
-.divide-yellow-400 > :not(template) ~ :not(template) {
+.divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
   border-color: #fbbf24;
 }
 
-.divide-yellow-500 > :not(template) ~ :not(template) {
+.divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
   border-color: #f59e0b;
 }
 
-.divide-yellow-600 > :not(template) ~ :not(template) {
+.divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
   border-color: #d97706;
 }
 
-.divide-yellow-700 > :not(template) ~ :not(template) {
+.divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
   border-color: #b45309;
 }
 
-.divide-yellow-800 > :not(template) ~ :not(template) {
+.divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
   border-color: #92400e;
 }
 
-.divide-yellow-900 > :not(template) ~ :not(template) {
+.divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
   border-color: #78350f;
 }
 
-.divide-green-50 > :not(template) ~ :not(template) {
+.divide-green-50 > :not([hidden]) ~ :not([hidden]) {
   border-color: #ecfdf5;
 }
 
-.divide-green-100 > :not(template) ~ :not(template) {
+.divide-green-100 > :not([hidden]) ~ :not([hidden]) {
   border-color: #d1fae5;
 }
 
-.divide-green-200 > :not(template) ~ :not(template) {
+.divide-green-200 > :not([hidden]) ~ :not([hidden]) {
   border-color: #a7f3d0;
 }
 
-.divide-green-300 > :not(template) ~ :not(template) {
+.divide-green-300 > :not([hidden]) ~ :not([hidden]) {
   border-color: #6ee7b7;
 }
 
-.divide-green-400 > :not(template) ~ :not(template) {
+.divide-green-400 > :not([hidden]) ~ :not([hidden]) {
   border-color: #34d399;
 }
 
-.divide-green-500 > :not(template) ~ :not(template) {
+.divide-green-500 > :not([hidden]) ~ :not([hidden]) {
   border-color: #10b981;
 }
 
-.divide-green-600 > :not(template) ~ :not(template) {
+.divide-green-600 > :not([hidden]) ~ :not([hidden]) {
   border-color: #059669;
 }
 
-.divide-green-700 > :not(template) ~ :not(template) {
+.divide-green-700 > :not([hidden]) ~ :not([hidden]) {
   border-color: #047857;
 }
 
-.divide-green-800 > :not(template) ~ :not(template) {
+.divide-green-800 > :not([hidden]) ~ :not([hidden]) {
   border-color: #065f46;
 }
 
-.divide-green-900 > :not(template) ~ :not(template) {
+.divide-green-900 > :not([hidden]) ~ :not([hidden]) {
   border-color: #064e3b;
 }
 
-.divide-blue-50 > :not(template) ~ :not(template) {
+.divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
   border-color: #eff6ff;
 }
 
-.divide-blue-100 > :not(template) ~ :not(template) {
+.divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
   border-color: #dbeafe;
 }
 
-.divide-blue-200 > :not(template) ~ :not(template) {
+.divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
   border-color: #bfdbfe;
 }
 
-.divide-blue-300 > :not(template) ~ :not(template) {
+.divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
   border-color: #93c5fd;
 }
 
-.divide-blue-400 > :not(template) ~ :not(template) {
+.divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
   border-color: #60a5fa;
 }
 
-.divide-blue-500 > :not(template) ~ :not(template) {
+.divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
   border-color: #3b82f6;
 }
 
-.divide-blue-600 > :not(template) ~ :not(template) {
+.divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
   border-color: #2563eb;
 }
 
-.divide-blue-700 > :not(template) ~ :not(template) {
+.divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
   border-color: #1d4ed8;
 }
 
-.divide-blue-800 > :not(template) ~ :not(template) {
+.divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
   border-color: #1e40af;
 }
 
-.divide-blue-900 > :not(template) ~ :not(template) {
+.divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
   border-color: #1e3a8a;
 }
 
-.divide-purple-50 > :not(template) ~ :not(template) {
+.divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
   border-color: #f5f3ff;
 }
 
-.divide-purple-100 > :not(template) ~ :not(template) {
+.divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
   border-color: #ede9fe;
 }
 
-.divide-purple-200 > :not(template) ~ :not(template) {
+.divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
   border-color: #ddd6fe;
 }
 
-.divide-purple-300 > :not(template) ~ :not(template) {
+.divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
   border-color: #c4b5fd;
 }
 
-.divide-purple-400 > :not(template) ~ :not(template) {
+.divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
   border-color: #a78bfa;
 }
 
-.divide-purple-500 > :not(template) ~ :not(template) {
+.divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
   border-color: #8b5cf6;
 }
 
-.divide-purple-600 > :not(template) ~ :not(template) {
+.divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
   border-color: #7c3aed;
 }
 
-.divide-purple-700 > :not(template) ~ :not(template) {
+.divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
   border-color: #6d28d9;
 }
 
-.divide-purple-800 > :not(template) ~ :not(template) {
+.divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
   border-color: #5b21b6;
 }
 
-.divide-purple-900 > :not(template) ~ :not(template) {
+.divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
   border-color: #4c1d95;
 }
 
-.divide-pink-50 > :not(template) ~ :not(template) {
+.divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
   border-color: #fdf2f8;
 }
 
-.divide-pink-100 > :not(template) ~ :not(template) {
+.divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
   border-color: #fce7f3;
 }
 
-.divide-pink-200 > :not(template) ~ :not(template) {
+.divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
   border-color: #fbcfe8;
 }
 
-.divide-pink-300 > :not(template) ~ :not(template) {
+.divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
   border-color: #f9a8d4;
 }
 
-.divide-pink-400 > :not(template) ~ :not(template) {
+.divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
   border-color: #f472b6;
 }
 
-.divide-pink-500 > :not(template) ~ :not(template) {
+.divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
   border-color: #ec4899;
 }
 
-.divide-pink-600 > :not(template) ~ :not(template) {
+.divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
   border-color: #db2777;
 }
 
-.divide-pink-700 > :not(template) ~ :not(template) {
+.divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
   border-color: #be185d;
 }
 
-.divide-pink-800 > :not(template) ~ :not(template) {
+.divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
   border-color: #9d174d;
 }
 
-.divide-pink-900 > :not(template) ~ :not(template) {
+.divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
   border-color: #831843;
 }
 
-.divide-solid > :not(template) ~ :not(template) {
+.divide-solid > :not([hidden]) ~ :not([hidden]) {
   border-style: solid;
 }
 
-.divide-dashed > :not(template) ~ :not(template) {
+.divide-dashed > :not([hidden]) ~ :not([hidden]) {
   border-style: dashed;
 }
 
-.divide-dotted > :not(template) ~ :not(template) {
+.divide-dotted > :not([hidden]) ~ :not([hidden]) {
   border-style: dotted;
 }
 
-.divide-double > :not(template) ~ :not(template) {
+.divide-double > :not([hidden]) ~ :not([hidden]) {
   border-style: double;
 }
 
-.divide-none > :not(template) ~ :not(template) {
+.divide-none > :not([hidden]) ~ :not([hidden]) {
   border-style: none;
 }
 
@@ -21676,1199 +21676,1199 @@ video {
     }
   }
 
-  .sm\:space-y-0 > :not(template) ~ :not(template) {
+  .sm\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0px * var(--space-y-reverse));
   }
 
-  .sm\:space-x-0 > :not(template) ~ :not(template) {
+  .sm\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0px * var(--space-x-reverse));
     margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-1 > :not(template) ~ :not(template) {
+  .sm\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.25rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-1 > :not(template) ~ :not(template) {
+  .sm\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-2 > :not(template) ~ :not(template) {
+  .sm\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.5rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-2 > :not(template) ~ :not(template) {
+  .sm\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-3 > :not(template) ~ :not(template) {
+  .sm\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.75rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-3 > :not(template) ~ :not(template) {
+  .sm\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-4 > :not(template) ~ :not(template) {
+  .sm\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-4 > :not(template) ~ :not(template) {
+  .sm\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1rem * var(--space-x-reverse));
     margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-5 > :not(template) ~ :not(template) {
+  .sm\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.25rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-5 > :not(template) ~ :not(template) {
+  .sm\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-6 > :not(template) ~ :not(template) {
+  .sm\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.5rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-6 > :not(template) ~ :not(template) {
+  .sm\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-7 > :not(template) ~ :not(template) {
+  .sm\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.75rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-7 > :not(template) ~ :not(template) {
+  .sm\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-8 > :not(template) ~ :not(template) {
+  .sm\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-8 > :not(template) ~ :not(template) {
+  .sm\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2rem * var(--space-x-reverse));
     margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-9 > :not(template) ~ :not(template) {
+  .sm\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.25rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-9 > :not(template) ~ :not(template) {
+  .sm\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-10 > :not(template) ~ :not(template) {
+  .sm\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.5rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-10 > :not(template) ~ :not(template) {
+  .sm\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-12 > :not(template) ~ :not(template) {
+  .sm\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-12 > :not(template) ~ :not(template) {
+  .sm\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3rem * var(--space-x-reverse));
     margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-14 > :not(template) ~ :not(template) {
+  .sm\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3.5rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-14 > :not(template) ~ :not(template) {
+  .sm\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-16 > :not(template) ~ :not(template) {
+  .sm\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(4rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-16 > :not(template) ~ :not(template) {
+  .sm\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(4rem * var(--space-x-reverse));
     margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-20 > :not(template) ~ :not(template) {
+  .sm\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(5rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-20 > :not(template) ~ :not(template) {
+  .sm\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(5rem * var(--space-x-reverse));
     margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-24 > :not(template) ~ :not(template) {
+  .sm\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(6rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-24 > :not(template) ~ :not(template) {
+  .sm\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(6rem * var(--space-x-reverse));
     margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-28 > :not(template) ~ :not(template) {
+  .sm\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(7rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-28 > :not(template) ~ :not(template) {
+  .sm\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(7rem * var(--space-x-reverse));
     margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-32 > :not(template) ~ :not(template) {
+  .sm\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(8rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-32 > :not(template) ~ :not(template) {
+  .sm\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(8rem * var(--space-x-reverse));
     margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-36 > :not(template) ~ :not(template) {
+  .sm\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(9rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-36 > :not(template) ~ :not(template) {
+  .sm\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(9rem * var(--space-x-reverse));
     margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-40 > :not(template) ~ :not(template) {
+  .sm\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(10rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-40 > :not(template) ~ :not(template) {
+  .sm\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(10rem * var(--space-x-reverse));
     margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-44 > :not(template) ~ :not(template) {
+  .sm\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(11rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-44 > :not(template) ~ :not(template) {
+  .sm\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(11rem * var(--space-x-reverse));
     margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-48 > :not(template) ~ :not(template) {
+  .sm\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(12rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-48 > :not(template) ~ :not(template) {
+  .sm\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(12rem * var(--space-x-reverse));
     margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-52 > :not(template) ~ :not(template) {
+  .sm\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(13rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-52 > :not(template) ~ :not(template) {
+  .sm\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(13rem * var(--space-x-reverse));
     margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-56 > :not(template) ~ :not(template) {
+  .sm\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(14rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-56 > :not(template) ~ :not(template) {
+  .sm\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(14rem * var(--space-x-reverse));
     margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-60 > :not(template) ~ :not(template) {
+  .sm\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(15rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-60 > :not(template) ~ :not(template) {
+  .sm\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(15rem * var(--space-x-reverse));
     margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-64 > :not(template) ~ :not(template) {
+  .sm\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(16rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-64 > :not(template) ~ :not(template) {
+  .sm\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(16rem * var(--space-x-reverse));
     margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-72 > :not(template) ~ :not(template) {
+  .sm\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(18rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-72 > :not(template) ~ :not(template) {
+  .sm\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(18rem * var(--space-x-reverse));
     margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-80 > :not(template) ~ :not(template) {
+  .sm\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(20rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-80 > :not(template) ~ :not(template) {
+  .sm\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(20rem * var(--space-x-reverse));
     margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-96 > :not(template) ~ :not(template) {
+  .sm\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(24rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-96 > :not(template) ~ :not(template) {
+  .sm\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(24rem * var(--space-x-reverse));
     margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-px > :not(template) ~ :not(template) {
+  .sm\:space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1px * var(--space-y-reverse));
   }
 
-  .sm\:space-x-px > :not(template) ~ :not(template) {
+  .sm\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1px * var(--space-x-reverse));
     margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-0\.5 > :not(template) ~ :not(template) {
+  .sm\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.125rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-0\.5 > :not(template) ~ :not(template) {
+  .sm\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-1\.5 > :not(template) ~ :not(template) {
+  .sm\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.375rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-1\.5 > :not(template) ~ :not(template) {
+  .sm\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-2\.5 > :not(template) ~ :not(template) {
+  .sm\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.625rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-2\.5 > :not(template) ~ :not(template) {
+  .sm\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-3\.5 > :not(template) ~ :not(template) {
+  .sm\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.875rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-3\.5 > :not(template) ~ :not(template) {
+  .sm\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-1 > :not(template) ~ :not(template) {
+  .sm\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.25rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-1 > :not(template) ~ :not(template) {
+  .sm\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-2 > :not(template) ~ :not(template) {
+  .sm\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.5rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-2 > :not(template) ~ :not(template) {
+  .sm\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-3 > :not(template) ~ :not(template) {
+  .sm\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.75rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-3 > :not(template) ~ :not(template) {
+  .sm\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-4 > :not(template) ~ :not(template) {
+  .sm\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-4 > :not(template) ~ :not(template) {
+  .sm\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1rem * var(--space-x-reverse));
     margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-5 > :not(template) ~ :not(template) {
+  .sm\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.25rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-5 > :not(template) ~ :not(template) {
+  .sm\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-6 > :not(template) ~ :not(template) {
+  .sm\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.5rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-6 > :not(template) ~ :not(template) {
+  .sm\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-7 > :not(template) ~ :not(template) {
+  .sm\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.75rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-7 > :not(template) ~ :not(template) {
+  .sm\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-8 > :not(template) ~ :not(template) {
+  .sm\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-8 > :not(template) ~ :not(template) {
+  .sm\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2rem * var(--space-x-reverse));
     margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-9 > :not(template) ~ :not(template) {
+  .sm\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.25rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-9 > :not(template) ~ :not(template) {
+  .sm\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-10 > :not(template) ~ :not(template) {
+  .sm\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.5rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-10 > :not(template) ~ :not(template) {
+  .sm\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-12 > :not(template) ~ :not(template) {
+  .sm\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-12 > :not(template) ~ :not(template) {
+  .sm\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3rem * var(--space-x-reverse));
     margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-14 > :not(template) ~ :not(template) {
+  .sm\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3.5rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-14 > :not(template) ~ :not(template) {
+  .sm\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-16 > :not(template) ~ :not(template) {
+  .sm\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-4rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-16 > :not(template) ~ :not(template) {
+  .sm\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-4rem * var(--space-x-reverse));
     margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-20 > :not(template) ~ :not(template) {
+  .sm\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-5rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-20 > :not(template) ~ :not(template) {
+  .sm\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-5rem * var(--space-x-reverse));
     margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-24 > :not(template) ~ :not(template) {
+  .sm\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-6rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-24 > :not(template) ~ :not(template) {
+  .sm\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-6rem * var(--space-x-reverse));
     margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-28 > :not(template) ~ :not(template) {
+  .sm\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-7rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-28 > :not(template) ~ :not(template) {
+  .sm\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-7rem * var(--space-x-reverse));
     margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-32 > :not(template) ~ :not(template) {
+  .sm\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-8rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-32 > :not(template) ~ :not(template) {
+  .sm\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-8rem * var(--space-x-reverse));
     margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-36 > :not(template) ~ :not(template) {
+  .sm\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-9rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-36 > :not(template) ~ :not(template) {
+  .sm\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-9rem * var(--space-x-reverse));
     margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-40 > :not(template) ~ :not(template) {
+  .sm\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-10rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-40 > :not(template) ~ :not(template) {
+  .sm\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-10rem * var(--space-x-reverse));
     margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-44 > :not(template) ~ :not(template) {
+  .sm\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-11rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-44 > :not(template) ~ :not(template) {
+  .sm\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-11rem * var(--space-x-reverse));
     margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-48 > :not(template) ~ :not(template) {
+  .sm\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-12rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-48 > :not(template) ~ :not(template) {
+  .sm\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-12rem * var(--space-x-reverse));
     margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-52 > :not(template) ~ :not(template) {
+  .sm\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-13rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-52 > :not(template) ~ :not(template) {
+  .sm\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-13rem * var(--space-x-reverse));
     margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-56 > :not(template) ~ :not(template) {
+  .sm\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-14rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-56 > :not(template) ~ :not(template) {
+  .sm\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-14rem * var(--space-x-reverse));
     margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-60 > :not(template) ~ :not(template) {
+  .sm\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-15rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-60 > :not(template) ~ :not(template) {
+  .sm\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-15rem * var(--space-x-reverse));
     margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-64 > :not(template) ~ :not(template) {
+  .sm\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-16rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-64 > :not(template) ~ :not(template) {
+  .sm\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-16rem * var(--space-x-reverse));
     margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-72 > :not(template) ~ :not(template) {
+  .sm\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-18rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-72 > :not(template) ~ :not(template) {
+  .sm\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-18rem * var(--space-x-reverse));
     margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-80 > :not(template) ~ :not(template) {
+  .sm\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-20rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-80 > :not(template) ~ :not(template) {
+  .sm\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-20rem * var(--space-x-reverse));
     margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-96 > :not(template) ~ :not(template) {
+  .sm\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-24rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-96 > :not(template) ~ :not(template) {
+  .sm\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-24rem * var(--space-x-reverse));
     margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-px > :not(template) ~ :not(template) {
+  .sm\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1px * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-px > :not(template) ~ :not(template) {
+  .sm\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1px * var(--space-x-reverse));
     margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-0\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.125rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-0\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-1\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.375rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-1\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-2\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.625rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-2\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-3\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.875rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-3\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-reverse > :not(template) ~ :not(template) {
+  .sm\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 1;
   }
 
-  .sm\:space-x-reverse > :not(template) ~ :not(template) {
+  .sm\:space-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 1;
   }
 
-  .sm\:divide-y-0 > :not(template) ~ :not(template) {
+  .sm\:divide-y-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(0px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(0px * var(--divide-y-reverse));
   }
 
-  .sm\:divide-x-0 > :not(template) ~ :not(template) {
+  .sm\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(0px * var(--divide-x-reverse));
     border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .sm\:divide-y-2 > :not(template) ~ :not(template) {
+  .sm\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(2px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(2px * var(--divide-y-reverse));
   }
 
-  .sm\:divide-x-2 > :not(template) ~ :not(template) {
+  .sm\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(2px * var(--divide-x-reverse));
     border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .sm\:divide-y-4 > :not(template) ~ :not(template) {
+  .sm\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(4px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(4px * var(--divide-y-reverse));
   }
 
-  .sm\:divide-x-4 > :not(template) ~ :not(template) {
+  .sm\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(4px * var(--divide-x-reverse));
     border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .sm\:divide-y-8 > :not(template) ~ :not(template) {
+  .sm\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(8px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(8px * var(--divide-y-reverse));
   }
 
-  .sm\:divide-x-8 > :not(template) ~ :not(template) {
+  .sm\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(8px * var(--divide-x-reverse));
     border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .sm\:divide-y > :not(template) ~ :not(template) {
+  .sm\:divide-y > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(1px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(1px * var(--divide-y-reverse));
   }
 
-  .sm\:divide-x > :not(template) ~ :not(template) {
+  .sm\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(1px * var(--divide-x-reverse));
     border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .sm\:divide-y-reverse > :not(template) ~ :not(template) {
+  .sm\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 1;
   }
 
-  .sm\:divide-x-reverse > :not(template) ~ :not(template) {
+  .sm\:divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 1;
   }
 
-  .sm\:divide-transparent > :not(template) ~ :not(template) {
+  .sm\:divide-transparent > :not([hidden]) ~ :not([hidden]) {
     border-color: transparent;
   }
 
-  .sm\:divide-current > :not(template) ~ :not(template) {
+  .sm\:divide-current > :not([hidden]) ~ :not([hidden]) {
     border-color: currentColor;
   }
 
-  .sm\:divide-black > :not(template) ~ :not(template) {
+  .sm\:divide-black > :not([hidden]) ~ :not([hidden]) {
     border-color: #000;
   }
 
-  .sm\:divide-white > :not(template) ~ :not(template) {
+  .sm\:divide-white > :not([hidden]) ~ :not([hidden]) {
     border-color: #fff;
   }
 
-  .sm\:divide-gray-50 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fafafa;
   }
 
-  .sm\:divide-gray-100 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f4f4f5;
   }
 
-  .sm\:divide-gray-200 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #e4e4e7;
   }
 
-  .sm\:divide-gray-300 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #d4d4d8;
   }
 
-  .sm\:divide-gray-400 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #a1a1aa;
   }
 
-  .sm\:divide-gray-500 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #71717a;
   }
 
-  .sm\:divide-gray-600 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #52525b;
   }
 
-  .sm\:divide-gray-700 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #3f3f46;
   }
 
-  .sm\:divide-gray-800 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #27272a;
   }
 
-  .sm\:divide-gray-900 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #18181b;
   }
 
-  .sm\:divide-red-50 > :not(template) ~ :not(template) {
+  .sm\:divide-red-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fef2f2;
   }
 
-  .sm\:divide-red-100 > :not(template) ~ :not(template) {
+  .sm\:divide-red-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fee2e2;
   }
 
-  .sm\:divide-red-200 > :not(template) ~ :not(template) {
+  .sm\:divide-red-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fecaca;
   }
 
-  .sm\:divide-red-300 > :not(template) ~ :not(template) {
+  .sm\:divide-red-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fca5a5;
   }
 
-  .sm\:divide-red-400 > :not(template) ~ :not(template) {
+  .sm\:divide-red-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f87171;
   }
 
-  .sm\:divide-red-500 > :not(template) ~ :not(template) {
+  .sm\:divide-red-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ef4444;
   }
 
-  .sm\:divide-red-600 > :not(template) ~ :not(template) {
+  .sm\:divide-red-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #dc2626;
   }
 
-  .sm\:divide-red-700 > :not(template) ~ :not(template) {
+  .sm\:divide-red-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #b91c1c;
   }
 
-  .sm\:divide-red-800 > :not(template) ~ :not(template) {
+  .sm\:divide-red-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #991b1b;
   }
 
-  .sm\:divide-red-900 > :not(template) ~ :not(template) {
+  .sm\:divide-red-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #7f1d1d;
   }
 
-  .sm\:divide-yellow-50 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fffbeb;
   }
 
-  .sm\:divide-yellow-100 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fef3c7;
   }
 
-  .sm\:divide-yellow-200 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fde68a;
   }
 
-  .sm\:divide-yellow-300 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fcd34d;
   }
 
-  .sm\:divide-yellow-400 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fbbf24;
   }
 
-  .sm\:divide-yellow-500 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f59e0b;
   }
 
-  .sm\:divide-yellow-600 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #d97706;
   }
 
-  .sm\:divide-yellow-700 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #b45309;
   }
 
-  .sm\:divide-yellow-800 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #92400e;
   }
 
-  .sm\:divide-yellow-900 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #78350f;
   }
 
-  .sm\:divide-green-50 > :not(template) ~ :not(template) {
+  .sm\:divide-green-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ecfdf5;
   }
 
-  .sm\:divide-green-100 > :not(template) ~ :not(template) {
+  .sm\:divide-green-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #d1fae5;
   }
 
-  .sm\:divide-green-200 > :not(template) ~ :not(template) {
+  .sm\:divide-green-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #a7f3d0;
   }
 
-  .sm\:divide-green-300 > :not(template) ~ :not(template) {
+  .sm\:divide-green-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #6ee7b7;
   }
 
-  .sm\:divide-green-400 > :not(template) ~ :not(template) {
+  .sm\:divide-green-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #34d399;
   }
 
-  .sm\:divide-green-500 > :not(template) ~ :not(template) {
+  .sm\:divide-green-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #10b981;
   }
 
-  .sm\:divide-green-600 > :not(template) ~ :not(template) {
+  .sm\:divide-green-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #059669;
   }
 
-  .sm\:divide-green-700 > :not(template) ~ :not(template) {
+  .sm\:divide-green-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #047857;
   }
 
-  .sm\:divide-green-800 > :not(template) ~ :not(template) {
+  .sm\:divide-green-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #065f46;
   }
 
-  .sm\:divide-green-900 > :not(template) ~ :not(template) {
+  .sm\:divide-green-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #064e3b;
   }
 
-  .sm\:divide-blue-50 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #eff6ff;
   }
 
-  .sm\:divide-blue-100 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #dbeafe;
   }
 
-  .sm\:divide-blue-200 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #bfdbfe;
   }
 
-  .sm\:divide-blue-300 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #93c5fd;
   }
 
-  .sm\:divide-blue-400 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #60a5fa;
   }
 
-  .sm\:divide-blue-500 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #3b82f6;
   }
 
-  .sm\:divide-blue-600 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #2563eb;
   }
 
-  .sm\:divide-blue-700 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #1d4ed8;
   }
 
-  .sm\:divide-blue-800 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #1e40af;
   }
 
-  .sm\:divide-blue-900 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #1e3a8a;
   }
 
-  .sm\:divide-purple-50 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f5f3ff;
   }
 
-  .sm\:divide-purple-100 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ede9fe;
   }
 
-  .sm\:divide-purple-200 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ddd6fe;
   }
 
-  .sm\:divide-purple-300 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #c4b5fd;
   }
 
-  .sm\:divide-purple-400 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #a78bfa;
   }
 
-  .sm\:divide-purple-500 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #8b5cf6;
   }
 
-  .sm\:divide-purple-600 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #7c3aed;
   }
 
-  .sm\:divide-purple-700 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #6d28d9;
   }
 
-  .sm\:divide-purple-800 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #5b21b6;
   }
 
-  .sm\:divide-purple-900 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #4c1d95;
   }
 
-  .sm\:divide-pink-50 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fdf2f8;
   }
 
-  .sm\:divide-pink-100 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fce7f3;
   }
 
-  .sm\:divide-pink-200 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fbcfe8;
   }
 
-  .sm\:divide-pink-300 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f9a8d4;
   }
 
-  .sm\:divide-pink-400 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f472b6;
   }
 
-  .sm\:divide-pink-500 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ec4899;
   }
 
-  .sm\:divide-pink-600 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #db2777;
   }
 
-  .sm\:divide-pink-700 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #be185d;
   }
 
-  .sm\:divide-pink-800 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #9d174d;
   }
 
-  .sm\:divide-pink-900 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #831843;
   }
 
-  .sm\:divide-solid > :not(template) ~ :not(template) {
+  .sm\:divide-solid > :not([hidden]) ~ :not([hidden]) {
     border-style: solid;
   }
 
-  .sm\:divide-dashed > :not(template) ~ :not(template) {
+  .sm\:divide-dashed > :not([hidden]) ~ :not([hidden]) {
     border-style: dashed;
   }
 
-  .sm\:divide-dotted > :not(template) ~ :not(template) {
+  .sm\:divide-dotted > :not([hidden]) ~ :not([hidden]) {
     border-style: dotted;
   }
 
-  .sm\:divide-double > :not(template) ~ :not(template) {
+  .sm\:divide-double > :not([hidden]) ~ :not([hidden]) {
     border-style: double;
   }
 
-  .sm\:divide-none > :not(template) ~ :not(template) {
+  .sm\:divide-none > :not([hidden]) ~ :not([hidden]) {
     border-style: none;
   }
 
@@ -42762,1199 +42762,1199 @@ video {
     }
   }
 
-  .md\:space-y-0 > :not(template) ~ :not(template) {
+  .md\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0px * var(--space-y-reverse));
   }
 
-  .md\:space-x-0 > :not(template) ~ :not(template) {
+  .md\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0px * var(--space-x-reverse));
     margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-1 > :not(template) ~ :not(template) {
+  .md\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.25rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-1 > :not(template) ~ :not(template) {
+  .md\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-2 > :not(template) ~ :not(template) {
+  .md\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.5rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-2 > :not(template) ~ :not(template) {
+  .md\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-3 > :not(template) ~ :not(template) {
+  .md\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.75rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-3 > :not(template) ~ :not(template) {
+  .md\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-4 > :not(template) ~ :not(template) {
+  .md\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-4 > :not(template) ~ :not(template) {
+  .md\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1rem * var(--space-x-reverse));
     margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-5 > :not(template) ~ :not(template) {
+  .md\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.25rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-5 > :not(template) ~ :not(template) {
+  .md\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-6 > :not(template) ~ :not(template) {
+  .md\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.5rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-6 > :not(template) ~ :not(template) {
+  .md\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-7 > :not(template) ~ :not(template) {
+  .md\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.75rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-7 > :not(template) ~ :not(template) {
+  .md\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-8 > :not(template) ~ :not(template) {
+  .md\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-8 > :not(template) ~ :not(template) {
+  .md\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2rem * var(--space-x-reverse));
     margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-9 > :not(template) ~ :not(template) {
+  .md\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.25rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-9 > :not(template) ~ :not(template) {
+  .md\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-10 > :not(template) ~ :not(template) {
+  .md\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.5rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-10 > :not(template) ~ :not(template) {
+  .md\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-12 > :not(template) ~ :not(template) {
+  .md\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-12 > :not(template) ~ :not(template) {
+  .md\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3rem * var(--space-x-reverse));
     margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-14 > :not(template) ~ :not(template) {
+  .md\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3.5rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-14 > :not(template) ~ :not(template) {
+  .md\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-16 > :not(template) ~ :not(template) {
+  .md\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(4rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-16 > :not(template) ~ :not(template) {
+  .md\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(4rem * var(--space-x-reverse));
     margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-20 > :not(template) ~ :not(template) {
+  .md\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(5rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-20 > :not(template) ~ :not(template) {
+  .md\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(5rem * var(--space-x-reverse));
     margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-24 > :not(template) ~ :not(template) {
+  .md\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(6rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-24 > :not(template) ~ :not(template) {
+  .md\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(6rem * var(--space-x-reverse));
     margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-28 > :not(template) ~ :not(template) {
+  .md\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(7rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-28 > :not(template) ~ :not(template) {
+  .md\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(7rem * var(--space-x-reverse));
     margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-32 > :not(template) ~ :not(template) {
+  .md\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(8rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-32 > :not(template) ~ :not(template) {
+  .md\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(8rem * var(--space-x-reverse));
     margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-36 > :not(template) ~ :not(template) {
+  .md\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(9rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-36 > :not(template) ~ :not(template) {
+  .md\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(9rem * var(--space-x-reverse));
     margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-40 > :not(template) ~ :not(template) {
+  .md\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(10rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-40 > :not(template) ~ :not(template) {
+  .md\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(10rem * var(--space-x-reverse));
     margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-44 > :not(template) ~ :not(template) {
+  .md\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(11rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-44 > :not(template) ~ :not(template) {
+  .md\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(11rem * var(--space-x-reverse));
     margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-48 > :not(template) ~ :not(template) {
+  .md\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(12rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-48 > :not(template) ~ :not(template) {
+  .md\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(12rem * var(--space-x-reverse));
     margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-52 > :not(template) ~ :not(template) {
+  .md\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(13rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-52 > :not(template) ~ :not(template) {
+  .md\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(13rem * var(--space-x-reverse));
     margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-56 > :not(template) ~ :not(template) {
+  .md\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(14rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-56 > :not(template) ~ :not(template) {
+  .md\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(14rem * var(--space-x-reverse));
     margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-60 > :not(template) ~ :not(template) {
+  .md\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(15rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-60 > :not(template) ~ :not(template) {
+  .md\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(15rem * var(--space-x-reverse));
     margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-64 > :not(template) ~ :not(template) {
+  .md\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(16rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-64 > :not(template) ~ :not(template) {
+  .md\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(16rem * var(--space-x-reverse));
     margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-72 > :not(template) ~ :not(template) {
+  .md\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(18rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-72 > :not(template) ~ :not(template) {
+  .md\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(18rem * var(--space-x-reverse));
     margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-80 > :not(template) ~ :not(template) {
+  .md\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(20rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-80 > :not(template) ~ :not(template) {
+  .md\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(20rem * var(--space-x-reverse));
     margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-96 > :not(template) ~ :not(template) {
+  .md\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(24rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-96 > :not(template) ~ :not(template) {
+  .md\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(24rem * var(--space-x-reverse));
     margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-px > :not(template) ~ :not(template) {
+  .md\:space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1px * var(--space-y-reverse));
   }
 
-  .md\:space-x-px > :not(template) ~ :not(template) {
+  .md\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1px * var(--space-x-reverse));
     margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-0\.5 > :not(template) ~ :not(template) {
+  .md\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.125rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-0\.5 > :not(template) ~ :not(template) {
+  .md\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-1\.5 > :not(template) ~ :not(template) {
+  .md\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.375rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-1\.5 > :not(template) ~ :not(template) {
+  .md\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-2\.5 > :not(template) ~ :not(template) {
+  .md\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.625rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-2\.5 > :not(template) ~ :not(template) {
+  .md\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-3\.5 > :not(template) ~ :not(template) {
+  .md\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.875rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-3\.5 > :not(template) ~ :not(template) {
+  .md\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-1 > :not(template) ~ :not(template) {
+  .md\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.25rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-1 > :not(template) ~ :not(template) {
+  .md\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-2 > :not(template) ~ :not(template) {
+  .md\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.5rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-2 > :not(template) ~ :not(template) {
+  .md\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-3 > :not(template) ~ :not(template) {
+  .md\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.75rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-3 > :not(template) ~ :not(template) {
+  .md\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-4 > :not(template) ~ :not(template) {
+  .md\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-4 > :not(template) ~ :not(template) {
+  .md\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1rem * var(--space-x-reverse));
     margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-5 > :not(template) ~ :not(template) {
+  .md\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.25rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-5 > :not(template) ~ :not(template) {
+  .md\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-6 > :not(template) ~ :not(template) {
+  .md\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.5rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-6 > :not(template) ~ :not(template) {
+  .md\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-7 > :not(template) ~ :not(template) {
+  .md\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.75rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-7 > :not(template) ~ :not(template) {
+  .md\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-8 > :not(template) ~ :not(template) {
+  .md\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-8 > :not(template) ~ :not(template) {
+  .md\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2rem * var(--space-x-reverse));
     margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-9 > :not(template) ~ :not(template) {
+  .md\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.25rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-9 > :not(template) ~ :not(template) {
+  .md\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-10 > :not(template) ~ :not(template) {
+  .md\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.5rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-10 > :not(template) ~ :not(template) {
+  .md\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-12 > :not(template) ~ :not(template) {
+  .md\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-12 > :not(template) ~ :not(template) {
+  .md\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3rem * var(--space-x-reverse));
     margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-14 > :not(template) ~ :not(template) {
+  .md\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3.5rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-14 > :not(template) ~ :not(template) {
+  .md\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-16 > :not(template) ~ :not(template) {
+  .md\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-4rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-16 > :not(template) ~ :not(template) {
+  .md\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-4rem * var(--space-x-reverse));
     margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-20 > :not(template) ~ :not(template) {
+  .md\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-5rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-20 > :not(template) ~ :not(template) {
+  .md\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-5rem * var(--space-x-reverse));
     margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-24 > :not(template) ~ :not(template) {
+  .md\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-6rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-24 > :not(template) ~ :not(template) {
+  .md\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-6rem * var(--space-x-reverse));
     margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-28 > :not(template) ~ :not(template) {
+  .md\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-7rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-28 > :not(template) ~ :not(template) {
+  .md\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-7rem * var(--space-x-reverse));
     margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-32 > :not(template) ~ :not(template) {
+  .md\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-8rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-32 > :not(template) ~ :not(template) {
+  .md\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-8rem * var(--space-x-reverse));
     margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-36 > :not(template) ~ :not(template) {
+  .md\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-9rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-36 > :not(template) ~ :not(template) {
+  .md\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-9rem * var(--space-x-reverse));
     margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-40 > :not(template) ~ :not(template) {
+  .md\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-10rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-40 > :not(template) ~ :not(template) {
+  .md\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-10rem * var(--space-x-reverse));
     margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-44 > :not(template) ~ :not(template) {
+  .md\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-11rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-44 > :not(template) ~ :not(template) {
+  .md\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-11rem * var(--space-x-reverse));
     margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-48 > :not(template) ~ :not(template) {
+  .md\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-12rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-48 > :not(template) ~ :not(template) {
+  .md\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-12rem * var(--space-x-reverse));
     margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-52 > :not(template) ~ :not(template) {
+  .md\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-13rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-52 > :not(template) ~ :not(template) {
+  .md\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-13rem * var(--space-x-reverse));
     margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-56 > :not(template) ~ :not(template) {
+  .md\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-14rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-56 > :not(template) ~ :not(template) {
+  .md\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-14rem * var(--space-x-reverse));
     margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-60 > :not(template) ~ :not(template) {
+  .md\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-15rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-60 > :not(template) ~ :not(template) {
+  .md\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-15rem * var(--space-x-reverse));
     margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-64 > :not(template) ~ :not(template) {
+  .md\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-16rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-64 > :not(template) ~ :not(template) {
+  .md\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-16rem * var(--space-x-reverse));
     margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-72 > :not(template) ~ :not(template) {
+  .md\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-18rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-72 > :not(template) ~ :not(template) {
+  .md\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-18rem * var(--space-x-reverse));
     margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-80 > :not(template) ~ :not(template) {
+  .md\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-20rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-80 > :not(template) ~ :not(template) {
+  .md\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-20rem * var(--space-x-reverse));
     margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-96 > :not(template) ~ :not(template) {
+  .md\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-24rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-96 > :not(template) ~ :not(template) {
+  .md\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-24rem * var(--space-x-reverse));
     margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-px > :not(template) ~ :not(template) {
+  .md\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1px * var(--space-y-reverse));
   }
 
-  .md\:-space-x-px > :not(template) ~ :not(template) {
+  .md\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1px * var(--space-x-reverse));
     margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-0\.5 > :not(template) ~ :not(template) {
+  .md\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.125rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-0\.5 > :not(template) ~ :not(template) {
+  .md\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-1\.5 > :not(template) ~ :not(template) {
+  .md\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.375rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-1\.5 > :not(template) ~ :not(template) {
+  .md\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-2\.5 > :not(template) ~ :not(template) {
+  .md\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.625rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-2\.5 > :not(template) ~ :not(template) {
+  .md\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-3\.5 > :not(template) ~ :not(template) {
+  .md\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.875rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-3\.5 > :not(template) ~ :not(template) {
+  .md\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-reverse > :not(template) ~ :not(template) {
+  .md\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 1;
   }
 
-  .md\:space-x-reverse > :not(template) ~ :not(template) {
+  .md\:space-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 1;
   }
 
-  .md\:divide-y-0 > :not(template) ~ :not(template) {
+  .md\:divide-y-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(0px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(0px * var(--divide-y-reverse));
   }
 
-  .md\:divide-x-0 > :not(template) ~ :not(template) {
+  .md\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(0px * var(--divide-x-reverse));
     border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .md\:divide-y-2 > :not(template) ~ :not(template) {
+  .md\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(2px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(2px * var(--divide-y-reverse));
   }
 
-  .md\:divide-x-2 > :not(template) ~ :not(template) {
+  .md\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(2px * var(--divide-x-reverse));
     border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .md\:divide-y-4 > :not(template) ~ :not(template) {
+  .md\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(4px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(4px * var(--divide-y-reverse));
   }
 
-  .md\:divide-x-4 > :not(template) ~ :not(template) {
+  .md\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(4px * var(--divide-x-reverse));
     border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .md\:divide-y-8 > :not(template) ~ :not(template) {
+  .md\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(8px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(8px * var(--divide-y-reverse));
   }
 
-  .md\:divide-x-8 > :not(template) ~ :not(template) {
+  .md\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(8px * var(--divide-x-reverse));
     border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .md\:divide-y > :not(template) ~ :not(template) {
+  .md\:divide-y > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(1px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(1px * var(--divide-y-reverse));
   }
 
-  .md\:divide-x > :not(template) ~ :not(template) {
+  .md\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(1px * var(--divide-x-reverse));
     border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .md\:divide-y-reverse > :not(template) ~ :not(template) {
+  .md\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 1;
   }
 
-  .md\:divide-x-reverse > :not(template) ~ :not(template) {
+  .md\:divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 1;
   }
 
-  .md\:divide-transparent > :not(template) ~ :not(template) {
+  .md\:divide-transparent > :not([hidden]) ~ :not([hidden]) {
     border-color: transparent;
   }
 
-  .md\:divide-current > :not(template) ~ :not(template) {
+  .md\:divide-current > :not([hidden]) ~ :not([hidden]) {
     border-color: currentColor;
   }
 
-  .md\:divide-black > :not(template) ~ :not(template) {
+  .md\:divide-black > :not([hidden]) ~ :not([hidden]) {
     border-color: #000;
   }
 
-  .md\:divide-white > :not(template) ~ :not(template) {
+  .md\:divide-white > :not([hidden]) ~ :not([hidden]) {
     border-color: #fff;
   }
 
-  .md\:divide-gray-50 > :not(template) ~ :not(template) {
+  .md\:divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fafafa;
   }
 
-  .md\:divide-gray-100 > :not(template) ~ :not(template) {
+  .md\:divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f4f4f5;
   }
 
-  .md\:divide-gray-200 > :not(template) ~ :not(template) {
+  .md\:divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #e4e4e7;
   }
 
-  .md\:divide-gray-300 > :not(template) ~ :not(template) {
+  .md\:divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #d4d4d8;
   }
 
-  .md\:divide-gray-400 > :not(template) ~ :not(template) {
+  .md\:divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #a1a1aa;
   }
 
-  .md\:divide-gray-500 > :not(template) ~ :not(template) {
+  .md\:divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #71717a;
   }
 
-  .md\:divide-gray-600 > :not(template) ~ :not(template) {
+  .md\:divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #52525b;
   }
 
-  .md\:divide-gray-700 > :not(template) ~ :not(template) {
+  .md\:divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #3f3f46;
   }
 
-  .md\:divide-gray-800 > :not(template) ~ :not(template) {
+  .md\:divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #27272a;
   }
 
-  .md\:divide-gray-900 > :not(template) ~ :not(template) {
+  .md\:divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #18181b;
   }
 
-  .md\:divide-red-50 > :not(template) ~ :not(template) {
+  .md\:divide-red-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fef2f2;
   }
 
-  .md\:divide-red-100 > :not(template) ~ :not(template) {
+  .md\:divide-red-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fee2e2;
   }
 
-  .md\:divide-red-200 > :not(template) ~ :not(template) {
+  .md\:divide-red-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fecaca;
   }
 
-  .md\:divide-red-300 > :not(template) ~ :not(template) {
+  .md\:divide-red-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fca5a5;
   }
 
-  .md\:divide-red-400 > :not(template) ~ :not(template) {
+  .md\:divide-red-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f87171;
   }
 
-  .md\:divide-red-500 > :not(template) ~ :not(template) {
+  .md\:divide-red-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ef4444;
   }
 
-  .md\:divide-red-600 > :not(template) ~ :not(template) {
+  .md\:divide-red-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #dc2626;
   }
 
-  .md\:divide-red-700 > :not(template) ~ :not(template) {
+  .md\:divide-red-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #b91c1c;
   }
 
-  .md\:divide-red-800 > :not(template) ~ :not(template) {
+  .md\:divide-red-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #991b1b;
   }
 
-  .md\:divide-red-900 > :not(template) ~ :not(template) {
+  .md\:divide-red-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #7f1d1d;
   }
 
-  .md\:divide-yellow-50 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fffbeb;
   }
 
-  .md\:divide-yellow-100 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fef3c7;
   }
 
-  .md\:divide-yellow-200 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fde68a;
   }
 
-  .md\:divide-yellow-300 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fcd34d;
   }
 
-  .md\:divide-yellow-400 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fbbf24;
   }
 
-  .md\:divide-yellow-500 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f59e0b;
   }
 
-  .md\:divide-yellow-600 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #d97706;
   }
 
-  .md\:divide-yellow-700 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #b45309;
   }
 
-  .md\:divide-yellow-800 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #92400e;
   }
 
-  .md\:divide-yellow-900 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #78350f;
   }
 
-  .md\:divide-green-50 > :not(template) ~ :not(template) {
+  .md\:divide-green-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ecfdf5;
   }
 
-  .md\:divide-green-100 > :not(template) ~ :not(template) {
+  .md\:divide-green-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #d1fae5;
   }
 
-  .md\:divide-green-200 > :not(template) ~ :not(template) {
+  .md\:divide-green-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #a7f3d0;
   }
 
-  .md\:divide-green-300 > :not(template) ~ :not(template) {
+  .md\:divide-green-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #6ee7b7;
   }
 
-  .md\:divide-green-400 > :not(template) ~ :not(template) {
+  .md\:divide-green-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #34d399;
   }
 
-  .md\:divide-green-500 > :not(template) ~ :not(template) {
+  .md\:divide-green-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #10b981;
   }
 
-  .md\:divide-green-600 > :not(template) ~ :not(template) {
+  .md\:divide-green-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #059669;
   }
 
-  .md\:divide-green-700 > :not(template) ~ :not(template) {
+  .md\:divide-green-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #047857;
   }
 
-  .md\:divide-green-800 > :not(template) ~ :not(template) {
+  .md\:divide-green-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #065f46;
   }
 
-  .md\:divide-green-900 > :not(template) ~ :not(template) {
+  .md\:divide-green-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #064e3b;
   }
 
-  .md\:divide-blue-50 > :not(template) ~ :not(template) {
+  .md\:divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #eff6ff;
   }
 
-  .md\:divide-blue-100 > :not(template) ~ :not(template) {
+  .md\:divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #dbeafe;
   }
 
-  .md\:divide-blue-200 > :not(template) ~ :not(template) {
+  .md\:divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #bfdbfe;
   }
 
-  .md\:divide-blue-300 > :not(template) ~ :not(template) {
+  .md\:divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #93c5fd;
   }
 
-  .md\:divide-blue-400 > :not(template) ~ :not(template) {
+  .md\:divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #60a5fa;
   }
 
-  .md\:divide-blue-500 > :not(template) ~ :not(template) {
+  .md\:divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #3b82f6;
   }
 
-  .md\:divide-blue-600 > :not(template) ~ :not(template) {
+  .md\:divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #2563eb;
   }
 
-  .md\:divide-blue-700 > :not(template) ~ :not(template) {
+  .md\:divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #1d4ed8;
   }
 
-  .md\:divide-blue-800 > :not(template) ~ :not(template) {
+  .md\:divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #1e40af;
   }
 
-  .md\:divide-blue-900 > :not(template) ~ :not(template) {
+  .md\:divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #1e3a8a;
   }
 
-  .md\:divide-purple-50 > :not(template) ~ :not(template) {
+  .md\:divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f5f3ff;
   }
 
-  .md\:divide-purple-100 > :not(template) ~ :not(template) {
+  .md\:divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ede9fe;
   }
 
-  .md\:divide-purple-200 > :not(template) ~ :not(template) {
+  .md\:divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ddd6fe;
   }
 
-  .md\:divide-purple-300 > :not(template) ~ :not(template) {
+  .md\:divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #c4b5fd;
   }
 
-  .md\:divide-purple-400 > :not(template) ~ :not(template) {
+  .md\:divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #a78bfa;
   }
 
-  .md\:divide-purple-500 > :not(template) ~ :not(template) {
+  .md\:divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #8b5cf6;
   }
 
-  .md\:divide-purple-600 > :not(template) ~ :not(template) {
+  .md\:divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #7c3aed;
   }
 
-  .md\:divide-purple-700 > :not(template) ~ :not(template) {
+  .md\:divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #6d28d9;
   }
 
-  .md\:divide-purple-800 > :not(template) ~ :not(template) {
+  .md\:divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #5b21b6;
   }
 
-  .md\:divide-purple-900 > :not(template) ~ :not(template) {
+  .md\:divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #4c1d95;
   }
 
-  .md\:divide-pink-50 > :not(template) ~ :not(template) {
+  .md\:divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fdf2f8;
   }
 
-  .md\:divide-pink-100 > :not(template) ~ :not(template) {
+  .md\:divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fce7f3;
   }
 
-  .md\:divide-pink-200 > :not(template) ~ :not(template) {
+  .md\:divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fbcfe8;
   }
 
-  .md\:divide-pink-300 > :not(template) ~ :not(template) {
+  .md\:divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f9a8d4;
   }
 
-  .md\:divide-pink-400 > :not(template) ~ :not(template) {
+  .md\:divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f472b6;
   }
 
-  .md\:divide-pink-500 > :not(template) ~ :not(template) {
+  .md\:divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ec4899;
   }
 
-  .md\:divide-pink-600 > :not(template) ~ :not(template) {
+  .md\:divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #db2777;
   }
 
-  .md\:divide-pink-700 > :not(template) ~ :not(template) {
+  .md\:divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #be185d;
   }
 
-  .md\:divide-pink-800 > :not(template) ~ :not(template) {
+  .md\:divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #9d174d;
   }
 
-  .md\:divide-pink-900 > :not(template) ~ :not(template) {
+  .md\:divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #831843;
   }
 
-  .md\:divide-solid > :not(template) ~ :not(template) {
+  .md\:divide-solid > :not([hidden]) ~ :not([hidden]) {
     border-style: solid;
   }
 
-  .md\:divide-dashed > :not(template) ~ :not(template) {
+  .md\:divide-dashed > :not([hidden]) ~ :not([hidden]) {
     border-style: dashed;
   }
 
-  .md\:divide-dotted > :not(template) ~ :not(template) {
+  .md\:divide-dotted > :not([hidden]) ~ :not([hidden]) {
     border-style: dotted;
   }
 
-  .md\:divide-double > :not(template) ~ :not(template) {
+  .md\:divide-double > :not([hidden]) ~ :not([hidden]) {
     border-style: double;
   }
 
-  .md\:divide-none > :not(template) ~ :not(template) {
+  .md\:divide-none > :not([hidden]) ~ :not([hidden]) {
     border-style: none;
   }
 
@@ -63848,1199 +63848,1199 @@ video {
     }
   }
 
-  .lg\:space-y-0 > :not(template) ~ :not(template) {
+  .lg\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0px * var(--space-y-reverse));
   }
 
-  .lg\:space-x-0 > :not(template) ~ :not(template) {
+  .lg\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0px * var(--space-x-reverse));
     margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-1 > :not(template) ~ :not(template) {
+  .lg\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.25rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-1 > :not(template) ~ :not(template) {
+  .lg\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-2 > :not(template) ~ :not(template) {
+  .lg\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.5rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-2 > :not(template) ~ :not(template) {
+  .lg\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-3 > :not(template) ~ :not(template) {
+  .lg\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.75rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-3 > :not(template) ~ :not(template) {
+  .lg\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-4 > :not(template) ~ :not(template) {
+  .lg\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-4 > :not(template) ~ :not(template) {
+  .lg\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1rem * var(--space-x-reverse));
     margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-5 > :not(template) ~ :not(template) {
+  .lg\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.25rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-5 > :not(template) ~ :not(template) {
+  .lg\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-6 > :not(template) ~ :not(template) {
+  .lg\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.5rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-6 > :not(template) ~ :not(template) {
+  .lg\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-7 > :not(template) ~ :not(template) {
+  .lg\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.75rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-7 > :not(template) ~ :not(template) {
+  .lg\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-8 > :not(template) ~ :not(template) {
+  .lg\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-8 > :not(template) ~ :not(template) {
+  .lg\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2rem * var(--space-x-reverse));
     margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-9 > :not(template) ~ :not(template) {
+  .lg\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.25rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-9 > :not(template) ~ :not(template) {
+  .lg\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-10 > :not(template) ~ :not(template) {
+  .lg\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.5rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-10 > :not(template) ~ :not(template) {
+  .lg\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-12 > :not(template) ~ :not(template) {
+  .lg\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-12 > :not(template) ~ :not(template) {
+  .lg\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3rem * var(--space-x-reverse));
     margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-14 > :not(template) ~ :not(template) {
+  .lg\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3.5rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-14 > :not(template) ~ :not(template) {
+  .lg\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-16 > :not(template) ~ :not(template) {
+  .lg\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(4rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-16 > :not(template) ~ :not(template) {
+  .lg\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(4rem * var(--space-x-reverse));
     margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-20 > :not(template) ~ :not(template) {
+  .lg\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(5rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-20 > :not(template) ~ :not(template) {
+  .lg\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(5rem * var(--space-x-reverse));
     margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-24 > :not(template) ~ :not(template) {
+  .lg\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(6rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-24 > :not(template) ~ :not(template) {
+  .lg\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(6rem * var(--space-x-reverse));
     margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-28 > :not(template) ~ :not(template) {
+  .lg\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(7rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-28 > :not(template) ~ :not(template) {
+  .lg\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(7rem * var(--space-x-reverse));
     margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-32 > :not(template) ~ :not(template) {
+  .lg\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(8rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-32 > :not(template) ~ :not(template) {
+  .lg\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(8rem * var(--space-x-reverse));
     margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-36 > :not(template) ~ :not(template) {
+  .lg\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(9rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-36 > :not(template) ~ :not(template) {
+  .lg\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(9rem * var(--space-x-reverse));
     margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-40 > :not(template) ~ :not(template) {
+  .lg\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(10rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-40 > :not(template) ~ :not(template) {
+  .lg\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(10rem * var(--space-x-reverse));
     margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-44 > :not(template) ~ :not(template) {
+  .lg\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(11rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-44 > :not(template) ~ :not(template) {
+  .lg\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(11rem * var(--space-x-reverse));
     margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-48 > :not(template) ~ :not(template) {
+  .lg\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(12rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-48 > :not(template) ~ :not(template) {
+  .lg\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(12rem * var(--space-x-reverse));
     margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-52 > :not(template) ~ :not(template) {
+  .lg\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(13rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-52 > :not(template) ~ :not(template) {
+  .lg\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(13rem * var(--space-x-reverse));
     margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-56 > :not(template) ~ :not(template) {
+  .lg\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(14rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-56 > :not(template) ~ :not(template) {
+  .lg\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(14rem * var(--space-x-reverse));
     margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-60 > :not(template) ~ :not(template) {
+  .lg\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(15rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-60 > :not(template) ~ :not(template) {
+  .lg\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(15rem * var(--space-x-reverse));
     margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-64 > :not(template) ~ :not(template) {
+  .lg\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(16rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-64 > :not(template) ~ :not(template) {
+  .lg\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(16rem * var(--space-x-reverse));
     margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-72 > :not(template) ~ :not(template) {
+  .lg\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(18rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-72 > :not(template) ~ :not(template) {
+  .lg\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(18rem * var(--space-x-reverse));
     margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-80 > :not(template) ~ :not(template) {
+  .lg\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(20rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-80 > :not(template) ~ :not(template) {
+  .lg\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(20rem * var(--space-x-reverse));
     margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-96 > :not(template) ~ :not(template) {
+  .lg\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(24rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-96 > :not(template) ~ :not(template) {
+  .lg\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(24rem * var(--space-x-reverse));
     margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-px > :not(template) ~ :not(template) {
+  .lg\:space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1px * var(--space-y-reverse));
   }
 
-  .lg\:space-x-px > :not(template) ~ :not(template) {
+  .lg\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1px * var(--space-x-reverse));
     margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-0\.5 > :not(template) ~ :not(template) {
+  .lg\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.125rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-0\.5 > :not(template) ~ :not(template) {
+  .lg\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-1\.5 > :not(template) ~ :not(template) {
+  .lg\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.375rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-1\.5 > :not(template) ~ :not(template) {
+  .lg\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-2\.5 > :not(template) ~ :not(template) {
+  .lg\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.625rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-2\.5 > :not(template) ~ :not(template) {
+  .lg\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-3\.5 > :not(template) ~ :not(template) {
+  .lg\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.875rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-3\.5 > :not(template) ~ :not(template) {
+  .lg\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-1 > :not(template) ~ :not(template) {
+  .lg\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.25rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-1 > :not(template) ~ :not(template) {
+  .lg\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-2 > :not(template) ~ :not(template) {
+  .lg\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.5rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-2 > :not(template) ~ :not(template) {
+  .lg\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-3 > :not(template) ~ :not(template) {
+  .lg\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.75rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-3 > :not(template) ~ :not(template) {
+  .lg\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-4 > :not(template) ~ :not(template) {
+  .lg\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-4 > :not(template) ~ :not(template) {
+  .lg\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1rem * var(--space-x-reverse));
     margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-5 > :not(template) ~ :not(template) {
+  .lg\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.25rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-5 > :not(template) ~ :not(template) {
+  .lg\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-6 > :not(template) ~ :not(template) {
+  .lg\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.5rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-6 > :not(template) ~ :not(template) {
+  .lg\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-7 > :not(template) ~ :not(template) {
+  .lg\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.75rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-7 > :not(template) ~ :not(template) {
+  .lg\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-8 > :not(template) ~ :not(template) {
+  .lg\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-8 > :not(template) ~ :not(template) {
+  .lg\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2rem * var(--space-x-reverse));
     margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-9 > :not(template) ~ :not(template) {
+  .lg\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.25rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-9 > :not(template) ~ :not(template) {
+  .lg\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-10 > :not(template) ~ :not(template) {
+  .lg\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.5rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-10 > :not(template) ~ :not(template) {
+  .lg\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-12 > :not(template) ~ :not(template) {
+  .lg\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-12 > :not(template) ~ :not(template) {
+  .lg\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3rem * var(--space-x-reverse));
     margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-14 > :not(template) ~ :not(template) {
+  .lg\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3.5rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-14 > :not(template) ~ :not(template) {
+  .lg\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-16 > :not(template) ~ :not(template) {
+  .lg\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-4rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-16 > :not(template) ~ :not(template) {
+  .lg\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-4rem * var(--space-x-reverse));
     margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-20 > :not(template) ~ :not(template) {
+  .lg\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-5rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-20 > :not(template) ~ :not(template) {
+  .lg\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-5rem * var(--space-x-reverse));
     margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-24 > :not(template) ~ :not(template) {
+  .lg\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-6rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-24 > :not(template) ~ :not(template) {
+  .lg\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-6rem * var(--space-x-reverse));
     margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-28 > :not(template) ~ :not(template) {
+  .lg\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-7rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-28 > :not(template) ~ :not(template) {
+  .lg\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-7rem * var(--space-x-reverse));
     margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-32 > :not(template) ~ :not(template) {
+  .lg\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-8rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-32 > :not(template) ~ :not(template) {
+  .lg\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-8rem * var(--space-x-reverse));
     margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-36 > :not(template) ~ :not(template) {
+  .lg\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-9rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-36 > :not(template) ~ :not(template) {
+  .lg\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-9rem * var(--space-x-reverse));
     margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-40 > :not(template) ~ :not(template) {
+  .lg\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-10rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-40 > :not(template) ~ :not(template) {
+  .lg\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-10rem * var(--space-x-reverse));
     margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-44 > :not(template) ~ :not(template) {
+  .lg\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-11rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-44 > :not(template) ~ :not(template) {
+  .lg\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-11rem * var(--space-x-reverse));
     margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-48 > :not(template) ~ :not(template) {
+  .lg\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-12rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-48 > :not(template) ~ :not(template) {
+  .lg\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-12rem * var(--space-x-reverse));
     margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-52 > :not(template) ~ :not(template) {
+  .lg\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-13rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-52 > :not(template) ~ :not(template) {
+  .lg\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-13rem * var(--space-x-reverse));
     margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-56 > :not(template) ~ :not(template) {
+  .lg\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-14rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-56 > :not(template) ~ :not(template) {
+  .lg\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-14rem * var(--space-x-reverse));
     margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-60 > :not(template) ~ :not(template) {
+  .lg\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-15rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-60 > :not(template) ~ :not(template) {
+  .lg\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-15rem * var(--space-x-reverse));
     margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-64 > :not(template) ~ :not(template) {
+  .lg\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-16rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-64 > :not(template) ~ :not(template) {
+  .lg\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-16rem * var(--space-x-reverse));
     margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-72 > :not(template) ~ :not(template) {
+  .lg\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-18rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-72 > :not(template) ~ :not(template) {
+  .lg\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-18rem * var(--space-x-reverse));
     margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-80 > :not(template) ~ :not(template) {
+  .lg\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-20rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-80 > :not(template) ~ :not(template) {
+  .lg\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-20rem * var(--space-x-reverse));
     margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-96 > :not(template) ~ :not(template) {
+  .lg\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-24rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-96 > :not(template) ~ :not(template) {
+  .lg\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-24rem * var(--space-x-reverse));
     margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-px > :not(template) ~ :not(template) {
+  .lg\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1px * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-px > :not(template) ~ :not(template) {
+  .lg\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1px * var(--space-x-reverse));
     margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-0\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.125rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-0\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-1\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.375rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-1\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-2\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.625rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-2\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-3\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.875rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-3\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-reverse > :not(template) ~ :not(template) {
+  .lg\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 1;
   }
 
-  .lg\:space-x-reverse > :not(template) ~ :not(template) {
+  .lg\:space-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 1;
   }
 
-  .lg\:divide-y-0 > :not(template) ~ :not(template) {
+  .lg\:divide-y-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(0px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(0px * var(--divide-y-reverse));
   }
 
-  .lg\:divide-x-0 > :not(template) ~ :not(template) {
+  .lg\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(0px * var(--divide-x-reverse));
     border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .lg\:divide-y-2 > :not(template) ~ :not(template) {
+  .lg\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(2px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(2px * var(--divide-y-reverse));
   }
 
-  .lg\:divide-x-2 > :not(template) ~ :not(template) {
+  .lg\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(2px * var(--divide-x-reverse));
     border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .lg\:divide-y-4 > :not(template) ~ :not(template) {
+  .lg\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(4px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(4px * var(--divide-y-reverse));
   }
 
-  .lg\:divide-x-4 > :not(template) ~ :not(template) {
+  .lg\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(4px * var(--divide-x-reverse));
     border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .lg\:divide-y-8 > :not(template) ~ :not(template) {
+  .lg\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(8px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(8px * var(--divide-y-reverse));
   }
 
-  .lg\:divide-x-8 > :not(template) ~ :not(template) {
+  .lg\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(8px * var(--divide-x-reverse));
     border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .lg\:divide-y > :not(template) ~ :not(template) {
+  .lg\:divide-y > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(1px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(1px * var(--divide-y-reverse));
   }
 
-  .lg\:divide-x > :not(template) ~ :not(template) {
+  .lg\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(1px * var(--divide-x-reverse));
     border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .lg\:divide-y-reverse > :not(template) ~ :not(template) {
+  .lg\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 1;
   }
 
-  .lg\:divide-x-reverse > :not(template) ~ :not(template) {
+  .lg\:divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 1;
   }
 
-  .lg\:divide-transparent > :not(template) ~ :not(template) {
+  .lg\:divide-transparent > :not([hidden]) ~ :not([hidden]) {
     border-color: transparent;
   }
 
-  .lg\:divide-current > :not(template) ~ :not(template) {
+  .lg\:divide-current > :not([hidden]) ~ :not([hidden]) {
     border-color: currentColor;
   }
 
-  .lg\:divide-black > :not(template) ~ :not(template) {
+  .lg\:divide-black > :not([hidden]) ~ :not([hidden]) {
     border-color: #000;
   }
 
-  .lg\:divide-white > :not(template) ~ :not(template) {
+  .lg\:divide-white > :not([hidden]) ~ :not([hidden]) {
     border-color: #fff;
   }
 
-  .lg\:divide-gray-50 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fafafa;
   }
 
-  .lg\:divide-gray-100 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f4f4f5;
   }
 
-  .lg\:divide-gray-200 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #e4e4e7;
   }
 
-  .lg\:divide-gray-300 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #d4d4d8;
   }
 
-  .lg\:divide-gray-400 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #a1a1aa;
   }
 
-  .lg\:divide-gray-500 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #71717a;
   }
 
-  .lg\:divide-gray-600 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #52525b;
   }
 
-  .lg\:divide-gray-700 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #3f3f46;
   }
 
-  .lg\:divide-gray-800 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #27272a;
   }
 
-  .lg\:divide-gray-900 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #18181b;
   }
 
-  .lg\:divide-red-50 > :not(template) ~ :not(template) {
+  .lg\:divide-red-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fef2f2;
   }
 
-  .lg\:divide-red-100 > :not(template) ~ :not(template) {
+  .lg\:divide-red-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fee2e2;
   }
 
-  .lg\:divide-red-200 > :not(template) ~ :not(template) {
+  .lg\:divide-red-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fecaca;
   }
 
-  .lg\:divide-red-300 > :not(template) ~ :not(template) {
+  .lg\:divide-red-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fca5a5;
   }
 
-  .lg\:divide-red-400 > :not(template) ~ :not(template) {
+  .lg\:divide-red-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f87171;
   }
 
-  .lg\:divide-red-500 > :not(template) ~ :not(template) {
+  .lg\:divide-red-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ef4444;
   }
 
-  .lg\:divide-red-600 > :not(template) ~ :not(template) {
+  .lg\:divide-red-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #dc2626;
   }
 
-  .lg\:divide-red-700 > :not(template) ~ :not(template) {
+  .lg\:divide-red-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #b91c1c;
   }
 
-  .lg\:divide-red-800 > :not(template) ~ :not(template) {
+  .lg\:divide-red-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #991b1b;
   }
 
-  .lg\:divide-red-900 > :not(template) ~ :not(template) {
+  .lg\:divide-red-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #7f1d1d;
   }
 
-  .lg\:divide-yellow-50 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fffbeb;
   }
 
-  .lg\:divide-yellow-100 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fef3c7;
   }
 
-  .lg\:divide-yellow-200 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fde68a;
   }
 
-  .lg\:divide-yellow-300 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fcd34d;
   }
 
-  .lg\:divide-yellow-400 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fbbf24;
   }
 
-  .lg\:divide-yellow-500 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f59e0b;
   }
 
-  .lg\:divide-yellow-600 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #d97706;
   }
 
-  .lg\:divide-yellow-700 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #b45309;
   }
 
-  .lg\:divide-yellow-800 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #92400e;
   }
 
-  .lg\:divide-yellow-900 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #78350f;
   }
 
-  .lg\:divide-green-50 > :not(template) ~ :not(template) {
+  .lg\:divide-green-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ecfdf5;
   }
 
-  .lg\:divide-green-100 > :not(template) ~ :not(template) {
+  .lg\:divide-green-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #d1fae5;
   }
 
-  .lg\:divide-green-200 > :not(template) ~ :not(template) {
+  .lg\:divide-green-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #a7f3d0;
   }
 
-  .lg\:divide-green-300 > :not(template) ~ :not(template) {
+  .lg\:divide-green-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #6ee7b7;
   }
 
-  .lg\:divide-green-400 > :not(template) ~ :not(template) {
+  .lg\:divide-green-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #34d399;
   }
 
-  .lg\:divide-green-500 > :not(template) ~ :not(template) {
+  .lg\:divide-green-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #10b981;
   }
 
-  .lg\:divide-green-600 > :not(template) ~ :not(template) {
+  .lg\:divide-green-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #059669;
   }
 
-  .lg\:divide-green-700 > :not(template) ~ :not(template) {
+  .lg\:divide-green-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #047857;
   }
 
-  .lg\:divide-green-800 > :not(template) ~ :not(template) {
+  .lg\:divide-green-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #065f46;
   }
 
-  .lg\:divide-green-900 > :not(template) ~ :not(template) {
+  .lg\:divide-green-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #064e3b;
   }
 
-  .lg\:divide-blue-50 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #eff6ff;
   }
 
-  .lg\:divide-blue-100 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #dbeafe;
   }
 
-  .lg\:divide-blue-200 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #bfdbfe;
   }
 
-  .lg\:divide-blue-300 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #93c5fd;
   }
 
-  .lg\:divide-blue-400 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #60a5fa;
   }
 
-  .lg\:divide-blue-500 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #3b82f6;
   }
 
-  .lg\:divide-blue-600 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #2563eb;
   }
 
-  .lg\:divide-blue-700 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #1d4ed8;
   }
 
-  .lg\:divide-blue-800 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #1e40af;
   }
 
-  .lg\:divide-blue-900 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #1e3a8a;
   }
 
-  .lg\:divide-purple-50 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f5f3ff;
   }
 
-  .lg\:divide-purple-100 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ede9fe;
   }
 
-  .lg\:divide-purple-200 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ddd6fe;
   }
 
-  .lg\:divide-purple-300 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #c4b5fd;
   }
 
-  .lg\:divide-purple-400 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #a78bfa;
   }
 
-  .lg\:divide-purple-500 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #8b5cf6;
   }
 
-  .lg\:divide-purple-600 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #7c3aed;
   }
 
-  .lg\:divide-purple-700 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #6d28d9;
   }
 
-  .lg\:divide-purple-800 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #5b21b6;
   }
 
-  .lg\:divide-purple-900 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #4c1d95;
   }
 
-  .lg\:divide-pink-50 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fdf2f8;
   }
 
-  .lg\:divide-pink-100 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fce7f3;
   }
 
-  .lg\:divide-pink-200 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fbcfe8;
   }
 
-  .lg\:divide-pink-300 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f9a8d4;
   }
 
-  .lg\:divide-pink-400 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f472b6;
   }
 
-  .lg\:divide-pink-500 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ec4899;
   }
 
-  .lg\:divide-pink-600 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #db2777;
   }
 
-  .lg\:divide-pink-700 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #be185d;
   }
 
-  .lg\:divide-pink-800 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #9d174d;
   }
 
-  .lg\:divide-pink-900 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #831843;
   }
 
-  .lg\:divide-solid > :not(template) ~ :not(template) {
+  .lg\:divide-solid > :not([hidden]) ~ :not([hidden]) {
     border-style: solid;
   }
 
-  .lg\:divide-dashed > :not(template) ~ :not(template) {
+  .lg\:divide-dashed > :not([hidden]) ~ :not([hidden]) {
     border-style: dashed;
   }
 
-  .lg\:divide-dotted > :not(template) ~ :not(template) {
+  .lg\:divide-dotted > :not([hidden]) ~ :not([hidden]) {
     border-style: dotted;
   }
 
-  .lg\:divide-double > :not(template) ~ :not(template) {
+  .lg\:divide-double > :not([hidden]) ~ :not([hidden]) {
     border-style: double;
   }
 
-  .lg\:divide-none > :not(template) ~ :not(template) {
+  .lg\:divide-none > :not([hidden]) ~ :not([hidden]) {
     border-style: none;
   }
 
@@ -84934,1199 +84934,1199 @@ video {
     }
   }
 
-  .xl\:space-y-0 > :not(template) ~ :not(template) {
+  .xl\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0px * var(--space-y-reverse));
   }
 
-  .xl\:space-x-0 > :not(template) ~ :not(template) {
+  .xl\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0px * var(--space-x-reverse));
     margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-1 > :not(template) ~ :not(template) {
+  .xl\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.25rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-1 > :not(template) ~ :not(template) {
+  .xl\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-2 > :not(template) ~ :not(template) {
+  .xl\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.5rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-2 > :not(template) ~ :not(template) {
+  .xl\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-3 > :not(template) ~ :not(template) {
+  .xl\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.75rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-3 > :not(template) ~ :not(template) {
+  .xl\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-4 > :not(template) ~ :not(template) {
+  .xl\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-4 > :not(template) ~ :not(template) {
+  .xl\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1rem * var(--space-x-reverse));
     margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-5 > :not(template) ~ :not(template) {
+  .xl\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.25rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-5 > :not(template) ~ :not(template) {
+  .xl\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-6 > :not(template) ~ :not(template) {
+  .xl\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.5rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-6 > :not(template) ~ :not(template) {
+  .xl\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-7 > :not(template) ~ :not(template) {
+  .xl\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.75rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-7 > :not(template) ~ :not(template) {
+  .xl\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-8 > :not(template) ~ :not(template) {
+  .xl\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-8 > :not(template) ~ :not(template) {
+  .xl\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2rem * var(--space-x-reverse));
     margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-9 > :not(template) ~ :not(template) {
+  .xl\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.25rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-9 > :not(template) ~ :not(template) {
+  .xl\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-10 > :not(template) ~ :not(template) {
+  .xl\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.5rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-10 > :not(template) ~ :not(template) {
+  .xl\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-12 > :not(template) ~ :not(template) {
+  .xl\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-12 > :not(template) ~ :not(template) {
+  .xl\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3rem * var(--space-x-reverse));
     margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-14 > :not(template) ~ :not(template) {
+  .xl\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3.5rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-14 > :not(template) ~ :not(template) {
+  .xl\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-16 > :not(template) ~ :not(template) {
+  .xl\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(4rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-16 > :not(template) ~ :not(template) {
+  .xl\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(4rem * var(--space-x-reverse));
     margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-20 > :not(template) ~ :not(template) {
+  .xl\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(5rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-20 > :not(template) ~ :not(template) {
+  .xl\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(5rem * var(--space-x-reverse));
     margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-24 > :not(template) ~ :not(template) {
+  .xl\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(6rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-24 > :not(template) ~ :not(template) {
+  .xl\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(6rem * var(--space-x-reverse));
     margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-28 > :not(template) ~ :not(template) {
+  .xl\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(7rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-28 > :not(template) ~ :not(template) {
+  .xl\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(7rem * var(--space-x-reverse));
     margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-32 > :not(template) ~ :not(template) {
+  .xl\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(8rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-32 > :not(template) ~ :not(template) {
+  .xl\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(8rem * var(--space-x-reverse));
     margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-36 > :not(template) ~ :not(template) {
+  .xl\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(9rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-36 > :not(template) ~ :not(template) {
+  .xl\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(9rem * var(--space-x-reverse));
     margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-40 > :not(template) ~ :not(template) {
+  .xl\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(10rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-40 > :not(template) ~ :not(template) {
+  .xl\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(10rem * var(--space-x-reverse));
     margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-44 > :not(template) ~ :not(template) {
+  .xl\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(11rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-44 > :not(template) ~ :not(template) {
+  .xl\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(11rem * var(--space-x-reverse));
     margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-48 > :not(template) ~ :not(template) {
+  .xl\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(12rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-48 > :not(template) ~ :not(template) {
+  .xl\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(12rem * var(--space-x-reverse));
     margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-52 > :not(template) ~ :not(template) {
+  .xl\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(13rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-52 > :not(template) ~ :not(template) {
+  .xl\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(13rem * var(--space-x-reverse));
     margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-56 > :not(template) ~ :not(template) {
+  .xl\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(14rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-56 > :not(template) ~ :not(template) {
+  .xl\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(14rem * var(--space-x-reverse));
     margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-60 > :not(template) ~ :not(template) {
+  .xl\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(15rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-60 > :not(template) ~ :not(template) {
+  .xl\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(15rem * var(--space-x-reverse));
     margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-64 > :not(template) ~ :not(template) {
+  .xl\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(16rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-64 > :not(template) ~ :not(template) {
+  .xl\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(16rem * var(--space-x-reverse));
     margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-72 > :not(template) ~ :not(template) {
+  .xl\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(18rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-72 > :not(template) ~ :not(template) {
+  .xl\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(18rem * var(--space-x-reverse));
     margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-80 > :not(template) ~ :not(template) {
+  .xl\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(20rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-80 > :not(template) ~ :not(template) {
+  .xl\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(20rem * var(--space-x-reverse));
     margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-96 > :not(template) ~ :not(template) {
+  .xl\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(24rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-96 > :not(template) ~ :not(template) {
+  .xl\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(24rem * var(--space-x-reverse));
     margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-px > :not(template) ~ :not(template) {
+  .xl\:space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1px * var(--space-y-reverse));
   }
 
-  .xl\:space-x-px > :not(template) ~ :not(template) {
+  .xl\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1px * var(--space-x-reverse));
     margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-0\.5 > :not(template) ~ :not(template) {
+  .xl\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.125rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-0\.5 > :not(template) ~ :not(template) {
+  .xl\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-1\.5 > :not(template) ~ :not(template) {
+  .xl\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.375rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-1\.5 > :not(template) ~ :not(template) {
+  .xl\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-2\.5 > :not(template) ~ :not(template) {
+  .xl\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.625rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-2\.5 > :not(template) ~ :not(template) {
+  .xl\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-3\.5 > :not(template) ~ :not(template) {
+  .xl\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.875rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-3\.5 > :not(template) ~ :not(template) {
+  .xl\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-1 > :not(template) ~ :not(template) {
+  .xl\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.25rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-1 > :not(template) ~ :not(template) {
+  .xl\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-2 > :not(template) ~ :not(template) {
+  .xl\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.5rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-2 > :not(template) ~ :not(template) {
+  .xl\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-3 > :not(template) ~ :not(template) {
+  .xl\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.75rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-3 > :not(template) ~ :not(template) {
+  .xl\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-4 > :not(template) ~ :not(template) {
+  .xl\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-4 > :not(template) ~ :not(template) {
+  .xl\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1rem * var(--space-x-reverse));
     margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-5 > :not(template) ~ :not(template) {
+  .xl\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.25rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-5 > :not(template) ~ :not(template) {
+  .xl\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-6 > :not(template) ~ :not(template) {
+  .xl\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.5rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-6 > :not(template) ~ :not(template) {
+  .xl\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-7 > :not(template) ~ :not(template) {
+  .xl\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.75rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-7 > :not(template) ~ :not(template) {
+  .xl\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-8 > :not(template) ~ :not(template) {
+  .xl\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-8 > :not(template) ~ :not(template) {
+  .xl\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2rem * var(--space-x-reverse));
     margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-9 > :not(template) ~ :not(template) {
+  .xl\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.25rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-9 > :not(template) ~ :not(template) {
+  .xl\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-10 > :not(template) ~ :not(template) {
+  .xl\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.5rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-10 > :not(template) ~ :not(template) {
+  .xl\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-12 > :not(template) ~ :not(template) {
+  .xl\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-12 > :not(template) ~ :not(template) {
+  .xl\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3rem * var(--space-x-reverse));
     margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-14 > :not(template) ~ :not(template) {
+  .xl\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3.5rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-14 > :not(template) ~ :not(template) {
+  .xl\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-16 > :not(template) ~ :not(template) {
+  .xl\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-4rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-16 > :not(template) ~ :not(template) {
+  .xl\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-4rem * var(--space-x-reverse));
     margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-20 > :not(template) ~ :not(template) {
+  .xl\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-5rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-20 > :not(template) ~ :not(template) {
+  .xl\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-5rem * var(--space-x-reverse));
     margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-24 > :not(template) ~ :not(template) {
+  .xl\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-6rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-24 > :not(template) ~ :not(template) {
+  .xl\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-6rem * var(--space-x-reverse));
     margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-28 > :not(template) ~ :not(template) {
+  .xl\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-7rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-28 > :not(template) ~ :not(template) {
+  .xl\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-7rem * var(--space-x-reverse));
     margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-32 > :not(template) ~ :not(template) {
+  .xl\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-8rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-32 > :not(template) ~ :not(template) {
+  .xl\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-8rem * var(--space-x-reverse));
     margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-36 > :not(template) ~ :not(template) {
+  .xl\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-9rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-36 > :not(template) ~ :not(template) {
+  .xl\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-9rem * var(--space-x-reverse));
     margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-40 > :not(template) ~ :not(template) {
+  .xl\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-10rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-40 > :not(template) ~ :not(template) {
+  .xl\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-10rem * var(--space-x-reverse));
     margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-44 > :not(template) ~ :not(template) {
+  .xl\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-11rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-44 > :not(template) ~ :not(template) {
+  .xl\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-11rem * var(--space-x-reverse));
     margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-48 > :not(template) ~ :not(template) {
+  .xl\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-12rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-48 > :not(template) ~ :not(template) {
+  .xl\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-12rem * var(--space-x-reverse));
     margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-52 > :not(template) ~ :not(template) {
+  .xl\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-13rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-52 > :not(template) ~ :not(template) {
+  .xl\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-13rem * var(--space-x-reverse));
     margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-56 > :not(template) ~ :not(template) {
+  .xl\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-14rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-56 > :not(template) ~ :not(template) {
+  .xl\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-14rem * var(--space-x-reverse));
     margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-60 > :not(template) ~ :not(template) {
+  .xl\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-15rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-60 > :not(template) ~ :not(template) {
+  .xl\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-15rem * var(--space-x-reverse));
     margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-64 > :not(template) ~ :not(template) {
+  .xl\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-16rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-64 > :not(template) ~ :not(template) {
+  .xl\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-16rem * var(--space-x-reverse));
     margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-72 > :not(template) ~ :not(template) {
+  .xl\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-18rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-72 > :not(template) ~ :not(template) {
+  .xl\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-18rem * var(--space-x-reverse));
     margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-80 > :not(template) ~ :not(template) {
+  .xl\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-20rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-80 > :not(template) ~ :not(template) {
+  .xl\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-20rem * var(--space-x-reverse));
     margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-96 > :not(template) ~ :not(template) {
+  .xl\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-24rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-96 > :not(template) ~ :not(template) {
+  .xl\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-24rem * var(--space-x-reverse));
     margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-px > :not(template) ~ :not(template) {
+  .xl\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1px * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-px > :not(template) ~ :not(template) {
+  .xl\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1px * var(--space-x-reverse));
     margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-0\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.125rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-0\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-1\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.375rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-1\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-2\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.625rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-2\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-3\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.875rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-3\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-reverse > :not(template) ~ :not(template) {
+  .xl\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 1;
   }
 
-  .xl\:space-x-reverse > :not(template) ~ :not(template) {
+  .xl\:space-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 1;
   }
 
-  .xl\:divide-y-0 > :not(template) ~ :not(template) {
+  .xl\:divide-y-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(0px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(0px * var(--divide-y-reverse));
   }
 
-  .xl\:divide-x-0 > :not(template) ~ :not(template) {
+  .xl\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(0px * var(--divide-x-reverse));
     border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .xl\:divide-y-2 > :not(template) ~ :not(template) {
+  .xl\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(2px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(2px * var(--divide-y-reverse));
   }
 
-  .xl\:divide-x-2 > :not(template) ~ :not(template) {
+  .xl\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(2px * var(--divide-x-reverse));
     border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .xl\:divide-y-4 > :not(template) ~ :not(template) {
+  .xl\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(4px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(4px * var(--divide-y-reverse));
   }
 
-  .xl\:divide-x-4 > :not(template) ~ :not(template) {
+  .xl\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(4px * var(--divide-x-reverse));
     border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .xl\:divide-y-8 > :not(template) ~ :not(template) {
+  .xl\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(8px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(8px * var(--divide-y-reverse));
   }
 
-  .xl\:divide-x-8 > :not(template) ~ :not(template) {
+  .xl\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(8px * var(--divide-x-reverse));
     border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .xl\:divide-y > :not(template) ~ :not(template) {
+  .xl\:divide-y > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(1px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(1px * var(--divide-y-reverse));
   }
 
-  .xl\:divide-x > :not(template) ~ :not(template) {
+  .xl\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(1px * var(--divide-x-reverse));
     border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .xl\:divide-y-reverse > :not(template) ~ :not(template) {
+  .xl\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 1;
   }
 
-  .xl\:divide-x-reverse > :not(template) ~ :not(template) {
+  .xl\:divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 1;
   }
 
-  .xl\:divide-transparent > :not(template) ~ :not(template) {
+  .xl\:divide-transparent > :not([hidden]) ~ :not([hidden]) {
     border-color: transparent;
   }
 
-  .xl\:divide-current > :not(template) ~ :not(template) {
+  .xl\:divide-current > :not([hidden]) ~ :not([hidden]) {
     border-color: currentColor;
   }
 
-  .xl\:divide-black > :not(template) ~ :not(template) {
+  .xl\:divide-black > :not([hidden]) ~ :not([hidden]) {
     border-color: #000;
   }
 
-  .xl\:divide-white > :not(template) ~ :not(template) {
+  .xl\:divide-white > :not([hidden]) ~ :not([hidden]) {
     border-color: #fff;
   }
 
-  .xl\:divide-gray-50 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fafafa;
   }
 
-  .xl\:divide-gray-100 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f4f4f5;
   }
 
-  .xl\:divide-gray-200 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #e4e4e7;
   }
 
-  .xl\:divide-gray-300 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #d4d4d8;
   }
 
-  .xl\:divide-gray-400 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #a1a1aa;
   }
 
-  .xl\:divide-gray-500 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #71717a;
   }
 
-  .xl\:divide-gray-600 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #52525b;
   }
 
-  .xl\:divide-gray-700 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #3f3f46;
   }
 
-  .xl\:divide-gray-800 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #27272a;
   }
 
-  .xl\:divide-gray-900 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #18181b;
   }
 
-  .xl\:divide-red-50 > :not(template) ~ :not(template) {
+  .xl\:divide-red-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fef2f2;
   }
 
-  .xl\:divide-red-100 > :not(template) ~ :not(template) {
+  .xl\:divide-red-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fee2e2;
   }
 
-  .xl\:divide-red-200 > :not(template) ~ :not(template) {
+  .xl\:divide-red-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fecaca;
   }
 
-  .xl\:divide-red-300 > :not(template) ~ :not(template) {
+  .xl\:divide-red-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fca5a5;
   }
 
-  .xl\:divide-red-400 > :not(template) ~ :not(template) {
+  .xl\:divide-red-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f87171;
   }
 
-  .xl\:divide-red-500 > :not(template) ~ :not(template) {
+  .xl\:divide-red-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ef4444;
   }
 
-  .xl\:divide-red-600 > :not(template) ~ :not(template) {
+  .xl\:divide-red-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #dc2626;
   }
 
-  .xl\:divide-red-700 > :not(template) ~ :not(template) {
+  .xl\:divide-red-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #b91c1c;
   }
 
-  .xl\:divide-red-800 > :not(template) ~ :not(template) {
+  .xl\:divide-red-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #991b1b;
   }
 
-  .xl\:divide-red-900 > :not(template) ~ :not(template) {
+  .xl\:divide-red-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #7f1d1d;
   }
 
-  .xl\:divide-yellow-50 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fffbeb;
   }
 
-  .xl\:divide-yellow-100 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fef3c7;
   }
 
-  .xl\:divide-yellow-200 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fde68a;
   }
 
-  .xl\:divide-yellow-300 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fcd34d;
   }
 
-  .xl\:divide-yellow-400 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fbbf24;
   }
 
-  .xl\:divide-yellow-500 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f59e0b;
   }
 
-  .xl\:divide-yellow-600 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #d97706;
   }
 
-  .xl\:divide-yellow-700 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #b45309;
   }
 
-  .xl\:divide-yellow-800 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #92400e;
   }
 
-  .xl\:divide-yellow-900 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #78350f;
   }
 
-  .xl\:divide-green-50 > :not(template) ~ :not(template) {
+  .xl\:divide-green-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ecfdf5;
   }
 
-  .xl\:divide-green-100 > :not(template) ~ :not(template) {
+  .xl\:divide-green-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #d1fae5;
   }
 
-  .xl\:divide-green-200 > :not(template) ~ :not(template) {
+  .xl\:divide-green-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #a7f3d0;
   }
 
-  .xl\:divide-green-300 > :not(template) ~ :not(template) {
+  .xl\:divide-green-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #6ee7b7;
   }
 
-  .xl\:divide-green-400 > :not(template) ~ :not(template) {
+  .xl\:divide-green-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #34d399;
   }
 
-  .xl\:divide-green-500 > :not(template) ~ :not(template) {
+  .xl\:divide-green-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #10b981;
   }
 
-  .xl\:divide-green-600 > :not(template) ~ :not(template) {
+  .xl\:divide-green-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #059669;
   }
 
-  .xl\:divide-green-700 > :not(template) ~ :not(template) {
+  .xl\:divide-green-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #047857;
   }
 
-  .xl\:divide-green-800 > :not(template) ~ :not(template) {
+  .xl\:divide-green-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #065f46;
   }
 
-  .xl\:divide-green-900 > :not(template) ~ :not(template) {
+  .xl\:divide-green-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #064e3b;
   }
 
-  .xl\:divide-blue-50 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #eff6ff;
   }
 
-  .xl\:divide-blue-100 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #dbeafe;
   }
 
-  .xl\:divide-blue-200 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #bfdbfe;
   }
 
-  .xl\:divide-blue-300 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #93c5fd;
   }
 
-  .xl\:divide-blue-400 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #60a5fa;
   }
 
-  .xl\:divide-blue-500 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #3b82f6;
   }
 
-  .xl\:divide-blue-600 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #2563eb;
   }
 
-  .xl\:divide-blue-700 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #1d4ed8;
   }
 
-  .xl\:divide-blue-800 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #1e40af;
   }
 
-  .xl\:divide-blue-900 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #1e3a8a;
   }
 
-  .xl\:divide-purple-50 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f5f3ff;
   }
 
-  .xl\:divide-purple-100 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ede9fe;
   }
 
-  .xl\:divide-purple-200 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ddd6fe;
   }
 
-  .xl\:divide-purple-300 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #c4b5fd;
   }
 
-  .xl\:divide-purple-400 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #a78bfa;
   }
 
-  .xl\:divide-purple-500 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #8b5cf6;
   }
 
-  .xl\:divide-purple-600 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #7c3aed;
   }
 
-  .xl\:divide-purple-700 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #6d28d9;
   }
 
-  .xl\:divide-purple-800 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #5b21b6;
   }
 
-  .xl\:divide-purple-900 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #4c1d95;
   }
 
-  .xl\:divide-pink-50 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fdf2f8;
   }
 
-  .xl\:divide-pink-100 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fce7f3;
   }
 
-  .xl\:divide-pink-200 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fbcfe8;
   }
 
-  .xl\:divide-pink-300 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f9a8d4;
   }
 
-  .xl\:divide-pink-400 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f472b6;
   }
 
-  .xl\:divide-pink-500 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ec4899;
   }
 
-  .xl\:divide-pink-600 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #db2777;
   }
 
-  .xl\:divide-pink-700 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #be185d;
   }
 
-  .xl\:divide-pink-800 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #9d174d;
   }
 
-  .xl\:divide-pink-900 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #831843;
   }
 
-  .xl\:divide-solid > :not(template) ~ :not(template) {
+  .xl\:divide-solid > :not([hidden]) ~ :not([hidden]) {
     border-style: solid;
   }
 
-  .xl\:divide-dashed > :not(template) ~ :not(template) {
+  .xl\:divide-dashed > :not([hidden]) ~ :not([hidden]) {
     border-style: dashed;
   }
 
-  .xl\:divide-dotted > :not(template) ~ :not(template) {
+  .xl\:divide-dotted > :not([hidden]) ~ :not([hidden]) {
     border-style: dotted;
   }
 
-  .xl\:divide-double > :not(template) ~ :not(template) {
+  .xl\:divide-double > :not([hidden]) ~ :not([hidden]) {
     border-style: double;
   }
 
-  .xl\:divide-none > :not(template) ~ :not(template) {
+  .xl\:divide-none > :not([hidden]) ~ :not([hidden]) {
     border-style: none;
   }
 
@@ -106020,1199 +106020,1199 @@ video {
     }
   }
 
-  .\32xl\:space-y-0 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0px * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-0 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0px * var(--space-x-reverse));
     margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-1 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.25rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-1 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-2 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-2 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-3 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.75rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-3 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-4 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-4 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1rem * var(--space-x-reverse));
     margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-5 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.25rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-5 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-6 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-6 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-7 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.75rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-7 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-8 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-8 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2rem * var(--space-x-reverse));
     margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-9 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.25rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-9 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-10 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-10 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-12 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-12 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3rem * var(--space-x-reverse));
     margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-14 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-14 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-16 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(4rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-16 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(4rem * var(--space-x-reverse));
     margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-20 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-20 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(5rem * var(--space-x-reverse));
     margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-24 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(6rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-24 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(6rem * var(--space-x-reverse));
     margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-28 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(7rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-28 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(7rem * var(--space-x-reverse));
     margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-32 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(8rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-32 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(8rem * var(--space-x-reverse));
     margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-36 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(9rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-36 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(9rem * var(--space-x-reverse));
     margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-40 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(10rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-40 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(10rem * var(--space-x-reverse));
     margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-44 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(11rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-44 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(11rem * var(--space-x-reverse));
     margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-48 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(12rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-48 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(12rem * var(--space-x-reverse));
     margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-52 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(13rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-52 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(13rem * var(--space-x-reverse));
     margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-56 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(14rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-56 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(14rem * var(--space-x-reverse));
     margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-60 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(15rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-60 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(15rem * var(--space-x-reverse));
     margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-64 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(16rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-64 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(16rem * var(--space-x-reverse));
     margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-72 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(18rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-72 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(18rem * var(--space-x-reverse));
     margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-80 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(20rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-80 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(20rem * var(--space-x-reverse));
     margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-96 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(24rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-96 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(24rem * var(--space-x-reverse));
     margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-px > :not(template) ~ :not(template) {
+  .\32xl\:space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1px * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-px > :not(template) ~ :not(template) {
+  .\32xl\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1px * var(--space-x-reverse));
     margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-0\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.125rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-0\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-1\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.375rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-1\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-2\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.625rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-2\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-3\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.875rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-3\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-1 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.25rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-1 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-2 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-2 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-3 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.75rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-3 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-4 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-4 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1rem * var(--space-x-reverse));
     margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.25rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-6 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-6 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-7 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.75rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-7 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-8 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-8 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2rem * var(--space-x-reverse));
     margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-9 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.25rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-9 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-10 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-10 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-12 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-12 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3rem * var(--space-x-reverse));
     margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-14 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-14 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-16 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-4rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-16 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-4rem * var(--space-x-reverse));
     margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-20 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-20 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-5rem * var(--space-x-reverse));
     margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-24 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-6rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-24 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-6rem * var(--space-x-reverse));
     margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-28 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-7rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-28 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-7rem * var(--space-x-reverse));
     margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-32 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-8rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-32 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-8rem * var(--space-x-reverse));
     margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-36 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-9rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-36 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-9rem * var(--space-x-reverse));
     margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-40 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-10rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-40 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-10rem * var(--space-x-reverse));
     margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-44 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-11rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-44 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-11rem * var(--space-x-reverse));
     margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-48 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-12rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-48 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-12rem * var(--space-x-reverse));
     margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-52 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-13rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-52 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-13rem * var(--space-x-reverse));
     margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-56 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-14rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-56 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-14rem * var(--space-x-reverse));
     margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-60 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-15rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-60 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-15rem * var(--space-x-reverse));
     margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-64 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-16rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-64 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-16rem * var(--space-x-reverse));
     margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-72 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-18rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-72 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-18rem * var(--space-x-reverse));
     margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-80 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-20rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-80 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-20rem * var(--space-x-reverse));
     margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-96 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-24rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-96 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-24rem * var(--space-x-reverse));
     margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-px > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1px * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-px > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1px * var(--space-x-reverse));
     margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-0\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.125rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-0\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-1\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.375rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-1\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-2\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.625rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-2\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-3\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.875rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-3\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-reverse > :not(template) ~ :not(template) {
+  .\32xl\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 1;
   }
 
-  .\32xl\:space-x-reverse > :not(template) ~ :not(template) {
+  .\32xl\:space-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 1;
   }
 
-  .\32xl\:divide-y-0 > :not(template) ~ :not(template) {
+  .\32xl\:divide-y-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(0px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(0px * var(--divide-y-reverse));
   }
 
-  .\32xl\:divide-x-0 > :not(template) ~ :not(template) {
+  .\32xl\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(0px * var(--divide-x-reverse));
     border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .\32xl\:divide-y-2 > :not(template) ~ :not(template) {
+  .\32xl\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(2px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(2px * var(--divide-y-reverse));
   }
 
-  .\32xl\:divide-x-2 > :not(template) ~ :not(template) {
+  .\32xl\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(2px * var(--divide-x-reverse));
     border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .\32xl\:divide-y-4 > :not(template) ~ :not(template) {
+  .\32xl\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(4px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(4px * var(--divide-y-reverse));
   }
 
-  .\32xl\:divide-x-4 > :not(template) ~ :not(template) {
+  .\32xl\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(4px * var(--divide-x-reverse));
     border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .\32xl\:divide-y-8 > :not(template) ~ :not(template) {
+  .\32xl\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(8px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(8px * var(--divide-y-reverse));
   }
 
-  .\32xl\:divide-x-8 > :not(template) ~ :not(template) {
+  .\32xl\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(8px * var(--divide-x-reverse));
     border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .\32xl\:divide-y > :not(template) ~ :not(template) {
+  .\32xl\:divide-y > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(1px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(1px * var(--divide-y-reverse));
   }
 
-  .\32xl\:divide-x > :not(template) ~ :not(template) {
+  .\32xl\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(1px * var(--divide-x-reverse));
     border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .\32xl\:divide-y-reverse > :not(template) ~ :not(template) {
+  .\32xl\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 1;
   }
 
-  .\32xl\:divide-x-reverse > :not(template) ~ :not(template) {
+  .\32xl\:divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 1;
   }
 
-  .\32xl\:divide-transparent > :not(template) ~ :not(template) {
+  .\32xl\:divide-transparent > :not([hidden]) ~ :not([hidden]) {
     border-color: transparent;
   }
 
-  .\32xl\:divide-current > :not(template) ~ :not(template) {
+  .\32xl\:divide-current > :not([hidden]) ~ :not([hidden]) {
     border-color: currentColor;
   }
 
-  .\32xl\:divide-black > :not(template) ~ :not(template) {
+  .\32xl\:divide-black > :not([hidden]) ~ :not([hidden]) {
     border-color: #000;
   }
 
-  .\32xl\:divide-white > :not(template) ~ :not(template) {
+  .\32xl\:divide-white > :not([hidden]) ~ :not([hidden]) {
     border-color: #fff;
   }
 
-  .\32xl\:divide-gray-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fafafa;
   }
 
-  .\32xl\:divide-gray-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f4f4f5;
   }
 
-  .\32xl\:divide-gray-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #e4e4e7;
   }
 
-  .\32xl\:divide-gray-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #d4d4d8;
   }
 
-  .\32xl\:divide-gray-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #a1a1aa;
   }
 
-  .\32xl\:divide-gray-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #71717a;
   }
 
-  .\32xl\:divide-gray-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #52525b;
   }
 
-  .\32xl\:divide-gray-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #3f3f46;
   }
 
-  .\32xl\:divide-gray-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #27272a;
   }
 
-  .\32xl\:divide-gray-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #18181b;
   }
 
-  .\32xl\:divide-red-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fef2f2;
   }
 
-  .\32xl\:divide-red-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fee2e2;
   }
 
-  .\32xl\:divide-red-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fecaca;
   }
 
-  .\32xl\:divide-red-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fca5a5;
   }
 
-  .\32xl\:divide-red-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f87171;
   }
 
-  .\32xl\:divide-red-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ef4444;
   }
 
-  .\32xl\:divide-red-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #dc2626;
   }
 
-  .\32xl\:divide-red-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #b91c1c;
   }
 
-  .\32xl\:divide-red-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #991b1b;
   }
 
-  .\32xl\:divide-red-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #7f1d1d;
   }
 
-  .\32xl\:divide-yellow-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fffbeb;
   }
 
-  .\32xl\:divide-yellow-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fef3c7;
   }
 
-  .\32xl\:divide-yellow-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fde68a;
   }
 
-  .\32xl\:divide-yellow-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fcd34d;
   }
 
-  .\32xl\:divide-yellow-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fbbf24;
   }
 
-  .\32xl\:divide-yellow-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f59e0b;
   }
 
-  .\32xl\:divide-yellow-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #d97706;
   }
 
-  .\32xl\:divide-yellow-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #b45309;
   }
 
-  .\32xl\:divide-yellow-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #92400e;
   }
 
-  .\32xl\:divide-yellow-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #78350f;
   }
 
-  .\32xl\:divide-green-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ecfdf5;
   }
 
-  .\32xl\:divide-green-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #d1fae5;
   }
 
-  .\32xl\:divide-green-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #a7f3d0;
   }
 
-  .\32xl\:divide-green-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #6ee7b7;
   }
 
-  .\32xl\:divide-green-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #34d399;
   }
 
-  .\32xl\:divide-green-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #10b981;
   }
 
-  .\32xl\:divide-green-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #059669;
   }
 
-  .\32xl\:divide-green-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #047857;
   }
 
-  .\32xl\:divide-green-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #065f46;
   }
 
-  .\32xl\:divide-green-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #064e3b;
   }
 
-  .\32xl\:divide-blue-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #eff6ff;
   }
 
-  .\32xl\:divide-blue-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #dbeafe;
   }
 
-  .\32xl\:divide-blue-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #bfdbfe;
   }
 
-  .\32xl\:divide-blue-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #93c5fd;
   }
 
-  .\32xl\:divide-blue-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #60a5fa;
   }
 
-  .\32xl\:divide-blue-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #3b82f6;
   }
 
-  .\32xl\:divide-blue-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #2563eb;
   }
 
-  .\32xl\:divide-blue-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #1d4ed8;
   }
 
-  .\32xl\:divide-blue-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #1e40af;
   }
 
-  .\32xl\:divide-blue-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #1e3a8a;
   }
 
-  .\32xl\:divide-purple-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f5f3ff;
   }
 
-  .\32xl\:divide-purple-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ede9fe;
   }
 
-  .\32xl\:divide-purple-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ddd6fe;
   }
 
-  .\32xl\:divide-purple-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #c4b5fd;
   }
 
-  .\32xl\:divide-purple-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #a78bfa;
   }
 
-  .\32xl\:divide-purple-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #8b5cf6;
   }
 
-  .\32xl\:divide-purple-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #7c3aed;
   }
 
-  .\32xl\:divide-purple-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #6d28d9;
   }
 
-  .\32xl\:divide-purple-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #5b21b6;
   }
 
-  .\32xl\:divide-purple-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #4c1d95;
   }
 
-  .\32xl\:divide-pink-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fdf2f8;
   }
 
-  .\32xl\:divide-pink-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fce7f3;
   }
 
-  .\32xl\:divide-pink-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
     border-color: #fbcfe8;
   }
 
-  .\32xl\:divide-pink-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f9a8d4;
   }
 
-  .\32xl\:divide-pink-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
     border-color: #f472b6;
   }
 
-  .\32xl\:divide-pink-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
     border-color: #ec4899;
   }
 
-  .\32xl\:divide-pink-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
     border-color: #db2777;
   }
 
-  .\32xl\:divide-pink-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
     border-color: #be185d;
   }
 
-  .\32xl\:divide-pink-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
     border-color: #9d174d;
   }
 
-  .\32xl\:divide-pink-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
     border-color: #831843;
   }
 
-  .\32xl\:divide-solid > :not(template) ~ :not(template) {
+  .\32xl\:divide-solid > :not([hidden]) ~ :not([hidden]) {
     border-style: solid;
   }
 
-  .\32xl\:divide-dashed > :not(template) ~ :not(template) {
+  .\32xl\:divide-dashed > :not([hidden]) ~ :not([hidden]) {
     border-style: dashed;
   }
 
-  .\32xl\:divide-dotted > :not(template) ~ :not(template) {
+  .\32xl\:divide-dotted > :not([hidden]) ~ :not([hidden]) {
     border-style: dotted;
   }
 
-  .\32xl\:divide-double > :not(template) ~ :not(template) {
+  .\32xl\:divide-double > :not([hidden]) ~ :not([hidden]) {
     border-style: double;
   }
 
-  .\32xl\:divide-none > :not(template) ~ :not(template) {
+  .\32xl\:divide-none > :not([hidden]) ~ :not([hidden]) {
     border-style: none;
   }
 

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -560,1323 +560,1323 @@ video {
   }
 }
 
-.space-y-0 > :not(template) ~ :not(template) {
+.space-y-0 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0px * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0px * var(--space-y-reverse));
 }
 
-.space-x-0 > :not(template) ~ :not(template) {
+.space-x-0 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0px * var(--space-x-reverse));
   margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-1 > :not(template) ~ :not(template) {
+.space-y-1 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0.25rem * var(--space-y-reverse));
 }
 
-.space-x-1 > :not(template) ~ :not(template) {
+.space-x-1 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0.25rem * var(--space-x-reverse));
   margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-2 > :not(template) ~ :not(template) {
+.space-y-2 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0.5rem * var(--space-y-reverse));
 }
 
-.space-x-2 > :not(template) ~ :not(template) {
+.space-x-2 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0.5rem * var(--space-x-reverse));
   margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-3 > :not(template) ~ :not(template) {
+.space-y-3 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0.75rem * var(--space-y-reverse));
 }
 
-.space-x-3 > :not(template) ~ :not(template) {
+.space-x-3 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0.75rem * var(--space-x-reverse));
   margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-4 > :not(template) ~ :not(template) {
+.space-y-4 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(1rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(1rem * var(--space-y-reverse));
 }
 
-.space-x-4 > :not(template) ~ :not(template) {
+.space-x-4 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(1rem * var(--space-x-reverse));
   margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-5 > :not(template) ~ :not(template) {
+.space-y-5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(1.25rem * var(--space-y-reverse));
 }
 
-.space-x-5 > :not(template) ~ :not(template) {
+.space-x-5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(1.25rem * var(--space-x-reverse));
   margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-6 > :not(template) ~ :not(template) {
+.space-y-6 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(1.5rem * var(--space-y-reverse));
 }
 
-.space-x-6 > :not(template) ~ :not(template) {
+.space-x-6 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(1.5rem * var(--space-x-reverse));
   margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-7 > :not(template) ~ :not(template) {
+.space-y-7 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(1.75rem * var(--space-y-reverse));
 }
 
-.space-x-7 > :not(template) ~ :not(template) {
+.space-x-7 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(1.75rem * var(--space-x-reverse));
   margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-8 > :not(template) ~ :not(template) {
+.space-y-8 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(2rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(2rem * var(--space-y-reverse));
 }
 
-.space-x-8 > :not(template) ~ :not(template) {
+.space-x-8 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(2rem * var(--space-x-reverse));
   margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-9 > :not(template) ~ :not(template) {
+.space-y-9 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(2.25rem * var(--space-y-reverse));
 }
 
-.space-x-9 > :not(template) ~ :not(template) {
+.space-x-9 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(2.25rem * var(--space-x-reverse));
   margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-10 > :not(template) ~ :not(template) {
+.space-y-10 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(2.5rem * var(--space-y-reverse));
 }
 
-.space-x-10 > :not(template) ~ :not(template) {
+.space-x-10 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(2.5rem * var(--space-x-reverse));
   margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-12 > :not(template) ~ :not(template) {
+.space-y-12 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(3rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(3rem * var(--space-y-reverse));
 }
 
-.space-x-12 > :not(template) ~ :not(template) {
+.space-x-12 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(3rem * var(--space-x-reverse));
   margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-14 > :not(template) ~ :not(template) {
+.space-y-14 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(3.5rem * var(--space-y-reverse));
 }
 
-.space-x-14 > :not(template) ~ :not(template) {
+.space-x-14 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(3.5rem * var(--space-x-reverse));
   margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-16 > :not(template) ~ :not(template) {
+.space-y-16 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(4rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(4rem * var(--space-y-reverse));
 }
 
-.space-x-16 > :not(template) ~ :not(template) {
+.space-x-16 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(4rem * var(--space-x-reverse));
   margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-20 > :not(template) ~ :not(template) {
+.space-y-20 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(5rem * var(--space-y-reverse));
 }
 
-.space-x-20 > :not(template) ~ :not(template) {
+.space-x-20 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(5rem * var(--space-x-reverse));
   margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-24 > :not(template) ~ :not(template) {
+.space-y-24 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(6rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(6rem * var(--space-y-reverse));
 }
 
-.space-x-24 > :not(template) ~ :not(template) {
+.space-x-24 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(6rem * var(--space-x-reverse));
   margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-28 > :not(template) ~ :not(template) {
+.space-y-28 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(7rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(7rem * var(--space-y-reverse));
 }
 
-.space-x-28 > :not(template) ~ :not(template) {
+.space-x-28 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(7rem * var(--space-x-reverse));
   margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-32 > :not(template) ~ :not(template) {
+.space-y-32 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(8rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(8rem * var(--space-y-reverse));
 }
 
-.space-x-32 > :not(template) ~ :not(template) {
+.space-x-32 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(8rem * var(--space-x-reverse));
   margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-36 > :not(template) ~ :not(template) {
+.space-y-36 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(9rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(9rem * var(--space-y-reverse));
 }
 
-.space-x-36 > :not(template) ~ :not(template) {
+.space-x-36 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(9rem * var(--space-x-reverse));
   margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-40 > :not(template) ~ :not(template) {
+.space-y-40 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(10rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(10rem * var(--space-y-reverse));
 }
 
-.space-x-40 > :not(template) ~ :not(template) {
+.space-x-40 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(10rem * var(--space-x-reverse));
   margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-44 > :not(template) ~ :not(template) {
+.space-y-44 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(11rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(11rem * var(--space-y-reverse));
 }
 
-.space-x-44 > :not(template) ~ :not(template) {
+.space-x-44 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(11rem * var(--space-x-reverse));
   margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-48 > :not(template) ~ :not(template) {
+.space-y-48 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(12rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(12rem * var(--space-y-reverse));
 }
 
-.space-x-48 > :not(template) ~ :not(template) {
+.space-x-48 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(12rem * var(--space-x-reverse));
   margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-52 > :not(template) ~ :not(template) {
+.space-y-52 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(13rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(13rem * var(--space-y-reverse));
 }
 
-.space-x-52 > :not(template) ~ :not(template) {
+.space-x-52 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(13rem * var(--space-x-reverse));
   margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-56 > :not(template) ~ :not(template) {
+.space-y-56 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(14rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(14rem * var(--space-y-reverse));
 }
 
-.space-x-56 > :not(template) ~ :not(template) {
+.space-x-56 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(14rem * var(--space-x-reverse));
   margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-60 > :not(template) ~ :not(template) {
+.space-y-60 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(15rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(15rem * var(--space-y-reverse));
 }
 
-.space-x-60 > :not(template) ~ :not(template) {
+.space-x-60 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(15rem * var(--space-x-reverse));
   margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-64 > :not(template) ~ :not(template) {
+.space-y-64 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(16rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(16rem * var(--space-y-reverse));
 }
 
-.space-x-64 > :not(template) ~ :not(template) {
+.space-x-64 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(16rem * var(--space-x-reverse));
   margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-72 > :not(template) ~ :not(template) {
+.space-y-72 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(18rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(18rem * var(--space-y-reverse));
 }
 
-.space-x-72 > :not(template) ~ :not(template) {
+.space-x-72 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(18rem * var(--space-x-reverse));
   margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-80 > :not(template) ~ :not(template) {
+.space-y-80 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(20rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(20rem * var(--space-y-reverse));
 }
 
-.space-x-80 > :not(template) ~ :not(template) {
+.space-x-80 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(20rem * var(--space-x-reverse));
   margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-96 > :not(template) ~ :not(template) {
+.space-y-96 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(24rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(24rem * var(--space-y-reverse));
 }
 
-.space-x-96 > :not(template) ~ :not(template) {
+.space-x-96 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(24rem * var(--space-x-reverse));
   margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-px > :not(template) ~ :not(template) {
+.space-y-px > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(1px * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(1px * var(--space-y-reverse));
 }
 
-.space-x-px > :not(template) ~ :not(template) {
+.space-x-px > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(1px * var(--space-x-reverse));
   margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-0\.5 > :not(template) ~ :not(template) {
+.space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0.125rem * var(--space-y-reverse));
 }
 
-.space-x-0\.5 > :not(template) ~ :not(template) {
+.space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0.125rem * var(--space-x-reverse));
   margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-1\.5 > :not(template) ~ :not(template) {
+.space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0.375rem * var(--space-y-reverse));
 }
 
-.space-x-1\.5 > :not(template) ~ :not(template) {
+.space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0.375rem * var(--space-x-reverse));
   margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-2\.5 > :not(template) ~ :not(template) {
+.space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0.625rem * var(--space-y-reverse));
 }
 
-.space-x-2\.5 > :not(template) ~ :not(template) {
+.space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0.625rem * var(--space-x-reverse));
   margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-3\.5 > :not(template) ~ :not(template) {
+.space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(0.875rem * var(--space-y-reverse));
 }
 
-.space-x-3\.5 > :not(template) ~ :not(template) {
+.space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(0.875rem * var(--space-x-reverse));
   margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-1 > :not(template) ~ :not(template) {
+.-space-y-1 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-0.25rem * var(--space-y-reverse));
 }
 
-.-space-x-1 > :not(template) ~ :not(template) {
+.-space-x-1 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
   margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-2 > :not(template) ~ :not(template) {
+.-space-y-2 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-0.5rem * var(--space-y-reverse));
 }
 
-.-space-x-2 > :not(template) ~ :not(template) {
+.-space-x-2 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
   margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-3 > :not(template) ~ :not(template) {
+.-space-y-3 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-0.75rem * var(--space-y-reverse));
 }
 
-.-space-x-3 > :not(template) ~ :not(template) {
+.-space-x-3 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
   margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-4 > :not(template) ~ :not(template) {
+.-space-y-4 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-1rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-1rem * var(--space-y-reverse));
 }
 
-.-space-x-4 > :not(template) ~ :not(template) {
+.-space-x-4 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-1rem * var(--space-x-reverse));
   margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-5 > :not(template) ~ :not(template) {
+.-space-y-5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-1.25rem * var(--space-y-reverse));
 }
 
-.-space-x-5 > :not(template) ~ :not(template) {
+.-space-x-5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
   margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-6 > :not(template) ~ :not(template) {
+.-space-y-6 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-1.5rem * var(--space-y-reverse));
 }
 
-.-space-x-6 > :not(template) ~ :not(template) {
+.-space-x-6 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
   margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-7 > :not(template) ~ :not(template) {
+.-space-y-7 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-1.75rem * var(--space-y-reverse));
 }
 
-.-space-x-7 > :not(template) ~ :not(template) {
+.-space-x-7 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
   margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-8 > :not(template) ~ :not(template) {
+.-space-y-8 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-2rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-2rem * var(--space-y-reverse));
 }
 
-.-space-x-8 > :not(template) ~ :not(template) {
+.-space-x-8 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-2rem * var(--space-x-reverse));
   margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-9 > :not(template) ~ :not(template) {
+.-space-y-9 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-2.25rem * var(--space-y-reverse));
 }
 
-.-space-x-9 > :not(template) ~ :not(template) {
+.-space-x-9 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
   margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-10 > :not(template) ~ :not(template) {
+.-space-y-10 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-2.5rem * var(--space-y-reverse));
 }
 
-.-space-x-10 > :not(template) ~ :not(template) {
+.-space-x-10 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
   margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-12 > :not(template) ~ :not(template) {
+.-space-y-12 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-3rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-3rem * var(--space-y-reverse));
 }
 
-.-space-x-12 > :not(template) ~ :not(template) {
+.-space-x-12 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-3rem * var(--space-x-reverse));
   margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-14 > :not(template) ~ :not(template) {
+.-space-y-14 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-3.5rem * var(--space-y-reverse));
 }
 
-.-space-x-14 > :not(template) ~ :not(template) {
+.-space-x-14 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
   margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-16 > :not(template) ~ :not(template) {
+.-space-y-16 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-4rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-4rem * var(--space-y-reverse));
 }
 
-.-space-x-16 > :not(template) ~ :not(template) {
+.-space-x-16 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-4rem * var(--space-x-reverse));
   margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-20 > :not(template) ~ :not(template) {
+.-space-y-20 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-5rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-5rem * var(--space-y-reverse));
 }
 
-.-space-x-20 > :not(template) ~ :not(template) {
+.-space-x-20 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-5rem * var(--space-x-reverse));
   margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-24 > :not(template) ~ :not(template) {
+.-space-y-24 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-6rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-6rem * var(--space-y-reverse));
 }
 
-.-space-x-24 > :not(template) ~ :not(template) {
+.-space-x-24 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-6rem * var(--space-x-reverse));
   margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-28 > :not(template) ~ :not(template) {
+.-space-y-28 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-7rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-7rem * var(--space-y-reverse));
 }
 
-.-space-x-28 > :not(template) ~ :not(template) {
+.-space-x-28 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-7rem * var(--space-x-reverse));
   margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-32 > :not(template) ~ :not(template) {
+.-space-y-32 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-8rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-8rem * var(--space-y-reverse));
 }
 
-.-space-x-32 > :not(template) ~ :not(template) {
+.-space-x-32 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-8rem * var(--space-x-reverse));
   margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-36 > :not(template) ~ :not(template) {
+.-space-y-36 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-9rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-9rem * var(--space-y-reverse));
 }
 
-.-space-x-36 > :not(template) ~ :not(template) {
+.-space-x-36 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-9rem * var(--space-x-reverse));
   margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-40 > :not(template) ~ :not(template) {
+.-space-y-40 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-10rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-10rem * var(--space-y-reverse));
 }
 
-.-space-x-40 > :not(template) ~ :not(template) {
+.-space-x-40 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-10rem * var(--space-x-reverse));
   margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-44 > :not(template) ~ :not(template) {
+.-space-y-44 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-11rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-11rem * var(--space-y-reverse));
 }
 
-.-space-x-44 > :not(template) ~ :not(template) {
+.-space-x-44 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-11rem * var(--space-x-reverse));
   margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-48 > :not(template) ~ :not(template) {
+.-space-y-48 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-12rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-12rem * var(--space-y-reverse));
 }
 
-.-space-x-48 > :not(template) ~ :not(template) {
+.-space-x-48 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-12rem * var(--space-x-reverse));
   margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-52 > :not(template) ~ :not(template) {
+.-space-y-52 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-13rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-13rem * var(--space-y-reverse));
 }
 
-.-space-x-52 > :not(template) ~ :not(template) {
+.-space-x-52 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-13rem * var(--space-x-reverse));
   margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-56 > :not(template) ~ :not(template) {
+.-space-y-56 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-14rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-14rem * var(--space-y-reverse));
 }
 
-.-space-x-56 > :not(template) ~ :not(template) {
+.-space-x-56 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-14rem * var(--space-x-reverse));
   margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-60 > :not(template) ~ :not(template) {
+.-space-y-60 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-15rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-15rem * var(--space-y-reverse));
 }
 
-.-space-x-60 > :not(template) ~ :not(template) {
+.-space-x-60 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-15rem * var(--space-x-reverse));
   margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-64 > :not(template) ~ :not(template) {
+.-space-y-64 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-16rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-16rem * var(--space-y-reverse));
 }
 
-.-space-x-64 > :not(template) ~ :not(template) {
+.-space-x-64 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-16rem * var(--space-x-reverse));
   margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-72 > :not(template) ~ :not(template) {
+.-space-y-72 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-18rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-18rem * var(--space-y-reverse));
 }
 
-.-space-x-72 > :not(template) ~ :not(template) {
+.-space-x-72 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-18rem * var(--space-x-reverse));
   margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-80 > :not(template) ~ :not(template) {
+.-space-y-80 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-20rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-20rem * var(--space-y-reverse));
 }
 
-.-space-x-80 > :not(template) ~ :not(template) {
+.-space-x-80 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-20rem * var(--space-x-reverse));
   margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-96 > :not(template) ~ :not(template) {
+.-space-y-96 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-24rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-24rem * var(--space-y-reverse));
 }
 
-.-space-x-96 > :not(template) ~ :not(template) {
+.-space-x-96 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-24rem * var(--space-x-reverse));
   margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-px > :not(template) ~ :not(template) {
+.-space-y-px > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-1px * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-1px * var(--space-y-reverse));
 }
 
-.-space-x-px > :not(template) ~ :not(template) {
+.-space-x-px > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-1px * var(--space-x-reverse));
   margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-0\.5 > :not(template) ~ :not(template) {
+.-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-0.125rem * var(--space-y-reverse));
 }
 
-.-space-x-0\.5 > :not(template) ~ :not(template) {
+.-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
   margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-1\.5 > :not(template) ~ :not(template) {
+.-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-0.375rem * var(--space-y-reverse));
 }
 
-.-space-x-1\.5 > :not(template) ~ :not(template) {
+.-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
   margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-2\.5 > :not(template) ~ :not(template) {
+.-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-0.625rem * var(--space-y-reverse));
 }
 
-.-space-x-2\.5 > :not(template) ~ :not(template) {
+.-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
   margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
 }
 
-.-space-y-3\.5 > :not(template) ~ :not(template) {
+.-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 0;
   margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse)));
   margin-bottom: calc(-0.875rem * var(--space-y-reverse));
 }
 
-.-space-x-3\.5 > :not(template) ~ :not(template) {
+.-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
   margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
   margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
 }
 
-.space-y-reverse > :not(template) ~ :not(template) {
+.space-y-reverse > :not([hidden]) ~ :not([hidden]) {
   --space-y-reverse: 1;
 }
 
-.space-x-reverse > :not(template) ~ :not(template) {
+.space-x-reverse > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 1;
 }
 
-.divide-y-0 > :not(template) ~ :not(template) {
+.divide-y-0 > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 0;
   border-top-width: calc(0px * calc(1 - var(--divide-y-reverse)));
   border-bottom-width: calc(0px * var(--divide-y-reverse));
 }
 
-.divide-x-0 > :not(template) ~ :not(template) {
+.divide-x-0 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
   border-inline-end-width: calc(0px * var(--divide-x-reverse));
   border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
 }
 
-.divide-y-2 > :not(template) ~ :not(template) {
+.divide-y-2 > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 0;
   border-top-width: calc(2px * calc(1 - var(--divide-y-reverse)));
   border-bottom-width: calc(2px * var(--divide-y-reverse));
 }
 
-.divide-x-2 > :not(template) ~ :not(template) {
+.divide-x-2 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
   border-inline-end-width: calc(2px * var(--divide-x-reverse));
   border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
 }
 
-.divide-y-4 > :not(template) ~ :not(template) {
+.divide-y-4 > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 0;
   border-top-width: calc(4px * calc(1 - var(--divide-y-reverse)));
   border-bottom-width: calc(4px * var(--divide-y-reverse));
 }
 
-.divide-x-4 > :not(template) ~ :not(template) {
+.divide-x-4 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
   border-inline-end-width: calc(4px * var(--divide-x-reverse));
   border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
 }
 
-.divide-y-8 > :not(template) ~ :not(template) {
+.divide-y-8 > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 0;
   border-top-width: calc(8px * calc(1 - var(--divide-y-reverse)));
   border-bottom-width: calc(8px * var(--divide-y-reverse));
 }
 
-.divide-x-8 > :not(template) ~ :not(template) {
+.divide-x-8 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
   border-inline-end-width: calc(8px * var(--divide-x-reverse));
   border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
 }
 
-.divide-y > :not(template) ~ :not(template) {
+.divide-y > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 0;
   border-top-width: calc(1px * calc(1 - var(--divide-y-reverse)));
   border-bottom-width: calc(1px * var(--divide-y-reverse));
 }
 
-.divide-x > :not(template) ~ :not(template) {
+.divide-x > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
   border-inline-end-width: calc(1px * var(--divide-x-reverse));
   border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
 }
 
-.divide-y-reverse > :not(template) ~ :not(template) {
+.divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
   --divide-y-reverse: 1;
 }
 
-.divide-x-reverse > :not(template) ~ :not(template) {
+.divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 1;
 }
 
-.divide-transparent > :not(template) ~ :not(template) {
+.divide-transparent > :not([hidden]) ~ :not([hidden]) {
   border-color: transparent;
 }
 
-.divide-current > :not(template) ~ :not(template) {
+.divide-current > :not([hidden]) ~ :not([hidden]) {
   border-color: currentColor;
 }
 
-.divide-black > :not(template) ~ :not(template) {
+.divide-black > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(0, 0, 0, var(--divide-opacity));
 }
 
-.divide-white > :not(template) ~ :not(template) {
+.divide-white > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(255, 255, 255, var(--divide-opacity));
 }
 
-.divide-gray-50 > :not(template) ~ :not(template) {
+.divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(250, 250, 250, var(--divide-opacity));
 }
 
-.divide-gray-100 > :not(template) ~ :not(template) {
+.divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(244, 244, 245, var(--divide-opacity));
 }
 
-.divide-gray-200 > :not(template) ~ :not(template) {
+.divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(228, 228, 231, var(--divide-opacity));
 }
 
-.divide-gray-300 > :not(template) ~ :not(template) {
+.divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(212, 212, 216, var(--divide-opacity));
 }
 
-.divide-gray-400 > :not(template) ~ :not(template) {
+.divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(161, 161, 170, var(--divide-opacity));
 }
 
-.divide-gray-500 > :not(template) ~ :not(template) {
+.divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(113, 113, 122, var(--divide-opacity));
 }
 
-.divide-gray-600 > :not(template) ~ :not(template) {
+.divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(82, 82, 91, var(--divide-opacity));
 }
 
-.divide-gray-700 > :not(template) ~ :not(template) {
+.divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(63, 63, 70, var(--divide-opacity));
 }
 
-.divide-gray-800 > :not(template) ~ :not(template) {
+.divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(39, 39, 42, var(--divide-opacity));
 }
 
-.divide-gray-900 > :not(template) ~ :not(template) {
+.divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(24, 24, 27, var(--divide-opacity));
 }
 
-.divide-red-50 > :not(template) ~ :not(template) {
+.divide-red-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(254, 242, 242, var(--divide-opacity));
 }
 
-.divide-red-100 > :not(template) ~ :not(template) {
+.divide-red-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(254, 226, 226, var(--divide-opacity));
 }
 
-.divide-red-200 > :not(template) ~ :not(template) {
+.divide-red-200 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(254, 202, 202, var(--divide-opacity));
 }
 
-.divide-red-300 > :not(template) ~ :not(template) {
+.divide-red-300 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(252, 165, 165, var(--divide-opacity));
 }
 
-.divide-red-400 > :not(template) ~ :not(template) {
+.divide-red-400 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(248, 113, 113, var(--divide-opacity));
 }
 
-.divide-red-500 > :not(template) ~ :not(template) {
+.divide-red-500 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(239, 68, 68, var(--divide-opacity));
 }
 
-.divide-red-600 > :not(template) ~ :not(template) {
+.divide-red-600 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(220, 38, 38, var(--divide-opacity));
 }
 
-.divide-red-700 > :not(template) ~ :not(template) {
+.divide-red-700 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(185, 28, 28, var(--divide-opacity));
 }
 
-.divide-red-800 > :not(template) ~ :not(template) {
+.divide-red-800 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(153, 27, 27, var(--divide-opacity));
 }
 
-.divide-red-900 > :not(template) ~ :not(template) {
+.divide-red-900 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(127, 29, 29, var(--divide-opacity));
 }
 
-.divide-yellow-50 > :not(template) ~ :not(template) {
+.divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(255, 251, 235, var(--divide-opacity));
 }
 
-.divide-yellow-100 > :not(template) ~ :not(template) {
+.divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(254, 243, 199, var(--divide-opacity));
 }
 
-.divide-yellow-200 > :not(template) ~ :not(template) {
+.divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(253, 230, 138, var(--divide-opacity));
 }
 
-.divide-yellow-300 > :not(template) ~ :not(template) {
+.divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(252, 211, 77, var(--divide-opacity));
 }
 
-.divide-yellow-400 > :not(template) ~ :not(template) {
+.divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(251, 191, 36, var(--divide-opacity));
 }
 
-.divide-yellow-500 > :not(template) ~ :not(template) {
+.divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(245, 158, 11, var(--divide-opacity));
 }
 
-.divide-yellow-600 > :not(template) ~ :not(template) {
+.divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(217, 119, 6, var(--divide-opacity));
 }
 
-.divide-yellow-700 > :not(template) ~ :not(template) {
+.divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(180, 83, 9, var(--divide-opacity));
 }
 
-.divide-yellow-800 > :not(template) ~ :not(template) {
+.divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(146, 64, 14, var(--divide-opacity));
 }
 
-.divide-yellow-900 > :not(template) ~ :not(template) {
+.divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(120, 53, 15, var(--divide-opacity));
 }
 
-.divide-green-50 > :not(template) ~ :not(template) {
+.divide-green-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(236, 253, 245, var(--divide-opacity));
 }
 
-.divide-green-100 > :not(template) ~ :not(template) {
+.divide-green-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(209, 250, 229, var(--divide-opacity));
 }
 
-.divide-green-200 > :not(template) ~ :not(template) {
+.divide-green-200 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(167, 243, 208, var(--divide-opacity));
 }
 
-.divide-green-300 > :not(template) ~ :not(template) {
+.divide-green-300 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(110, 231, 183, var(--divide-opacity));
 }
 
-.divide-green-400 > :not(template) ~ :not(template) {
+.divide-green-400 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(52, 211, 153, var(--divide-opacity));
 }
 
-.divide-green-500 > :not(template) ~ :not(template) {
+.divide-green-500 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(16, 185, 129, var(--divide-opacity));
 }
 
-.divide-green-600 > :not(template) ~ :not(template) {
+.divide-green-600 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(5, 150, 105, var(--divide-opacity));
 }
 
-.divide-green-700 > :not(template) ~ :not(template) {
+.divide-green-700 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(4, 120, 87, var(--divide-opacity));
 }
 
-.divide-green-800 > :not(template) ~ :not(template) {
+.divide-green-800 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(6, 95, 70, var(--divide-opacity));
 }
 
-.divide-green-900 > :not(template) ~ :not(template) {
+.divide-green-900 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(6, 78, 59, var(--divide-opacity));
 }
 
-.divide-blue-50 > :not(template) ~ :not(template) {
+.divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(239, 246, 255, var(--divide-opacity));
 }
 
-.divide-blue-100 > :not(template) ~ :not(template) {
+.divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(219, 234, 254, var(--divide-opacity));
 }
 
-.divide-blue-200 > :not(template) ~ :not(template) {
+.divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(191, 219, 254, var(--divide-opacity));
 }
 
-.divide-blue-300 > :not(template) ~ :not(template) {
+.divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(147, 197, 253, var(--divide-opacity));
 }
 
-.divide-blue-400 > :not(template) ~ :not(template) {
+.divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(96, 165, 250, var(--divide-opacity));
 }
 
-.divide-blue-500 > :not(template) ~ :not(template) {
+.divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(59, 130, 246, var(--divide-opacity));
 }
 
-.divide-blue-600 > :not(template) ~ :not(template) {
+.divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(37, 99, 235, var(--divide-opacity));
 }
 
-.divide-blue-700 > :not(template) ~ :not(template) {
+.divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(29, 78, 216, var(--divide-opacity));
 }
 
-.divide-blue-800 > :not(template) ~ :not(template) {
+.divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(30, 64, 175, var(--divide-opacity));
 }
 
-.divide-blue-900 > :not(template) ~ :not(template) {
+.divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(30, 58, 138, var(--divide-opacity));
 }
 
-.divide-purple-50 > :not(template) ~ :not(template) {
+.divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(245, 243, 255, var(--divide-opacity));
 }
 
-.divide-purple-100 > :not(template) ~ :not(template) {
+.divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(237, 233, 254, var(--divide-opacity));
 }
 
-.divide-purple-200 > :not(template) ~ :not(template) {
+.divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(221, 214, 254, var(--divide-opacity));
 }
 
-.divide-purple-300 > :not(template) ~ :not(template) {
+.divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(196, 181, 253, var(--divide-opacity));
 }
 
-.divide-purple-400 > :not(template) ~ :not(template) {
+.divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(167, 139, 250, var(--divide-opacity));
 }
 
-.divide-purple-500 > :not(template) ~ :not(template) {
+.divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(139, 92, 246, var(--divide-opacity));
 }
 
-.divide-purple-600 > :not(template) ~ :not(template) {
+.divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(124, 58, 237, var(--divide-opacity));
 }
 
-.divide-purple-700 > :not(template) ~ :not(template) {
+.divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(109, 40, 217, var(--divide-opacity));
 }
 
-.divide-purple-800 > :not(template) ~ :not(template) {
+.divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(91, 33, 182, var(--divide-opacity));
 }
 
-.divide-purple-900 > :not(template) ~ :not(template) {
+.divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(76, 29, 149, var(--divide-opacity));
 }
 
-.divide-pink-50 > :not(template) ~ :not(template) {
+.divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(253, 242, 248, var(--divide-opacity));
 }
 
-.divide-pink-100 > :not(template) ~ :not(template) {
+.divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(252, 231, 243, var(--divide-opacity));
 }
 
-.divide-pink-200 > :not(template) ~ :not(template) {
+.divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(251, 207, 232, var(--divide-opacity));
 }
 
-.divide-pink-300 > :not(template) ~ :not(template) {
+.divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(249, 168, 212, var(--divide-opacity));
 }
 
-.divide-pink-400 > :not(template) ~ :not(template) {
+.divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(244, 114, 182, var(--divide-opacity));
 }
 
-.divide-pink-500 > :not(template) ~ :not(template) {
+.divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(236, 72, 153, var(--divide-opacity));
 }
 
-.divide-pink-600 > :not(template) ~ :not(template) {
+.divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(219, 39, 119, var(--divide-opacity));
 }
 
-.divide-pink-700 > :not(template) ~ :not(template) {
+.divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(190, 24, 93, var(--divide-opacity));
 }
 
-.divide-pink-800 > :not(template) ~ :not(template) {
+.divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(157, 23, 77, var(--divide-opacity));
 }
 
-.divide-pink-900 > :not(template) ~ :not(template) {
+.divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
   border-color: rgba(131, 24, 67, var(--divide-opacity));
 }
 
-.divide-solid > :not(template) ~ :not(template) {
+.divide-solid > :not([hidden]) ~ :not([hidden]) {
   border-style: solid;
 }
 
-.divide-dashed > :not(template) ~ :not(template) {
+.divide-dashed > :not([hidden]) ~ :not([hidden]) {
   border-style: dashed;
 }
 
-.divide-dotted > :not(template) ~ :not(template) {
+.divide-dotted > :not([hidden]) ~ :not([hidden]) {
   border-style: dotted;
 }
 
-.divide-double > :not(template) ~ :not(template) {
+.divide-double > :not([hidden]) ~ :not([hidden]) {
   border-style: double;
 }
 
-.divide-none > :not(template) ~ :not(template) {
+.divide-none > :not([hidden]) ~ :not([hidden]) {
   border-style: none;
 }
 
-.divide-opacity-0 > :not(template) ~ :not(template) {
+.divide-opacity-0 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0;
 }
 
-.divide-opacity-10 > :not(template) ~ :not(template) {
+.divide-opacity-10 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.1;
 }
 
-.divide-opacity-20 > :not(template) ~ :not(template) {
+.divide-opacity-20 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.2;
 }
 
-.divide-opacity-25 > :not(template) ~ :not(template) {
+.divide-opacity-25 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.25;
 }
 
-.divide-opacity-30 > :not(template) ~ :not(template) {
+.divide-opacity-30 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.3;
 }
 
-.divide-opacity-40 > :not(template) ~ :not(template) {
+.divide-opacity-40 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.4;
 }
 
-.divide-opacity-50 > :not(template) ~ :not(template) {
+.divide-opacity-50 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.5;
 }
 
-.divide-opacity-60 > :not(template) ~ :not(template) {
+.divide-opacity-60 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.6;
 }
 
-.divide-opacity-70 > :not(template) ~ :not(template) {
+.divide-opacity-70 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.7;
 }
 
-.divide-opacity-75 > :not(template) ~ :not(template) {
+.divide-opacity-75 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.75;
 }
 
-.divide-opacity-80 > :not(template) ~ :not(template) {
+.divide-opacity-80 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.8;
 }
 
-.divide-opacity-90 > :not(template) ~ :not(template) {
+.divide-opacity-90 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 0.9;
 }
 
-.divide-opacity-100 > :not(template) ~ :not(template) {
+.divide-opacity-100 > :not([hidden]) ~ :not([hidden]) {
   --divide-opacity: 1;
 }
 
@@ -23536,1323 +23536,1323 @@ video {
     }
   }
 
-  .sm\:space-y-0 > :not(template) ~ :not(template) {
+  .sm\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0px * var(--space-y-reverse));
   }
 
-  .sm\:space-x-0 > :not(template) ~ :not(template) {
+  .sm\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0px * var(--space-x-reverse));
     margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-1 > :not(template) ~ :not(template) {
+  .sm\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.25rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-1 > :not(template) ~ :not(template) {
+  .sm\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-2 > :not(template) ~ :not(template) {
+  .sm\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.5rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-2 > :not(template) ~ :not(template) {
+  .sm\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-3 > :not(template) ~ :not(template) {
+  .sm\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.75rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-3 > :not(template) ~ :not(template) {
+  .sm\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-4 > :not(template) ~ :not(template) {
+  .sm\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-4 > :not(template) ~ :not(template) {
+  .sm\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1rem * var(--space-x-reverse));
     margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-5 > :not(template) ~ :not(template) {
+  .sm\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.25rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-5 > :not(template) ~ :not(template) {
+  .sm\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-6 > :not(template) ~ :not(template) {
+  .sm\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.5rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-6 > :not(template) ~ :not(template) {
+  .sm\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-7 > :not(template) ~ :not(template) {
+  .sm\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.75rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-7 > :not(template) ~ :not(template) {
+  .sm\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-8 > :not(template) ~ :not(template) {
+  .sm\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-8 > :not(template) ~ :not(template) {
+  .sm\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2rem * var(--space-x-reverse));
     margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-9 > :not(template) ~ :not(template) {
+  .sm\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.25rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-9 > :not(template) ~ :not(template) {
+  .sm\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-10 > :not(template) ~ :not(template) {
+  .sm\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.5rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-10 > :not(template) ~ :not(template) {
+  .sm\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-12 > :not(template) ~ :not(template) {
+  .sm\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-12 > :not(template) ~ :not(template) {
+  .sm\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3rem * var(--space-x-reverse));
     margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-14 > :not(template) ~ :not(template) {
+  .sm\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3.5rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-14 > :not(template) ~ :not(template) {
+  .sm\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-16 > :not(template) ~ :not(template) {
+  .sm\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(4rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-16 > :not(template) ~ :not(template) {
+  .sm\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(4rem * var(--space-x-reverse));
     margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-20 > :not(template) ~ :not(template) {
+  .sm\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(5rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-20 > :not(template) ~ :not(template) {
+  .sm\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(5rem * var(--space-x-reverse));
     margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-24 > :not(template) ~ :not(template) {
+  .sm\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(6rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-24 > :not(template) ~ :not(template) {
+  .sm\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(6rem * var(--space-x-reverse));
     margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-28 > :not(template) ~ :not(template) {
+  .sm\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(7rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-28 > :not(template) ~ :not(template) {
+  .sm\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(7rem * var(--space-x-reverse));
     margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-32 > :not(template) ~ :not(template) {
+  .sm\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(8rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-32 > :not(template) ~ :not(template) {
+  .sm\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(8rem * var(--space-x-reverse));
     margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-36 > :not(template) ~ :not(template) {
+  .sm\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(9rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-36 > :not(template) ~ :not(template) {
+  .sm\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(9rem * var(--space-x-reverse));
     margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-40 > :not(template) ~ :not(template) {
+  .sm\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(10rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-40 > :not(template) ~ :not(template) {
+  .sm\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(10rem * var(--space-x-reverse));
     margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-44 > :not(template) ~ :not(template) {
+  .sm\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(11rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-44 > :not(template) ~ :not(template) {
+  .sm\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(11rem * var(--space-x-reverse));
     margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-48 > :not(template) ~ :not(template) {
+  .sm\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(12rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-48 > :not(template) ~ :not(template) {
+  .sm\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(12rem * var(--space-x-reverse));
     margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-52 > :not(template) ~ :not(template) {
+  .sm\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(13rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-52 > :not(template) ~ :not(template) {
+  .sm\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(13rem * var(--space-x-reverse));
     margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-56 > :not(template) ~ :not(template) {
+  .sm\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(14rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-56 > :not(template) ~ :not(template) {
+  .sm\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(14rem * var(--space-x-reverse));
     margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-60 > :not(template) ~ :not(template) {
+  .sm\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(15rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-60 > :not(template) ~ :not(template) {
+  .sm\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(15rem * var(--space-x-reverse));
     margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-64 > :not(template) ~ :not(template) {
+  .sm\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(16rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-64 > :not(template) ~ :not(template) {
+  .sm\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(16rem * var(--space-x-reverse));
     margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-72 > :not(template) ~ :not(template) {
+  .sm\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(18rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-72 > :not(template) ~ :not(template) {
+  .sm\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(18rem * var(--space-x-reverse));
     margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-80 > :not(template) ~ :not(template) {
+  .sm\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(20rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-80 > :not(template) ~ :not(template) {
+  .sm\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(20rem * var(--space-x-reverse));
     margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-96 > :not(template) ~ :not(template) {
+  .sm\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(24rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-96 > :not(template) ~ :not(template) {
+  .sm\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(24rem * var(--space-x-reverse));
     margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-px > :not(template) ~ :not(template) {
+  .sm\:space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1px * var(--space-y-reverse));
   }
 
-  .sm\:space-x-px > :not(template) ~ :not(template) {
+  .sm\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1px * var(--space-x-reverse));
     margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-0\.5 > :not(template) ~ :not(template) {
+  .sm\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.125rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-0\.5 > :not(template) ~ :not(template) {
+  .sm\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-1\.5 > :not(template) ~ :not(template) {
+  .sm\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.375rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-1\.5 > :not(template) ~ :not(template) {
+  .sm\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-2\.5 > :not(template) ~ :not(template) {
+  .sm\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.625rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-2\.5 > :not(template) ~ :not(template) {
+  .sm\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-3\.5 > :not(template) ~ :not(template) {
+  .sm\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.875rem * var(--space-y-reverse));
   }
 
-  .sm\:space-x-3\.5 > :not(template) ~ :not(template) {
+  .sm\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-1 > :not(template) ~ :not(template) {
+  .sm\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.25rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-1 > :not(template) ~ :not(template) {
+  .sm\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-2 > :not(template) ~ :not(template) {
+  .sm\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.5rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-2 > :not(template) ~ :not(template) {
+  .sm\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-3 > :not(template) ~ :not(template) {
+  .sm\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.75rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-3 > :not(template) ~ :not(template) {
+  .sm\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-4 > :not(template) ~ :not(template) {
+  .sm\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-4 > :not(template) ~ :not(template) {
+  .sm\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1rem * var(--space-x-reverse));
     margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-5 > :not(template) ~ :not(template) {
+  .sm\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.25rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-5 > :not(template) ~ :not(template) {
+  .sm\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-6 > :not(template) ~ :not(template) {
+  .sm\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.5rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-6 > :not(template) ~ :not(template) {
+  .sm\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-7 > :not(template) ~ :not(template) {
+  .sm\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.75rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-7 > :not(template) ~ :not(template) {
+  .sm\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-8 > :not(template) ~ :not(template) {
+  .sm\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-8 > :not(template) ~ :not(template) {
+  .sm\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2rem * var(--space-x-reverse));
     margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-9 > :not(template) ~ :not(template) {
+  .sm\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.25rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-9 > :not(template) ~ :not(template) {
+  .sm\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-10 > :not(template) ~ :not(template) {
+  .sm\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.5rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-10 > :not(template) ~ :not(template) {
+  .sm\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-12 > :not(template) ~ :not(template) {
+  .sm\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-12 > :not(template) ~ :not(template) {
+  .sm\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3rem * var(--space-x-reverse));
     margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-14 > :not(template) ~ :not(template) {
+  .sm\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3.5rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-14 > :not(template) ~ :not(template) {
+  .sm\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-16 > :not(template) ~ :not(template) {
+  .sm\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-4rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-16 > :not(template) ~ :not(template) {
+  .sm\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-4rem * var(--space-x-reverse));
     margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-20 > :not(template) ~ :not(template) {
+  .sm\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-5rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-20 > :not(template) ~ :not(template) {
+  .sm\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-5rem * var(--space-x-reverse));
     margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-24 > :not(template) ~ :not(template) {
+  .sm\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-6rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-24 > :not(template) ~ :not(template) {
+  .sm\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-6rem * var(--space-x-reverse));
     margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-28 > :not(template) ~ :not(template) {
+  .sm\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-7rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-28 > :not(template) ~ :not(template) {
+  .sm\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-7rem * var(--space-x-reverse));
     margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-32 > :not(template) ~ :not(template) {
+  .sm\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-8rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-32 > :not(template) ~ :not(template) {
+  .sm\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-8rem * var(--space-x-reverse));
     margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-36 > :not(template) ~ :not(template) {
+  .sm\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-9rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-36 > :not(template) ~ :not(template) {
+  .sm\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-9rem * var(--space-x-reverse));
     margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-40 > :not(template) ~ :not(template) {
+  .sm\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-10rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-40 > :not(template) ~ :not(template) {
+  .sm\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-10rem * var(--space-x-reverse));
     margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-44 > :not(template) ~ :not(template) {
+  .sm\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-11rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-44 > :not(template) ~ :not(template) {
+  .sm\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-11rem * var(--space-x-reverse));
     margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-48 > :not(template) ~ :not(template) {
+  .sm\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-12rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-48 > :not(template) ~ :not(template) {
+  .sm\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-12rem * var(--space-x-reverse));
     margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-52 > :not(template) ~ :not(template) {
+  .sm\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-13rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-52 > :not(template) ~ :not(template) {
+  .sm\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-13rem * var(--space-x-reverse));
     margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-56 > :not(template) ~ :not(template) {
+  .sm\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-14rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-56 > :not(template) ~ :not(template) {
+  .sm\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-14rem * var(--space-x-reverse));
     margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-60 > :not(template) ~ :not(template) {
+  .sm\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-15rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-60 > :not(template) ~ :not(template) {
+  .sm\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-15rem * var(--space-x-reverse));
     margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-64 > :not(template) ~ :not(template) {
+  .sm\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-16rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-64 > :not(template) ~ :not(template) {
+  .sm\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-16rem * var(--space-x-reverse));
     margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-72 > :not(template) ~ :not(template) {
+  .sm\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-18rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-72 > :not(template) ~ :not(template) {
+  .sm\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-18rem * var(--space-x-reverse));
     margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-80 > :not(template) ~ :not(template) {
+  .sm\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-20rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-80 > :not(template) ~ :not(template) {
+  .sm\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-20rem * var(--space-x-reverse));
     margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-96 > :not(template) ~ :not(template) {
+  .sm\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-24rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-96 > :not(template) ~ :not(template) {
+  .sm\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-24rem * var(--space-x-reverse));
     margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-px > :not(template) ~ :not(template) {
+  .sm\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1px * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-px > :not(template) ~ :not(template) {
+  .sm\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1px * var(--space-x-reverse));
     margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-0\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.125rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-0\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-1\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.375rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-1\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-2\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.625rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-2\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:-space-y-3\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.875rem * var(--space-y-reverse));
   }
 
-  .sm\:-space-x-3\.5 > :not(template) ~ :not(template) {
+  .sm\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .sm\:space-y-reverse > :not(template) ~ :not(template) {
+  .sm\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 1;
   }
 
-  .sm\:space-x-reverse > :not(template) ~ :not(template) {
+  .sm\:space-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 1;
   }
 
-  .sm\:divide-y-0 > :not(template) ~ :not(template) {
+  .sm\:divide-y-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(0px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(0px * var(--divide-y-reverse));
   }
 
-  .sm\:divide-x-0 > :not(template) ~ :not(template) {
+  .sm\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(0px * var(--divide-x-reverse));
     border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .sm\:divide-y-2 > :not(template) ~ :not(template) {
+  .sm\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(2px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(2px * var(--divide-y-reverse));
   }
 
-  .sm\:divide-x-2 > :not(template) ~ :not(template) {
+  .sm\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(2px * var(--divide-x-reverse));
     border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .sm\:divide-y-4 > :not(template) ~ :not(template) {
+  .sm\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(4px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(4px * var(--divide-y-reverse));
   }
 
-  .sm\:divide-x-4 > :not(template) ~ :not(template) {
+  .sm\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(4px * var(--divide-x-reverse));
     border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .sm\:divide-y-8 > :not(template) ~ :not(template) {
+  .sm\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(8px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(8px * var(--divide-y-reverse));
   }
 
-  .sm\:divide-x-8 > :not(template) ~ :not(template) {
+  .sm\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(8px * var(--divide-x-reverse));
     border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .sm\:divide-y > :not(template) ~ :not(template) {
+  .sm\:divide-y > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(1px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(1px * var(--divide-y-reverse));
   }
 
-  .sm\:divide-x > :not(template) ~ :not(template) {
+  .sm\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(1px * var(--divide-x-reverse));
     border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .sm\:divide-y-reverse > :not(template) ~ :not(template) {
+  .sm\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 1;
   }
 
-  .sm\:divide-x-reverse > :not(template) ~ :not(template) {
+  .sm\:divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 1;
   }
 
-  .sm\:divide-transparent > :not(template) ~ :not(template) {
+  .sm\:divide-transparent > :not([hidden]) ~ :not([hidden]) {
     border-color: transparent;
   }
 
-  .sm\:divide-current > :not(template) ~ :not(template) {
+  .sm\:divide-current > :not([hidden]) ~ :not([hidden]) {
     border-color: currentColor;
   }
 
-  .sm\:divide-black > :not(template) ~ :not(template) {
+  .sm\:divide-black > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(0, 0, 0, var(--divide-opacity));
   }
 
-  .sm\:divide-white > :not(template) ~ :not(template) {
+  .sm\:divide-white > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(255, 255, 255, var(--divide-opacity));
   }
 
-  .sm\:divide-gray-50 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(250, 250, 250, var(--divide-opacity));
   }
 
-  .sm\:divide-gray-100 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(244, 244, 245, var(--divide-opacity));
   }
 
-  .sm\:divide-gray-200 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(228, 228, 231, var(--divide-opacity));
   }
 
-  .sm\:divide-gray-300 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(212, 212, 216, var(--divide-opacity));
   }
 
-  .sm\:divide-gray-400 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(161, 161, 170, var(--divide-opacity));
   }
 
-  .sm\:divide-gray-500 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(113, 113, 122, var(--divide-opacity));
   }
 
-  .sm\:divide-gray-600 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(82, 82, 91, var(--divide-opacity));
   }
 
-  .sm\:divide-gray-700 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(63, 63, 70, var(--divide-opacity));
   }
 
-  .sm\:divide-gray-800 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(39, 39, 42, var(--divide-opacity));
   }
 
-  .sm\:divide-gray-900 > :not(template) ~ :not(template) {
+  .sm\:divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(24, 24, 27, var(--divide-opacity));
   }
 
-  .sm\:divide-red-50 > :not(template) ~ :not(template) {
+  .sm\:divide-red-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 242, 242, var(--divide-opacity));
   }
 
-  .sm\:divide-red-100 > :not(template) ~ :not(template) {
+  .sm\:divide-red-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 226, 226, var(--divide-opacity));
   }
 
-  .sm\:divide-red-200 > :not(template) ~ :not(template) {
+  .sm\:divide-red-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 202, 202, var(--divide-opacity));
   }
 
-  .sm\:divide-red-300 > :not(template) ~ :not(template) {
+  .sm\:divide-red-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 165, 165, var(--divide-opacity));
   }
 
-  .sm\:divide-red-400 > :not(template) ~ :not(template) {
+  .sm\:divide-red-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(248, 113, 113, var(--divide-opacity));
   }
 
-  .sm\:divide-red-500 > :not(template) ~ :not(template) {
+  .sm\:divide-red-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(239, 68, 68, var(--divide-opacity));
   }
 
-  .sm\:divide-red-600 > :not(template) ~ :not(template) {
+  .sm\:divide-red-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(220, 38, 38, var(--divide-opacity));
   }
 
-  .sm\:divide-red-700 > :not(template) ~ :not(template) {
+  .sm\:divide-red-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(185, 28, 28, var(--divide-opacity));
   }
 
-  .sm\:divide-red-800 > :not(template) ~ :not(template) {
+  .sm\:divide-red-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(153, 27, 27, var(--divide-opacity));
   }
 
-  .sm\:divide-red-900 > :not(template) ~ :not(template) {
+  .sm\:divide-red-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(127, 29, 29, var(--divide-opacity));
   }
 
-  .sm\:divide-yellow-50 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(255, 251, 235, var(--divide-opacity));
   }
 
-  .sm\:divide-yellow-100 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 243, 199, var(--divide-opacity));
   }
 
-  .sm\:divide-yellow-200 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(253, 230, 138, var(--divide-opacity));
   }
 
-  .sm\:divide-yellow-300 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 211, 77, var(--divide-opacity));
   }
 
-  .sm\:divide-yellow-400 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(251, 191, 36, var(--divide-opacity));
   }
 
-  .sm\:divide-yellow-500 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(245, 158, 11, var(--divide-opacity));
   }
 
-  .sm\:divide-yellow-600 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(217, 119, 6, var(--divide-opacity));
   }
 
-  .sm\:divide-yellow-700 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(180, 83, 9, var(--divide-opacity));
   }
 
-  .sm\:divide-yellow-800 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(146, 64, 14, var(--divide-opacity));
   }
 
-  .sm\:divide-yellow-900 > :not(template) ~ :not(template) {
+  .sm\:divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(120, 53, 15, var(--divide-opacity));
   }
 
-  .sm\:divide-green-50 > :not(template) ~ :not(template) {
+  .sm\:divide-green-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(236, 253, 245, var(--divide-opacity));
   }
 
-  .sm\:divide-green-100 > :not(template) ~ :not(template) {
+  .sm\:divide-green-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(209, 250, 229, var(--divide-opacity));
   }
 
-  .sm\:divide-green-200 > :not(template) ~ :not(template) {
+  .sm\:divide-green-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(167, 243, 208, var(--divide-opacity));
   }
 
-  .sm\:divide-green-300 > :not(template) ~ :not(template) {
+  .sm\:divide-green-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(110, 231, 183, var(--divide-opacity));
   }
 
-  .sm\:divide-green-400 > :not(template) ~ :not(template) {
+  .sm\:divide-green-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(52, 211, 153, var(--divide-opacity));
   }
 
-  .sm\:divide-green-500 > :not(template) ~ :not(template) {
+  .sm\:divide-green-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(16, 185, 129, var(--divide-opacity));
   }
 
-  .sm\:divide-green-600 > :not(template) ~ :not(template) {
+  .sm\:divide-green-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(5, 150, 105, var(--divide-opacity));
   }
 
-  .sm\:divide-green-700 > :not(template) ~ :not(template) {
+  .sm\:divide-green-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(4, 120, 87, var(--divide-opacity));
   }
 
-  .sm\:divide-green-800 > :not(template) ~ :not(template) {
+  .sm\:divide-green-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(6, 95, 70, var(--divide-opacity));
   }
 
-  .sm\:divide-green-900 > :not(template) ~ :not(template) {
+  .sm\:divide-green-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(6, 78, 59, var(--divide-opacity));
   }
 
-  .sm\:divide-blue-50 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(239, 246, 255, var(--divide-opacity));
   }
 
-  .sm\:divide-blue-100 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(219, 234, 254, var(--divide-opacity));
   }
 
-  .sm\:divide-blue-200 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(191, 219, 254, var(--divide-opacity));
   }
 
-  .sm\:divide-blue-300 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(147, 197, 253, var(--divide-opacity));
   }
 
-  .sm\:divide-blue-400 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(96, 165, 250, var(--divide-opacity));
   }
 
-  .sm\:divide-blue-500 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(59, 130, 246, var(--divide-opacity));
   }
 
-  .sm\:divide-blue-600 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(37, 99, 235, var(--divide-opacity));
   }
 
-  .sm\:divide-blue-700 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(29, 78, 216, var(--divide-opacity));
   }
 
-  .sm\:divide-blue-800 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(30, 64, 175, var(--divide-opacity));
   }
 
-  .sm\:divide-blue-900 > :not(template) ~ :not(template) {
+  .sm\:divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(30, 58, 138, var(--divide-opacity));
   }
 
-  .sm\:divide-purple-50 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(245, 243, 255, var(--divide-opacity));
   }
 
-  .sm\:divide-purple-100 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(237, 233, 254, var(--divide-opacity));
   }
 
-  .sm\:divide-purple-200 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(221, 214, 254, var(--divide-opacity));
   }
 
-  .sm\:divide-purple-300 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(196, 181, 253, var(--divide-opacity));
   }
 
-  .sm\:divide-purple-400 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(167, 139, 250, var(--divide-opacity));
   }
 
-  .sm\:divide-purple-500 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(139, 92, 246, var(--divide-opacity));
   }
 
-  .sm\:divide-purple-600 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(124, 58, 237, var(--divide-opacity));
   }
 
-  .sm\:divide-purple-700 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(109, 40, 217, var(--divide-opacity));
   }
 
-  .sm\:divide-purple-800 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(91, 33, 182, var(--divide-opacity));
   }
 
-  .sm\:divide-purple-900 > :not(template) ~ :not(template) {
+  .sm\:divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(76, 29, 149, var(--divide-opacity));
   }
 
-  .sm\:divide-pink-50 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(253, 242, 248, var(--divide-opacity));
   }
 
-  .sm\:divide-pink-100 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 231, 243, var(--divide-opacity));
   }
 
-  .sm\:divide-pink-200 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(251, 207, 232, var(--divide-opacity));
   }
 
-  .sm\:divide-pink-300 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(249, 168, 212, var(--divide-opacity));
   }
 
-  .sm\:divide-pink-400 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(244, 114, 182, var(--divide-opacity));
   }
 
-  .sm\:divide-pink-500 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(236, 72, 153, var(--divide-opacity));
   }
 
-  .sm\:divide-pink-600 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(219, 39, 119, var(--divide-opacity));
   }
 
-  .sm\:divide-pink-700 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(190, 24, 93, var(--divide-opacity));
   }
 
-  .sm\:divide-pink-800 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(157, 23, 77, var(--divide-opacity));
   }
 
-  .sm\:divide-pink-900 > :not(template) ~ :not(template) {
+  .sm\:divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(131, 24, 67, var(--divide-opacity));
   }
 
-  .sm\:divide-solid > :not(template) ~ :not(template) {
+  .sm\:divide-solid > :not([hidden]) ~ :not([hidden]) {
     border-style: solid;
   }
 
-  .sm\:divide-dashed > :not(template) ~ :not(template) {
+  .sm\:divide-dashed > :not([hidden]) ~ :not([hidden]) {
     border-style: dashed;
   }
 
-  .sm\:divide-dotted > :not(template) ~ :not(template) {
+  .sm\:divide-dotted > :not([hidden]) ~ :not([hidden]) {
     border-style: dotted;
   }
 
-  .sm\:divide-double > :not(template) ~ :not(template) {
+  .sm\:divide-double > :not([hidden]) ~ :not([hidden]) {
     border-style: double;
   }
 
-  .sm\:divide-none > :not(template) ~ :not(template) {
+  .sm\:divide-none > :not([hidden]) ~ :not([hidden]) {
     border-style: none;
   }
 
-  .sm\:divide-opacity-0 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0;
   }
 
-  .sm\:divide-opacity-10 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-10 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.1;
   }
 
-  .sm\:divide-opacity-20 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-20 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.2;
   }
 
-  .sm\:divide-opacity-25 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-25 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.25;
   }
 
-  .sm\:divide-opacity-30 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-30 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.3;
   }
 
-  .sm\:divide-opacity-40 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-40 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.4;
   }
 
-  .sm\:divide-opacity-50 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.5;
   }
 
-  .sm\:divide-opacity-60 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-60 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.6;
   }
 
-  .sm\:divide-opacity-70 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-70 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.7;
   }
 
-  .sm\:divide-opacity-75 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-75 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.75;
   }
 
-  .sm\:divide-opacity-80 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-80 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.8;
   }
 
-  .sm\:divide-opacity-90 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-90 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.9;
   }
 
-  .sm\:divide-opacity-100 > :not(template) ~ :not(template) {
+  .sm\:divide-opacity-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
   }
 
@@ -46482,1323 +46482,1323 @@ video {
     }
   }
 
-  .md\:space-y-0 > :not(template) ~ :not(template) {
+  .md\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0px * var(--space-y-reverse));
   }
 
-  .md\:space-x-0 > :not(template) ~ :not(template) {
+  .md\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0px * var(--space-x-reverse));
     margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-1 > :not(template) ~ :not(template) {
+  .md\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.25rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-1 > :not(template) ~ :not(template) {
+  .md\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-2 > :not(template) ~ :not(template) {
+  .md\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.5rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-2 > :not(template) ~ :not(template) {
+  .md\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-3 > :not(template) ~ :not(template) {
+  .md\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.75rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-3 > :not(template) ~ :not(template) {
+  .md\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-4 > :not(template) ~ :not(template) {
+  .md\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-4 > :not(template) ~ :not(template) {
+  .md\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1rem * var(--space-x-reverse));
     margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-5 > :not(template) ~ :not(template) {
+  .md\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.25rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-5 > :not(template) ~ :not(template) {
+  .md\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-6 > :not(template) ~ :not(template) {
+  .md\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.5rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-6 > :not(template) ~ :not(template) {
+  .md\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-7 > :not(template) ~ :not(template) {
+  .md\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.75rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-7 > :not(template) ~ :not(template) {
+  .md\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-8 > :not(template) ~ :not(template) {
+  .md\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-8 > :not(template) ~ :not(template) {
+  .md\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2rem * var(--space-x-reverse));
     margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-9 > :not(template) ~ :not(template) {
+  .md\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.25rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-9 > :not(template) ~ :not(template) {
+  .md\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-10 > :not(template) ~ :not(template) {
+  .md\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.5rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-10 > :not(template) ~ :not(template) {
+  .md\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-12 > :not(template) ~ :not(template) {
+  .md\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-12 > :not(template) ~ :not(template) {
+  .md\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3rem * var(--space-x-reverse));
     margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-14 > :not(template) ~ :not(template) {
+  .md\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3.5rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-14 > :not(template) ~ :not(template) {
+  .md\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-16 > :not(template) ~ :not(template) {
+  .md\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(4rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-16 > :not(template) ~ :not(template) {
+  .md\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(4rem * var(--space-x-reverse));
     margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-20 > :not(template) ~ :not(template) {
+  .md\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(5rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-20 > :not(template) ~ :not(template) {
+  .md\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(5rem * var(--space-x-reverse));
     margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-24 > :not(template) ~ :not(template) {
+  .md\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(6rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-24 > :not(template) ~ :not(template) {
+  .md\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(6rem * var(--space-x-reverse));
     margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-28 > :not(template) ~ :not(template) {
+  .md\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(7rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-28 > :not(template) ~ :not(template) {
+  .md\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(7rem * var(--space-x-reverse));
     margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-32 > :not(template) ~ :not(template) {
+  .md\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(8rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-32 > :not(template) ~ :not(template) {
+  .md\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(8rem * var(--space-x-reverse));
     margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-36 > :not(template) ~ :not(template) {
+  .md\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(9rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-36 > :not(template) ~ :not(template) {
+  .md\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(9rem * var(--space-x-reverse));
     margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-40 > :not(template) ~ :not(template) {
+  .md\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(10rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-40 > :not(template) ~ :not(template) {
+  .md\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(10rem * var(--space-x-reverse));
     margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-44 > :not(template) ~ :not(template) {
+  .md\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(11rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-44 > :not(template) ~ :not(template) {
+  .md\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(11rem * var(--space-x-reverse));
     margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-48 > :not(template) ~ :not(template) {
+  .md\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(12rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-48 > :not(template) ~ :not(template) {
+  .md\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(12rem * var(--space-x-reverse));
     margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-52 > :not(template) ~ :not(template) {
+  .md\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(13rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-52 > :not(template) ~ :not(template) {
+  .md\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(13rem * var(--space-x-reverse));
     margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-56 > :not(template) ~ :not(template) {
+  .md\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(14rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-56 > :not(template) ~ :not(template) {
+  .md\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(14rem * var(--space-x-reverse));
     margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-60 > :not(template) ~ :not(template) {
+  .md\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(15rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-60 > :not(template) ~ :not(template) {
+  .md\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(15rem * var(--space-x-reverse));
     margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-64 > :not(template) ~ :not(template) {
+  .md\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(16rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-64 > :not(template) ~ :not(template) {
+  .md\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(16rem * var(--space-x-reverse));
     margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-72 > :not(template) ~ :not(template) {
+  .md\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(18rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-72 > :not(template) ~ :not(template) {
+  .md\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(18rem * var(--space-x-reverse));
     margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-80 > :not(template) ~ :not(template) {
+  .md\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(20rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-80 > :not(template) ~ :not(template) {
+  .md\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(20rem * var(--space-x-reverse));
     margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-96 > :not(template) ~ :not(template) {
+  .md\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(24rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-96 > :not(template) ~ :not(template) {
+  .md\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(24rem * var(--space-x-reverse));
     margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-px > :not(template) ~ :not(template) {
+  .md\:space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1px * var(--space-y-reverse));
   }
 
-  .md\:space-x-px > :not(template) ~ :not(template) {
+  .md\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1px * var(--space-x-reverse));
     margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-0\.5 > :not(template) ~ :not(template) {
+  .md\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.125rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-0\.5 > :not(template) ~ :not(template) {
+  .md\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-1\.5 > :not(template) ~ :not(template) {
+  .md\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.375rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-1\.5 > :not(template) ~ :not(template) {
+  .md\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-2\.5 > :not(template) ~ :not(template) {
+  .md\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.625rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-2\.5 > :not(template) ~ :not(template) {
+  .md\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-3\.5 > :not(template) ~ :not(template) {
+  .md\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.875rem * var(--space-y-reverse));
   }
 
-  .md\:space-x-3\.5 > :not(template) ~ :not(template) {
+  .md\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-1 > :not(template) ~ :not(template) {
+  .md\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.25rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-1 > :not(template) ~ :not(template) {
+  .md\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-2 > :not(template) ~ :not(template) {
+  .md\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.5rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-2 > :not(template) ~ :not(template) {
+  .md\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-3 > :not(template) ~ :not(template) {
+  .md\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.75rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-3 > :not(template) ~ :not(template) {
+  .md\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-4 > :not(template) ~ :not(template) {
+  .md\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-4 > :not(template) ~ :not(template) {
+  .md\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1rem * var(--space-x-reverse));
     margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-5 > :not(template) ~ :not(template) {
+  .md\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.25rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-5 > :not(template) ~ :not(template) {
+  .md\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-6 > :not(template) ~ :not(template) {
+  .md\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.5rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-6 > :not(template) ~ :not(template) {
+  .md\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-7 > :not(template) ~ :not(template) {
+  .md\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.75rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-7 > :not(template) ~ :not(template) {
+  .md\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-8 > :not(template) ~ :not(template) {
+  .md\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-8 > :not(template) ~ :not(template) {
+  .md\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2rem * var(--space-x-reverse));
     margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-9 > :not(template) ~ :not(template) {
+  .md\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.25rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-9 > :not(template) ~ :not(template) {
+  .md\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-10 > :not(template) ~ :not(template) {
+  .md\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.5rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-10 > :not(template) ~ :not(template) {
+  .md\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-12 > :not(template) ~ :not(template) {
+  .md\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-12 > :not(template) ~ :not(template) {
+  .md\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3rem * var(--space-x-reverse));
     margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-14 > :not(template) ~ :not(template) {
+  .md\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3.5rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-14 > :not(template) ~ :not(template) {
+  .md\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-16 > :not(template) ~ :not(template) {
+  .md\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-4rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-16 > :not(template) ~ :not(template) {
+  .md\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-4rem * var(--space-x-reverse));
     margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-20 > :not(template) ~ :not(template) {
+  .md\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-5rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-20 > :not(template) ~ :not(template) {
+  .md\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-5rem * var(--space-x-reverse));
     margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-24 > :not(template) ~ :not(template) {
+  .md\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-6rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-24 > :not(template) ~ :not(template) {
+  .md\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-6rem * var(--space-x-reverse));
     margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-28 > :not(template) ~ :not(template) {
+  .md\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-7rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-28 > :not(template) ~ :not(template) {
+  .md\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-7rem * var(--space-x-reverse));
     margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-32 > :not(template) ~ :not(template) {
+  .md\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-8rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-32 > :not(template) ~ :not(template) {
+  .md\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-8rem * var(--space-x-reverse));
     margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-36 > :not(template) ~ :not(template) {
+  .md\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-9rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-36 > :not(template) ~ :not(template) {
+  .md\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-9rem * var(--space-x-reverse));
     margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-40 > :not(template) ~ :not(template) {
+  .md\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-10rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-40 > :not(template) ~ :not(template) {
+  .md\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-10rem * var(--space-x-reverse));
     margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-44 > :not(template) ~ :not(template) {
+  .md\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-11rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-44 > :not(template) ~ :not(template) {
+  .md\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-11rem * var(--space-x-reverse));
     margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-48 > :not(template) ~ :not(template) {
+  .md\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-12rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-48 > :not(template) ~ :not(template) {
+  .md\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-12rem * var(--space-x-reverse));
     margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-52 > :not(template) ~ :not(template) {
+  .md\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-13rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-52 > :not(template) ~ :not(template) {
+  .md\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-13rem * var(--space-x-reverse));
     margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-56 > :not(template) ~ :not(template) {
+  .md\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-14rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-56 > :not(template) ~ :not(template) {
+  .md\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-14rem * var(--space-x-reverse));
     margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-60 > :not(template) ~ :not(template) {
+  .md\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-15rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-60 > :not(template) ~ :not(template) {
+  .md\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-15rem * var(--space-x-reverse));
     margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-64 > :not(template) ~ :not(template) {
+  .md\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-16rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-64 > :not(template) ~ :not(template) {
+  .md\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-16rem * var(--space-x-reverse));
     margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-72 > :not(template) ~ :not(template) {
+  .md\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-18rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-72 > :not(template) ~ :not(template) {
+  .md\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-18rem * var(--space-x-reverse));
     margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-80 > :not(template) ~ :not(template) {
+  .md\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-20rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-80 > :not(template) ~ :not(template) {
+  .md\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-20rem * var(--space-x-reverse));
     margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-96 > :not(template) ~ :not(template) {
+  .md\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-24rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-96 > :not(template) ~ :not(template) {
+  .md\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-24rem * var(--space-x-reverse));
     margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-px > :not(template) ~ :not(template) {
+  .md\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1px * var(--space-y-reverse));
   }
 
-  .md\:-space-x-px > :not(template) ~ :not(template) {
+  .md\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1px * var(--space-x-reverse));
     margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-0\.5 > :not(template) ~ :not(template) {
+  .md\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.125rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-0\.5 > :not(template) ~ :not(template) {
+  .md\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-1\.5 > :not(template) ~ :not(template) {
+  .md\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.375rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-1\.5 > :not(template) ~ :not(template) {
+  .md\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-2\.5 > :not(template) ~ :not(template) {
+  .md\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.625rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-2\.5 > :not(template) ~ :not(template) {
+  .md\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:-space-y-3\.5 > :not(template) ~ :not(template) {
+  .md\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.875rem * var(--space-y-reverse));
   }
 
-  .md\:-space-x-3\.5 > :not(template) ~ :not(template) {
+  .md\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .md\:space-y-reverse > :not(template) ~ :not(template) {
+  .md\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 1;
   }
 
-  .md\:space-x-reverse > :not(template) ~ :not(template) {
+  .md\:space-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 1;
   }
 
-  .md\:divide-y-0 > :not(template) ~ :not(template) {
+  .md\:divide-y-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(0px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(0px * var(--divide-y-reverse));
   }
 
-  .md\:divide-x-0 > :not(template) ~ :not(template) {
+  .md\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(0px * var(--divide-x-reverse));
     border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .md\:divide-y-2 > :not(template) ~ :not(template) {
+  .md\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(2px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(2px * var(--divide-y-reverse));
   }
 
-  .md\:divide-x-2 > :not(template) ~ :not(template) {
+  .md\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(2px * var(--divide-x-reverse));
     border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .md\:divide-y-4 > :not(template) ~ :not(template) {
+  .md\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(4px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(4px * var(--divide-y-reverse));
   }
 
-  .md\:divide-x-4 > :not(template) ~ :not(template) {
+  .md\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(4px * var(--divide-x-reverse));
     border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .md\:divide-y-8 > :not(template) ~ :not(template) {
+  .md\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(8px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(8px * var(--divide-y-reverse));
   }
 
-  .md\:divide-x-8 > :not(template) ~ :not(template) {
+  .md\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(8px * var(--divide-x-reverse));
     border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .md\:divide-y > :not(template) ~ :not(template) {
+  .md\:divide-y > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(1px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(1px * var(--divide-y-reverse));
   }
 
-  .md\:divide-x > :not(template) ~ :not(template) {
+  .md\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(1px * var(--divide-x-reverse));
     border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .md\:divide-y-reverse > :not(template) ~ :not(template) {
+  .md\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 1;
   }
 
-  .md\:divide-x-reverse > :not(template) ~ :not(template) {
+  .md\:divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 1;
   }
 
-  .md\:divide-transparent > :not(template) ~ :not(template) {
+  .md\:divide-transparent > :not([hidden]) ~ :not([hidden]) {
     border-color: transparent;
   }
 
-  .md\:divide-current > :not(template) ~ :not(template) {
+  .md\:divide-current > :not([hidden]) ~ :not([hidden]) {
     border-color: currentColor;
   }
 
-  .md\:divide-black > :not(template) ~ :not(template) {
+  .md\:divide-black > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(0, 0, 0, var(--divide-opacity));
   }
 
-  .md\:divide-white > :not(template) ~ :not(template) {
+  .md\:divide-white > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(255, 255, 255, var(--divide-opacity));
   }
 
-  .md\:divide-gray-50 > :not(template) ~ :not(template) {
+  .md\:divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(250, 250, 250, var(--divide-opacity));
   }
 
-  .md\:divide-gray-100 > :not(template) ~ :not(template) {
+  .md\:divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(244, 244, 245, var(--divide-opacity));
   }
 
-  .md\:divide-gray-200 > :not(template) ~ :not(template) {
+  .md\:divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(228, 228, 231, var(--divide-opacity));
   }
 
-  .md\:divide-gray-300 > :not(template) ~ :not(template) {
+  .md\:divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(212, 212, 216, var(--divide-opacity));
   }
 
-  .md\:divide-gray-400 > :not(template) ~ :not(template) {
+  .md\:divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(161, 161, 170, var(--divide-opacity));
   }
 
-  .md\:divide-gray-500 > :not(template) ~ :not(template) {
+  .md\:divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(113, 113, 122, var(--divide-opacity));
   }
 
-  .md\:divide-gray-600 > :not(template) ~ :not(template) {
+  .md\:divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(82, 82, 91, var(--divide-opacity));
   }
 
-  .md\:divide-gray-700 > :not(template) ~ :not(template) {
+  .md\:divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(63, 63, 70, var(--divide-opacity));
   }
 
-  .md\:divide-gray-800 > :not(template) ~ :not(template) {
+  .md\:divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(39, 39, 42, var(--divide-opacity));
   }
 
-  .md\:divide-gray-900 > :not(template) ~ :not(template) {
+  .md\:divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(24, 24, 27, var(--divide-opacity));
   }
 
-  .md\:divide-red-50 > :not(template) ~ :not(template) {
+  .md\:divide-red-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 242, 242, var(--divide-opacity));
   }
 
-  .md\:divide-red-100 > :not(template) ~ :not(template) {
+  .md\:divide-red-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 226, 226, var(--divide-opacity));
   }
 
-  .md\:divide-red-200 > :not(template) ~ :not(template) {
+  .md\:divide-red-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 202, 202, var(--divide-opacity));
   }
 
-  .md\:divide-red-300 > :not(template) ~ :not(template) {
+  .md\:divide-red-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 165, 165, var(--divide-opacity));
   }
 
-  .md\:divide-red-400 > :not(template) ~ :not(template) {
+  .md\:divide-red-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(248, 113, 113, var(--divide-opacity));
   }
 
-  .md\:divide-red-500 > :not(template) ~ :not(template) {
+  .md\:divide-red-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(239, 68, 68, var(--divide-opacity));
   }
 
-  .md\:divide-red-600 > :not(template) ~ :not(template) {
+  .md\:divide-red-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(220, 38, 38, var(--divide-opacity));
   }
 
-  .md\:divide-red-700 > :not(template) ~ :not(template) {
+  .md\:divide-red-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(185, 28, 28, var(--divide-opacity));
   }
 
-  .md\:divide-red-800 > :not(template) ~ :not(template) {
+  .md\:divide-red-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(153, 27, 27, var(--divide-opacity));
   }
 
-  .md\:divide-red-900 > :not(template) ~ :not(template) {
+  .md\:divide-red-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(127, 29, 29, var(--divide-opacity));
   }
 
-  .md\:divide-yellow-50 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(255, 251, 235, var(--divide-opacity));
   }
 
-  .md\:divide-yellow-100 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 243, 199, var(--divide-opacity));
   }
 
-  .md\:divide-yellow-200 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(253, 230, 138, var(--divide-opacity));
   }
 
-  .md\:divide-yellow-300 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 211, 77, var(--divide-opacity));
   }
 
-  .md\:divide-yellow-400 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(251, 191, 36, var(--divide-opacity));
   }
 
-  .md\:divide-yellow-500 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(245, 158, 11, var(--divide-opacity));
   }
 
-  .md\:divide-yellow-600 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(217, 119, 6, var(--divide-opacity));
   }
 
-  .md\:divide-yellow-700 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(180, 83, 9, var(--divide-opacity));
   }
 
-  .md\:divide-yellow-800 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(146, 64, 14, var(--divide-opacity));
   }
 
-  .md\:divide-yellow-900 > :not(template) ~ :not(template) {
+  .md\:divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(120, 53, 15, var(--divide-opacity));
   }
 
-  .md\:divide-green-50 > :not(template) ~ :not(template) {
+  .md\:divide-green-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(236, 253, 245, var(--divide-opacity));
   }
 
-  .md\:divide-green-100 > :not(template) ~ :not(template) {
+  .md\:divide-green-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(209, 250, 229, var(--divide-opacity));
   }
 
-  .md\:divide-green-200 > :not(template) ~ :not(template) {
+  .md\:divide-green-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(167, 243, 208, var(--divide-opacity));
   }
 
-  .md\:divide-green-300 > :not(template) ~ :not(template) {
+  .md\:divide-green-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(110, 231, 183, var(--divide-opacity));
   }
 
-  .md\:divide-green-400 > :not(template) ~ :not(template) {
+  .md\:divide-green-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(52, 211, 153, var(--divide-opacity));
   }
 
-  .md\:divide-green-500 > :not(template) ~ :not(template) {
+  .md\:divide-green-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(16, 185, 129, var(--divide-opacity));
   }
 
-  .md\:divide-green-600 > :not(template) ~ :not(template) {
+  .md\:divide-green-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(5, 150, 105, var(--divide-opacity));
   }
 
-  .md\:divide-green-700 > :not(template) ~ :not(template) {
+  .md\:divide-green-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(4, 120, 87, var(--divide-opacity));
   }
 
-  .md\:divide-green-800 > :not(template) ~ :not(template) {
+  .md\:divide-green-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(6, 95, 70, var(--divide-opacity));
   }
 
-  .md\:divide-green-900 > :not(template) ~ :not(template) {
+  .md\:divide-green-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(6, 78, 59, var(--divide-opacity));
   }
 
-  .md\:divide-blue-50 > :not(template) ~ :not(template) {
+  .md\:divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(239, 246, 255, var(--divide-opacity));
   }
 
-  .md\:divide-blue-100 > :not(template) ~ :not(template) {
+  .md\:divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(219, 234, 254, var(--divide-opacity));
   }
 
-  .md\:divide-blue-200 > :not(template) ~ :not(template) {
+  .md\:divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(191, 219, 254, var(--divide-opacity));
   }
 
-  .md\:divide-blue-300 > :not(template) ~ :not(template) {
+  .md\:divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(147, 197, 253, var(--divide-opacity));
   }
 
-  .md\:divide-blue-400 > :not(template) ~ :not(template) {
+  .md\:divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(96, 165, 250, var(--divide-opacity));
   }
 
-  .md\:divide-blue-500 > :not(template) ~ :not(template) {
+  .md\:divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(59, 130, 246, var(--divide-opacity));
   }
 
-  .md\:divide-blue-600 > :not(template) ~ :not(template) {
+  .md\:divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(37, 99, 235, var(--divide-opacity));
   }
 
-  .md\:divide-blue-700 > :not(template) ~ :not(template) {
+  .md\:divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(29, 78, 216, var(--divide-opacity));
   }
 
-  .md\:divide-blue-800 > :not(template) ~ :not(template) {
+  .md\:divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(30, 64, 175, var(--divide-opacity));
   }
 
-  .md\:divide-blue-900 > :not(template) ~ :not(template) {
+  .md\:divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(30, 58, 138, var(--divide-opacity));
   }
 
-  .md\:divide-purple-50 > :not(template) ~ :not(template) {
+  .md\:divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(245, 243, 255, var(--divide-opacity));
   }
 
-  .md\:divide-purple-100 > :not(template) ~ :not(template) {
+  .md\:divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(237, 233, 254, var(--divide-opacity));
   }
 
-  .md\:divide-purple-200 > :not(template) ~ :not(template) {
+  .md\:divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(221, 214, 254, var(--divide-opacity));
   }
 
-  .md\:divide-purple-300 > :not(template) ~ :not(template) {
+  .md\:divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(196, 181, 253, var(--divide-opacity));
   }
 
-  .md\:divide-purple-400 > :not(template) ~ :not(template) {
+  .md\:divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(167, 139, 250, var(--divide-opacity));
   }
 
-  .md\:divide-purple-500 > :not(template) ~ :not(template) {
+  .md\:divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(139, 92, 246, var(--divide-opacity));
   }
 
-  .md\:divide-purple-600 > :not(template) ~ :not(template) {
+  .md\:divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(124, 58, 237, var(--divide-opacity));
   }
 
-  .md\:divide-purple-700 > :not(template) ~ :not(template) {
+  .md\:divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(109, 40, 217, var(--divide-opacity));
   }
 
-  .md\:divide-purple-800 > :not(template) ~ :not(template) {
+  .md\:divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(91, 33, 182, var(--divide-opacity));
   }
 
-  .md\:divide-purple-900 > :not(template) ~ :not(template) {
+  .md\:divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(76, 29, 149, var(--divide-opacity));
   }
 
-  .md\:divide-pink-50 > :not(template) ~ :not(template) {
+  .md\:divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(253, 242, 248, var(--divide-opacity));
   }
 
-  .md\:divide-pink-100 > :not(template) ~ :not(template) {
+  .md\:divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 231, 243, var(--divide-opacity));
   }
 
-  .md\:divide-pink-200 > :not(template) ~ :not(template) {
+  .md\:divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(251, 207, 232, var(--divide-opacity));
   }
 
-  .md\:divide-pink-300 > :not(template) ~ :not(template) {
+  .md\:divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(249, 168, 212, var(--divide-opacity));
   }
 
-  .md\:divide-pink-400 > :not(template) ~ :not(template) {
+  .md\:divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(244, 114, 182, var(--divide-opacity));
   }
 
-  .md\:divide-pink-500 > :not(template) ~ :not(template) {
+  .md\:divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(236, 72, 153, var(--divide-opacity));
   }
 
-  .md\:divide-pink-600 > :not(template) ~ :not(template) {
+  .md\:divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(219, 39, 119, var(--divide-opacity));
   }
 
-  .md\:divide-pink-700 > :not(template) ~ :not(template) {
+  .md\:divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(190, 24, 93, var(--divide-opacity));
   }
 
-  .md\:divide-pink-800 > :not(template) ~ :not(template) {
+  .md\:divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(157, 23, 77, var(--divide-opacity));
   }
 
-  .md\:divide-pink-900 > :not(template) ~ :not(template) {
+  .md\:divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(131, 24, 67, var(--divide-opacity));
   }
 
-  .md\:divide-solid > :not(template) ~ :not(template) {
+  .md\:divide-solid > :not([hidden]) ~ :not([hidden]) {
     border-style: solid;
   }
 
-  .md\:divide-dashed > :not(template) ~ :not(template) {
+  .md\:divide-dashed > :not([hidden]) ~ :not([hidden]) {
     border-style: dashed;
   }
 
-  .md\:divide-dotted > :not(template) ~ :not(template) {
+  .md\:divide-dotted > :not([hidden]) ~ :not([hidden]) {
     border-style: dotted;
   }
 
-  .md\:divide-double > :not(template) ~ :not(template) {
+  .md\:divide-double > :not([hidden]) ~ :not([hidden]) {
     border-style: double;
   }
 
-  .md\:divide-none > :not(template) ~ :not(template) {
+  .md\:divide-none > :not([hidden]) ~ :not([hidden]) {
     border-style: none;
   }
 
-  .md\:divide-opacity-0 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0;
   }
 
-  .md\:divide-opacity-10 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-10 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.1;
   }
 
-  .md\:divide-opacity-20 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-20 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.2;
   }
 
-  .md\:divide-opacity-25 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-25 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.25;
   }
 
-  .md\:divide-opacity-30 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-30 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.3;
   }
 
-  .md\:divide-opacity-40 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-40 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.4;
   }
 
-  .md\:divide-opacity-50 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.5;
   }
 
-  .md\:divide-opacity-60 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-60 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.6;
   }
 
-  .md\:divide-opacity-70 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-70 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.7;
   }
 
-  .md\:divide-opacity-75 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-75 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.75;
   }
 
-  .md\:divide-opacity-80 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-80 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.8;
   }
 
-  .md\:divide-opacity-90 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-90 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.9;
   }
 
-  .md\:divide-opacity-100 > :not(template) ~ :not(template) {
+  .md\:divide-opacity-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
   }
 
@@ -69428,1323 +69428,1323 @@ video {
     }
   }
 
-  .lg\:space-y-0 > :not(template) ~ :not(template) {
+  .lg\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0px * var(--space-y-reverse));
   }
 
-  .lg\:space-x-0 > :not(template) ~ :not(template) {
+  .lg\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0px * var(--space-x-reverse));
     margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-1 > :not(template) ~ :not(template) {
+  .lg\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.25rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-1 > :not(template) ~ :not(template) {
+  .lg\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-2 > :not(template) ~ :not(template) {
+  .lg\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.5rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-2 > :not(template) ~ :not(template) {
+  .lg\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-3 > :not(template) ~ :not(template) {
+  .lg\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.75rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-3 > :not(template) ~ :not(template) {
+  .lg\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-4 > :not(template) ~ :not(template) {
+  .lg\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-4 > :not(template) ~ :not(template) {
+  .lg\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1rem * var(--space-x-reverse));
     margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-5 > :not(template) ~ :not(template) {
+  .lg\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.25rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-5 > :not(template) ~ :not(template) {
+  .lg\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-6 > :not(template) ~ :not(template) {
+  .lg\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.5rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-6 > :not(template) ~ :not(template) {
+  .lg\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-7 > :not(template) ~ :not(template) {
+  .lg\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.75rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-7 > :not(template) ~ :not(template) {
+  .lg\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-8 > :not(template) ~ :not(template) {
+  .lg\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-8 > :not(template) ~ :not(template) {
+  .lg\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2rem * var(--space-x-reverse));
     margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-9 > :not(template) ~ :not(template) {
+  .lg\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.25rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-9 > :not(template) ~ :not(template) {
+  .lg\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-10 > :not(template) ~ :not(template) {
+  .lg\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.5rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-10 > :not(template) ~ :not(template) {
+  .lg\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-12 > :not(template) ~ :not(template) {
+  .lg\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-12 > :not(template) ~ :not(template) {
+  .lg\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3rem * var(--space-x-reverse));
     margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-14 > :not(template) ~ :not(template) {
+  .lg\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3.5rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-14 > :not(template) ~ :not(template) {
+  .lg\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-16 > :not(template) ~ :not(template) {
+  .lg\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(4rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-16 > :not(template) ~ :not(template) {
+  .lg\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(4rem * var(--space-x-reverse));
     margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-20 > :not(template) ~ :not(template) {
+  .lg\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(5rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-20 > :not(template) ~ :not(template) {
+  .lg\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(5rem * var(--space-x-reverse));
     margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-24 > :not(template) ~ :not(template) {
+  .lg\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(6rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-24 > :not(template) ~ :not(template) {
+  .lg\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(6rem * var(--space-x-reverse));
     margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-28 > :not(template) ~ :not(template) {
+  .lg\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(7rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-28 > :not(template) ~ :not(template) {
+  .lg\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(7rem * var(--space-x-reverse));
     margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-32 > :not(template) ~ :not(template) {
+  .lg\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(8rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-32 > :not(template) ~ :not(template) {
+  .lg\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(8rem * var(--space-x-reverse));
     margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-36 > :not(template) ~ :not(template) {
+  .lg\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(9rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-36 > :not(template) ~ :not(template) {
+  .lg\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(9rem * var(--space-x-reverse));
     margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-40 > :not(template) ~ :not(template) {
+  .lg\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(10rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-40 > :not(template) ~ :not(template) {
+  .lg\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(10rem * var(--space-x-reverse));
     margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-44 > :not(template) ~ :not(template) {
+  .lg\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(11rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-44 > :not(template) ~ :not(template) {
+  .lg\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(11rem * var(--space-x-reverse));
     margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-48 > :not(template) ~ :not(template) {
+  .lg\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(12rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-48 > :not(template) ~ :not(template) {
+  .lg\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(12rem * var(--space-x-reverse));
     margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-52 > :not(template) ~ :not(template) {
+  .lg\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(13rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-52 > :not(template) ~ :not(template) {
+  .lg\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(13rem * var(--space-x-reverse));
     margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-56 > :not(template) ~ :not(template) {
+  .lg\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(14rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-56 > :not(template) ~ :not(template) {
+  .lg\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(14rem * var(--space-x-reverse));
     margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-60 > :not(template) ~ :not(template) {
+  .lg\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(15rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-60 > :not(template) ~ :not(template) {
+  .lg\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(15rem * var(--space-x-reverse));
     margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-64 > :not(template) ~ :not(template) {
+  .lg\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(16rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-64 > :not(template) ~ :not(template) {
+  .lg\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(16rem * var(--space-x-reverse));
     margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-72 > :not(template) ~ :not(template) {
+  .lg\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(18rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-72 > :not(template) ~ :not(template) {
+  .lg\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(18rem * var(--space-x-reverse));
     margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-80 > :not(template) ~ :not(template) {
+  .lg\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(20rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-80 > :not(template) ~ :not(template) {
+  .lg\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(20rem * var(--space-x-reverse));
     margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-96 > :not(template) ~ :not(template) {
+  .lg\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(24rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-96 > :not(template) ~ :not(template) {
+  .lg\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(24rem * var(--space-x-reverse));
     margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-px > :not(template) ~ :not(template) {
+  .lg\:space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1px * var(--space-y-reverse));
   }
 
-  .lg\:space-x-px > :not(template) ~ :not(template) {
+  .lg\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1px * var(--space-x-reverse));
     margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-0\.5 > :not(template) ~ :not(template) {
+  .lg\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.125rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-0\.5 > :not(template) ~ :not(template) {
+  .lg\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-1\.5 > :not(template) ~ :not(template) {
+  .lg\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.375rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-1\.5 > :not(template) ~ :not(template) {
+  .lg\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-2\.5 > :not(template) ~ :not(template) {
+  .lg\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.625rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-2\.5 > :not(template) ~ :not(template) {
+  .lg\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-3\.5 > :not(template) ~ :not(template) {
+  .lg\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.875rem * var(--space-y-reverse));
   }
 
-  .lg\:space-x-3\.5 > :not(template) ~ :not(template) {
+  .lg\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-1 > :not(template) ~ :not(template) {
+  .lg\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.25rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-1 > :not(template) ~ :not(template) {
+  .lg\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-2 > :not(template) ~ :not(template) {
+  .lg\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.5rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-2 > :not(template) ~ :not(template) {
+  .lg\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-3 > :not(template) ~ :not(template) {
+  .lg\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.75rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-3 > :not(template) ~ :not(template) {
+  .lg\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-4 > :not(template) ~ :not(template) {
+  .lg\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-4 > :not(template) ~ :not(template) {
+  .lg\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1rem * var(--space-x-reverse));
     margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-5 > :not(template) ~ :not(template) {
+  .lg\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.25rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-5 > :not(template) ~ :not(template) {
+  .lg\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-6 > :not(template) ~ :not(template) {
+  .lg\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.5rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-6 > :not(template) ~ :not(template) {
+  .lg\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-7 > :not(template) ~ :not(template) {
+  .lg\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.75rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-7 > :not(template) ~ :not(template) {
+  .lg\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-8 > :not(template) ~ :not(template) {
+  .lg\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-8 > :not(template) ~ :not(template) {
+  .lg\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2rem * var(--space-x-reverse));
     margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-9 > :not(template) ~ :not(template) {
+  .lg\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.25rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-9 > :not(template) ~ :not(template) {
+  .lg\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-10 > :not(template) ~ :not(template) {
+  .lg\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.5rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-10 > :not(template) ~ :not(template) {
+  .lg\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-12 > :not(template) ~ :not(template) {
+  .lg\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-12 > :not(template) ~ :not(template) {
+  .lg\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3rem * var(--space-x-reverse));
     margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-14 > :not(template) ~ :not(template) {
+  .lg\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3.5rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-14 > :not(template) ~ :not(template) {
+  .lg\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-16 > :not(template) ~ :not(template) {
+  .lg\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-4rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-16 > :not(template) ~ :not(template) {
+  .lg\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-4rem * var(--space-x-reverse));
     margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-20 > :not(template) ~ :not(template) {
+  .lg\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-5rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-20 > :not(template) ~ :not(template) {
+  .lg\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-5rem * var(--space-x-reverse));
     margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-24 > :not(template) ~ :not(template) {
+  .lg\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-6rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-24 > :not(template) ~ :not(template) {
+  .lg\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-6rem * var(--space-x-reverse));
     margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-28 > :not(template) ~ :not(template) {
+  .lg\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-7rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-28 > :not(template) ~ :not(template) {
+  .lg\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-7rem * var(--space-x-reverse));
     margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-32 > :not(template) ~ :not(template) {
+  .lg\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-8rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-32 > :not(template) ~ :not(template) {
+  .lg\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-8rem * var(--space-x-reverse));
     margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-36 > :not(template) ~ :not(template) {
+  .lg\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-9rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-36 > :not(template) ~ :not(template) {
+  .lg\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-9rem * var(--space-x-reverse));
     margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-40 > :not(template) ~ :not(template) {
+  .lg\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-10rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-40 > :not(template) ~ :not(template) {
+  .lg\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-10rem * var(--space-x-reverse));
     margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-44 > :not(template) ~ :not(template) {
+  .lg\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-11rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-44 > :not(template) ~ :not(template) {
+  .lg\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-11rem * var(--space-x-reverse));
     margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-48 > :not(template) ~ :not(template) {
+  .lg\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-12rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-48 > :not(template) ~ :not(template) {
+  .lg\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-12rem * var(--space-x-reverse));
     margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-52 > :not(template) ~ :not(template) {
+  .lg\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-13rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-52 > :not(template) ~ :not(template) {
+  .lg\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-13rem * var(--space-x-reverse));
     margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-56 > :not(template) ~ :not(template) {
+  .lg\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-14rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-56 > :not(template) ~ :not(template) {
+  .lg\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-14rem * var(--space-x-reverse));
     margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-60 > :not(template) ~ :not(template) {
+  .lg\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-15rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-60 > :not(template) ~ :not(template) {
+  .lg\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-15rem * var(--space-x-reverse));
     margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-64 > :not(template) ~ :not(template) {
+  .lg\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-16rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-64 > :not(template) ~ :not(template) {
+  .lg\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-16rem * var(--space-x-reverse));
     margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-72 > :not(template) ~ :not(template) {
+  .lg\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-18rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-72 > :not(template) ~ :not(template) {
+  .lg\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-18rem * var(--space-x-reverse));
     margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-80 > :not(template) ~ :not(template) {
+  .lg\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-20rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-80 > :not(template) ~ :not(template) {
+  .lg\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-20rem * var(--space-x-reverse));
     margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-96 > :not(template) ~ :not(template) {
+  .lg\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-24rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-96 > :not(template) ~ :not(template) {
+  .lg\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-24rem * var(--space-x-reverse));
     margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-px > :not(template) ~ :not(template) {
+  .lg\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1px * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-px > :not(template) ~ :not(template) {
+  .lg\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1px * var(--space-x-reverse));
     margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-0\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.125rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-0\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-1\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.375rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-1\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-2\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.625rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-2\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:-space-y-3\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.875rem * var(--space-y-reverse));
   }
 
-  .lg\:-space-x-3\.5 > :not(template) ~ :not(template) {
+  .lg\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .lg\:space-y-reverse > :not(template) ~ :not(template) {
+  .lg\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 1;
   }
 
-  .lg\:space-x-reverse > :not(template) ~ :not(template) {
+  .lg\:space-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 1;
   }
 
-  .lg\:divide-y-0 > :not(template) ~ :not(template) {
+  .lg\:divide-y-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(0px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(0px * var(--divide-y-reverse));
   }
 
-  .lg\:divide-x-0 > :not(template) ~ :not(template) {
+  .lg\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(0px * var(--divide-x-reverse));
     border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .lg\:divide-y-2 > :not(template) ~ :not(template) {
+  .lg\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(2px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(2px * var(--divide-y-reverse));
   }
 
-  .lg\:divide-x-2 > :not(template) ~ :not(template) {
+  .lg\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(2px * var(--divide-x-reverse));
     border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .lg\:divide-y-4 > :not(template) ~ :not(template) {
+  .lg\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(4px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(4px * var(--divide-y-reverse));
   }
 
-  .lg\:divide-x-4 > :not(template) ~ :not(template) {
+  .lg\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(4px * var(--divide-x-reverse));
     border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .lg\:divide-y-8 > :not(template) ~ :not(template) {
+  .lg\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(8px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(8px * var(--divide-y-reverse));
   }
 
-  .lg\:divide-x-8 > :not(template) ~ :not(template) {
+  .lg\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(8px * var(--divide-x-reverse));
     border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .lg\:divide-y > :not(template) ~ :not(template) {
+  .lg\:divide-y > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(1px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(1px * var(--divide-y-reverse));
   }
 
-  .lg\:divide-x > :not(template) ~ :not(template) {
+  .lg\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(1px * var(--divide-x-reverse));
     border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .lg\:divide-y-reverse > :not(template) ~ :not(template) {
+  .lg\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 1;
   }
 
-  .lg\:divide-x-reverse > :not(template) ~ :not(template) {
+  .lg\:divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 1;
   }
 
-  .lg\:divide-transparent > :not(template) ~ :not(template) {
+  .lg\:divide-transparent > :not([hidden]) ~ :not([hidden]) {
     border-color: transparent;
   }
 
-  .lg\:divide-current > :not(template) ~ :not(template) {
+  .lg\:divide-current > :not([hidden]) ~ :not([hidden]) {
     border-color: currentColor;
   }
 
-  .lg\:divide-black > :not(template) ~ :not(template) {
+  .lg\:divide-black > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(0, 0, 0, var(--divide-opacity));
   }
 
-  .lg\:divide-white > :not(template) ~ :not(template) {
+  .lg\:divide-white > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(255, 255, 255, var(--divide-opacity));
   }
 
-  .lg\:divide-gray-50 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(250, 250, 250, var(--divide-opacity));
   }
 
-  .lg\:divide-gray-100 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(244, 244, 245, var(--divide-opacity));
   }
 
-  .lg\:divide-gray-200 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(228, 228, 231, var(--divide-opacity));
   }
 
-  .lg\:divide-gray-300 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(212, 212, 216, var(--divide-opacity));
   }
 
-  .lg\:divide-gray-400 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(161, 161, 170, var(--divide-opacity));
   }
 
-  .lg\:divide-gray-500 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(113, 113, 122, var(--divide-opacity));
   }
 
-  .lg\:divide-gray-600 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(82, 82, 91, var(--divide-opacity));
   }
 
-  .lg\:divide-gray-700 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(63, 63, 70, var(--divide-opacity));
   }
 
-  .lg\:divide-gray-800 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(39, 39, 42, var(--divide-opacity));
   }
 
-  .lg\:divide-gray-900 > :not(template) ~ :not(template) {
+  .lg\:divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(24, 24, 27, var(--divide-opacity));
   }
 
-  .lg\:divide-red-50 > :not(template) ~ :not(template) {
+  .lg\:divide-red-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 242, 242, var(--divide-opacity));
   }
 
-  .lg\:divide-red-100 > :not(template) ~ :not(template) {
+  .lg\:divide-red-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 226, 226, var(--divide-opacity));
   }
 
-  .lg\:divide-red-200 > :not(template) ~ :not(template) {
+  .lg\:divide-red-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 202, 202, var(--divide-opacity));
   }
 
-  .lg\:divide-red-300 > :not(template) ~ :not(template) {
+  .lg\:divide-red-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 165, 165, var(--divide-opacity));
   }
 
-  .lg\:divide-red-400 > :not(template) ~ :not(template) {
+  .lg\:divide-red-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(248, 113, 113, var(--divide-opacity));
   }
 
-  .lg\:divide-red-500 > :not(template) ~ :not(template) {
+  .lg\:divide-red-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(239, 68, 68, var(--divide-opacity));
   }
 
-  .lg\:divide-red-600 > :not(template) ~ :not(template) {
+  .lg\:divide-red-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(220, 38, 38, var(--divide-opacity));
   }
 
-  .lg\:divide-red-700 > :not(template) ~ :not(template) {
+  .lg\:divide-red-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(185, 28, 28, var(--divide-opacity));
   }
 
-  .lg\:divide-red-800 > :not(template) ~ :not(template) {
+  .lg\:divide-red-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(153, 27, 27, var(--divide-opacity));
   }
 
-  .lg\:divide-red-900 > :not(template) ~ :not(template) {
+  .lg\:divide-red-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(127, 29, 29, var(--divide-opacity));
   }
 
-  .lg\:divide-yellow-50 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(255, 251, 235, var(--divide-opacity));
   }
 
-  .lg\:divide-yellow-100 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 243, 199, var(--divide-opacity));
   }
 
-  .lg\:divide-yellow-200 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(253, 230, 138, var(--divide-opacity));
   }
 
-  .lg\:divide-yellow-300 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 211, 77, var(--divide-opacity));
   }
 
-  .lg\:divide-yellow-400 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(251, 191, 36, var(--divide-opacity));
   }
 
-  .lg\:divide-yellow-500 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(245, 158, 11, var(--divide-opacity));
   }
 
-  .lg\:divide-yellow-600 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(217, 119, 6, var(--divide-opacity));
   }
 
-  .lg\:divide-yellow-700 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(180, 83, 9, var(--divide-opacity));
   }
 
-  .lg\:divide-yellow-800 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(146, 64, 14, var(--divide-opacity));
   }
 
-  .lg\:divide-yellow-900 > :not(template) ~ :not(template) {
+  .lg\:divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(120, 53, 15, var(--divide-opacity));
   }
 
-  .lg\:divide-green-50 > :not(template) ~ :not(template) {
+  .lg\:divide-green-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(236, 253, 245, var(--divide-opacity));
   }
 
-  .lg\:divide-green-100 > :not(template) ~ :not(template) {
+  .lg\:divide-green-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(209, 250, 229, var(--divide-opacity));
   }
 
-  .lg\:divide-green-200 > :not(template) ~ :not(template) {
+  .lg\:divide-green-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(167, 243, 208, var(--divide-opacity));
   }
 
-  .lg\:divide-green-300 > :not(template) ~ :not(template) {
+  .lg\:divide-green-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(110, 231, 183, var(--divide-opacity));
   }
 
-  .lg\:divide-green-400 > :not(template) ~ :not(template) {
+  .lg\:divide-green-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(52, 211, 153, var(--divide-opacity));
   }
 
-  .lg\:divide-green-500 > :not(template) ~ :not(template) {
+  .lg\:divide-green-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(16, 185, 129, var(--divide-opacity));
   }
 
-  .lg\:divide-green-600 > :not(template) ~ :not(template) {
+  .lg\:divide-green-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(5, 150, 105, var(--divide-opacity));
   }
 
-  .lg\:divide-green-700 > :not(template) ~ :not(template) {
+  .lg\:divide-green-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(4, 120, 87, var(--divide-opacity));
   }
 
-  .lg\:divide-green-800 > :not(template) ~ :not(template) {
+  .lg\:divide-green-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(6, 95, 70, var(--divide-opacity));
   }
 
-  .lg\:divide-green-900 > :not(template) ~ :not(template) {
+  .lg\:divide-green-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(6, 78, 59, var(--divide-opacity));
   }
 
-  .lg\:divide-blue-50 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(239, 246, 255, var(--divide-opacity));
   }
 
-  .lg\:divide-blue-100 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(219, 234, 254, var(--divide-opacity));
   }
 
-  .lg\:divide-blue-200 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(191, 219, 254, var(--divide-opacity));
   }
 
-  .lg\:divide-blue-300 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(147, 197, 253, var(--divide-opacity));
   }
 
-  .lg\:divide-blue-400 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(96, 165, 250, var(--divide-opacity));
   }
 
-  .lg\:divide-blue-500 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(59, 130, 246, var(--divide-opacity));
   }
 
-  .lg\:divide-blue-600 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(37, 99, 235, var(--divide-opacity));
   }
 
-  .lg\:divide-blue-700 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(29, 78, 216, var(--divide-opacity));
   }
 
-  .lg\:divide-blue-800 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(30, 64, 175, var(--divide-opacity));
   }
 
-  .lg\:divide-blue-900 > :not(template) ~ :not(template) {
+  .lg\:divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(30, 58, 138, var(--divide-opacity));
   }
 
-  .lg\:divide-purple-50 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(245, 243, 255, var(--divide-opacity));
   }
 
-  .lg\:divide-purple-100 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(237, 233, 254, var(--divide-opacity));
   }
 
-  .lg\:divide-purple-200 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(221, 214, 254, var(--divide-opacity));
   }
 
-  .lg\:divide-purple-300 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(196, 181, 253, var(--divide-opacity));
   }
 
-  .lg\:divide-purple-400 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(167, 139, 250, var(--divide-opacity));
   }
 
-  .lg\:divide-purple-500 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(139, 92, 246, var(--divide-opacity));
   }
 
-  .lg\:divide-purple-600 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(124, 58, 237, var(--divide-opacity));
   }
 
-  .lg\:divide-purple-700 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(109, 40, 217, var(--divide-opacity));
   }
 
-  .lg\:divide-purple-800 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(91, 33, 182, var(--divide-opacity));
   }
 
-  .lg\:divide-purple-900 > :not(template) ~ :not(template) {
+  .lg\:divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(76, 29, 149, var(--divide-opacity));
   }
 
-  .lg\:divide-pink-50 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(253, 242, 248, var(--divide-opacity));
   }
 
-  .lg\:divide-pink-100 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 231, 243, var(--divide-opacity));
   }
 
-  .lg\:divide-pink-200 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(251, 207, 232, var(--divide-opacity));
   }
 
-  .lg\:divide-pink-300 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(249, 168, 212, var(--divide-opacity));
   }
 
-  .lg\:divide-pink-400 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(244, 114, 182, var(--divide-opacity));
   }
 
-  .lg\:divide-pink-500 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(236, 72, 153, var(--divide-opacity));
   }
 
-  .lg\:divide-pink-600 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(219, 39, 119, var(--divide-opacity));
   }
 
-  .lg\:divide-pink-700 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(190, 24, 93, var(--divide-opacity));
   }
 
-  .lg\:divide-pink-800 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(157, 23, 77, var(--divide-opacity));
   }
 
-  .lg\:divide-pink-900 > :not(template) ~ :not(template) {
+  .lg\:divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(131, 24, 67, var(--divide-opacity));
   }
 
-  .lg\:divide-solid > :not(template) ~ :not(template) {
+  .lg\:divide-solid > :not([hidden]) ~ :not([hidden]) {
     border-style: solid;
   }
 
-  .lg\:divide-dashed > :not(template) ~ :not(template) {
+  .lg\:divide-dashed > :not([hidden]) ~ :not([hidden]) {
     border-style: dashed;
   }
 
-  .lg\:divide-dotted > :not(template) ~ :not(template) {
+  .lg\:divide-dotted > :not([hidden]) ~ :not([hidden]) {
     border-style: dotted;
   }
 
-  .lg\:divide-double > :not(template) ~ :not(template) {
+  .lg\:divide-double > :not([hidden]) ~ :not([hidden]) {
     border-style: double;
   }
 
-  .lg\:divide-none > :not(template) ~ :not(template) {
+  .lg\:divide-none > :not([hidden]) ~ :not([hidden]) {
     border-style: none;
   }
 
-  .lg\:divide-opacity-0 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0;
   }
 
-  .lg\:divide-opacity-10 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-10 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.1;
   }
 
-  .lg\:divide-opacity-20 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-20 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.2;
   }
 
-  .lg\:divide-opacity-25 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-25 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.25;
   }
 
-  .lg\:divide-opacity-30 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-30 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.3;
   }
 
-  .lg\:divide-opacity-40 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-40 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.4;
   }
 
-  .lg\:divide-opacity-50 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.5;
   }
 
-  .lg\:divide-opacity-60 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-60 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.6;
   }
 
-  .lg\:divide-opacity-70 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-70 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.7;
   }
 
-  .lg\:divide-opacity-75 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-75 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.75;
   }
 
-  .lg\:divide-opacity-80 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-80 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.8;
   }
 
-  .lg\:divide-opacity-90 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-90 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.9;
   }
 
-  .lg\:divide-opacity-100 > :not(template) ~ :not(template) {
+  .lg\:divide-opacity-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
   }
 
@@ -92374,1323 +92374,1323 @@ video {
     }
   }
 
-  .xl\:space-y-0 > :not(template) ~ :not(template) {
+  .xl\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0px * var(--space-y-reverse));
   }
 
-  .xl\:space-x-0 > :not(template) ~ :not(template) {
+  .xl\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0px * var(--space-x-reverse));
     margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-1 > :not(template) ~ :not(template) {
+  .xl\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.25rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-1 > :not(template) ~ :not(template) {
+  .xl\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-2 > :not(template) ~ :not(template) {
+  .xl\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.5rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-2 > :not(template) ~ :not(template) {
+  .xl\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-3 > :not(template) ~ :not(template) {
+  .xl\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.75rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-3 > :not(template) ~ :not(template) {
+  .xl\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-4 > :not(template) ~ :not(template) {
+  .xl\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-4 > :not(template) ~ :not(template) {
+  .xl\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1rem * var(--space-x-reverse));
     margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-5 > :not(template) ~ :not(template) {
+  .xl\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.25rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-5 > :not(template) ~ :not(template) {
+  .xl\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-6 > :not(template) ~ :not(template) {
+  .xl\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.5rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-6 > :not(template) ~ :not(template) {
+  .xl\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-7 > :not(template) ~ :not(template) {
+  .xl\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.75rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-7 > :not(template) ~ :not(template) {
+  .xl\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-8 > :not(template) ~ :not(template) {
+  .xl\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-8 > :not(template) ~ :not(template) {
+  .xl\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2rem * var(--space-x-reverse));
     margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-9 > :not(template) ~ :not(template) {
+  .xl\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.25rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-9 > :not(template) ~ :not(template) {
+  .xl\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-10 > :not(template) ~ :not(template) {
+  .xl\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.5rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-10 > :not(template) ~ :not(template) {
+  .xl\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-12 > :not(template) ~ :not(template) {
+  .xl\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-12 > :not(template) ~ :not(template) {
+  .xl\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3rem * var(--space-x-reverse));
     margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-14 > :not(template) ~ :not(template) {
+  .xl\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3.5rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-14 > :not(template) ~ :not(template) {
+  .xl\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-16 > :not(template) ~ :not(template) {
+  .xl\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(4rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-16 > :not(template) ~ :not(template) {
+  .xl\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(4rem * var(--space-x-reverse));
     margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-20 > :not(template) ~ :not(template) {
+  .xl\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(5rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-20 > :not(template) ~ :not(template) {
+  .xl\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(5rem * var(--space-x-reverse));
     margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-24 > :not(template) ~ :not(template) {
+  .xl\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(6rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-24 > :not(template) ~ :not(template) {
+  .xl\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(6rem * var(--space-x-reverse));
     margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-28 > :not(template) ~ :not(template) {
+  .xl\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(7rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-28 > :not(template) ~ :not(template) {
+  .xl\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(7rem * var(--space-x-reverse));
     margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-32 > :not(template) ~ :not(template) {
+  .xl\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(8rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-32 > :not(template) ~ :not(template) {
+  .xl\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(8rem * var(--space-x-reverse));
     margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-36 > :not(template) ~ :not(template) {
+  .xl\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(9rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-36 > :not(template) ~ :not(template) {
+  .xl\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(9rem * var(--space-x-reverse));
     margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-40 > :not(template) ~ :not(template) {
+  .xl\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(10rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-40 > :not(template) ~ :not(template) {
+  .xl\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(10rem * var(--space-x-reverse));
     margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-44 > :not(template) ~ :not(template) {
+  .xl\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(11rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-44 > :not(template) ~ :not(template) {
+  .xl\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(11rem * var(--space-x-reverse));
     margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-48 > :not(template) ~ :not(template) {
+  .xl\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(12rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-48 > :not(template) ~ :not(template) {
+  .xl\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(12rem * var(--space-x-reverse));
     margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-52 > :not(template) ~ :not(template) {
+  .xl\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(13rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-52 > :not(template) ~ :not(template) {
+  .xl\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(13rem * var(--space-x-reverse));
     margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-56 > :not(template) ~ :not(template) {
+  .xl\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(14rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-56 > :not(template) ~ :not(template) {
+  .xl\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(14rem * var(--space-x-reverse));
     margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-60 > :not(template) ~ :not(template) {
+  .xl\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(15rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-60 > :not(template) ~ :not(template) {
+  .xl\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(15rem * var(--space-x-reverse));
     margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-64 > :not(template) ~ :not(template) {
+  .xl\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(16rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-64 > :not(template) ~ :not(template) {
+  .xl\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(16rem * var(--space-x-reverse));
     margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-72 > :not(template) ~ :not(template) {
+  .xl\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(18rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-72 > :not(template) ~ :not(template) {
+  .xl\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(18rem * var(--space-x-reverse));
     margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-80 > :not(template) ~ :not(template) {
+  .xl\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(20rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-80 > :not(template) ~ :not(template) {
+  .xl\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(20rem * var(--space-x-reverse));
     margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-96 > :not(template) ~ :not(template) {
+  .xl\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(24rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-96 > :not(template) ~ :not(template) {
+  .xl\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(24rem * var(--space-x-reverse));
     margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-px > :not(template) ~ :not(template) {
+  .xl\:space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1px * var(--space-y-reverse));
   }
 
-  .xl\:space-x-px > :not(template) ~ :not(template) {
+  .xl\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1px * var(--space-x-reverse));
     margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-0\.5 > :not(template) ~ :not(template) {
+  .xl\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.125rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-0\.5 > :not(template) ~ :not(template) {
+  .xl\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-1\.5 > :not(template) ~ :not(template) {
+  .xl\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.375rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-1\.5 > :not(template) ~ :not(template) {
+  .xl\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-2\.5 > :not(template) ~ :not(template) {
+  .xl\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.625rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-2\.5 > :not(template) ~ :not(template) {
+  .xl\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-3\.5 > :not(template) ~ :not(template) {
+  .xl\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.875rem * var(--space-y-reverse));
   }
 
-  .xl\:space-x-3\.5 > :not(template) ~ :not(template) {
+  .xl\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-1 > :not(template) ~ :not(template) {
+  .xl\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.25rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-1 > :not(template) ~ :not(template) {
+  .xl\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-2 > :not(template) ~ :not(template) {
+  .xl\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.5rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-2 > :not(template) ~ :not(template) {
+  .xl\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-3 > :not(template) ~ :not(template) {
+  .xl\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.75rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-3 > :not(template) ~ :not(template) {
+  .xl\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-4 > :not(template) ~ :not(template) {
+  .xl\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-4 > :not(template) ~ :not(template) {
+  .xl\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1rem * var(--space-x-reverse));
     margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-5 > :not(template) ~ :not(template) {
+  .xl\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.25rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-5 > :not(template) ~ :not(template) {
+  .xl\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-6 > :not(template) ~ :not(template) {
+  .xl\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.5rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-6 > :not(template) ~ :not(template) {
+  .xl\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-7 > :not(template) ~ :not(template) {
+  .xl\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.75rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-7 > :not(template) ~ :not(template) {
+  .xl\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-8 > :not(template) ~ :not(template) {
+  .xl\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-8 > :not(template) ~ :not(template) {
+  .xl\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2rem * var(--space-x-reverse));
     margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-9 > :not(template) ~ :not(template) {
+  .xl\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.25rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-9 > :not(template) ~ :not(template) {
+  .xl\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-10 > :not(template) ~ :not(template) {
+  .xl\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.5rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-10 > :not(template) ~ :not(template) {
+  .xl\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-12 > :not(template) ~ :not(template) {
+  .xl\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-12 > :not(template) ~ :not(template) {
+  .xl\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3rem * var(--space-x-reverse));
     margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-14 > :not(template) ~ :not(template) {
+  .xl\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3.5rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-14 > :not(template) ~ :not(template) {
+  .xl\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-16 > :not(template) ~ :not(template) {
+  .xl\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-4rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-16 > :not(template) ~ :not(template) {
+  .xl\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-4rem * var(--space-x-reverse));
     margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-20 > :not(template) ~ :not(template) {
+  .xl\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-5rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-20 > :not(template) ~ :not(template) {
+  .xl\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-5rem * var(--space-x-reverse));
     margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-24 > :not(template) ~ :not(template) {
+  .xl\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-6rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-24 > :not(template) ~ :not(template) {
+  .xl\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-6rem * var(--space-x-reverse));
     margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-28 > :not(template) ~ :not(template) {
+  .xl\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-7rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-28 > :not(template) ~ :not(template) {
+  .xl\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-7rem * var(--space-x-reverse));
     margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-32 > :not(template) ~ :not(template) {
+  .xl\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-8rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-32 > :not(template) ~ :not(template) {
+  .xl\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-8rem * var(--space-x-reverse));
     margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-36 > :not(template) ~ :not(template) {
+  .xl\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-9rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-36 > :not(template) ~ :not(template) {
+  .xl\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-9rem * var(--space-x-reverse));
     margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-40 > :not(template) ~ :not(template) {
+  .xl\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-10rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-40 > :not(template) ~ :not(template) {
+  .xl\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-10rem * var(--space-x-reverse));
     margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-44 > :not(template) ~ :not(template) {
+  .xl\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-11rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-44 > :not(template) ~ :not(template) {
+  .xl\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-11rem * var(--space-x-reverse));
     margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-48 > :not(template) ~ :not(template) {
+  .xl\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-12rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-48 > :not(template) ~ :not(template) {
+  .xl\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-12rem * var(--space-x-reverse));
     margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-52 > :not(template) ~ :not(template) {
+  .xl\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-13rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-52 > :not(template) ~ :not(template) {
+  .xl\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-13rem * var(--space-x-reverse));
     margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-56 > :not(template) ~ :not(template) {
+  .xl\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-14rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-56 > :not(template) ~ :not(template) {
+  .xl\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-14rem * var(--space-x-reverse));
     margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-60 > :not(template) ~ :not(template) {
+  .xl\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-15rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-60 > :not(template) ~ :not(template) {
+  .xl\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-15rem * var(--space-x-reverse));
     margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-64 > :not(template) ~ :not(template) {
+  .xl\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-16rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-64 > :not(template) ~ :not(template) {
+  .xl\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-16rem * var(--space-x-reverse));
     margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-72 > :not(template) ~ :not(template) {
+  .xl\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-18rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-72 > :not(template) ~ :not(template) {
+  .xl\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-18rem * var(--space-x-reverse));
     margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-80 > :not(template) ~ :not(template) {
+  .xl\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-20rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-80 > :not(template) ~ :not(template) {
+  .xl\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-20rem * var(--space-x-reverse));
     margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-96 > :not(template) ~ :not(template) {
+  .xl\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-24rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-96 > :not(template) ~ :not(template) {
+  .xl\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-24rem * var(--space-x-reverse));
     margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-px > :not(template) ~ :not(template) {
+  .xl\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1px * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-px > :not(template) ~ :not(template) {
+  .xl\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1px * var(--space-x-reverse));
     margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-0\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.125rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-0\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-1\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.375rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-1\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-2\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.625rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-2\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:-space-y-3\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.875rem * var(--space-y-reverse));
   }
 
-  .xl\:-space-x-3\.5 > :not(template) ~ :not(template) {
+  .xl\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .xl\:space-y-reverse > :not(template) ~ :not(template) {
+  .xl\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 1;
   }
 
-  .xl\:space-x-reverse > :not(template) ~ :not(template) {
+  .xl\:space-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 1;
   }
 
-  .xl\:divide-y-0 > :not(template) ~ :not(template) {
+  .xl\:divide-y-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(0px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(0px * var(--divide-y-reverse));
   }
 
-  .xl\:divide-x-0 > :not(template) ~ :not(template) {
+  .xl\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(0px * var(--divide-x-reverse));
     border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .xl\:divide-y-2 > :not(template) ~ :not(template) {
+  .xl\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(2px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(2px * var(--divide-y-reverse));
   }
 
-  .xl\:divide-x-2 > :not(template) ~ :not(template) {
+  .xl\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(2px * var(--divide-x-reverse));
     border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .xl\:divide-y-4 > :not(template) ~ :not(template) {
+  .xl\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(4px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(4px * var(--divide-y-reverse));
   }
 
-  .xl\:divide-x-4 > :not(template) ~ :not(template) {
+  .xl\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(4px * var(--divide-x-reverse));
     border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .xl\:divide-y-8 > :not(template) ~ :not(template) {
+  .xl\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(8px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(8px * var(--divide-y-reverse));
   }
 
-  .xl\:divide-x-8 > :not(template) ~ :not(template) {
+  .xl\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(8px * var(--divide-x-reverse));
     border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .xl\:divide-y > :not(template) ~ :not(template) {
+  .xl\:divide-y > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(1px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(1px * var(--divide-y-reverse));
   }
 
-  .xl\:divide-x > :not(template) ~ :not(template) {
+  .xl\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(1px * var(--divide-x-reverse));
     border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .xl\:divide-y-reverse > :not(template) ~ :not(template) {
+  .xl\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 1;
   }
 
-  .xl\:divide-x-reverse > :not(template) ~ :not(template) {
+  .xl\:divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 1;
   }
 
-  .xl\:divide-transparent > :not(template) ~ :not(template) {
+  .xl\:divide-transparent > :not([hidden]) ~ :not([hidden]) {
     border-color: transparent;
   }
 
-  .xl\:divide-current > :not(template) ~ :not(template) {
+  .xl\:divide-current > :not([hidden]) ~ :not([hidden]) {
     border-color: currentColor;
   }
 
-  .xl\:divide-black > :not(template) ~ :not(template) {
+  .xl\:divide-black > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(0, 0, 0, var(--divide-opacity));
   }
 
-  .xl\:divide-white > :not(template) ~ :not(template) {
+  .xl\:divide-white > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(255, 255, 255, var(--divide-opacity));
   }
 
-  .xl\:divide-gray-50 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(250, 250, 250, var(--divide-opacity));
   }
 
-  .xl\:divide-gray-100 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(244, 244, 245, var(--divide-opacity));
   }
 
-  .xl\:divide-gray-200 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(228, 228, 231, var(--divide-opacity));
   }
 
-  .xl\:divide-gray-300 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(212, 212, 216, var(--divide-opacity));
   }
 
-  .xl\:divide-gray-400 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(161, 161, 170, var(--divide-opacity));
   }
 
-  .xl\:divide-gray-500 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(113, 113, 122, var(--divide-opacity));
   }
 
-  .xl\:divide-gray-600 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(82, 82, 91, var(--divide-opacity));
   }
 
-  .xl\:divide-gray-700 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(63, 63, 70, var(--divide-opacity));
   }
 
-  .xl\:divide-gray-800 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(39, 39, 42, var(--divide-opacity));
   }
 
-  .xl\:divide-gray-900 > :not(template) ~ :not(template) {
+  .xl\:divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(24, 24, 27, var(--divide-opacity));
   }
 
-  .xl\:divide-red-50 > :not(template) ~ :not(template) {
+  .xl\:divide-red-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 242, 242, var(--divide-opacity));
   }
 
-  .xl\:divide-red-100 > :not(template) ~ :not(template) {
+  .xl\:divide-red-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 226, 226, var(--divide-opacity));
   }
 
-  .xl\:divide-red-200 > :not(template) ~ :not(template) {
+  .xl\:divide-red-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 202, 202, var(--divide-opacity));
   }
 
-  .xl\:divide-red-300 > :not(template) ~ :not(template) {
+  .xl\:divide-red-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 165, 165, var(--divide-opacity));
   }
 
-  .xl\:divide-red-400 > :not(template) ~ :not(template) {
+  .xl\:divide-red-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(248, 113, 113, var(--divide-opacity));
   }
 
-  .xl\:divide-red-500 > :not(template) ~ :not(template) {
+  .xl\:divide-red-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(239, 68, 68, var(--divide-opacity));
   }
 
-  .xl\:divide-red-600 > :not(template) ~ :not(template) {
+  .xl\:divide-red-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(220, 38, 38, var(--divide-opacity));
   }
 
-  .xl\:divide-red-700 > :not(template) ~ :not(template) {
+  .xl\:divide-red-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(185, 28, 28, var(--divide-opacity));
   }
 
-  .xl\:divide-red-800 > :not(template) ~ :not(template) {
+  .xl\:divide-red-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(153, 27, 27, var(--divide-opacity));
   }
 
-  .xl\:divide-red-900 > :not(template) ~ :not(template) {
+  .xl\:divide-red-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(127, 29, 29, var(--divide-opacity));
   }
 
-  .xl\:divide-yellow-50 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(255, 251, 235, var(--divide-opacity));
   }
 
-  .xl\:divide-yellow-100 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 243, 199, var(--divide-opacity));
   }
 
-  .xl\:divide-yellow-200 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(253, 230, 138, var(--divide-opacity));
   }
 
-  .xl\:divide-yellow-300 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 211, 77, var(--divide-opacity));
   }
 
-  .xl\:divide-yellow-400 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(251, 191, 36, var(--divide-opacity));
   }
 
-  .xl\:divide-yellow-500 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(245, 158, 11, var(--divide-opacity));
   }
 
-  .xl\:divide-yellow-600 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(217, 119, 6, var(--divide-opacity));
   }
 
-  .xl\:divide-yellow-700 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(180, 83, 9, var(--divide-opacity));
   }
 
-  .xl\:divide-yellow-800 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(146, 64, 14, var(--divide-opacity));
   }
 
-  .xl\:divide-yellow-900 > :not(template) ~ :not(template) {
+  .xl\:divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(120, 53, 15, var(--divide-opacity));
   }
 
-  .xl\:divide-green-50 > :not(template) ~ :not(template) {
+  .xl\:divide-green-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(236, 253, 245, var(--divide-opacity));
   }
 
-  .xl\:divide-green-100 > :not(template) ~ :not(template) {
+  .xl\:divide-green-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(209, 250, 229, var(--divide-opacity));
   }
 
-  .xl\:divide-green-200 > :not(template) ~ :not(template) {
+  .xl\:divide-green-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(167, 243, 208, var(--divide-opacity));
   }
 
-  .xl\:divide-green-300 > :not(template) ~ :not(template) {
+  .xl\:divide-green-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(110, 231, 183, var(--divide-opacity));
   }
 
-  .xl\:divide-green-400 > :not(template) ~ :not(template) {
+  .xl\:divide-green-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(52, 211, 153, var(--divide-opacity));
   }
 
-  .xl\:divide-green-500 > :not(template) ~ :not(template) {
+  .xl\:divide-green-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(16, 185, 129, var(--divide-opacity));
   }
 
-  .xl\:divide-green-600 > :not(template) ~ :not(template) {
+  .xl\:divide-green-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(5, 150, 105, var(--divide-opacity));
   }
 
-  .xl\:divide-green-700 > :not(template) ~ :not(template) {
+  .xl\:divide-green-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(4, 120, 87, var(--divide-opacity));
   }
 
-  .xl\:divide-green-800 > :not(template) ~ :not(template) {
+  .xl\:divide-green-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(6, 95, 70, var(--divide-opacity));
   }
 
-  .xl\:divide-green-900 > :not(template) ~ :not(template) {
+  .xl\:divide-green-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(6, 78, 59, var(--divide-opacity));
   }
 
-  .xl\:divide-blue-50 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(239, 246, 255, var(--divide-opacity));
   }
 
-  .xl\:divide-blue-100 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(219, 234, 254, var(--divide-opacity));
   }
 
-  .xl\:divide-blue-200 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(191, 219, 254, var(--divide-opacity));
   }
 
-  .xl\:divide-blue-300 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(147, 197, 253, var(--divide-opacity));
   }
 
-  .xl\:divide-blue-400 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(96, 165, 250, var(--divide-opacity));
   }
 
-  .xl\:divide-blue-500 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(59, 130, 246, var(--divide-opacity));
   }
 
-  .xl\:divide-blue-600 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(37, 99, 235, var(--divide-opacity));
   }
 
-  .xl\:divide-blue-700 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(29, 78, 216, var(--divide-opacity));
   }
 
-  .xl\:divide-blue-800 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(30, 64, 175, var(--divide-opacity));
   }
 
-  .xl\:divide-blue-900 > :not(template) ~ :not(template) {
+  .xl\:divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(30, 58, 138, var(--divide-opacity));
   }
 
-  .xl\:divide-purple-50 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(245, 243, 255, var(--divide-opacity));
   }
 
-  .xl\:divide-purple-100 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(237, 233, 254, var(--divide-opacity));
   }
 
-  .xl\:divide-purple-200 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(221, 214, 254, var(--divide-opacity));
   }
 
-  .xl\:divide-purple-300 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(196, 181, 253, var(--divide-opacity));
   }
 
-  .xl\:divide-purple-400 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(167, 139, 250, var(--divide-opacity));
   }
 
-  .xl\:divide-purple-500 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(139, 92, 246, var(--divide-opacity));
   }
 
-  .xl\:divide-purple-600 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(124, 58, 237, var(--divide-opacity));
   }
 
-  .xl\:divide-purple-700 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(109, 40, 217, var(--divide-opacity));
   }
 
-  .xl\:divide-purple-800 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(91, 33, 182, var(--divide-opacity));
   }
 
-  .xl\:divide-purple-900 > :not(template) ~ :not(template) {
+  .xl\:divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(76, 29, 149, var(--divide-opacity));
   }
 
-  .xl\:divide-pink-50 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(253, 242, 248, var(--divide-opacity));
   }
 
-  .xl\:divide-pink-100 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 231, 243, var(--divide-opacity));
   }
 
-  .xl\:divide-pink-200 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(251, 207, 232, var(--divide-opacity));
   }
 
-  .xl\:divide-pink-300 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(249, 168, 212, var(--divide-opacity));
   }
 
-  .xl\:divide-pink-400 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(244, 114, 182, var(--divide-opacity));
   }
 
-  .xl\:divide-pink-500 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(236, 72, 153, var(--divide-opacity));
   }
 
-  .xl\:divide-pink-600 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(219, 39, 119, var(--divide-opacity));
   }
 
-  .xl\:divide-pink-700 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(190, 24, 93, var(--divide-opacity));
   }
 
-  .xl\:divide-pink-800 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(157, 23, 77, var(--divide-opacity));
   }
 
-  .xl\:divide-pink-900 > :not(template) ~ :not(template) {
+  .xl\:divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(131, 24, 67, var(--divide-opacity));
   }
 
-  .xl\:divide-solid > :not(template) ~ :not(template) {
+  .xl\:divide-solid > :not([hidden]) ~ :not([hidden]) {
     border-style: solid;
   }
 
-  .xl\:divide-dashed > :not(template) ~ :not(template) {
+  .xl\:divide-dashed > :not([hidden]) ~ :not([hidden]) {
     border-style: dashed;
   }
 
-  .xl\:divide-dotted > :not(template) ~ :not(template) {
+  .xl\:divide-dotted > :not([hidden]) ~ :not([hidden]) {
     border-style: dotted;
   }
 
-  .xl\:divide-double > :not(template) ~ :not(template) {
+  .xl\:divide-double > :not([hidden]) ~ :not([hidden]) {
     border-style: double;
   }
 
-  .xl\:divide-none > :not(template) ~ :not(template) {
+  .xl\:divide-none > :not([hidden]) ~ :not([hidden]) {
     border-style: none;
   }
 
-  .xl\:divide-opacity-0 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0;
   }
 
-  .xl\:divide-opacity-10 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-10 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.1;
   }
 
-  .xl\:divide-opacity-20 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-20 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.2;
   }
 
-  .xl\:divide-opacity-25 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-25 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.25;
   }
 
-  .xl\:divide-opacity-30 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-30 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.3;
   }
 
-  .xl\:divide-opacity-40 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-40 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.4;
   }
 
-  .xl\:divide-opacity-50 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.5;
   }
 
-  .xl\:divide-opacity-60 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-60 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.6;
   }
 
-  .xl\:divide-opacity-70 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-70 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.7;
   }
 
-  .xl\:divide-opacity-75 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-75 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.75;
   }
 
-  .xl\:divide-opacity-80 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-80 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.8;
   }
 
-  .xl\:divide-opacity-90 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-90 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.9;
   }
 
-  .xl\:divide-opacity-100 > :not(template) ~ :not(template) {
+  .xl\:divide-opacity-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
   }
 
@@ -115320,1323 +115320,1323 @@ video {
     }
   }
 
-  .\32xl\:space-y-0 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-0 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0px * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-0 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0px * var(--space-x-reverse));
     margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-1 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.25rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-1 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-2 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-2 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-3 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.75rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-3 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-4 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-4 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1rem * var(--space-x-reverse));
     margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-5 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.25rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-5 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-6 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-6 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-7 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1.75rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-7 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-8 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-8 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2rem * var(--space-x-reverse));
     margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-9 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.25rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-9 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-10 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(2.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-10 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-12 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-12 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3rem * var(--space-x-reverse));
     margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-14 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(3.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-14 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-16 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(4rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-16 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(4rem * var(--space-x-reverse));
     margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-20 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-20 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(5rem * var(--space-x-reverse));
     margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-24 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(6rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-24 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(6rem * var(--space-x-reverse));
     margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-28 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(7rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-28 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(7rem * var(--space-x-reverse));
     margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-32 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(8rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-32 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(8rem * var(--space-x-reverse));
     margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-36 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(9rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-36 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(9rem * var(--space-x-reverse));
     margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-40 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(10rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-40 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(10rem * var(--space-x-reverse));
     margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-44 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(11rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-44 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(11rem * var(--space-x-reverse));
     margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-48 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(12rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-48 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(12rem * var(--space-x-reverse));
     margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-52 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(13rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-52 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(13rem * var(--space-x-reverse));
     margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-56 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(14rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-56 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(14rem * var(--space-x-reverse));
     margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-60 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(15rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-60 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(15rem * var(--space-x-reverse));
     margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-64 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(16rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-64 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(16rem * var(--space-x-reverse));
     margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-72 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(18rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-72 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(18rem * var(--space-x-reverse));
     margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-80 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(20rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-80 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(20rem * var(--space-x-reverse));
     margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-96 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(24rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-96 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(24rem * var(--space-x-reverse));
     margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-px > :not(template) ~ :not(template) {
+  .\32xl\:space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(1px * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-px > :not(template) ~ :not(template) {
+  .\32xl\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(1px * var(--space-x-reverse));
     margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-0\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.125rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-0\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-1\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.375rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-1\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-2\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.625rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-2\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-3\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(0.875rem * var(--space-y-reverse));
   }
 
-  .\32xl\:space-x-3\.5 > :not(template) ~ :not(template) {
+  .\32xl\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-1 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.25rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-1 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-2 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-2 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-3 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.75rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-3 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-4 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-4 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1rem * var(--space-x-reverse));
     margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.25rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-6 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-6 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-7 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1.75rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1.75rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-7 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
     margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-8 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-8 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2rem * var(--space-x-reverse));
     margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-9 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.25rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.25rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-9 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-10 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-2.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-2.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-10 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-12 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-12 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3rem * var(--space-x-reverse));
     margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-14 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-3.5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-3.5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-14 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
     margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-16 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-4rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-4rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-16 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-4rem * var(--space-x-reverse));
     margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-20 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-5rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-5rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-20 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-5rem * var(--space-x-reverse));
     margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-24 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-6rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-6rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-24 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-6rem * var(--space-x-reverse));
     margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-28 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-7rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-7rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-28 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-7rem * var(--space-x-reverse));
     margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-32 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-8rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-8rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-32 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-8rem * var(--space-x-reverse));
     margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-36 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-9rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-9rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-36 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-9rem * var(--space-x-reverse));
     margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-40 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-10rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-10rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-40 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-10rem * var(--space-x-reverse));
     margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-44 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-11rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-11rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-44 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-11rem * var(--space-x-reverse));
     margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-48 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-12rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-12rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-48 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-12rem * var(--space-x-reverse));
     margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-52 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-13rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-13rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-52 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-13rem * var(--space-x-reverse));
     margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-56 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-14rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-14rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-56 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-14rem * var(--space-x-reverse));
     margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-60 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-15rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-15rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-60 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-15rem * var(--space-x-reverse));
     margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-64 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-16rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-16rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-64 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-16rem * var(--space-x-reverse));
     margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-72 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-18rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-18rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-72 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-18rem * var(--space-x-reverse));
     margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-80 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-20rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-20rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-80 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-20rem * var(--space-x-reverse));
     margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-96 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-24rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-24rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-96 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-24rem * var(--space-x-reverse));
     margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-px > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-1px * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-1px * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-px > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-1px * var(--space-x-reverse));
     margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-0\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.125rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.125rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-0\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-1\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.375rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.375rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-1\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-2\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.625rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.625rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-2\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:-space-y-3\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 0;
     margin-top: calc(-0.875rem * calc(1 - var(--space-y-reverse)));
     margin-bottom: calc(-0.875rem * var(--space-y-reverse));
   }
 
-  .\32xl\:-space-x-3\.5 > :not(template) ~ :not(template) {
+  .\32xl\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
     margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
     margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
-  .\32xl\:space-y-reverse > :not(template) ~ :not(template) {
+  .\32xl\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-y-reverse: 1;
   }
 
-  .\32xl\:space-x-reverse > :not(template) ~ :not(template) {
+  .\32xl\:space-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 1;
   }
 
-  .\32xl\:divide-y-0 > :not(template) ~ :not(template) {
+  .\32xl\:divide-y-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(0px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(0px * var(--divide-y-reverse));
   }
 
-  .\32xl\:divide-x-0 > :not(template) ~ :not(template) {
+  .\32xl\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(0px * var(--divide-x-reverse));
     border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .\32xl\:divide-y-2 > :not(template) ~ :not(template) {
+  .\32xl\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(2px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(2px * var(--divide-y-reverse));
   }
 
-  .\32xl\:divide-x-2 > :not(template) ~ :not(template) {
+  .\32xl\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(2px * var(--divide-x-reverse));
     border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .\32xl\:divide-y-4 > :not(template) ~ :not(template) {
+  .\32xl\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(4px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(4px * var(--divide-y-reverse));
   }
 
-  .\32xl\:divide-x-4 > :not(template) ~ :not(template) {
+  .\32xl\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(4px * var(--divide-x-reverse));
     border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .\32xl\:divide-y-8 > :not(template) ~ :not(template) {
+  .\32xl\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(8px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(8px * var(--divide-y-reverse));
   }
 
-  .\32xl\:divide-x-8 > :not(template) ~ :not(template) {
+  .\32xl\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(8px * var(--divide-x-reverse));
     border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .\32xl\:divide-y > :not(template) ~ :not(template) {
+  .\32xl\:divide-y > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 0;
     border-top-width: calc(1px * calc(1 - var(--divide-y-reverse)));
     border-bottom-width: calc(1px * var(--divide-y-reverse));
   }
 
-  .\32xl\:divide-x > :not(template) ~ :not(template) {
+  .\32xl\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
     border-inline-end-width: calc(1px * var(--divide-x-reverse));
     border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
-  .\32xl\:divide-y-reverse > :not(template) ~ :not(template) {
+  .\32xl\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-y-reverse: 1;
   }
 
-  .\32xl\:divide-x-reverse > :not(template) ~ :not(template) {
+  .\32xl\:divide-x-reverse > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 1;
   }
 
-  .\32xl\:divide-transparent > :not(template) ~ :not(template) {
+  .\32xl\:divide-transparent > :not([hidden]) ~ :not([hidden]) {
     border-color: transparent;
   }
 
-  .\32xl\:divide-current > :not(template) ~ :not(template) {
+  .\32xl\:divide-current > :not([hidden]) ~ :not([hidden]) {
     border-color: currentColor;
   }
 
-  .\32xl\:divide-black > :not(template) ~ :not(template) {
+  .\32xl\:divide-black > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(0, 0, 0, var(--divide-opacity));
   }
 
-  .\32xl\:divide-white > :not(template) ~ :not(template) {
+  .\32xl\:divide-white > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(255, 255, 255, var(--divide-opacity));
   }
 
-  .\32xl\:divide-gray-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(250, 250, 250, var(--divide-opacity));
   }
 
-  .\32xl\:divide-gray-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(244, 244, 245, var(--divide-opacity));
   }
 
-  .\32xl\:divide-gray-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(228, 228, 231, var(--divide-opacity));
   }
 
-  .\32xl\:divide-gray-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(212, 212, 216, var(--divide-opacity));
   }
 
-  .\32xl\:divide-gray-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(161, 161, 170, var(--divide-opacity));
   }
 
-  .\32xl\:divide-gray-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(113, 113, 122, var(--divide-opacity));
   }
 
-  .\32xl\:divide-gray-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(82, 82, 91, var(--divide-opacity));
   }
 
-  .\32xl\:divide-gray-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(63, 63, 70, var(--divide-opacity));
   }
 
-  .\32xl\:divide-gray-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(39, 39, 42, var(--divide-opacity));
   }
 
-  .\32xl\:divide-gray-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-gray-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(24, 24, 27, var(--divide-opacity));
   }
 
-  .\32xl\:divide-red-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 242, 242, var(--divide-opacity));
   }
 
-  .\32xl\:divide-red-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 226, 226, var(--divide-opacity));
   }
 
-  .\32xl\:divide-red-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 202, 202, var(--divide-opacity));
   }
 
-  .\32xl\:divide-red-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 165, 165, var(--divide-opacity));
   }
 
-  .\32xl\:divide-red-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(248, 113, 113, var(--divide-opacity));
   }
 
-  .\32xl\:divide-red-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(239, 68, 68, var(--divide-opacity));
   }
 
-  .\32xl\:divide-red-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(220, 38, 38, var(--divide-opacity));
   }
 
-  .\32xl\:divide-red-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(185, 28, 28, var(--divide-opacity));
   }
 
-  .\32xl\:divide-red-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(153, 27, 27, var(--divide-opacity));
   }
 
-  .\32xl\:divide-red-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-red-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(127, 29, 29, var(--divide-opacity));
   }
 
-  .\32xl\:divide-yellow-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(255, 251, 235, var(--divide-opacity));
   }
 
-  .\32xl\:divide-yellow-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(254, 243, 199, var(--divide-opacity));
   }
 
-  .\32xl\:divide-yellow-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(253, 230, 138, var(--divide-opacity));
   }
 
-  .\32xl\:divide-yellow-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 211, 77, var(--divide-opacity));
   }
 
-  .\32xl\:divide-yellow-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(251, 191, 36, var(--divide-opacity));
   }
 
-  .\32xl\:divide-yellow-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(245, 158, 11, var(--divide-opacity));
   }
 
-  .\32xl\:divide-yellow-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(217, 119, 6, var(--divide-opacity));
   }
 
-  .\32xl\:divide-yellow-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(180, 83, 9, var(--divide-opacity));
   }
 
-  .\32xl\:divide-yellow-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(146, 64, 14, var(--divide-opacity));
   }
 
-  .\32xl\:divide-yellow-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-yellow-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(120, 53, 15, var(--divide-opacity));
   }
 
-  .\32xl\:divide-green-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(236, 253, 245, var(--divide-opacity));
   }
 
-  .\32xl\:divide-green-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(209, 250, 229, var(--divide-opacity));
   }
 
-  .\32xl\:divide-green-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(167, 243, 208, var(--divide-opacity));
   }
 
-  .\32xl\:divide-green-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(110, 231, 183, var(--divide-opacity));
   }
 
-  .\32xl\:divide-green-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(52, 211, 153, var(--divide-opacity));
   }
 
-  .\32xl\:divide-green-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(16, 185, 129, var(--divide-opacity));
   }
 
-  .\32xl\:divide-green-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(5, 150, 105, var(--divide-opacity));
   }
 
-  .\32xl\:divide-green-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(4, 120, 87, var(--divide-opacity));
   }
 
-  .\32xl\:divide-green-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(6, 95, 70, var(--divide-opacity));
   }
 
-  .\32xl\:divide-green-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-green-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(6, 78, 59, var(--divide-opacity));
   }
 
-  .\32xl\:divide-blue-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(239, 246, 255, var(--divide-opacity));
   }
 
-  .\32xl\:divide-blue-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(219, 234, 254, var(--divide-opacity));
   }
 
-  .\32xl\:divide-blue-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(191, 219, 254, var(--divide-opacity));
   }
 
-  .\32xl\:divide-blue-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(147, 197, 253, var(--divide-opacity));
   }
 
-  .\32xl\:divide-blue-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(96, 165, 250, var(--divide-opacity));
   }
 
-  .\32xl\:divide-blue-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(59, 130, 246, var(--divide-opacity));
   }
 
-  .\32xl\:divide-blue-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(37, 99, 235, var(--divide-opacity));
   }
 
-  .\32xl\:divide-blue-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(29, 78, 216, var(--divide-opacity));
   }
 
-  .\32xl\:divide-blue-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(30, 64, 175, var(--divide-opacity));
   }
 
-  .\32xl\:divide-blue-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-blue-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(30, 58, 138, var(--divide-opacity));
   }
 
-  .\32xl\:divide-purple-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(245, 243, 255, var(--divide-opacity));
   }
 
-  .\32xl\:divide-purple-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(237, 233, 254, var(--divide-opacity));
   }
 
-  .\32xl\:divide-purple-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(221, 214, 254, var(--divide-opacity));
   }
 
-  .\32xl\:divide-purple-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(196, 181, 253, var(--divide-opacity));
   }
 
-  .\32xl\:divide-purple-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(167, 139, 250, var(--divide-opacity));
   }
 
-  .\32xl\:divide-purple-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(139, 92, 246, var(--divide-opacity));
   }
 
-  .\32xl\:divide-purple-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(124, 58, 237, var(--divide-opacity));
   }
 
-  .\32xl\:divide-purple-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(109, 40, 217, var(--divide-opacity));
   }
 
-  .\32xl\:divide-purple-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(91, 33, 182, var(--divide-opacity));
   }
 
-  .\32xl\:divide-purple-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-purple-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(76, 29, 149, var(--divide-opacity));
   }
 
-  .\32xl\:divide-pink-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(253, 242, 248, var(--divide-opacity));
   }
 
-  .\32xl\:divide-pink-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(252, 231, 243, var(--divide-opacity));
   }
 
-  .\32xl\:divide-pink-200 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-200 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(251, 207, 232, var(--divide-opacity));
   }
 
-  .\32xl\:divide-pink-300 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-300 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(249, 168, 212, var(--divide-opacity));
   }
 
-  .\32xl\:divide-pink-400 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-400 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(244, 114, 182, var(--divide-opacity));
   }
 
-  .\32xl\:divide-pink-500 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-500 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(236, 72, 153, var(--divide-opacity));
   }
 
-  .\32xl\:divide-pink-600 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-600 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(219, 39, 119, var(--divide-opacity));
   }
 
-  .\32xl\:divide-pink-700 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-700 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(190, 24, 93, var(--divide-opacity));
   }
 
-  .\32xl\:divide-pink-800 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-800 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(157, 23, 77, var(--divide-opacity));
   }
 
-  .\32xl\:divide-pink-900 > :not(template) ~ :not(template) {
+  .\32xl\:divide-pink-900 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
     border-color: rgba(131, 24, 67, var(--divide-opacity));
   }
 
-  .\32xl\:divide-solid > :not(template) ~ :not(template) {
+  .\32xl\:divide-solid > :not([hidden]) ~ :not([hidden]) {
     border-style: solid;
   }
 
-  .\32xl\:divide-dashed > :not(template) ~ :not(template) {
+  .\32xl\:divide-dashed > :not([hidden]) ~ :not([hidden]) {
     border-style: dashed;
   }
 
-  .\32xl\:divide-dotted > :not(template) ~ :not(template) {
+  .\32xl\:divide-dotted > :not([hidden]) ~ :not([hidden]) {
     border-style: dotted;
   }
 
-  .\32xl\:divide-double > :not(template) ~ :not(template) {
+  .\32xl\:divide-double > :not([hidden]) ~ :not([hidden]) {
     border-style: double;
   }
 
-  .\32xl\:divide-none > :not(template) ~ :not(template) {
+  .\32xl\:divide-none > :not([hidden]) ~ :not([hidden]) {
     border-style: none;
   }
 
-  .\32xl\:divide-opacity-0 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0;
   }
 
-  .\32xl\:divide-opacity-10 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-10 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.1;
   }
 
-  .\32xl\:divide-opacity-20 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-20 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.2;
   }
 
-  .\32xl\:divide-opacity-25 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-25 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.25;
   }
 
-  .\32xl\:divide-opacity-30 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-30 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.3;
   }
 
-  .\32xl\:divide-opacity-40 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-40 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.4;
   }
 
-  .\32xl\:divide-opacity-50 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-50 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.5;
   }
 
-  .\32xl\:divide-opacity-60 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-60 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.6;
   }
 
-  .\32xl\:divide-opacity-70 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-70 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.7;
   }
 
-  .\32xl\:divide-opacity-75 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-75 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.75;
   }
 
-  .\32xl\:divide-opacity-80 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-80 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.8;
   }
 
-  .\32xl\:divide-opacity-90 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-90 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 0.9;
   }
 
-  .\32xl\:divide-opacity-100 > :not(template) ~ :not(template) {
+  .\32xl\:divide-opacity-100 > :not([hidden]) ~ :not([hidden]) {
     --divide-opacity: 1;
   }
 

--- a/__tests__/plugins/divideColor.test.js
+++ b/__tests__/plugins/divideColor.test.js
@@ -18,7 +18,7 @@ test('defining color as a function', () => {
   expect(utilities).toEqual([
     [
       {
-        '.divide-black > :not(template) ~ :not(template)': {
+        '.divide-black > :not([hidden]) ~ :not([hidden])': {
           'border-color': 'black',
         },
       },

--- a/__tests__/plugins/divideWidth.test.js
+++ b/__tests__/plugins/divideWidth.test.js
@@ -21,50 +21,50 @@ test('generating divide width utilities', () => {
   expect(utilities).toEqual([
     [
       {
-        '.divide-y > :not(template) ~ :not(template)': {
+        '.divide-y > :not([hidden]) ~ :not([hidden])': {
           '--divide-y-reverse': '0',
           'border-top-width': 'calc(1px * calc(1 - var(--divide-y-reverse)))',
           'border-bottom-width': 'calc(1px * var(--divide-y-reverse))',
         },
-        '.divide-x > :not(template) ~ :not(template)': {
+        '.divide-x > :not([hidden]) ~ :not([hidden])': {
           '--divide-x-reverse': '0',
           'border-inline-end-width': 'calc(1px * var(--divide-x-reverse))',
           'border-inline-start-width': 'calc(1px * calc(1 - var(--divide-x-reverse)))',
         },
-        '.divide-y-0 > :not(template) ~ :not(template)': {
+        '.divide-y-0 > :not([hidden]) ~ :not([hidden])': {
           '--divide-y-reverse': '0',
           'border-top-width': 'calc(0px * calc(1 - var(--divide-y-reverse)))',
           'border-bottom-width': 'calc(0px * var(--divide-y-reverse))',
         },
-        '.divide-x-0 > :not(template) ~ :not(template)': {
+        '.divide-x-0 > :not([hidden]) ~ :not([hidden])': {
           '--divide-x-reverse': '0',
           'border-inline-end-width': 'calc(0px * var(--divide-x-reverse))',
           'border-inline-start-width': 'calc(0px * calc(1 - var(--divide-x-reverse)))',
         },
-        '.divide-y-2 > :not(template) ~ :not(template)': {
+        '.divide-y-2 > :not([hidden]) ~ :not([hidden])': {
           '--divide-y-reverse': '0',
           'border-top-width': 'calc(2px * calc(1 - var(--divide-y-reverse)))',
           'border-bottom-width': 'calc(2px * var(--divide-y-reverse))',
         },
-        '.divide-x-2 > :not(template) ~ :not(template)': {
+        '.divide-x-2 > :not([hidden]) ~ :not([hidden])': {
           '--divide-x-reverse': '0',
           'border-inline-end-width': 'calc(2px * var(--divide-x-reverse))',
           'border-inline-start-width': 'calc(2px * calc(1 - var(--divide-x-reverse)))',
         },
-        '.divide-y-4 > :not(template) ~ :not(template)': {
+        '.divide-y-4 > :not([hidden]) ~ :not([hidden])': {
           '--divide-y-reverse': '0',
           'border-top-width': 'calc(4px * calc(1 - var(--divide-y-reverse)))',
           'border-bottom-width': 'calc(4px * var(--divide-y-reverse))',
         },
-        '.divide-x-4 > :not(template) ~ :not(template)': {
+        '.divide-x-4 > :not([hidden]) ~ :not([hidden])': {
           '--divide-x-reverse': '0',
           'border-inline-end-width': 'calc(4px * var(--divide-x-reverse))',
           'border-inline-start-width': 'calc(4px * calc(1 - var(--divide-x-reverse)))',
         },
-        '.divide-y-reverse > :not(template) ~ :not(template)': {
+        '.divide-y-reverse > :not([hidden]) ~ :not([hidden])': {
           '--divide-y-reverse': '1',
         },
-        '.divide-x-reverse > :not(template) ~ :not(template)': {
+        '.divide-x-reverse > :not([hidden]) ~ :not([hidden])': {
           '--divide-x-reverse': '1',
         },
       },

--- a/__tests__/plugins/space.test.js
+++ b/__tests__/plugins/space.test.js
@@ -23,70 +23,70 @@ test('generating space utilities', () => {
   expect(utilities).toEqual([
     [
       {
-        '.space-y-0 > :not(template) ~ :not(template)': {
+        '.space-y-0 > :not([hidden]) ~ :not([hidden])': {
           '--space-y-reverse': '0',
           'margin-top': 'calc(0px * calc(1 - var(--space-y-reverse)))',
           'margin-bottom': 'calc(0px * var(--space-y-reverse))',
         },
-        '.space-x-0 > :not(template) ~ :not(template)': {
+        '.space-x-0 > :not([hidden]) ~ :not([hidden])': {
           '--space-x-reverse': '0',
           'margin-inline-end': 'calc(0px * var(--space-x-reverse))',
           'margin-inline-start': 'calc(0px * calc(1 - var(--space-x-reverse)))',
         },
-        '.space-y-1 > :not(template) ~ :not(template)': {
+        '.space-y-1 > :not([hidden]) ~ :not([hidden])': {
           '--space-y-reverse': '0',
           'margin-top': 'calc(1px * calc(1 - var(--space-y-reverse)))',
           'margin-bottom': 'calc(1px * var(--space-y-reverse))',
         },
-        '.space-x-1 > :not(template) ~ :not(template)': {
+        '.space-x-1 > :not([hidden]) ~ :not([hidden])': {
           '--space-x-reverse': '0',
           'margin-inline-end': 'calc(1px * var(--space-x-reverse))',
           'margin-inline-start': 'calc(1px * calc(1 - var(--space-x-reverse)))',
         },
-        '.space-y-2 > :not(template) ~ :not(template)': {
+        '.space-y-2 > :not([hidden]) ~ :not([hidden])': {
           '--space-y-reverse': '0',
           'margin-top': 'calc(2px * calc(1 - var(--space-y-reverse)))',
           'margin-bottom': 'calc(2px * var(--space-y-reverse))',
         },
-        '.space-x-2 > :not(template) ~ :not(template)': {
+        '.space-x-2 > :not([hidden]) ~ :not([hidden])': {
           '--space-x-reverse': '0',
           'margin-inline-end': 'calc(2px * var(--space-x-reverse))',
           'margin-inline-start': 'calc(2px * calc(1 - var(--space-x-reverse)))',
         },
-        '.space-y-4 > :not(template) ~ :not(template)': {
+        '.space-y-4 > :not([hidden]) ~ :not([hidden])': {
           '--space-y-reverse': '0',
           'margin-top': 'calc(4px * calc(1 - var(--space-y-reverse)))',
           'margin-bottom': 'calc(4px * var(--space-y-reverse))',
         },
-        '.space-x-4 > :not(template) ~ :not(template)': {
+        '.space-x-4 > :not([hidden]) ~ :not([hidden])': {
           '--space-x-reverse': '0',
           'margin-inline-end': 'calc(4px * var(--space-x-reverse))',
           'margin-inline-start': 'calc(4px * calc(1 - var(--space-x-reverse)))',
         },
-        '.-space-y-2 > :not(template) ~ :not(template)': {
+        '.-space-y-2 > :not([hidden]) ~ :not([hidden])': {
           '--space-y-reverse': '0',
           'margin-top': 'calc(-2px * calc(1 - var(--space-y-reverse)))',
           'margin-bottom': 'calc(-2px * var(--space-y-reverse))',
         },
-        '.-space-x-2 > :not(template) ~ :not(template)': {
+        '.-space-x-2 > :not([hidden]) ~ :not([hidden])': {
           '--space-x-reverse': '0',
           'margin-inline-end': 'calc(-2px * var(--space-x-reverse))',
           'margin-inline-start': 'calc(-2px * calc(1 - var(--space-x-reverse)))',
         },
-        '.-space-y-1 > :not(template) ~ :not(template)': {
+        '.-space-y-1 > :not([hidden]) ~ :not([hidden])': {
           '--space-y-reverse': '0',
           'margin-top': 'calc(-1px * calc(1 - var(--space-y-reverse)))',
           'margin-bottom': 'calc(-1px * var(--space-y-reverse))',
         },
-        '.-space-x-1 > :not(template) ~ :not(template)': {
+        '.-space-x-1 > :not([hidden]) ~ :not([hidden])': {
           '--space-x-reverse': '0',
           'margin-inline-end': 'calc(-1px * var(--space-x-reverse))',
           'margin-inline-start': 'calc(-1px * calc(1 - var(--space-x-reverse)))',
         },
-        '.space-y-reverse > :not(template) ~ :not(template)': {
+        '.space-y-reverse > :not([hidden]) ~ :not([hidden])': {
           '--space-y-reverse': '1',
         },
-        '.space-x-reverse > :not(template) ~ :not(template)': {
+        '.space-x-reverse > :not([hidden]) ~ :not([hidden])': {
           '--space-x-reverse': '1',
         },
       },

--- a/src/plugins/divideColor.js
+++ b/src/plugins/divideColor.js
@@ -23,7 +23,7 @@ export default function () {
     const utilities = _.fromPairs(
       _.map(_.omit(colors, 'DEFAULT'), (value, modifier) => {
         return [
-          `${nameClass('divide', modifier)} > :not(template) ~ :not(template)`,
+          `${nameClass('divide', modifier)} > :not([hidden]) ~ :not([hidden])`,
           getProperties(value),
         ]
       })

--- a/src/plugins/divideOpacity.js
+++ b/src/plugins/divideOpacity.js
@@ -6,7 +6,7 @@ export default function () {
     const utilities = _.fromPairs(
       _.map(theme('divideOpacity'), (value, modifier) => {
         return [
-          `${nameClass('divide-opacity', modifier)} > :not(template) ~ :not(template)`,
+          `${nameClass('divide-opacity', modifier)} > :not([hidden]) ~ :not([hidden])`,
           {
             '--divide-opacity': value,
           },

--- a/src/plugins/divideStyle.js
+++ b/src/plugins/divideStyle.js
@@ -2,19 +2,19 @@ export default function () {
   return function ({ addUtilities, variants }) {
     addUtilities(
       {
-        '.divide-solid > :not(template) ~ :not(template)': {
+        '.divide-solid > :not([hidden]) ~ :not([hidden])': {
           'border-style': 'solid',
         },
-        '.divide-dashed > :not(template) ~ :not(template)': {
+        '.divide-dashed > :not([hidden]) ~ :not([hidden])': {
           'border-style': 'dashed',
         },
-        '.divide-dotted > :not(template) ~ :not(template)': {
+        '.divide-dotted > :not([hidden]) ~ :not([hidden])': {
           'border-style': 'dotted',
         },
-        '.divide-double > :not(template) ~ :not(template)': {
+        '.divide-double > :not([hidden]) ~ :not([hidden])': {
           'border-style': 'double',
         },
-        '.divide-none > :not(template) ~ :not(template)': {
+        '.divide-none > :not([hidden]) ~ :not([hidden])': {
           'border-style': 'none',
         },
       },

--- a/src/plugins/divideWidth.js
+++ b/src/plugins/divideWidth.js
@@ -7,12 +7,12 @@ export default function () {
       (_size, modifier) => {
         const size = _size === '0' ? '0px' : _size
         return {
-          [`${nameClass('divide-y', modifier)} > :not(template) ~ :not(template)`]: {
+          [`${nameClass('divide-y', modifier)} > :not([hidden]) ~ :not([hidden])`]: {
             '--divide-y-reverse': '0',
             'border-top-width': `calc(${size} * calc(1 - var(--divide-y-reverse)))`,
             'border-bottom-width': `calc(${size} * var(--divide-y-reverse))`,
           },
-          [`${nameClass('divide-x', modifier)} > :not(template) ~ :not(template)`]: {
+          [`${nameClass('divide-x', modifier)} > :not([hidden]) ~ :not([hidden])`]: {
             '--divide-x-reverse': '0',
             'border-inline-end-width': `calc(${size} * var(--divide-x-reverse))`,
             'border-inline-start-width': `calc(${size} * calc(1 - var(--divide-x-reverse)))`,
@@ -27,10 +27,10 @@ export default function () {
           return generator(value, modifier)
         }),
         {
-          '.divide-y-reverse > :not(template) ~ :not(template)': {
+          '.divide-y-reverse > :not([hidden]) ~ :not([hidden])': {
             '--divide-y-reverse': '1',
           },
-          '.divide-x-reverse > :not(template) ~ :not(template)': {
+          '.divide-x-reverse > :not([hidden]) ~ :not([hidden])': {
             '--divide-x-reverse': '1',
           },
         },

--- a/src/plugins/space.js
+++ b/src/plugins/space.js
@@ -7,12 +7,12 @@ export default function () {
       (_size, modifier) => {
         const size = _size === '0' ? '0px' : _size
         return {
-          [`${nameClass('space-y', modifier)} > :not(template) ~ :not(template)`]: {
+          [`${nameClass('space-y', modifier)} > :not([hidden]) ~ :not([hidden])`]: {
             '--space-y-reverse': '0',
             'margin-top': `calc(${size} * calc(1 - var(--space-y-reverse)))`,
             'margin-bottom': `calc(${size} * var(--space-y-reverse))`,
           },
-          [`${nameClass('space-x', modifier)} > :not(template) ~ :not(template)`]: {
+          [`${nameClass('space-x', modifier)} > :not([hidden]) ~ :not([hidden])`]: {
             '--space-x-reverse': '0',
             'margin-inline-end': `calc(${size} * var(--space-x-reverse))`,
             'margin-inline-start': `calc(${size} * calc(1 - var(--space-x-reverse)))`,
@@ -25,10 +25,10 @@ export default function () {
       return [
         ..._.flatMap(theme('space'), generator),
         {
-          '.space-y-reverse > :not(template) ~ :not(template)': {
+          '.space-y-reverse > :not([hidden]) ~ :not([hidden])': {
             '--space-y-reverse': '1',
           },
-          '.space-x-reverse > :not(template) ~ :not(template)': {
+          '.space-x-reverse > :not([hidden]) ~ :not([hidden])': {
             '--space-x-reverse': '1',
           },
         },


### PR DESCRIPTION
This PR updates the selectors for the `space` and `divide` utilities to be less-Alpine specific and more universally useful by rewriting them like this:

```diff
- .space-x-4 > :not(template) ~ :not(template)
+ .space-x-4 > :not([hidden]) ~ :not([hidden])
```

Now any `hidden` element will not be considered when deciding which elements to apply the margin/border to. This is still not "perfect" in the sense that it can't account for arbitrary usage of `display: none` and stuff via CSS, but it is much more universally useful than just looking at `template` tags.

This is a breaking change for Alpine users but they can get around it by adding `hidden` to their `template` tags:

```diff
- <template>
+ <template hidden>
```

