### PR TITLE
Add 'word-break': 'keep-all'

### DIFF
--- a/__tests__/fixtures/tailwind-output-flagged.css
+++ b/__tests__/fixtures/tailwind-output-flagged.css
@@ -24851,6 +24851,10 @@ video {
   overflow-wrap: break-word;
 }
 
+.break-keep-all {
+  word-break: keep-all;
+}
+
 .break-all {
   word-break: break-all;
 }

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -24851,6 +24851,10 @@ video {
   overflow-wrap: break-word !important;
 }
 
+.break-keep-all {
+  word-break: keep-all !important;
+}
+
 .break-all {
   word-break: break-all !important;
 }

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -22295,6 +22295,10 @@ video {
   overflow-wrap: break-word;
 }
 
+.break-keep-all {
+  word-break: keep-all;
+}
+
 .break-all {
   word-break: break-all;
 }

--- a/src/plugins/wordBreak.js
+++ b/src/plugins/wordBreak.js
@@ -9,6 +9,9 @@ export default function () {
         '.break-words': {
           'overflow-wrap': 'break-word',
         },
+        '.break-keep-all': {
+          'overflow-wrap': 'keep-all',
+        },
         '.break-all': { 'word-break': 'break-all' },
       },
       variants('wordBreak')

--- a/src/plugins/wordBreak.js
+++ b/src/plugins/wordBreak.js
@@ -9,9 +9,7 @@ export default function () {
         '.break-words': {
           'overflow-wrap': 'break-word',
         },
-        '.break-keep-all': {
-          'overflow-wrap': 'keep-all',
-        },
+        '.break-keep-all': { 'word-break': 'keep-all'},
         '.break-all': { 'word-break': 'break-all' },
       },
       variants('wordBreak')


### PR DESCRIPTION
### Describe the problem:

No 'word-break': 'keep-all'.

I want to 'word-break': 'keep-all' and I add `.break-keep-all`

```javascript
export default function () {
  return function ({ addUtilities, variants }) {
    addUtilities(
      {
        '.break-normal': {
          'overflow-wrap': 'normal',
          'word-break': 'normal',
        },
        '.break-words': {
          'overflow-wrap': 'break-word',
        },
        '.break-keep-all': { 'word-break': 'keep-all'}, // This
        '.break-all': { 'word-break': 'break-all' },
      },
      variants('wordBreak')
    )
  }
}
```
