### PR TITLE
Rename whitespace-no-wrap to whitespace-nowrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `space` and `divide` utilities ignore elements with `[hidden]` now instead of only ignoring `template` elements ([#2642](https://github.com/tailwindlabs/tailwindcss/pull/2642))
 - Set default font on `body`, not just `html` ([#2643](https://github.com/tailwindlabs/tailwindcss/pull/2643))
 - Automatically prefix keyframes and animation names when a prefix is configured ([#2621](https://github.com/tailwindlabs/tailwindcss/pull/2621), [#2641](https://github.com/tailwindlabs/tailwindcss/pull/2641))
+- Rename `whitespace-no-wrap` to `whitespace-nowrap` ([#2664](https://github.com/tailwindlabs/tailwindcss/pull/2664))
 
 ## [1.9.6]
 

--- a/__tests__/fixtures/purge-example.html
+++ b/__tests__/fixtures/purge-example.html
@@ -40,5 +40,5 @@ span.inline-grid.grid-cols-3(class="px-1.5")
 
 <!-- JSON -->
 {
-  "helloThere": "Hello there, <span class=\"whitespace-no-wrap\">Mr. Jones</span>"
+  "helloThere": "Hello there, <span class=\"whitespace-nowrap\">Mr. Jones</span>"
 }

--- a/__tests__/fixtures/tailwind-output-flagged.css
+++ b/__tests__/fixtures/tailwind-output-flagged.css
@@ -19230,7 +19230,7 @@ video {
   white-space: normal;
 }
 
-.whitespace-no-wrap {
+.whitespace-nowrap {
   white-space: nowrap;
 }
 
@@ -42210,7 +42210,7 @@ video {
     white-space: normal;
   }
 
-  .sm\:whitespace-no-wrap {
+  .sm\:whitespace-nowrap {
     white-space: nowrap;
   }
 
@@ -65160,7 +65160,7 @@ video {
     white-space: normal;
   }
 
-  .md\:whitespace-no-wrap {
+  .md\:whitespace-nowrap {
     white-space: nowrap;
   }
 
@@ -88110,7 +88110,7 @@ video {
     white-space: normal;
   }
 
-  .lg\:whitespace-no-wrap {
+  .lg\:whitespace-nowrap {
     white-space: nowrap;
   }
 
@@ -111060,7 +111060,7 @@ video {
     white-space: normal;
   }
 
-  .xl\:whitespace-no-wrap {
+  .xl\:whitespace-nowrap {
     white-space: nowrap;
   }
 
@@ -134010,7 +134010,7 @@ video {
     white-space: normal;
   }
 
-  .\32xl\:whitespace-no-wrap {
+  .\32xl\:whitespace-nowrap {
     white-space: nowrap;
   }
 

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -19230,7 +19230,7 @@ video {
   white-space: normal !important;
 }
 
-.whitespace-no-wrap {
+.whitespace-nowrap {
   white-space: nowrap !important;
 }
 
@@ -42210,7 +42210,7 @@ video {
     white-space: normal !important;
   }
 
-  .sm\:whitespace-no-wrap {
+  .sm\:whitespace-nowrap {
     white-space: nowrap !important;
   }
 
@@ -65160,7 +65160,7 @@ video {
     white-space: normal !important;
   }
 
-  .md\:whitespace-no-wrap {
+  .md\:whitespace-nowrap {
     white-space: nowrap !important;
   }
 
@@ -88110,7 +88110,7 @@ video {
     white-space: normal !important;
   }
 
-  .lg\:whitespace-no-wrap {
+  .lg\:whitespace-nowrap {
     white-space: nowrap !important;
   }
 
@@ -111060,7 +111060,7 @@ video {
     white-space: normal !important;
   }
 
-  .xl\:whitespace-no-wrap {
+  .xl\:whitespace-nowrap {
     white-space: nowrap !important;
   }
 
@@ -134010,7 +134010,7 @@ video {
     white-space: normal !important;
   }
 
-  .\32xl\:whitespace-no-wrap {
+  .\32xl\:whitespace-nowrap {
     white-space: nowrap !important;
   }
 

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -17370,7 +17370,7 @@ video {
   white-space: normal;
 }
 
-.whitespace-no-wrap {
+.whitespace-nowrap {
   white-space: nowrap;
 }
 
@@ -38490,7 +38490,7 @@ video {
     white-space: normal;
   }
 
-  .sm\:whitespace-no-wrap {
+  .sm\:whitespace-nowrap {
     white-space: nowrap;
   }
 
@@ -59580,7 +59580,7 @@ video {
     white-space: normal;
   }
 
-  .md\:whitespace-no-wrap {
+  .md\:whitespace-nowrap {
     white-space: nowrap;
   }
 
@@ -80670,7 +80670,7 @@ video {
     white-space: normal;
   }
 
-  .lg\:whitespace-no-wrap {
+  .lg\:whitespace-nowrap {
     white-space: nowrap;
   }
 
@@ -101760,7 +101760,7 @@ video {
     white-space: normal;
   }
 
-  .xl\:whitespace-no-wrap {
+  .xl\:whitespace-nowrap {
     white-space: nowrap;
   }
 
@@ -122850,7 +122850,7 @@ video {
     white-space: normal;
   }
 
-  .\32xl\:whitespace-no-wrap {
+  .\32xl\:whitespace-nowrap {
     white-space: nowrap;
   }
 

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -19230,7 +19230,7 @@ video {
   white-space: normal;
 }
 
-.whitespace-no-wrap {
+.whitespace-nowrap {
   white-space: nowrap;
 }
 
@@ -42210,7 +42210,7 @@ video {
     white-space: normal;
   }
 
-  .sm\:whitespace-no-wrap {
+  .sm\:whitespace-nowrap {
     white-space: nowrap;
   }
 
@@ -65160,7 +65160,7 @@ video {
     white-space: normal;
   }
 
-  .md\:whitespace-no-wrap {
+  .md\:whitespace-nowrap {
     white-space: nowrap;
   }
 
@@ -88110,7 +88110,7 @@ video {
     white-space: normal;
   }
 
-  .lg\:whitespace-no-wrap {
+  .lg\:whitespace-nowrap {
     white-space: nowrap;
   }
 
@@ -111060,7 +111060,7 @@ video {
     white-space: normal;
   }
 
-  .xl\:whitespace-no-wrap {
+  .xl\:whitespace-nowrap {
     white-space: nowrap;
   }
 
@@ -134010,7 +134010,7 @@ video {
     white-space: normal;
   }
 
-  .\32xl\:whitespace-no-wrap {
+  .\32xl\:whitespace-nowrap {
     white-space: nowrap;
   }
 

--- a/__tests__/purgeUnusedStyles.test.js
+++ b/__tests__/purgeUnusedStyles.test.js
@@ -92,7 +92,7 @@ function assertPurged(result) {
   expect(result.css).toContain('.font-mono')
   expect(result.css).toContain('.col-span-4')
   expect(result.css).toContain('.tracking-tight')
-  expect(result.css).toContain('.whitespace-no-wrap')
+  expect(result.css).toContain('.whitespace-nowrap')
 }
 
 test('purges unused classes', () => {

--- a/src/plugins/whitespace.js
+++ b/src/plugins/whitespace.js
@@ -3,7 +3,7 @@ export default function () {
     addUtilities(
       {
         '.whitespace-normal': { 'white-space': 'normal' },
-        '.whitespace-no-wrap': { 'white-space': 'nowrap' },
+        '.whitespace-nowrap': { 'white-space': 'nowrap' },
         '.whitespace-pre': { 'white-space': 'pre' },
         '.whitespace-pre-line': { 'white-space': 'pre-line' },
         '.whitespace-pre-wrap': { 'white-space': 'pre-wrap' },


### PR DESCRIPTION
This PR renames `whitespace-no-wrap` to `whitespace-nowrap` so it is a bit closer to the CSS. It was the only whitespace utility where the suffix didn't match the CSS value.

This is a breaking change but /whitespace-no-wrap/whitespace-nowrap/s is easy come on.