### PR TITLE
🎨 Add CSS custom property definitions for color utilities

### DIFF
--- a/__tests__/withAlphaVariable.test.js
+++ b/__tests__/withAlphaVariable.test.js
@@ -2,9 +2,15 @@ import withAlphaVariable from '../src/util/withAlphaVariable'
 
 test('it adds the right custom property', () => {
   expect(
-    withAlphaVariable({ color: '#ff0000', property: 'color', variable: '--tw-text-opacity' })
+    withAlphaVariable({
+      color: '#ff0000',
+      property: 'color',
+      variable: '--tw-text-opacity',
+      ownProperty: '--tw-text-color',
+    })
   ).toEqual({
     '--tw-text-opacity': '1',
+    '--tw-text-color': 'rgba(255, 0, 0, var(--text-opacity))',
     color: 'rgba(255, 0, 0, var(--tw-text-opacity))',
   })
 })

--- a/src/plugins/backgroundColor.js
+++ b/src/plugins/backgroundColor.js
@@ -13,7 +13,8 @@ export default function () {
         return withAlphaVariable({
           color: value,
           property: 'background-color',
-          variable: '--tw-bg-opacity',
+          variable: '--bg-opacity',
+          ownProperty: '--tw-bg-color',
         })
       }
 

--- a/src/plugins/borderColor.js
+++ b/src/plugins/borderColor.js
@@ -14,6 +14,7 @@ export default function () {
           color: value,
           property: 'border-color',
           variable: '--tw-border-opacity',
+          ownProperty: '--tw-border-color',
         })
       }
 

--- a/src/plugins/divideColor.js
+++ b/src/plugins/divideColor.js
@@ -14,6 +14,7 @@ export default function () {
           color: value,
           property: 'border-color',
           variable: '--tw-divide-opacity',
+          ownProperty: '--tw-divide-color',
         })
       }
 

--- a/src/plugins/placeholderColor.js
+++ b/src/plugins/placeholderColor.js
@@ -14,6 +14,7 @@ export default function () {
           color: value,
           property: 'color',
           variable: '--tw-placeholder-opacity',
+          ownProperty: '--tw-placeholder-color',
         })
       }
 

--- a/src/plugins/textColor.js
+++ b/src/plugins/textColor.js
@@ -14,6 +14,7 @@ export default function () {
           color: value,
           property: 'color',
           variable: '--tw-text-opacity',
+          ownProperty: '--tw-text-color',
         })
       }
 

--- a/src/util/withAlphaVariable.js
+++ b/src/util/withAlphaVariable.js
@@ -16,7 +16,7 @@ export function toRgba(color) {
   return [r, g, b, a === undefined && hasAlpha(color) ? 1 : a]
 }
 
-export default function withAlphaVariable({ color, property, variable }) {
+export default function withAlphaVariable({ color, property, variable, ownProperty }) {
   if (_.isFunction(color)) {
     return {
       [variable]: '1',
@@ -35,6 +35,7 @@ export default function withAlphaVariable({ color, property, variable }) {
 
     return {
       [variable]: '1',
+      [ownProperty]: `rgba(${r}, ${g}, ${b}, var(${variable}))`,
       [property]: `rgba(${r}, ${g}, ${b}, var(${variable}))`,
     }
   } catch (error) {


### PR DESCRIPTION
Not a significant feature, but a nice thing to have. While screwing around with bg-gradient and custom underlines, I found a need to create a text-shadow that referenced the current background color. Having that as a custom property would be super useful.

Output winds up looking like this:

```css
.text-blue-100 {
  --text-opacity: 1;
  --tw-text-color: rgba(219, 234, 254, var(--text-opacity));
  color: rgba(219, 234, 254, var(--text-opacity));
}
```

Since Tailwind 2 won't support IE11, you could probably even take it down to this.

```css
.text-blue-100 {
  --text-opacity: 1;
  --tw-text-color: rgba(219, 234, 254, var(--text-opacity));
  color: var(--tw-text-color);
}
```

## Todo

- [ ] update fixtures to ensure sanity tests pass