### PR TITLE
Add 'inherit' to default color palette

### DIFF
--- a/__tests__/fixtures/tailwind-output-ie11.css
+++ b/__tests__/fixtures/tailwind-output-ie11.css
@@ -945,6 +945,10 @@ video {
   border-color: transparent;
 }
 
+.divide-inherit > :not(template) ~ :not(template) {
+  border-color: inherit;
+}
+
 .divide-current > :not(template) ~ :not(template) {
   border-color: currentColor;
 }
@@ -1415,6 +1419,10 @@ video {
   background-color: transparent;
 }
 
+.bg-inherit {
+  background-color: inherit;
+}
+
 .bg-current {
   background-color: currentColor;
 }
@@ -1791,6 +1799,10 @@ video {
   background-color: transparent;
 }
 
+.hover\:bg-inherit:hover {
+  background-color: inherit;
+}
+
 .hover\:bg-current:hover {
   background-color: currentColor;
 }
@@ -2165,6 +2177,10 @@ video {
 
 .focus\:bg-transparent:focus {
   background-color: transparent;
+}
+
+.focus\:bg-inherit:focus {
+  background-color: inherit;
 }
 
 .focus\:bg-current:focus {
@@ -2627,6 +2643,10 @@ video {
   border-color: transparent;
 }
 
+.border-inherit {
+  border-color: inherit;
+}
+
 .border-current {
   border-color: currentColor;
 }
@@ -3003,6 +3023,10 @@ video {
   border-color: transparent;
 }
 
+.hover\:border-inherit:hover {
+  border-color: inherit;
+}
+
 .hover\:border-current:hover {
   border-color: currentColor;
 }
@@ -3377,6 +3401,10 @@ video {
 
 .focus\:border-transparent:focus {
   border-color: transparent;
+}
+
+.focus\:border-inherit:focus {
+  border-color: inherit;
 }
 
 .focus\:border-current:focus {
@@ -6845,6 +6873,10 @@ video {
   color: transparent;
 }
 
+.placeholder-inherit::placeholder {
+  color: inherit;
+}
+
 .placeholder-current::placeholder {
   color: currentColor;
 }
@@ -7219,6 +7251,10 @@ video {
 
 .focus\:placeholder-transparent:focus::placeholder {
   color: transparent;
+}
+
+.focus\:placeholder-inherit:focus::placeholder {
+  color: inherit;
 }
 
 .focus\:placeholder-current:focus::placeholder {
@@ -7867,6 +7903,10 @@ video {
   color: transparent;
 }
 
+.text-inherit {
+  color: inherit;
+}
+
 .text-current {
   color: currentColor;
 }
@@ -8243,6 +8283,10 @@ video {
   color: transparent;
 }
 
+.hover\:text-inherit:hover {
+  color: inherit;
+}
+
 .hover\:text-current:hover {
   color: currentColor;
 }
@@ -8617,6 +8661,10 @@ video {
 
 .focus\:text-transparent:focus {
   color: transparent;
+}
+
+.focus\:text-inherit:focus {
+  color: inherit;
 }
 
 .focus\:text-current:focus {
@@ -11775,6 +11823,10 @@ video {
     border-color: transparent;
   }
 
+  .sm\:divide-inherit > :not(template) ~ :not(template) {
+    border-color: inherit;
+  }
+
   .sm\:divide-current > :not(template) ~ :not(template) {
     border-color: currentColor;
   }
@@ -12245,6 +12297,10 @@ video {
     background-color: transparent;
   }
 
+  .sm\:bg-inherit {
+    background-color: inherit;
+  }
+
   .sm\:bg-current {
     background-color: currentColor;
   }
@@ -12621,6 +12677,10 @@ video {
     background-color: transparent;
   }
 
+  .sm\:hover\:bg-inherit:hover {
+    background-color: inherit;
+  }
+
   .sm\:hover\:bg-current:hover {
     background-color: currentColor;
   }
@@ -12995,6 +13055,10 @@ video {
 
   .sm\:focus\:bg-transparent:focus {
     background-color: transparent;
+  }
+
+  .sm\:focus\:bg-inherit:focus {
+    background-color: inherit;
   }
 
   .sm\:focus\:bg-current:focus {
@@ -13457,6 +13521,10 @@ video {
     border-color: transparent;
   }
 
+  .sm\:border-inherit {
+    border-color: inherit;
+  }
+
   .sm\:border-current {
     border-color: currentColor;
   }
@@ -13833,6 +13901,10 @@ video {
     border-color: transparent;
   }
 
+  .sm\:hover\:border-inherit:hover {
+    border-color: inherit;
+  }
+
   .sm\:hover\:border-current:hover {
     border-color: currentColor;
   }
@@ -14207,6 +14279,10 @@ video {
 
   .sm\:focus\:border-transparent:focus {
     border-color: transparent;
+  }
+
+  .sm\:focus\:border-inherit:focus {
+    border-color: inherit;
   }
 
   .sm\:focus\:border-current:focus {
@@ -17675,6 +17751,10 @@ video {
     color: transparent;
   }
 
+  .sm\:placeholder-inherit::placeholder {
+    color: inherit;
+  }
+
   .sm\:placeholder-current::placeholder {
     color: currentColor;
   }
@@ -18049,6 +18129,10 @@ video {
 
   .sm\:focus\:placeholder-transparent:focus::placeholder {
     color: transparent;
+  }
+
+  .sm\:focus\:placeholder-inherit:focus::placeholder {
+    color: inherit;
   }
 
   .sm\:focus\:placeholder-current:focus::placeholder {
@@ -18697,6 +18781,10 @@ video {
     color: transparent;
   }
 
+  .sm\:text-inherit {
+    color: inherit;
+  }
+
   .sm\:text-current {
     color: currentColor;
   }
@@ -19073,6 +19161,10 @@ video {
     color: transparent;
   }
 
+  .sm\:hover\:text-inherit:hover {
+    color: inherit;
+  }
+
   .sm\:hover\:text-current:hover {
     color: currentColor;
   }
@@ -19447,6 +19539,10 @@ video {
 
   .sm\:focus\:text-transparent:focus {
     color: transparent;
+  }
+
+  .sm\:focus\:text-inherit:focus {
+    color: inherit;
   }
 
   .sm\:focus\:text-current:focus {
@@ -22575,6 +22671,10 @@ video {
     border-color: transparent;
   }
 
+  .md\:divide-inherit > :not(template) ~ :not(template) {
+    border-color: inherit;
+  }
+
   .md\:divide-current > :not(template) ~ :not(template) {
     border-color: currentColor;
   }
@@ -23045,6 +23145,10 @@ video {
     background-color: transparent;
   }
 
+  .md\:bg-inherit {
+    background-color: inherit;
+  }
+
   .md\:bg-current {
     background-color: currentColor;
   }
@@ -23421,6 +23525,10 @@ video {
     background-color: transparent;
   }
 
+  .md\:hover\:bg-inherit:hover {
+    background-color: inherit;
+  }
+
   .md\:hover\:bg-current:hover {
     background-color: currentColor;
   }
@@ -23795,6 +23903,10 @@ video {
 
   .md\:focus\:bg-transparent:focus {
     background-color: transparent;
+  }
+
+  .md\:focus\:bg-inherit:focus {
+    background-color: inherit;
   }
 
   .md\:focus\:bg-current:focus {
@@ -24257,6 +24369,10 @@ video {
     border-color: transparent;
   }
 
+  .md\:border-inherit {
+    border-color: inherit;
+  }
+
   .md\:border-current {
     border-color: currentColor;
   }
@@ -24633,6 +24749,10 @@ video {
     border-color: transparent;
   }
 
+  .md\:hover\:border-inherit:hover {
+    border-color: inherit;
+  }
+
   .md\:hover\:border-current:hover {
     border-color: currentColor;
   }
@@ -25007,6 +25127,10 @@ video {
 
   .md\:focus\:border-transparent:focus {
     border-color: transparent;
+  }
+
+  .md\:focus\:border-inherit:focus {
+    border-color: inherit;
   }
 
   .md\:focus\:border-current:focus {
@@ -28475,6 +28599,10 @@ video {
     color: transparent;
   }
 
+  .md\:placeholder-inherit::placeholder {
+    color: inherit;
+  }
+
   .md\:placeholder-current::placeholder {
     color: currentColor;
   }
@@ -28849,6 +28977,10 @@ video {
 
   .md\:focus\:placeholder-transparent:focus::placeholder {
     color: transparent;
+  }
+
+  .md\:focus\:placeholder-inherit:focus::placeholder {
+    color: inherit;
   }
 
   .md\:focus\:placeholder-current:focus::placeholder {
@@ -29497,6 +29629,10 @@ video {
     color: transparent;
   }
 
+  .md\:text-inherit {
+    color: inherit;
+  }
+
   .md\:text-current {
     color: currentColor;
   }
@@ -29873,6 +30009,10 @@ video {
     color: transparent;
   }
 
+  .md\:hover\:text-inherit:hover {
+    color: inherit;
+  }
+
   .md\:hover\:text-current:hover {
     color: currentColor;
   }
@@ -30247,6 +30387,10 @@ video {
 
   .md\:focus\:text-transparent:focus {
     color: transparent;
+  }
+
+  .md\:focus\:text-inherit:focus {
+    color: inherit;
   }
 
   .md\:focus\:text-current:focus {
@@ -33375,6 +33519,10 @@ video {
     border-color: transparent;
   }
 
+  .lg\:divide-inherit > :not(template) ~ :not(template) {
+    border-color: inherit;
+  }
+
   .lg\:divide-current > :not(template) ~ :not(template) {
     border-color: currentColor;
   }
@@ -33845,6 +33993,10 @@ video {
     background-color: transparent;
   }
 
+  .lg\:bg-inherit {
+    background-color: inherit;
+  }
+
   .lg\:bg-current {
     background-color: currentColor;
   }
@@ -34221,6 +34373,10 @@ video {
     background-color: transparent;
   }
 
+  .lg\:hover\:bg-inherit:hover {
+    background-color: inherit;
+  }
+
   .lg\:hover\:bg-current:hover {
     background-color: currentColor;
   }
@@ -34595,6 +34751,10 @@ video {
 
   .lg\:focus\:bg-transparent:focus {
     background-color: transparent;
+  }
+
+  .lg\:focus\:bg-inherit:focus {
+    background-color: inherit;
   }
 
   .lg\:focus\:bg-current:focus {
@@ -35057,6 +35217,10 @@ video {
     border-color: transparent;
   }
 
+  .lg\:border-inherit {
+    border-color: inherit;
+  }
+
   .lg\:border-current {
     border-color: currentColor;
   }
@@ -35433,6 +35597,10 @@ video {
     border-color: transparent;
   }
 
+  .lg\:hover\:border-inherit:hover {
+    border-color: inherit;
+  }
+
   .lg\:hover\:border-current:hover {
     border-color: currentColor;
   }
@@ -35807,6 +35975,10 @@ video {
 
   .lg\:focus\:border-transparent:focus {
     border-color: transparent;
+  }
+
+  .lg\:focus\:border-inherit:focus {
+    border-color: inherit;
   }
 
   .lg\:focus\:border-current:focus {
@@ -39275,6 +39447,10 @@ video {
     color: transparent;
   }
 
+  .lg\:placeholder-inherit::placeholder {
+    color: inherit;
+  }
+
   .lg\:placeholder-current::placeholder {
     color: currentColor;
   }
@@ -39649,6 +39825,10 @@ video {
 
   .lg\:focus\:placeholder-transparent:focus::placeholder {
     color: transparent;
+  }
+
+  .lg\:focus\:placeholder-inherit:focus::placeholder {
+    color: inherit;
   }
 
   .lg\:focus\:placeholder-current:focus::placeholder {
@@ -40297,6 +40477,10 @@ video {
     color: transparent;
   }
 
+  .lg\:text-inherit {
+    color: inherit;
+  }
+
   .lg\:text-current {
     color: currentColor;
   }
@@ -40673,6 +40857,10 @@ video {
     color: transparent;
   }
 
+  .lg\:hover\:text-inherit:hover {
+    color: inherit;
+  }
+
   .lg\:hover\:text-current:hover {
     color: currentColor;
   }
@@ -41047,6 +41235,10 @@ video {
 
   .lg\:focus\:text-transparent:focus {
     color: transparent;
+  }
+
+  .lg\:focus\:text-inherit:focus {
+    color: inherit;
   }
 
   .lg\:focus\:text-current:focus {
@@ -44175,6 +44367,10 @@ video {
     border-color: transparent;
   }
 
+  .xl\:divide-inherit > :not(template) ~ :not(template) {
+    border-color: inherit;
+  }
+
   .xl\:divide-current > :not(template) ~ :not(template) {
     border-color: currentColor;
   }
@@ -44645,6 +44841,10 @@ video {
     background-color: transparent;
   }
 
+  .xl\:bg-inherit {
+    background-color: inherit;
+  }
+
   .xl\:bg-current {
     background-color: currentColor;
   }
@@ -45021,6 +45221,10 @@ video {
     background-color: transparent;
   }
 
+  .xl\:hover\:bg-inherit:hover {
+    background-color: inherit;
+  }
+
   .xl\:hover\:bg-current:hover {
     background-color: currentColor;
   }
@@ -45395,6 +45599,10 @@ video {
 
   .xl\:focus\:bg-transparent:focus {
     background-color: transparent;
+  }
+
+  .xl\:focus\:bg-inherit:focus {
+    background-color: inherit;
   }
 
   .xl\:focus\:bg-current:focus {
@@ -45857,6 +46065,10 @@ video {
     border-color: transparent;
   }
 
+  .xl\:border-inherit {
+    border-color: inherit;
+  }
+
   .xl\:border-current {
     border-color: currentColor;
   }
@@ -46233,6 +46445,10 @@ video {
     border-color: transparent;
   }
 
+  .xl\:hover\:border-inherit:hover {
+    border-color: inherit;
+  }
+
   .xl\:hover\:border-current:hover {
     border-color: currentColor;
   }
@@ -46607,6 +46823,10 @@ video {
 
   .xl\:focus\:border-transparent:focus {
     border-color: transparent;
+  }
+
+  .xl\:focus\:border-inherit:focus {
+    border-color: inherit;
   }
 
   .xl\:focus\:border-current:focus {
@@ -50075,6 +50295,10 @@ video {
     color: transparent;
   }
 
+  .xl\:placeholder-inherit::placeholder {
+    color: inherit;
+  }
+
   .xl\:placeholder-current::placeholder {
     color: currentColor;
   }
@@ -50449,6 +50673,10 @@ video {
 
   .xl\:focus\:placeholder-transparent:focus::placeholder {
     color: transparent;
+  }
+
+  .xl\:focus\:placeholder-inherit:focus::placeholder {
+    color: inherit;
   }
 
   .xl\:focus\:placeholder-current:focus::placeholder {
@@ -51097,6 +51325,10 @@ video {
     color: transparent;
   }
 
+  .xl\:text-inherit {
+    color: inherit;
+  }
+
   .xl\:text-current {
     color: currentColor;
   }
@@ -51473,6 +51705,10 @@ video {
     color: transparent;
   }
 
+  .xl\:hover\:text-inherit:hover {
+    color: inherit;
+  }
+
   .xl\:hover\:text-current:hover {
     color: currentColor;
   }
@@ -51847,6 +52083,10 @@ video {
 
   .xl\:focus\:text-transparent:focus {
     color: transparent;
+  }
+
+  .xl\:focus\:text-inherit:focus {
+    color: inherit;
   }
 
   .xl\:focus\:text-current:focus {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -1129,6 +1129,10 @@ video {
   border-color: transparent !important;
 }
 
+.divide-inherit > :not(template) ~ :not(template) {
+  border-color: inherit !important;
+}
+
 .divide-current > :not(template) ~ :not(template) {
   border-color: currentColor !important;
 }
@@ -1807,6 +1811,10 @@ video {
   background-color: transparent !important;
 }
 
+.bg-inherit {
+  background-color: inherit !important;
+}
+
 .bg-current {
   background-color: currentColor !important;
 }
@@ -2367,6 +2375,10 @@ video {
   background-color: transparent !important;
 }
 
+.hover\:bg-inherit:hover {
+  background-color: inherit !important;
+}
+
 .hover\:bg-current:hover {
   background-color: currentColor !important;
 }
@@ -2925,6 +2937,10 @@ video {
 
 .focus\:bg-transparent:focus {
   background-color: transparent !important;
+}
+
+.focus\:bg-inherit:focus {
+  background-color: inherit !important;
 }
 
 .focus\:bg-current:focus {
@@ -3524,6 +3540,11 @@ video {
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
 }
 
+.from-inherit {
+  --gradient-from-color: inherit !important;
+  --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
+}
+
 .from-current {
   --gradient-from-color: currentColor !important;
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
@@ -3992,6 +4013,11 @@ video {
 .via-transparent {
   --gradient-via-color: transparent !important;
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
+}
+
+.via-inherit {
+  --gradient-via-color: inherit !important;
+  --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
 }
 
 .via-current {
@@ -4463,6 +4489,10 @@ video {
   --gradient-to-color: transparent !important;
 }
 
+.to-inherit {
+  --gradient-to-color: inherit !important;
+}
+
 .to-current {
   --gradient-to-color: currentColor !important;
 }
@@ -4838,6 +4868,11 @@ video {
 .hover\:from-transparent:hover {
   --gradient-from-color: transparent !important;
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
+}
+
+.hover\:from-inherit:hover {
+  --gradient-from-color: inherit !important;
+  --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
 }
 
 .hover\:from-current:hover {
@@ -5310,6 +5345,11 @@ video {
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
 }
 
+.hover\:via-inherit:hover {
+  --gradient-via-color: inherit !important;
+  --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
+}
+
 .hover\:via-current:hover {
   --gradient-via-color: currentColor !important;
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
@@ -5779,6 +5819,10 @@ video {
   --gradient-to-color: transparent !important;
 }
 
+.hover\:to-inherit:hover {
+  --gradient-to-color: inherit !important;
+}
+
 .hover\:to-current:hover {
   --gradient-to-color: currentColor !important;
 }
@@ -6154,6 +6198,11 @@ video {
 .focus\:from-transparent:focus {
   --gradient-from-color: transparent !important;
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
+}
+
+.focus\:from-inherit:focus {
+  --gradient-from-color: inherit !important;
+  --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
 }
 
 .focus\:from-current:focus {
@@ -6626,6 +6675,11 @@ video {
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
 }
 
+.focus\:via-inherit:focus {
+  --gradient-via-color: inherit !important;
+  --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
+}
+
 .focus\:via-current:focus {
   --gradient-via-color: currentColor !important;
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
@@ -7093,6 +7147,10 @@ video {
 
 .focus\:to-transparent:focus {
   --gradient-to-color: transparent !important;
+}
+
+.focus\:to-inherit:focus {
+  --gradient-to-color: inherit !important;
 }
 
 .focus\:to-current:focus {
@@ -7609,6 +7667,10 @@ video {
 
 .border-transparent {
   border-color: transparent !important;
+}
+
+.border-inherit {
+  border-color: inherit !important;
 }
 
 .border-current {
@@ -8171,6 +8233,10 @@ video {
   border-color: transparent !important;
 }
 
+.hover\:border-inherit:hover {
+  border-color: inherit !important;
+}
+
 .hover\:border-current:hover {
   border-color: currentColor !important;
 }
@@ -8729,6 +8795,10 @@ video {
 
 .focus\:border-transparent:focus {
   border-color: transparent !important;
+}
+
+.focus\:border-inherit:focus {
+  border-color: inherit !important;
 }
 
 .focus\:border-current:focus {
@@ -12657,6 +12727,10 @@ video {
   color: transparent !important;
 }
 
+.placeholder-inherit::placeholder {
+  color: inherit !important;
+}
+
 .placeholder-current::placeholder {
   color: currentColor !important;
 }
@@ -13215,6 +13289,10 @@ video {
 
 .focus\:placeholder-transparent:focus::placeholder {
   color: transparent !important;
+}
+
+.focus\:placeholder-inherit:focus::placeholder {
+  color: inherit !important;
 }
 
 .focus\:placeholder-current:focus::placeholder {
@@ -14091,6 +14169,10 @@ video {
   color: transparent !important;
 }
 
+.text-inherit {
+  color: inherit !important;
+}
+
 .text-current {
   color: currentColor !important;
 }
@@ -14651,6 +14733,10 @@ video {
   color: transparent !important;
 }
 
+.hover\:text-inherit:hover {
+  color: inherit !important;
+}
+
 .hover\:text-current:hover {
   color: currentColor !important;
 }
@@ -15209,6 +15295,10 @@ video {
 
 .focus\:text-transparent:focus {
   color: transparent !important;
+}
+
+.focus\:text-inherit:focus {
+  color: inherit !important;
 }
 
 .focus\:text-current:focus {
@@ -19752,6 +19842,10 @@ video {
     border-color: transparent !important;
   }
 
+  .sm\:divide-inherit > :not(template) ~ :not(template) {
+    border-color: inherit !important;
+  }
+
   .sm\:divide-current > :not(template) ~ :not(template) {
     border-color: currentColor !important;
   }
@@ -20430,6 +20524,10 @@ video {
     background-color: transparent !important;
   }
 
+  .sm\:bg-inherit {
+    background-color: inherit !important;
+  }
+
   .sm\:bg-current {
     background-color: currentColor !important;
   }
@@ -20990,6 +21088,10 @@ video {
     background-color: transparent !important;
   }
 
+  .sm\:hover\:bg-inherit:hover {
+    background-color: inherit !important;
+  }
+
   .sm\:hover\:bg-current:hover {
     background-color: currentColor !important;
   }
@@ -21548,6 +21650,10 @@ video {
 
   .sm\:focus\:bg-transparent:focus {
     background-color: transparent !important;
+  }
+
+  .sm\:focus\:bg-inherit:focus {
+    background-color: inherit !important;
   }
 
   .sm\:focus\:bg-current:focus {
@@ -22147,6 +22253,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
   }
 
+  .sm\:from-inherit {
+    --gradient-from-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
+  }
+
   .sm\:from-current {
     --gradient-from-color: currentColor !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
@@ -22615,6 +22726,11 @@ video {
   .sm\:via-transparent {
     --gradient-via-color: transparent !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
+  }
+
+  .sm\:via-inherit {
+    --gradient-via-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
   }
 
   .sm\:via-current {
@@ -23086,6 +23202,10 @@ video {
     --gradient-to-color: transparent !important;
   }
 
+  .sm\:to-inherit {
+    --gradient-to-color: inherit !important;
+  }
+
   .sm\:to-current {
     --gradient-to-color: currentColor !important;
   }
@@ -23461,6 +23581,11 @@ video {
   .sm\:hover\:from-transparent:hover {
     --gradient-from-color: transparent !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
+  }
+
+  .sm\:hover\:from-inherit:hover {
+    --gradient-from-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
   }
 
   .sm\:hover\:from-current:hover {
@@ -23933,6 +24058,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
   }
 
+  .sm\:hover\:via-inherit:hover {
+    --gradient-via-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
+  }
+
   .sm\:hover\:via-current:hover {
     --gradient-via-color: currentColor !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
@@ -24402,6 +24532,10 @@ video {
     --gradient-to-color: transparent !important;
   }
 
+  .sm\:hover\:to-inherit:hover {
+    --gradient-to-color: inherit !important;
+  }
+
   .sm\:hover\:to-current:hover {
     --gradient-to-color: currentColor !important;
   }
@@ -24777,6 +24911,11 @@ video {
   .sm\:focus\:from-transparent:focus {
     --gradient-from-color: transparent !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
+  }
+
+  .sm\:focus\:from-inherit:focus {
+    --gradient-from-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
   }
 
   .sm\:focus\:from-current:focus {
@@ -25249,6 +25388,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
   }
 
+  .sm\:focus\:via-inherit:focus {
+    --gradient-via-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
+  }
+
   .sm\:focus\:via-current:focus {
     --gradient-via-color: currentColor !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
@@ -25716,6 +25860,10 @@ video {
 
   .sm\:focus\:to-transparent:focus {
     --gradient-to-color: transparent !important;
+  }
+
+  .sm\:focus\:to-inherit:focus {
+    --gradient-to-color: inherit !important;
   }
 
   .sm\:focus\:to-current:focus {
@@ -26232,6 +26380,10 @@ video {
 
   .sm\:border-transparent {
     border-color: transparent !important;
+  }
+
+  .sm\:border-inherit {
+    border-color: inherit !important;
   }
 
   .sm\:border-current {
@@ -26794,6 +26946,10 @@ video {
     border-color: transparent !important;
   }
 
+  .sm\:hover\:border-inherit:hover {
+    border-color: inherit !important;
+  }
+
   .sm\:hover\:border-current:hover {
     border-color: currentColor !important;
   }
@@ -27352,6 +27508,10 @@ video {
 
   .sm\:focus\:border-transparent:focus {
     border-color: transparent !important;
+  }
+
+  .sm\:focus\:border-inherit:focus {
+    border-color: inherit !important;
   }
 
   .sm\:focus\:border-current:focus {
@@ -31280,6 +31440,10 @@ video {
     color: transparent !important;
   }
 
+  .sm\:placeholder-inherit::placeholder {
+    color: inherit !important;
+  }
+
   .sm\:placeholder-current::placeholder {
     color: currentColor !important;
   }
@@ -31838,6 +32002,10 @@ video {
 
   .sm\:focus\:placeholder-transparent:focus::placeholder {
     color: transparent !important;
+  }
+
+  .sm\:focus\:placeholder-inherit:focus::placeholder {
+    color: inherit !important;
   }
 
   .sm\:focus\:placeholder-current:focus::placeholder {
@@ -32714,6 +32882,10 @@ video {
     color: transparent !important;
   }
 
+  .sm\:text-inherit {
+    color: inherit !important;
+  }
+
   .sm\:text-current {
     color: currentColor !important;
   }
@@ -33274,6 +33446,10 @@ video {
     color: transparent !important;
   }
 
+  .sm\:hover\:text-inherit:hover {
+    color: inherit !important;
+  }
+
   .sm\:hover\:text-current:hover {
     color: currentColor !important;
   }
@@ -33832,6 +34008,10 @@ video {
 
   .sm\:focus\:text-transparent:focus {
     color: transparent !important;
+  }
+
+  .sm\:focus\:text-inherit:focus {
+    color: inherit !important;
   }
 
   .sm\:focus\:text-current:focus {
@@ -38345,6 +38525,10 @@ video {
     border-color: transparent !important;
   }
 
+  .md\:divide-inherit > :not(template) ~ :not(template) {
+    border-color: inherit !important;
+  }
+
   .md\:divide-current > :not(template) ~ :not(template) {
     border-color: currentColor !important;
   }
@@ -39023,6 +39207,10 @@ video {
     background-color: transparent !important;
   }
 
+  .md\:bg-inherit {
+    background-color: inherit !important;
+  }
+
   .md\:bg-current {
     background-color: currentColor !important;
   }
@@ -39583,6 +39771,10 @@ video {
     background-color: transparent !important;
   }
 
+  .md\:hover\:bg-inherit:hover {
+    background-color: inherit !important;
+  }
+
   .md\:hover\:bg-current:hover {
     background-color: currentColor !important;
   }
@@ -40141,6 +40333,10 @@ video {
 
   .md\:focus\:bg-transparent:focus {
     background-color: transparent !important;
+  }
+
+  .md\:focus\:bg-inherit:focus {
+    background-color: inherit !important;
   }
 
   .md\:focus\:bg-current:focus {
@@ -40740,6 +40936,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
   }
 
+  .md\:from-inherit {
+    --gradient-from-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
+  }
+
   .md\:from-current {
     --gradient-from-color: currentColor !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
@@ -41208,6 +41409,11 @@ video {
   .md\:via-transparent {
     --gradient-via-color: transparent !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
+  }
+
+  .md\:via-inherit {
+    --gradient-via-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
   }
 
   .md\:via-current {
@@ -41679,6 +41885,10 @@ video {
     --gradient-to-color: transparent !important;
   }
 
+  .md\:to-inherit {
+    --gradient-to-color: inherit !important;
+  }
+
   .md\:to-current {
     --gradient-to-color: currentColor !important;
   }
@@ -42054,6 +42264,11 @@ video {
   .md\:hover\:from-transparent:hover {
     --gradient-from-color: transparent !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
+  }
+
+  .md\:hover\:from-inherit:hover {
+    --gradient-from-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
   }
 
   .md\:hover\:from-current:hover {
@@ -42526,6 +42741,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
   }
 
+  .md\:hover\:via-inherit:hover {
+    --gradient-via-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
+  }
+
   .md\:hover\:via-current:hover {
     --gradient-via-color: currentColor !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
@@ -42995,6 +43215,10 @@ video {
     --gradient-to-color: transparent !important;
   }
 
+  .md\:hover\:to-inherit:hover {
+    --gradient-to-color: inherit !important;
+  }
+
   .md\:hover\:to-current:hover {
     --gradient-to-color: currentColor !important;
   }
@@ -43370,6 +43594,11 @@ video {
   .md\:focus\:from-transparent:focus {
     --gradient-from-color: transparent !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
+  }
+
+  .md\:focus\:from-inherit:focus {
+    --gradient-from-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
   }
 
   .md\:focus\:from-current:focus {
@@ -43842,6 +44071,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
   }
 
+  .md\:focus\:via-inherit:focus {
+    --gradient-via-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
+  }
+
   .md\:focus\:via-current:focus {
     --gradient-via-color: currentColor !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
@@ -44309,6 +44543,10 @@ video {
 
   .md\:focus\:to-transparent:focus {
     --gradient-to-color: transparent !important;
+  }
+
+  .md\:focus\:to-inherit:focus {
+    --gradient-to-color: inherit !important;
   }
 
   .md\:focus\:to-current:focus {
@@ -44825,6 +45063,10 @@ video {
 
   .md\:border-transparent {
     border-color: transparent !important;
+  }
+
+  .md\:border-inherit {
+    border-color: inherit !important;
   }
 
   .md\:border-current {
@@ -45387,6 +45629,10 @@ video {
     border-color: transparent !important;
   }
 
+  .md\:hover\:border-inherit:hover {
+    border-color: inherit !important;
+  }
+
   .md\:hover\:border-current:hover {
     border-color: currentColor !important;
   }
@@ -45945,6 +46191,10 @@ video {
 
   .md\:focus\:border-transparent:focus {
     border-color: transparent !important;
+  }
+
+  .md\:focus\:border-inherit:focus {
+    border-color: inherit !important;
   }
 
   .md\:focus\:border-current:focus {
@@ -49873,6 +50123,10 @@ video {
     color: transparent !important;
   }
 
+  .md\:placeholder-inherit::placeholder {
+    color: inherit !important;
+  }
+
   .md\:placeholder-current::placeholder {
     color: currentColor !important;
   }
@@ -50431,6 +50685,10 @@ video {
 
   .md\:focus\:placeholder-transparent:focus::placeholder {
     color: transparent !important;
+  }
+
+  .md\:focus\:placeholder-inherit:focus::placeholder {
+    color: inherit !important;
   }
 
   .md\:focus\:placeholder-current:focus::placeholder {
@@ -51307,6 +51565,10 @@ video {
     color: transparent !important;
   }
 
+  .md\:text-inherit {
+    color: inherit !important;
+  }
+
   .md\:text-current {
     color: currentColor !important;
   }
@@ -51867,6 +52129,10 @@ video {
     color: transparent !important;
   }
 
+  .md\:hover\:text-inherit:hover {
+    color: inherit !important;
+  }
+
   .md\:hover\:text-current:hover {
     color: currentColor !important;
   }
@@ -52425,6 +52691,10 @@ video {
 
   .md\:focus\:text-transparent:focus {
     color: transparent !important;
+  }
+
+  .md\:focus\:text-inherit:focus {
+    color: inherit !important;
   }
 
   .md\:focus\:text-current:focus {
@@ -56938,6 +57208,10 @@ video {
     border-color: transparent !important;
   }
 
+  .lg\:divide-inherit > :not(template) ~ :not(template) {
+    border-color: inherit !important;
+  }
+
   .lg\:divide-current > :not(template) ~ :not(template) {
     border-color: currentColor !important;
   }
@@ -57616,6 +57890,10 @@ video {
     background-color: transparent !important;
   }
 
+  .lg\:bg-inherit {
+    background-color: inherit !important;
+  }
+
   .lg\:bg-current {
     background-color: currentColor !important;
   }
@@ -58176,6 +58454,10 @@ video {
     background-color: transparent !important;
   }
 
+  .lg\:hover\:bg-inherit:hover {
+    background-color: inherit !important;
+  }
+
   .lg\:hover\:bg-current:hover {
     background-color: currentColor !important;
   }
@@ -58734,6 +59016,10 @@ video {
 
   .lg\:focus\:bg-transparent:focus {
     background-color: transparent !important;
+  }
+
+  .lg\:focus\:bg-inherit:focus {
+    background-color: inherit !important;
   }
 
   .lg\:focus\:bg-current:focus {
@@ -59333,6 +59619,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
   }
 
+  .lg\:from-inherit {
+    --gradient-from-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
+  }
+
   .lg\:from-current {
     --gradient-from-color: currentColor !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
@@ -59801,6 +60092,11 @@ video {
   .lg\:via-transparent {
     --gradient-via-color: transparent !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
+  }
+
+  .lg\:via-inherit {
+    --gradient-via-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
   }
 
   .lg\:via-current {
@@ -60272,6 +60568,10 @@ video {
     --gradient-to-color: transparent !important;
   }
 
+  .lg\:to-inherit {
+    --gradient-to-color: inherit !important;
+  }
+
   .lg\:to-current {
     --gradient-to-color: currentColor !important;
   }
@@ -60647,6 +60947,11 @@ video {
   .lg\:hover\:from-transparent:hover {
     --gradient-from-color: transparent !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
+  }
+
+  .lg\:hover\:from-inherit:hover {
+    --gradient-from-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
   }
 
   .lg\:hover\:from-current:hover {
@@ -61119,6 +61424,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
   }
 
+  .lg\:hover\:via-inherit:hover {
+    --gradient-via-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
+  }
+
   .lg\:hover\:via-current:hover {
     --gradient-via-color: currentColor !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
@@ -61588,6 +61898,10 @@ video {
     --gradient-to-color: transparent !important;
   }
 
+  .lg\:hover\:to-inherit:hover {
+    --gradient-to-color: inherit !important;
+  }
+
   .lg\:hover\:to-current:hover {
     --gradient-to-color: currentColor !important;
   }
@@ -61963,6 +62277,11 @@ video {
   .lg\:focus\:from-transparent:focus {
     --gradient-from-color: transparent !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
+  }
+
+  .lg\:focus\:from-inherit:focus {
+    --gradient-from-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
   }
 
   .lg\:focus\:from-current:focus {
@@ -62435,6 +62754,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
   }
 
+  .lg\:focus\:via-inherit:focus {
+    --gradient-via-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
+  }
+
   .lg\:focus\:via-current:focus {
     --gradient-via-color: currentColor !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
@@ -62902,6 +63226,10 @@ video {
 
   .lg\:focus\:to-transparent:focus {
     --gradient-to-color: transparent !important;
+  }
+
+  .lg\:focus\:to-inherit:focus {
+    --gradient-to-color: inherit !important;
   }
 
   .lg\:focus\:to-current:focus {
@@ -63418,6 +63746,10 @@ video {
 
   .lg\:border-transparent {
     border-color: transparent !important;
+  }
+
+  .lg\:border-inherit {
+    border-color: inherit !important;
   }
 
   .lg\:border-current {
@@ -63980,6 +64312,10 @@ video {
     border-color: transparent !important;
   }
 
+  .lg\:hover\:border-inherit:hover {
+    border-color: inherit !important;
+  }
+
   .lg\:hover\:border-current:hover {
     border-color: currentColor !important;
   }
@@ -64538,6 +64874,10 @@ video {
 
   .lg\:focus\:border-transparent:focus {
     border-color: transparent !important;
+  }
+
+  .lg\:focus\:border-inherit:focus {
+    border-color: inherit !important;
   }
 
   .lg\:focus\:border-current:focus {
@@ -68466,6 +68806,10 @@ video {
     color: transparent !important;
   }
 
+  .lg\:placeholder-inherit::placeholder {
+    color: inherit !important;
+  }
+
   .lg\:placeholder-current::placeholder {
     color: currentColor !important;
   }
@@ -69024,6 +69368,10 @@ video {
 
   .lg\:focus\:placeholder-transparent:focus::placeholder {
     color: transparent !important;
+  }
+
+  .lg\:focus\:placeholder-inherit:focus::placeholder {
+    color: inherit !important;
   }
 
   .lg\:focus\:placeholder-current:focus::placeholder {
@@ -69900,6 +70248,10 @@ video {
     color: transparent !important;
   }
 
+  .lg\:text-inherit {
+    color: inherit !important;
+  }
+
   .lg\:text-current {
     color: currentColor !important;
   }
@@ -70460,6 +70812,10 @@ video {
     color: transparent !important;
   }
 
+  .lg\:hover\:text-inherit:hover {
+    color: inherit !important;
+  }
+
   .lg\:hover\:text-current:hover {
     color: currentColor !important;
   }
@@ -71018,6 +71374,10 @@ video {
 
   .lg\:focus\:text-transparent:focus {
     color: transparent !important;
+  }
+
+  .lg\:focus\:text-inherit:focus {
+    color: inherit !important;
   }
 
   .lg\:focus\:text-current:focus {
@@ -75531,6 +75891,10 @@ video {
     border-color: transparent !important;
   }
 
+  .xl\:divide-inherit > :not(template) ~ :not(template) {
+    border-color: inherit !important;
+  }
+
   .xl\:divide-current > :not(template) ~ :not(template) {
     border-color: currentColor !important;
   }
@@ -76209,6 +76573,10 @@ video {
     background-color: transparent !important;
   }
 
+  .xl\:bg-inherit {
+    background-color: inherit !important;
+  }
+
   .xl\:bg-current {
     background-color: currentColor !important;
   }
@@ -76769,6 +77137,10 @@ video {
     background-color: transparent !important;
   }
 
+  .xl\:hover\:bg-inherit:hover {
+    background-color: inherit !important;
+  }
+
   .xl\:hover\:bg-current:hover {
     background-color: currentColor !important;
   }
@@ -77327,6 +77699,10 @@ video {
 
   .xl\:focus\:bg-transparent:focus {
     background-color: transparent !important;
+  }
+
+  .xl\:focus\:bg-inherit:focus {
+    background-color: inherit !important;
   }
 
   .xl\:focus\:bg-current:focus {
@@ -77926,6 +78302,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
   }
 
+  .xl\:from-inherit {
+    --gradient-from-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
+  }
+
   .xl\:from-current {
     --gradient-from-color: currentColor !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
@@ -78394,6 +78775,11 @@ video {
   .xl\:via-transparent {
     --gradient-via-color: transparent !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
+  }
+
+  .xl\:via-inherit {
+    --gradient-via-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
   }
 
   .xl\:via-current {
@@ -78865,6 +79251,10 @@ video {
     --gradient-to-color: transparent !important;
   }
 
+  .xl\:to-inherit {
+    --gradient-to-color: inherit !important;
+  }
+
   .xl\:to-current {
     --gradient-to-color: currentColor !important;
   }
@@ -79240,6 +79630,11 @@ video {
   .xl\:hover\:from-transparent:hover {
     --gradient-from-color: transparent !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
+  }
+
+  .xl\:hover\:from-inherit:hover {
+    --gradient-from-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
   }
 
   .xl\:hover\:from-current:hover {
@@ -79712,6 +80107,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
   }
 
+  .xl\:hover\:via-inherit:hover {
+    --gradient-via-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
+  }
+
   .xl\:hover\:via-current:hover {
     --gradient-via-color: currentColor !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
@@ -80181,6 +80581,10 @@ video {
     --gradient-to-color: transparent !important;
   }
 
+  .xl\:hover\:to-inherit:hover {
+    --gradient-to-color: inherit !important;
+  }
+
   .xl\:hover\:to-current:hover {
     --gradient-to-color: currentColor !important;
   }
@@ -80556,6 +80960,11 @@ video {
   .xl\:focus\:from-transparent:focus {
     --gradient-from-color: transparent !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
+  }
+
+  .xl\:focus\:from-inherit:focus {
+    --gradient-from-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
   }
 
   .xl\:focus\:from-current:focus {
@@ -81028,6 +81437,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0)) !important;
   }
 
+  .xl\:focus\:via-inherit:focus {
+    --gradient-via-color: inherit !important;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
+  }
+
   .xl\:focus\:via-current:focus {
     --gradient-via-color: currentColor !important;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0)) !important;
@@ -81495,6 +81909,10 @@ video {
 
   .xl\:focus\:to-transparent:focus {
     --gradient-to-color: transparent !important;
+  }
+
+  .xl\:focus\:to-inherit:focus {
+    --gradient-to-color: inherit !important;
   }
 
   .xl\:focus\:to-current:focus {
@@ -82011,6 +82429,10 @@ video {
 
   .xl\:border-transparent {
     border-color: transparent !important;
+  }
+
+  .xl\:border-inherit {
+    border-color: inherit !important;
   }
 
   .xl\:border-current {
@@ -82573,6 +82995,10 @@ video {
     border-color: transparent !important;
   }
 
+  .xl\:hover\:border-inherit:hover {
+    border-color: inherit !important;
+  }
+
   .xl\:hover\:border-current:hover {
     border-color: currentColor !important;
   }
@@ -83131,6 +83557,10 @@ video {
 
   .xl\:focus\:border-transparent:focus {
     border-color: transparent !important;
+  }
+
+  .xl\:focus\:border-inherit:focus {
+    border-color: inherit !important;
   }
 
   .xl\:focus\:border-current:focus {
@@ -87059,6 +87489,10 @@ video {
     color: transparent !important;
   }
 
+  .xl\:placeholder-inherit::placeholder {
+    color: inherit !important;
+  }
+
   .xl\:placeholder-current::placeholder {
     color: currentColor !important;
   }
@@ -87617,6 +88051,10 @@ video {
 
   .xl\:focus\:placeholder-transparent:focus::placeholder {
     color: transparent !important;
+  }
+
+  .xl\:focus\:placeholder-inherit:focus::placeholder {
+    color: inherit !important;
   }
 
   .xl\:focus\:placeholder-current:focus::placeholder {
@@ -88493,6 +88931,10 @@ video {
     color: transparent !important;
   }
 
+  .xl\:text-inherit {
+    color: inherit !important;
+  }
+
   .xl\:text-current {
     color: currentColor !important;
   }
@@ -89053,6 +89495,10 @@ video {
     color: transparent !important;
   }
 
+  .xl\:hover\:text-inherit:hover {
+    color: inherit !important;
+  }
+
   .xl\:hover\:text-current:hover {
     color: currentColor !important;
   }
@@ -89611,6 +90057,10 @@ video {
 
   .xl\:focus\:text-transparent:focus {
     color: transparent !important;
+  }
+
+  .xl\:focus\:text-inherit:focus {
+    color: inherit !important;
   }
 
   .xl\:focus\:text-current:focus {

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -1129,6 +1129,10 @@ video {
   border-color: transparent;
 }
 
+.divide-inherit > :not(template) ~ :not(template) {
+  border-color: inherit;
+}
+
 .divide-current > :not(template) ~ :not(template) {
   border-color: currentColor;
 }
@@ -1603,6 +1607,10 @@ video {
   background-color: transparent;
 }
 
+.bg-inherit {
+  background-color: inherit;
+}
+
 .bg-current {
   background-color: currentColor;
 }
@@ -1979,6 +1987,10 @@ video {
   background-color: transparent;
 }
 
+.hover\:bg-inherit:hover {
+  background-color: inherit;
+}
+
 .hover\:bg-current:hover {
   background-color: currentColor;
 }
@@ -2353,6 +2365,10 @@ video {
 
 .focus\:bg-transparent:focus {
   background-color: transparent;
+}
+
+.focus\:bg-inherit:focus {
+  background-color: inherit;
 }
 
 .focus\:bg-current:focus {
@@ -2766,6 +2782,11 @@ video {
 .from-transparent {
   --gradient-from-color: transparent;
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+}
+
+.from-inherit {
+  --gradient-from-color: inherit;
+  --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
 }
 
 .from-current {
@@ -3238,6 +3259,11 @@ video {
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
 }
 
+.via-inherit {
+  --gradient-via-color: inherit;
+  --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+}
+
 .via-current {
   --gradient-via-color: currentColor;
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -3707,6 +3733,10 @@ video {
   --gradient-to-color: transparent;
 }
 
+.to-inherit {
+  --gradient-to-color: inherit;
+}
+
 .to-current {
   --gradient-to-color: currentColor;
 }
@@ -4082,6 +4112,11 @@ video {
 .hover\:from-transparent:hover {
   --gradient-from-color: transparent;
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+}
+
+.hover\:from-inherit:hover {
+  --gradient-from-color: inherit;
+  --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
 }
 
 .hover\:from-current:hover {
@@ -4554,6 +4589,11 @@ video {
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
 }
 
+.hover\:via-inherit:hover {
+  --gradient-via-color: inherit;
+  --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+}
+
 .hover\:via-current:hover {
   --gradient-via-color: currentColor;
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -5023,6 +5063,10 @@ video {
   --gradient-to-color: transparent;
 }
 
+.hover\:to-inherit:hover {
+  --gradient-to-color: inherit;
+}
+
 .hover\:to-current:hover {
   --gradient-to-color: currentColor;
 }
@@ -5398,6 +5442,11 @@ video {
 .focus\:from-transparent:focus {
   --gradient-from-color: transparent;
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+}
+
+.focus\:from-inherit:focus {
+  --gradient-from-color: inherit;
+  --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
 }
 
 .focus\:from-current:focus {
@@ -5870,6 +5919,11 @@ video {
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
 }
 
+.focus\:via-inherit:focus {
+  --gradient-via-color: inherit;
+  --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+}
+
 .focus\:via-current:focus {
   --gradient-via-color: currentColor;
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -6339,6 +6393,10 @@ video {
   --gradient-to-color: transparent;
 }
 
+.focus\:to-inherit:focus {
+  --gradient-to-color: inherit;
+}
+
 .focus\:to-current:focus {
   --gradient-to-color: currentColor;
 }
@@ -6795,6 +6853,10 @@ video {
   border-color: transparent;
 }
 
+.border-inherit {
+  border-color: inherit;
+}
+
 .border-current {
   border-color: currentColor;
 }
@@ -7171,6 +7233,10 @@ video {
   border-color: transparent;
 }
 
+.hover\:border-inherit:hover {
+  border-color: inherit;
+}
+
 .hover\:border-current:hover {
   border-color: currentColor;
 }
@@ -7545,6 +7611,10 @@ video {
 
 .focus\:border-transparent:focus {
   border-color: transparent;
+}
+
+.focus\:border-inherit:focus {
+  border-color: inherit;
 }
 
 .focus\:border-current:focus {
@@ -11229,6 +11299,10 @@ video {
   color: transparent;
 }
 
+.placeholder-inherit::placeholder {
+  color: inherit;
+}
+
 .placeholder-current::placeholder {
   color: currentColor;
 }
@@ -11603,6 +11677,10 @@ video {
 
 .focus\:placeholder-transparent:focus::placeholder {
   color: transparent;
+}
+
+.focus\:placeholder-inherit:focus::placeholder {
+  color: inherit;
 }
 
 .focus\:placeholder-current:focus::placeholder {
@@ -12255,6 +12333,10 @@ video {
   color: transparent;
 }
 
+.text-inherit {
+  color: inherit;
+}
+
 .text-current {
   color: currentColor;
 }
@@ -12631,6 +12713,10 @@ video {
   color: transparent;
 }
 
+.hover\:text-inherit:hover {
+  color: inherit;
+}
+
 .hover\:text-current:hover {
   color: currentColor;
 }
@@ -13005,6 +13091,10 @@ video {
 
 .focus\:text-transparent:focus {
   color: transparent;
+}
+
+.focus\:text-inherit:focus {
+  color: inherit;
 }
 
 .focus\:text-current:focus {
@@ -17304,6 +17394,10 @@ video {
     border-color: transparent;
   }
 
+  .sm\:divide-inherit > :not(template) ~ :not(template) {
+    border-color: inherit;
+  }
+
   .sm\:divide-current > :not(template) ~ :not(template) {
     border-color: currentColor;
   }
@@ -17778,6 +17872,10 @@ video {
     background-color: transparent;
   }
 
+  .sm\:bg-inherit {
+    background-color: inherit;
+  }
+
   .sm\:bg-current {
     background-color: currentColor;
   }
@@ -18154,6 +18252,10 @@ video {
     background-color: transparent;
   }
 
+  .sm\:hover\:bg-inherit:hover {
+    background-color: inherit;
+  }
+
   .sm\:hover\:bg-current:hover {
     background-color: currentColor;
   }
@@ -18528,6 +18630,10 @@ video {
 
   .sm\:focus\:bg-transparent:focus {
     background-color: transparent;
+  }
+
+  .sm\:focus\:bg-inherit:focus {
+    background-color: inherit;
   }
 
   .sm\:focus\:bg-current:focus {
@@ -18941,6 +19047,11 @@ video {
   .sm\:from-transparent {
     --gradient-from-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .sm\:from-inherit {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .sm\:from-current {
@@ -19413,6 +19524,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .sm\:via-inherit {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .sm\:via-current {
     --gradient-via-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -19882,6 +19998,10 @@ video {
     --gradient-to-color: transparent;
   }
 
+  .sm\:to-inherit {
+    --gradient-to-color: inherit;
+  }
+
   .sm\:to-current {
     --gradient-to-color: currentColor;
   }
@@ -20257,6 +20377,11 @@ video {
   .sm\:hover\:from-transparent:hover {
     --gradient-from-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .sm\:hover\:from-inherit:hover {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .sm\:hover\:from-current:hover {
@@ -20729,6 +20854,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .sm\:hover\:via-inherit:hover {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .sm\:hover\:via-current:hover {
     --gradient-via-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -21198,6 +21328,10 @@ video {
     --gradient-to-color: transparent;
   }
 
+  .sm\:hover\:to-inherit:hover {
+    --gradient-to-color: inherit;
+  }
+
   .sm\:hover\:to-current:hover {
     --gradient-to-color: currentColor;
   }
@@ -21573,6 +21707,11 @@ video {
   .sm\:focus\:from-transparent:focus {
     --gradient-from-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .sm\:focus\:from-inherit:focus {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .sm\:focus\:from-current:focus {
@@ -22045,6 +22184,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .sm\:focus\:via-inherit:focus {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .sm\:focus\:via-current:focus {
     --gradient-via-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -22514,6 +22658,10 @@ video {
     --gradient-to-color: transparent;
   }
 
+  .sm\:focus\:to-inherit:focus {
+    --gradient-to-color: inherit;
+  }
+
   .sm\:focus\:to-current:focus {
     --gradient-to-color: currentColor;
   }
@@ -22970,6 +23118,10 @@ video {
     border-color: transparent;
   }
 
+  .sm\:border-inherit {
+    border-color: inherit;
+  }
+
   .sm\:border-current {
     border-color: currentColor;
   }
@@ -23346,6 +23498,10 @@ video {
     border-color: transparent;
   }
 
+  .sm\:hover\:border-inherit:hover {
+    border-color: inherit;
+  }
+
   .sm\:hover\:border-current:hover {
     border-color: currentColor;
   }
@@ -23720,6 +23876,10 @@ video {
 
   .sm\:focus\:border-transparent:focus {
     border-color: transparent;
+  }
+
+  .sm\:focus\:border-inherit:focus {
+    border-color: inherit;
   }
 
   .sm\:focus\:border-current:focus {
@@ -27404,6 +27564,10 @@ video {
     color: transparent;
   }
 
+  .sm\:placeholder-inherit::placeholder {
+    color: inherit;
+  }
+
   .sm\:placeholder-current::placeholder {
     color: currentColor;
   }
@@ -27778,6 +27942,10 @@ video {
 
   .sm\:focus\:placeholder-transparent:focus::placeholder {
     color: transparent;
+  }
+
+  .sm\:focus\:placeholder-inherit:focus::placeholder {
+    color: inherit;
   }
 
   .sm\:focus\:placeholder-current:focus::placeholder {
@@ -28430,6 +28598,10 @@ video {
     color: transparent;
   }
 
+  .sm\:text-inherit {
+    color: inherit;
+  }
+
   .sm\:text-current {
     color: currentColor;
   }
@@ -28806,6 +28978,10 @@ video {
     color: transparent;
   }
 
+  .sm\:hover\:text-inherit:hover {
+    color: inherit;
+  }
+
   .sm\:hover\:text-current:hover {
     color: currentColor;
   }
@@ -29180,6 +29356,10 @@ video {
 
   .sm\:focus\:text-transparent:focus {
     color: transparent;
+  }
+
+  .sm\:focus\:text-inherit:focus {
+    color: inherit;
   }
 
   .sm\:focus\:text-current:focus {
@@ -33449,6 +33629,10 @@ video {
     border-color: transparent;
   }
 
+  .md\:divide-inherit > :not(template) ~ :not(template) {
+    border-color: inherit;
+  }
+
   .md\:divide-current > :not(template) ~ :not(template) {
     border-color: currentColor;
   }
@@ -33923,6 +34107,10 @@ video {
     background-color: transparent;
   }
 
+  .md\:bg-inherit {
+    background-color: inherit;
+  }
+
   .md\:bg-current {
     background-color: currentColor;
   }
@@ -34299,6 +34487,10 @@ video {
     background-color: transparent;
   }
 
+  .md\:hover\:bg-inherit:hover {
+    background-color: inherit;
+  }
+
   .md\:hover\:bg-current:hover {
     background-color: currentColor;
   }
@@ -34673,6 +34865,10 @@ video {
 
   .md\:focus\:bg-transparent:focus {
     background-color: transparent;
+  }
+
+  .md\:focus\:bg-inherit:focus {
+    background-color: inherit;
   }
 
   .md\:focus\:bg-current:focus {
@@ -35086,6 +35282,11 @@ video {
   .md\:from-transparent {
     --gradient-from-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .md\:from-inherit {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .md\:from-current {
@@ -35558,6 +35759,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .md\:via-inherit {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .md\:via-current {
     --gradient-via-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -36027,6 +36233,10 @@ video {
     --gradient-to-color: transparent;
   }
 
+  .md\:to-inherit {
+    --gradient-to-color: inherit;
+  }
+
   .md\:to-current {
     --gradient-to-color: currentColor;
   }
@@ -36402,6 +36612,11 @@ video {
   .md\:hover\:from-transparent:hover {
     --gradient-from-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .md\:hover\:from-inherit:hover {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .md\:hover\:from-current:hover {
@@ -36874,6 +37089,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .md\:hover\:via-inherit:hover {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .md\:hover\:via-current:hover {
     --gradient-via-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -37343,6 +37563,10 @@ video {
     --gradient-to-color: transparent;
   }
 
+  .md\:hover\:to-inherit:hover {
+    --gradient-to-color: inherit;
+  }
+
   .md\:hover\:to-current:hover {
     --gradient-to-color: currentColor;
   }
@@ -37718,6 +37942,11 @@ video {
   .md\:focus\:from-transparent:focus {
     --gradient-from-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .md\:focus\:from-inherit:focus {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .md\:focus\:from-current:focus {
@@ -38190,6 +38419,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .md\:focus\:via-inherit:focus {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .md\:focus\:via-current:focus {
     --gradient-via-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -38659,6 +38893,10 @@ video {
     --gradient-to-color: transparent;
   }
 
+  .md\:focus\:to-inherit:focus {
+    --gradient-to-color: inherit;
+  }
+
   .md\:focus\:to-current:focus {
     --gradient-to-color: currentColor;
   }
@@ -39115,6 +39353,10 @@ video {
     border-color: transparent;
   }
 
+  .md\:border-inherit {
+    border-color: inherit;
+  }
+
   .md\:border-current {
     border-color: currentColor;
   }
@@ -39491,6 +39733,10 @@ video {
     border-color: transparent;
   }
 
+  .md\:hover\:border-inherit:hover {
+    border-color: inherit;
+  }
+
   .md\:hover\:border-current:hover {
     border-color: currentColor;
   }
@@ -39865,6 +40111,10 @@ video {
 
   .md\:focus\:border-transparent:focus {
     border-color: transparent;
+  }
+
+  .md\:focus\:border-inherit:focus {
+    border-color: inherit;
   }
 
   .md\:focus\:border-current:focus {
@@ -43549,6 +43799,10 @@ video {
     color: transparent;
   }
 
+  .md\:placeholder-inherit::placeholder {
+    color: inherit;
+  }
+
   .md\:placeholder-current::placeholder {
     color: currentColor;
   }
@@ -43923,6 +44177,10 @@ video {
 
   .md\:focus\:placeholder-transparent:focus::placeholder {
     color: transparent;
+  }
+
+  .md\:focus\:placeholder-inherit:focus::placeholder {
+    color: inherit;
   }
 
   .md\:focus\:placeholder-current:focus::placeholder {
@@ -44575,6 +44833,10 @@ video {
     color: transparent;
   }
 
+  .md\:text-inherit {
+    color: inherit;
+  }
+
   .md\:text-current {
     color: currentColor;
   }
@@ -44951,6 +45213,10 @@ video {
     color: transparent;
   }
 
+  .md\:hover\:text-inherit:hover {
+    color: inherit;
+  }
+
   .md\:hover\:text-current:hover {
     color: currentColor;
   }
@@ -45325,6 +45591,10 @@ video {
 
   .md\:focus\:text-transparent:focus {
     color: transparent;
+  }
+
+  .md\:focus\:text-inherit:focus {
+    color: inherit;
   }
 
   .md\:focus\:text-current:focus {
@@ -49594,6 +49864,10 @@ video {
     border-color: transparent;
   }
 
+  .lg\:divide-inherit > :not(template) ~ :not(template) {
+    border-color: inherit;
+  }
+
   .lg\:divide-current > :not(template) ~ :not(template) {
     border-color: currentColor;
   }
@@ -50068,6 +50342,10 @@ video {
     background-color: transparent;
   }
 
+  .lg\:bg-inherit {
+    background-color: inherit;
+  }
+
   .lg\:bg-current {
     background-color: currentColor;
   }
@@ -50444,6 +50722,10 @@ video {
     background-color: transparent;
   }
 
+  .lg\:hover\:bg-inherit:hover {
+    background-color: inherit;
+  }
+
   .lg\:hover\:bg-current:hover {
     background-color: currentColor;
   }
@@ -50818,6 +51100,10 @@ video {
 
   .lg\:focus\:bg-transparent:focus {
     background-color: transparent;
+  }
+
+  .lg\:focus\:bg-inherit:focus {
+    background-color: inherit;
   }
 
   .lg\:focus\:bg-current:focus {
@@ -51231,6 +51517,11 @@ video {
   .lg\:from-transparent {
     --gradient-from-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .lg\:from-inherit {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .lg\:from-current {
@@ -51703,6 +51994,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .lg\:via-inherit {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .lg\:via-current {
     --gradient-via-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -52172,6 +52468,10 @@ video {
     --gradient-to-color: transparent;
   }
 
+  .lg\:to-inherit {
+    --gradient-to-color: inherit;
+  }
+
   .lg\:to-current {
     --gradient-to-color: currentColor;
   }
@@ -52547,6 +52847,11 @@ video {
   .lg\:hover\:from-transparent:hover {
     --gradient-from-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .lg\:hover\:from-inherit:hover {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .lg\:hover\:from-current:hover {
@@ -53019,6 +53324,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .lg\:hover\:via-inherit:hover {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .lg\:hover\:via-current:hover {
     --gradient-via-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -53488,6 +53798,10 @@ video {
     --gradient-to-color: transparent;
   }
 
+  .lg\:hover\:to-inherit:hover {
+    --gradient-to-color: inherit;
+  }
+
   .lg\:hover\:to-current:hover {
     --gradient-to-color: currentColor;
   }
@@ -53863,6 +54177,11 @@ video {
   .lg\:focus\:from-transparent:focus {
     --gradient-from-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .lg\:focus\:from-inherit:focus {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .lg\:focus\:from-current:focus {
@@ -54335,6 +54654,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .lg\:focus\:via-inherit:focus {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .lg\:focus\:via-current:focus {
     --gradient-via-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -54804,6 +55128,10 @@ video {
     --gradient-to-color: transparent;
   }
 
+  .lg\:focus\:to-inherit:focus {
+    --gradient-to-color: inherit;
+  }
+
   .lg\:focus\:to-current:focus {
     --gradient-to-color: currentColor;
   }
@@ -55260,6 +55588,10 @@ video {
     border-color: transparent;
   }
 
+  .lg\:border-inherit {
+    border-color: inherit;
+  }
+
   .lg\:border-current {
     border-color: currentColor;
   }
@@ -55636,6 +55968,10 @@ video {
     border-color: transparent;
   }
 
+  .lg\:hover\:border-inherit:hover {
+    border-color: inherit;
+  }
+
   .lg\:hover\:border-current:hover {
     border-color: currentColor;
   }
@@ -56010,6 +56346,10 @@ video {
 
   .lg\:focus\:border-transparent:focus {
     border-color: transparent;
+  }
+
+  .lg\:focus\:border-inherit:focus {
+    border-color: inherit;
   }
 
   .lg\:focus\:border-current:focus {
@@ -59694,6 +60034,10 @@ video {
     color: transparent;
   }
 
+  .lg\:placeholder-inherit::placeholder {
+    color: inherit;
+  }
+
   .lg\:placeholder-current::placeholder {
     color: currentColor;
   }
@@ -60068,6 +60412,10 @@ video {
 
   .lg\:focus\:placeholder-transparent:focus::placeholder {
     color: transparent;
+  }
+
+  .lg\:focus\:placeholder-inherit:focus::placeholder {
+    color: inherit;
   }
 
   .lg\:focus\:placeholder-current:focus::placeholder {
@@ -60720,6 +61068,10 @@ video {
     color: transparent;
   }
 
+  .lg\:text-inherit {
+    color: inherit;
+  }
+
   .lg\:text-current {
     color: currentColor;
   }
@@ -61096,6 +61448,10 @@ video {
     color: transparent;
   }
 
+  .lg\:hover\:text-inherit:hover {
+    color: inherit;
+  }
+
   .lg\:hover\:text-current:hover {
     color: currentColor;
   }
@@ -61470,6 +61826,10 @@ video {
 
   .lg\:focus\:text-transparent:focus {
     color: transparent;
+  }
+
+  .lg\:focus\:text-inherit:focus {
+    color: inherit;
   }
 
   .lg\:focus\:text-current:focus {
@@ -65739,6 +66099,10 @@ video {
     border-color: transparent;
   }
 
+  .xl\:divide-inherit > :not(template) ~ :not(template) {
+    border-color: inherit;
+  }
+
   .xl\:divide-current > :not(template) ~ :not(template) {
     border-color: currentColor;
   }
@@ -66213,6 +66577,10 @@ video {
     background-color: transparent;
   }
 
+  .xl\:bg-inherit {
+    background-color: inherit;
+  }
+
   .xl\:bg-current {
     background-color: currentColor;
   }
@@ -66589,6 +66957,10 @@ video {
     background-color: transparent;
   }
 
+  .xl\:hover\:bg-inherit:hover {
+    background-color: inherit;
+  }
+
   .xl\:hover\:bg-current:hover {
     background-color: currentColor;
   }
@@ -66963,6 +67335,10 @@ video {
 
   .xl\:focus\:bg-transparent:focus {
     background-color: transparent;
+  }
+
+  .xl\:focus\:bg-inherit:focus {
+    background-color: inherit;
   }
 
   .xl\:focus\:bg-current:focus {
@@ -67376,6 +67752,11 @@ video {
   .xl\:from-transparent {
     --gradient-from-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .xl\:from-inherit {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .xl\:from-current {
@@ -67848,6 +68229,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .xl\:via-inherit {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .xl\:via-current {
     --gradient-via-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -68317,6 +68703,10 @@ video {
     --gradient-to-color: transparent;
   }
 
+  .xl\:to-inherit {
+    --gradient-to-color: inherit;
+  }
+
   .xl\:to-current {
     --gradient-to-color: currentColor;
   }
@@ -68692,6 +69082,11 @@ video {
   .xl\:hover\:from-transparent:hover {
     --gradient-from-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .xl\:hover\:from-inherit:hover {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .xl\:hover\:from-current:hover {
@@ -69164,6 +69559,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .xl\:hover\:via-inherit:hover {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .xl\:hover\:via-current:hover {
     --gradient-via-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -69633,6 +70033,10 @@ video {
     --gradient-to-color: transparent;
   }
 
+  .xl\:hover\:to-inherit:hover {
+    --gradient-to-color: inherit;
+  }
+
   .xl\:hover\:to-current:hover {
     --gradient-to-color: currentColor;
   }
@@ -70008,6 +70412,11 @@ video {
   .xl\:focus\:from-transparent:focus {
     --gradient-from-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .xl\:focus\:from-inherit:focus {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .xl\:focus\:from-current:focus {
@@ -70480,6 +70889,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .xl\:focus\:via-inherit:focus {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .xl\:focus\:via-current:focus {
     --gradient-via-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -70949,6 +71363,10 @@ video {
     --gradient-to-color: transparent;
   }
 
+  .xl\:focus\:to-inherit:focus {
+    --gradient-to-color: inherit;
+  }
+
   .xl\:focus\:to-current:focus {
     --gradient-to-color: currentColor;
   }
@@ -71405,6 +71823,10 @@ video {
     border-color: transparent;
   }
 
+  .xl\:border-inherit {
+    border-color: inherit;
+  }
+
   .xl\:border-current {
     border-color: currentColor;
   }
@@ -71781,6 +72203,10 @@ video {
     border-color: transparent;
   }
 
+  .xl\:hover\:border-inherit:hover {
+    border-color: inherit;
+  }
+
   .xl\:hover\:border-current:hover {
     border-color: currentColor;
   }
@@ -72155,6 +72581,10 @@ video {
 
   .xl\:focus\:border-transparent:focus {
     border-color: transparent;
+  }
+
+  .xl\:focus\:border-inherit:focus {
+    border-color: inherit;
   }
 
   .xl\:focus\:border-current:focus {
@@ -75839,6 +76269,10 @@ video {
     color: transparent;
   }
 
+  .xl\:placeholder-inherit::placeholder {
+    color: inherit;
+  }
+
   .xl\:placeholder-current::placeholder {
     color: currentColor;
   }
@@ -76213,6 +76647,10 @@ video {
 
   .xl\:focus\:placeholder-transparent:focus::placeholder {
     color: transparent;
+  }
+
+  .xl\:focus\:placeholder-inherit:focus::placeholder {
+    color: inherit;
   }
 
   .xl\:focus\:placeholder-current:focus::placeholder {
@@ -76865,6 +77303,10 @@ video {
     color: transparent;
   }
 
+  .xl\:text-inherit {
+    color: inherit;
+  }
+
   .xl\:text-current {
     color: currentColor;
   }
@@ -77241,6 +77683,10 @@ video {
     color: transparent;
   }
 
+  .xl\:hover\:text-inherit:hover {
+    color: inherit;
+  }
+
   .xl\:hover\:text-current:hover {
     color: currentColor;
   }
@@ -77615,6 +78061,10 @@ video {
 
   .xl\:focus\:text-transparent:focus {
     color: transparent;
+  }
+
+  .xl\:focus\:text-inherit:focus {
+    color: inherit;
   }
 
   .xl\:focus\:text-current:focus {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -1129,6 +1129,10 @@ video {
   border-color: transparent;
 }
 
+.divide-inherit > :not(template) ~ :not(template) {
+  border-color: inherit;
+}
+
 .divide-current > :not(template) ~ :not(template) {
   border-color: currentColor;
 }
@@ -1807,6 +1811,10 @@ video {
   background-color: transparent;
 }
 
+.bg-inherit {
+  background-color: inherit;
+}
+
 .bg-current {
   background-color: currentColor;
 }
@@ -2367,6 +2375,10 @@ video {
   background-color: transparent;
 }
 
+.hover\:bg-inherit:hover {
+  background-color: inherit;
+}
+
 .hover\:bg-current:hover {
   background-color: currentColor;
 }
@@ -2925,6 +2937,10 @@ video {
 
 .focus\:bg-transparent:focus {
   background-color: transparent;
+}
+
+.focus\:bg-inherit:focus {
+  background-color: inherit;
 }
 
 .focus\:bg-current:focus {
@@ -3524,6 +3540,11 @@ video {
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
 }
 
+.from-inherit {
+  --gradient-from-color: inherit;
+  --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+}
+
 .from-current {
   --gradient-from-color: currentColor;
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -3992,6 +4013,11 @@ video {
 .via-transparent {
   --gradient-via-color: transparent;
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+}
+
+.via-inherit {
+  --gradient-via-color: inherit;
+  --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
 }
 
 .via-current {
@@ -4463,6 +4489,10 @@ video {
   --gradient-to-color: transparent;
 }
 
+.to-inherit {
+  --gradient-to-color: inherit;
+}
+
 .to-current {
   --gradient-to-color: currentColor;
 }
@@ -4838,6 +4868,11 @@ video {
 .hover\:from-transparent:hover {
   --gradient-from-color: transparent;
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+}
+
+.hover\:from-inherit:hover {
+  --gradient-from-color: inherit;
+  --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
 }
 
 .hover\:from-current:hover {
@@ -5310,6 +5345,11 @@ video {
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
 }
 
+.hover\:via-inherit:hover {
+  --gradient-via-color: inherit;
+  --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+}
+
 .hover\:via-current:hover {
   --gradient-via-color: currentColor;
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -5779,6 +5819,10 @@ video {
   --gradient-to-color: transparent;
 }
 
+.hover\:to-inherit:hover {
+  --gradient-to-color: inherit;
+}
+
 .hover\:to-current:hover {
   --gradient-to-color: currentColor;
 }
@@ -6154,6 +6198,11 @@ video {
 .focus\:from-transparent:focus {
   --gradient-from-color: transparent;
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+}
+
+.focus\:from-inherit:focus {
+  --gradient-from-color: inherit;
+  --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
 }
 
 .focus\:from-current:focus {
@@ -6626,6 +6675,11 @@ video {
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
 }
 
+.focus\:via-inherit:focus {
+  --gradient-via-color: inherit;
+  --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+}
+
 .focus\:via-current:focus {
   --gradient-via-color: currentColor;
   --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -7093,6 +7147,10 @@ video {
 
 .focus\:to-transparent:focus {
   --gradient-to-color: transparent;
+}
+
+.focus\:to-inherit:focus {
+  --gradient-to-color: inherit;
 }
 
 .focus\:to-current:focus {
@@ -7609,6 +7667,10 @@ video {
 
 .border-transparent {
   border-color: transparent;
+}
+
+.border-inherit {
+  border-color: inherit;
 }
 
 .border-current {
@@ -8171,6 +8233,10 @@ video {
   border-color: transparent;
 }
 
+.hover\:border-inherit:hover {
+  border-color: inherit;
+}
+
 .hover\:border-current:hover {
   border-color: currentColor;
 }
@@ -8729,6 +8795,10 @@ video {
 
 .focus\:border-transparent:focus {
   border-color: transparent;
+}
+
+.focus\:border-inherit:focus {
+  border-color: inherit;
 }
 
 .focus\:border-current:focus {
@@ -12657,6 +12727,10 @@ video {
   color: transparent;
 }
 
+.placeholder-inherit::placeholder {
+  color: inherit;
+}
+
 .placeholder-current::placeholder {
   color: currentColor;
 }
@@ -13215,6 +13289,10 @@ video {
 
 .focus\:placeholder-transparent:focus::placeholder {
   color: transparent;
+}
+
+.focus\:placeholder-inherit:focus::placeholder {
+  color: inherit;
 }
 
 .focus\:placeholder-current:focus::placeholder {
@@ -14091,6 +14169,10 @@ video {
   color: transparent;
 }
 
+.text-inherit {
+  color: inherit;
+}
+
 .text-current {
   color: currentColor;
 }
@@ -14651,6 +14733,10 @@ video {
   color: transparent;
 }
 
+.hover\:text-inherit:hover {
+  color: inherit;
+}
+
 .hover\:text-current:hover {
   color: currentColor;
 }
@@ -15209,6 +15295,10 @@ video {
 
 .focus\:text-transparent:focus {
   color: transparent;
+}
+
+.focus\:text-inherit:focus {
+  color: inherit;
 }
 
 .focus\:text-current:focus {
@@ -19752,6 +19842,10 @@ video {
     border-color: transparent;
   }
 
+  .sm\:divide-inherit > :not(template) ~ :not(template) {
+    border-color: inherit;
+  }
+
   .sm\:divide-current > :not(template) ~ :not(template) {
     border-color: currentColor;
   }
@@ -20430,6 +20524,10 @@ video {
     background-color: transparent;
   }
 
+  .sm\:bg-inherit {
+    background-color: inherit;
+  }
+
   .sm\:bg-current {
     background-color: currentColor;
   }
@@ -20990,6 +21088,10 @@ video {
     background-color: transparent;
   }
 
+  .sm\:hover\:bg-inherit:hover {
+    background-color: inherit;
+  }
+
   .sm\:hover\:bg-current:hover {
     background-color: currentColor;
   }
@@ -21548,6 +21650,10 @@ video {
 
   .sm\:focus\:bg-transparent:focus {
     background-color: transparent;
+  }
+
+  .sm\:focus\:bg-inherit:focus {
+    background-color: inherit;
   }
 
   .sm\:focus\:bg-current:focus {
@@ -22147,6 +22253,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .sm\:from-inherit {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .sm\:from-current {
     --gradient-from-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -22615,6 +22726,11 @@ video {
   .sm\:via-transparent {
     --gradient-via-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .sm\:via-inherit {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .sm\:via-current {
@@ -23086,6 +23202,10 @@ video {
     --gradient-to-color: transparent;
   }
 
+  .sm\:to-inherit {
+    --gradient-to-color: inherit;
+  }
+
   .sm\:to-current {
     --gradient-to-color: currentColor;
   }
@@ -23461,6 +23581,11 @@ video {
   .sm\:hover\:from-transparent:hover {
     --gradient-from-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .sm\:hover\:from-inherit:hover {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .sm\:hover\:from-current:hover {
@@ -23933,6 +24058,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .sm\:hover\:via-inherit:hover {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .sm\:hover\:via-current:hover {
     --gradient-via-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -24402,6 +24532,10 @@ video {
     --gradient-to-color: transparent;
   }
 
+  .sm\:hover\:to-inherit:hover {
+    --gradient-to-color: inherit;
+  }
+
   .sm\:hover\:to-current:hover {
     --gradient-to-color: currentColor;
   }
@@ -24777,6 +24911,11 @@ video {
   .sm\:focus\:from-transparent:focus {
     --gradient-from-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .sm\:focus\:from-inherit:focus {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .sm\:focus\:from-current:focus {
@@ -25249,6 +25388,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .sm\:focus\:via-inherit:focus {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .sm\:focus\:via-current:focus {
     --gradient-via-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -25716,6 +25860,10 @@ video {
 
   .sm\:focus\:to-transparent:focus {
     --gradient-to-color: transparent;
+  }
+
+  .sm\:focus\:to-inherit:focus {
+    --gradient-to-color: inherit;
   }
 
   .sm\:focus\:to-current:focus {
@@ -26232,6 +26380,10 @@ video {
 
   .sm\:border-transparent {
     border-color: transparent;
+  }
+
+  .sm\:border-inherit {
+    border-color: inherit;
   }
 
   .sm\:border-current {
@@ -26794,6 +26946,10 @@ video {
     border-color: transparent;
   }
 
+  .sm\:hover\:border-inherit:hover {
+    border-color: inherit;
+  }
+
   .sm\:hover\:border-current:hover {
     border-color: currentColor;
   }
@@ -27352,6 +27508,10 @@ video {
 
   .sm\:focus\:border-transparent:focus {
     border-color: transparent;
+  }
+
+  .sm\:focus\:border-inherit:focus {
+    border-color: inherit;
   }
 
   .sm\:focus\:border-current:focus {
@@ -31280,6 +31440,10 @@ video {
     color: transparent;
   }
 
+  .sm\:placeholder-inherit::placeholder {
+    color: inherit;
+  }
+
   .sm\:placeholder-current::placeholder {
     color: currentColor;
   }
@@ -31838,6 +32002,10 @@ video {
 
   .sm\:focus\:placeholder-transparent:focus::placeholder {
     color: transparent;
+  }
+
+  .sm\:focus\:placeholder-inherit:focus::placeholder {
+    color: inherit;
   }
 
   .sm\:focus\:placeholder-current:focus::placeholder {
@@ -32714,6 +32882,10 @@ video {
     color: transparent;
   }
 
+  .sm\:text-inherit {
+    color: inherit;
+  }
+
   .sm\:text-current {
     color: currentColor;
   }
@@ -33274,6 +33446,10 @@ video {
     color: transparent;
   }
 
+  .sm\:hover\:text-inherit:hover {
+    color: inherit;
+  }
+
   .sm\:hover\:text-current:hover {
     color: currentColor;
   }
@@ -33832,6 +34008,10 @@ video {
 
   .sm\:focus\:text-transparent:focus {
     color: transparent;
+  }
+
+  .sm\:focus\:text-inherit:focus {
+    color: inherit;
   }
 
   .sm\:focus\:text-current:focus {
@@ -38345,6 +38525,10 @@ video {
     border-color: transparent;
   }
 
+  .md\:divide-inherit > :not(template) ~ :not(template) {
+    border-color: inherit;
+  }
+
   .md\:divide-current > :not(template) ~ :not(template) {
     border-color: currentColor;
   }
@@ -39023,6 +39207,10 @@ video {
     background-color: transparent;
   }
 
+  .md\:bg-inherit {
+    background-color: inherit;
+  }
+
   .md\:bg-current {
     background-color: currentColor;
   }
@@ -39583,6 +39771,10 @@ video {
     background-color: transparent;
   }
 
+  .md\:hover\:bg-inherit:hover {
+    background-color: inherit;
+  }
+
   .md\:hover\:bg-current:hover {
     background-color: currentColor;
   }
@@ -40141,6 +40333,10 @@ video {
 
   .md\:focus\:bg-transparent:focus {
     background-color: transparent;
+  }
+
+  .md\:focus\:bg-inherit:focus {
+    background-color: inherit;
   }
 
   .md\:focus\:bg-current:focus {
@@ -40740,6 +40936,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .md\:from-inherit {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .md\:from-current {
     --gradient-from-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -41208,6 +41409,11 @@ video {
   .md\:via-transparent {
     --gradient-via-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .md\:via-inherit {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .md\:via-current {
@@ -41679,6 +41885,10 @@ video {
     --gradient-to-color: transparent;
   }
 
+  .md\:to-inherit {
+    --gradient-to-color: inherit;
+  }
+
   .md\:to-current {
     --gradient-to-color: currentColor;
   }
@@ -42054,6 +42264,11 @@ video {
   .md\:hover\:from-transparent:hover {
     --gradient-from-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .md\:hover\:from-inherit:hover {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .md\:hover\:from-current:hover {
@@ -42526,6 +42741,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .md\:hover\:via-inherit:hover {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .md\:hover\:via-current:hover {
     --gradient-via-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -42995,6 +43215,10 @@ video {
     --gradient-to-color: transparent;
   }
 
+  .md\:hover\:to-inherit:hover {
+    --gradient-to-color: inherit;
+  }
+
   .md\:hover\:to-current:hover {
     --gradient-to-color: currentColor;
   }
@@ -43370,6 +43594,11 @@ video {
   .md\:focus\:from-transparent:focus {
     --gradient-from-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .md\:focus\:from-inherit:focus {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .md\:focus\:from-current:focus {
@@ -43842,6 +44071,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .md\:focus\:via-inherit:focus {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .md\:focus\:via-current:focus {
     --gradient-via-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -44309,6 +44543,10 @@ video {
 
   .md\:focus\:to-transparent:focus {
     --gradient-to-color: transparent;
+  }
+
+  .md\:focus\:to-inherit:focus {
+    --gradient-to-color: inherit;
   }
 
   .md\:focus\:to-current:focus {
@@ -44825,6 +45063,10 @@ video {
 
   .md\:border-transparent {
     border-color: transparent;
+  }
+
+  .md\:border-inherit {
+    border-color: inherit;
   }
 
   .md\:border-current {
@@ -45387,6 +45629,10 @@ video {
     border-color: transparent;
   }
 
+  .md\:hover\:border-inherit:hover {
+    border-color: inherit;
+  }
+
   .md\:hover\:border-current:hover {
     border-color: currentColor;
   }
@@ -45945,6 +46191,10 @@ video {
 
   .md\:focus\:border-transparent:focus {
     border-color: transparent;
+  }
+
+  .md\:focus\:border-inherit:focus {
+    border-color: inherit;
   }
 
   .md\:focus\:border-current:focus {
@@ -49873,6 +50123,10 @@ video {
     color: transparent;
   }
 
+  .md\:placeholder-inherit::placeholder {
+    color: inherit;
+  }
+
   .md\:placeholder-current::placeholder {
     color: currentColor;
   }
@@ -50431,6 +50685,10 @@ video {
 
   .md\:focus\:placeholder-transparent:focus::placeholder {
     color: transparent;
+  }
+
+  .md\:focus\:placeholder-inherit:focus::placeholder {
+    color: inherit;
   }
 
   .md\:focus\:placeholder-current:focus::placeholder {
@@ -51307,6 +51565,10 @@ video {
     color: transparent;
   }
 
+  .md\:text-inherit {
+    color: inherit;
+  }
+
   .md\:text-current {
     color: currentColor;
   }
@@ -51867,6 +52129,10 @@ video {
     color: transparent;
   }
 
+  .md\:hover\:text-inherit:hover {
+    color: inherit;
+  }
+
   .md\:hover\:text-current:hover {
     color: currentColor;
   }
@@ -52425,6 +52691,10 @@ video {
 
   .md\:focus\:text-transparent:focus {
     color: transparent;
+  }
+
+  .md\:focus\:text-inherit:focus {
+    color: inherit;
   }
 
   .md\:focus\:text-current:focus {
@@ -56938,6 +57208,10 @@ video {
     border-color: transparent;
   }
 
+  .lg\:divide-inherit > :not(template) ~ :not(template) {
+    border-color: inherit;
+  }
+
   .lg\:divide-current > :not(template) ~ :not(template) {
     border-color: currentColor;
   }
@@ -57616,6 +57890,10 @@ video {
     background-color: transparent;
   }
 
+  .lg\:bg-inherit {
+    background-color: inherit;
+  }
+
   .lg\:bg-current {
     background-color: currentColor;
   }
@@ -58176,6 +58454,10 @@ video {
     background-color: transparent;
   }
 
+  .lg\:hover\:bg-inherit:hover {
+    background-color: inherit;
+  }
+
   .lg\:hover\:bg-current:hover {
     background-color: currentColor;
   }
@@ -58734,6 +59016,10 @@ video {
 
   .lg\:focus\:bg-transparent:focus {
     background-color: transparent;
+  }
+
+  .lg\:focus\:bg-inherit:focus {
+    background-color: inherit;
   }
 
   .lg\:focus\:bg-current:focus {
@@ -59333,6 +59619,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .lg\:from-inherit {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .lg\:from-current {
     --gradient-from-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -59801,6 +60092,11 @@ video {
   .lg\:via-transparent {
     --gradient-via-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .lg\:via-inherit {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .lg\:via-current {
@@ -60272,6 +60568,10 @@ video {
     --gradient-to-color: transparent;
   }
 
+  .lg\:to-inherit {
+    --gradient-to-color: inherit;
+  }
+
   .lg\:to-current {
     --gradient-to-color: currentColor;
   }
@@ -60647,6 +60947,11 @@ video {
   .lg\:hover\:from-transparent:hover {
     --gradient-from-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .lg\:hover\:from-inherit:hover {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .lg\:hover\:from-current:hover {
@@ -61119,6 +61424,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .lg\:hover\:via-inherit:hover {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .lg\:hover\:via-current:hover {
     --gradient-via-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -61588,6 +61898,10 @@ video {
     --gradient-to-color: transparent;
   }
 
+  .lg\:hover\:to-inherit:hover {
+    --gradient-to-color: inherit;
+  }
+
   .lg\:hover\:to-current:hover {
     --gradient-to-color: currentColor;
   }
@@ -61963,6 +62277,11 @@ video {
   .lg\:focus\:from-transparent:focus {
     --gradient-from-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .lg\:focus\:from-inherit:focus {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .lg\:focus\:from-current:focus {
@@ -62435,6 +62754,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .lg\:focus\:via-inherit:focus {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .lg\:focus\:via-current:focus {
     --gradient-via-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -62902,6 +63226,10 @@ video {
 
   .lg\:focus\:to-transparent:focus {
     --gradient-to-color: transparent;
+  }
+
+  .lg\:focus\:to-inherit:focus {
+    --gradient-to-color: inherit;
   }
 
   .lg\:focus\:to-current:focus {
@@ -63418,6 +63746,10 @@ video {
 
   .lg\:border-transparent {
     border-color: transparent;
+  }
+
+  .lg\:border-inherit {
+    border-color: inherit;
   }
 
   .lg\:border-current {
@@ -63980,6 +64312,10 @@ video {
     border-color: transparent;
   }
 
+  .lg\:hover\:border-inherit:hover {
+    border-color: inherit;
+  }
+
   .lg\:hover\:border-current:hover {
     border-color: currentColor;
   }
@@ -64538,6 +64874,10 @@ video {
 
   .lg\:focus\:border-transparent:focus {
     border-color: transparent;
+  }
+
+  .lg\:focus\:border-inherit:focus {
+    border-color: inherit;
   }
 
   .lg\:focus\:border-current:focus {
@@ -68466,6 +68806,10 @@ video {
     color: transparent;
   }
 
+  .lg\:placeholder-inherit::placeholder {
+    color: inherit;
+  }
+
   .lg\:placeholder-current::placeholder {
     color: currentColor;
   }
@@ -69024,6 +69368,10 @@ video {
 
   .lg\:focus\:placeholder-transparent:focus::placeholder {
     color: transparent;
+  }
+
+  .lg\:focus\:placeholder-inherit:focus::placeholder {
+    color: inherit;
   }
 
   .lg\:focus\:placeholder-current:focus::placeholder {
@@ -69900,6 +70248,10 @@ video {
     color: transparent;
   }
 
+  .lg\:text-inherit {
+    color: inherit;
+  }
+
   .lg\:text-current {
     color: currentColor;
   }
@@ -70460,6 +70812,10 @@ video {
     color: transparent;
   }
 
+  .lg\:hover\:text-inherit:hover {
+    color: inherit;
+  }
+
   .lg\:hover\:text-current:hover {
     color: currentColor;
   }
@@ -71018,6 +71374,10 @@ video {
 
   .lg\:focus\:text-transparent:focus {
     color: transparent;
+  }
+
+  .lg\:focus\:text-inherit:focus {
+    color: inherit;
   }
 
   .lg\:focus\:text-current:focus {
@@ -75531,6 +75891,10 @@ video {
     border-color: transparent;
   }
 
+  .xl\:divide-inherit > :not(template) ~ :not(template) {
+    border-color: inherit;
+  }
+
   .xl\:divide-current > :not(template) ~ :not(template) {
     border-color: currentColor;
   }
@@ -76209,6 +76573,10 @@ video {
     background-color: transparent;
   }
 
+  .xl\:bg-inherit {
+    background-color: inherit;
+  }
+
   .xl\:bg-current {
     background-color: currentColor;
   }
@@ -76769,6 +77137,10 @@ video {
     background-color: transparent;
   }
 
+  .xl\:hover\:bg-inherit:hover {
+    background-color: inherit;
+  }
+
   .xl\:hover\:bg-current:hover {
     background-color: currentColor;
   }
@@ -77327,6 +77699,10 @@ video {
 
   .xl\:focus\:bg-transparent:focus {
     background-color: transparent;
+  }
+
+  .xl\:focus\:bg-inherit:focus {
+    background-color: inherit;
   }
 
   .xl\:focus\:bg-current:focus {
@@ -77926,6 +78302,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .xl\:from-inherit {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .xl\:from-current {
     --gradient-from-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -78394,6 +78775,11 @@ video {
   .xl\:via-transparent {
     --gradient-via-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .xl\:via-inherit {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .xl\:via-current {
@@ -78865,6 +79251,10 @@ video {
     --gradient-to-color: transparent;
   }
 
+  .xl\:to-inherit {
+    --gradient-to-color: inherit;
+  }
+
   .xl\:to-current {
     --gradient-to-color: currentColor;
   }
@@ -79240,6 +79630,11 @@ video {
   .xl\:hover\:from-transparent:hover {
     --gradient-from-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .xl\:hover\:from-inherit:hover {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .xl\:hover\:from-current:hover {
@@ -79712,6 +80107,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .xl\:hover\:via-inherit:hover {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .xl\:hover\:via-current:hover {
     --gradient-via-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -80181,6 +80581,10 @@ video {
     --gradient-to-color: transparent;
   }
 
+  .xl\:hover\:to-inherit:hover {
+    --gradient-to-color: inherit;
+  }
+
   .xl\:hover\:to-current:hover {
     --gradient-to-color: currentColor;
   }
@@ -80556,6 +80960,11 @@ video {
   .xl\:focus\:from-transparent:focus {
     --gradient-from-color: transparent;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
+  }
+
+  .xl\:focus\:from-inherit:focus {
+    --gradient-from-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
   }
 
   .xl\:focus\:from-current:focus {
@@ -81028,6 +81437,11 @@ video {
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(0, 0, 0, 0));
   }
 
+  .xl\:focus\:via-inherit:focus {
+    --gradient-via-color: inherit;
+    --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
+  }
+
   .xl\:focus\:via-current:focus {
     --gradient-via-color: currentColor;
     --gradient-color-stops: var(--gradient-from-color), var(--gradient-via-color), var(--gradient-to-color, rgba(255, 255, 255, 0));
@@ -81495,6 +81909,10 @@ video {
 
   .xl\:focus\:to-transparent:focus {
     --gradient-to-color: transparent;
+  }
+
+  .xl\:focus\:to-inherit:focus {
+    --gradient-to-color: inherit;
   }
 
   .xl\:focus\:to-current:focus {
@@ -82011,6 +82429,10 @@ video {
 
   .xl\:border-transparent {
     border-color: transparent;
+  }
+
+  .xl\:border-inherit {
+    border-color: inherit;
   }
 
   .xl\:border-current {
@@ -82573,6 +82995,10 @@ video {
     border-color: transparent;
   }
 
+  .xl\:hover\:border-inherit:hover {
+    border-color: inherit;
+  }
+
   .xl\:hover\:border-current:hover {
     border-color: currentColor;
   }
@@ -83131,6 +83557,10 @@ video {
 
   .xl\:focus\:border-transparent:focus {
     border-color: transparent;
+  }
+
+  .xl\:focus\:border-inherit:focus {
+    border-color: inherit;
   }
 
   .xl\:focus\:border-current:focus {
@@ -87059,6 +87489,10 @@ video {
     color: transparent;
   }
 
+  .xl\:placeholder-inherit::placeholder {
+    color: inherit;
+  }
+
   .xl\:placeholder-current::placeholder {
     color: currentColor;
   }
@@ -87617,6 +88051,10 @@ video {
 
   .xl\:focus\:placeholder-transparent:focus::placeholder {
     color: transparent;
+  }
+
+  .xl\:focus\:placeholder-inherit:focus::placeholder {
+    color: inherit;
   }
 
   .xl\:focus\:placeholder-current:focus::placeholder {
@@ -88493,6 +88931,10 @@ video {
     color: transparent;
   }
 
+  .xl\:text-inherit {
+    color: inherit;
+  }
+
   .xl\:text-current {
     color: currentColor;
   }
@@ -89053,6 +89495,10 @@ video {
     color: transparent;
   }
 
+  .xl\:hover\:text-inherit:hover {
+    color: inherit;
+  }
+
   .xl\:hover\:text-current:hover {
     color: currentColor;
   }
@@ -89611,6 +90057,10 @@ video {
 
   .xl\:focus\:text-transparent:focus {
     color: transparent;
+  }
+
+  .xl\:focus\:text-inherit:focus {
+    color: inherit;
   }
 
   .xl\:focus\:text-current:focus {

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -18,6 +18,7 @@ module.exports = {
     },
     colors: {
       transparent: 'transparent',
+      inherit: 'inherit',
       current: 'currentColor',
 
       black: '#000',


### PR DESCRIPTION
Basically, what I called on #2622, so PR wasn't that big deal.

What this allows is for component-type implementations to provide a "default styling" while still giving the end developer the ability to "modify" the colors they want to use.

This can get kind of hard sometimes, since classes like `border-gray-500` have a greater priority to `border-gray-300` in the default config file.

Headless components sure are a big help for this, since you can call for whatever styling you want, but for pre-styled components, well, I think the point is clear.

[Here is an example Codepen](https://codepen.io/iksaku/pen/dyXXLzY) demonstrating a potential use case while working with pre-styled components.