### PR TITLE
Rename flex-no-wrap to flex-nowrap

### DIFF
--- a/__tests__/fixtures/tailwind-output-flagged.css
+++ b/__tests__/fixtures/tailwind-output-flagged.css
@@ -9158,7 +9158,7 @@ video {
   flex-wrap: wrap-reverse;
 }
 
-.flex-no-wrap {
+.flex-nowrap {
   flex-wrap: nowrap;
 }
 
@@ -32138,7 +32138,7 @@ video {
     flex-wrap: wrap-reverse;
   }
 
-  .sm\:flex-no-wrap {
+  .sm\:flex-nowrap {
     flex-wrap: nowrap;
   }
 
@@ -55088,7 +55088,7 @@ video {
     flex-wrap: wrap-reverse;
   }
 
-  .md\:flex-no-wrap {
+  .md\:flex-nowrap {
     flex-wrap: nowrap;
   }
 
@@ -78038,7 +78038,7 @@ video {
     flex-wrap: wrap-reverse;
   }
 
-  .lg\:flex-no-wrap {
+  .lg\:flex-nowrap {
     flex-wrap: nowrap;
   }
 
@@ -100988,7 +100988,7 @@ video {
     flex-wrap: wrap-reverse;
   }
 
-  .xl\:flex-no-wrap {
+  .xl\:flex-nowrap {
     flex-wrap: nowrap;
   }
 
@@ -123938,7 +123938,7 @@ video {
     flex-wrap: wrap-reverse;
   }
 
-  .\32xl\:flex-no-wrap {
+  .\32xl\:flex-nowrap {
     flex-wrap: nowrap;
   }
 

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -9158,7 +9158,7 @@ video {
   flex-wrap: wrap-reverse !important;
 }
 
-.flex-no-wrap {
+.flex-nowrap {
   flex-wrap: nowrap !important;
 }
 
@@ -32138,7 +32138,7 @@ video {
     flex-wrap: wrap-reverse !important;
   }
 
-  .sm\:flex-no-wrap {
+  .sm\:flex-nowrap {
     flex-wrap: nowrap !important;
   }
 
@@ -55088,7 +55088,7 @@ video {
     flex-wrap: wrap-reverse !important;
   }
 
-  .md\:flex-no-wrap {
+  .md\:flex-nowrap {
     flex-wrap: nowrap !important;
   }
 
@@ -78038,7 +78038,7 @@ video {
     flex-wrap: wrap-reverse !important;
   }
 
-  .lg\:flex-no-wrap {
+  .lg\:flex-nowrap {
     flex-wrap: nowrap !important;
   }
 
@@ -100988,7 +100988,7 @@ video {
     flex-wrap: wrap-reverse !important;
   }
 
-  .xl\:flex-no-wrap {
+  .xl\:flex-nowrap {
     flex-wrap: nowrap !important;
   }
 
@@ -123938,7 +123938,7 @@ video {
     flex-wrap: wrap-reverse !important;
   }
 
-  .\32xl\:flex-no-wrap {
+  .\32xl\:flex-nowrap {
     flex-wrap: nowrap !important;
   }
 

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -8042,7 +8042,7 @@ video {
   flex-wrap: wrap-reverse;
 }
 
-.flex-no-wrap {
+.flex-nowrap {
   flex-wrap: nowrap;
 }
 
@@ -29162,7 +29162,7 @@ video {
     flex-wrap: wrap-reverse;
   }
 
-  .sm\:flex-no-wrap {
+  .sm\:flex-nowrap {
     flex-wrap: nowrap;
   }
 
@@ -50252,7 +50252,7 @@ video {
     flex-wrap: wrap-reverse;
   }
 
-  .md\:flex-no-wrap {
+  .md\:flex-nowrap {
     flex-wrap: nowrap;
   }
 
@@ -71342,7 +71342,7 @@ video {
     flex-wrap: wrap-reverse;
   }
 
-  .lg\:flex-no-wrap {
+  .lg\:flex-nowrap {
     flex-wrap: nowrap;
   }
 
@@ -92432,7 +92432,7 @@ video {
     flex-wrap: wrap-reverse;
   }
 
-  .xl\:flex-no-wrap {
+  .xl\:flex-nowrap {
     flex-wrap: nowrap;
   }
 
@@ -113522,7 +113522,7 @@ video {
     flex-wrap: wrap-reverse;
   }
 
-  .\32xl\:flex-no-wrap {
+  .\32xl\:flex-nowrap {
     flex-wrap: nowrap;
   }
 

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -9158,7 +9158,7 @@ video {
   flex-wrap: wrap-reverse;
 }
 
-.flex-no-wrap {
+.flex-nowrap {
   flex-wrap: nowrap;
 }
 
@@ -32138,7 +32138,7 @@ video {
     flex-wrap: wrap-reverse;
   }
 
-  .sm\:flex-no-wrap {
+  .sm\:flex-nowrap {
     flex-wrap: nowrap;
   }
 
@@ -55088,7 +55088,7 @@ video {
     flex-wrap: wrap-reverse;
   }
 
-  .md\:flex-no-wrap {
+  .md\:flex-nowrap {
     flex-wrap: nowrap;
   }
 
@@ -78038,7 +78038,7 @@ video {
     flex-wrap: wrap-reverse;
   }
 
-  .lg\:flex-no-wrap {
+  .lg\:flex-nowrap {
     flex-wrap: nowrap;
   }
 
@@ -100988,7 +100988,7 @@ video {
     flex-wrap: wrap-reverse;
   }
 
-  .xl\:flex-no-wrap {
+  .xl\:flex-nowrap {
     flex-wrap: nowrap;
   }
 
@@ -123938,7 +123938,7 @@ video {
     flex-wrap: wrap-reverse;
   }
 
-  .\32xl\:flex-no-wrap {
+  .\32xl\:flex-nowrap {
     flex-wrap: nowrap;
   }
 

--- a/src/plugins/flexWrap.js
+++ b/src/plugins/flexWrap.js
@@ -8,7 +8,7 @@ export default function () {
         '.flex-wrap-reverse': {
           'flex-wrap': 'wrap-reverse',
         },
-        '.flex-no-wrap': {
+        '.flex-nowrap': {
           'flex-wrap': 'nowrap',
         },
       },


### PR DESCRIPTION
This PR is basically the opposite of #2675, and renames `flex-no-wrap` to `flex-nowrap` to be consistent with `whitespace-nowrap` if we choose to keep that change. Going to just leave both open until I decide what to do 🤔