### PR TITLE
Re-order browserslist for no reason

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
   },
   "browserslist": [
     "> 1%",
-    "not edge <= 18",
     "not ie 11",
+    "not edge <= 18",
     "not op_mini all"
   ],
   "babel": {


### PR DESCRIPTION
This PR re-orders the browserslist config for no reason other than to have some change to commit, in hopes that running the same CI tests in a pull request passes since running them on master fails for no reason.