### PR TITLE
feat: add 'buildColors' function to colors module

### DIFF
--- a/__tests__/tailwindColors.test.js
+++ b/__tests__/tailwindColors.test.js
@@ -1,0 +1,22 @@
+import tailwindColors from '../colors'
+
+test('generate colors using buildColors function', () => {
+  const colors = tailwindColors.buildColors({
+    green: 'green',
+    gray: 'coolGray',
+  })
+
+  expect(new Set(Object.keys(colors))).toEqual(new Set(['green', 'gray', 'transparent', 'current']))
+  expect(typeof colors.green).toBe('object')
+  expect(typeof colors.gray).toBe('object')
+  expect(colors.transparent).toBe('transparent')
+  expect(colors.current).toBe('currentColor')
+})
+
+test('failing buildColors function', () => {
+  expect(() =>
+    tailwindColors.buildColors({
+      green: 'notAColor',
+    })
+  ).toThrow()
+})

--- a/colors.js
+++ b/colors.js
@@ -1,4 +1,4 @@
-module.exports = {
+const tailwindColors = {
   black: '#000',
   white: '#fff',
   rose: {
@@ -265,4 +265,29 @@ module.exports = {
     800: '#1e293b',
     900: '#0f172a',
   },
+}
+
+/**
+ *
+ * @param {Object.<string, keyof tailwindColors>} colors
+ */
+function buildColors(colors) {
+  var selectedColors = {}
+  for (const key in colors) {
+    if (Object.keys(tailwindColors).includes(colors[key])) {
+      selectedColors[key] = tailwindColors[colors[key]]
+    } else {
+      throw new Error(`'${colors[key]}' is not a color of the 'tailwindcss/colors' module.`)
+    }
+  }
+  return {
+    transparent: 'transparent',
+    current: 'currentColor',
+    ...selectedColors,
+  }
+}
+
+module.exports = {
+  ...tailwindColors,
+  buildColors,
 }


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->

Discussed in #2827 
Does not contain breaking changes.

Usage example:
```js
const colors = require('tailwindcss/colors')

module.exports = {
  theme: {
    colors: buildColors({
      primary: 'blue',
      gray: 'coolGray',
      rose: 'rose',
    }),
  }
}
```
output:
```js
colors: {
  primary: { ... },
  gray: { ... },
  rose: { ... },
  transparent: 'transparent',
  current: 'currentColor',
}
```