### PR TITLE
Use left/right instead of inline-start/end for space/divide utilities

### DIFF
--- a/__tests__/fixtures/tailwind-output-flagged.css
+++ b/__tests__/fixtures/tailwind-output-flagged.css
@@ -568,8 +568,8 @@ video {
 
 .space-x-0 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0px * var(--space-x-reverse));
-  margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0px * var(--space-x-reverse));
+  margin-left: calc(0px * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -580,8 +580,8 @@ video {
 
 .space-x-1 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0.25rem * var(--space-x-reverse));
-  margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0.25rem * var(--space-x-reverse));
+  margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -592,8 +592,8 @@ video {
 
 .space-x-2 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0.5rem * var(--space-x-reverse));
+  margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -604,8 +604,8 @@ video {
 
 .space-x-3 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0.75rem * var(--space-x-reverse));
-  margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0.75rem * var(--space-x-reverse));
+  margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -616,8 +616,8 @@ video {
 
 .space-x-4 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(1rem * var(--space-x-reverse));
-  margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(1rem * var(--space-x-reverse));
+  margin-left: calc(1rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -628,8 +628,8 @@ video {
 
 .space-x-5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(1.25rem * var(--space-x-reverse));
-  margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(1.25rem * var(--space-x-reverse));
+  margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -640,8 +640,8 @@ video {
 
 .space-x-6 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(1.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(1.5rem * var(--space-x-reverse));
+  margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -652,8 +652,8 @@ video {
 
 .space-x-7 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(1.75rem * var(--space-x-reverse));
-  margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(1.75rem * var(--space-x-reverse));
+  margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -664,8 +664,8 @@ video {
 
 .space-x-8 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(2rem * var(--space-x-reverse));
-  margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(2rem * var(--space-x-reverse));
+  margin-left: calc(2rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -676,8 +676,8 @@ video {
 
 .space-x-9 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(2.25rem * var(--space-x-reverse));
-  margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(2.25rem * var(--space-x-reverse));
+  margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -688,8 +688,8 @@ video {
 
 .space-x-10 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(2.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(2.5rem * var(--space-x-reverse));
+  margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -700,8 +700,8 @@ video {
 
 .space-x-12 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(3rem * var(--space-x-reverse));
-  margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(3rem * var(--space-x-reverse));
+  margin-left: calc(3rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -712,8 +712,8 @@ video {
 
 .space-x-14 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(3.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(3.5rem * var(--space-x-reverse));
+  margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -724,8 +724,8 @@ video {
 
 .space-x-16 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(4rem * var(--space-x-reverse));
-  margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(4rem * var(--space-x-reverse));
+  margin-left: calc(4rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -736,8 +736,8 @@ video {
 
 .space-x-20 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(5rem * var(--space-x-reverse));
-  margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(5rem * var(--space-x-reverse));
+  margin-left: calc(5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -748,8 +748,8 @@ video {
 
 .space-x-24 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(6rem * var(--space-x-reverse));
-  margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(6rem * var(--space-x-reverse));
+  margin-left: calc(6rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -760,8 +760,8 @@ video {
 
 .space-x-28 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(7rem * var(--space-x-reverse));
-  margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(7rem * var(--space-x-reverse));
+  margin-left: calc(7rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -772,8 +772,8 @@ video {
 
 .space-x-32 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(8rem * var(--space-x-reverse));
-  margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(8rem * var(--space-x-reverse));
+  margin-left: calc(8rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -784,8 +784,8 @@ video {
 
 .space-x-36 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(9rem * var(--space-x-reverse));
-  margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(9rem * var(--space-x-reverse));
+  margin-left: calc(9rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -796,8 +796,8 @@ video {
 
 .space-x-40 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(10rem * var(--space-x-reverse));
-  margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(10rem * var(--space-x-reverse));
+  margin-left: calc(10rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -808,8 +808,8 @@ video {
 
 .space-x-44 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(11rem * var(--space-x-reverse));
-  margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(11rem * var(--space-x-reverse));
+  margin-left: calc(11rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -820,8 +820,8 @@ video {
 
 .space-x-48 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(12rem * var(--space-x-reverse));
-  margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(12rem * var(--space-x-reverse));
+  margin-left: calc(12rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -832,8 +832,8 @@ video {
 
 .space-x-52 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(13rem * var(--space-x-reverse));
-  margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(13rem * var(--space-x-reverse));
+  margin-left: calc(13rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -844,8 +844,8 @@ video {
 
 .space-x-56 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(14rem * var(--space-x-reverse));
-  margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(14rem * var(--space-x-reverse));
+  margin-left: calc(14rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -856,8 +856,8 @@ video {
 
 .space-x-60 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(15rem * var(--space-x-reverse));
-  margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(15rem * var(--space-x-reverse));
+  margin-left: calc(15rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -868,8 +868,8 @@ video {
 
 .space-x-64 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(16rem * var(--space-x-reverse));
-  margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(16rem * var(--space-x-reverse));
+  margin-left: calc(16rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -880,8 +880,8 @@ video {
 
 .space-x-72 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(18rem * var(--space-x-reverse));
-  margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(18rem * var(--space-x-reverse));
+  margin-left: calc(18rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -892,8 +892,8 @@ video {
 
 .space-x-80 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(20rem * var(--space-x-reverse));
-  margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(20rem * var(--space-x-reverse));
+  margin-left: calc(20rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -904,8 +904,8 @@ video {
 
 .space-x-96 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(24rem * var(--space-x-reverse));
-  margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(24rem * var(--space-x-reverse));
+  margin-left: calc(24rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -916,8 +916,8 @@ video {
 
 .space-x-px > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(1px * var(--space-x-reverse));
-  margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(1px * var(--space-x-reverse));
+  margin-left: calc(1px * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -928,8 +928,8 @@ video {
 
 .space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0.125rem * var(--space-x-reverse));
-  margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0.125rem * var(--space-x-reverse));
+  margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -940,8 +940,8 @@ video {
 
 .space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0.375rem * var(--space-x-reverse));
-  margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0.375rem * var(--space-x-reverse));
+  margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -952,8 +952,8 @@ video {
 
 .space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0.625rem * var(--space-x-reverse));
-  margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0.625rem * var(--space-x-reverse));
+  margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -964,8 +964,8 @@ video {
 
 .space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0.875rem * var(--space-x-reverse));
-  margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0.875rem * var(--space-x-reverse));
+  margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -976,8 +976,8 @@ video {
 
 .-space-x-1 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
-  margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-0.25rem * var(--space-x-reverse));
+  margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -988,8 +988,8 @@ video {
 
 .-space-x-2 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-0.5rem * var(--space-x-reverse));
+  margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -1000,8 +1000,8 @@ video {
 
 .-space-x-3 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
-  margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-0.75rem * var(--space-x-reverse));
+  margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -1012,8 +1012,8 @@ video {
 
 .-space-x-4 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-1rem * var(--space-x-reverse));
-  margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-1rem * var(--space-x-reverse));
+  margin-left: calc(-1rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -1024,8 +1024,8 @@ video {
 
 .-space-x-5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
-  margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-1.25rem * var(--space-x-reverse));
+  margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -1036,8 +1036,8 @@ video {
 
 .-space-x-6 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-1.5rem * var(--space-x-reverse));
+  margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -1048,8 +1048,8 @@ video {
 
 .-space-x-7 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
-  margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-1.75rem * var(--space-x-reverse));
+  margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -1060,8 +1060,8 @@ video {
 
 .-space-x-8 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-2rem * var(--space-x-reverse));
-  margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-2rem * var(--space-x-reverse));
+  margin-left: calc(-2rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -1072,8 +1072,8 @@ video {
 
 .-space-x-9 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
-  margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-2.25rem * var(--space-x-reverse));
+  margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -1084,8 +1084,8 @@ video {
 
 .-space-x-10 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-2.5rem * var(--space-x-reverse));
+  margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -1096,8 +1096,8 @@ video {
 
 .-space-x-12 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-3rem * var(--space-x-reverse));
-  margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-3rem * var(--space-x-reverse));
+  margin-left: calc(-3rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -1108,8 +1108,8 @@ video {
 
 .-space-x-14 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-3.5rem * var(--space-x-reverse));
+  margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -1120,8 +1120,8 @@ video {
 
 .-space-x-16 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-4rem * var(--space-x-reverse));
-  margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-4rem * var(--space-x-reverse));
+  margin-left: calc(-4rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -1132,8 +1132,8 @@ video {
 
 .-space-x-20 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-5rem * var(--space-x-reverse));
-  margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-5rem * var(--space-x-reverse));
+  margin-left: calc(-5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -1144,8 +1144,8 @@ video {
 
 .-space-x-24 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-6rem * var(--space-x-reverse));
-  margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-6rem * var(--space-x-reverse));
+  margin-left: calc(-6rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -1156,8 +1156,8 @@ video {
 
 .-space-x-28 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-7rem * var(--space-x-reverse));
-  margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-7rem * var(--space-x-reverse));
+  margin-left: calc(-7rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -1168,8 +1168,8 @@ video {
 
 .-space-x-32 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-8rem * var(--space-x-reverse));
-  margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-8rem * var(--space-x-reverse));
+  margin-left: calc(-8rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -1180,8 +1180,8 @@ video {
 
 .-space-x-36 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-9rem * var(--space-x-reverse));
-  margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-9rem * var(--space-x-reverse));
+  margin-left: calc(-9rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -1192,8 +1192,8 @@ video {
 
 .-space-x-40 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-10rem * var(--space-x-reverse));
-  margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-10rem * var(--space-x-reverse));
+  margin-left: calc(-10rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -1204,8 +1204,8 @@ video {
 
 .-space-x-44 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-11rem * var(--space-x-reverse));
-  margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-11rem * var(--space-x-reverse));
+  margin-left: calc(-11rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -1216,8 +1216,8 @@ video {
 
 .-space-x-48 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-12rem * var(--space-x-reverse));
-  margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-12rem * var(--space-x-reverse));
+  margin-left: calc(-12rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -1228,8 +1228,8 @@ video {
 
 .-space-x-52 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-13rem * var(--space-x-reverse));
-  margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-13rem * var(--space-x-reverse));
+  margin-left: calc(-13rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -1240,8 +1240,8 @@ video {
 
 .-space-x-56 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-14rem * var(--space-x-reverse));
-  margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-14rem * var(--space-x-reverse));
+  margin-left: calc(-14rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -1252,8 +1252,8 @@ video {
 
 .-space-x-60 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-15rem * var(--space-x-reverse));
-  margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-15rem * var(--space-x-reverse));
+  margin-left: calc(-15rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -1264,8 +1264,8 @@ video {
 
 .-space-x-64 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-16rem * var(--space-x-reverse));
-  margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-16rem * var(--space-x-reverse));
+  margin-left: calc(-16rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -1276,8 +1276,8 @@ video {
 
 .-space-x-72 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-18rem * var(--space-x-reverse));
-  margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-18rem * var(--space-x-reverse));
+  margin-left: calc(-18rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -1288,8 +1288,8 @@ video {
 
 .-space-x-80 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-20rem * var(--space-x-reverse));
-  margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-20rem * var(--space-x-reverse));
+  margin-left: calc(-20rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -1300,8 +1300,8 @@ video {
 
 .-space-x-96 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-24rem * var(--space-x-reverse));
-  margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-24rem * var(--space-x-reverse));
+  margin-left: calc(-24rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -1312,8 +1312,8 @@ video {
 
 .-space-x-px > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-1px * var(--space-x-reverse));
-  margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-1px * var(--space-x-reverse));
+  margin-left: calc(-1px * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -1324,8 +1324,8 @@ video {
 
 .-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
-  margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-0.125rem * var(--space-x-reverse));
+  margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -1336,8 +1336,8 @@ video {
 
 .-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
-  margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-0.375rem * var(--space-x-reverse));
+  margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -1348,8 +1348,8 @@ video {
 
 .-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
-  margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-0.625rem * var(--space-x-reverse));
+  margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -1360,8 +1360,8 @@ video {
 
 .-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
-  margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-0.875rem * var(--space-x-reverse));
+  margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -1380,8 +1380,8 @@ video {
 
 .divide-x-0 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
-  border-inline-end-width: calc(0px * var(--divide-x-reverse));
-  border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
+  border-right-width: calc(0px * var(--divide-x-reverse));
+  border-left-width: calc(0px * calc(1 - var(--divide-x-reverse)));
 }
 
 .divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -1392,8 +1392,8 @@ video {
 
 .divide-x-2 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
-  border-inline-end-width: calc(2px * var(--divide-x-reverse));
-  border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
+  border-right-width: calc(2px * var(--divide-x-reverse));
+  border-left-width: calc(2px * calc(1 - var(--divide-x-reverse)));
 }
 
 .divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -1404,8 +1404,8 @@ video {
 
 .divide-x-4 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
-  border-inline-end-width: calc(4px * var(--divide-x-reverse));
-  border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
+  border-right-width: calc(4px * var(--divide-x-reverse));
+  border-left-width: calc(4px * calc(1 - var(--divide-x-reverse)));
 }
 
 .divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -1416,8 +1416,8 @@ video {
 
 .divide-x-8 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
-  border-inline-end-width: calc(8px * var(--divide-x-reverse));
-  border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
+  border-right-width: calc(8px * var(--divide-x-reverse));
+  border-left-width: calc(8px * calc(1 - var(--divide-x-reverse)));
 }
 
 .divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -1428,8 +1428,8 @@ video {
 
 .divide-x > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
-  border-inline-end-width: calc(1px * var(--divide-x-reverse));
-  border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
+  border-right-width: calc(1px * var(--divide-x-reverse));
+  border-left-width: calc(1px * calc(1 - var(--divide-x-reverse)));
 }
 
 .divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -23544,8 +23544,8 @@ video {
 
   .sm\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0px * var(--space-x-reverse));
-    margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0px * var(--space-x-reverse));
+    margin-left: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -23556,8 +23556,8 @@ video {
 
   .sm\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.25rem * var(--space-x-reverse));
+    margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -23568,8 +23568,8 @@ video {
 
   .sm\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.5rem * var(--space-x-reverse));
+    margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -23580,8 +23580,8 @@ video {
 
   .sm\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.75rem * var(--space-x-reverse));
+    margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -23592,8 +23592,8 @@ video {
 
   .sm\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1rem * var(--space-x-reverse));
-    margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1rem * var(--space-x-reverse));
+    margin-left: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -23604,8 +23604,8 @@ video {
 
   .sm\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.25rem * var(--space-x-reverse));
+    margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -23616,8 +23616,8 @@ video {
 
   .sm\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.5rem * var(--space-x-reverse));
+    margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -23628,8 +23628,8 @@ video {
 
   .sm\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.75rem * var(--space-x-reverse));
+    margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -23640,8 +23640,8 @@ video {
 
   .sm\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2rem * var(--space-x-reverse));
-    margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2rem * var(--space-x-reverse));
+    margin-left: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -23652,8 +23652,8 @@ video {
 
   .sm\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.25rem * var(--space-x-reverse));
+    margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -23664,8 +23664,8 @@ video {
 
   .sm\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.5rem * var(--space-x-reverse));
+    margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -23676,8 +23676,8 @@ video {
 
   .sm\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3rem * var(--space-x-reverse));
-    margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3rem * var(--space-x-reverse));
+    margin-left: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -23688,8 +23688,8 @@ video {
 
   .sm\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3.5rem * var(--space-x-reverse));
+    margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -23700,8 +23700,8 @@ video {
 
   .sm\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(4rem * var(--space-x-reverse));
-    margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(4rem * var(--space-x-reverse));
+    margin-left: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -23712,8 +23712,8 @@ video {
 
   .sm\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(5rem * var(--space-x-reverse));
-    margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(5rem * var(--space-x-reverse));
+    margin-left: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -23724,8 +23724,8 @@ video {
 
   .sm\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(6rem * var(--space-x-reverse));
-    margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(6rem * var(--space-x-reverse));
+    margin-left: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -23736,8 +23736,8 @@ video {
 
   .sm\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(7rem * var(--space-x-reverse));
-    margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(7rem * var(--space-x-reverse));
+    margin-left: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -23748,8 +23748,8 @@ video {
 
   .sm\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(8rem * var(--space-x-reverse));
-    margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(8rem * var(--space-x-reverse));
+    margin-left: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -23760,8 +23760,8 @@ video {
 
   .sm\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(9rem * var(--space-x-reverse));
-    margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(9rem * var(--space-x-reverse));
+    margin-left: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -23772,8 +23772,8 @@ video {
 
   .sm\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(10rem * var(--space-x-reverse));
-    margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(10rem * var(--space-x-reverse));
+    margin-left: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -23784,8 +23784,8 @@ video {
 
   .sm\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(11rem * var(--space-x-reverse));
-    margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(11rem * var(--space-x-reverse));
+    margin-left: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -23796,8 +23796,8 @@ video {
 
   .sm\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(12rem * var(--space-x-reverse));
-    margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(12rem * var(--space-x-reverse));
+    margin-left: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -23808,8 +23808,8 @@ video {
 
   .sm\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(13rem * var(--space-x-reverse));
-    margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(13rem * var(--space-x-reverse));
+    margin-left: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -23820,8 +23820,8 @@ video {
 
   .sm\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(14rem * var(--space-x-reverse));
-    margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(14rem * var(--space-x-reverse));
+    margin-left: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -23832,8 +23832,8 @@ video {
 
   .sm\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(15rem * var(--space-x-reverse));
-    margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(15rem * var(--space-x-reverse));
+    margin-left: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -23844,8 +23844,8 @@ video {
 
   .sm\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(16rem * var(--space-x-reverse));
-    margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(16rem * var(--space-x-reverse));
+    margin-left: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -23856,8 +23856,8 @@ video {
 
   .sm\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(18rem * var(--space-x-reverse));
-    margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(18rem * var(--space-x-reverse));
+    margin-left: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -23868,8 +23868,8 @@ video {
 
   .sm\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(20rem * var(--space-x-reverse));
-    margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(20rem * var(--space-x-reverse));
+    margin-left: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -23880,8 +23880,8 @@ video {
 
   .sm\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(24rem * var(--space-x-reverse));
-    margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(24rem * var(--space-x-reverse));
+    margin-left: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -23892,8 +23892,8 @@ video {
 
   .sm\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1px * var(--space-x-reverse));
-    margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1px * var(--space-x-reverse));
+    margin-left: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -23904,8 +23904,8 @@ video {
 
   .sm\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.125rem * var(--space-x-reverse));
+    margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -23916,8 +23916,8 @@ video {
 
   .sm\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.375rem * var(--space-x-reverse));
+    margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -23928,8 +23928,8 @@ video {
 
   .sm\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.625rem * var(--space-x-reverse));
+    margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -23940,8 +23940,8 @@ video {
 
   .sm\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.875rem * var(--space-x-reverse));
+    margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -23952,8 +23952,8 @@ video {
 
   .sm\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.25rem * var(--space-x-reverse));
+    margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -23964,8 +23964,8 @@ video {
 
   .sm\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.5rem * var(--space-x-reverse));
+    margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -23976,8 +23976,8 @@ video {
 
   .sm\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.75rem * var(--space-x-reverse));
+    margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -23988,8 +23988,8 @@ video {
 
   .sm\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1rem * var(--space-x-reverse));
+    margin-left: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -24000,8 +24000,8 @@ video {
 
   .sm\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.25rem * var(--space-x-reverse));
+    margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -24012,8 +24012,8 @@ video {
 
   .sm\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.5rem * var(--space-x-reverse));
+    margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -24024,8 +24024,8 @@ video {
 
   .sm\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.75rem * var(--space-x-reverse));
+    margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -24036,8 +24036,8 @@ video {
 
   .sm\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2rem * var(--space-x-reverse));
+    margin-left: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -24048,8 +24048,8 @@ video {
 
   .sm\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.25rem * var(--space-x-reverse));
+    margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -24060,8 +24060,8 @@ video {
 
   .sm\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.5rem * var(--space-x-reverse));
+    margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -24072,8 +24072,8 @@ video {
 
   .sm\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3rem * var(--space-x-reverse));
+    margin-left: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -24084,8 +24084,8 @@ video {
 
   .sm\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3.5rem * var(--space-x-reverse));
+    margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -24096,8 +24096,8 @@ video {
 
   .sm\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-4rem * var(--space-x-reverse));
-    margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-4rem * var(--space-x-reverse));
+    margin-left: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -24108,8 +24108,8 @@ video {
 
   .sm\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-5rem * var(--space-x-reverse));
+    margin-left: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -24120,8 +24120,8 @@ video {
 
   .sm\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-6rem * var(--space-x-reverse));
-    margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-6rem * var(--space-x-reverse));
+    margin-left: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -24132,8 +24132,8 @@ video {
 
   .sm\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-7rem * var(--space-x-reverse));
-    margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-7rem * var(--space-x-reverse));
+    margin-left: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -24144,8 +24144,8 @@ video {
 
   .sm\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-8rem * var(--space-x-reverse));
-    margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-8rem * var(--space-x-reverse));
+    margin-left: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -24156,8 +24156,8 @@ video {
 
   .sm\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-9rem * var(--space-x-reverse));
-    margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-9rem * var(--space-x-reverse));
+    margin-left: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -24168,8 +24168,8 @@ video {
 
   .sm\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-10rem * var(--space-x-reverse));
-    margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-10rem * var(--space-x-reverse));
+    margin-left: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -24180,8 +24180,8 @@ video {
 
   .sm\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-11rem * var(--space-x-reverse));
-    margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-11rem * var(--space-x-reverse));
+    margin-left: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -24192,8 +24192,8 @@ video {
 
   .sm\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-12rem * var(--space-x-reverse));
-    margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-12rem * var(--space-x-reverse));
+    margin-left: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -24204,8 +24204,8 @@ video {
 
   .sm\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-13rem * var(--space-x-reverse));
-    margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-13rem * var(--space-x-reverse));
+    margin-left: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -24216,8 +24216,8 @@ video {
 
   .sm\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-14rem * var(--space-x-reverse));
-    margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-14rem * var(--space-x-reverse));
+    margin-left: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -24228,8 +24228,8 @@ video {
 
   .sm\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-15rem * var(--space-x-reverse));
-    margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-15rem * var(--space-x-reverse));
+    margin-left: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -24240,8 +24240,8 @@ video {
 
   .sm\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-16rem * var(--space-x-reverse));
-    margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-16rem * var(--space-x-reverse));
+    margin-left: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -24252,8 +24252,8 @@ video {
 
   .sm\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-18rem * var(--space-x-reverse));
-    margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-18rem * var(--space-x-reverse));
+    margin-left: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -24264,8 +24264,8 @@ video {
 
   .sm\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-20rem * var(--space-x-reverse));
-    margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-20rem * var(--space-x-reverse));
+    margin-left: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -24276,8 +24276,8 @@ video {
 
   .sm\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-24rem * var(--space-x-reverse));
-    margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-24rem * var(--space-x-reverse));
+    margin-left: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -24288,8 +24288,8 @@ video {
 
   .sm\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1px * var(--space-x-reverse));
-    margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1px * var(--space-x-reverse));
+    margin-left: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -24300,8 +24300,8 @@ video {
 
   .sm\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.125rem * var(--space-x-reverse));
+    margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -24312,8 +24312,8 @@ video {
 
   .sm\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.375rem * var(--space-x-reverse));
+    margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -24324,8 +24324,8 @@ video {
 
   .sm\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.625rem * var(--space-x-reverse));
+    margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -24336,8 +24336,8 @@ video {
 
   .sm\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.875rem * var(--space-x-reverse));
+    margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -24356,8 +24356,8 @@ video {
 
   .sm\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(0px * var(--divide-x-reverse));
-    border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(0px * var(--divide-x-reverse));
+    border-left-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
   .sm\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -24368,8 +24368,8 @@ video {
 
   .sm\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(2px * var(--divide-x-reverse));
-    border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(2px * var(--divide-x-reverse));
+    border-left-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
   .sm\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -24380,8 +24380,8 @@ video {
 
   .sm\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(4px * var(--divide-x-reverse));
-    border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(4px * var(--divide-x-reverse));
+    border-left-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
   .sm\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -24392,8 +24392,8 @@ video {
 
   .sm\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(8px * var(--divide-x-reverse));
-    border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(8px * var(--divide-x-reverse));
+    border-left-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
   .sm\:divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -24404,8 +24404,8 @@ video {
 
   .sm\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(1px * var(--divide-x-reverse));
-    border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(1px * var(--divide-x-reverse));
+    border-left-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
   .sm\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -46490,8 +46490,8 @@ video {
 
   .md\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0px * var(--space-x-reverse));
-    margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0px * var(--space-x-reverse));
+    margin-left: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -46502,8 +46502,8 @@ video {
 
   .md\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.25rem * var(--space-x-reverse));
+    margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -46514,8 +46514,8 @@ video {
 
   .md\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.5rem * var(--space-x-reverse));
+    margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -46526,8 +46526,8 @@ video {
 
   .md\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.75rem * var(--space-x-reverse));
+    margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -46538,8 +46538,8 @@ video {
 
   .md\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1rem * var(--space-x-reverse));
-    margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1rem * var(--space-x-reverse));
+    margin-left: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -46550,8 +46550,8 @@ video {
 
   .md\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.25rem * var(--space-x-reverse));
+    margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -46562,8 +46562,8 @@ video {
 
   .md\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.5rem * var(--space-x-reverse));
+    margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -46574,8 +46574,8 @@ video {
 
   .md\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.75rem * var(--space-x-reverse));
+    margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -46586,8 +46586,8 @@ video {
 
   .md\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2rem * var(--space-x-reverse));
-    margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2rem * var(--space-x-reverse));
+    margin-left: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -46598,8 +46598,8 @@ video {
 
   .md\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.25rem * var(--space-x-reverse));
+    margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -46610,8 +46610,8 @@ video {
 
   .md\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.5rem * var(--space-x-reverse));
+    margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -46622,8 +46622,8 @@ video {
 
   .md\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3rem * var(--space-x-reverse));
-    margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3rem * var(--space-x-reverse));
+    margin-left: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -46634,8 +46634,8 @@ video {
 
   .md\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3.5rem * var(--space-x-reverse));
+    margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -46646,8 +46646,8 @@ video {
 
   .md\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(4rem * var(--space-x-reverse));
-    margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(4rem * var(--space-x-reverse));
+    margin-left: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -46658,8 +46658,8 @@ video {
 
   .md\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(5rem * var(--space-x-reverse));
-    margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(5rem * var(--space-x-reverse));
+    margin-left: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -46670,8 +46670,8 @@ video {
 
   .md\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(6rem * var(--space-x-reverse));
-    margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(6rem * var(--space-x-reverse));
+    margin-left: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -46682,8 +46682,8 @@ video {
 
   .md\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(7rem * var(--space-x-reverse));
-    margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(7rem * var(--space-x-reverse));
+    margin-left: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -46694,8 +46694,8 @@ video {
 
   .md\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(8rem * var(--space-x-reverse));
-    margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(8rem * var(--space-x-reverse));
+    margin-left: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -46706,8 +46706,8 @@ video {
 
   .md\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(9rem * var(--space-x-reverse));
-    margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(9rem * var(--space-x-reverse));
+    margin-left: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -46718,8 +46718,8 @@ video {
 
   .md\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(10rem * var(--space-x-reverse));
-    margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(10rem * var(--space-x-reverse));
+    margin-left: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -46730,8 +46730,8 @@ video {
 
   .md\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(11rem * var(--space-x-reverse));
-    margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(11rem * var(--space-x-reverse));
+    margin-left: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -46742,8 +46742,8 @@ video {
 
   .md\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(12rem * var(--space-x-reverse));
-    margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(12rem * var(--space-x-reverse));
+    margin-left: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -46754,8 +46754,8 @@ video {
 
   .md\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(13rem * var(--space-x-reverse));
-    margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(13rem * var(--space-x-reverse));
+    margin-left: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -46766,8 +46766,8 @@ video {
 
   .md\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(14rem * var(--space-x-reverse));
-    margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(14rem * var(--space-x-reverse));
+    margin-left: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -46778,8 +46778,8 @@ video {
 
   .md\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(15rem * var(--space-x-reverse));
-    margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(15rem * var(--space-x-reverse));
+    margin-left: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -46790,8 +46790,8 @@ video {
 
   .md\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(16rem * var(--space-x-reverse));
-    margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(16rem * var(--space-x-reverse));
+    margin-left: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -46802,8 +46802,8 @@ video {
 
   .md\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(18rem * var(--space-x-reverse));
-    margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(18rem * var(--space-x-reverse));
+    margin-left: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -46814,8 +46814,8 @@ video {
 
   .md\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(20rem * var(--space-x-reverse));
-    margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(20rem * var(--space-x-reverse));
+    margin-left: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -46826,8 +46826,8 @@ video {
 
   .md\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(24rem * var(--space-x-reverse));
-    margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(24rem * var(--space-x-reverse));
+    margin-left: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -46838,8 +46838,8 @@ video {
 
   .md\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1px * var(--space-x-reverse));
-    margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1px * var(--space-x-reverse));
+    margin-left: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -46850,8 +46850,8 @@ video {
 
   .md\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.125rem * var(--space-x-reverse));
+    margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -46862,8 +46862,8 @@ video {
 
   .md\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.375rem * var(--space-x-reverse));
+    margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -46874,8 +46874,8 @@ video {
 
   .md\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.625rem * var(--space-x-reverse));
+    margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -46886,8 +46886,8 @@ video {
 
   .md\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.875rem * var(--space-x-reverse));
+    margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -46898,8 +46898,8 @@ video {
 
   .md\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.25rem * var(--space-x-reverse));
+    margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -46910,8 +46910,8 @@ video {
 
   .md\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.5rem * var(--space-x-reverse));
+    margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -46922,8 +46922,8 @@ video {
 
   .md\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.75rem * var(--space-x-reverse));
+    margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -46934,8 +46934,8 @@ video {
 
   .md\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1rem * var(--space-x-reverse));
+    margin-left: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -46946,8 +46946,8 @@ video {
 
   .md\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.25rem * var(--space-x-reverse));
+    margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -46958,8 +46958,8 @@ video {
 
   .md\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.5rem * var(--space-x-reverse));
+    margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -46970,8 +46970,8 @@ video {
 
   .md\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.75rem * var(--space-x-reverse));
+    margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -46982,8 +46982,8 @@ video {
 
   .md\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2rem * var(--space-x-reverse));
+    margin-left: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -46994,8 +46994,8 @@ video {
 
   .md\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.25rem * var(--space-x-reverse));
+    margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -47006,8 +47006,8 @@ video {
 
   .md\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.5rem * var(--space-x-reverse));
+    margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -47018,8 +47018,8 @@ video {
 
   .md\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3rem * var(--space-x-reverse));
+    margin-left: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -47030,8 +47030,8 @@ video {
 
   .md\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3.5rem * var(--space-x-reverse));
+    margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -47042,8 +47042,8 @@ video {
 
   .md\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-4rem * var(--space-x-reverse));
-    margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-4rem * var(--space-x-reverse));
+    margin-left: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -47054,8 +47054,8 @@ video {
 
   .md\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-5rem * var(--space-x-reverse));
+    margin-left: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -47066,8 +47066,8 @@ video {
 
   .md\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-6rem * var(--space-x-reverse));
-    margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-6rem * var(--space-x-reverse));
+    margin-left: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -47078,8 +47078,8 @@ video {
 
   .md\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-7rem * var(--space-x-reverse));
-    margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-7rem * var(--space-x-reverse));
+    margin-left: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -47090,8 +47090,8 @@ video {
 
   .md\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-8rem * var(--space-x-reverse));
-    margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-8rem * var(--space-x-reverse));
+    margin-left: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -47102,8 +47102,8 @@ video {
 
   .md\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-9rem * var(--space-x-reverse));
-    margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-9rem * var(--space-x-reverse));
+    margin-left: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -47114,8 +47114,8 @@ video {
 
   .md\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-10rem * var(--space-x-reverse));
-    margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-10rem * var(--space-x-reverse));
+    margin-left: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -47126,8 +47126,8 @@ video {
 
   .md\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-11rem * var(--space-x-reverse));
-    margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-11rem * var(--space-x-reverse));
+    margin-left: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -47138,8 +47138,8 @@ video {
 
   .md\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-12rem * var(--space-x-reverse));
-    margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-12rem * var(--space-x-reverse));
+    margin-left: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -47150,8 +47150,8 @@ video {
 
   .md\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-13rem * var(--space-x-reverse));
-    margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-13rem * var(--space-x-reverse));
+    margin-left: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -47162,8 +47162,8 @@ video {
 
   .md\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-14rem * var(--space-x-reverse));
-    margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-14rem * var(--space-x-reverse));
+    margin-left: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -47174,8 +47174,8 @@ video {
 
   .md\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-15rem * var(--space-x-reverse));
-    margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-15rem * var(--space-x-reverse));
+    margin-left: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -47186,8 +47186,8 @@ video {
 
   .md\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-16rem * var(--space-x-reverse));
-    margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-16rem * var(--space-x-reverse));
+    margin-left: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -47198,8 +47198,8 @@ video {
 
   .md\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-18rem * var(--space-x-reverse));
-    margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-18rem * var(--space-x-reverse));
+    margin-left: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -47210,8 +47210,8 @@ video {
 
   .md\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-20rem * var(--space-x-reverse));
-    margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-20rem * var(--space-x-reverse));
+    margin-left: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -47222,8 +47222,8 @@ video {
 
   .md\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-24rem * var(--space-x-reverse));
-    margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-24rem * var(--space-x-reverse));
+    margin-left: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -47234,8 +47234,8 @@ video {
 
   .md\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1px * var(--space-x-reverse));
-    margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1px * var(--space-x-reverse));
+    margin-left: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -47246,8 +47246,8 @@ video {
 
   .md\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.125rem * var(--space-x-reverse));
+    margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -47258,8 +47258,8 @@ video {
 
   .md\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.375rem * var(--space-x-reverse));
+    margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -47270,8 +47270,8 @@ video {
 
   .md\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.625rem * var(--space-x-reverse));
+    margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -47282,8 +47282,8 @@ video {
 
   .md\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.875rem * var(--space-x-reverse));
+    margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -47302,8 +47302,8 @@ video {
 
   .md\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(0px * var(--divide-x-reverse));
-    border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(0px * var(--divide-x-reverse));
+    border-left-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
   .md\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -47314,8 +47314,8 @@ video {
 
   .md\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(2px * var(--divide-x-reverse));
-    border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(2px * var(--divide-x-reverse));
+    border-left-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
   .md\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -47326,8 +47326,8 @@ video {
 
   .md\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(4px * var(--divide-x-reverse));
-    border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(4px * var(--divide-x-reverse));
+    border-left-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
   .md\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -47338,8 +47338,8 @@ video {
 
   .md\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(8px * var(--divide-x-reverse));
-    border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(8px * var(--divide-x-reverse));
+    border-left-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
   .md\:divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -47350,8 +47350,8 @@ video {
 
   .md\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(1px * var(--divide-x-reverse));
-    border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(1px * var(--divide-x-reverse));
+    border-left-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
   .md\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -69436,8 +69436,8 @@ video {
 
   .lg\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0px * var(--space-x-reverse));
-    margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0px * var(--space-x-reverse));
+    margin-left: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -69448,8 +69448,8 @@ video {
 
   .lg\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.25rem * var(--space-x-reverse));
+    margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -69460,8 +69460,8 @@ video {
 
   .lg\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.5rem * var(--space-x-reverse));
+    margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -69472,8 +69472,8 @@ video {
 
   .lg\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.75rem * var(--space-x-reverse));
+    margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -69484,8 +69484,8 @@ video {
 
   .lg\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1rem * var(--space-x-reverse));
-    margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1rem * var(--space-x-reverse));
+    margin-left: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -69496,8 +69496,8 @@ video {
 
   .lg\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.25rem * var(--space-x-reverse));
+    margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -69508,8 +69508,8 @@ video {
 
   .lg\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.5rem * var(--space-x-reverse));
+    margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -69520,8 +69520,8 @@ video {
 
   .lg\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.75rem * var(--space-x-reverse));
+    margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -69532,8 +69532,8 @@ video {
 
   .lg\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2rem * var(--space-x-reverse));
-    margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2rem * var(--space-x-reverse));
+    margin-left: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -69544,8 +69544,8 @@ video {
 
   .lg\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.25rem * var(--space-x-reverse));
+    margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -69556,8 +69556,8 @@ video {
 
   .lg\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.5rem * var(--space-x-reverse));
+    margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -69568,8 +69568,8 @@ video {
 
   .lg\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3rem * var(--space-x-reverse));
-    margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3rem * var(--space-x-reverse));
+    margin-left: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -69580,8 +69580,8 @@ video {
 
   .lg\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3.5rem * var(--space-x-reverse));
+    margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -69592,8 +69592,8 @@ video {
 
   .lg\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(4rem * var(--space-x-reverse));
-    margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(4rem * var(--space-x-reverse));
+    margin-left: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -69604,8 +69604,8 @@ video {
 
   .lg\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(5rem * var(--space-x-reverse));
-    margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(5rem * var(--space-x-reverse));
+    margin-left: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -69616,8 +69616,8 @@ video {
 
   .lg\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(6rem * var(--space-x-reverse));
-    margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(6rem * var(--space-x-reverse));
+    margin-left: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -69628,8 +69628,8 @@ video {
 
   .lg\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(7rem * var(--space-x-reverse));
-    margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(7rem * var(--space-x-reverse));
+    margin-left: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -69640,8 +69640,8 @@ video {
 
   .lg\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(8rem * var(--space-x-reverse));
-    margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(8rem * var(--space-x-reverse));
+    margin-left: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -69652,8 +69652,8 @@ video {
 
   .lg\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(9rem * var(--space-x-reverse));
-    margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(9rem * var(--space-x-reverse));
+    margin-left: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -69664,8 +69664,8 @@ video {
 
   .lg\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(10rem * var(--space-x-reverse));
-    margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(10rem * var(--space-x-reverse));
+    margin-left: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -69676,8 +69676,8 @@ video {
 
   .lg\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(11rem * var(--space-x-reverse));
-    margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(11rem * var(--space-x-reverse));
+    margin-left: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -69688,8 +69688,8 @@ video {
 
   .lg\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(12rem * var(--space-x-reverse));
-    margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(12rem * var(--space-x-reverse));
+    margin-left: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -69700,8 +69700,8 @@ video {
 
   .lg\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(13rem * var(--space-x-reverse));
-    margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(13rem * var(--space-x-reverse));
+    margin-left: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -69712,8 +69712,8 @@ video {
 
   .lg\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(14rem * var(--space-x-reverse));
-    margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(14rem * var(--space-x-reverse));
+    margin-left: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -69724,8 +69724,8 @@ video {
 
   .lg\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(15rem * var(--space-x-reverse));
-    margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(15rem * var(--space-x-reverse));
+    margin-left: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -69736,8 +69736,8 @@ video {
 
   .lg\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(16rem * var(--space-x-reverse));
-    margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(16rem * var(--space-x-reverse));
+    margin-left: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -69748,8 +69748,8 @@ video {
 
   .lg\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(18rem * var(--space-x-reverse));
-    margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(18rem * var(--space-x-reverse));
+    margin-left: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -69760,8 +69760,8 @@ video {
 
   .lg\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(20rem * var(--space-x-reverse));
-    margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(20rem * var(--space-x-reverse));
+    margin-left: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -69772,8 +69772,8 @@ video {
 
   .lg\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(24rem * var(--space-x-reverse));
-    margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(24rem * var(--space-x-reverse));
+    margin-left: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -69784,8 +69784,8 @@ video {
 
   .lg\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1px * var(--space-x-reverse));
-    margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1px * var(--space-x-reverse));
+    margin-left: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -69796,8 +69796,8 @@ video {
 
   .lg\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.125rem * var(--space-x-reverse));
+    margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -69808,8 +69808,8 @@ video {
 
   .lg\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.375rem * var(--space-x-reverse));
+    margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -69820,8 +69820,8 @@ video {
 
   .lg\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.625rem * var(--space-x-reverse));
+    margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -69832,8 +69832,8 @@ video {
 
   .lg\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.875rem * var(--space-x-reverse));
+    margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -69844,8 +69844,8 @@ video {
 
   .lg\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.25rem * var(--space-x-reverse));
+    margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -69856,8 +69856,8 @@ video {
 
   .lg\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.5rem * var(--space-x-reverse));
+    margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -69868,8 +69868,8 @@ video {
 
   .lg\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.75rem * var(--space-x-reverse));
+    margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -69880,8 +69880,8 @@ video {
 
   .lg\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1rem * var(--space-x-reverse));
+    margin-left: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -69892,8 +69892,8 @@ video {
 
   .lg\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.25rem * var(--space-x-reverse));
+    margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -69904,8 +69904,8 @@ video {
 
   .lg\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.5rem * var(--space-x-reverse));
+    margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -69916,8 +69916,8 @@ video {
 
   .lg\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.75rem * var(--space-x-reverse));
+    margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -69928,8 +69928,8 @@ video {
 
   .lg\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2rem * var(--space-x-reverse));
+    margin-left: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -69940,8 +69940,8 @@ video {
 
   .lg\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.25rem * var(--space-x-reverse));
+    margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -69952,8 +69952,8 @@ video {
 
   .lg\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.5rem * var(--space-x-reverse));
+    margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -69964,8 +69964,8 @@ video {
 
   .lg\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3rem * var(--space-x-reverse));
+    margin-left: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -69976,8 +69976,8 @@ video {
 
   .lg\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3.5rem * var(--space-x-reverse));
+    margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -69988,8 +69988,8 @@ video {
 
   .lg\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-4rem * var(--space-x-reverse));
-    margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-4rem * var(--space-x-reverse));
+    margin-left: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -70000,8 +70000,8 @@ video {
 
   .lg\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-5rem * var(--space-x-reverse));
+    margin-left: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -70012,8 +70012,8 @@ video {
 
   .lg\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-6rem * var(--space-x-reverse));
-    margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-6rem * var(--space-x-reverse));
+    margin-left: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -70024,8 +70024,8 @@ video {
 
   .lg\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-7rem * var(--space-x-reverse));
-    margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-7rem * var(--space-x-reverse));
+    margin-left: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -70036,8 +70036,8 @@ video {
 
   .lg\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-8rem * var(--space-x-reverse));
-    margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-8rem * var(--space-x-reverse));
+    margin-left: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -70048,8 +70048,8 @@ video {
 
   .lg\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-9rem * var(--space-x-reverse));
-    margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-9rem * var(--space-x-reverse));
+    margin-left: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -70060,8 +70060,8 @@ video {
 
   .lg\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-10rem * var(--space-x-reverse));
-    margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-10rem * var(--space-x-reverse));
+    margin-left: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -70072,8 +70072,8 @@ video {
 
   .lg\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-11rem * var(--space-x-reverse));
-    margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-11rem * var(--space-x-reverse));
+    margin-left: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -70084,8 +70084,8 @@ video {
 
   .lg\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-12rem * var(--space-x-reverse));
-    margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-12rem * var(--space-x-reverse));
+    margin-left: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -70096,8 +70096,8 @@ video {
 
   .lg\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-13rem * var(--space-x-reverse));
-    margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-13rem * var(--space-x-reverse));
+    margin-left: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -70108,8 +70108,8 @@ video {
 
   .lg\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-14rem * var(--space-x-reverse));
-    margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-14rem * var(--space-x-reverse));
+    margin-left: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -70120,8 +70120,8 @@ video {
 
   .lg\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-15rem * var(--space-x-reverse));
-    margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-15rem * var(--space-x-reverse));
+    margin-left: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -70132,8 +70132,8 @@ video {
 
   .lg\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-16rem * var(--space-x-reverse));
-    margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-16rem * var(--space-x-reverse));
+    margin-left: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -70144,8 +70144,8 @@ video {
 
   .lg\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-18rem * var(--space-x-reverse));
-    margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-18rem * var(--space-x-reverse));
+    margin-left: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -70156,8 +70156,8 @@ video {
 
   .lg\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-20rem * var(--space-x-reverse));
-    margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-20rem * var(--space-x-reverse));
+    margin-left: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -70168,8 +70168,8 @@ video {
 
   .lg\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-24rem * var(--space-x-reverse));
-    margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-24rem * var(--space-x-reverse));
+    margin-left: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -70180,8 +70180,8 @@ video {
 
   .lg\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1px * var(--space-x-reverse));
-    margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1px * var(--space-x-reverse));
+    margin-left: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -70192,8 +70192,8 @@ video {
 
   .lg\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.125rem * var(--space-x-reverse));
+    margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -70204,8 +70204,8 @@ video {
 
   .lg\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.375rem * var(--space-x-reverse));
+    margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -70216,8 +70216,8 @@ video {
 
   .lg\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.625rem * var(--space-x-reverse));
+    margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -70228,8 +70228,8 @@ video {
 
   .lg\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.875rem * var(--space-x-reverse));
+    margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -70248,8 +70248,8 @@ video {
 
   .lg\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(0px * var(--divide-x-reverse));
-    border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(0px * var(--divide-x-reverse));
+    border-left-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
   .lg\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -70260,8 +70260,8 @@ video {
 
   .lg\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(2px * var(--divide-x-reverse));
-    border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(2px * var(--divide-x-reverse));
+    border-left-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
   .lg\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -70272,8 +70272,8 @@ video {
 
   .lg\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(4px * var(--divide-x-reverse));
-    border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(4px * var(--divide-x-reverse));
+    border-left-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
   .lg\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -70284,8 +70284,8 @@ video {
 
   .lg\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(8px * var(--divide-x-reverse));
-    border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(8px * var(--divide-x-reverse));
+    border-left-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
   .lg\:divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -70296,8 +70296,8 @@ video {
 
   .lg\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(1px * var(--divide-x-reverse));
-    border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(1px * var(--divide-x-reverse));
+    border-left-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
   .lg\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -92382,8 +92382,8 @@ video {
 
   .xl\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0px * var(--space-x-reverse));
-    margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0px * var(--space-x-reverse));
+    margin-left: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -92394,8 +92394,8 @@ video {
 
   .xl\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.25rem * var(--space-x-reverse));
+    margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -92406,8 +92406,8 @@ video {
 
   .xl\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.5rem * var(--space-x-reverse));
+    margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -92418,8 +92418,8 @@ video {
 
   .xl\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.75rem * var(--space-x-reverse));
+    margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -92430,8 +92430,8 @@ video {
 
   .xl\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1rem * var(--space-x-reverse));
-    margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1rem * var(--space-x-reverse));
+    margin-left: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -92442,8 +92442,8 @@ video {
 
   .xl\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.25rem * var(--space-x-reverse));
+    margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -92454,8 +92454,8 @@ video {
 
   .xl\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.5rem * var(--space-x-reverse));
+    margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -92466,8 +92466,8 @@ video {
 
   .xl\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.75rem * var(--space-x-reverse));
+    margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -92478,8 +92478,8 @@ video {
 
   .xl\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2rem * var(--space-x-reverse));
-    margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2rem * var(--space-x-reverse));
+    margin-left: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -92490,8 +92490,8 @@ video {
 
   .xl\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.25rem * var(--space-x-reverse));
+    margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -92502,8 +92502,8 @@ video {
 
   .xl\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.5rem * var(--space-x-reverse));
+    margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -92514,8 +92514,8 @@ video {
 
   .xl\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3rem * var(--space-x-reverse));
-    margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3rem * var(--space-x-reverse));
+    margin-left: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -92526,8 +92526,8 @@ video {
 
   .xl\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3.5rem * var(--space-x-reverse));
+    margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -92538,8 +92538,8 @@ video {
 
   .xl\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(4rem * var(--space-x-reverse));
-    margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(4rem * var(--space-x-reverse));
+    margin-left: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -92550,8 +92550,8 @@ video {
 
   .xl\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(5rem * var(--space-x-reverse));
-    margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(5rem * var(--space-x-reverse));
+    margin-left: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -92562,8 +92562,8 @@ video {
 
   .xl\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(6rem * var(--space-x-reverse));
-    margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(6rem * var(--space-x-reverse));
+    margin-left: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -92574,8 +92574,8 @@ video {
 
   .xl\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(7rem * var(--space-x-reverse));
-    margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(7rem * var(--space-x-reverse));
+    margin-left: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -92586,8 +92586,8 @@ video {
 
   .xl\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(8rem * var(--space-x-reverse));
-    margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(8rem * var(--space-x-reverse));
+    margin-left: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -92598,8 +92598,8 @@ video {
 
   .xl\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(9rem * var(--space-x-reverse));
-    margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(9rem * var(--space-x-reverse));
+    margin-left: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -92610,8 +92610,8 @@ video {
 
   .xl\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(10rem * var(--space-x-reverse));
-    margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(10rem * var(--space-x-reverse));
+    margin-left: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -92622,8 +92622,8 @@ video {
 
   .xl\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(11rem * var(--space-x-reverse));
-    margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(11rem * var(--space-x-reverse));
+    margin-left: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -92634,8 +92634,8 @@ video {
 
   .xl\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(12rem * var(--space-x-reverse));
-    margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(12rem * var(--space-x-reverse));
+    margin-left: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -92646,8 +92646,8 @@ video {
 
   .xl\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(13rem * var(--space-x-reverse));
-    margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(13rem * var(--space-x-reverse));
+    margin-left: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -92658,8 +92658,8 @@ video {
 
   .xl\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(14rem * var(--space-x-reverse));
-    margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(14rem * var(--space-x-reverse));
+    margin-left: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -92670,8 +92670,8 @@ video {
 
   .xl\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(15rem * var(--space-x-reverse));
-    margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(15rem * var(--space-x-reverse));
+    margin-left: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -92682,8 +92682,8 @@ video {
 
   .xl\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(16rem * var(--space-x-reverse));
-    margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(16rem * var(--space-x-reverse));
+    margin-left: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -92694,8 +92694,8 @@ video {
 
   .xl\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(18rem * var(--space-x-reverse));
-    margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(18rem * var(--space-x-reverse));
+    margin-left: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -92706,8 +92706,8 @@ video {
 
   .xl\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(20rem * var(--space-x-reverse));
-    margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(20rem * var(--space-x-reverse));
+    margin-left: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -92718,8 +92718,8 @@ video {
 
   .xl\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(24rem * var(--space-x-reverse));
-    margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(24rem * var(--space-x-reverse));
+    margin-left: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -92730,8 +92730,8 @@ video {
 
   .xl\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1px * var(--space-x-reverse));
-    margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1px * var(--space-x-reverse));
+    margin-left: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -92742,8 +92742,8 @@ video {
 
   .xl\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.125rem * var(--space-x-reverse));
+    margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -92754,8 +92754,8 @@ video {
 
   .xl\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.375rem * var(--space-x-reverse));
+    margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -92766,8 +92766,8 @@ video {
 
   .xl\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.625rem * var(--space-x-reverse));
+    margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -92778,8 +92778,8 @@ video {
 
   .xl\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.875rem * var(--space-x-reverse));
+    margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -92790,8 +92790,8 @@ video {
 
   .xl\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.25rem * var(--space-x-reverse));
+    margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -92802,8 +92802,8 @@ video {
 
   .xl\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.5rem * var(--space-x-reverse));
+    margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -92814,8 +92814,8 @@ video {
 
   .xl\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.75rem * var(--space-x-reverse));
+    margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -92826,8 +92826,8 @@ video {
 
   .xl\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1rem * var(--space-x-reverse));
+    margin-left: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -92838,8 +92838,8 @@ video {
 
   .xl\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.25rem * var(--space-x-reverse));
+    margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -92850,8 +92850,8 @@ video {
 
   .xl\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.5rem * var(--space-x-reverse));
+    margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -92862,8 +92862,8 @@ video {
 
   .xl\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.75rem * var(--space-x-reverse));
+    margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -92874,8 +92874,8 @@ video {
 
   .xl\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2rem * var(--space-x-reverse));
+    margin-left: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -92886,8 +92886,8 @@ video {
 
   .xl\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.25rem * var(--space-x-reverse));
+    margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -92898,8 +92898,8 @@ video {
 
   .xl\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.5rem * var(--space-x-reverse));
+    margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -92910,8 +92910,8 @@ video {
 
   .xl\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3rem * var(--space-x-reverse));
+    margin-left: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -92922,8 +92922,8 @@ video {
 
   .xl\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3.5rem * var(--space-x-reverse));
+    margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -92934,8 +92934,8 @@ video {
 
   .xl\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-4rem * var(--space-x-reverse));
-    margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-4rem * var(--space-x-reverse));
+    margin-left: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -92946,8 +92946,8 @@ video {
 
   .xl\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-5rem * var(--space-x-reverse));
+    margin-left: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -92958,8 +92958,8 @@ video {
 
   .xl\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-6rem * var(--space-x-reverse));
-    margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-6rem * var(--space-x-reverse));
+    margin-left: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -92970,8 +92970,8 @@ video {
 
   .xl\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-7rem * var(--space-x-reverse));
-    margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-7rem * var(--space-x-reverse));
+    margin-left: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -92982,8 +92982,8 @@ video {
 
   .xl\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-8rem * var(--space-x-reverse));
-    margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-8rem * var(--space-x-reverse));
+    margin-left: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -92994,8 +92994,8 @@ video {
 
   .xl\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-9rem * var(--space-x-reverse));
-    margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-9rem * var(--space-x-reverse));
+    margin-left: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -93006,8 +93006,8 @@ video {
 
   .xl\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-10rem * var(--space-x-reverse));
-    margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-10rem * var(--space-x-reverse));
+    margin-left: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -93018,8 +93018,8 @@ video {
 
   .xl\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-11rem * var(--space-x-reverse));
-    margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-11rem * var(--space-x-reverse));
+    margin-left: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -93030,8 +93030,8 @@ video {
 
   .xl\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-12rem * var(--space-x-reverse));
-    margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-12rem * var(--space-x-reverse));
+    margin-left: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -93042,8 +93042,8 @@ video {
 
   .xl\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-13rem * var(--space-x-reverse));
-    margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-13rem * var(--space-x-reverse));
+    margin-left: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -93054,8 +93054,8 @@ video {
 
   .xl\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-14rem * var(--space-x-reverse));
-    margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-14rem * var(--space-x-reverse));
+    margin-left: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -93066,8 +93066,8 @@ video {
 
   .xl\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-15rem * var(--space-x-reverse));
-    margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-15rem * var(--space-x-reverse));
+    margin-left: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -93078,8 +93078,8 @@ video {
 
   .xl\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-16rem * var(--space-x-reverse));
-    margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-16rem * var(--space-x-reverse));
+    margin-left: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -93090,8 +93090,8 @@ video {
 
   .xl\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-18rem * var(--space-x-reverse));
-    margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-18rem * var(--space-x-reverse));
+    margin-left: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -93102,8 +93102,8 @@ video {
 
   .xl\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-20rem * var(--space-x-reverse));
-    margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-20rem * var(--space-x-reverse));
+    margin-left: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -93114,8 +93114,8 @@ video {
 
   .xl\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-24rem * var(--space-x-reverse));
-    margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-24rem * var(--space-x-reverse));
+    margin-left: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -93126,8 +93126,8 @@ video {
 
   .xl\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1px * var(--space-x-reverse));
-    margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1px * var(--space-x-reverse));
+    margin-left: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -93138,8 +93138,8 @@ video {
 
   .xl\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.125rem * var(--space-x-reverse));
+    margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -93150,8 +93150,8 @@ video {
 
   .xl\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.375rem * var(--space-x-reverse));
+    margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -93162,8 +93162,8 @@ video {
 
   .xl\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.625rem * var(--space-x-reverse));
+    margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -93174,8 +93174,8 @@ video {
 
   .xl\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.875rem * var(--space-x-reverse));
+    margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -93194,8 +93194,8 @@ video {
 
   .xl\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(0px * var(--divide-x-reverse));
-    border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(0px * var(--divide-x-reverse));
+    border-left-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
   .xl\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -93206,8 +93206,8 @@ video {
 
   .xl\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(2px * var(--divide-x-reverse));
-    border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(2px * var(--divide-x-reverse));
+    border-left-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
   .xl\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -93218,8 +93218,8 @@ video {
 
   .xl\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(4px * var(--divide-x-reverse));
-    border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(4px * var(--divide-x-reverse));
+    border-left-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
   .xl\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -93230,8 +93230,8 @@ video {
 
   .xl\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(8px * var(--divide-x-reverse));
-    border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(8px * var(--divide-x-reverse));
+    border-left-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
   .xl\:divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -93242,8 +93242,8 @@ video {
 
   .xl\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(1px * var(--divide-x-reverse));
-    border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(1px * var(--divide-x-reverse));
+    border-left-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
   .xl\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -115328,8 +115328,8 @@ video {
 
   .\32xl\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0px * var(--space-x-reverse));
-    margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0px * var(--space-x-reverse));
+    margin-left: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -115340,8 +115340,8 @@ video {
 
   .\32xl\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.25rem * var(--space-x-reverse));
+    margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -115352,8 +115352,8 @@ video {
 
   .\32xl\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.5rem * var(--space-x-reverse));
+    margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -115364,8 +115364,8 @@ video {
 
   .\32xl\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.75rem * var(--space-x-reverse));
+    margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -115376,8 +115376,8 @@ video {
 
   .\32xl\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1rem * var(--space-x-reverse));
-    margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1rem * var(--space-x-reverse));
+    margin-left: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -115388,8 +115388,8 @@ video {
 
   .\32xl\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.25rem * var(--space-x-reverse));
+    margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -115400,8 +115400,8 @@ video {
 
   .\32xl\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.5rem * var(--space-x-reverse));
+    margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -115412,8 +115412,8 @@ video {
 
   .\32xl\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.75rem * var(--space-x-reverse));
+    margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -115424,8 +115424,8 @@ video {
 
   .\32xl\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2rem * var(--space-x-reverse));
-    margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2rem * var(--space-x-reverse));
+    margin-left: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -115436,8 +115436,8 @@ video {
 
   .\32xl\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.25rem * var(--space-x-reverse));
+    margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -115448,8 +115448,8 @@ video {
 
   .\32xl\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.5rem * var(--space-x-reverse));
+    margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -115460,8 +115460,8 @@ video {
 
   .\32xl\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3rem * var(--space-x-reverse));
-    margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3rem * var(--space-x-reverse));
+    margin-left: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -115472,8 +115472,8 @@ video {
 
   .\32xl\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3.5rem * var(--space-x-reverse));
+    margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -115484,8 +115484,8 @@ video {
 
   .\32xl\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(4rem * var(--space-x-reverse));
-    margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(4rem * var(--space-x-reverse));
+    margin-left: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -115496,8 +115496,8 @@ video {
 
   .\32xl\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(5rem * var(--space-x-reverse));
-    margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(5rem * var(--space-x-reverse));
+    margin-left: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -115508,8 +115508,8 @@ video {
 
   .\32xl\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(6rem * var(--space-x-reverse));
-    margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(6rem * var(--space-x-reverse));
+    margin-left: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -115520,8 +115520,8 @@ video {
 
   .\32xl\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(7rem * var(--space-x-reverse));
-    margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(7rem * var(--space-x-reverse));
+    margin-left: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -115532,8 +115532,8 @@ video {
 
   .\32xl\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(8rem * var(--space-x-reverse));
-    margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(8rem * var(--space-x-reverse));
+    margin-left: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -115544,8 +115544,8 @@ video {
 
   .\32xl\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(9rem * var(--space-x-reverse));
-    margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(9rem * var(--space-x-reverse));
+    margin-left: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -115556,8 +115556,8 @@ video {
 
   .\32xl\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(10rem * var(--space-x-reverse));
-    margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(10rem * var(--space-x-reverse));
+    margin-left: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -115568,8 +115568,8 @@ video {
 
   .\32xl\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(11rem * var(--space-x-reverse));
-    margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(11rem * var(--space-x-reverse));
+    margin-left: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -115580,8 +115580,8 @@ video {
 
   .\32xl\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(12rem * var(--space-x-reverse));
-    margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(12rem * var(--space-x-reverse));
+    margin-left: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -115592,8 +115592,8 @@ video {
 
   .\32xl\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(13rem * var(--space-x-reverse));
-    margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(13rem * var(--space-x-reverse));
+    margin-left: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -115604,8 +115604,8 @@ video {
 
   .\32xl\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(14rem * var(--space-x-reverse));
-    margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(14rem * var(--space-x-reverse));
+    margin-left: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -115616,8 +115616,8 @@ video {
 
   .\32xl\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(15rem * var(--space-x-reverse));
-    margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(15rem * var(--space-x-reverse));
+    margin-left: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -115628,8 +115628,8 @@ video {
 
   .\32xl\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(16rem * var(--space-x-reverse));
-    margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(16rem * var(--space-x-reverse));
+    margin-left: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -115640,8 +115640,8 @@ video {
 
   .\32xl\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(18rem * var(--space-x-reverse));
-    margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(18rem * var(--space-x-reverse));
+    margin-left: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -115652,8 +115652,8 @@ video {
 
   .\32xl\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(20rem * var(--space-x-reverse));
-    margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(20rem * var(--space-x-reverse));
+    margin-left: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -115664,8 +115664,8 @@ video {
 
   .\32xl\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(24rem * var(--space-x-reverse));
-    margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(24rem * var(--space-x-reverse));
+    margin-left: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -115676,8 +115676,8 @@ video {
 
   .\32xl\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1px * var(--space-x-reverse));
-    margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1px * var(--space-x-reverse));
+    margin-left: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -115688,8 +115688,8 @@ video {
 
   .\32xl\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.125rem * var(--space-x-reverse));
+    margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -115700,8 +115700,8 @@ video {
 
   .\32xl\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.375rem * var(--space-x-reverse));
+    margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -115712,8 +115712,8 @@ video {
 
   .\32xl\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.625rem * var(--space-x-reverse));
+    margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -115724,8 +115724,8 @@ video {
 
   .\32xl\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.875rem * var(--space-x-reverse));
+    margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -115736,8 +115736,8 @@ video {
 
   .\32xl\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.25rem * var(--space-x-reverse));
+    margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -115748,8 +115748,8 @@ video {
 
   .\32xl\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.5rem * var(--space-x-reverse));
+    margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -115760,8 +115760,8 @@ video {
 
   .\32xl\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.75rem * var(--space-x-reverse));
+    margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -115772,8 +115772,8 @@ video {
 
   .\32xl\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1rem * var(--space-x-reverse));
+    margin-left: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -115784,8 +115784,8 @@ video {
 
   .\32xl\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.25rem * var(--space-x-reverse));
+    margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -115796,8 +115796,8 @@ video {
 
   .\32xl\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.5rem * var(--space-x-reverse));
+    margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -115808,8 +115808,8 @@ video {
 
   .\32xl\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.75rem * var(--space-x-reverse));
+    margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -115820,8 +115820,8 @@ video {
 
   .\32xl\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2rem * var(--space-x-reverse));
+    margin-left: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -115832,8 +115832,8 @@ video {
 
   .\32xl\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.25rem * var(--space-x-reverse));
+    margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -115844,8 +115844,8 @@ video {
 
   .\32xl\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.5rem * var(--space-x-reverse));
+    margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -115856,8 +115856,8 @@ video {
 
   .\32xl\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3rem * var(--space-x-reverse));
+    margin-left: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -115868,8 +115868,8 @@ video {
 
   .\32xl\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3.5rem * var(--space-x-reverse));
+    margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -115880,8 +115880,8 @@ video {
 
   .\32xl\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-4rem * var(--space-x-reverse));
-    margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-4rem * var(--space-x-reverse));
+    margin-left: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -115892,8 +115892,8 @@ video {
 
   .\32xl\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-5rem * var(--space-x-reverse));
+    margin-left: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -115904,8 +115904,8 @@ video {
 
   .\32xl\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-6rem * var(--space-x-reverse));
-    margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-6rem * var(--space-x-reverse));
+    margin-left: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -115916,8 +115916,8 @@ video {
 
   .\32xl\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-7rem * var(--space-x-reverse));
-    margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-7rem * var(--space-x-reverse));
+    margin-left: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -115928,8 +115928,8 @@ video {
 
   .\32xl\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-8rem * var(--space-x-reverse));
-    margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-8rem * var(--space-x-reverse));
+    margin-left: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -115940,8 +115940,8 @@ video {
 
   .\32xl\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-9rem * var(--space-x-reverse));
-    margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-9rem * var(--space-x-reverse));
+    margin-left: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -115952,8 +115952,8 @@ video {
 
   .\32xl\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-10rem * var(--space-x-reverse));
-    margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-10rem * var(--space-x-reverse));
+    margin-left: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -115964,8 +115964,8 @@ video {
 
   .\32xl\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-11rem * var(--space-x-reverse));
-    margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-11rem * var(--space-x-reverse));
+    margin-left: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -115976,8 +115976,8 @@ video {
 
   .\32xl\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-12rem * var(--space-x-reverse));
-    margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-12rem * var(--space-x-reverse));
+    margin-left: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -115988,8 +115988,8 @@ video {
 
   .\32xl\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-13rem * var(--space-x-reverse));
-    margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-13rem * var(--space-x-reverse));
+    margin-left: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -116000,8 +116000,8 @@ video {
 
   .\32xl\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-14rem * var(--space-x-reverse));
-    margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-14rem * var(--space-x-reverse));
+    margin-left: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -116012,8 +116012,8 @@ video {
 
   .\32xl\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-15rem * var(--space-x-reverse));
-    margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-15rem * var(--space-x-reverse));
+    margin-left: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -116024,8 +116024,8 @@ video {
 
   .\32xl\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-16rem * var(--space-x-reverse));
-    margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-16rem * var(--space-x-reverse));
+    margin-left: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -116036,8 +116036,8 @@ video {
 
   .\32xl\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-18rem * var(--space-x-reverse));
-    margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-18rem * var(--space-x-reverse));
+    margin-left: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -116048,8 +116048,8 @@ video {
 
   .\32xl\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-20rem * var(--space-x-reverse));
-    margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-20rem * var(--space-x-reverse));
+    margin-left: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -116060,8 +116060,8 @@ video {
 
   .\32xl\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-24rem * var(--space-x-reverse));
-    margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-24rem * var(--space-x-reverse));
+    margin-left: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -116072,8 +116072,8 @@ video {
 
   .\32xl\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1px * var(--space-x-reverse));
-    margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1px * var(--space-x-reverse));
+    margin-left: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -116084,8 +116084,8 @@ video {
 
   .\32xl\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.125rem * var(--space-x-reverse));
+    margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -116096,8 +116096,8 @@ video {
 
   .\32xl\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.375rem * var(--space-x-reverse));
+    margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -116108,8 +116108,8 @@ video {
 
   .\32xl\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.625rem * var(--space-x-reverse));
+    margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -116120,8 +116120,8 @@ video {
 
   .\32xl\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.875rem * var(--space-x-reverse));
+    margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -116140,8 +116140,8 @@ video {
 
   .\32xl\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(0px * var(--divide-x-reverse));
-    border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(0px * var(--divide-x-reverse));
+    border-left-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
   .\32xl\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -116152,8 +116152,8 @@ video {
 
   .\32xl\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(2px * var(--divide-x-reverse));
-    border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(2px * var(--divide-x-reverse));
+    border-left-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
   .\32xl\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -116164,8 +116164,8 @@ video {
 
   .\32xl\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(4px * var(--divide-x-reverse));
-    border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(4px * var(--divide-x-reverse));
+    border-left-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
   .\32xl\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -116176,8 +116176,8 @@ video {
 
   .\32xl\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(8px * var(--divide-x-reverse));
-    border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(8px * var(--divide-x-reverse));
+    border-left-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
   .\32xl\:divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -116188,8 +116188,8 @@ video {
 
   .\32xl\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(1px * var(--divide-x-reverse));
-    border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(1px * var(--divide-x-reverse));
+    border-left-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
   .\32xl\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -568,8 +568,8 @@ video {
 
 .space-x-0 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(0px * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(0px * var(--space-x-reverse)) !important;
+  margin-left: calc(0px * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -580,8 +580,8 @@ video {
 
 .space-x-1 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(0.25rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(0.25rem * var(--space-x-reverse)) !important;
+  margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -592,8 +592,8 @@ video {
 
 .space-x-2 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(0.5rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(0.5rem * var(--space-x-reverse)) !important;
+  margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -604,8 +604,8 @@ video {
 
 .space-x-3 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(0.75rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(0.75rem * var(--space-x-reverse)) !important;
+  margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -616,8 +616,8 @@ video {
 
 .space-x-4 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(1rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(1rem * var(--space-x-reverse)) !important;
+  margin-left: calc(1rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -628,8 +628,8 @@ video {
 
 .space-x-5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(1.25rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(1.25rem * var(--space-x-reverse)) !important;
+  margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -640,8 +640,8 @@ video {
 
 .space-x-6 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(1.5rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(1.5rem * var(--space-x-reverse)) !important;
+  margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -652,8 +652,8 @@ video {
 
 .space-x-7 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(1.75rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(1.75rem * var(--space-x-reverse)) !important;
+  margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -664,8 +664,8 @@ video {
 
 .space-x-8 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(2rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(2rem * var(--space-x-reverse)) !important;
+  margin-left: calc(2rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -676,8 +676,8 @@ video {
 
 .space-x-9 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(2.25rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(2.25rem * var(--space-x-reverse)) !important;
+  margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -688,8 +688,8 @@ video {
 
 .space-x-10 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(2.5rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(2.5rem * var(--space-x-reverse)) !important;
+  margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -700,8 +700,8 @@ video {
 
 .space-x-12 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(3rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(3rem * var(--space-x-reverse)) !important;
+  margin-left: calc(3rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -712,8 +712,8 @@ video {
 
 .space-x-14 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(3.5rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(3.5rem * var(--space-x-reverse)) !important;
+  margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -724,8 +724,8 @@ video {
 
 .space-x-16 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(4rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(4rem * var(--space-x-reverse)) !important;
+  margin-left: calc(4rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -736,8 +736,8 @@ video {
 
 .space-x-20 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(5rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(5rem * var(--space-x-reverse)) !important;
+  margin-left: calc(5rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -748,8 +748,8 @@ video {
 
 .space-x-24 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(6rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(6rem * var(--space-x-reverse)) !important;
+  margin-left: calc(6rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -760,8 +760,8 @@ video {
 
 .space-x-28 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(7rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(7rem * var(--space-x-reverse)) !important;
+  margin-left: calc(7rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -772,8 +772,8 @@ video {
 
 .space-x-32 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(8rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(8rem * var(--space-x-reverse)) !important;
+  margin-left: calc(8rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -784,8 +784,8 @@ video {
 
 .space-x-36 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(9rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(9rem * var(--space-x-reverse)) !important;
+  margin-left: calc(9rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -796,8 +796,8 @@ video {
 
 .space-x-40 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(10rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(10rem * var(--space-x-reverse)) !important;
+  margin-left: calc(10rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -808,8 +808,8 @@ video {
 
 .space-x-44 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(11rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(11rem * var(--space-x-reverse)) !important;
+  margin-left: calc(11rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -820,8 +820,8 @@ video {
 
 .space-x-48 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(12rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(12rem * var(--space-x-reverse)) !important;
+  margin-left: calc(12rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -832,8 +832,8 @@ video {
 
 .space-x-52 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(13rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(13rem * var(--space-x-reverse)) !important;
+  margin-left: calc(13rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -844,8 +844,8 @@ video {
 
 .space-x-56 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(14rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(14rem * var(--space-x-reverse)) !important;
+  margin-left: calc(14rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -856,8 +856,8 @@ video {
 
 .space-x-60 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(15rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(15rem * var(--space-x-reverse)) !important;
+  margin-left: calc(15rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -868,8 +868,8 @@ video {
 
 .space-x-64 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(16rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(16rem * var(--space-x-reverse)) !important;
+  margin-left: calc(16rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -880,8 +880,8 @@ video {
 
 .space-x-72 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(18rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(18rem * var(--space-x-reverse)) !important;
+  margin-left: calc(18rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -892,8 +892,8 @@ video {
 
 .space-x-80 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(20rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(20rem * var(--space-x-reverse)) !important;
+  margin-left: calc(20rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -904,8 +904,8 @@ video {
 
 .space-x-96 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(24rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(24rem * var(--space-x-reverse)) !important;
+  margin-left: calc(24rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -916,8 +916,8 @@ video {
 
 .space-x-px > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(1px * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(1px * var(--space-x-reverse)) !important;
+  margin-left: calc(1px * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -928,8 +928,8 @@ video {
 
 .space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(0.125rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(0.125rem * var(--space-x-reverse)) !important;
+  margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -940,8 +940,8 @@ video {
 
 .space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(0.375rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(0.375rem * var(--space-x-reverse)) !important;
+  margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -952,8 +952,8 @@ video {
 
 .space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(0.625rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(0.625rem * var(--space-x-reverse)) !important;
+  margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -964,8 +964,8 @@ video {
 
 .space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(0.875rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(0.875rem * var(--space-x-reverse)) !important;
+  margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -976,8 +976,8 @@ video {
 
 .-space-x-1 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-0.25rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-0.25rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -988,8 +988,8 @@ video {
 
 .-space-x-2 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-0.5rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-0.5rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -1000,8 +1000,8 @@ video {
 
 .-space-x-3 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-0.75rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-0.75rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -1012,8 +1012,8 @@ video {
 
 .-space-x-4 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-1rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-1rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-1rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -1024,8 +1024,8 @@ video {
 
 .-space-x-5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-1.25rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-1.25rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -1036,8 +1036,8 @@ video {
 
 .-space-x-6 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-1.5rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-1.5rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -1048,8 +1048,8 @@ video {
 
 .-space-x-7 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-1.75rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-1.75rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -1060,8 +1060,8 @@ video {
 
 .-space-x-8 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-2rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-2rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-2rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -1072,8 +1072,8 @@ video {
 
 .-space-x-9 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-2.25rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-2.25rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -1084,8 +1084,8 @@ video {
 
 .-space-x-10 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-2.5rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-2.5rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -1096,8 +1096,8 @@ video {
 
 .-space-x-12 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-3rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-3rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-3rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -1108,8 +1108,8 @@ video {
 
 .-space-x-14 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-3.5rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-3.5rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -1120,8 +1120,8 @@ video {
 
 .-space-x-16 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-4rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-4rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-4rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -1132,8 +1132,8 @@ video {
 
 .-space-x-20 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-5rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-5rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-5rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -1144,8 +1144,8 @@ video {
 
 .-space-x-24 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-6rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-6rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-6rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -1156,8 +1156,8 @@ video {
 
 .-space-x-28 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-7rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-7rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-7rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -1168,8 +1168,8 @@ video {
 
 .-space-x-32 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-8rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-8rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-8rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -1180,8 +1180,8 @@ video {
 
 .-space-x-36 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-9rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-9rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-9rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -1192,8 +1192,8 @@ video {
 
 .-space-x-40 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-10rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-10rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-10rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -1204,8 +1204,8 @@ video {
 
 .-space-x-44 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-11rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-11rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-11rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -1216,8 +1216,8 @@ video {
 
 .-space-x-48 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-12rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-12rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-12rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -1228,8 +1228,8 @@ video {
 
 .-space-x-52 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-13rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-13rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-13rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -1240,8 +1240,8 @@ video {
 
 .-space-x-56 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-14rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-14rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-14rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -1252,8 +1252,8 @@ video {
 
 .-space-x-60 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-15rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-15rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-15rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -1264,8 +1264,8 @@ video {
 
 .-space-x-64 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-16rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-16rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-16rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -1276,8 +1276,8 @@ video {
 
 .-space-x-72 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-18rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-18rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-18rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -1288,8 +1288,8 @@ video {
 
 .-space-x-80 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-20rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-20rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-20rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -1300,8 +1300,8 @@ video {
 
 .-space-x-96 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-24rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-24rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-24rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -1312,8 +1312,8 @@ video {
 
 .-space-x-px > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-1px * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-1px * var(--space-x-reverse)) !important;
+  margin-left: calc(-1px * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -1324,8 +1324,8 @@ video {
 
 .-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-0.125rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-0.125rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -1336,8 +1336,8 @@ video {
 
 .-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-0.375rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-0.375rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -1348,8 +1348,8 @@ video {
 
 .-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-0.625rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-0.625rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -1360,8 +1360,8 @@ video {
 
 .-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0 !important;
-  margin-inline-end: calc(-0.875rem * var(--space-x-reverse)) !important;
-  margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse))) !important;
+  margin-right: calc(-0.875rem * var(--space-x-reverse)) !important;
+  margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse))) !important;
 }
 
 .space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -1380,8 +1380,8 @@ video {
 
 .divide-x-0 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0 !important;
-  border-inline-end-width: calc(0px * var(--divide-x-reverse)) !important;
-  border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse))) !important;
+  border-right-width: calc(0px * var(--divide-x-reverse)) !important;
+  border-left-width: calc(0px * calc(1 - var(--divide-x-reverse))) !important;
 }
 
 .divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -1392,8 +1392,8 @@ video {
 
 .divide-x-2 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0 !important;
-  border-inline-end-width: calc(2px * var(--divide-x-reverse)) !important;
-  border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse))) !important;
+  border-right-width: calc(2px * var(--divide-x-reverse)) !important;
+  border-left-width: calc(2px * calc(1 - var(--divide-x-reverse))) !important;
 }
 
 .divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -1404,8 +1404,8 @@ video {
 
 .divide-x-4 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0 !important;
-  border-inline-end-width: calc(4px * var(--divide-x-reverse)) !important;
-  border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse))) !important;
+  border-right-width: calc(4px * var(--divide-x-reverse)) !important;
+  border-left-width: calc(4px * calc(1 - var(--divide-x-reverse))) !important;
 }
 
 .divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -1416,8 +1416,8 @@ video {
 
 .divide-x-8 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0 !important;
-  border-inline-end-width: calc(8px * var(--divide-x-reverse)) !important;
-  border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse))) !important;
+  border-right-width: calc(8px * var(--divide-x-reverse)) !important;
+  border-left-width: calc(8px * calc(1 - var(--divide-x-reverse))) !important;
 }
 
 .divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -1428,8 +1428,8 @@ video {
 
 .divide-x > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0 !important;
-  border-inline-end-width: calc(1px * var(--divide-x-reverse)) !important;
-  border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse))) !important;
+  border-right-width: calc(1px * var(--divide-x-reverse)) !important;
+  border-left-width: calc(1px * calc(1 - var(--divide-x-reverse))) !important;
 }
 
 .divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -23544,8 +23544,8 @@ video {
 
   .sm\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0px * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0px * var(--space-x-reverse)) !important;
+    margin-left: calc(0px * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -23556,8 +23556,8 @@ video {
 
   .sm\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -23568,8 +23568,8 @@ video {
 
   .sm\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -23580,8 +23580,8 @@ video {
 
   .sm\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.75rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.75rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -23592,8 +23592,8 @@ video {
 
   .sm\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1rem * var(--space-x-reverse)) !important;
+    margin-left: calc(1rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -23604,8 +23604,8 @@ video {
 
   .sm\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -23616,8 +23616,8 @@ video {
 
   .sm\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -23628,8 +23628,8 @@ video {
 
   .sm\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1.75rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1.75rem * var(--space-x-reverse)) !important;
+    margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -23640,8 +23640,8 @@ video {
 
   .sm\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(2rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(2rem * var(--space-x-reverse)) !important;
+    margin-left: calc(2rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -23652,8 +23652,8 @@ video {
 
   .sm\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(2.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(2.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -23664,8 +23664,8 @@ video {
 
   .sm\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(2.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(2.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -23676,8 +23676,8 @@ video {
 
   .sm\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(3rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(3rem * var(--space-x-reverse)) !important;
+    margin-left: calc(3rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -23688,8 +23688,8 @@ video {
 
   .sm\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(3.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(3.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -23700,8 +23700,8 @@ video {
 
   .sm\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(4rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(4rem * var(--space-x-reverse)) !important;
+    margin-left: calc(4rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -23712,8 +23712,8 @@ video {
 
   .sm\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -23724,8 +23724,8 @@ video {
 
   .sm\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(6rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(6rem * var(--space-x-reverse)) !important;
+    margin-left: calc(6rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -23736,8 +23736,8 @@ video {
 
   .sm\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(7rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(7rem * var(--space-x-reverse)) !important;
+    margin-left: calc(7rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -23748,8 +23748,8 @@ video {
 
   .sm\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(8rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(8rem * var(--space-x-reverse)) !important;
+    margin-left: calc(8rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -23760,8 +23760,8 @@ video {
 
   .sm\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(9rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(9rem * var(--space-x-reverse)) !important;
+    margin-left: calc(9rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -23772,8 +23772,8 @@ video {
 
   .sm\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(10rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(10rem * var(--space-x-reverse)) !important;
+    margin-left: calc(10rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -23784,8 +23784,8 @@ video {
 
   .sm\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(11rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(11rem * var(--space-x-reverse)) !important;
+    margin-left: calc(11rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -23796,8 +23796,8 @@ video {
 
   .sm\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(12rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(12rem * var(--space-x-reverse)) !important;
+    margin-left: calc(12rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -23808,8 +23808,8 @@ video {
 
   .sm\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(13rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(13rem * var(--space-x-reverse)) !important;
+    margin-left: calc(13rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -23820,8 +23820,8 @@ video {
 
   .sm\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(14rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(14rem * var(--space-x-reverse)) !important;
+    margin-left: calc(14rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -23832,8 +23832,8 @@ video {
 
   .sm\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(15rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(15rem * var(--space-x-reverse)) !important;
+    margin-left: calc(15rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -23844,8 +23844,8 @@ video {
 
   .sm\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(16rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(16rem * var(--space-x-reverse)) !important;
+    margin-left: calc(16rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -23856,8 +23856,8 @@ video {
 
   .sm\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(18rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(18rem * var(--space-x-reverse)) !important;
+    margin-left: calc(18rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -23868,8 +23868,8 @@ video {
 
   .sm\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(20rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(20rem * var(--space-x-reverse)) !important;
+    margin-left: calc(20rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -23880,8 +23880,8 @@ video {
 
   .sm\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(24rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(24rem * var(--space-x-reverse)) !important;
+    margin-left: calc(24rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -23892,8 +23892,8 @@ video {
 
   .sm\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1px * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1px * var(--space-x-reverse)) !important;
+    margin-left: calc(1px * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -23904,8 +23904,8 @@ video {
 
   .sm\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.125rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.125rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -23916,8 +23916,8 @@ video {
 
   .sm\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.375rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.375rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -23928,8 +23928,8 @@ video {
 
   .sm\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.625rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.625rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -23940,8 +23940,8 @@ video {
 
   .sm\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.875rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.875rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -23952,8 +23952,8 @@ video {
 
   .sm\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -23964,8 +23964,8 @@ video {
 
   .sm\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -23976,8 +23976,8 @@ video {
 
   .sm\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.75rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.75rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -23988,8 +23988,8 @@ video {
 
   .sm\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-1rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -24000,8 +24000,8 @@ video {
 
   .sm\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -24012,8 +24012,8 @@ video {
 
   .sm\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -24024,8 +24024,8 @@ video {
 
   .sm\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1.75rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1.75rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -24036,8 +24036,8 @@ video {
 
   .sm\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-2rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-2rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-2rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -24048,8 +24048,8 @@ video {
 
   .sm\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-2.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-2.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -24060,8 +24060,8 @@ video {
 
   .sm\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-2.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-2.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -24072,8 +24072,8 @@ video {
 
   .sm\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-3rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-3rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-3rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -24084,8 +24084,8 @@ video {
 
   .sm\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-3.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-3.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -24096,8 +24096,8 @@ video {
 
   .sm\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-4rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-4rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-4rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -24108,8 +24108,8 @@ video {
 
   .sm\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -24120,8 +24120,8 @@ video {
 
   .sm\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-6rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-6rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-6rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -24132,8 +24132,8 @@ video {
 
   .sm\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-7rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-7rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-7rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -24144,8 +24144,8 @@ video {
 
   .sm\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-8rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-8rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-8rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -24156,8 +24156,8 @@ video {
 
   .sm\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-9rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-9rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-9rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -24168,8 +24168,8 @@ video {
 
   .sm\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-10rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-10rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-10rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -24180,8 +24180,8 @@ video {
 
   .sm\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-11rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-11rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-11rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -24192,8 +24192,8 @@ video {
 
   .sm\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-12rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-12rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-12rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -24204,8 +24204,8 @@ video {
 
   .sm\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-13rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-13rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-13rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -24216,8 +24216,8 @@ video {
 
   .sm\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-14rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-14rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-14rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -24228,8 +24228,8 @@ video {
 
   .sm\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-15rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-15rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-15rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -24240,8 +24240,8 @@ video {
 
   .sm\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-16rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-16rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-16rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -24252,8 +24252,8 @@ video {
 
   .sm\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-18rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-18rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-18rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -24264,8 +24264,8 @@ video {
 
   .sm\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-20rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-20rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-20rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -24276,8 +24276,8 @@ video {
 
   .sm\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-24rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-24rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-24rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -24288,8 +24288,8 @@ video {
 
   .sm\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1px * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1px * var(--space-x-reverse)) !important;
+    margin-left: calc(-1px * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -24300,8 +24300,8 @@ video {
 
   .sm\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.125rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.125rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -24312,8 +24312,8 @@ video {
 
   .sm\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.375rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.375rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -24324,8 +24324,8 @@ video {
 
   .sm\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.625rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.625rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -24336,8 +24336,8 @@ video {
 
   .sm\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.875rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.875rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .sm\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -24356,8 +24356,8 @@ video {
 
   .sm\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(0px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(0px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(0px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .sm\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -24368,8 +24368,8 @@ video {
 
   .sm\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(2px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(2px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(2px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .sm\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -24380,8 +24380,8 @@ video {
 
   .sm\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(4px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(4px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(4px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .sm\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -24392,8 +24392,8 @@ video {
 
   .sm\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(8px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(8px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(8px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .sm\:divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -24404,8 +24404,8 @@ video {
 
   .sm\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(1px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(1px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(1px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .sm\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -46490,8 +46490,8 @@ video {
 
   .md\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0px * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0px * var(--space-x-reverse)) !important;
+    margin-left: calc(0px * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -46502,8 +46502,8 @@ video {
 
   .md\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -46514,8 +46514,8 @@ video {
 
   .md\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -46526,8 +46526,8 @@ video {
 
   .md\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.75rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.75rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -46538,8 +46538,8 @@ video {
 
   .md\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1rem * var(--space-x-reverse)) !important;
+    margin-left: calc(1rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -46550,8 +46550,8 @@ video {
 
   .md\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -46562,8 +46562,8 @@ video {
 
   .md\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -46574,8 +46574,8 @@ video {
 
   .md\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1.75rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1.75rem * var(--space-x-reverse)) !important;
+    margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -46586,8 +46586,8 @@ video {
 
   .md\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(2rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(2rem * var(--space-x-reverse)) !important;
+    margin-left: calc(2rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -46598,8 +46598,8 @@ video {
 
   .md\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(2.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(2.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -46610,8 +46610,8 @@ video {
 
   .md\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(2.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(2.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -46622,8 +46622,8 @@ video {
 
   .md\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(3rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(3rem * var(--space-x-reverse)) !important;
+    margin-left: calc(3rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -46634,8 +46634,8 @@ video {
 
   .md\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(3.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(3.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -46646,8 +46646,8 @@ video {
 
   .md\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(4rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(4rem * var(--space-x-reverse)) !important;
+    margin-left: calc(4rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -46658,8 +46658,8 @@ video {
 
   .md\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -46670,8 +46670,8 @@ video {
 
   .md\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(6rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(6rem * var(--space-x-reverse)) !important;
+    margin-left: calc(6rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -46682,8 +46682,8 @@ video {
 
   .md\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(7rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(7rem * var(--space-x-reverse)) !important;
+    margin-left: calc(7rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -46694,8 +46694,8 @@ video {
 
   .md\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(8rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(8rem * var(--space-x-reverse)) !important;
+    margin-left: calc(8rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -46706,8 +46706,8 @@ video {
 
   .md\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(9rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(9rem * var(--space-x-reverse)) !important;
+    margin-left: calc(9rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -46718,8 +46718,8 @@ video {
 
   .md\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(10rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(10rem * var(--space-x-reverse)) !important;
+    margin-left: calc(10rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -46730,8 +46730,8 @@ video {
 
   .md\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(11rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(11rem * var(--space-x-reverse)) !important;
+    margin-left: calc(11rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -46742,8 +46742,8 @@ video {
 
   .md\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(12rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(12rem * var(--space-x-reverse)) !important;
+    margin-left: calc(12rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -46754,8 +46754,8 @@ video {
 
   .md\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(13rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(13rem * var(--space-x-reverse)) !important;
+    margin-left: calc(13rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -46766,8 +46766,8 @@ video {
 
   .md\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(14rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(14rem * var(--space-x-reverse)) !important;
+    margin-left: calc(14rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -46778,8 +46778,8 @@ video {
 
   .md\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(15rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(15rem * var(--space-x-reverse)) !important;
+    margin-left: calc(15rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -46790,8 +46790,8 @@ video {
 
   .md\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(16rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(16rem * var(--space-x-reverse)) !important;
+    margin-left: calc(16rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -46802,8 +46802,8 @@ video {
 
   .md\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(18rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(18rem * var(--space-x-reverse)) !important;
+    margin-left: calc(18rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -46814,8 +46814,8 @@ video {
 
   .md\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(20rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(20rem * var(--space-x-reverse)) !important;
+    margin-left: calc(20rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -46826,8 +46826,8 @@ video {
 
   .md\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(24rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(24rem * var(--space-x-reverse)) !important;
+    margin-left: calc(24rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -46838,8 +46838,8 @@ video {
 
   .md\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1px * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1px * var(--space-x-reverse)) !important;
+    margin-left: calc(1px * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -46850,8 +46850,8 @@ video {
 
   .md\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.125rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.125rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -46862,8 +46862,8 @@ video {
 
   .md\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.375rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.375rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -46874,8 +46874,8 @@ video {
 
   .md\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.625rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.625rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -46886,8 +46886,8 @@ video {
 
   .md\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.875rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.875rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -46898,8 +46898,8 @@ video {
 
   .md\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -46910,8 +46910,8 @@ video {
 
   .md\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -46922,8 +46922,8 @@ video {
 
   .md\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.75rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.75rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -46934,8 +46934,8 @@ video {
 
   .md\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-1rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -46946,8 +46946,8 @@ video {
 
   .md\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -46958,8 +46958,8 @@ video {
 
   .md\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -46970,8 +46970,8 @@ video {
 
   .md\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1.75rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1.75rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -46982,8 +46982,8 @@ video {
 
   .md\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-2rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-2rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-2rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -46994,8 +46994,8 @@ video {
 
   .md\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-2.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-2.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -47006,8 +47006,8 @@ video {
 
   .md\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-2.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-2.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -47018,8 +47018,8 @@ video {
 
   .md\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-3rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-3rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-3rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -47030,8 +47030,8 @@ video {
 
   .md\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-3.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-3.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -47042,8 +47042,8 @@ video {
 
   .md\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-4rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-4rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-4rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -47054,8 +47054,8 @@ video {
 
   .md\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -47066,8 +47066,8 @@ video {
 
   .md\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-6rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-6rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-6rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -47078,8 +47078,8 @@ video {
 
   .md\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-7rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-7rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-7rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -47090,8 +47090,8 @@ video {
 
   .md\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-8rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-8rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-8rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -47102,8 +47102,8 @@ video {
 
   .md\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-9rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-9rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-9rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -47114,8 +47114,8 @@ video {
 
   .md\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-10rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-10rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-10rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -47126,8 +47126,8 @@ video {
 
   .md\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-11rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-11rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-11rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -47138,8 +47138,8 @@ video {
 
   .md\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-12rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-12rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-12rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -47150,8 +47150,8 @@ video {
 
   .md\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-13rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-13rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-13rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -47162,8 +47162,8 @@ video {
 
   .md\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-14rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-14rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-14rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -47174,8 +47174,8 @@ video {
 
   .md\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-15rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-15rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-15rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -47186,8 +47186,8 @@ video {
 
   .md\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-16rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-16rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-16rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -47198,8 +47198,8 @@ video {
 
   .md\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-18rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-18rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-18rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -47210,8 +47210,8 @@ video {
 
   .md\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-20rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-20rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-20rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -47222,8 +47222,8 @@ video {
 
   .md\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-24rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-24rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-24rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -47234,8 +47234,8 @@ video {
 
   .md\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1px * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1px * var(--space-x-reverse)) !important;
+    margin-left: calc(-1px * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -47246,8 +47246,8 @@ video {
 
   .md\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.125rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.125rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -47258,8 +47258,8 @@ video {
 
   .md\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.375rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.375rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -47270,8 +47270,8 @@ video {
 
   .md\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.625rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.625rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -47282,8 +47282,8 @@ video {
 
   .md\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.875rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.875rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .md\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -47302,8 +47302,8 @@ video {
 
   .md\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(0px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(0px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(0px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .md\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -47314,8 +47314,8 @@ video {
 
   .md\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(2px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(2px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(2px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .md\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -47326,8 +47326,8 @@ video {
 
   .md\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(4px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(4px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(4px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .md\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -47338,8 +47338,8 @@ video {
 
   .md\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(8px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(8px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(8px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .md\:divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -47350,8 +47350,8 @@ video {
 
   .md\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(1px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(1px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(1px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .md\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -69436,8 +69436,8 @@ video {
 
   .lg\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0px * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0px * var(--space-x-reverse)) !important;
+    margin-left: calc(0px * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -69448,8 +69448,8 @@ video {
 
   .lg\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -69460,8 +69460,8 @@ video {
 
   .lg\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -69472,8 +69472,8 @@ video {
 
   .lg\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.75rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.75rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -69484,8 +69484,8 @@ video {
 
   .lg\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1rem * var(--space-x-reverse)) !important;
+    margin-left: calc(1rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -69496,8 +69496,8 @@ video {
 
   .lg\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -69508,8 +69508,8 @@ video {
 
   .lg\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -69520,8 +69520,8 @@ video {
 
   .lg\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1.75rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1.75rem * var(--space-x-reverse)) !important;
+    margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -69532,8 +69532,8 @@ video {
 
   .lg\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(2rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(2rem * var(--space-x-reverse)) !important;
+    margin-left: calc(2rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -69544,8 +69544,8 @@ video {
 
   .lg\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(2.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(2.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -69556,8 +69556,8 @@ video {
 
   .lg\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(2.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(2.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -69568,8 +69568,8 @@ video {
 
   .lg\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(3rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(3rem * var(--space-x-reverse)) !important;
+    margin-left: calc(3rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -69580,8 +69580,8 @@ video {
 
   .lg\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(3.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(3.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -69592,8 +69592,8 @@ video {
 
   .lg\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(4rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(4rem * var(--space-x-reverse)) !important;
+    margin-left: calc(4rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -69604,8 +69604,8 @@ video {
 
   .lg\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -69616,8 +69616,8 @@ video {
 
   .lg\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(6rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(6rem * var(--space-x-reverse)) !important;
+    margin-left: calc(6rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -69628,8 +69628,8 @@ video {
 
   .lg\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(7rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(7rem * var(--space-x-reverse)) !important;
+    margin-left: calc(7rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -69640,8 +69640,8 @@ video {
 
   .lg\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(8rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(8rem * var(--space-x-reverse)) !important;
+    margin-left: calc(8rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -69652,8 +69652,8 @@ video {
 
   .lg\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(9rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(9rem * var(--space-x-reverse)) !important;
+    margin-left: calc(9rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -69664,8 +69664,8 @@ video {
 
   .lg\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(10rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(10rem * var(--space-x-reverse)) !important;
+    margin-left: calc(10rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -69676,8 +69676,8 @@ video {
 
   .lg\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(11rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(11rem * var(--space-x-reverse)) !important;
+    margin-left: calc(11rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -69688,8 +69688,8 @@ video {
 
   .lg\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(12rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(12rem * var(--space-x-reverse)) !important;
+    margin-left: calc(12rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -69700,8 +69700,8 @@ video {
 
   .lg\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(13rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(13rem * var(--space-x-reverse)) !important;
+    margin-left: calc(13rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -69712,8 +69712,8 @@ video {
 
   .lg\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(14rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(14rem * var(--space-x-reverse)) !important;
+    margin-left: calc(14rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -69724,8 +69724,8 @@ video {
 
   .lg\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(15rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(15rem * var(--space-x-reverse)) !important;
+    margin-left: calc(15rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -69736,8 +69736,8 @@ video {
 
   .lg\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(16rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(16rem * var(--space-x-reverse)) !important;
+    margin-left: calc(16rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -69748,8 +69748,8 @@ video {
 
   .lg\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(18rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(18rem * var(--space-x-reverse)) !important;
+    margin-left: calc(18rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -69760,8 +69760,8 @@ video {
 
   .lg\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(20rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(20rem * var(--space-x-reverse)) !important;
+    margin-left: calc(20rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -69772,8 +69772,8 @@ video {
 
   .lg\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(24rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(24rem * var(--space-x-reverse)) !important;
+    margin-left: calc(24rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -69784,8 +69784,8 @@ video {
 
   .lg\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1px * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1px * var(--space-x-reverse)) !important;
+    margin-left: calc(1px * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -69796,8 +69796,8 @@ video {
 
   .lg\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.125rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.125rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -69808,8 +69808,8 @@ video {
 
   .lg\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.375rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.375rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -69820,8 +69820,8 @@ video {
 
   .lg\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.625rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.625rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -69832,8 +69832,8 @@ video {
 
   .lg\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.875rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.875rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -69844,8 +69844,8 @@ video {
 
   .lg\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -69856,8 +69856,8 @@ video {
 
   .lg\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -69868,8 +69868,8 @@ video {
 
   .lg\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.75rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.75rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -69880,8 +69880,8 @@ video {
 
   .lg\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-1rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -69892,8 +69892,8 @@ video {
 
   .lg\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -69904,8 +69904,8 @@ video {
 
   .lg\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -69916,8 +69916,8 @@ video {
 
   .lg\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1.75rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1.75rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -69928,8 +69928,8 @@ video {
 
   .lg\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-2rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-2rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-2rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -69940,8 +69940,8 @@ video {
 
   .lg\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-2.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-2.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -69952,8 +69952,8 @@ video {
 
   .lg\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-2.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-2.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -69964,8 +69964,8 @@ video {
 
   .lg\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-3rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-3rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-3rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -69976,8 +69976,8 @@ video {
 
   .lg\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-3.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-3.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -69988,8 +69988,8 @@ video {
 
   .lg\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-4rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-4rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-4rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -70000,8 +70000,8 @@ video {
 
   .lg\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -70012,8 +70012,8 @@ video {
 
   .lg\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-6rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-6rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-6rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -70024,8 +70024,8 @@ video {
 
   .lg\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-7rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-7rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-7rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -70036,8 +70036,8 @@ video {
 
   .lg\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-8rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-8rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-8rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -70048,8 +70048,8 @@ video {
 
   .lg\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-9rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-9rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-9rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -70060,8 +70060,8 @@ video {
 
   .lg\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-10rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-10rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-10rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -70072,8 +70072,8 @@ video {
 
   .lg\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-11rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-11rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-11rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -70084,8 +70084,8 @@ video {
 
   .lg\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-12rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-12rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-12rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -70096,8 +70096,8 @@ video {
 
   .lg\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-13rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-13rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-13rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -70108,8 +70108,8 @@ video {
 
   .lg\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-14rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-14rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-14rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -70120,8 +70120,8 @@ video {
 
   .lg\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-15rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-15rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-15rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -70132,8 +70132,8 @@ video {
 
   .lg\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-16rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-16rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-16rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -70144,8 +70144,8 @@ video {
 
   .lg\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-18rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-18rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-18rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -70156,8 +70156,8 @@ video {
 
   .lg\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-20rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-20rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-20rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -70168,8 +70168,8 @@ video {
 
   .lg\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-24rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-24rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-24rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -70180,8 +70180,8 @@ video {
 
   .lg\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1px * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1px * var(--space-x-reverse)) !important;
+    margin-left: calc(-1px * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -70192,8 +70192,8 @@ video {
 
   .lg\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.125rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.125rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -70204,8 +70204,8 @@ video {
 
   .lg\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.375rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.375rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -70216,8 +70216,8 @@ video {
 
   .lg\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.625rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.625rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -70228,8 +70228,8 @@ video {
 
   .lg\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.875rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.875rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .lg\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -70248,8 +70248,8 @@ video {
 
   .lg\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(0px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(0px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(0px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .lg\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -70260,8 +70260,8 @@ video {
 
   .lg\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(2px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(2px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(2px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .lg\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -70272,8 +70272,8 @@ video {
 
   .lg\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(4px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(4px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(4px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .lg\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -70284,8 +70284,8 @@ video {
 
   .lg\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(8px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(8px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(8px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .lg\:divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -70296,8 +70296,8 @@ video {
 
   .lg\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(1px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(1px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(1px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .lg\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -92382,8 +92382,8 @@ video {
 
   .xl\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0px * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0px * var(--space-x-reverse)) !important;
+    margin-left: calc(0px * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -92394,8 +92394,8 @@ video {
 
   .xl\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -92406,8 +92406,8 @@ video {
 
   .xl\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -92418,8 +92418,8 @@ video {
 
   .xl\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.75rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.75rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -92430,8 +92430,8 @@ video {
 
   .xl\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1rem * var(--space-x-reverse)) !important;
+    margin-left: calc(1rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -92442,8 +92442,8 @@ video {
 
   .xl\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -92454,8 +92454,8 @@ video {
 
   .xl\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -92466,8 +92466,8 @@ video {
 
   .xl\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1.75rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1.75rem * var(--space-x-reverse)) !important;
+    margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -92478,8 +92478,8 @@ video {
 
   .xl\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(2rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(2rem * var(--space-x-reverse)) !important;
+    margin-left: calc(2rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -92490,8 +92490,8 @@ video {
 
   .xl\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(2.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(2.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -92502,8 +92502,8 @@ video {
 
   .xl\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(2.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(2.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -92514,8 +92514,8 @@ video {
 
   .xl\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(3rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(3rem * var(--space-x-reverse)) !important;
+    margin-left: calc(3rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -92526,8 +92526,8 @@ video {
 
   .xl\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(3.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(3.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -92538,8 +92538,8 @@ video {
 
   .xl\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(4rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(4rem * var(--space-x-reverse)) !important;
+    margin-left: calc(4rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -92550,8 +92550,8 @@ video {
 
   .xl\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -92562,8 +92562,8 @@ video {
 
   .xl\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(6rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(6rem * var(--space-x-reverse)) !important;
+    margin-left: calc(6rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -92574,8 +92574,8 @@ video {
 
   .xl\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(7rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(7rem * var(--space-x-reverse)) !important;
+    margin-left: calc(7rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -92586,8 +92586,8 @@ video {
 
   .xl\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(8rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(8rem * var(--space-x-reverse)) !important;
+    margin-left: calc(8rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -92598,8 +92598,8 @@ video {
 
   .xl\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(9rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(9rem * var(--space-x-reverse)) !important;
+    margin-left: calc(9rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -92610,8 +92610,8 @@ video {
 
   .xl\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(10rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(10rem * var(--space-x-reverse)) !important;
+    margin-left: calc(10rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -92622,8 +92622,8 @@ video {
 
   .xl\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(11rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(11rem * var(--space-x-reverse)) !important;
+    margin-left: calc(11rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -92634,8 +92634,8 @@ video {
 
   .xl\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(12rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(12rem * var(--space-x-reverse)) !important;
+    margin-left: calc(12rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -92646,8 +92646,8 @@ video {
 
   .xl\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(13rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(13rem * var(--space-x-reverse)) !important;
+    margin-left: calc(13rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -92658,8 +92658,8 @@ video {
 
   .xl\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(14rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(14rem * var(--space-x-reverse)) !important;
+    margin-left: calc(14rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -92670,8 +92670,8 @@ video {
 
   .xl\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(15rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(15rem * var(--space-x-reverse)) !important;
+    margin-left: calc(15rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -92682,8 +92682,8 @@ video {
 
   .xl\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(16rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(16rem * var(--space-x-reverse)) !important;
+    margin-left: calc(16rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -92694,8 +92694,8 @@ video {
 
   .xl\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(18rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(18rem * var(--space-x-reverse)) !important;
+    margin-left: calc(18rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -92706,8 +92706,8 @@ video {
 
   .xl\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(20rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(20rem * var(--space-x-reverse)) !important;
+    margin-left: calc(20rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -92718,8 +92718,8 @@ video {
 
   .xl\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(24rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(24rem * var(--space-x-reverse)) !important;
+    margin-left: calc(24rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -92730,8 +92730,8 @@ video {
 
   .xl\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1px * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1px * var(--space-x-reverse)) !important;
+    margin-left: calc(1px * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -92742,8 +92742,8 @@ video {
 
   .xl\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.125rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.125rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -92754,8 +92754,8 @@ video {
 
   .xl\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.375rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.375rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -92766,8 +92766,8 @@ video {
 
   .xl\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.625rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.625rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -92778,8 +92778,8 @@ video {
 
   .xl\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.875rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.875rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -92790,8 +92790,8 @@ video {
 
   .xl\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -92802,8 +92802,8 @@ video {
 
   .xl\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -92814,8 +92814,8 @@ video {
 
   .xl\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.75rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.75rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -92826,8 +92826,8 @@ video {
 
   .xl\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-1rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -92838,8 +92838,8 @@ video {
 
   .xl\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -92850,8 +92850,8 @@ video {
 
   .xl\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -92862,8 +92862,8 @@ video {
 
   .xl\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1.75rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1.75rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -92874,8 +92874,8 @@ video {
 
   .xl\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-2rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-2rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-2rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -92886,8 +92886,8 @@ video {
 
   .xl\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-2.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-2.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -92898,8 +92898,8 @@ video {
 
   .xl\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-2.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-2.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -92910,8 +92910,8 @@ video {
 
   .xl\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-3rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-3rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-3rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -92922,8 +92922,8 @@ video {
 
   .xl\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-3.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-3.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -92934,8 +92934,8 @@ video {
 
   .xl\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-4rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-4rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-4rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -92946,8 +92946,8 @@ video {
 
   .xl\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -92958,8 +92958,8 @@ video {
 
   .xl\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-6rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-6rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-6rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -92970,8 +92970,8 @@ video {
 
   .xl\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-7rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-7rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-7rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -92982,8 +92982,8 @@ video {
 
   .xl\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-8rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-8rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-8rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -92994,8 +92994,8 @@ video {
 
   .xl\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-9rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-9rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-9rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -93006,8 +93006,8 @@ video {
 
   .xl\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-10rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-10rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-10rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -93018,8 +93018,8 @@ video {
 
   .xl\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-11rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-11rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-11rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -93030,8 +93030,8 @@ video {
 
   .xl\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-12rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-12rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-12rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -93042,8 +93042,8 @@ video {
 
   .xl\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-13rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-13rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-13rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -93054,8 +93054,8 @@ video {
 
   .xl\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-14rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-14rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-14rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -93066,8 +93066,8 @@ video {
 
   .xl\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-15rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-15rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-15rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -93078,8 +93078,8 @@ video {
 
   .xl\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-16rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-16rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-16rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -93090,8 +93090,8 @@ video {
 
   .xl\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-18rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-18rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-18rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -93102,8 +93102,8 @@ video {
 
   .xl\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-20rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-20rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-20rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -93114,8 +93114,8 @@ video {
 
   .xl\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-24rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-24rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-24rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -93126,8 +93126,8 @@ video {
 
   .xl\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1px * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1px * var(--space-x-reverse)) !important;
+    margin-left: calc(-1px * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -93138,8 +93138,8 @@ video {
 
   .xl\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.125rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.125rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -93150,8 +93150,8 @@ video {
 
   .xl\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.375rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.375rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -93162,8 +93162,8 @@ video {
 
   .xl\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.625rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.625rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -93174,8 +93174,8 @@ video {
 
   .xl\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.875rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.875rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .xl\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -93194,8 +93194,8 @@ video {
 
   .xl\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(0px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(0px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(0px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .xl\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -93206,8 +93206,8 @@ video {
 
   .xl\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(2px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(2px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(2px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .xl\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -93218,8 +93218,8 @@ video {
 
   .xl\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(4px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(4px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(4px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .xl\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -93230,8 +93230,8 @@ video {
 
   .xl\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(8px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(8px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(8px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .xl\:divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -93242,8 +93242,8 @@ video {
 
   .xl\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(1px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(1px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(1px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .xl\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -115328,8 +115328,8 @@ video {
 
   .\32xl\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0px * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0px * var(--space-x-reverse)) !important;
+    margin-left: calc(0px * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -115340,8 +115340,8 @@ video {
 
   .\32xl\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -115352,8 +115352,8 @@ video {
 
   .\32xl\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -115364,8 +115364,8 @@ video {
 
   .\32xl\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.75rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.75rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -115376,8 +115376,8 @@ video {
 
   .\32xl\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1rem * var(--space-x-reverse)) !important;
+    margin-left: calc(1rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -115388,8 +115388,8 @@ video {
 
   .\32xl\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -115400,8 +115400,8 @@ video {
 
   .\32xl\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -115412,8 +115412,8 @@ video {
 
   .\32xl\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1.75rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1.75rem * var(--space-x-reverse)) !important;
+    margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -115424,8 +115424,8 @@ video {
 
   .\32xl\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(2rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(2rem * var(--space-x-reverse)) !important;
+    margin-left: calc(2rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -115436,8 +115436,8 @@ video {
 
   .\32xl\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(2.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(2.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -115448,8 +115448,8 @@ video {
 
   .\32xl\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(2.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(2.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -115460,8 +115460,8 @@ video {
 
   .\32xl\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(3rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(3rem * var(--space-x-reverse)) !important;
+    margin-left: calc(3rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -115472,8 +115472,8 @@ video {
 
   .\32xl\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(3.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(3.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -115484,8 +115484,8 @@ video {
 
   .\32xl\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(4rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(4rem * var(--space-x-reverse)) !important;
+    margin-left: calc(4rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -115496,8 +115496,8 @@ video {
 
   .\32xl\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -115508,8 +115508,8 @@ video {
 
   .\32xl\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(6rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(6rem * var(--space-x-reverse)) !important;
+    margin-left: calc(6rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -115520,8 +115520,8 @@ video {
 
   .\32xl\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(7rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(7rem * var(--space-x-reverse)) !important;
+    margin-left: calc(7rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -115532,8 +115532,8 @@ video {
 
   .\32xl\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(8rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(8rem * var(--space-x-reverse)) !important;
+    margin-left: calc(8rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -115544,8 +115544,8 @@ video {
 
   .\32xl\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(9rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(9rem * var(--space-x-reverse)) !important;
+    margin-left: calc(9rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -115556,8 +115556,8 @@ video {
 
   .\32xl\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(10rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(10rem * var(--space-x-reverse)) !important;
+    margin-left: calc(10rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -115568,8 +115568,8 @@ video {
 
   .\32xl\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(11rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(11rem * var(--space-x-reverse)) !important;
+    margin-left: calc(11rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -115580,8 +115580,8 @@ video {
 
   .\32xl\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(12rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(12rem * var(--space-x-reverse)) !important;
+    margin-left: calc(12rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -115592,8 +115592,8 @@ video {
 
   .\32xl\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(13rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(13rem * var(--space-x-reverse)) !important;
+    margin-left: calc(13rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -115604,8 +115604,8 @@ video {
 
   .\32xl\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(14rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(14rem * var(--space-x-reverse)) !important;
+    margin-left: calc(14rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -115616,8 +115616,8 @@ video {
 
   .\32xl\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(15rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(15rem * var(--space-x-reverse)) !important;
+    margin-left: calc(15rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -115628,8 +115628,8 @@ video {
 
   .\32xl\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(16rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(16rem * var(--space-x-reverse)) !important;
+    margin-left: calc(16rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -115640,8 +115640,8 @@ video {
 
   .\32xl\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(18rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(18rem * var(--space-x-reverse)) !important;
+    margin-left: calc(18rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -115652,8 +115652,8 @@ video {
 
   .\32xl\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(20rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(20rem * var(--space-x-reverse)) !important;
+    margin-left: calc(20rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -115664,8 +115664,8 @@ video {
 
   .\32xl\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(24rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(24rem * var(--space-x-reverse)) !important;
+    margin-left: calc(24rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -115676,8 +115676,8 @@ video {
 
   .\32xl\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(1px * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(1px * var(--space-x-reverse)) !important;
+    margin-left: calc(1px * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -115688,8 +115688,8 @@ video {
 
   .\32xl\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.125rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.125rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -115700,8 +115700,8 @@ video {
 
   .\32xl\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.375rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.375rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -115712,8 +115712,8 @@ video {
 
   .\32xl\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.625rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.625rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -115724,8 +115724,8 @@ video {
 
   .\32xl\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(0.875rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(0.875rem * var(--space-x-reverse)) !important;
+    margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -115736,8 +115736,8 @@ video {
 
   .\32xl\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -115748,8 +115748,8 @@ video {
 
   .\32xl\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -115760,8 +115760,8 @@ video {
 
   .\32xl\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.75rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.75rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -115772,8 +115772,8 @@ video {
 
   .\32xl\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-1rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -115784,8 +115784,8 @@ video {
 
   .\32xl\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -115796,8 +115796,8 @@ video {
 
   .\32xl\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -115808,8 +115808,8 @@ video {
 
   .\32xl\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1.75rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1.75rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -115820,8 +115820,8 @@ video {
 
   .\32xl\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-2rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-2rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-2rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -115832,8 +115832,8 @@ video {
 
   .\32xl\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-2.25rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-2.25rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -115844,8 +115844,8 @@ video {
 
   .\32xl\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-2.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-2.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -115856,8 +115856,8 @@ video {
 
   .\32xl\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-3rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-3rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-3rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -115868,8 +115868,8 @@ video {
 
   .\32xl\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-3.5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-3.5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -115880,8 +115880,8 @@ video {
 
   .\32xl\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-4rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-4rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-4rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -115892,8 +115892,8 @@ video {
 
   .\32xl\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-5rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-5rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-5rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -115904,8 +115904,8 @@ video {
 
   .\32xl\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-6rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-6rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-6rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -115916,8 +115916,8 @@ video {
 
   .\32xl\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-7rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-7rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-7rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -115928,8 +115928,8 @@ video {
 
   .\32xl\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-8rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-8rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-8rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -115940,8 +115940,8 @@ video {
 
   .\32xl\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-9rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-9rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-9rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -115952,8 +115952,8 @@ video {
 
   .\32xl\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-10rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-10rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-10rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -115964,8 +115964,8 @@ video {
 
   .\32xl\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-11rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-11rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-11rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -115976,8 +115976,8 @@ video {
 
   .\32xl\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-12rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-12rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-12rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -115988,8 +115988,8 @@ video {
 
   .\32xl\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-13rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-13rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-13rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -116000,8 +116000,8 @@ video {
 
   .\32xl\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-14rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-14rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-14rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -116012,8 +116012,8 @@ video {
 
   .\32xl\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-15rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-15rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-15rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -116024,8 +116024,8 @@ video {
 
   .\32xl\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-16rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-16rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-16rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -116036,8 +116036,8 @@ video {
 
   .\32xl\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-18rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-18rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-18rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -116048,8 +116048,8 @@ video {
 
   .\32xl\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-20rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-20rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-20rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -116060,8 +116060,8 @@ video {
 
   .\32xl\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-24rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-24rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-24rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -116072,8 +116072,8 @@ video {
 
   .\32xl\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-1px * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-1px * var(--space-x-reverse)) !important;
+    margin-left: calc(-1px * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -116084,8 +116084,8 @@ video {
 
   .\32xl\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.125rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.125rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -116096,8 +116096,8 @@ video {
 
   .\32xl\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.375rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.375rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -116108,8 +116108,8 @@ video {
 
   .\32xl\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.625rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.625rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -116120,8 +116120,8 @@ video {
 
   .\32xl\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0 !important;
-    margin-inline-end: calc(-0.875rem * var(--space-x-reverse)) !important;
-    margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse))) !important;
+    margin-right: calc(-0.875rem * var(--space-x-reverse)) !important;
+    margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse))) !important;
   }
 
   .\32xl\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -116140,8 +116140,8 @@ video {
 
   .\32xl\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(0px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(0px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(0px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .\32xl\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -116152,8 +116152,8 @@ video {
 
   .\32xl\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(2px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(2px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(2px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .\32xl\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -116164,8 +116164,8 @@ video {
 
   .\32xl\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(4px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(4px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(4px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .\32xl\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -116176,8 +116176,8 @@ video {
 
   .\32xl\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(8px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(8px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(8px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .\32xl\:divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -116188,8 +116188,8 @@ video {
 
   .\32xl\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0 !important;
-    border-inline-end-width: calc(1px * var(--divide-x-reverse)) !important;
-    border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse))) !important;
+    border-right-width: calc(1px * var(--divide-x-reverse)) !important;
+    border-left-width: calc(1px * calc(1 - var(--divide-x-reverse))) !important;
   }
 
   .\32xl\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -568,8 +568,8 @@ video {
 
 .space-x-0 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0px * var(--space-x-reverse));
-  margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0px * var(--space-x-reverse));
+  margin-left: calc(0px * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -580,8 +580,8 @@ video {
 
 .space-x-1 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0.25rem * var(--space-x-reverse));
-  margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0.25rem * var(--space-x-reverse));
+  margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -592,8 +592,8 @@ video {
 
 .space-x-2 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0.5rem * var(--space-x-reverse));
+  margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -604,8 +604,8 @@ video {
 
 .space-x-3 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0.75rem * var(--space-x-reverse));
-  margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0.75rem * var(--space-x-reverse));
+  margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -616,8 +616,8 @@ video {
 
 .space-x-4 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(1rem * var(--space-x-reverse));
-  margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(1rem * var(--space-x-reverse));
+  margin-left: calc(1rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -628,8 +628,8 @@ video {
 
 .space-x-5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(1.25rem * var(--space-x-reverse));
-  margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(1.25rem * var(--space-x-reverse));
+  margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -640,8 +640,8 @@ video {
 
 .space-x-6 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(1.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(1.5rem * var(--space-x-reverse));
+  margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -652,8 +652,8 @@ video {
 
 .space-x-7 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(1.75rem * var(--space-x-reverse));
-  margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(1.75rem * var(--space-x-reverse));
+  margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -664,8 +664,8 @@ video {
 
 .space-x-8 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(2rem * var(--space-x-reverse));
-  margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(2rem * var(--space-x-reverse));
+  margin-left: calc(2rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -676,8 +676,8 @@ video {
 
 .space-x-9 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(2.25rem * var(--space-x-reverse));
-  margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(2.25rem * var(--space-x-reverse));
+  margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -688,8 +688,8 @@ video {
 
 .space-x-10 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(2.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(2.5rem * var(--space-x-reverse));
+  margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -700,8 +700,8 @@ video {
 
 .space-x-12 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(3rem * var(--space-x-reverse));
-  margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(3rem * var(--space-x-reverse));
+  margin-left: calc(3rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -712,8 +712,8 @@ video {
 
 .space-x-14 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(3.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(3.5rem * var(--space-x-reverse));
+  margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -724,8 +724,8 @@ video {
 
 .space-x-16 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(4rem * var(--space-x-reverse));
-  margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(4rem * var(--space-x-reverse));
+  margin-left: calc(4rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -736,8 +736,8 @@ video {
 
 .space-x-20 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(5rem * var(--space-x-reverse));
-  margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(5rem * var(--space-x-reverse));
+  margin-left: calc(5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -748,8 +748,8 @@ video {
 
 .space-x-24 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(6rem * var(--space-x-reverse));
-  margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(6rem * var(--space-x-reverse));
+  margin-left: calc(6rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -760,8 +760,8 @@ video {
 
 .space-x-28 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(7rem * var(--space-x-reverse));
-  margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(7rem * var(--space-x-reverse));
+  margin-left: calc(7rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -772,8 +772,8 @@ video {
 
 .space-x-32 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(8rem * var(--space-x-reverse));
-  margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(8rem * var(--space-x-reverse));
+  margin-left: calc(8rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -784,8 +784,8 @@ video {
 
 .space-x-36 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(9rem * var(--space-x-reverse));
-  margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(9rem * var(--space-x-reverse));
+  margin-left: calc(9rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -796,8 +796,8 @@ video {
 
 .space-x-40 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(10rem * var(--space-x-reverse));
-  margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(10rem * var(--space-x-reverse));
+  margin-left: calc(10rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -808,8 +808,8 @@ video {
 
 .space-x-44 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(11rem * var(--space-x-reverse));
-  margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(11rem * var(--space-x-reverse));
+  margin-left: calc(11rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -820,8 +820,8 @@ video {
 
 .space-x-48 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(12rem * var(--space-x-reverse));
-  margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(12rem * var(--space-x-reverse));
+  margin-left: calc(12rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -832,8 +832,8 @@ video {
 
 .space-x-52 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(13rem * var(--space-x-reverse));
-  margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(13rem * var(--space-x-reverse));
+  margin-left: calc(13rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -844,8 +844,8 @@ video {
 
 .space-x-56 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(14rem * var(--space-x-reverse));
-  margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(14rem * var(--space-x-reverse));
+  margin-left: calc(14rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -856,8 +856,8 @@ video {
 
 .space-x-60 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(15rem * var(--space-x-reverse));
-  margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(15rem * var(--space-x-reverse));
+  margin-left: calc(15rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -868,8 +868,8 @@ video {
 
 .space-x-64 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(16rem * var(--space-x-reverse));
-  margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(16rem * var(--space-x-reverse));
+  margin-left: calc(16rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -880,8 +880,8 @@ video {
 
 .space-x-72 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(18rem * var(--space-x-reverse));
-  margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(18rem * var(--space-x-reverse));
+  margin-left: calc(18rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -892,8 +892,8 @@ video {
 
 .space-x-80 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(20rem * var(--space-x-reverse));
-  margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(20rem * var(--space-x-reverse));
+  margin-left: calc(20rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -904,8 +904,8 @@ video {
 
 .space-x-96 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(24rem * var(--space-x-reverse));
-  margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(24rem * var(--space-x-reverse));
+  margin-left: calc(24rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -916,8 +916,8 @@ video {
 
 .space-x-px > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(1px * var(--space-x-reverse));
-  margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(1px * var(--space-x-reverse));
+  margin-left: calc(1px * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -928,8 +928,8 @@ video {
 
 .space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0.125rem * var(--space-x-reverse));
-  margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0.125rem * var(--space-x-reverse));
+  margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -940,8 +940,8 @@ video {
 
 .space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0.375rem * var(--space-x-reverse));
-  margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0.375rem * var(--space-x-reverse));
+  margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -952,8 +952,8 @@ video {
 
 .space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0.625rem * var(--space-x-reverse));
-  margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0.625rem * var(--space-x-reverse));
+  margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -964,8 +964,8 @@ video {
 
 .space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0.875rem * var(--space-x-reverse));
-  margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0.875rem * var(--space-x-reverse));
+  margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -976,8 +976,8 @@ video {
 
 .-space-x-1 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
-  margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-0.25rem * var(--space-x-reverse));
+  margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -988,8 +988,8 @@ video {
 
 .-space-x-2 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-0.5rem * var(--space-x-reverse));
+  margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -1000,8 +1000,8 @@ video {
 
 .-space-x-3 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
-  margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-0.75rem * var(--space-x-reverse));
+  margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -1012,8 +1012,8 @@ video {
 
 .-space-x-4 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-1rem * var(--space-x-reverse));
-  margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-1rem * var(--space-x-reverse));
+  margin-left: calc(-1rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -1024,8 +1024,8 @@ video {
 
 .-space-x-5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
-  margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-1.25rem * var(--space-x-reverse));
+  margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -1036,8 +1036,8 @@ video {
 
 .-space-x-6 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-1.5rem * var(--space-x-reverse));
+  margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -1048,8 +1048,8 @@ video {
 
 .-space-x-7 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
-  margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-1.75rem * var(--space-x-reverse));
+  margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -1060,8 +1060,8 @@ video {
 
 .-space-x-8 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-2rem * var(--space-x-reverse));
-  margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-2rem * var(--space-x-reverse));
+  margin-left: calc(-2rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -1072,8 +1072,8 @@ video {
 
 .-space-x-9 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
-  margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-2.25rem * var(--space-x-reverse));
+  margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -1084,8 +1084,8 @@ video {
 
 .-space-x-10 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-2.5rem * var(--space-x-reverse));
+  margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -1096,8 +1096,8 @@ video {
 
 .-space-x-12 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-3rem * var(--space-x-reverse));
-  margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-3rem * var(--space-x-reverse));
+  margin-left: calc(-3rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -1108,8 +1108,8 @@ video {
 
 .-space-x-14 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-3.5rem * var(--space-x-reverse));
+  margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -1120,8 +1120,8 @@ video {
 
 .-space-x-16 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-4rem * var(--space-x-reverse));
-  margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-4rem * var(--space-x-reverse));
+  margin-left: calc(-4rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -1132,8 +1132,8 @@ video {
 
 .-space-x-20 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-5rem * var(--space-x-reverse));
-  margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-5rem * var(--space-x-reverse));
+  margin-left: calc(-5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -1144,8 +1144,8 @@ video {
 
 .-space-x-24 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-6rem * var(--space-x-reverse));
-  margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-6rem * var(--space-x-reverse));
+  margin-left: calc(-6rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -1156,8 +1156,8 @@ video {
 
 .-space-x-28 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-7rem * var(--space-x-reverse));
-  margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-7rem * var(--space-x-reverse));
+  margin-left: calc(-7rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -1168,8 +1168,8 @@ video {
 
 .-space-x-32 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-8rem * var(--space-x-reverse));
-  margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-8rem * var(--space-x-reverse));
+  margin-left: calc(-8rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -1180,8 +1180,8 @@ video {
 
 .-space-x-36 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-9rem * var(--space-x-reverse));
-  margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-9rem * var(--space-x-reverse));
+  margin-left: calc(-9rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -1192,8 +1192,8 @@ video {
 
 .-space-x-40 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-10rem * var(--space-x-reverse));
-  margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-10rem * var(--space-x-reverse));
+  margin-left: calc(-10rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -1204,8 +1204,8 @@ video {
 
 .-space-x-44 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-11rem * var(--space-x-reverse));
-  margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-11rem * var(--space-x-reverse));
+  margin-left: calc(-11rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -1216,8 +1216,8 @@ video {
 
 .-space-x-48 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-12rem * var(--space-x-reverse));
-  margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-12rem * var(--space-x-reverse));
+  margin-left: calc(-12rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -1228,8 +1228,8 @@ video {
 
 .-space-x-52 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-13rem * var(--space-x-reverse));
-  margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-13rem * var(--space-x-reverse));
+  margin-left: calc(-13rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -1240,8 +1240,8 @@ video {
 
 .-space-x-56 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-14rem * var(--space-x-reverse));
-  margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-14rem * var(--space-x-reverse));
+  margin-left: calc(-14rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -1252,8 +1252,8 @@ video {
 
 .-space-x-60 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-15rem * var(--space-x-reverse));
-  margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-15rem * var(--space-x-reverse));
+  margin-left: calc(-15rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -1264,8 +1264,8 @@ video {
 
 .-space-x-64 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-16rem * var(--space-x-reverse));
-  margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-16rem * var(--space-x-reverse));
+  margin-left: calc(-16rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -1276,8 +1276,8 @@ video {
 
 .-space-x-72 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-18rem * var(--space-x-reverse));
-  margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-18rem * var(--space-x-reverse));
+  margin-left: calc(-18rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -1288,8 +1288,8 @@ video {
 
 .-space-x-80 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-20rem * var(--space-x-reverse));
-  margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-20rem * var(--space-x-reverse));
+  margin-left: calc(-20rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -1300,8 +1300,8 @@ video {
 
 .-space-x-96 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-24rem * var(--space-x-reverse));
-  margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-24rem * var(--space-x-reverse));
+  margin-left: calc(-24rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -1312,8 +1312,8 @@ video {
 
 .-space-x-px > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-1px * var(--space-x-reverse));
-  margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-1px * var(--space-x-reverse));
+  margin-left: calc(-1px * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -1324,8 +1324,8 @@ video {
 
 .-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
-  margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-0.125rem * var(--space-x-reverse));
+  margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -1336,8 +1336,8 @@ video {
 
 .-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
-  margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-0.375rem * var(--space-x-reverse));
+  margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -1348,8 +1348,8 @@ video {
 
 .-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
-  margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-0.625rem * var(--space-x-reverse));
+  margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -1360,8 +1360,8 @@ video {
 
 .-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
-  margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-0.875rem * var(--space-x-reverse));
+  margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -1380,8 +1380,8 @@ video {
 
 .divide-x-0 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
-  border-inline-end-width: calc(0px * var(--divide-x-reverse));
-  border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
+  border-right-width: calc(0px * var(--divide-x-reverse));
+  border-left-width: calc(0px * calc(1 - var(--divide-x-reverse)));
 }
 
 .divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -1392,8 +1392,8 @@ video {
 
 .divide-x-2 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
-  border-inline-end-width: calc(2px * var(--divide-x-reverse));
-  border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
+  border-right-width: calc(2px * var(--divide-x-reverse));
+  border-left-width: calc(2px * calc(1 - var(--divide-x-reverse)));
 }
 
 .divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -1404,8 +1404,8 @@ video {
 
 .divide-x-4 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
-  border-inline-end-width: calc(4px * var(--divide-x-reverse));
-  border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
+  border-right-width: calc(4px * var(--divide-x-reverse));
+  border-left-width: calc(4px * calc(1 - var(--divide-x-reverse)));
 }
 
 .divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -1416,8 +1416,8 @@ video {
 
 .divide-x-8 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
-  border-inline-end-width: calc(8px * var(--divide-x-reverse));
-  border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
+  border-right-width: calc(8px * var(--divide-x-reverse));
+  border-left-width: calc(8px * calc(1 - var(--divide-x-reverse)));
 }
 
 .divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -1428,8 +1428,8 @@ video {
 
 .divide-x > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
-  border-inline-end-width: calc(1px * var(--divide-x-reverse));
-  border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
+  border-right-width: calc(1px * var(--divide-x-reverse));
+  border-left-width: calc(1px * calc(1 - var(--divide-x-reverse)));
 }
 
 .divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -21684,8 +21684,8 @@ video {
 
   .sm\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0px * var(--space-x-reverse));
-    margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0px * var(--space-x-reverse));
+    margin-left: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -21696,8 +21696,8 @@ video {
 
   .sm\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.25rem * var(--space-x-reverse));
+    margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -21708,8 +21708,8 @@ video {
 
   .sm\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.5rem * var(--space-x-reverse));
+    margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -21720,8 +21720,8 @@ video {
 
   .sm\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.75rem * var(--space-x-reverse));
+    margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -21732,8 +21732,8 @@ video {
 
   .sm\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1rem * var(--space-x-reverse));
-    margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1rem * var(--space-x-reverse));
+    margin-left: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -21744,8 +21744,8 @@ video {
 
   .sm\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.25rem * var(--space-x-reverse));
+    margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -21756,8 +21756,8 @@ video {
 
   .sm\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.5rem * var(--space-x-reverse));
+    margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -21768,8 +21768,8 @@ video {
 
   .sm\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.75rem * var(--space-x-reverse));
+    margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -21780,8 +21780,8 @@ video {
 
   .sm\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2rem * var(--space-x-reverse));
-    margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2rem * var(--space-x-reverse));
+    margin-left: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -21792,8 +21792,8 @@ video {
 
   .sm\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.25rem * var(--space-x-reverse));
+    margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -21804,8 +21804,8 @@ video {
 
   .sm\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.5rem * var(--space-x-reverse));
+    margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -21816,8 +21816,8 @@ video {
 
   .sm\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3rem * var(--space-x-reverse));
-    margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3rem * var(--space-x-reverse));
+    margin-left: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -21828,8 +21828,8 @@ video {
 
   .sm\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3.5rem * var(--space-x-reverse));
+    margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -21840,8 +21840,8 @@ video {
 
   .sm\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(4rem * var(--space-x-reverse));
-    margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(4rem * var(--space-x-reverse));
+    margin-left: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -21852,8 +21852,8 @@ video {
 
   .sm\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(5rem * var(--space-x-reverse));
-    margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(5rem * var(--space-x-reverse));
+    margin-left: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -21864,8 +21864,8 @@ video {
 
   .sm\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(6rem * var(--space-x-reverse));
-    margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(6rem * var(--space-x-reverse));
+    margin-left: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -21876,8 +21876,8 @@ video {
 
   .sm\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(7rem * var(--space-x-reverse));
-    margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(7rem * var(--space-x-reverse));
+    margin-left: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -21888,8 +21888,8 @@ video {
 
   .sm\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(8rem * var(--space-x-reverse));
-    margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(8rem * var(--space-x-reverse));
+    margin-left: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -21900,8 +21900,8 @@ video {
 
   .sm\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(9rem * var(--space-x-reverse));
-    margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(9rem * var(--space-x-reverse));
+    margin-left: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -21912,8 +21912,8 @@ video {
 
   .sm\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(10rem * var(--space-x-reverse));
-    margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(10rem * var(--space-x-reverse));
+    margin-left: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -21924,8 +21924,8 @@ video {
 
   .sm\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(11rem * var(--space-x-reverse));
-    margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(11rem * var(--space-x-reverse));
+    margin-left: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -21936,8 +21936,8 @@ video {
 
   .sm\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(12rem * var(--space-x-reverse));
-    margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(12rem * var(--space-x-reverse));
+    margin-left: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -21948,8 +21948,8 @@ video {
 
   .sm\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(13rem * var(--space-x-reverse));
-    margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(13rem * var(--space-x-reverse));
+    margin-left: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -21960,8 +21960,8 @@ video {
 
   .sm\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(14rem * var(--space-x-reverse));
-    margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(14rem * var(--space-x-reverse));
+    margin-left: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -21972,8 +21972,8 @@ video {
 
   .sm\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(15rem * var(--space-x-reverse));
-    margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(15rem * var(--space-x-reverse));
+    margin-left: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -21984,8 +21984,8 @@ video {
 
   .sm\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(16rem * var(--space-x-reverse));
-    margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(16rem * var(--space-x-reverse));
+    margin-left: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -21996,8 +21996,8 @@ video {
 
   .sm\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(18rem * var(--space-x-reverse));
-    margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(18rem * var(--space-x-reverse));
+    margin-left: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -22008,8 +22008,8 @@ video {
 
   .sm\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(20rem * var(--space-x-reverse));
-    margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(20rem * var(--space-x-reverse));
+    margin-left: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -22020,8 +22020,8 @@ video {
 
   .sm\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(24rem * var(--space-x-reverse));
-    margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(24rem * var(--space-x-reverse));
+    margin-left: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -22032,8 +22032,8 @@ video {
 
   .sm\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1px * var(--space-x-reverse));
-    margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1px * var(--space-x-reverse));
+    margin-left: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -22044,8 +22044,8 @@ video {
 
   .sm\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.125rem * var(--space-x-reverse));
+    margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -22056,8 +22056,8 @@ video {
 
   .sm\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.375rem * var(--space-x-reverse));
+    margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -22068,8 +22068,8 @@ video {
 
   .sm\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.625rem * var(--space-x-reverse));
+    margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -22080,8 +22080,8 @@ video {
 
   .sm\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.875rem * var(--space-x-reverse));
+    margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -22092,8 +22092,8 @@ video {
 
   .sm\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.25rem * var(--space-x-reverse));
+    margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -22104,8 +22104,8 @@ video {
 
   .sm\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.5rem * var(--space-x-reverse));
+    margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -22116,8 +22116,8 @@ video {
 
   .sm\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.75rem * var(--space-x-reverse));
+    margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -22128,8 +22128,8 @@ video {
 
   .sm\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1rem * var(--space-x-reverse));
+    margin-left: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -22140,8 +22140,8 @@ video {
 
   .sm\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.25rem * var(--space-x-reverse));
+    margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -22152,8 +22152,8 @@ video {
 
   .sm\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.5rem * var(--space-x-reverse));
+    margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -22164,8 +22164,8 @@ video {
 
   .sm\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.75rem * var(--space-x-reverse));
+    margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -22176,8 +22176,8 @@ video {
 
   .sm\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2rem * var(--space-x-reverse));
+    margin-left: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -22188,8 +22188,8 @@ video {
 
   .sm\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.25rem * var(--space-x-reverse));
+    margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -22200,8 +22200,8 @@ video {
 
   .sm\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.5rem * var(--space-x-reverse));
+    margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -22212,8 +22212,8 @@ video {
 
   .sm\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3rem * var(--space-x-reverse));
+    margin-left: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -22224,8 +22224,8 @@ video {
 
   .sm\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3.5rem * var(--space-x-reverse));
+    margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -22236,8 +22236,8 @@ video {
 
   .sm\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-4rem * var(--space-x-reverse));
-    margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-4rem * var(--space-x-reverse));
+    margin-left: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -22248,8 +22248,8 @@ video {
 
   .sm\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-5rem * var(--space-x-reverse));
+    margin-left: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -22260,8 +22260,8 @@ video {
 
   .sm\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-6rem * var(--space-x-reverse));
-    margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-6rem * var(--space-x-reverse));
+    margin-left: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -22272,8 +22272,8 @@ video {
 
   .sm\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-7rem * var(--space-x-reverse));
-    margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-7rem * var(--space-x-reverse));
+    margin-left: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -22284,8 +22284,8 @@ video {
 
   .sm\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-8rem * var(--space-x-reverse));
-    margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-8rem * var(--space-x-reverse));
+    margin-left: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -22296,8 +22296,8 @@ video {
 
   .sm\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-9rem * var(--space-x-reverse));
-    margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-9rem * var(--space-x-reverse));
+    margin-left: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -22308,8 +22308,8 @@ video {
 
   .sm\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-10rem * var(--space-x-reverse));
-    margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-10rem * var(--space-x-reverse));
+    margin-left: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -22320,8 +22320,8 @@ video {
 
   .sm\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-11rem * var(--space-x-reverse));
-    margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-11rem * var(--space-x-reverse));
+    margin-left: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -22332,8 +22332,8 @@ video {
 
   .sm\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-12rem * var(--space-x-reverse));
-    margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-12rem * var(--space-x-reverse));
+    margin-left: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -22344,8 +22344,8 @@ video {
 
   .sm\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-13rem * var(--space-x-reverse));
-    margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-13rem * var(--space-x-reverse));
+    margin-left: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -22356,8 +22356,8 @@ video {
 
   .sm\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-14rem * var(--space-x-reverse));
-    margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-14rem * var(--space-x-reverse));
+    margin-left: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -22368,8 +22368,8 @@ video {
 
   .sm\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-15rem * var(--space-x-reverse));
-    margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-15rem * var(--space-x-reverse));
+    margin-left: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -22380,8 +22380,8 @@ video {
 
   .sm\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-16rem * var(--space-x-reverse));
-    margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-16rem * var(--space-x-reverse));
+    margin-left: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -22392,8 +22392,8 @@ video {
 
   .sm\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-18rem * var(--space-x-reverse));
-    margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-18rem * var(--space-x-reverse));
+    margin-left: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -22404,8 +22404,8 @@ video {
 
   .sm\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-20rem * var(--space-x-reverse));
-    margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-20rem * var(--space-x-reverse));
+    margin-left: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -22416,8 +22416,8 @@ video {
 
   .sm\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-24rem * var(--space-x-reverse));
-    margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-24rem * var(--space-x-reverse));
+    margin-left: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -22428,8 +22428,8 @@ video {
 
   .sm\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1px * var(--space-x-reverse));
-    margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1px * var(--space-x-reverse));
+    margin-left: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -22440,8 +22440,8 @@ video {
 
   .sm\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.125rem * var(--space-x-reverse));
+    margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -22452,8 +22452,8 @@ video {
 
   .sm\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.375rem * var(--space-x-reverse));
+    margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -22464,8 +22464,8 @@ video {
 
   .sm\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.625rem * var(--space-x-reverse));
+    margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -22476,8 +22476,8 @@ video {
 
   .sm\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.875rem * var(--space-x-reverse));
+    margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -22496,8 +22496,8 @@ video {
 
   .sm\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(0px * var(--divide-x-reverse));
-    border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(0px * var(--divide-x-reverse));
+    border-left-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
   .sm\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -22508,8 +22508,8 @@ video {
 
   .sm\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(2px * var(--divide-x-reverse));
-    border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(2px * var(--divide-x-reverse));
+    border-left-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
   .sm\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -22520,8 +22520,8 @@ video {
 
   .sm\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(4px * var(--divide-x-reverse));
-    border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(4px * var(--divide-x-reverse));
+    border-left-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
   .sm\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -22532,8 +22532,8 @@ video {
 
   .sm\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(8px * var(--divide-x-reverse));
-    border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(8px * var(--divide-x-reverse));
+    border-left-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
   .sm\:divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -22544,8 +22544,8 @@ video {
 
   .sm\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(1px * var(--divide-x-reverse));
-    border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(1px * var(--divide-x-reverse));
+    border-left-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
   .sm\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -42770,8 +42770,8 @@ video {
 
   .md\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0px * var(--space-x-reverse));
-    margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0px * var(--space-x-reverse));
+    margin-left: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -42782,8 +42782,8 @@ video {
 
   .md\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.25rem * var(--space-x-reverse));
+    margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -42794,8 +42794,8 @@ video {
 
   .md\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.5rem * var(--space-x-reverse));
+    margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -42806,8 +42806,8 @@ video {
 
   .md\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.75rem * var(--space-x-reverse));
+    margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -42818,8 +42818,8 @@ video {
 
   .md\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1rem * var(--space-x-reverse));
-    margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1rem * var(--space-x-reverse));
+    margin-left: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -42830,8 +42830,8 @@ video {
 
   .md\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.25rem * var(--space-x-reverse));
+    margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -42842,8 +42842,8 @@ video {
 
   .md\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.5rem * var(--space-x-reverse));
+    margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -42854,8 +42854,8 @@ video {
 
   .md\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.75rem * var(--space-x-reverse));
+    margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -42866,8 +42866,8 @@ video {
 
   .md\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2rem * var(--space-x-reverse));
-    margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2rem * var(--space-x-reverse));
+    margin-left: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -42878,8 +42878,8 @@ video {
 
   .md\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.25rem * var(--space-x-reverse));
+    margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -42890,8 +42890,8 @@ video {
 
   .md\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.5rem * var(--space-x-reverse));
+    margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -42902,8 +42902,8 @@ video {
 
   .md\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3rem * var(--space-x-reverse));
-    margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3rem * var(--space-x-reverse));
+    margin-left: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -42914,8 +42914,8 @@ video {
 
   .md\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3.5rem * var(--space-x-reverse));
+    margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -42926,8 +42926,8 @@ video {
 
   .md\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(4rem * var(--space-x-reverse));
-    margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(4rem * var(--space-x-reverse));
+    margin-left: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -42938,8 +42938,8 @@ video {
 
   .md\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(5rem * var(--space-x-reverse));
-    margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(5rem * var(--space-x-reverse));
+    margin-left: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -42950,8 +42950,8 @@ video {
 
   .md\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(6rem * var(--space-x-reverse));
-    margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(6rem * var(--space-x-reverse));
+    margin-left: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -42962,8 +42962,8 @@ video {
 
   .md\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(7rem * var(--space-x-reverse));
-    margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(7rem * var(--space-x-reverse));
+    margin-left: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -42974,8 +42974,8 @@ video {
 
   .md\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(8rem * var(--space-x-reverse));
-    margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(8rem * var(--space-x-reverse));
+    margin-left: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -42986,8 +42986,8 @@ video {
 
   .md\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(9rem * var(--space-x-reverse));
-    margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(9rem * var(--space-x-reverse));
+    margin-left: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -42998,8 +42998,8 @@ video {
 
   .md\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(10rem * var(--space-x-reverse));
-    margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(10rem * var(--space-x-reverse));
+    margin-left: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -43010,8 +43010,8 @@ video {
 
   .md\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(11rem * var(--space-x-reverse));
-    margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(11rem * var(--space-x-reverse));
+    margin-left: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -43022,8 +43022,8 @@ video {
 
   .md\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(12rem * var(--space-x-reverse));
-    margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(12rem * var(--space-x-reverse));
+    margin-left: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -43034,8 +43034,8 @@ video {
 
   .md\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(13rem * var(--space-x-reverse));
-    margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(13rem * var(--space-x-reverse));
+    margin-left: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -43046,8 +43046,8 @@ video {
 
   .md\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(14rem * var(--space-x-reverse));
-    margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(14rem * var(--space-x-reverse));
+    margin-left: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -43058,8 +43058,8 @@ video {
 
   .md\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(15rem * var(--space-x-reverse));
-    margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(15rem * var(--space-x-reverse));
+    margin-left: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -43070,8 +43070,8 @@ video {
 
   .md\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(16rem * var(--space-x-reverse));
-    margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(16rem * var(--space-x-reverse));
+    margin-left: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -43082,8 +43082,8 @@ video {
 
   .md\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(18rem * var(--space-x-reverse));
-    margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(18rem * var(--space-x-reverse));
+    margin-left: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -43094,8 +43094,8 @@ video {
 
   .md\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(20rem * var(--space-x-reverse));
-    margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(20rem * var(--space-x-reverse));
+    margin-left: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -43106,8 +43106,8 @@ video {
 
   .md\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(24rem * var(--space-x-reverse));
-    margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(24rem * var(--space-x-reverse));
+    margin-left: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -43118,8 +43118,8 @@ video {
 
   .md\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1px * var(--space-x-reverse));
-    margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1px * var(--space-x-reverse));
+    margin-left: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -43130,8 +43130,8 @@ video {
 
   .md\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.125rem * var(--space-x-reverse));
+    margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -43142,8 +43142,8 @@ video {
 
   .md\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.375rem * var(--space-x-reverse));
+    margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -43154,8 +43154,8 @@ video {
 
   .md\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.625rem * var(--space-x-reverse));
+    margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -43166,8 +43166,8 @@ video {
 
   .md\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.875rem * var(--space-x-reverse));
+    margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -43178,8 +43178,8 @@ video {
 
   .md\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.25rem * var(--space-x-reverse));
+    margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -43190,8 +43190,8 @@ video {
 
   .md\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.5rem * var(--space-x-reverse));
+    margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -43202,8 +43202,8 @@ video {
 
   .md\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.75rem * var(--space-x-reverse));
+    margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -43214,8 +43214,8 @@ video {
 
   .md\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1rem * var(--space-x-reverse));
+    margin-left: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -43226,8 +43226,8 @@ video {
 
   .md\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.25rem * var(--space-x-reverse));
+    margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -43238,8 +43238,8 @@ video {
 
   .md\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.5rem * var(--space-x-reverse));
+    margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -43250,8 +43250,8 @@ video {
 
   .md\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.75rem * var(--space-x-reverse));
+    margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -43262,8 +43262,8 @@ video {
 
   .md\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2rem * var(--space-x-reverse));
+    margin-left: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -43274,8 +43274,8 @@ video {
 
   .md\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.25rem * var(--space-x-reverse));
+    margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -43286,8 +43286,8 @@ video {
 
   .md\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.5rem * var(--space-x-reverse));
+    margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -43298,8 +43298,8 @@ video {
 
   .md\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3rem * var(--space-x-reverse));
+    margin-left: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -43310,8 +43310,8 @@ video {
 
   .md\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3.5rem * var(--space-x-reverse));
+    margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -43322,8 +43322,8 @@ video {
 
   .md\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-4rem * var(--space-x-reverse));
-    margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-4rem * var(--space-x-reverse));
+    margin-left: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -43334,8 +43334,8 @@ video {
 
   .md\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-5rem * var(--space-x-reverse));
+    margin-left: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -43346,8 +43346,8 @@ video {
 
   .md\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-6rem * var(--space-x-reverse));
-    margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-6rem * var(--space-x-reverse));
+    margin-left: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -43358,8 +43358,8 @@ video {
 
   .md\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-7rem * var(--space-x-reverse));
-    margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-7rem * var(--space-x-reverse));
+    margin-left: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -43370,8 +43370,8 @@ video {
 
   .md\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-8rem * var(--space-x-reverse));
-    margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-8rem * var(--space-x-reverse));
+    margin-left: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -43382,8 +43382,8 @@ video {
 
   .md\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-9rem * var(--space-x-reverse));
-    margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-9rem * var(--space-x-reverse));
+    margin-left: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -43394,8 +43394,8 @@ video {
 
   .md\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-10rem * var(--space-x-reverse));
-    margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-10rem * var(--space-x-reverse));
+    margin-left: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -43406,8 +43406,8 @@ video {
 
   .md\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-11rem * var(--space-x-reverse));
-    margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-11rem * var(--space-x-reverse));
+    margin-left: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -43418,8 +43418,8 @@ video {
 
   .md\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-12rem * var(--space-x-reverse));
-    margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-12rem * var(--space-x-reverse));
+    margin-left: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -43430,8 +43430,8 @@ video {
 
   .md\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-13rem * var(--space-x-reverse));
-    margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-13rem * var(--space-x-reverse));
+    margin-left: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -43442,8 +43442,8 @@ video {
 
   .md\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-14rem * var(--space-x-reverse));
-    margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-14rem * var(--space-x-reverse));
+    margin-left: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -43454,8 +43454,8 @@ video {
 
   .md\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-15rem * var(--space-x-reverse));
-    margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-15rem * var(--space-x-reverse));
+    margin-left: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -43466,8 +43466,8 @@ video {
 
   .md\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-16rem * var(--space-x-reverse));
-    margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-16rem * var(--space-x-reverse));
+    margin-left: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -43478,8 +43478,8 @@ video {
 
   .md\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-18rem * var(--space-x-reverse));
-    margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-18rem * var(--space-x-reverse));
+    margin-left: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -43490,8 +43490,8 @@ video {
 
   .md\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-20rem * var(--space-x-reverse));
-    margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-20rem * var(--space-x-reverse));
+    margin-left: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -43502,8 +43502,8 @@ video {
 
   .md\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-24rem * var(--space-x-reverse));
-    margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-24rem * var(--space-x-reverse));
+    margin-left: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -43514,8 +43514,8 @@ video {
 
   .md\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1px * var(--space-x-reverse));
-    margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1px * var(--space-x-reverse));
+    margin-left: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -43526,8 +43526,8 @@ video {
 
   .md\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.125rem * var(--space-x-reverse));
+    margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -43538,8 +43538,8 @@ video {
 
   .md\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.375rem * var(--space-x-reverse));
+    margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -43550,8 +43550,8 @@ video {
 
   .md\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.625rem * var(--space-x-reverse));
+    margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -43562,8 +43562,8 @@ video {
 
   .md\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.875rem * var(--space-x-reverse));
+    margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -43582,8 +43582,8 @@ video {
 
   .md\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(0px * var(--divide-x-reverse));
-    border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(0px * var(--divide-x-reverse));
+    border-left-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
   .md\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -43594,8 +43594,8 @@ video {
 
   .md\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(2px * var(--divide-x-reverse));
-    border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(2px * var(--divide-x-reverse));
+    border-left-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
   .md\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -43606,8 +43606,8 @@ video {
 
   .md\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(4px * var(--divide-x-reverse));
-    border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(4px * var(--divide-x-reverse));
+    border-left-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
   .md\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -43618,8 +43618,8 @@ video {
 
   .md\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(8px * var(--divide-x-reverse));
-    border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(8px * var(--divide-x-reverse));
+    border-left-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
   .md\:divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -43630,8 +43630,8 @@ video {
 
   .md\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(1px * var(--divide-x-reverse));
-    border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(1px * var(--divide-x-reverse));
+    border-left-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
   .md\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -63856,8 +63856,8 @@ video {
 
   .lg\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0px * var(--space-x-reverse));
-    margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0px * var(--space-x-reverse));
+    margin-left: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -63868,8 +63868,8 @@ video {
 
   .lg\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.25rem * var(--space-x-reverse));
+    margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -63880,8 +63880,8 @@ video {
 
   .lg\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.5rem * var(--space-x-reverse));
+    margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -63892,8 +63892,8 @@ video {
 
   .lg\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.75rem * var(--space-x-reverse));
+    margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -63904,8 +63904,8 @@ video {
 
   .lg\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1rem * var(--space-x-reverse));
-    margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1rem * var(--space-x-reverse));
+    margin-left: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -63916,8 +63916,8 @@ video {
 
   .lg\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.25rem * var(--space-x-reverse));
+    margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -63928,8 +63928,8 @@ video {
 
   .lg\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.5rem * var(--space-x-reverse));
+    margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -63940,8 +63940,8 @@ video {
 
   .lg\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.75rem * var(--space-x-reverse));
+    margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -63952,8 +63952,8 @@ video {
 
   .lg\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2rem * var(--space-x-reverse));
-    margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2rem * var(--space-x-reverse));
+    margin-left: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -63964,8 +63964,8 @@ video {
 
   .lg\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.25rem * var(--space-x-reverse));
+    margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -63976,8 +63976,8 @@ video {
 
   .lg\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.5rem * var(--space-x-reverse));
+    margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -63988,8 +63988,8 @@ video {
 
   .lg\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3rem * var(--space-x-reverse));
-    margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3rem * var(--space-x-reverse));
+    margin-left: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -64000,8 +64000,8 @@ video {
 
   .lg\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3.5rem * var(--space-x-reverse));
+    margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -64012,8 +64012,8 @@ video {
 
   .lg\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(4rem * var(--space-x-reverse));
-    margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(4rem * var(--space-x-reverse));
+    margin-left: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -64024,8 +64024,8 @@ video {
 
   .lg\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(5rem * var(--space-x-reverse));
-    margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(5rem * var(--space-x-reverse));
+    margin-left: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -64036,8 +64036,8 @@ video {
 
   .lg\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(6rem * var(--space-x-reverse));
-    margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(6rem * var(--space-x-reverse));
+    margin-left: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -64048,8 +64048,8 @@ video {
 
   .lg\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(7rem * var(--space-x-reverse));
-    margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(7rem * var(--space-x-reverse));
+    margin-left: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -64060,8 +64060,8 @@ video {
 
   .lg\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(8rem * var(--space-x-reverse));
-    margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(8rem * var(--space-x-reverse));
+    margin-left: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -64072,8 +64072,8 @@ video {
 
   .lg\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(9rem * var(--space-x-reverse));
-    margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(9rem * var(--space-x-reverse));
+    margin-left: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -64084,8 +64084,8 @@ video {
 
   .lg\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(10rem * var(--space-x-reverse));
-    margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(10rem * var(--space-x-reverse));
+    margin-left: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -64096,8 +64096,8 @@ video {
 
   .lg\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(11rem * var(--space-x-reverse));
-    margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(11rem * var(--space-x-reverse));
+    margin-left: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -64108,8 +64108,8 @@ video {
 
   .lg\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(12rem * var(--space-x-reverse));
-    margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(12rem * var(--space-x-reverse));
+    margin-left: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -64120,8 +64120,8 @@ video {
 
   .lg\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(13rem * var(--space-x-reverse));
-    margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(13rem * var(--space-x-reverse));
+    margin-left: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -64132,8 +64132,8 @@ video {
 
   .lg\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(14rem * var(--space-x-reverse));
-    margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(14rem * var(--space-x-reverse));
+    margin-left: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -64144,8 +64144,8 @@ video {
 
   .lg\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(15rem * var(--space-x-reverse));
-    margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(15rem * var(--space-x-reverse));
+    margin-left: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -64156,8 +64156,8 @@ video {
 
   .lg\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(16rem * var(--space-x-reverse));
-    margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(16rem * var(--space-x-reverse));
+    margin-left: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -64168,8 +64168,8 @@ video {
 
   .lg\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(18rem * var(--space-x-reverse));
-    margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(18rem * var(--space-x-reverse));
+    margin-left: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -64180,8 +64180,8 @@ video {
 
   .lg\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(20rem * var(--space-x-reverse));
-    margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(20rem * var(--space-x-reverse));
+    margin-left: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -64192,8 +64192,8 @@ video {
 
   .lg\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(24rem * var(--space-x-reverse));
-    margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(24rem * var(--space-x-reverse));
+    margin-left: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -64204,8 +64204,8 @@ video {
 
   .lg\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1px * var(--space-x-reverse));
-    margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1px * var(--space-x-reverse));
+    margin-left: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -64216,8 +64216,8 @@ video {
 
   .lg\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.125rem * var(--space-x-reverse));
+    margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -64228,8 +64228,8 @@ video {
 
   .lg\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.375rem * var(--space-x-reverse));
+    margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -64240,8 +64240,8 @@ video {
 
   .lg\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.625rem * var(--space-x-reverse));
+    margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -64252,8 +64252,8 @@ video {
 
   .lg\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.875rem * var(--space-x-reverse));
+    margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -64264,8 +64264,8 @@ video {
 
   .lg\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.25rem * var(--space-x-reverse));
+    margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -64276,8 +64276,8 @@ video {
 
   .lg\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.5rem * var(--space-x-reverse));
+    margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -64288,8 +64288,8 @@ video {
 
   .lg\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.75rem * var(--space-x-reverse));
+    margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -64300,8 +64300,8 @@ video {
 
   .lg\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1rem * var(--space-x-reverse));
+    margin-left: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -64312,8 +64312,8 @@ video {
 
   .lg\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.25rem * var(--space-x-reverse));
+    margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -64324,8 +64324,8 @@ video {
 
   .lg\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.5rem * var(--space-x-reverse));
+    margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -64336,8 +64336,8 @@ video {
 
   .lg\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.75rem * var(--space-x-reverse));
+    margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -64348,8 +64348,8 @@ video {
 
   .lg\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2rem * var(--space-x-reverse));
+    margin-left: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -64360,8 +64360,8 @@ video {
 
   .lg\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.25rem * var(--space-x-reverse));
+    margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -64372,8 +64372,8 @@ video {
 
   .lg\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.5rem * var(--space-x-reverse));
+    margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -64384,8 +64384,8 @@ video {
 
   .lg\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3rem * var(--space-x-reverse));
+    margin-left: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -64396,8 +64396,8 @@ video {
 
   .lg\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3.5rem * var(--space-x-reverse));
+    margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -64408,8 +64408,8 @@ video {
 
   .lg\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-4rem * var(--space-x-reverse));
-    margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-4rem * var(--space-x-reverse));
+    margin-left: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -64420,8 +64420,8 @@ video {
 
   .lg\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-5rem * var(--space-x-reverse));
+    margin-left: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -64432,8 +64432,8 @@ video {
 
   .lg\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-6rem * var(--space-x-reverse));
-    margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-6rem * var(--space-x-reverse));
+    margin-left: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -64444,8 +64444,8 @@ video {
 
   .lg\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-7rem * var(--space-x-reverse));
-    margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-7rem * var(--space-x-reverse));
+    margin-left: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -64456,8 +64456,8 @@ video {
 
   .lg\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-8rem * var(--space-x-reverse));
-    margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-8rem * var(--space-x-reverse));
+    margin-left: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -64468,8 +64468,8 @@ video {
 
   .lg\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-9rem * var(--space-x-reverse));
-    margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-9rem * var(--space-x-reverse));
+    margin-left: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -64480,8 +64480,8 @@ video {
 
   .lg\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-10rem * var(--space-x-reverse));
-    margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-10rem * var(--space-x-reverse));
+    margin-left: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -64492,8 +64492,8 @@ video {
 
   .lg\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-11rem * var(--space-x-reverse));
-    margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-11rem * var(--space-x-reverse));
+    margin-left: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -64504,8 +64504,8 @@ video {
 
   .lg\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-12rem * var(--space-x-reverse));
-    margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-12rem * var(--space-x-reverse));
+    margin-left: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -64516,8 +64516,8 @@ video {
 
   .lg\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-13rem * var(--space-x-reverse));
-    margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-13rem * var(--space-x-reverse));
+    margin-left: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -64528,8 +64528,8 @@ video {
 
   .lg\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-14rem * var(--space-x-reverse));
-    margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-14rem * var(--space-x-reverse));
+    margin-left: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -64540,8 +64540,8 @@ video {
 
   .lg\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-15rem * var(--space-x-reverse));
-    margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-15rem * var(--space-x-reverse));
+    margin-left: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -64552,8 +64552,8 @@ video {
 
   .lg\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-16rem * var(--space-x-reverse));
-    margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-16rem * var(--space-x-reverse));
+    margin-left: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -64564,8 +64564,8 @@ video {
 
   .lg\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-18rem * var(--space-x-reverse));
-    margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-18rem * var(--space-x-reverse));
+    margin-left: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -64576,8 +64576,8 @@ video {
 
   .lg\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-20rem * var(--space-x-reverse));
-    margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-20rem * var(--space-x-reverse));
+    margin-left: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -64588,8 +64588,8 @@ video {
 
   .lg\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-24rem * var(--space-x-reverse));
-    margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-24rem * var(--space-x-reverse));
+    margin-left: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -64600,8 +64600,8 @@ video {
 
   .lg\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1px * var(--space-x-reverse));
-    margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1px * var(--space-x-reverse));
+    margin-left: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -64612,8 +64612,8 @@ video {
 
   .lg\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.125rem * var(--space-x-reverse));
+    margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -64624,8 +64624,8 @@ video {
 
   .lg\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.375rem * var(--space-x-reverse));
+    margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -64636,8 +64636,8 @@ video {
 
   .lg\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.625rem * var(--space-x-reverse));
+    margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -64648,8 +64648,8 @@ video {
 
   .lg\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.875rem * var(--space-x-reverse));
+    margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -64668,8 +64668,8 @@ video {
 
   .lg\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(0px * var(--divide-x-reverse));
-    border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(0px * var(--divide-x-reverse));
+    border-left-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
   .lg\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -64680,8 +64680,8 @@ video {
 
   .lg\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(2px * var(--divide-x-reverse));
-    border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(2px * var(--divide-x-reverse));
+    border-left-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
   .lg\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -64692,8 +64692,8 @@ video {
 
   .lg\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(4px * var(--divide-x-reverse));
-    border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(4px * var(--divide-x-reverse));
+    border-left-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
   .lg\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -64704,8 +64704,8 @@ video {
 
   .lg\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(8px * var(--divide-x-reverse));
-    border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(8px * var(--divide-x-reverse));
+    border-left-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
   .lg\:divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -64716,8 +64716,8 @@ video {
 
   .lg\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(1px * var(--divide-x-reverse));
-    border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(1px * var(--divide-x-reverse));
+    border-left-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
   .lg\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -84942,8 +84942,8 @@ video {
 
   .xl\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0px * var(--space-x-reverse));
-    margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0px * var(--space-x-reverse));
+    margin-left: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -84954,8 +84954,8 @@ video {
 
   .xl\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.25rem * var(--space-x-reverse));
+    margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -84966,8 +84966,8 @@ video {
 
   .xl\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.5rem * var(--space-x-reverse));
+    margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -84978,8 +84978,8 @@ video {
 
   .xl\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.75rem * var(--space-x-reverse));
+    margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -84990,8 +84990,8 @@ video {
 
   .xl\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1rem * var(--space-x-reverse));
-    margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1rem * var(--space-x-reverse));
+    margin-left: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -85002,8 +85002,8 @@ video {
 
   .xl\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.25rem * var(--space-x-reverse));
+    margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -85014,8 +85014,8 @@ video {
 
   .xl\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.5rem * var(--space-x-reverse));
+    margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -85026,8 +85026,8 @@ video {
 
   .xl\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.75rem * var(--space-x-reverse));
+    margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -85038,8 +85038,8 @@ video {
 
   .xl\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2rem * var(--space-x-reverse));
-    margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2rem * var(--space-x-reverse));
+    margin-left: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -85050,8 +85050,8 @@ video {
 
   .xl\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.25rem * var(--space-x-reverse));
+    margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -85062,8 +85062,8 @@ video {
 
   .xl\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.5rem * var(--space-x-reverse));
+    margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -85074,8 +85074,8 @@ video {
 
   .xl\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3rem * var(--space-x-reverse));
-    margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3rem * var(--space-x-reverse));
+    margin-left: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -85086,8 +85086,8 @@ video {
 
   .xl\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3.5rem * var(--space-x-reverse));
+    margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -85098,8 +85098,8 @@ video {
 
   .xl\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(4rem * var(--space-x-reverse));
-    margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(4rem * var(--space-x-reverse));
+    margin-left: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -85110,8 +85110,8 @@ video {
 
   .xl\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(5rem * var(--space-x-reverse));
-    margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(5rem * var(--space-x-reverse));
+    margin-left: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -85122,8 +85122,8 @@ video {
 
   .xl\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(6rem * var(--space-x-reverse));
-    margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(6rem * var(--space-x-reverse));
+    margin-left: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -85134,8 +85134,8 @@ video {
 
   .xl\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(7rem * var(--space-x-reverse));
-    margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(7rem * var(--space-x-reverse));
+    margin-left: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -85146,8 +85146,8 @@ video {
 
   .xl\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(8rem * var(--space-x-reverse));
-    margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(8rem * var(--space-x-reverse));
+    margin-left: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -85158,8 +85158,8 @@ video {
 
   .xl\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(9rem * var(--space-x-reverse));
-    margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(9rem * var(--space-x-reverse));
+    margin-left: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -85170,8 +85170,8 @@ video {
 
   .xl\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(10rem * var(--space-x-reverse));
-    margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(10rem * var(--space-x-reverse));
+    margin-left: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -85182,8 +85182,8 @@ video {
 
   .xl\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(11rem * var(--space-x-reverse));
-    margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(11rem * var(--space-x-reverse));
+    margin-left: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -85194,8 +85194,8 @@ video {
 
   .xl\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(12rem * var(--space-x-reverse));
-    margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(12rem * var(--space-x-reverse));
+    margin-left: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -85206,8 +85206,8 @@ video {
 
   .xl\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(13rem * var(--space-x-reverse));
-    margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(13rem * var(--space-x-reverse));
+    margin-left: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -85218,8 +85218,8 @@ video {
 
   .xl\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(14rem * var(--space-x-reverse));
-    margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(14rem * var(--space-x-reverse));
+    margin-left: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -85230,8 +85230,8 @@ video {
 
   .xl\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(15rem * var(--space-x-reverse));
-    margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(15rem * var(--space-x-reverse));
+    margin-left: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -85242,8 +85242,8 @@ video {
 
   .xl\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(16rem * var(--space-x-reverse));
-    margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(16rem * var(--space-x-reverse));
+    margin-left: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -85254,8 +85254,8 @@ video {
 
   .xl\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(18rem * var(--space-x-reverse));
-    margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(18rem * var(--space-x-reverse));
+    margin-left: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -85266,8 +85266,8 @@ video {
 
   .xl\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(20rem * var(--space-x-reverse));
-    margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(20rem * var(--space-x-reverse));
+    margin-left: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -85278,8 +85278,8 @@ video {
 
   .xl\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(24rem * var(--space-x-reverse));
-    margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(24rem * var(--space-x-reverse));
+    margin-left: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -85290,8 +85290,8 @@ video {
 
   .xl\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1px * var(--space-x-reverse));
-    margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1px * var(--space-x-reverse));
+    margin-left: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -85302,8 +85302,8 @@ video {
 
   .xl\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.125rem * var(--space-x-reverse));
+    margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -85314,8 +85314,8 @@ video {
 
   .xl\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.375rem * var(--space-x-reverse));
+    margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -85326,8 +85326,8 @@ video {
 
   .xl\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.625rem * var(--space-x-reverse));
+    margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -85338,8 +85338,8 @@ video {
 
   .xl\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.875rem * var(--space-x-reverse));
+    margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -85350,8 +85350,8 @@ video {
 
   .xl\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.25rem * var(--space-x-reverse));
+    margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -85362,8 +85362,8 @@ video {
 
   .xl\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.5rem * var(--space-x-reverse));
+    margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -85374,8 +85374,8 @@ video {
 
   .xl\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.75rem * var(--space-x-reverse));
+    margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -85386,8 +85386,8 @@ video {
 
   .xl\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1rem * var(--space-x-reverse));
+    margin-left: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -85398,8 +85398,8 @@ video {
 
   .xl\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.25rem * var(--space-x-reverse));
+    margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -85410,8 +85410,8 @@ video {
 
   .xl\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.5rem * var(--space-x-reverse));
+    margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -85422,8 +85422,8 @@ video {
 
   .xl\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.75rem * var(--space-x-reverse));
+    margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -85434,8 +85434,8 @@ video {
 
   .xl\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2rem * var(--space-x-reverse));
+    margin-left: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -85446,8 +85446,8 @@ video {
 
   .xl\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.25rem * var(--space-x-reverse));
+    margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -85458,8 +85458,8 @@ video {
 
   .xl\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.5rem * var(--space-x-reverse));
+    margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -85470,8 +85470,8 @@ video {
 
   .xl\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3rem * var(--space-x-reverse));
+    margin-left: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -85482,8 +85482,8 @@ video {
 
   .xl\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3.5rem * var(--space-x-reverse));
+    margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -85494,8 +85494,8 @@ video {
 
   .xl\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-4rem * var(--space-x-reverse));
-    margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-4rem * var(--space-x-reverse));
+    margin-left: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -85506,8 +85506,8 @@ video {
 
   .xl\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-5rem * var(--space-x-reverse));
+    margin-left: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -85518,8 +85518,8 @@ video {
 
   .xl\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-6rem * var(--space-x-reverse));
-    margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-6rem * var(--space-x-reverse));
+    margin-left: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -85530,8 +85530,8 @@ video {
 
   .xl\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-7rem * var(--space-x-reverse));
-    margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-7rem * var(--space-x-reverse));
+    margin-left: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -85542,8 +85542,8 @@ video {
 
   .xl\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-8rem * var(--space-x-reverse));
-    margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-8rem * var(--space-x-reverse));
+    margin-left: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -85554,8 +85554,8 @@ video {
 
   .xl\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-9rem * var(--space-x-reverse));
-    margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-9rem * var(--space-x-reverse));
+    margin-left: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -85566,8 +85566,8 @@ video {
 
   .xl\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-10rem * var(--space-x-reverse));
-    margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-10rem * var(--space-x-reverse));
+    margin-left: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -85578,8 +85578,8 @@ video {
 
   .xl\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-11rem * var(--space-x-reverse));
-    margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-11rem * var(--space-x-reverse));
+    margin-left: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -85590,8 +85590,8 @@ video {
 
   .xl\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-12rem * var(--space-x-reverse));
-    margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-12rem * var(--space-x-reverse));
+    margin-left: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -85602,8 +85602,8 @@ video {
 
   .xl\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-13rem * var(--space-x-reverse));
-    margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-13rem * var(--space-x-reverse));
+    margin-left: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -85614,8 +85614,8 @@ video {
 
   .xl\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-14rem * var(--space-x-reverse));
-    margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-14rem * var(--space-x-reverse));
+    margin-left: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -85626,8 +85626,8 @@ video {
 
   .xl\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-15rem * var(--space-x-reverse));
-    margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-15rem * var(--space-x-reverse));
+    margin-left: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -85638,8 +85638,8 @@ video {
 
   .xl\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-16rem * var(--space-x-reverse));
-    margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-16rem * var(--space-x-reverse));
+    margin-left: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -85650,8 +85650,8 @@ video {
 
   .xl\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-18rem * var(--space-x-reverse));
-    margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-18rem * var(--space-x-reverse));
+    margin-left: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -85662,8 +85662,8 @@ video {
 
   .xl\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-20rem * var(--space-x-reverse));
-    margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-20rem * var(--space-x-reverse));
+    margin-left: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -85674,8 +85674,8 @@ video {
 
   .xl\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-24rem * var(--space-x-reverse));
-    margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-24rem * var(--space-x-reverse));
+    margin-left: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -85686,8 +85686,8 @@ video {
 
   .xl\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1px * var(--space-x-reverse));
-    margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1px * var(--space-x-reverse));
+    margin-left: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -85698,8 +85698,8 @@ video {
 
   .xl\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.125rem * var(--space-x-reverse));
+    margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -85710,8 +85710,8 @@ video {
 
   .xl\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.375rem * var(--space-x-reverse));
+    margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -85722,8 +85722,8 @@ video {
 
   .xl\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.625rem * var(--space-x-reverse));
+    margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -85734,8 +85734,8 @@ video {
 
   .xl\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.875rem * var(--space-x-reverse));
+    margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -85754,8 +85754,8 @@ video {
 
   .xl\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(0px * var(--divide-x-reverse));
-    border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(0px * var(--divide-x-reverse));
+    border-left-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
   .xl\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -85766,8 +85766,8 @@ video {
 
   .xl\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(2px * var(--divide-x-reverse));
-    border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(2px * var(--divide-x-reverse));
+    border-left-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
   .xl\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -85778,8 +85778,8 @@ video {
 
   .xl\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(4px * var(--divide-x-reverse));
-    border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(4px * var(--divide-x-reverse));
+    border-left-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
   .xl\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -85790,8 +85790,8 @@ video {
 
   .xl\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(8px * var(--divide-x-reverse));
-    border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(8px * var(--divide-x-reverse));
+    border-left-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
   .xl\:divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -85802,8 +85802,8 @@ video {
 
   .xl\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(1px * var(--divide-x-reverse));
-    border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(1px * var(--divide-x-reverse));
+    border-left-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
   .xl\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -106028,8 +106028,8 @@ video {
 
   .\32xl\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0px * var(--space-x-reverse));
-    margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0px * var(--space-x-reverse));
+    margin-left: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -106040,8 +106040,8 @@ video {
 
   .\32xl\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.25rem * var(--space-x-reverse));
+    margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -106052,8 +106052,8 @@ video {
 
   .\32xl\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.5rem * var(--space-x-reverse));
+    margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -106064,8 +106064,8 @@ video {
 
   .\32xl\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.75rem * var(--space-x-reverse));
+    margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -106076,8 +106076,8 @@ video {
 
   .\32xl\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1rem * var(--space-x-reverse));
-    margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1rem * var(--space-x-reverse));
+    margin-left: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -106088,8 +106088,8 @@ video {
 
   .\32xl\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.25rem * var(--space-x-reverse));
+    margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -106100,8 +106100,8 @@ video {
 
   .\32xl\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.5rem * var(--space-x-reverse));
+    margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -106112,8 +106112,8 @@ video {
 
   .\32xl\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.75rem * var(--space-x-reverse));
+    margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -106124,8 +106124,8 @@ video {
 
   .\32xl\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2rem * var(--space-x-reverse));
-    margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2rem * var(--space-x-reverse));
+    margin-left: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -106136,8 +106136,8 @@ video {
 
   .\32xl\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.25rem * var(--space-x-reverse));
+    margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -106148,8 +106148,8 @@ video {
 
   .\32xl\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.5rem * var(--space-x-reverse));
+    margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -106160,8 +106160,8 @@ video {
 
   .\32xl\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3rem * var(--space-x-reverse));
-    margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3rem * var(--space-x-reverse));
+    margin-left: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -106172,8 +106172,8 @@ video {
 
   .\32xl\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3.5rem * var(--space-x-reverse));
+    margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -106184,8 +106184,8 @@ video {
 
   .\32xl\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(4rem * var(--space-x-reverse));
-    margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(4rem * var(--space-x-reverse));
+    margin-left: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -106196,8 +106196,8 @@ video {
 
   .\32xl\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(5rem * var(--space-x-reverse));
-    margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(5rem * var(--space-x-reverse));
+    margin-left: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -106208,8 +106208,8 @@ video {
 
   .\32xl\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(6rem * var(--space-x-reverse));
-    margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(6rem * var(--space-x-reverse));
+    margin-left: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -106220,8 +106220,8 @@ video {
 
   .\32xl\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(7rem * var(--space-x-reverse));
-    margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(7rem * var(--space-x-reverse));
+    margin-left: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -106232,8 +106232,8 @@ video {
 
   .\32xl\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(8rem * var(--space-x-reverse));
-    margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(8rem * var(--space-x-reverse));
+    margin-left: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -106244,8 +106244,8 @@ video {
 
   .\32xl\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(9rem * var(--space-x-reverse));
-    margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(9rem * var(--space-x-reverse));
+    margin-left: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -106256,8 +106256,8 @@ video {
 
   .\32xl\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(10rem * var(--space-x-reverse));
-    margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(10rem * var(--space-x-reverse));
+    margin-left: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -106268,8 +106268,8 @@ video {
 
   .\32xl\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(11rem * var(--space-x-reverse));
-    margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(11rem * var(--space-x-reverse));
+    margin-left: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -106280,8 +106280,8 @@ video {
 
   .\32xl\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(12rem * var(--space-x-reverse));
-    margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(12rem * var(--space-x-reverse));
+    margin-left: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -106292,8 +106292,8 @@ video {
 
   .\32xl\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(13rem * var(--space-x-reverse));
-    margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(13rem * var(--space-x-reverse));
+    margin-left: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -106304,8 +106304,8 @@ video {
 
   .\32xl\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(14rem * var(--space-x-reverse));
-    margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(14rem * var(--space-x-reverse));
+    margin-left: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -106316,8 +106316,8 @@ video {
 
   .\32xl\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(15rem * var(--space-x-reverse));
-    margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(15rem * var(--space-x-reverse));
+    margin-left: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -106328,8 +106328,8 @@ video {
 
   .\32xl\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(16rem * var(--space-x-reverse));
-    margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(16rem * var(--space-x-reverse));
+    margin-left: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -106340,8 +106340,8 @@ video {
 
   .\32xl\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(18rem * var(--space-x-reverse));
-    margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(18rem * var(--space-x-reverse));
+    margin-left: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -106352,8 +106352,8 @@ video {
 
   .\32xl\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(20rem * var(--space-x-reverse));
-    margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(20rem * var(--space-x-reverse));
+    margin-left: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -106364,8 +106364,8 @@ video {
 
   .\32xl\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(24rem * var(--space-x-reverse));
-    margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(24rem * var(--space-x-reverse));
+    margin-left: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -106376,8 +106376,8 @@ video {
 
   .\32xl\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1px * var(--space-x-reverse));
-    margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1px * var(--space-x-reverse));
+    margin-left: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -106388,8 +106388,8 @@ video {
 
   .\32xl\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.125rem * var(--space-x-reverse));
+    margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -106400,8 +106400,8 @@ video {
 
   .\32xl\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.375rem * var(--space-x-reverse));
+    margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -106412,8 +106412,8 @@ video {
 
   .\32xl\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.625rem * var(--space-x-reverse));
+    margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -106424,8 +106424,8 @@ video {
 
   .\32xl\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.875rem * var(--space-x-reverse));
+    margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -106436,8 +106436,8 @@ video {
 
   .\32xl\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.25rem * var(--space-x-reverse));
+    margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -106448,8 +106448,8 @@ video {
 
   .\32xl\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.5rem * var(--space-x-reverse));
+    margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -106460,8 +106460,8 @@ video {
 
   .\32xl\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.75rem * var(--space-x-reverse));
+    margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -106472,8 +106472,8 @@ video {
 
   .\32xl\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1rem * var(--space-x-reverse));
+    margin-left: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -106484,8 +106484,8 @@ video {
 
   .\32xl\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.25rem * var(--space-x-reverse));
+    margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -106496,8 +106496,8 @@ video {
 
   .\32xl\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.5rem * var(--space-x-reverse));
+    margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -106508,8 +106508,8 @@ video {
 
   .\32xl\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.75rem * var(--space-x-reverse));
+    margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -106520,8 +106520,8 @@ video {
 
   .\32xl\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2rem * var(--space-x-reverse));
+    margin-left: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -106532,8 +106532,8 @@ video {
 
   .\32xl\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.25rem * var(--space-x-reverse));
+    margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -106544,8 +106544,8 @@ video {
 
   .\32xl\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.5rem * var(--space-x-reverse));
+    margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -106556,8 +106556,8 @@ video {
 
   .\32xl\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3rem * var(--space-x-reverse));
+    margin-left: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -106568,8 +106568,8 @@ video {
 
   .\32xl\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3.5rem * var(--space-x-reverse));
+    margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -106580,8 +106580,8 @@ video {
 
   .\32xl\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-4rem * var(--space-x-reverse));
-    margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-4rem * var(--space-x-reverse));
+    margin-left: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -106592,8 +106592,8 @@ video {
 
   .\32xl\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-5rem * var(--space-x-reverse));
+    margin-left: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -106604,8 +106604,8 @@ video {
 
   .\32xl\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-6rem * var(--space-x-reverse));
-    margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-6rem * var(--space-x-reverse));
+    margin-left: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -106616,8 +106616,8 @@ video {
 
   .\32xl\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-7rem * var(--space-x-reverse));
-    margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-7rem * var(--space-x-reverse));
+    margin-left: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -106628,8 +106628,8 @@ video {
 
   .\32xl\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-8rem * var(--space-x-reverse));
-    margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-8rem * var(--space-x-reverse));
+    margin-left: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -106640,8 +106640,8 @@ video {
 
   .\32xl\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-9rem * var(--space-x-reverse));
-    margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-9rem * var(--space-x-reverse));
+    margin-left: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -106652,8 +106652,8 @@ video {
 
   .\32xl\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-10rem * var(--space-x-reverse));
-    margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-10rem * var(--space-x-reverse));
+    margin-left: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -106664,8 +106664,8 @@ video {
 
   .\32xl\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-11rem * var(--space-x-reverse));
-    margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-11rem * var(--space-x-reverse));
+    margin-left: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -106676,8 +106676,8 @@ video {
 
   .\32xl\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-12rem * var(--space-x-reverse));
-    margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-12rem * var(--space-x-reverse));
+    margin-left: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -106688,8 +106688,8 @@ video {
 
   .\32xl\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-13rem * var(--space-x-reverse));
-    margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-13rem * var(--space-x-reverse));
+    margin-left: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -106700,8 +106700,8 @@ video {
 
   .\32xl\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-14rem * var(--space-x-reverse));
-    margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-14rem * var(--space-x-reverse));
+    margin-left: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -106712,8 +106712,8 @@ video {
 
   .\32xl\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-15rem * var(--space-x-reverse));
-    margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-15rem * var(--space-x-reverse));
+    margin-left: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -106724,8 +106724,8 @@ video {
 
   .\32xl\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-16rem * var(--space-x-reverse));
-    margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-16rem * var(--space-x-reverse));
+    margin-left: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -106736,8 +106736,8 @@ video {
 
   .\32xl\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-18rem * var(--space-x-reverse));
-    margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-18rem * var(--space-x-reverse));
+    margin-left: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -106748,8 +106748,8 @@ video {
 
   .\32xl\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-20rem * var(--space-x-reverse));
-    margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-20rem * var(--space-x-reverse));
+    margin-left: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -106760,8 +106760,8 @@ video {
 
   .\32xl\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-24rem * var(--space-x-reverse));
-    margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-24rem * var(--space-x-reverse));
+    margin-left: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -106772,8 +106772,8 @@ video {
 
   .\32xl\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1px * var(--space-x-reverse));
-    margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1px * var(--space-x-reverse));
+    margin-left: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -106784,8 +106784,8 @@ video {
 
   .\32xl\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.125rem * var(--space-x-reverse));
+    margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -106796,8 +106796,8 @@ video {
 
   .\32xl\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.375rem * var(--space-x-reverse));
+    margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -106808,8 +106808,8 @@ video {
 
   .\32xl\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.625rem * var(--space-x-reverse));
+    margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -106820,8 +106820,8 @@ video {
 
   .\32xl\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.875rem * var(--space-x-reverse));
+    margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -106840,8 +106840,8 @@ video {
 
   .\32xl\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(0px * var(--divide-x-reverse));
-    border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(0px * var(--divide-x-reverse));
+    border-left-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
   .\32xl\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -106852,8 +106852,8 @@ video {
 
   .\32xl\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(2px * var(--divide-x-reverse));
-    border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(2px * var(--divide-x-reverse));
+    border-left-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
   .\32xl\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -106864,8 +106864,8 @@ video {
 
   .\32xl\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(4px * var(--divide-x-reverse));
-    border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(4px * var(--divide-x-reverse));
+    border-left-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
   .\32xl\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -106876,8 +106876,8 @@ video {
 
   .\32xl\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(8px * var(--divide-x-reverse));
-    border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(8px * var(--divide-x-reverse));
+    border-left-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
   .\32xl\:divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -106888,8 +106888,8 @@ video {
 
   .\32xl\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(1px * var(--divide-x-reverse));
-    border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(1px * var(--divide-x-reverse));
+    border-left-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
   .\32xl\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -568,8 +568,8 @@ video {
 
 .space-x-0 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0px * var(--space-x-reverse));
-  margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0px * var(--space-x-reverse));
+  margin-left: calc(0px * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -580,8 +580,8 @@ video {
 
 .space-x-1 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0.25rem * var(--space-x-reverse));
-  margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0.25rem * var(--space-x-reverse));
+  margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -592,8 +592,8 @@ video {
 
 .space-x-2 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0.5rem * var(--space-x-reverse));
+  margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -604,8 +604,8 @@ video {
 
 .space-x-3 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0.75rem * var(--space-x-reverse));
-  margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0.75rem * var(--space-x-reverse));
+  margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -616,8 +616,8 @@ video {
 
 .space-x-4 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(1rem * var(--space-x-reverse));
-  margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(1rem * var(--space-x-reverse));
+  margin-left: calc(1rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -628,8 +628,8 @@ video {
 
 .space-x-5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(1.25rem * var(--space-x-reverse));
-  margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(1.25rem * var(--space-x-reverse));
+  margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -640,8 +640,8 @@ video {
 
 .space-x-6 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(1.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(1.5rem * var(--space-x-reverse));
+  margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -652,8 +652,8 @@ video {
 
 .space-x-7 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(1.75rem * var(--space-x-reverse));
-  margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(1.75rem * var(--space-x-reverse));
+  margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -664,8 +664,8 @@ video {
 
 .space-x-8 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(2rem * var(--space-x-reverse));
-  margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(2rem * var(--space-x-reverse));
+  margin-left: calc(2rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -676,8 +676,8 @@ video {
 
 .space-x-9 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(2.25rem * var(--space-x-reverse));
-  margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(2.25rem * var(--space-x-reverse));
+  margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -688,8 +688,8 @@ video {
 
 .space-x-10 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(2.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(2.5rem * var(--space-x-reverse));
+  margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -700,8 +700,8 @@ video {
 
 .space-x-12 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(3rem * var(--space-x-reverse));
-  margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(3rem * var(--space-x-reverse));
+  margin-left: calc(3rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -712,8 +712,8 @@ video {
 
 .space-x-14 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(3.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(3.5rem * var(--space-x-reverse));
+  margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -724,8 +724,8 @@ video {
 
 .space-x-16 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(4rem * var(--space-x-reverse));
-  margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(4rem * var(--space-x-reverse));
+  margin-left: calc(4rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -736,8 +736,8 @@ video {
 
 .space-x-20 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(5rem * var(--space-x-reverse));
-  margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(5rem * var(--space-x-reverse));
+  margin-left: calc(5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -748,8 +748,8 @@ video {
 
 .space-x-24 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(6rem * var(--space-x-reverse));
-  margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(6rem * var(--space-x-reverse));
+  margin-left: calc(6rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -760,8 +760,8 @@ video {
 
 .space-x-28 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(7rem * var(--space-x-reverse));
-  margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(7rem * var(--space-x-reverse));
+  margin-left: calc(7rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -772,8 +772,8 @@ video {
 
 .space-x-32 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(8rem * var(--space-x-reverse));
-  margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(8rem * var(--space-x-reverse));
+  margin-left: calc(8rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -784,8 +784,8 @@ video {
 
 .space-x-36 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(9rem * var(--space-x-reverse));
-  margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(9rem * var(--space-x-reverse));
+  margin-left: calc(9rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -796,8 +796,8 @@ video {
 
 .space-x-40 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(10rem * var(--space-x-reverse));
-  margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(10rem * var(--space-x-reverse));
+  margin-left: calc(10rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -808,8 +808,8 @@ video {
 
 .space-x-44 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(11rem * var(--space-x-reverse));
-  margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(11rem * var(--space-x-reverse));
+  margin-left: calc(11rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -820,8 +820,8 @@ video {
 
 .space-x-48 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(12rem * var(--space-x-reverse));
-  margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(12rem * var(--space-x-reverse));
+  margin-left: calc(12rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -832,8 +832,8 @@ video {
 
 .space-x-52 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(13rem * var(--space-x-reverse));
-  margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(13rem * var(--space-x-reverse));
+  margin-left: calc(13rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -844,8 +844,8 @@ video {
 
 .space-x-56 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(14rem * var(--space-x-reverse));
-  margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(14rem * var(--space-x-reverse));
+  margin-left: calc(14rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -856,8 +856,8 @@ video {
 
 .space-x-60 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(15rem * var(--space-x-reverse));
-  margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(15rem * var(--space-x-reverse));
+  margin-left: calc(15rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -868,8 +868,8 @@ video {
 
 .space-x-64 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(16rem * var(--space-x-reverse));
-  margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(16rem * var(--space-x-reverse));
+  margin-left: calc(16rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -880,8 +880,8 @@ video {
 
 .space-x-72 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(18rem * var(--space-x-reverse));
-  margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(18rem * var(--space-x-reverse));
+  margin-left: calc(18rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -892,8 +892,8 @@ video {
 
 .space-x-80 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(20rem * var(--space-x-reverse));
-  margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(20rem * var(--space-x-reverse));
+  margin-left: calc(20rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -904,8 +904,8 @@ video {
 
 .space-x-96 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(24rem * var(--space-x-reverse));
-  margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(24rem * var(--space-x-reverse));
+  margin-left: calc(24rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -916,8 +916,8 @@ video {
 
 .space-x-px > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(1px * var(--space-x-reverse));
-  margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(1px * var(--space-x-reverse));
+  margin-left: calc(1px * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -928,8 +928,8 @@ video {
 
 .space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0.125rem * var(--space-x-reverse));
-  margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0.125rem * var(--space-x-reverse));
+  margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -940,8 +940,8 @@ video {
 
 .space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0.375rem * var(--space-x-reverse));
-  margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0.375rem * var(--space-x-reverse));
+  margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -952,8 +952,8 @@ video {
 
 .space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0.625rem * var(--space-x-reverse));
-  margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0.625rem * var(--space-x-reverse));
+  margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -964,8 +964,8 @@ video {
 
 .space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(0.875rem * var(--space-x-reverse));
-  margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(0.875rem * var(--space-x-reverse));
+  margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -976,8 +976,8 @@ video {
 
 .-space-x-1 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
-  margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-0.25rem * var(--space-x-reverse));
+  margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -988,8 +988,8 @@ video {
 
 .-space-x-2 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-0.5rem * var(--space-x-reverse));
+  margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -1000,8 +1000,8 @@ video {
 
 .-space-x-3 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
-  margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-0.75rem * var(--space-x-reverse));
+  margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -1012,8 +1012,8 @@ video {
 
 .-space-x-4 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-1rem * var(--space-x-reverse));
-  margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-1rem * var(--space-x-reverse));
+  margin-left: calc(-1rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -1024,8 +1024,8 @@ video {
 
 .-space-x-5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
-  margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-1.25rem * var(--space-x-reverse));
+  margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -1036,8 +1036,8 @@ video {
 
 .-space-x-6 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-1.5rem * var(--space-x-reverse));
+  margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -1048,8 +1048,8 @@ video {
 
 .-space-x-7 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
-  margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-1.75rem * var(--space-x-reverse));
+  margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -1060,8 +1060,8 @@ video {
 
 .-space-x-8 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-2rem * var(--space-x-reverse));
-  margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-2rem * var(--space-x-reverse));
+  margin-left: calc(-2rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -1072,8 +1072,8 @@ video {
 
 .-space-x-9 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
-  margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-2.25rem * var(--space-x-reverse));
+  margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -1084,8 +1084,8 @@ video {
 
 .-space-x-10 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-2.5rem * var(--space-x-reverse));
+  margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -1096,8 +1096,8 @@ video {
 
 .-space-x-12 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-3rem * var(--space-x-reverse));
-  margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-3rem * var(--space-x-reverse));
+  margin-left: calc(-3rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -1108,8 +1108,8 @@ video {
 
 .-space-x-14 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
-  margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-3.5rem * var(--space-x-reverse));
+  margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -1120,8 +1120,8 @@ video {
 
 .-space-x-16 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-4rem * var(--space-x-reverse));
-  margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-4rem * var(--space-x-reverse));
+  margin-left: calc(-4rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -1132,8 +1132,8 @@ video {
 
 .-space-x-20 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-5rem * var(--space-x-reverse));
-  margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-5rem * var(--space-x-reverse));
+  margin-left: calc(-5rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -1144,8 +1144,8 @@ video {
 
 .-space-x-24 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-6rem * var(--space-x-reverse));
-  margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-6rem * var(--space-x-reverse));
+  margin-left: calc(-6rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -1156,8 +1156,8 @@ video {
 
 .-space-x-28 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-7rem * var(--space-x-reverse));
-  margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-7rem * var(--space-x-reverse));
+  margin-left: calc(-7rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -1168,8 +1168,8 @@ video {
 
 .-space-x-32 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-8rem * var(--space-x-reverse));
-  margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-8rem * var(--space-x-reverse));
+  margin-left: calc(-8rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -1180,8 +1180,8 @@ video {
 
 .-space-x-36 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-9rem * var(--space-x-reverse));
-  margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-9rem * var(--space-x-reverse));
+  margin-left: calc(-9rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -1192,8 +1192,8 @@ video {
 
 .-space-x-40 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-10rem * var(--space-x-reverse));
-  margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-10rem * var(--space-x-reverse));
+  margin-left: calc(-10rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -1204,8 +1204,8 @@ video {
 
 .-space-x-44 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-11rem * var(--space-x-reverse));
-  margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-11rem * var(--space-x-reverse));
+  margin-left: calc(-11rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -1216,8 +1216,8 @@ video {
 
 .-space-x-48 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-12rem * var(--space-x-reverse));
-  margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-12rem * var(--space-x-reverse));
+  margin-left: calc(-12rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -1228,8 +1228,8 @@ video {
 
 .-space-x-52 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-13rem * var(--space-x-reverse));
-  margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-13rem * var(--space-x-reverse));
+  margin-left: calc(-13rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -1240,8 +1240,8 @@ video {
 
 .-space-x-56 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-14rem * var(--space-x-reverse));
-  margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-14rem * var(--space-x-reverse));
+  margin-left: calc(-14rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -1252,8 +1252,8 @@ video {
 
 .-space-x-60 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-15rem * var(--space-x-reverse));
-  margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-15rem * var(--space-x-reverse));
+  margin-left: calc(-15rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -1264,8 +1264,8 @@ video {
 
 .-space-x-64 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-16rem * var(--space-x-reverse));
-  margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-16rem * var(--space-x-reverse));
+  margin-left: calc(-16rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -1276,8 +1276,8 @@ video {
 
 .-space-x-72 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-18rem * var(--space-x-reverse));
-  margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-18rem * var(--space-x-reverse));
+  margin-left: calc(-18rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -1288,8 +1288,8 @@ video {
 
 .-space-x-80 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-20rem * var(--space-x-reverse));
-  margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-20rem * var(--space-x-reverse));
+  margin-left: calc(-20rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -1300,8 +1300,8 @@ video {
 
 .-space-x-96 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-24rem * var(--space-x-reverse));
-  margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-24rem * var(--space-x-reverse));
+  margin-left: calc(-24rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -1312,8 +1312,8 @@ video {
 
 .-space-x-px > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-1px * var(--space-x-reverse));
-  margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-1px * var(--space-x-reverse));
+  margin-left: calc(-1px * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -1324,8 +1324,8 @@ video {
 
 .-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
-  margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-0.125rem * var(--space-x-reverse));
+  margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -1336,8 +1336,8 @@ video {
 
 .-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
-  margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-0.375rem * var(--space-x-reverse));
+  margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -1348,8 +1348,8 @@ video {
 
 .-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
-  margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-0.625rem * var(--space-x-reverse));
+  margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
 }
 
 .-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -1360,8 +1360,8 @@ video {
 
 .-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
   --space-x-reverse: 0;
-  margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
-  margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
+  margin-right: calc(-0.875rem * var(--space-x-reverse));
+  margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
 }
 
 .space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -1380,8 +1380,8 @@ video {
 
 .divide-x-0 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
-  border-inline-end-width: calc(0px * var(--divide-x-reverse));
-  border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
+  border-right-width: calc(0px * var(--divide-x-reverse));
+  border-left-width: calc(0px * calc(1 - var(--divide-x-reverse)));
 }
 
 .divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -1392,8 +1392,8 @@ video {
 
 .divide-x-2 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
-  border-inline-end-width: calc(2px * var(--divide-x-reverse));
-  border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
+  border-right-width: calc(2px * var(--divide-x-reverse));
+  border-left-width: calc(2px * calc(1 - var(--divide-x-reverse)));
 }
 
 .divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -1404,8 +1404,8 @@ video {
 
 .divide-x-4 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
-  border-inline-end-width: calc(4px * var(--divide-x-reverse));
-  border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
+  border-right-width: calc(4px * var(--divide-x-reverse));
+  border-left-width: calc(4px * calc(1 - var(--divide-x-reverse)));
 }
 
 .divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -1416,8 +1416,8 @@ video {
 
 .divide-x-8 > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
-  border-inline-end-width: calc(8px * var(--divide-x-reverse));
-  border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
+  border-right-width: calc(8px * var(--divide-x-reverse));
+  border-left-width: calc(8px * calc(1 - var(--divide-x-reverse)));
 }
 
 .divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -1428,8 +1428,8 @@ video {
 
 .divide-x > :not([hidden]) ~ :not([hidden]) {
   --divide-x-reverse: 0;
-  border-inline-end-width: calc(1px * var(--divide-x-reverse));
-  border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
+  border-right-width: calc(1px * var(--divide-x-reverse));
+  border-left-width: calc(1px * calc(1 - var(--divide-x-reverse)));
 }
 
 .divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -23544,8 +23544,8 @@ video {
 
   .sm\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0px * var(--space-x-reverse));
-    margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0px * var(--space-x-reverse));
+    margin-left: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -23556,8 +23556,8 @@ video {
 
   .sm\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.25rem * var(--space-x-reverse));
+    margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -23568,8 +23568,8 @@ video {
 
   .sm\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.5rem * var(--space-x-reverse));
+    margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -23580,8 +23580,8 @@ video {
 
   .sm\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.75rem * var(--space-x-reverse));
+    margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -23592,8 +23592,8 @@ video {
 
   .sm\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1rem * var(--space-x-reverse));
-    margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1rem * var(--space-x-reverse));
+    margin-left: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -23604,8 +23604,8 @@ video {
 
   .sm\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.25rem * var(--space-x-reverse));
+    margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -23616,8 +23616,8 @@ video {
 
   .sm\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.5rem * var(--space-x-reverse));
+    margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -23628,8 +23628,8 @@ video {
 
   .sm\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.75rem * var(--space-x-reverse));
+    margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -23640,8 +23640,8 @@ video {
 
   .sm\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2rem * var(--space-x-reverse));
-    margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2rem * var(--space-x-reverse));
+    margin-left: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -23652,8 +23652,8 @@ video {
 
   .sm\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.25rem * var(--space-x-reverse));
+    margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -23664,8 +23664,8 @@ video {
 
   .sm\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.5rem * var(--space-x-reverse));
+    margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -23676,8 +23676,8 @@ video {
 
   .sm\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3rem * var(--space-x-reverse));
-    margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3rem * var(--space-x-reverse));
+    margin-left: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -23688,8 +23688,8 @@ video {
 
   .sm\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3.5rem * var(--space-x-reverse));
+    margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -23700,8 +23700,8 @@ video {
 
   .sm\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(4rem * var(--space-x-reverse));
-    margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(4rem * var(--space-x-reverse));
+    margin-left: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -23712,8 +23712,8 @@ video {
 
   .sm\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(5rem * var(--space-x-reverse));
-    margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(5rem * var(--space-x-reverse));
+    margin-left: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -23724,8 +23724,8 @@ video {
 
   .sm\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(6rem * var(--space-x-reverse));
-    margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(6rem * var(--space-x-reverse));
+    margin-left: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -23736,8 +23736,8 @@ video {
 
   .sm\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(7rem * var(--space-x-reverse));
-    margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(7rem * var(--space-x-reverse));
+    margin-left: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -23748,8 +23748,8 @@ video {
 
   .sm\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(8rem * var(--space-x-reverse));
-    margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(8rem * var(--space-x-reverse));
+    margin-left: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -23760,8 +23760,8 @@ video {
 
   .sm\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(9rem * var(--space-x-reverse));
-    margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(9rem * var(--space-x-reverse));
+    margin-left: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -23772,8 +23772,8 @@ video {
 
   .sm\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(10rem * var(--space-x-reverse));
-    margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(10rem * var(--space-x-reverse));
+    margin-left: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -23784,8 +23784,8 @@ video {
 
   .sm\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(11rem * var(--space-x-reverse));
-    margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(11rem * var(--space-x-reverse));
+    margin-left: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -23796,8 +23796,8 @@ video {
 
   .sm\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(12rem * var(--space-x-reverse));
-    margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(12rem * var(--space-x-reverse));
+    margin-left: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -23808,8 +23808,8 @@ video {
 
   .sm\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(13rem * var(--space-x-reverse));
-    margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(13rem * var(--space-x-reverse));
+    margin-left: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -23820,8 +23820,8 @@ video {
 
   .sm\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(14rem * var(--space-x-reverse));
-    margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(14rem * var(--space-x-reverse));
+    margin-left: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -23832,8 +23832,8 @@ video {
 
   .sm\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(15rem * var(--space-x-reverse));
-    margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(15rem * var(--space-x-reverse));
+    margin-left: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -23844,8 +23844,8 @@ video {
 
   .sm\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(16rem * var(--space-x-reverse));
-    margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(16rem * var(--space-x-reverse));
+    margin-left: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -23856,8 +23856,8 @@ video {
 
   .sm\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(18rem * var(--space-x-reverse));
-    margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(18rem * var(--space-x-reverse));
+    margin-left: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -23868,8 +23868,8 @@ video {
 
   .sm\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(20rem * var(--space-x-reverse));
-    margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(20rem * var(--space-x-reverse));
+    margin-left: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -23880,8 +23880,8 @@ video {
 
   .sm\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(24rem * var(--space-x-reverse));
-    margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(24rem * var(--space-x-reverse));
+    margin-left: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -23892,8 +23892,8 @@ video {
 
   .sm\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1px * var(--space-x-reverse));
-    margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1px * var(--space-x-reverse));
+    margin-left: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -23904,8 +23904,8 @@ video {
 
   .sm\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.125rem * var(--space-x-reverse));
+    margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -23916,8 +23916,8 @@ video {
 
   .sm\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.375rem * var(--space-x-reverse));
+    margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -23928,8 +23928,8 @@ video {
 
   .sm\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.625rem * var(--space-x-reverse));
+    margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -23940,8 +23940,8 @@ video {
 
   .sm\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.875rem * var(--space-x-reverse));
+    margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -23952,8 +23952,8 @@ video {
 
   .sm\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.25rem * var(--space-x-reverse));
+    margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -23964,8 +23964,8 @@ video {
 
   .sm\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.5rem * var(--space-x-reverse));
+    margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -23976,8 +23976,8 @@ video {
 
   .sm\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.75rem * var(--space-x-reverse));
+    margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -23988,8 +23988,8 @@ video {
 
   .sm\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1rem * var(--space-x-reverse));
+    margin-left: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -24000,8 +24000,8 @@ video {
 
   .sm\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.25rem * var(--space-x-reverse));
+    margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -24012,8 +24012,8 @@ video {
 
   .sm\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.5rem * var(--space-x-reverse));
+    margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -24024,8 +24024,8 @@ video {
 
   .sm\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.75rem * var(--space-x-reverse));
+    margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -24036,8 +24036,8 @@ video {
 
   .sm\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2rem * var(--space-x-reverse));
+    margin-left: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -24048,8 +24048,8 @@ video {
 
   .sm\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.25rem * var(--space-x-reverse));
+    margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -24060,8 +24060,8 @@ video {
 
   .sm\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.5rem * var(--space-x-reverse));
+    margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -24072,8 +24072,8 @@ video {
 
   .sm\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3rem * var(--space-x-reverse));
+    margin-left: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -24084,8 +24084,8 @@ video {
 
   .sm\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3.5rem * var(--space-x-reverse));
+    margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -24096,8 +24096,8 @@ video {
 
   .sm\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-4rem * var(--space-x-reverse));
-    margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-4rem * var(--space-x-reverse));
+    margin-left: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -24108,8 +24108,8 @@ video {
 
   .sm\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-5rem * var(--space-x-reverse));
+    margin-left: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -24120,8 +24120,8 @@ video {
 
   .sm\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-6rem * var(--space-x-reverse));
-    margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-6rem * var(--space-x-reverse));
+    margin-left: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -24132,8 +24132,8 @@ video {
 
   .sm\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-7rem * var(--space-x-reverse));
-    margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-7rem * var(--space-x-reverse));
+    margin-left: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -24144,8 +24144,8 @@ video {
 
   .sm\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-8rem * var(--space-x-reverse));
-    margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-8rem * var(--space-x-reverse));
+    margin-left: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -24156,8 +24156,8 @@ video {
 
   .sm\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-9rem * var(--space-x-reverse));
-    margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-9rem * var(--space-x-reverse));
+    margin-left: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -24168,8 +24168,8 @@ video {
 
   .sm\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-10rem * var(--space-x-reverse));
-    margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-10rem * var(--space-x-reverse));
+    margin-left: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -24180,8 +24180,8 @@ video {
 
   .sm\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-11rem * var(--space-x-reverse));
-    margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-11rem * var(--space-x-reverse));
+    margin-left: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -24192,8 +24192,8 @@ video {
 
   .sm\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-12rem * var(--space-x-reverse));
-    margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-12rem * var(--space-x-reverse));
+    margin-left: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -24204,8 +24204,8 @@ video {
 
   .sm\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-13rem * var(--space-x-reverse));
-    margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-13rem * var(--space-x-reverse));
+    margin-left: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -24216,8 +24216,8 @@ video {
 
   .sm\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-14rem * var(--space-x-reverse));
-    margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-14rem * var(--space-x-reverse));
+    margin-left: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -24228,8 +24228,8 @@ video {
 
   .sm\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-15rem * var(--space-x-reverse));
-    margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-15rem * var(--space-x-reverse));
+    margin-left: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -24240,8 +24240,8 @@ video {
 
   .sm\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-16rem * var(--space-x-reverse));
-    margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-16rem * var(--space-x-reverse));
+    margin-left: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -24252,8 +24252,8 @@ video {
 
   .sm\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-18rem * var(--space-x-reverse));
-    margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-18rem * var(--space-x-reverse));
+    margin-left: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -24264,8 +24264,8 @@ video {
 
   .sm\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-20rem * var(--space-x-reverse));
-    margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-20rem * var(--space-x-reverse));
+    margin-left: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -24276,8 +24276,8 @@ video {
 
   .sm\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-24rem * var(--space-x-reverse));
-    margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-24rem * var(--space-x-reverse));
+    margin-left: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -24288,8 +24288,8 @@ video {
 
   .sm\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1px * var(--space-x-reverse));
-    margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1px * var(--space-x-reverse));
+    margin-left: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -24300,8 +24300,8 @@ video {
 
   .sm\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.125rem * var(--space-x-reverse));
+    margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -24312,8 +24312,8 @@ video {
 
   .sm\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.375rem * var(--space-x-reverse));
+    margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -24324,8 +24324,8 @@ video {
 
   .sm\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.625rem * var(--space-x-reverse));
+    margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -24336,8 +24336,8 @@ video {
 
   .sm\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.875rem * var(--space-x-reverse));
+    margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .sm\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -24356,8 +24356,8 @@ video {
 
   .sm\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(0px * var(--divide-x-reverse));
-    border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(0px * var(--divide-x-reverse));
+    border-left-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
   .sm\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -24368,8 +24368,8 @@ video {
 
   .sm\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(2px * var(--divide-x-reverse));
-    border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(2px * var(--divide-x-reverse));
+    border-left-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
   .sm\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -24380,8 +24380,8 @@ video {
 
   .sm\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(4px * var(--divide-x-reverse));
-    border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(4px * var(--divide-x-reverse));
+    border-left-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
   .sm\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -24392,8 +24392,8 @@ video {
 
   .sm\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(8px * var(--divide-x-reverse));
-    border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(8px * var(--divide-x-reverse));
+    border-left-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
   .sm\:divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -24404,8 +24404,8 @@ video {
 
   .sm\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(1px * var(--divide-x-reverse));
-    border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(1px * var(--divide-x-reverse));
+    border-left-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
   .sm\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -46490,8 +46490,8 @@ video {
 
   .md\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0px * var(--space-x-reverse));
-    margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0px * var(--space-x-reverse));
+    margin-left: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -46502,8 +46502,8 @@ video {
 
   .md\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.25rem * var(--space-x-reverse));
+    margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -46514,8 +46514,8 @@ video {
 
   .md\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.5rem * var(--space-x-reverse));
+    margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -46526,8 +46526,8 @@ video {
 
   .md\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.75rem * var(--space-x-reverse));
+    margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -46538,8 +46538,8 @@ video {
 
   .md\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1rem * var(--space-x-reverse));
-    margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1rem * var(--space-x-reverse));
+    margin-left: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -46550,8 +46550,8 @@ video {
 
   .md\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.25rem * var(--space-x-reverse));
+    margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -46562,8 +46562,8 @@ video {
 
   .md\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.5rem * var(--space-x-reverse));
+    margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -46574,8 +46574,8 @@ video {
 
   .md\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.75rem * var(--space-x-reverse));
+    margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -46586,8 +46586,8 @@ video {
 
   .md\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2rem * var(--space-x-reverse));
-    margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2rem * var(--space-x-reverse));
+    margin-left: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -46598,8 +46598,8 @@ video {
 
   .md\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.25rem * var(--space-x-reverse));
+    margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -46610,8 +46610,8 @@ video {
 
   .md\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.5rem * var(--space-x-reverse));
+    margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -46622,8 +46622,8 @@ video {
 
   .md\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3rem * var(--space-x-reverse));
-    margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3rem * var(--space-x-reverse));
+    margin-left: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -46634,8 +46634,8 @@ video {
 
   .md\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3.5rem * var(--space-x-reverse));
+    margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -46646,8 +46646,8 @@ video {
 
   .md\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(4rem * var(--space-x-reverse));
-    margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(4rem * var(--space-x-reverse));
+    margin-left: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -46658,8 +46658,8 @@ video {
 
   .md\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(5rem * var(--space-x-reverse));
-    margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(5rem * var(--space-x-reverse));
+    margin-left: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -46670,8 +46670,8 @@ video {
 
   .md\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(6rem * var(--space-x-reverse));
-    margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(6rem * var(--space-x-reverse));
+    margin-left: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -46682,8 +46682,8 @@ video {
 
   .md\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(7rem * var(--space-x-reverse));
-    margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(7rem * var(--space-x-reverse));
+    margin-left: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -46694,8 +46694,8 @@ video {
 
   .md\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(8rem * var(--space-x-reverse));
-    margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(8rem * var(--space-x-reverse));
+    margin-left: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -46706,8 +46706,8 @@ video {
 
   .md\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(9rem * var(--space-x-reverse));
-    margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(9rem * var(--space-x-reverse));
+    margin-left: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -46718,8 +46718,8 @@ video {
 
   .md\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(10rem * var(--space-x-reverse));
-    margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(10rem * var(--space-x-reverse));
+    margin-left: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -46730,8 +46730,8 @@ video {
 
   .md\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(11rem * var(--space-x-reverse));
-    margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(11rem * var(--space-x-reverse));
+    margin-left: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -46742,8 +46742,8 @@ video {
 
   .md\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(12rem * var(--space-x-reverse));
-    margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(12rem * var(--space-x-reverse));
+    margin-left: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -46754,8 +46754,8 @@ video {
 
   .md\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(13rem * var(--space-x-reverse));
-    margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(13rem * var(--space-x-reverse));
+    margin-left: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -46766,8 +46766,8 @@ video {
 
   .md\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(14rem * var(--space-x-reverse));
-    margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(14rem * var(--space-x-reverse));
+    margin-left: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -46778,8 +46778,8 @@ video {
 
   .md\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(15rem * var(--space-x-reverse));
-    margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(15rem * var(--space-x-reverse));
+    margin-left: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -46790,8 +46790,8 @@ video {
 
   .md\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(16rem * var(--space-x-reverse));
-    margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(16rem * var(--space-x-reverse));
+    margin-left: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -46802,8 +46802,8 @@ video {
 
   .md\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(18rem * var(--space-x-reverse));
-    margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(18rem * var(--space-x-reverse));
+    margin-left: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -46814,8 +46814,8 @@ video {
 
   .md\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(20rem * var(--space-x-reverse));
-    margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(20rem * var(--space-x-reverse));
+    margin-left: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -46826,8 +46826,8 @@ video {
 
   .md\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(24rem * var(--space-x-reverse));
-    margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(24rem * var(--space-x-reverse));
+    margin-left: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -46838,8 +46838,8 @@ video {
 
   .md\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1px * var(--space-x-reverse));
-    margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1px * var(--space-x-reverse));
+    margin-left: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -46850,8 +46850,8 @@ video {
 
   .md\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.125rem * var(--space-x-reverse));
+    margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -46862,8 +46862,8 @@ video {
 
   .md\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.375rem * var(--space-x-reverse));
+    margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -46874,8 +46874,8 @@ video {
 
   .md\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.625rem * var(--space-x-reverse));
+    margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -46886,8 +46886,8 @@ video {
 
   .md\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.875rem * var(--space-x-reverse));
+    margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -46898,8 +46898,8 @@ video {
 
   .md\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.25rem * var(--space-x-reverse));
+    margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -46910,8 +46910,8 @@ video {
 
   .md\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.5rem * var(--space-x-reverse));
+    margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -46922,8 +46922,8 @@ video {
 
   .md\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.75rem * var(--space-x-reverse));
+    margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -46934,8 +46934,8 @@ video {
 
   .md\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1rem * var(--space-x-reverse));
+    margin-left: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -46946,8 +46946,8 @@ video {
 
   .md\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.25rem * var(--space-x-reverse));
+    margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -46958,8 +46958,8 @@ video {
 
   .md\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.5rem * var(--space-x-reverse));
+    margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -46970,8 +46970,8 @@ video {
 
   .md\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.75rem * var(--space-x-reverse));
+    margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -46982,8 +46982,8 @@ video {
 
   .md\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2rem * var(--space-x-reverse));
+    margin-left: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -46994,8 +46994,8 @@ video {
 
   .md\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.25rem * var(--space-x-reverse));
+    margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -47006,8 +47006,8 @@ video {
 
   .md\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.5rem * var(--space-x-reverse));
+    margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -47018,8 +47018,8 @@ video {
 
   .md\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3rem * var(--space-x-reverse));
+    margin-left: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -47030,8 +47030,8 @@ video {
 
   .md\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3.5rem * var(--space-x-reverse));
+    margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -47042,8 +47042,8 @@ video {
 
   .md\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-4rem * var(--space-x-reverse));
-    margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-4rem * var(--space-x-reverse));
+    margin-left: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -47054,8 +47054,8 @@ video {
 
   .md\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-5rem * var(--space-x-reverse));
+    margin-left: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -47066,8 +47066,8 @@ video {
 
   .md\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-6rem * var(--space-x-reverse));
-    margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-6rem * var(--space-x-reverse));
+    margin-left: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -47078,8 +47078,8 @@ video {
 
   .md\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-7rem * var(--space-x-reverse));
-    margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-7rem * var(--space-x-reverse));
+    margin-left: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -47090,8 +47090,8 @@ video {
 
   .md\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-8rem * var(--space-x-reverse));
-    margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-8rem * var(--space-x-reverse));
+    margin-left: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -47102,8 +47102,8 @@ video {
 
   .md\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-9rem * var(--space-x-reverse));
-    margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-9rem * var(--space-x-reverse));
+    margin-left: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -47114,8 +47114,8 @@ video {
 
   .md\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-10rem * var(--space-x-reverse));
-    margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-10rem * var(--space-x-reverse));
+    margin-left: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -47126,8 +47126,8 @@ video {
 
   .md\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-11rem * var(--space-x-reverse));
-    margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-11rem * var(--space-x-reverse));
+    margin-left: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -47138,8 +47138,8 @@ video {
 
   .md\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-12rem * var(--space-x-reverse));
-    margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-12rem * var(--space-x-reverse));
+    margin-left: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -47150,8 +47150,8 @@ video {
 
   .md\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-13rem * var(--space-x-reverse));
-    margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-13rem * var(--space-x-reverse));
+    margin-left: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -47162,8 +47162,8 @@ video {
 
   .md\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-14rem * var(--space-x-reverse));
-    margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-14rem * var(--space-x-reverse));
+    margin-left: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -47174,8 +47174,8 @@ video {
 
   .md\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-15rem * var(--space-x-reverse));
-    margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-15rem * var(--space-x-reverse));
+    margin-left: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -47186,8 +47186,8 @@ video {
 
   .md\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-16rem * var(--space-x-reverse));
-    margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-16rem * var(--space-x-reverse));
+    margin-left: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -47198,8 +47198,8 @@ video {
 
   .md\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-18rem * var(--space-x-reverse));
-    margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-18rem * var(--space-x-reverse));
+    margin-left: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -47210,8 +47210,8 @@ video {
 
   .md\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-20rem * var(--space-x-reverse));
-    margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-20rem * var(--space-x-reverse));
+    margin-left: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -47222,8 +47222,8 @@ video {
 
   .md\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-24rem * var(--space-x-reverse));
-    margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-24rem * var(--space-x-reverse));
+    margin-left: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -47234,8 +47234,8 @@ video {
 
   .md\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1px * var(--space-x-reverse));
-    margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1px * var(--space-x-reverse));
+    margin-left: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -47246,8 +47246,8 @@ video {
 
   .md\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.125rem * var(--space-x-reverse));
+    margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -47258,8 +47258,8 @@ video {
 
   .md\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.375rem * var(--space-x-reverse));
+    margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -47270,8 +47270,8 @@ video {
 
   .md\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.625rem * var(--space-x-reverse));
+    margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -47282,8 +47282,8 @@ video {
 
   .md\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.875rem * var(--space-x-reverse));
+    margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .md\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -47302,8 +47302,8 @@ video {
 
   .md\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(0px * var(--divide-x-reverse));
-    border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(0px * var(--divide-x-reverse));
+    border-left-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
   .md\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -47314,8 +47314,8 @@ video {
 
   .md\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(2px * var(--divide-x-reverse));
-    border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(2px * var(--divide-x-reverse));
+    border-left-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
   .md\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -47326,8 +47326,8 @@ video {
 
   .md\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(4px * var(--divide-x-reverse));
-    border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(4px * var(--divide-x-reverse));
+    border-left-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
   .md\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -47338,8 +47338,8 @@ video {
 
   .md\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(8px * var(--divide-x-reverse));
-    border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(8px * var(--divide-x-reverse));
+    border-left-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
   .md\:divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -47350,8 +47350,8 @@ video {
 
   .md\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(1px * var(--divide-x-reverse));
-    border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(1px * var(--divide-x-reverse));
+    border-left-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
   .md\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -69436,8 +69436,8 @@ video {
 
   .lg\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0px * var(--space-x-reverse));
-    margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0px * var(--space-x-reverse));
+    margin-left: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -69448,8 +69448,8 @@ video {
 
   .lg\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.25rem * var(--space-x-reverse));
+    margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -69460,8 +69460,8 @@ video {
 
   .lg\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.5rem * var(--space-x-reverse));
+    margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -69472,8 +69472,8 @@ video {
 
   .lg\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.75rem * var(--space-x-reverse));
+    margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -69484,8 +69484,8 @@ video {
 
   .lg\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1rem * var(--space-x-reverse));
-    margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1rem * var(--space-x-reverse));
+    margin-left: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -69496,8 +69496,8 @@ video {
 
   .lg\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.25rem * var(--space-x-reverse));
+    margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -69508,8 +69508,8 @@ video {
 
   .lg\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.5rem * var(--space-x-reverse));
+    margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -69520,8 +69520,8 @@ video {
 
   .lg\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.75rem * var(--space-x-reverse));
+    margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -69532,8 +69532,8 @@ video {
 
   .lg\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2rem * var(--space-x-reverse));
-    margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2rem * var(--space-x-reverse));
+    margin-left: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -69544,8 +69544,8 @@ video {
 
   .lg\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.25rem * var(--space-x-reverse));
+    margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -69556,8 +69556,8 @@ video {
 
   .lg\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.5rem * var(--space-x-reverse));
+    margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -69568,8 +69568,8 @@ video {
 
   .lg\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3rem * var(--space-x-reverse));
-    margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3rem * var(--space-x-reverse));
+    margin-left: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -69580,8 +69580,8 @@ video {
 
   .lg\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3.5rem * var(--space-x-reverse));
+    margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -69592,8 +69592,8 @@ video {
 
   .lg\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(4rem * var(--space-x-reverse));
-    margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(4rem * var(--space-x-reverse));
+    margin-left: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -69604,8 +69604,8 @@ video {
 
   .lg\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(5rem * var(--space-x-reverse));
-    margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(5rem * var(--space-x-reverse));
+    margin-left: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -69616,8 +69616,8 @@ video {
 
   .lg\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(6rem * var(--space-x-reverse));
-    margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(6rem * var(--space-x-reverse));
+    margin-left: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -69628,8 +69628,8 @@ video {
 
   .lg\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(7rem * var(--space-x-reverse));
-    margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(7rem * var(--space-x-reverse));
+    margin-left: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -69640,8 +69640,8 @@ video {
 
   .lg\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(8rem * var(--space-x-reverse));
-    margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(8rem * var(--space-x-reverse));
+    margin-left: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -69652,8 +69652,8 @@ video {
 
   .lg\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(9rem * var(--space-x-reverse));
-    margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(9rem * var(--space-x-reverse));
+    margin-left: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -69664,8 +69664,8 @@ video {
 
   .lg\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(10rem * var(--space-x-reverse));
-    margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(10rem * var(--space-x-reverse));
+    margin-left: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -69676,8 +69676,8 @@ video {
 
   .lg\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(11rem * var(--space-x-reverse));
-    margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(11rem * var(--space-x-reverse));
+    margin-left: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -69688,8 +69688,8 @@ video {
 
   .lg\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(12rem * var(--space-x-reverse));
-    margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(12rem * var(--space-x-reverse));
+    margin-left: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -69700,8 +69700,8 @@ video {
 
   .lg\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(13rem * var(--space-x-reverse));
-    margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(13rem * var(--space-x-reverse));
+    margin-left: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -69712,8 +69712,8 @@ video {
 
   .lg\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(14rem * var(--space-x-reverse));
-    margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(14rem * var(--space-x-reverse));
+    margin-left: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -69724,8 +69724,8 @@ video {
 
   .lg\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(15rem * var(--space-x-reverse));
-    margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(15rem * var(--space-x-reverse));
+    margin-left: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -69736,8 +69736,8 @@ video {
 
   .lg\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(16rem * var(--space-x-reverse));
-    margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(16rem * var(--space-x-reverse));
+    margin-left: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -69748,8 +69748,8 @@ video {
 
   .lg\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(18rem * var(--space-x-reverse));
-    margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(18rem * var(--space-x-reverse));
+    margin-left: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -69760,8 +69760,8 @@ video {
 
   .lg\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(20rem * var(--space-x-reverse));
-    margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(20rem * var(--space-x-reverse));
+    margin-left: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -69772,8 +69772,8 @@ video {
 
   .lg\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(24rem * var(--space-x-reverse));
-    margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(24rem * var(--space-x-reverse));
+    margin-left: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -69784,8 +69784,8 @@ video {
 
   .lg\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1px * var(--space-x-reverse));
-    margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1px * var(--space-x-reverse));
+    margin-left: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -69796,8 +69796,8 @@ video {
 
   .lg\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.125rem * var(--space-x-reverse));
+    margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -69808,8 +69808,8 @@ video {
 
   .lg\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.375rem * var(--space-x-reverse));
+    margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -69820,8 +69820,8 @@ video {
 
   .lg\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.625rem * var(--space-x-reverse));
+    margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -69832,8 +69832,8 @@ video {
 
   .lg\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.875rem * var(--space-x-reverse));
+    margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -69844,8 +69844,8 @@ video {
 
   .lg\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.25rem * var(--space-x-reverse));
+    margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -69856,8 +69856,8 @@ video {
 
   .lg\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.5rem * var(--space-x-reverse));
+    margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -69868,8 +69868,8 @@ video {
 
   .lg\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.75rem * var(--space-x-reverse));
+    margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -69880,8 +69880,8 @@ video {
 
   .lg\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1rem * var(--space-x-reverse));
+    margin-left: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -69892,8 +69892,8 @@ video {
 
   .lg\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.25rem * var(--space-x-reverse));
+    margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -69904,8 +69904,8 @@ video {
 
   .lg\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.5rem * var(--space-x-reverse));
+    margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -69916,8 +69916,8 @@ video {
 
   .lg\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.75rem * var(--space-x-reverse));
+    margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -69928,8 +69928,8 @@ video {
 
   .lg\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2rem * var(--space-x-reverse));
+    margin-left: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -69940,8 +69940,8 @@ video {
 
   .lg\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.25rem * var(--space-x-reverse));
+    margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -69952,8 +69952,8 @@ video {
 
   .lg\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.5rem * var(--space-x-reverse));
+    margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -69964,8 +69964,8 @@ video {
 
   .lg\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3rem * var(--space-x-reverse));
+    margin-left: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -69976,8 +69976,8 @@ video {
 
   .lg\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3.5rem * var(--space-x-reverse));
+    margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -69988,8 +69988,8 @@ video {
 
   .lg\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-4rem * var(--space-x-reverse));
-    margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-4rem * var(--space-x-reverse));
+    margin-left: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -70000,8 +70000,8 @@ video {
 
   .lg\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-5rem * var(--space-x-reverse));
+    margin-left: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -70012,8 +70012,8 @@ video {
 
   .lg\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-6rem * var(--space-x-reverse));
-    margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-6rem * var(--space-x-reverse));
+    margin-left: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -70024,8 +70024,8 @@ video {
 
   .lg\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-7rem * var(--space-x-reverse));
-    margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-7rem * var(--space-x-reverse));
+    margin-left: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -70036,8 +70036,8 @@ video {
 
   .lg\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-8rem * var(--space-x-reverse));
-    margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-8rem * var(--space-x-reverse));
+    margin-left: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -70048,8 +70048,8 @@ video {
 
   .lg\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-9rem * var(--space-x-reverse));
-    margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-9rem * var(--space-x-reverse));
+    margin-left: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -70060,8 +70060,8 @@ video {
 
   .lg\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-10rem * var(--space-x-reverse));
-    margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-10rem * var(--space-x-reverse));
+    margin-left: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -70072,8 +70072,8 @@ video {
 
   .lg\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-11rem * var(--space-x-reverse));
-    margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-11rem * var(--space-x-reverse));
+    margin-left: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -70084,8 +70084,8 @@ video {
 
   .lg\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-12rem * var(--space-x-reverse));
-    margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-12rem * var(--space-x-reverse));
+    margin-left: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -70096,8 +70096,8 @@ video {
 
   .lg\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-13rem * var(--space-x-reverse));
-    margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-13rem * var(--space-x-reverse));
+    margin-left: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -70108,8 +70108,8 @@ video {
 
   .lg\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-14rem * var(--space-x-reverse));
-    margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-14rem * var(--space-x-reverse));
+    margin-left: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -70120,8 +70120,8 @@ video {
 
   .lg\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-15rem * var(--space-x-reverse));
-    margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-15rem * var(--space-x-reverse));
+    margin-left: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -70132,8 +70132,8 @@ video {
 
   .lg\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-16rem * var(--space-x-reverse));
-    margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-16rem * var(--space-x-reverse));
+    margin-left: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -70144,8 +70144,8 @@ video {
 
   .lg\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-18rem * var(--space-x-reverse));
-    margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-18rem * var(--space-x-reverse));
+    margin-left: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -70156,8 +70156,8 @@ video {
 
   .lg\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-20rem * var(--space-x-reverse));
-    margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-20rem * var(--space-x-reverse));
+    margin-left: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -70168,8 +70168,8 @@ video {
 
   .lg\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-24rem * var(--space-x-reverse));
-    margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-24rem * var(--space-x-reverse));
+    margin-left: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -70180,8 +70180,8 @@ video {
 
   .lg\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1px * var(--space-x-reverse));
-    margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1px * var(--space-x-reverse));
+    margin-left: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -70192,8 +70192,8 @@ video {
 
   .lg\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.125rem * var(--space-x-reverse));
+    margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -70204,8 +70204,8 @@ video {
 
   .lg\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.375rem * var(--space-x-reverse));
+    margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -70216,8 +70216,8 @@ video {
 
   .lg\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.625rem * var(--space-x-reverse));
+    margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -70228,8 +70228,8 @@ video {
 
   .lg\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.875rem * var(--space-x-reverse));
+    margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .lg\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -70248,8 +70248,8 @@ video {
 
   .lg\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(0px * var(--divide-x-reverse));
-    border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(0px * var(--divide-x-reverse));
+    border-left-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
   .lg\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -70260,8 +70260,8 @@ video {
 
   .lg\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(2px * var(--divide-x-reverse));
-    border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(2px * var(--divide-x-reverse));
+    border-left-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
   .lg\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -70272,8 +70272,8 @@ video {
 
   .lg\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(4px * var(--divide-x-reverse));
-    border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(4px * var(--divide-x-reverse));
+    border-left-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
   .lg\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -70284,8 +70284,8 @@ video {
 
   .lg\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(8px * var(--divide-x-reverse));
-    border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(8px * var(--divide-x-reverse));
+    border-left-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
   .lg\:divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -70296,8 +70296,8 @@ video {
 
   .lg\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(1px * var(--divide-x-reverse));
-    border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(1px * var(--divide-x-reverse));
+    border-left-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
   .lg\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -92382,8 +92382,8 @@ video {
 
   .xl\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0px * var(--space-x-reverse));
-    margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0px * var(--space-x-reverse));
+    margin-left: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -92394,8 +92394,8 @@ video {
 
   .xl\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.25rem * var(--space-x-reverse));
+    margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -92406,8 +92406,8 @@ video {
 
   .xl\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.5rem * var(--space-x-reverse));
+    margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -92418,8 +92418,8 @@ video {
 
   .xl\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.75rem * var(--space-x-reverse));
+    margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -92430,8 +92430,8 @@ video {
 
   .xl\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1rem * var(--space-x-reverse));
-    margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1rem * var(--space-x-reverse));
+    margin-left: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -92442,8 +92442,8 @@ video {
 
   .xl\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.25rem * var(--space-x-reverse));
+    margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -92454,8 +92454,8 @@ video {
 
   .xl\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.5rem * var(--space-x-reverse));
+    margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -92466,8 +92466,8 @@ video {
 
   .xl\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.75rem * var(--space-x-reverse));
+    margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -92478,8 +92478,8 @@ video {
 
   .xl\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2rem * var(--space-x-reverse));
-    margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2rem * var(--space-x-reverse));
+    margin-left: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -92490,8 +92490,8 @@ video {
 
   .xl\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.25rem * var(--space-x-reverse));
+    margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -92502,8 +92502,8 @@ video {
 
   .xl\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.5rem * var(--space-x-reverse));
+    margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -92514,8 +92514,8 @@ video {
 
   .xl\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3rem * var(--space-x-reverse));
-    margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3rem * var(--space-x-reverse));
+    margin-left: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -92526,8 +92526,8 @@ video {
 
   .xl\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3.5rem * var(--space-x-reverse));
+    margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -92538,8 +92538,8 @@ video {
 
   .xl\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(4rem * var(--space-x-reverse));
-    margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(4rem * var(--space-x-reverse));
+    margin-left: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -92550,8 +92550,8 @@ video {
 
   .xl\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(5rem * var(--space-x-reverse));
-    margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(5rem * var(--space-x-reverse));
+    margin-left: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -92562,8 +92562,8 @@ video {
 
   .xl\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(6rem * var(--space-x-reverse));
-    margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(6rem * var(--space-x-reverse));
+    margin-left: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -92574,8 +92574,8 @@ video {
 
   .xl\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(7rem * var(--space-x-reverse));
-    margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(7rem * var(--space-x-reverse));
+    margin-left: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -92586,8 +92586,8 @@ video {
 
   .xl\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(8rem * var(--space-x-reverse));
-    margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(8rem * var(--space-x-reverse));
+    margin-left: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -92598,8 +92598,8 @@ video {
 
   .xl\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(9rem * var(--space-x-reverse));
-    margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(9rem * var(--space-x-reverse));
+    margin-left: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -92610,8 +92610,8 @@ video {
 
   .xl\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(10rem * var(--space-x-reverse));
-    margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(10rem * var(--space-x-reverse));
+    margin-left: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -92622,8 +92622,8 @@ video {
 
   .xl\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(11rem * var(--space-x-reverse));
-    margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(11rem * var(--space-x-reverse));
+    margin-left: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -92634,8 +92634,8 @@ video {
 
   .xl\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(12rem * var(--space-x-reverse));
-    margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(12rem * var(--space-x-reverse));
+    margin-left: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -92646,8 +92646,8 @@ video {
 
   .xl\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(13rem * var(--space-x-reverse));
-    margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(13rem * var(--space-x-reverse));
+    margin-left: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -92658,8 +92658,8 @@ video {
 
   .xl\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(14rem * var(--space-x-reverse));
-    margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(14rem * var(--space-x-reverse));
+    margin-left: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -92670,8 +92670,8 @@ video {
 
   .xl\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(15rem * var(--space-x-reverse));
-    margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(15rem * var(--space-x-reverse));
+    margin-left: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -92682,8 +92682,8 @@ video {
 
   .xl\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(16rem * var(--space-x-reverse));
-    margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(16rem * var(--space-x-reverse));
+    margin-left: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -92694,8 +92694,8 @@ video {
 
   .xl\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(18rem * var(--space-x-reverse));
-    margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(18rem * var(--space-x-reverse));
+    margin-left: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -92706,8 +92706,8 @@ video {
 
   .xl\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(20rem * var(--space-x-reverse));
-    margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(20rem * var(--space-x-reverse));
+    margin-left: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -92718,8 +92718,8 @@ video {
 
   .xl\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(24rem * var(--space-x-reverse));
-    margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(24rem * var(--space-x-reverse));
+    margin-left: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -92730,8 +92730,8 @@ video {
 
   .xl\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1px * var(--space-x-reverse));
-    margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1px * var(--space-x-reverse));
+    margin-left: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -92742,8 +92742,8 @@ video {
 
   .xl\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.125rem * var(--space-x-reverse));
+    margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -92754,8 +92754,8 @@ video {
 
   .xl\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.375rem * var(--space-x-reverse));
+    margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -92766,8 +92766,8 @@ video {
 
   .xl\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.625rem * var(--space-x-reverse));
+    margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -92778,8 +92778,8 @@ video {
 
   .xl\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.875rem * var(--space-x-reverse));
+    margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -92790,8 +92790,8 @@ video {
 
   .xl\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.25rem * var(--space-x-reverse));
+    margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -92802,8 +92802,8 @@ video {
 
   .xl\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.5rem * var(--space-x-reverse));
+    margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -92814,8 +92814,8 @@ video {
 
   .xl\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.75rem * var(--space-x-reverse));
+    margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -92826,8 +92826,8 @@ video {
 
   .xl\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1rem * var(--space-x-reverse));
+    margin-left: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -92838,8 +92838,8 @@ video {
 
   .xl\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.25rem * var(--space-x-reverse));
+    margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -92850,8 +92850,8 @@ video {
 
   .xl\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.5rem * var(--space-x-reverse));
+    margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -92862,8 +92862,8 @@ video {
 
   .xl\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.75rem * var(--space-x-reverse));
+    margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -92874,8 +92874,8 @@ video {
 
   .xl\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2rem * var(--space-x-reverse));
+    margin-left: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -92886,8 +92886,8 @@ video {
 
   .xl\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.25rem * var(--space-x-reverse));
+    margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -92898,8 +92898,8 @@ video {
 
   .xl\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.5rem * var(--space-x-reverse));
+    margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -92910,8 +92910,8 @@ video {
 
   .xl\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3rem * var(--space-x-reverse));
+    margin-left: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -92922,8 +92922,8 @@ video {
 
   .xl\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3.5rem * var(--space-x-reverse));
+    margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -92934,8 +92934,8 @@ video {
 
   .xl\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-4rem * var(--space-x-reverse));
-    margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-4rem * var(--space-x-reverse));
+    margin-left: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -92946,8 +92946,8 @@ video {
 
   .xl\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-5rem * var(--space-x-reverse));
+    margin-left: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -92958,8 +92958,8 @@ video {
 
   .xl\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-6rem * var(--space-x-reverse));
-    margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-6rem * var(--space-x-reverse));
+    margin-left: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -92970,8 +92970,8 @@ video {
 
   .xl\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-7rem * var(--space-x-reverse));
-    margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-7rem * var(--space-x-reverse));
+    margin-left: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -92982,8 +92982,8 @@ video {
 
   .xl\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-8rem * var(--space-x-reverse));
-    margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-8rem * var(--space-x-reverse));
+    margin-left: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -92994,8 +92994,8 @@ video {
 
   .xl\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-9rem * var(--space-x-reverse));
-    margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-9rem * var(--space-x-reverse));
+    margin-left: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -93006,8 +93006,8 @@ video {
 
   .xl\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-10rem * var(--space-x-reverse));
-    margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-10rem * var(--space-x-reverse));
+    margin-left: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -93018,8 +93018,8 @@ video {
 
   .xl\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-11rem * var(--space-x-reverse));
-    margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-11rem * var(--space-x-reverse));
+    margin-left: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -93030,8 +93030,8 @@ video {
 
   .xl\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-12rem * var(--space-x-reverse));
-    margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-12rem * var(--space-x-reverse));
+    margin-left: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -93042,8 +93042,8 @@ video {
 
   .xl\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-13rem * var(--space-x-reverse));
-    margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-13rem * var(--space-x-reverse));
+    margin-left: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -93054,8 +93054,8 @@ video {
 
   .xl\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-14rem * var(--space-x-reverse));
-    margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-14rem * var(--space-x-reverse));
+    margin-left: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -93066,8 +93066,8 @@ video {
 
   .xl\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-15rem * var(--space-x-reverse));
-    margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-15rem * var(--space-x-reverse));
+    margin-left: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -93078,8 +93078,8 @@ video {
 
   .xl\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-16rem * var(--space-x-reverse));
-    margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-16rem * var(--space-x-reverse));
+    margin-left: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -93090,8 +93090,8 @@ video {
 
   .xl\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-18rem * var(--space-x-reverse));
-    margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-18rem * var(--space-x-reverse));
+    margin-left: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -93102,8 +93102,8 @@ video {
 
   .xl\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-20rem * var(--space-x-reverse));
-    margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-20rem * var(--space-x-reverse));
+    margin-left: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -93114,8 +93114,8 @@ video {
 
   .xl\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-24rem * var(--space-x-reverse));
-    margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-24rem * var(--space-x-reverse));
+    margin-left: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -93126,8 +93126,8 @@ video {
 
   .xl\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1px * var(--space-x-reverse));
-    margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1px * var(--space-x-reverse));
+    margin-left: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -93138,8 +93138,8 @@ video {
 
   .xl\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.125rem * var(--space-x-reverse));
+    margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -93150,8 +93150,8 @@ video {
 
   .xl\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.375rem * var(--space-x-reverse));
+    margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -93162,8 +93162,8 @@ video {
 
   .xl\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.625rem * var(--space-x-reverse));
+    margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -93174,8 +93174,8 @@ video {
 
   .xl\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.875rem * var(--space-x-reverse));
+    margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .xl\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -93194,8 +93194,8 @@ video {
 
   .xl\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(0px * var(--divide-x-reverse));
-    border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(0px * var(--divide-x-reverse));
+    border-left-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
   .xl\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -93206,8 +93206,8 @@ video {
 
   .xl\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(2px * var(--divide-x-reverse));
-    border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(2px * var(--divide-x-reverse));
+    border-left-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
   .xl\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -93218,8 +93218,8 @@ video {
 
   .xl\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(4px * var(--divide-x-reverse));
-    border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(4px * var(--divide-x-reverse));
+    border-left-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
   .xl\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -93230,8 +93230,8 @@ video {
 
   .xl\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(8px * var(--divide-x-reverse));
-    border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(8px * var(--divide-x-reverse));
+    border-left-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
   .xl\:divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -93242,8 +93242,8 @@ video {
 
   .xl\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(1px * var(--divide-x-reverse));
-    border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(1px * var(--divide-x-reverse));
+    border-left-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
   .xl\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -115328,8 +115328,8 @@ video {
 
   .\32xl\:space-x-0 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0px * var(--space-x-reverse));
-    margin-inline-start: calc(0px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0px * var(--space-x-reverse));
+    margin-left: calc(0px * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -115340,8 +115340,8 @@ video {
 
   .\32xl\:space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.25rem * var(--space-x-reverse));
+    margin-left: calc(0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -115352,8 +115352,8 @@ video {
 
   .\32xl\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.5rem * var(--space-x-reverse));
+    margin-left: calc(0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -115364,8 +115364,8 @@ video {
 
   .\32xl\:space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.75rem * var(--space-x-reverse));
+    margin-left: calc(0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -115376,8 +115376,8 @@ video {
 
   .\32xl\:space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1rem * var(--space-x-reverse));
-    margin-inline-start: calc(1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1rem * var(--space-x-reverse));
+    margin-left: calc(1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -115388,8 +115388,8 @@ video {
 
   .\32xl\:space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.25rem * var(--space-x-reverse));
+    margin-left: calc(1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -115400,8 +115400,8 @@ video {
 
   .\32xl\:space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.5rem * var(--space-x-reverse));
+    margin-left: calc(1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -115412,8 +115412,8 @@ video {
 
   .\32xl\:space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1.75rem * var(--space-x-reverse));
+    margin-left: calc(1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -115424,8 +115424,8 @@ video {
 
   .\32xl\:space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2rem * var(--space-x-reverse));
-    margin-inline-start: calc(2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2rem * var(--space-x-reverse));
+    margin-left: calc(2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -115436,8 +115436,8 @@ video {
 
   .\32xl\:space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.25rem * var(--space-x-reverse));
+    margin-left: calc(2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -115448,8 +115448,8 @@ video {
 
   .\32xl\:space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(2.5rem * var(--space-x-reverse));
+    margin-left: calc(2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -115460,8 +115460,8 @@ video {
 
   .\32xl\:space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3rem * var(--space-x-reverse));
-    margin-inline-start: calc(3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3rem * var(--space-x-reverse));
+    margin-left: calc(3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -115472,8 +115472,8 @@ video {
 
   .\32xl\:space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(3.5rem * var(--space-x-reverse));
+    margin-left: calc(3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -115484,8 +115484,8 @@ video {
 
   .\32xl\:space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(4rem * var(--space-x-reverse));
-    margin-inline-start: calc(4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(4rem * var(--space-x-reverse));
+    margin-left: calc(4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -115496,8 +115496,8 @@ video {
 
   .\32xl\:space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(5rem * var(--space-x-reverse));
-    margin-inline-start: calc(5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(5rem * var(--space-x-reverse));
+    margin-left: calc(5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -115508,8 +115508,8 @@ video {
 
   .\32xl\:space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(6rem * var(--space-x-reverse));
-    margin-inline-start: calc(6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(6rem * var(--space-x-reverse));
+    margin-left: calc(6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -115520,8 +115520,8 @@ video {
 
   .\32xl\:space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(7rem * var(--space-x-reverse));
-    margin-inline-start: calc(7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(7rem * var(--space-x-reverse));
+    margin-left: calc(7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -115532,8 +115532,8 @@ video {
 
   .\32xl\:space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(8rem * var(--space-x-reverse));
-    margin-inline-start: calc(8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(8rem * var(--space-x-reverse));
+    margin-left: calc(8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -115544,8 +115544,8 @@ video {
 
   .\32xl\:space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(9rem * var(--space-x-reverse));
-    margin-inline-start: calc(9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(9rem * var(--space-x-reverse));
+    margin-left: calc(9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -115556,8 +115556,8 @@ video {
 
   .\32xl\:space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(10rem * var(--space-x-reverse));
-    margin-inline-start: calc(10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(10rem * var(--space-x-reverse));
+    margin-left: calc(10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -115568,8 +115568,8 @@ video {
 
   .\32xl\:space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(11rem * var(--space-x-reverse));
-    margin-inline-start: calc(11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(11rem * var(--space-x-reverse));
+    margin-left: calc(11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -115580,8 +115580,8 @@ video {
 
   .\32xl\:space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(12rem * var(--space-x-reverse));
-    margin-inline-start: calc(12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(12rem * var(--space-x-reverse));
+    margin-left: calc(12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -115592,8 +115592,8 @@ video {
 
   .\32xl\:space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(13rem * var(--space-x-reverse));
-    margin-inline-start: calc(13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(13rem * var(--space-x-reverse));
+    margin-left: calc(13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -115604,8 +115604,8 @@ video {
 
   .\32xl\:space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(14rem * var(--space-x-reverse));
-    margin-inline-start: calc(14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(14rem * var(--space-x-reverse));
+    margin-left: calc(14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -115616,8 +115616,8 @@ video {
 
   .\32xl\:space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(15rem * var(--space-x-reverse));
-    margin-inline-start: calc(15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(15rem * var(--space-x-reverse));
+    margin-left: calc(15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -115628,8 +115628,8 @@ video {
 
   .\32xl\:space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(16rem * var(--space-x-reverse));
-    margin-inline-start: calc(16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(16rem * var(--space-x-reverse));
+    margin-left: calc(16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -115640,8 +115640,8 @@ video {
 
   .\32xl\:space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(18rem * var(--space-x-reverse));
-    margin-inline-start: calc(18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(18rem * var(--space-x-reverse));
+    margin-left: calc(18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -115652,8 +115652,8 @@ video {
 
   .\32xl\:space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(20rem * var(--space-x-reverse));
-    margin-inline-start: calc(20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(20rem * var(--space-x-reverse));
+    margin-left: calc(20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -115664,8 +115664,8 @@ video {
 
   .\32xl\:space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(24rem * var(--space-x-reverse));
-    margin-inline-start: calc(24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(24rem * var(--space-x-reverse));
+    margin-left: calc(24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -115676,8 +115676,8 @@ video {
 
   .\32xl\:space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(1px * var(--space-x-reverse));
-    margin-inline-start: calc(1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(1px * var(--space-x-reverse));
+    margin-left: calc(1px * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -115688,8 +115688,8 @@ video {
 
   .\32xl\:space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.125rem * var(--space-x-reverse));
+    margin-left: calc(0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -115700,8 +115700,8 @@ video {
 
   .\32xl\:space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.375rem * var(--space-x-reverse));
+    margin-left: calc(0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -115712,8 +115712,8 @@ video {
 
   .\32xl\:space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.625rem * var(--space-x-reverse));
+    margin-left: calc(0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -115724,8 +115724,8 @@ video {
 
   .\32xl\:space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(0.875rem * var(--space-x-reverse));
+    margin-left: calc(0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-1 > :not([hidden]) ~ :not([hidden]) {
@@ -115736,8 +115736,8 @@ video {
 
   .\32xl\:-space-x-1 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.25rem * var(--space-x-reverse));
+    margin-left: calc(-0.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -115748,8 +115748,8 @@ video {
 
   .\32xl\:-space-x-2 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.5rem * var(--space-x-reverse));
+    margin-left: calc(-0.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-3 > :not([hidden]) ~ :not([hidden]) {
@@ -115760,8 +115760,8 @@ video {
 
   .\32xl\:-space-x-3 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.75rem * var(--space-x-reverse));
+    margin-left: calc(-0.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -115772,8 +115772,8 @@ video {
 
   .\32xl\:-space-x-4 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1rem * var(--space-x-reverse));
+    margin-left: calc(-1rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-5 > :not([hidden]) ~ :not([hidden]) {
@@ -115784,8 +115784,8 @@ video {
 
   .\32xl\:-space-x-5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.25rem * var(--space-x-reverse));
+    margin-left: calc(-1.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -115796,8 +115796,8 @@ video {
 
   .\32xl\:-space-x-6 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.5rem * var(--space-x-reverse));
+    margin-left: calc(-1.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-7 > :not([hidden]) ~ :not([hidden]) {
@@ -115808,8 +115808,8 @@ video {
 
   .\32xl\:-space-x-7 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1.75rem * var(--space-x-reverse));
-    margin-inline-start: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1.75rem * var(--space-x-reverse));
+    margin-left: calc(-1.75rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -115820,8 +115820,8 @@ video {
 
   .\32xl\:-space-x-8 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2rem * var(--space-x-reverse));
+    margin-left: calc(-2rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-9 > :not([hidden]) ~ :not([hidden]) {
@@ -115832,8 +115832,8 @@ video {
 
   .\32xl\:-space-x-9 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.25rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.25rem * var(--space-x-reverse));
+    margin-left: calc(-2.25rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-10 > :not([hidden]) ~ :not([hidden]) {
@@ -115844,8 +115844,8 @@ video {
 
   .\32xl\:-space-x-10 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-2.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-2.5rem * var(--space-x-reverse));
+    margin-left: calc(-2.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-12 > :not([hidden]) ~ :not([hidden]) {
@@ -115856,8 +115856,8 @@ video {
 
   .\32xl\:-space-x-12 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3rem * var(--space-x-reverse));
+    margin-left: calc(-3rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-14 > :not([hidden]) ~ :not([hidden]) {
@@ -115868,8 +115868,8 @@ video {
 
   .\32xl\:-space-x-14 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-3.5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-3.5rem * var(--space-x-reverse));
+    margin-left: calc(-3.5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-16 > :not([hidden]) ~ :not([hidden]) {
@@ -115880,8 +115880,8 @@ video {
 
   .\32xl\:-space-x-16 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-4rem * var(--space-x-reverse));
-    margin-inline-start: calc(-4rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-4rem * var(--space-x-reverse));
+    margin-left: calc(-4rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-20 > :not([hidden]) ~ :not([hidden]) {
@@ -115892,8 +115892,8 @@ video {
 
   .\32xl\:-space-x-20 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-5rem * var(--space-x-reverse));
-    margin-inline-start: calc(-5rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-5rem * var(--space-x-reverse));
+    margin-left: calc(-5rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-24 > :not([hidden]) ~ :not([hidden]) {
@@ -115904,8 +115904,8 @@ video {
 
   .\32xl\:-space-x-24 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-6rem * var(--space-x-reverse));
-    margin-inline-start: calc(-6rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-6rem * var(--space-x-reverse));
+    margin-left: calc(-6rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-28 > :not([hidden]) ~ :not([hidden]) {
@@ -115916,8 +115916,8 @@ video {
 
   .\32xl\:-space-x-28 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-7rem * var(--space-x-reverse));
-    margin-inline-start: calc(-7rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-7rem * var(--space-x-reverse));
+    margin-left: calc(-7rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-32 > :not([hidden]) ~ :not([hidden]) {
@@ -115928,8 +115928,8 @@ video {
 
   .\32xl\:-space-x-32 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-8rem * var(--space-x-reverse));
-    margin-inline-start: calc(-8rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-8rem * var(--space-x-reverse));
+    margin-left: calc(-8rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-36 > :not([hidden]) ~ :not([hidden]) {
@@ -115940,8 +115940,8 @@ video {
 
   .\32xl\:-space-x-36 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-9rem * var(--space-x-reverse));
-    margin-inline-start: calc(-9rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-9rem * var(--space-x-reverse));
+    margin-left: calc(-9rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-40 > :not([hidden]) ~ :not([hidden]) {
@@ -115952,8 +115952,8 @@ video {
 
   .\32xl\:-space-x-40 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-10rem * var(--space-x-reverse));
-    margin-inline-start: calc(-10rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-10rem * var(--space-x-reverse));
+    margin-left: calc(-10rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-44 > :not([hidden]) ~ :not([hidden]) {
@@ -115964,8 +115964,8 @@ video {
 
   .\32xl\:-space-x-44 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-11rem * var(--space-x-reverse));
-    margin-inline-start: calc(-11rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-11rem * var(--space-x-reverse));
+    margin-left: calc(-11rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-48 > :not([hidden]) ~ :not([hidden]) {
@@ -115976,8 +115976,8 @@ video {
 
   .\32xl\:-space-x-48 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-12rem * var(--space-x-reverse));
-    margin-inline-start: calc(-12rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-12rem * var(--space-x-reverse));
+    margin-left: calc(-12rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-52 > :not([hidden]) ~ :not([hidden]) {
@@ -115988,8 +115988,8 @@ video {
 
   .\32xl\:-space-x-52 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-13rem * var(--space-x-reverse));
-    margin-inline-start: calc(-13rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-13rem * var(--space-x-reverse));
+    margin-left: calc(-13rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-56 > :not([hidden]) ~ :not([hidden]) {
@@ -116000,8 +116000,8 @@ video {
 
   .\32xl\:-space-x-56 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-14rem * var(--space-x-reverse));
-    margin-inline-start: calc(-14rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-14rem * var(--space-x-reverse));
+    margin-left: calc(-14rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-60 > :not([hidden]) ~ :not([hidden]) {
@@ -116012,8 +116012,8 @@ video {
 
   .\32xl\:-space-x-60 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-15rem * var(--space-x-reverse));
-    margin-inline-start: calc(-15rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-15rem * var(--space-x-reverse));
+    margin-left: calc(-15rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-64 > :not([hidden]) ~ :not([hidden]) {
@@ -116024,8 +116024,8 @@ video {
 
   .\32xl\:-space-x-64 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-16rem * var(--space-x-reverse));
-    margin-inline-start: calc(-16rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-16rem * var(--space-x-reverse));
+    margin-left: calc(-16rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-72 > :not([hidden]) ~ :not([hidden]) {
@@ -116036,8 +116036,8 @@ video {
 
   .\32xl\:-space-x-72 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-18rem * var(--space-x-reverse));
-    margin-inline-start: calc(-18rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-18rem * var(--space-x-reverse));
+    margin-left: calc(-18rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-80 > :not([hidden]) ~ :not([hidden]) {
@@ -116048,8 +116048,8 @@ video {
 
   .\32xl\:-space-x-80 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-20rem * var(--space-x-reverse));
-    margin-inline-start: calc(-20rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-20rem * var(--space-x-reverse));
+    margin-left: calc(-20rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-96 > :not([hidden]) ~ :not([hidden]) {
@@ -116060,8 +116060,8 @@ video {
 
   .\32xl\:-space-x-96 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-24rem * var(--space-x-reverse));
-    margin-inline-start: calc(-24rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-24rem * var(--space-x-reverse));
+    margin-left: calc(-24rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-px > :not([hidden]) ~ :not([hidden]) {
@@ -116072,8 +116072,8 @@ video {
 
   .\32xl\:-space-x-px > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-1px * var(--space-x-reverse));
-    margin-inline-start: calc(-1px * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-1px * var(--space-x-reverse));
+    margin-left: calc(-1px * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-0\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -116084,8 +116084,8 @@ video {
 
   .\32xl\:-space-x-0\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.125rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.125rem * var(--space-x-reverse));
+    margin-left: calc(-0.125rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-1\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -116096,8 +116096,8 @@ video {
 
   .\32xl\:-space-x-1\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.375rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.375rem * var(--space-x-reverse));
+    margin-left: calc(-0.375rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-2\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -116108,8 +116108,8 @@ video {
 
   .\32xl\:-space-x-2\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.625rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.625rem * var(--space-x-reverse));
+    margin-left: calc(-0.625rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:-space-y-3\.5 > :not([hidden]) ~ :not([hidden]) {
@@ -116120,8 +116120,8 @@ video {
 
   .\32xl\:-space-x-3\.5 > :not([hidden]) ~ :not([hidden]) {
     --space-x-reverse: 0;
-    margin-inline-end: calc(-0.875rem * var(--space-x-reverse));
-    margin-inline-start: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
+    margin-right: calc(-0.875rem * var(--space-x-reverse));
+    margin-left: calc(-0.875rem * calc(1 - var(--space-x-reverse)));
   }
 
   .\32xl\:space-y-reverse > :not([hidden]) ~ :not([hidden]) {
@@ -116140,8 +116140,8 @@ video {
 
   .\32xl\:divide-x-0 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(0px * var(--divide-x-reverse));
-    border-inline-start-width: calc(0px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(0px * var(--divide-x-reverse));
+    border-left-width: calc(0px * calc(1 - var(--divide-x-reverse)));
   }
 
   .\32xl\:divide-y-2 > :not([hidden]) ~ :not([hidden]) {
@@ -116152,8 +116152,8 @@ video {
 
   .\32xl\:divide-x-2 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(2px * var(--divide-x-reverse));
-    border-inline-start-width: calc(2px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(2px * var(--divide-x-reverse));
+    border-left-width: calc(2px * calc(1 - var(--divide-x-reverse)));
   }
 
   .\32xl\:divide-y-4 > :not([hidden]) ~ :not([hidden]) {
@@ -116164,8 +116164,8 @@ video {
 
   .\32xl\:divide-x-4 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(4px * var(--divide-x-reverse));
-    border-inline-start-width: calc(4px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(4px * var(--divide-x-reverse));
+    border-left-width: calc(4px * calc(1 - var(--divide-x-reverse)));
   }
 
   .\32xl\:divide-y-8 > :not([hidden]) ~ :not([hidden]) {
@@ -116176,8 +116176,8 @@ video {
 
   .\32xl\:divide-x-8 > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(8px * var(--divide-x-reverse));
-    border-inline-start-width: calc(8px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(8px * var(--divide-x-reverse));
+    border-left-width: calc(8px * calc(1 - var(--divide-x-reverse)));
   }
 
   .\32xl\:divide-y > :not([hidden]) ~ :not([hidden]) {
@@ -116188,8 +116188,8 @@ video {
 
   .\32xl\:divide-x > :not([hidden]) ~ :not([hidden]) {
     --divide-x-reverse: 0;
-    border-inline-end-width: calc(1px * var(--divide-x-reverse));
-    border-inline-start-width: calc(1px * calc(1 - var(--divide-x-reverse)));
+    border-right-width: calc(1px * var(--divide-x-reverse));
+    border-left-width: calc(1px * calc(1 - var(--divide-x-reverse)));
   }
 
   .\32xl\:divide-y-reverse > :not([hidden]) ~ :not([hidden]) {

--- a/__tests__/plugins/divideWidth.test.js
+++ b/__tests__/plugins/divideWidth.test.js
@@ -28,8 +28,8 @@ test('generating divide width utilities', () => {
         },
         '.divide-x > :not([hidden]) ~ :not([hidden])': {
           '--divide-x-reverse': '0',
-          'border-inline-end-width': 'calc(1px * var(--divide-x-reverse))',
-          'border-inline-start-width': 'calc(1px * calc(1 - var(--divide-x-reverse)))',
+          'border-right-width': 'calc(1px * var(--divide-x-reverse))',
+          'border-left-width': 'calc(1px * calc(1 - var(--divide-x-reverse)))',
         },
         '.divide-y-0 > :not([hidden]) ~ :not([hidden])': {
           '--divide-y-reverse': '0',
@@ -38,8 +38,8 @@ test('generating divide width utilities', () => {
         },
         '.divide-x-0 > :not([hidden]) ~ :not([hidden])': {
           '--divide-x-reverse': '0',
-          'border-inline-end-width': 'calc(0px * var(--divide-x-reverse))',
-          'border-inline-start-width': 'calc(0px * calc(1 - var(--divide-x-reverse)))',
+          'border-right-width': 'calc(0px * var(--divide-x-reverse))',
+          'border-left-width': 'calc(0px * calc(1 - var(--divide-x-reverse)))',
         },
         '.divide-y-2 > :not([hidden]) ~ :not([hidden])': {
           '--divide-y-reverse': '0',
@@ -48,8 +48,8 @@ test('generating divide width utilities', () => {
         },
         '.divide-x-2 > :not([hidden]) ~ :not([hidden])': {
           '--divide-x-reverse': '0',
-          'border-inline-end-width': 'calc(2px * var(--divide-x-reverse))',
-          'border-inline-start-width': 'calc(2px * calc(1 - var(--divide-x-reverse)))',
+          'border-right-width': 'calc(2px * var(--divide-x-reverse))',
+          'border-left-width': 'calc(2px * calc(1 - var(--divide-x-reverse)))',
         },
         '.divide-y-4 > :not([hidden]) ~ :not([hidden])': {
           '--divide-y-reverse': '0',
@@ -58,8 +58,8 @@ test('generating divide width utilities', () => {
         },
         '.divide-x-4 > :not([hidden]) ~ :not([hidden])': {
           '--divide-x-reverse': '0',
-          'border-inline-end-width': 'calc(4px * var(--divide-x-reverse))',
-          'border-inline-start-width': 'calc(4px * calc(1 - var(--divide-x-reverse)))',
+          'border-right-width': 'calc(4px * var(--divide-x-reverse))',
+          'border-left-width': 'calc(4px * calc(1 - var(--divide-x-reverse)))',
         },
         '.divide-y-reverse > :not([hidden]) ~ :not([hidden])': {
           '--divide-y-reverse': '1',

--- a/__tests__/plugins/space.test.js
+++ b/__tests__/plugins/space.test.js
@@ -30,8 +30,8 @@ test('generating space utilities', () => {
         },
         '.space-x-0 > :not([hidden]) ~ :not([hidden])': {
           '--space-x-reverse': '0',
-          'margin-inline-end': 'calc(0px * var(--space-x-reverse))',
-          'margin-inline-start': 'calc(0px * calc(1 - var(--space-x-reverse)))',
+          'margin-right': 'calc(0px * var(--space-x-reverse))',
+          'margin-left': 'calc(0px * calc(1 - var(--space-x-reverse)))',
         },
         '.space-y-1 > :not([hidden]) ~ :not([hidden])': {
           '--space-y-reverse': '0',
@@ -40,8 +40,8 @@ test('generating space utilities', () => {
         },
         '.space-x-1 > :not([hidden]) ~ :not([hidden])': {
           '--space-x-reverse': '0',
-          'margin-inline-end': 'calc(1px * var(--space-x-reverse))',
-          'margin-inline-start': 'calc(1px * calc(1 - var(--space-x-reverse)))',
+          'margin-right': 'calc(1px * var(--space-x-reverse))',
+          'margin-left': 'calc(1px * calc(1 - var(--space-x-reverse)))',
         },
         '.space-y-2 > :not([hidden]) ~ :not([hidden])': {
           '--space-y-reverse': '0',
@@ -50,8 +50,8 @@ test('generating space utilities', () => {
         },
         '.space-x-2 > :not([hidden]) ~ :not([hidden])': {
           '--space-x-reverse': '0',
-          'margin-inline-end': 'calc(2px * var(--space-x-reverse))',
-          'margin-inline-start': 'calc(2px * calc(1 - var(--space-x-reverse)))',
+          'margin-right': 'calc(2px * var(--space-x-reverse))',
+          'margin-left': 'calc(2px * calc(1 - var(--space-x-reverse)))',
         },
         '.space-y-4 > :not([hidden]) ~ :not([hidden])': {
           '--space-y-reverse': '0',
@@ -60,8 +60,8 @@ test('generating space utilities', () => {
         },
         '.space-x-4 > :not([hidden]) ~ :not([hidden])': {
           '--space-x-reverse': '0',
-          'margin-inline-end': 'calc(4px * var(--space-x-reverse))',
-          'margin-inline-start': 'calc(4px * calc(1 - var(--space-x-reverse)))',
+          'margin-right': 'calc(4px * var(--space-x-reverse))',
+          'margin-left': 'calc(4px * calc(1 - var(--space-x-reverse)))',
         },
         '.-space-y-2 > :not([hidden]) ~ :not([hidden])': {
           '--space-y-reverse': '0',
@@ -70,8 +70,8 @@ test('generating space utilities', () => {
         },
         '.-space-x-2 > :not([hidden]) ~ :not([hidden])': {
           '--space-x-reverse': '0',
-          'margin-inline-end': 'calc(-2px * var(--space-x-reverse))',
-          'margin-inline-start': 'calc(-2px * calc(1 - var(--space-x-reverse)))',
+          'margin-right': 'calc(-2px * var(--space-x-reverse))',
+          'margin-left': 'calc(-2px * calc(1 - var(--space-x-reverse)))',
         },
         '.-space-y-1 > :not([hidden]) ~ :not([hidden])': {
           '--space-y-reverse': '0',
@@ -80,8 +80,8 @@ test('generating space utilities', () => {
         },
         '.-space-x-1 > :not([hidden]) ~ :not([hidden])': {
           '--space-x-reverse': '0',
-          'margin-inline-end': 'calc(-1px * var(--space-x-reverse))',
-          'margin-inline-start': 'calc(-1px * calc(1 - var(--space-x-reverse)))',
+          'margin-right': 'calc(-1px * var(--space-x-reverse))',
+          'margin-left': 'calc(-1px * calc(1 - var(--space-x-reverse)))',
         },
         '.space-y-reverse > :not([hidden]) ~ :not([hidden])': {
           '--space-y-reverse': '1',

--- a/src/plugins/divideWidth.js
+++ b/src/plugins/divideWidth.js
@@ -14,8 +14,8 @@ export default function () {
           },
           [`${nameClass('divide-x', modifier)} > :not([hidden]) ~ :not([hidden])`]: {
             '--divide-x-reverse': '0',
-            'border-inline-end-width': `calc(${size} * var(--divide-x-reverse))`,
-            'border-inline-start-width': `calc(${size} * calc(1 - var(--divide-x-reverse)))`,
+            'border-right-width': `calc(${size} * var(--divide-x-reverse))`,
+            'border-left-width': `calc(${size} * calc(1 - var(--divide-x-reverse)))`,
           },
         }
       },

--- a/src/plugins/space.js
+++ b/src/plugins/space.js
@@ -14,8 +14,8 @@ export default function () {
           },
           [`${nameClass('space-x', modifier)} > :not([hidden]) ~ :not([hidden])`]: {
             '--space-x-reverse': '0',
-            'margin-inline-end': `calc(${size} * var(--space-x-reverse))`,
-            'margin-inline-start': `calc(${size} * calc(1 - var(--space-x-reverse)))`,
+            'margin-right': `calc(${size} * var(--space-x-reverse))`,
+            'margin-left': `calc(${size} * calc(1 - var(--space-x-reverse)))`,
           },
         }
       },


### PR DESCRIPTION
This PR reverts the changes in #1883 and switches back to using left/right instead of inline-start/inline-end for the space/divide utilities. Spent literally the last 8 hours deliberating on this and working through the problem for multiple hours at a time with three trusted colleagues, so not a change I am making lightly.

The primary reason is that **space-x is not a good name for a utility that adds a gap on the inline axis**. The letter `x` means "horizontal", and `inline-start` and `inline-end` apply on the _inline_ axis which is not always horizontal — it's only horizontal in horizontal writing modes.

Switching these utilities to use these logical properties means that in vertical writing modes, `space-x` and `space-y` actually both apply along the vertical axis, which is weird and inconsistent.

The better solution here is utilities like `space-i` and `divide-i` for adding space/border on the _inline_ axis explicitly. Adding these though would increase the default file size considerably, and open the floodgates to requests for adding at a bare minimum `space-b` and `divide-b` utilities for the block axis, and likely `mis-4`, `pbe-6`, etc. for full-blown logical properties support.

I'm not quite prepared to tackle that project yet, and it feels wrong to change the implementation of `space-x` and `divide-x` to something that no longer matches the name as a half-measure, so I've decided to keep things as is.

The other reason is that this is technically a breaking change, as users building RTL sites are likely already working around the behavior this was trying to fix by adding `space-x-reverse` to their HTML. This would break those sites, which is a bit annoying even though the experience for those users would admittedly be better after they went through the upgrade process.

Since I am convinced that proper logical property support is the better way to solve this problem, I'm going to avoid changing this implementation and saving that project either for later, or for the community to handle. 

There are already plugins in the wild like this one that add most of these utilities:

https://github.com/stevecochrane/tailwindcss-logical

...and using Tailwind's `corePlugins` config, it is easy to disable any built-in plugins that are based on literal directions like left/right/top/bottom and use the logical property versions instead.

Sorry for the back and forth on this, it's been very hard to make this decision but ultimately I think it's always better to do nothing than to do something we may regret later ❤️ 