### PR TITLE
perf(preflight): reorder reset styles to help gzip

### DIFF
--- a/__tests__/fixtures/tailwind-output-flagged.css
+++ b/__tests__/fixtures/tailwind-output-flagged.css
@@ -307,20 +307,29 @@ summary {
  * Removes the default spacing and border for appropriate elements.
  */
 
-blockquote,
-dl,
-dd,
+p,
 h1,
 h2,
 h3,
 h4,
 h5,
 h6,
-hr,
+blockquote,
+dl,
+dd,
 figure,
-p,
-pre {
+pre,
+hr,
+fieldset,
+ol,
+ul {
   margin: 0;
+}
+
+fieldset,
+ol,
+ul {
+  padding: 0;
 }
 
 button {
@@ -338,16 +347,9 @@ button:focus {
   outline: 5px auto -webkit-focus-ring-color;
 }
 
-fieldset {
-  margin: 0;
-  padding: 0;
-}
-
 ol,
 ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+  list-style: none; /* Sets `list-style-type` */
 }
 
 /**

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -307,20 +307,29 @@ summary {
  * Removes the default spacing and border for appropriate elements.
  */
 
-blockquote,
-dl,
-dd,
+p,
 h1,
 h2,
 h3,
 h4,
 h5,
 h6,
-hr,
+blockquote,
+dl,
+dd,
 figure,
-p,
-pre {
+pre,
+hr,
+fieldset,
+ol,
+ul {
   margin: 0;
+}
+
+fieldset,
+ol,
+ul {
+  padding: 0;
 }
 
 button {
@@ -338,16 +347,9 @@ button:focus {
   outline: 5px auto -webkit-focus-ring-color;
 }
 
-fieldset {
-  margin: 0;
-  padding: 0;
-}
-
 ol,
 ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+  list-style: none; /* Sets `list-style-type` */
 }
 
 /**

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -307,20 +307,29 @@ summary {
  * Removes the default spacing and border for appropriate elements.
  */
 
-blockquote,
-dl,
-dd,
+p,
 h1,
 h2,
 h3,
 h4,
 h5,
 h6,
-hr,
+blockquote,
+dl,
+dd,
 figure,
-p,
-pre {
+pre,
+hr,
+fieldset,
+ol,
+ul {
   margin: 0;
+}
+
+fieldset,
+ol,
+ul {
+  padding: 0;
 }
 
 button {
@@ -338,16 +347,9 @@ button:focus {
   outline: 5px auto -webkit-focus-ring-color;
 }
 
-fieldset {
-  margin: 0;
-  padding: 0;
-}
-
 ol,
 ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+  list-style: none; /* Sets `list-style-type` */
 }
 
 /**

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -307,20 +307,29 @@ summary {
  * Removes the default spacing and border for appropriate elements.
  */
 
-blockquote,
-dl,
-dd,
+p,
 h1,
 h2,
 h3,
 h4,
 h5,
 h6,
-hr,
+blockquote,
+dl,
+dd,
 figure,
-p,
-pre {
+pre,
+hr,
+fieldset,
+ol,
+ul {
   margin: 0;
+}
+
+fieldset,
+ol,
+ul {
+  padding: 0;
 }
 
 button {
@@ -338,16 +347,9 @@ button:focus {
   outline: 5px auto -webkit-focus-ring-color;
 }
 
-fieldset {
-  margin: 0;
-  padding: 0;
-}
-
 ol,
 ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+  list-style: none; /* Sets `list-style-type` */
 }
 
 /**

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -8,20 +8,29 @@
  * Removes the default spacing and border for appropriate elements.
  */
 
-blockquote,
-dl,
-dd,
+p,
 h1,
 h2,
 h3,
 h4,
 h5,
 h6,
-hr,
+blockquote,
+dl,
+dd,
 figure,
-p,
-pre {
+pre,
+hr,
+fieldset,
+ol,
+ul {
   margin: 0;
+}
+
+fieldset,
+ol,
+ul {
+  padding: 0;
 }
 
 button {
@@ -39,16 +48,9 @@ button:focus {
   outline: 5px auto -webkit-focus-ring-color;
 }
 
-fieldset {
-  margin: 0;
-  padding: 0;
-}
-
 ol,
 ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+  list-style: none; /* Sets `list-style-type` */
 }
 
 /**


### PR DESCRIPTION
_(This PR is extracted from #2607 to be discussed on its own.)_

---

By reordering some reset styles and increasing repetition between selectors, CSS bundles can be compressed better with gzip and Brotli.