### PR TITLE
Add transparent color to colors.js

### DIFF
--- a/colors.js
+++ b/colors.js
@@ -1,4 +1,5 @@
 module.exports = {
+  transparent: 'transparent',
   black: '#000',
   white: '#fff',
   rose: {


### PR DESCRIPTION
The default behavior seems to be adding colors as colors.white,
e.g.
```
module.exports = {
  theme: {
    colors: {
      gray: colors.gray,
...
```

Transparent seems to be the only exception to this.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
