### PR TITLE
Added missing separator property to defaultConfig

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -4,6 +4,7 @@ module.exports = {
   purge: [],
   presets: [],
   darkMode: false,
+  separator: ':',
   theme: {
     screens: {
       sm: '640px',


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->

While trying to generate a CSS output file with the tailwind cli build command `npx tailwindcss@1.9.0 build -c  defaultConfig.stub.js -o tailwind-output.css` the separator is missing from all generated classes affected by variants. 

I tried this with every version from 1.9.0 up to 1.9.5 with the same result.

```css

@media (min-width: 640px) {
  .smundefinedcontent-center {
    align-content: center;
  }

  .smundefinedcontent-start {
    align-content: flex-start;
  }

  /*... */
}
```

While I guess it would be great to fallback to `:` if no separator is defined in the configuration, I do believe it would be a good step to fix this in this stub file as well. As it is linked on the [documentation page](https://tailwindcss.com/docs/configuration) as a default config example. 

