### PR TITLE
Improve preflight v3

### DIFF
--- a/__tests__/fixtures/tailwind-output-flagged.css
+++ b/__tests__/fixtures/tailwind-output-flagged.css
@@ -307,20 +307,29 @@ summary {
  * Removes the default spacing and border for appropriate elements.
  */
 
-blockquote,
-dl,
-dd,
+p,
 h1,
 h2,
 h3,
 h4,
 h5,
 h6,
-hr,
+blockquote,
+dl,
+dd,
 figure,
-p,
-pre {
+pre,
+hr,
+fieldset,
+ol,
+ul {
   margin: 0;
+}
+
+fieldset,
+ol,
+ul {
+  padding: 0;
 }
 
 button {
@@ -338,16 +347,9 @@ button:focus {
   outline: 5px auto -webkit-focus-ring-color;
 }
 
-fieldset {
-  margin: 0;
-  padding: 0;
-}
-
 ol,
 ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+  list-style: none; /* Sets `list-style-type` */
 }
 
 /**

--- a/__tests__/fixtures/tailwind-output-flagged.css
+++ b/__tests__/fixtures/tailwind-output-flagged.css
@@ -299,6 +299,7 @@ summary {
 
 /**
  * Manually forked from SUIT CSS Base: https://github.com/suitcss/base
+ * Modern reset styles inspired by: https://github.com/kripod/css-homogenizer
  * A thin layer on top of normalize.css that provides a starting point more
  * suitable for web applications.
  */
@@ -326,10 +327,18 @@ ul {
   margin: 0;
 }
 
+th,
+td,
+legend,
 fieldset,
 ol,
 ul {
   padding: 0;
+}
+
+fieldset,
+iframe {
+  border: 0;
 }
 
 button {
@@ -450,7 +459,12 @@ button,
 }
 
 table {
+  border-spacing: 0;
   border-collapse: collapse;
+}
+
+th {
+  text-align: inherit;
 }
 
 h1,
@@ -458,9 +472,10 @@ h2,
 h3,
 h4,
 h5,
-h6 {
-  font-size: inherit;
-  font-weight: inherit;
+h6,
+th,
+address {
+  font: inherit; /* Sets `font-size`, `font-weight` and `font-style` */
 }
 
 /**

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -307,20 +307,29 @@ summary {
  * Removes the default spacing and border for appropriate elements.
  */
 
-blockquote,
-dl,
-dd,
+p,
 h1,
 h2,
 h3,
 h4,
 h5,
 h6,
-hr,
+blockquote,
+dl,
+dd,
 figure,
-p,
-pre {
+pre,
+hr,
+fieldset,
+ol,
+ul {
   margin: 0;
+}
+
+fieldset,
+ol,
+ul {
+  padding: 0;
 }
 
 button {
@@ -338,16 +347,9 @@ button:focus {
   outline: 5px auto -webkit-focus-ring-color;
 }
 
-fieldset {
-  margin: 0;
-  padding: 0;
-}
-
 ol,
 ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+  list-style: none; /* Sets `list-style-type` */
 }
 
 /**

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -299,6 +299,7 @@ summary {
 
 /**
  * Manually forked from SUIT CSS Base: https://github.com/suitcss/base
+ * Modern reset styles inspired by: https://github.com/kripod/css-homogenizer
  * A thin layer on top of normalize.css that provides a starting point more
  * suitable for web applications.
  */
@@ -326,10 +327,18 @@ ul {
   margin: 0;
 }
 
+th,
+td,
+legend,
 fieldset,
 ol,
 ul {
   padding: 0;
+}
+
+fieldset,
+iframe {
+  border: 0;
 }
 
 button {
@@ -450,7 +459,12 @@ button,
 }
 
 table {
+  border-spacing: 0;
   border-collapse: collapse;
+}
+
+th {
+  text-align: inherit;
 }
 
 h1,
@@ -458,9 +472,10 @@ h2,
 h3,
 h4,
 h5,
-h6 {
-  font-size: inherit;
-  font-weight: inherit;
+h6,
+th,
+address {
+  font: inherit; /* Sets `font-size`, `font-weight` and `font-style` */
 }
 
 /**

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -307,20 +307,29 @@ summary {
  * Removes the default spacing and border for appropriate elements.
  */
 
-blockquote,
-dl,
-dd,
+p,
 h1,
 h2,
 h3,
 h4,
 h5,
 h6,
-hr,
+blockquote,
+dl,
+dd,
 figure,
-p,
-pre {
+pre,
+hr,
+fieldset,
+ol,
+ul {
   margin: 0;
+}
+
+fieldset,
+ol,
+ul {
+  padding: 0;
 }
 
 button {
@@ -338,16 +347,9 @@ button:focus {
   outline: 5px auto -webkit-focus-ring-color;
 }
 
-fieldset {
-  margin: 0;
-  padding: 0;
-}
-
 ol,
 ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+  list-style: none; /* Sets `list-style-type` */
 }
 
 /**

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -299,6 +299,7 @@ summary {
 
 /**
  * Manually forked from SUIT CSS Base: https://github.com/suitcss/base
+ * Modern reset styles inspired by: https://github.com/kripod/css-homogenizer
  * A thin layer on top of normalize.css that provides a starting point more
  * suitable for web applications.
  */
@@ -326,10 +327,18 @@ ul {
   margin: 0;
 }
 
+th,
+td,
+legend,
 fieldset,
 ol,
 ul {
   padding: 0;
+}
+
+fieldset,
+iframe {
+  border: 0;
 }
 
 button {
@@ -450,7 +459,12 @@ button,
 }
 
 table {
+  border-spacing: 0;
   border-collapse: collapse;
+}
+
+th {
+  text-align: inherit;
 }
 
 h1,
@@ -458,9 +472,10 @@ h2,
 h3,
 h4,
 h5,
-h6 {
-  font-size: inherit;
-  font-weight: inherit;
+h6,
+th,
+address {
+  font: inherit; /* Sets `font-size`, `font-weight` and `font-style` */
 }
 
 /**

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -307,20 +307,29 @@ summary {
  * Removes the default spacing and border for appropriate elements.
  */
 
-blockquote,
-dl,
-dd,
+p,
 h1,
 h2,
 h3,
 h4,
 h5,
 h6,
-hr,
+blockquote,
+dl,
+dd,
 figure,
-p,
-pre {
+pre,
+hr,
+fieldset,
+ol,
+ul {
   margin: 0;
+}
+
+fieldset,
+ol,
+ul {
+  padding: 0;
 }
 
 button {
@@ -338,16 +347,9 @@ button:focus {
   outline: 5px auto -webkit-focus-ring-color;
 }
 
-fieldset {
-  margin: 0;
-  padding: 0;
-}
-
 ol,
 ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+  list-style: none; /* Sets `list-style-type` */
 }
 
 /**

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -299,6 +299,7 @@ summary {
 
 /**
  * Manually forked from SUIT CSS Base: https://github.com/suitcss/base
+ * Modern reset styles inspired by: https://github.com/kripod/css-homogenizer
  * A thin layer on top of normalize.css that provides a starting point more
  * suitable for web applications.
  */
@@ -326,10 +327,18 @@ ul {
   margin: 0;
 }
 
+th,
+td,
+legend,
 fieldset,
 ol,
 ul {
   padding: 0;
+}
+
+fieldset,
+iframe {
+  border: 0;
 }
 
 button {
@@ -450,7 +459,12 @@ button,
 }
 
 table {
+  border-spacing: 0;
   border-collapse: collapse;
+}
+
+th {
+  text-align: inherit;
 }
 
 h1,
@@ -458,9 +472,10 @@ h2,
 h3,
 h4,
 h5,
-h6 {
-  font-size: inherit;
-  font-weight: inherit;
+h6,
+th,
+address {
+  font: inherit; /* Sets `font-size`, `font-weight` and `font-style` */
 }
 
 /**

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -1,5 +1,6 @@
 /**
  * Manually forked from SUIT CSS Base: https://github.com/suitcss/base
+ * Modern reset styles inspired by: https://github.com/kripod/css-homogenizer
  * A thin layer on top of normalize.css that provides a starting point more
  * suitable for web applications.
  */
@@ -27,10 +28,18 @@ ul {
   margin: 0;
 }
 
+th,
+td,
+legend,
 fieldset,
 ol,
 ul {
   padding: 0;
+}
+
+fieldset,
+iframe {
+  border: 0;
 }
 
 button {
@@ -152,7 +161,12 @@ button,
 }
 
 table {
+  border-spacing: 0;
   border-collapse: collapse;
+}
+
+th {
+  text-align: inherit;
 }
 
 h1,
@@ -160,9 +174,10 @@ h2,
 h3,
 h4,
 h5,
-h6 {
-  font-size: inherit;
-  font-weight: inherit;
+h6,
+th,
+address {
+  font: inherit; /* Sets `font-size`, `font-weight` and `font-style` */
 }
 
 /**

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -8,20 +8,29 @@
  * Removes the default spacing and border for appropriate elements.
  */
 
-blockquote,
-dl,
-dd,
+p,
 h1,
 h2,
 h3,
 h4,
 h5,
 h6,
-hr,
+blockquote,
+dl,
+dd,
 figure,
-p,
-pre {
+pre,
+hr,
+fieldset,
+ol,
+ul {
   margin: 0;
+}
+
+fieldset,
+ol,
+ul {
+  padding: 0;
 }
 
 button {
@@ -39,16 +48,9 @@ button:focus {
   outline: 5px auto -webkit-focus-ring-color;
 }
 
-fieldset {
-  margin: 0;
-  padding: 0;
-}
-
 ol,
 ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+  list-style: none; /* Sets `list-style-type` */
 }
 
 /**


### PR DESCRIPTION
This PR is a less opinionated implementation of #2607, removing:

- `menu` margin and padding resets, as they are not yet widely adopted
- `hr` border reset
- `overflow-wrap: break-word`

And adding:

- `th`, `td` and `legend` padding resets
- `fieldset` and `iframe` border resets
- `border-spacing: 0` to `table` elements
- `th` text alignment inheritance
- `th` and `address` – `font-size`, `font-weight` and `font-style` resets

Additionally, this PR is based upon #2759 to improve compression performance over the wire.