### PR TITLE
Performance improvements + memory leak fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix issue with `@apply` not working as expected with `!important` inside an atrule ([#2824](https://github.com/tailwindlabs/tailwindcss/pull/2824))
 - Fix issue with `@apply` not working as expected with defined classes ([#2832](https://github.com/tailwindlabs/tailwindcss/pull/2832))
+- Fix memory leak, and broken `@apply` when splitting up files ([#3032](https://github.com/tailwindlabs/tailwindcss/pull/3032))
 
 ### Added
 

--- a/__tests__/applyAtRule.test.js
+++ b/__tests__/applyAtRule.test.js
@@ -337,7 +337,7 @@ test('you can apply utility classes that do not actually exist as long as they w
   })
 })
 
-test('the shadow lookup is only used if no @tailwind rules were in the source tree', () => {
+test('shadow lookup will be constructed when we have missing @tailwind atrules', () => {
   const input = `
     @tailwind base;
     .foo { @apply mt-4; }
@@ -345,8 +345,8 @@ test('the shadow lookup is only used if no @tailwind rules were in the source tr
 
   expect.assertions(1)
 
-  return run(input).catch((e) => {
-    expect(e).toMatchObject({ name: 'CssSyntaxError' })
+  return run(input).then((result) => {
+    expect(result.css).toContain(`.foo { margin-top: 1rem;\n}`)
   })
 })
 

--- a/__tests__/applyAtRule.test.js
+++ b/__tests__/applyAtRule.test.js
@@ -340,6 +340,7 @@ test('you can apply utility classes that do not actually exist as long as they w
 test('shadow lookup will be constructed when we have missing @tailwind atrules', () => {
   const input = `
     @tailwind base;
+
     .foo { @apply mt-4; }
   `
 
@@ -1361,4 +1362,41 @@ test('declarations within a rule that uses @apply with !important remain not !im
     expect(result.css).toMatchCss(expected)
     expect(result.warnings().length).toBe(0)
   })
+})
+
+test('lookup tree is correctly cached based on used tailwind atrules', async () => {
+  const input1 = `
+    @tailwind utilities;
+
+    .foo { @apply mt-4; }
+  `
+
+  const input2 = `
+    @tailwind components;
+
+    .foo { @apply mt-4; }
+  `
+
+  let config = {
+    corePlugins: [],
+    plugins: [
+      function ({ addUtilities, addComponents }) {
+        addUtilities({ '.mt-4': { marginTop: '1rem' } }, [])
+        addComponents({ '.container': { maxWidth: '500px' } }, [])
+      },
+    ],
+  }
+
+  let output1 = await run(input1, config)
+  let output2 = await run(input2, config)
+
+  expect(output1.css).toMatchCss(`
+    .mt-4 { margin-top: 1rem; }
+    .foo { margin-top: 1rem; }
+  `)
+
+  expect(output2.css).toMatchCss(`
+    .container { max-width: 500px; }
+    .foo { margin-top: 1rem; }
+  `)
 })

--- a/perf/tailwind.config.js
+++ b/perf/tailwind.config.js
@@ -1,14 +1,12 @@
+let colors = require('../colors')
 module.exports = {
-  future: 'all',
-  experimental: 'all',
   purge: [],
+  darkMode: 'class',
   theme: {
-    extend: {},
+    extend: { colors },
   },
   variants: [
     'responsive',
-    'motion-safe',
-    'motion-reduce',
     'group-hover',
     'group-focus',
     'hover',
@@ -19,10 +17,6 @@ module.exports = {
     'visited',
     'disabled',
     'checked',
-    'first',
-    'last',
-    'odd',
-    'even',
   ],
   plugins: [],
 }

--- a/src/lib/substituteClassApplyAtRules.js
+++ b/src/lib/substituteClassApplyAtRules.js
@@ -310,7 +310,15 @@ export default function substituteClassApplyAtRules(config, getProcessedPlugins,
     }
 
     // Tree already contains @tailwind rules, don't prepend default Tailwind tree
-    if (hasAtRule(css, 'tailwind')) {
+    let requiredTailwindAtRules = ['utilities']
+    if (
+      hasAtRule(css, 'tailwind', (node) => {
+        let idx = requiredTailwindAtRules.indexOf(node.params)
+        if (idx !== -1) requiredTailwindAtRules.splice(idx, 1)
+        if (requiredTailwindAtRules.length <= 0) return true
+        return false
+      })
+    ) {
       return processApplyAtRules(css, postcss.root(), config)
     }
 

--- a/src/lib/substituteClassApplyAtRules.js
+++ b/src/lib/substituteClassApplyAtRules.js
@@ -11,15 +11,17 @@ import substituteScreenAtRules from './substituteScreenAtRules'
 import prefixSelector from '../util/prefixSelector'
 import { useMemo } from '../util/useMemo'
 
-function hasAtRule(css, atRule) {
-  let foundAtRule = false
+function hasAtRule(css, atRule, condition = () => true) {
+  let found = false
 
-  css.walkAtRules(atRule, () => {
-    foundAtRule = true
-    return false
+  css.walkAtRules(atRule, (node) => {
+    if (condition(node)) {
+      found = true
+      return false
+    }
   })
 
-  return foundAtRule
+  return found
 }
 
 function cloneWithoutChildren(node) {

--- a/src/processTailwindFeatures.js
+++ b/src/processTailwindFeatures.js
@@ -18,6 +18,7 @@ import { issueFlagNotices } from './featureFlags.js'
 
 import hash from 'object-hash'
 import log from './util/log'
+import { shared } from './util/disposables'
 
 let previousConfig = null
 let processedPlugins = null
@@ -30,6 +31,7 @@ export default function (getConfig) {
     previousConfig = config
 
     if (configChanged) {
+      shared.dispose()
       if (config.target) {
         log.warn([
           'The `target` feature has been removed in Tailwind CSS v2.0.',

--- a/src/util/disposables.js
+++ b/src/util/disposables.js
@@ -1,0 +1,22 @@
+export function disposables() {
+  let disposables = []
+
+  let api = {
+    add(cb) {
+      disposables.push(cb)
+
+      return () => {
+        let idx = disposables.indexOf(cb)
+        if (idx !== -1) disposables.splice(idx, 1)
+      }
+    },
+    dispose() {
+      disposables.splice(0).forEach((dispose) => dispose())
+    },
+  }
+
+  return api
+}
+
+// A shared disposables collection
+export let shared = disposables()

--- a/src/util/useMemo.js
+++ b/src/util/useMemo.js
@@ -1,14 +1,23 @@
+import { shared } from './disposables'
+
 export function useMemo(cb, keyResolver) {
-  const cache = new Map()
+  let cache = new Map()
+
+  function clearCache() {
+    cache.clear()
+    shared.add(clearCache)
+  }
+
+  shared.add(clearCache)
 
   return (...args) => {
-    const key = keyResolver(...args)
+    let key = keyResolver(...args)
 
     if (cache.has(key)) {
       return cache.get(key)
     }
 
-    const result = cb(...args)
+    let result = cb(...args)
     cache.set(key, result)
 
     return result


### PR DESCRIPTION
This PR will improve some of the performance issues people have seen. But even more importantly it also fixes a bad memory leak where if you use tailwindcss in a running process (like a webpack watch), it could happen that once in a while you get a "JavaScript heap out of memory" error and everything crashes. This has been fixed, and also improves a bit of performance.

Another issue that has been pointed out in #2544 and #2820 is that when you split up files, that you get an error that some utilities don't exist when using `@apply`. While splitting up is not a perfect solution, this PR will at least fix that issue.

Let's go in a bit more detail here:

### Broken `@apply`

When you split up files (splitting up `@tailwind base;`, `@tailwind utilities;` and `@tailwind components;`), and one of your files contains something like this:

```css
/* my-base.css */
@tailwind base;

body { @apply bg-gray-100; }
```

Then we made the assumption that if we found a `@tailwind` rule, that we don't have to re-compute all the utilities so that you can apply them. However, in this case only the `base` is included in the full css. Therefore you will get an error that `bg-gray-100` could not be found.

This PR fixes that, by looking if it contains a `@tailwind utilities;` rule. If it does, then we don't have to compute the all the utilities again because it already exists. If it doesn't exist then we will generate the tree so that you can apply those utilities. 

One of the main reasons for this is for example in Vue you can define css per component:

```css
.something { @apply text-xl }
```

But it would be very annoying to write the following code in every single component:

```css
@tailwind base;
@tailwind utilities;
@tailwind components;

.something { @apply text-xl }
```

### Memory leak

We have an optimization in the codebase with `useMemo` (not this is not React, yes I used the same name 🙈) so that we can cache certain calculations if we already did a calculation for the same key. However, every time the config changes (in a running process) we start re-calculating things. For example, imagine that you enabled `darkMode: 'class'` we have to make sure that we create new utilities for darkMode. However, if you remove darkMode again we didn't cleanup all those things. 

Long story short, in this PR we also make sure to clear all the caches when the config changes.

### Why splitting up is not that ideal, however, it's fast with webpack

In development the css output file of Tailwind can be easily `+3 MB`. Just to be clear, this is **NOT** an issue in production, purging is amazing! https://tailwindcss.com/docs/optimizing-for-production.

The main reason for this is the `@tailwind utilities;` being huge.

Some people started splitting up each part of `@tailwind ...` in separate chunks. This works, because `@tailwind utilities;` won't change as long as the config file doesn't change. This means that webpack can cache this file perfectly. When you have a separate file for your css, webpack only has to worry about that part.

However there is a catch... 

In Tailwind we have the concept of `@layer`'s (https://tailwindcss.com/docs/functions-and-directives#layer). This means that when you use something like:

```css
@tailwind base;
@tailwind components; /* (1) will be inserted in this spot */
@tailwind utilities;

@layer components { /* (1) this */
  .my-component { @apply text-xl; }
}
```

This means that we need a single css file so that we can insert custom css in the correct spot.
This won't work anymore once you start splitting up each `@tailwind` at rule in separate files, because now everything is separated. This can lead to incorrect behaviour and specificity because the order matters.

---

Fixes: #2986, #3024, #2544 and #2820