### PR TITLE
Revert renaming whitespace-no-wrap to whitespace-nowrap

### DIFF
--- a/__tests__/fixtures/purge-example.html
+++ b/__tests__/fixtures/purge-example.html
@@ -40,5 +40,5 @@ span.inline-grid.grid-cols-3(class="px-1.5")
 
 <!-- JSON -->
 {
-  "helloThere": "Hello there, <span class=\"whitespace-nowrap\">Mr. Jones</span>"
+  "helloThere": "Hello there, <span class=\"whitespace-no-wrap\">Mr. Jones</span>"
 }

--- a/__tests__/fixtures/tailwind-output-flagged.css
+++ b/__tests__/fixtures/tailwind-output-flagged.css
@@ -19230,7 +19230,7 @@ video {
   white-space: normal;
 }
 
-.whitespace-nowrap {
+.whitespace-no-wrap {
   white-space: nowrap;
 }
 
@@ -42210,7 +42210,7 @@ video {
     white-space: normal;
   }
 
-  .sm\:whitespace-nowrap {
+  .sm\:whitespace-no-wrap {
     white-space: nowrap;
   }
 
@@ -65160,7 +65160,7 @@ video {
     white-space: normal;
   }
 
-  .md\:whitespace-nowrap {
+  .md\:whitespace-no-wrap {
     white-space: nowrap;
   }
 
@@ -88110,7 +88110,7 @@ video {
     white-space: normal;
   }
 
-  .lg\:whitespace-nowrap {
+  .lg\:whitespace-no-wrap {
     white-space: nowrap;
   }
 
@@ -111060,7 +111060,7 @@ video {
     white-space: normal;
   }
 
-  .xl\:whitespace-nowrap {
+  .xl\:whitespace-no-wrap {
     white-space: nowrap;
   }
 
@@ -134010,7 +134010,7 @@ video {
     white-space: normal;
   }
 
-  .\32xl\:whitespace-nowrap {
+  .\32xl\:whitespace-no-wrap {
     white-space: nowrap;
   }
 

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -19230,7 +19230,7 @@ video {
   white-space: normal !important;
 }
 
-.whitespace-nowrap {
+.whitespace-no-wrap {
   white-space: nowrap !important;
 }
 
@@ -42210,7 +42210,7 @@ video {
     white-space: normal !important;
   }
 
-  .sm\:whitespace-nowrap {
+  .sm\:whitespace-no-wrap {
     white-space: nowrap !important;
   }
 
@@ -65160,7 +65160,7 @@ video {
     white-space: normal !important;
   }
 
-  .md\:whitespace-nowrap {
+  .md\:whitespace-no-wrap {
     white-space: nowrap !important;
   }
 
@@ -88110,7 +88110,7 @@ video {
     white-space: normal !important;
   }
 
-  .lg\:whitespace-nowrap {
+  .lg\:whitespace-no-wrap {
     white-space: nowrap !important;
   }
 
@@ -111060,7 +111060,7 @@ video {
     white-space: normal !important;
   }
 
-  .xl\:whitespace-nowrap {
+  .xl\:whitespace-no-wrap {
     white-space: nowrap !important;
   }
 
@@ -134010,7 +134010,7 @@ video {
     white-space: normal !important;
   }
 
-  .\32xl\:whitespace-nowrap {
+  .\32xl\:whitespace-no-wrap {
     white-space: nowrap !important;
   }
 

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -17370,7 +17370,7 @@ video {
   white-space: normal;
 }
 
-.whitespace-nowrap {
+.whitespace-no-wrap {
   white-space: nowrap;
 }
 
@@ -38490,7 +38490,7 @@ video {
     white-space: normal;
   }
 
-  .sm\:whitespace-nowrap {
+  .sm\:whitespace-no-wrap {
     white-space: nowrap;
   }
 
@@ -59580,7 +59580,7 @@ video {
     white-space: normal;
   }
 
-  .md\:whitespace-nowrap {
+  .md\:whitespace-no-wrap {
     white-space: nowrap;
   }
 
@@ -80670,7 +80670,7 @@ video {
     white-space: normal;
   }
 
-  .lg\:whitespace-nowrap {
+  .lg\:whitespace-no-wrap {
     white-space: nowrap;
   }
 
@@ -101760,7 +101760,7 @@ video {
     white-space: normal;
   }
 
-  .xl\:whitespace-nowrap {
+  .xl\:whitespace-no-wrap {
     white-space: nowrap;
   }
 
@@ -122850,7 +122850,7 @@ video {
     white-space: normal;
   }
 
-  .\32xl\:whitespace-nowrap {
+  .\32xl\:whitespace-no-wrap {
     white-space: nowrap;
   }
 

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -19230,7 +19230,7 @@ video {
   white-space: normal;
 }
 
-.whitespace-nowrap {
+.whitespace-no-wrap {
   white-space: nowrap;
 }
 
@@ -42210,7 +42210,7 @@ video {
     white-space: normal;
   }
 
-  .sm\:whitespace-nowrap {
+  .sm\:whitespace-no-wrap {
     white-space: nowrap;
   }
 
@@ -65160,7 +65160,7 @@ video {
     white-space: normal;
   }
 
-  .md\:whitespace-nowrap {
+  .md\:whitespace-no-wrap {
     white-space: nowrap;
   }
 
@@ -88110,7 +88110,7 @@ video {
     white-space: normal;
   }
 
-  .lg\:whitespace-nowrap {
+  .lg\:whitespace-no-wrap {
     white-space: nowrap;
   }
 
@@ -111060,7 +111060,7 @@ video {
     white-space: normal;
   }
 
-  .xl\:whitespace-nowrap {
+  .xl\:whitespace-no-wrap {
     white-space: nowrap;
   }
 
@@ -134010,7 +134010,7 @@ video {
     white-space: normal;
   }
 
-  .\32xl\:whitespace-nowrap {
+  .\32xl\:whitespace-no-wrap {
     white-space: nowrap;
   }
 

--- a/__tests__/purgeUnusedStyles.test.js
+++ b/__tests__/purgeUnusedStyles.test.js
@@ -92,7 +92,7 @@ function assertPurged(result) {
   expect(result.css).toContain('.font-mono')
   expect(result.css).toContain('.col-span-4')
   expect(result.css).toContain('.tracking-tight')
-  expect(result.css).toContain('.whitespace-nowrap')
+  expect(result.css).toContain('.whitespace-no-wrap')
 }
 
 test('purges unused classes', () => {

--- a/src/plugins/whitespace.js
+++ b/src/plugins/whitespace.js
@@ -3,7 +3,7 @@ export default function () {
     addUtilities(
       {
         '.whitespace-normal': { 'white-space': 'normal' },
-        '.whitespace-nowrap': { 'white-space': 'nowrap' },
+        '.whitespace-no-wrap': { 'white-space': 'nowrap' },
         '.whitespace-pre': { 'white-space': 'pre' },
         '.whitespace-pre-line': { 'white-space': 'pre-line' },
         '.whitespace-pre-wrap': { 'white-space': 'pre-wrap' },


### PR DESCRIPTION
We shouldn't change this unless we also change `flex-no-wrap` to `flex-nowrap`. Changing multiple class names starts to feel like a more annoying breaking change, so going to revert this and reconsider. We'll either change both in a future commit, or just leave it as-is.

Small chance we just add `flex-nowrap` and `whitespace-nowrap` as aliases and stop documenting the versions with the extra dash, then remove in 3.0, but feels kinda stupid to introduce a deprecation instead of a break, especially one that affects the the CSS bundle size sent to the client.