### PR TITLE
Merge `extend` objects deeply by default

### DIFF
--- a/__tests__/resolveConfig.test.js
+++ b/__tests__/resolveConfig.test.js
@@ -229,6 +229,55 @@ test('theme key is merged instead of replaced', () => {
   })
 })
 
+test('theme key is deeply merged instead of replaced', () => {
+  const userConfig = {
+    theme: {
+      extend: {
+        colors: {
+          grey: {
+            darker: '#606f7b',
+            dark: '#8795a1',
+          },
+        },
+      },
+    },
+  }
+
+  const defaultConfig = {
+    prefix: '-',
+    important: false,
+    separator: ':',
+    theme: {
+      colors: {
+        grey: {
+          grey: '#b8c2cc',
+          light: '#dae1e7',
+          lighter: '#f1f5f8',
+        },
+      },
+    },
+  }
+
+  const result = resolveConfig([userConfig, defaultConfig])
+
+  expect(result).toMatchObject({
+    prefix: '-',
+    important: false,
+    separator: ':',
+    theme: {
+      colors: {
+        grey: {
+          darker: '#606f7b',
+          dark: '#8795a1',
+          grey: '#b8c2cc',
+          light: '#dae1e7',
+          lighter: '#f1f5f8',
+        },
+      },
+    },
+  })
+})
+
 test('variants key is merged instead of replaced', () => {
   const userConfig = {
     variants: {
@@ -1775,6 +1824,70 @@ test('variants can be extended', () => {
       borderColor: ['hover', 'group-focus', 'focus'],
       backgroundColor: ['responsive', 'group-hover', 'hover', 'focus', 'active', 'disabled'],
       textColor: ['responsive', 'focus-within', 'hover', 'focus'],
+    },
+  })
+})
+
+test('extensions are applied in the right order', () => {
+  const userConfig = {
+    theme: {
+      extend: {
+        colors: {
+          grey: {
+            light: '#eee',
+          },
+        },
+      },
+    },
+  }
+
+  const otherConfig = {
+    theme: {
+      extend: {
+        colors: {
+          grey: {
+            light: '#ddd',
+            darker: '#111',
+          },
+        },
+      },
+    },
+  }
+
+  const anotherConfig = {
+    theme: {
+      extend: {
+        colors: {
+          grey: {
+            darker: '#222',
+          },
+        },
+      },
+    },
+  }
+
+  const defaultConfig = {
+    theme: {
+      colors: {
+        grey: {
+          light: '#ccc',
+          dark: '#333',
+        },
+      },
+    },
+  }
+
+  const result = resolveConfig([userConfig, otherConfig, anotherConfig, defaultConfig])
+
+  expect(result).toMatchObject({
+    theme: {
+      colors: {
+        grey: {
+          light: '#eee',
+          dark: '#333',
+          darker: '#111',
+        },
+      },
     },
   })
 })

--- a/src/util/resolveConfig.js
+++ b/src/util/resolveConfig.js
@@ -67,20 +67,23 @@ function mergeThemes(themes) {
   }
 }
 
+function mergeExtensionCustomizer(_merged, value) {
+  if (Array.isArray(value)) return value
+}
+
 function mergeExtensions({ extend, ...theme }) {
   return mergeWith(theme, extend, (themeValue, extensions) => {
     // The `extend` property is an array, so we need to check if it contains any functions
     if (!isFunction(themeValue) && !some(extensions, isFunction)) {
-      return {
-        ...themeValue,
-        ...Object.assign({}, ...extensions),
-      }
+      return mergeWith({}, themeValue, ...extensions, mergeExtensionCustomizer)
     }
 
-    return (resolveThemePath, utils) => ({
-      ...value(themeValue, resolveThemePath, utils),
-      ...Object.assign({}, ...extensions.map((e) => value(e, resolveThemePath, utils))),
-    })
+    return (resolveThemePath, utils) =>
+      mergeWith(
+        {},
+        ...[themeValue, ...extensions].map((e) => value(e, resolveThemePath, utils)),
+        mergeExtensionCustomizer
+      )
   })
 }
 


### PR DESCRIPTION
_Description by @adamwathan_

---

This PR changes how the `extend` behavior under `theme` works by default, and merges extensions deeply/recursively instead of shallowly.

Here's a simple example — given this input:

```js
module.exports = {
  theme: {
    extend: {
      colors: {
        red: {
          450: '#f45d5d'
        }
      }
    }
  }
}
```

...historically, you'd get this output:

```js
module.exports = {
  theme: {
    colors: {
      // ...
      red: {
        450: '#f45d5d'
      }
    }
  }
}
```

All of the `red` values would be _gone_, only `450` would exist because the new `red` object replaced the entire old `red` object.

After this PR, you'd get this output:

```js
module.exports = {
  theme: {
    colors: {
      // ...
      red: {
        50: '#fef2f2',
        100: '#fee2e2',
        200: '#fecaca',
        300: '#fca5a5',
        450: '#f45d5d'
        400: '#f87171',
        500: '#ef4444',
        600: '#dc2626',
        700: '#b91c1c',
        800: '#991b1b',
        900: '#7f1d1d',
      },
    }
  }
}
```

...where `450` is merged with the existing object.

This is a breaking change because some people might be depending on this behavior, especially third-party plugins that might have been authored with this behavior in mind when designing their own customization API.

This is one of the most common problems people run into when trying to do stuff like this in their config file though, so we think it's worth it to correct this default.

If someone did want to replace the entire color `red` after this PR is merged, they could still do so using one of two ways:

**1. Replace all of the same sub-values**

If your new color uses the same `50` – `900` scale as the built-in color, then things will just work:

```js
module.exports = {
  theme: {
    extend: {
      colors: {
        red: {
          50: '#fef3f2',
          100: '#fee3e2',
          200: '#fedaca',
          300: '#fca6a5',
          400: '#f97171',
          500: '#ef5444',
          600: '#dd2626',
          700: '#ba1c1c',
          800: '#9a1b1b',
          900: '#7f2d1d',
        }
      }
    }
  }
}
```

**2. Replace the color without using `extend`**

If you want to use a different naming scheme, don't use `extend` at all when overriding the values:

```js
module.exports = {
  theme: {
    colors: {
      red: {
        lightest: '#fef3f2',
        lighter: '#fedaca',
        light: '#f97171',
        DEFAULT: '#ef5444',
        dark: '#dd2626',
        darker: '#9a1b1b',
        darkest: '#7f2d1d',
      }
    }
  }
}
```

This will override _all_ of the colors so you will have to redefine each one you need, but you can do that like so:

```js
const defaultTheme = require('tailwindcss/defaultTheme')

module.exports = {
  theme: {
    colors: {
      ...defaultTheme.colors,
      red: {
        lightest: '#fef3f2',
        lighter: '#fedaca',
        light: '#f97171',
        DEFAULT: '#ef5444',
        dark: '#dd2626',
        darker: '#9a1b1b',
        darkest: '#7f2d1d',
      }
    }
  }
}
```

If you are renaming everything like this though you are likely already replacing all of the colors so this won't even be an issue.

---

Colors are the only place where this is applicable in the default theme (arrays like in `fontFamily` are _not_ deep merged), so we don't expect this will really have a big impact. If anything, I expect most people are already working around this by doing stuff like this:

```js
const defaultTheme = require('tailwindcss/defaultTheme')

module.exports = {
  theme: {
    extend: {
      colors: {
        red: {
          ...defaultTheme.colors.red,
          450: '#f45d5d'
        }
      }
    }
  }
}
```

...so they'll actually be able to just delete some of that workaround code that is no longer necessary.