### PR TITLE
Remove clearfix utility

### DIFF
--- a/__tests__/fixtures/tailwind-output-flagged.css
+++ b/__tests__/fixtures/tailwind-output-flagged.css
@@ -11417,12 +11417,6 @@ video {
   float: none;
 }
 
-.clearfix:after {
-  content: "";
-  display: table;
-  clear: both;
-}
-
 .clear-left {
   clear: left;
 }
@@ -40227,12 +40221,6 @@ video {
     float: none;
   }
 
-  .sm\:clearfix:after {
-    content: "";
-    display: table;
-    clear: both;
-  }
-
   .sm\:clear-left {
     clear: left;
   }
@@ -69005,12 +68993,6 @@ video {
 
   .md\:float-none {
     float: none;
-  }
-
-  .md\:clearfix:after {
-    content: "";
-    display: table;
-    clear: both;
   }
 
   .md\:clear-left {
@@ -97787,12 +97769,6 @@ video {
     float: none;
   }
 
-  .lg\:clearfix:after {
-    content: "";
-    display: table;
-    clear: both;
-  }
-
   .lg\:clear-left {
     clear: left;
   }
@@ -126567,12 +126543,6 @@ video {
     float: none;
   }
 
-  .xl\:clearfix:after {
-    content: "";
-    display: table;
-    clear: both;
-  }
-
   .xl\:clear-left {
     clear: left;
   }
@@ -155345,12 +155315,6 @@ video {
 
   .\32xl\:float-none {
     float: none;
-  }
-
-  .\32xl\:clearfix:after {
-    content: "";
-    display: table;
-    clear: both;
   }
 
   .\32xl\:clear-left {

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -9855,12 +9855,6 @@ video {
   float: none;
 }
 
-.clearfix:after {
-  content: "";
-  display: table;
-  clear: both;
-}
-
 .clear-left {
   clear: left;
 }
@@ -36109,12 +36103,6 @@ video {
     float: none;
   }
 
-  .sm\:clearfix:after {
-    content: "";
-    display: table;
-    clear: both;
-  }
-
   .sm\:clear-left {
     clear: left;
   }
@@ -62331,12 +62319,6 @@ video {
 
   .md\:float-none {
     float: none;
-  }
-
-  .md\:clearfix:after {
-    content: "";
-    display: table;
-    clear: both;
   }
 
   .md\:clear-left {
@@ -88557,12 +88539,6 @@ video {
     float: none;
   }
 
-  .lg\:clearfix:after {
-    content: "";
-    display: table;
-    clear: both;
-  }
-
   .lg\:clear-left {
     clear: left;
   }
@@ -114781,12 +114757,6 @@ video {
     float: none;
   }
 
-  .xl\:clearfix:after {
-    content: "";
-    display: table;
-    clear: both;
-  }
-
   .xl\:clear-left {
     clear: left;
   }
@@ -141003,12 +140973,6 @@ video {
 
   .\32xl\:float-none {
     float: none;
-  }
-
-  .\32xl\:clearfix:after {
-    content: "";
-    display: table;
-    clear: both;
   }
 
   .\32xl\:clear-left {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -11417,12 +11417,6 @@ video {
   float: none;
 }
 
-.clearfix:after {
-  content: "";
-  display: table;
-  clear: both;
-}
-
 .clear-left {
   clear: left;
 }
@@ -40227,12 +40221,6 @@ video {
     float: none;
   }
 
-  .sm\:clearfix:after {
-    content: "";
-    display: table;
-    clear: both;
-  }
-
   .sm\:clear-left {
     clear: left;
   }
@@ -69005,12 +68993,6 @@ video {
 
   .md\:float-none {
     float: none;
-  }
-
-  .md\:clearfix:after {
-    content: "";
-    display: table;
-    clear: both;
   }
 
   .md\:clear-left {
@@ -97787,12 +97769,6 @@ video {
     float: none;
   }
 
-  .lg\:clearfix:after {
-    content: "";
-    display: table;
-    clear: both;
-  }
-
   .lg\:clear-left {
     clear: left;
   }
@@ -126567,12 +126543,6 @@ video {
     float: none;
   }
 
-  .xl\:clearfix:after {
-    content: "";
-    display: table;
-    clear: both;
-  }
-
   .xl\:clear-left {
     clear: left;
   }
@@ -155345,12 +155315,6 @@ video {
 
   .\32xl\:float-none {
     float: none;
-  }
-
-  .\32xl\:clearfix:after {
-    content: "";
-    display: table;
-    clear: both;
   }
 
   .\32xl\:clear-left {

--- a/src/plugins/float.js
+++ b/src/plugins/float.js
@@ -5,11 +5,6 @@ export default function () {
         '.float-right': { float: 'right' },
         '.float-left': { float: 'left' },
         '.float-none': { float: 'none' },
-        '.clearfix:after': {
-          content: '""',
-          display: 'table',
-          clear: 'both',
-        },
       },
       variants('float')
     )


### PR DESCRIPTION
Now that Tailwind doesn't support IE11, we don't need this anymore since `flow-root` is a better solution with great browser support:

https://www.digitalocean.com/community/tutorials/css-no-more-clearfix-flow-root

It always annoyed me that this class lived in the `float` core plugin too, so it brings me great joy to delete this.