### PR TITLE
Added Fill and Stroke non options and fixed CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Please ensure that the tests are passing when submitting a pull request. If you'
 In addition to the automated tests, if you'd like to test the generated CSS manually with your own test HTML file, you can generate the default build by running:
 
 ```sh
-npm run prepare
+npm run prepublishOnly
 ```
 
 This will create new CSS files in the `/dist` folder which you can reference in your own test HTML file. We often test our own changes by creating an `index.html` file in the root of the Tailwind project itself that pulls in the `/dist/tailwind.css` stylesheet:

--- a/__tests__/fixtures/tailwind-output-flagged.css
+++ b/__tests__/fixtures/tailwind-output-flagged.css
@@ -22167,8 +22167,16 @@ video {
   fill: currentColor;
 }
 
+.fill-none {
+  fill: none;
+}
+
 .stroke-current {
   stroke: currentColor;
+}
+
+.stroke-none {
+  stroke: none;
 }
 
 .stroke-0 {
@@ -50746,8 +50754,16 @@ video {
     fill: currentColor;
   }
 
+  .sm\:fill-none {
+    fill: none;
+  }
+
   .sm\:stroke-current {
     stroke: currentColor;
+  }
+
+  .sm\:stroke-none {
+    stroke: none;
   }
 
   .sm\:stroke-0 {
@@ -79295,8 +79311,16 @@ video {
     fill: currentColor;
   }
 
+  .md\:fill-none {
+    fill: none;
+  }
+
   .md\:stroke-current {
     stroke: currentColor;
+  }
+
+  .md\:stroke-none {
+    stroke: none;
   }
 
   .md\:stroke-0 {
@@ -107844,8 +107868,16 @@ video {
     fill: currentColor;
   }
 
+  .lg\:fill-none {
+    fill: none;
+  }
+
   .lg\:stroke-current {
     stroke: currentColor;
+  }
+
+  .lg\:stroke-none {
+    stroke: none;
   }
 
   .lg\:stroke-0 {
@@ -136393,8 +136425,16 @@ video {
     fill: currentColor;
   }
 
+  .xl\:fill-none {
+    fill: none;
+  }
+
   .xl\:stroke-current {
     stroke: currentColor;
+  }
+
+  .xl\:stroke-none {
+    stroke: none;
   }
 
   .xl\:stroke-0 {
@@ -164942,8 +164982,16 @@ video {
     fill: currentColor;
   }
 
+  .\32xl\:fill-none {
+    fill: none;
+  }
+
   .\32xl\:stroke-current {
     stroke: currentColor;
+  }
+
+  .\32xl\:stroke-none {
+    stroke: none;
   }
 
   .\32xl\:stroke-0 {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -22167,8 +22167,16 @@ video {
   fill: currentColor !important;
 }
 
+.fill-none {
+  fill: none !important;
+}
+
 .stroke-current {
   stroke: currentColor !important;
+}
+
+.stroke-none {
+  stroke: none !important;
 }
 
 .stroke-0 {
@@ -50746,8 +50754,16 @@ video {
     fill: currentColor !important;
   }
 
+  .sm\:fill-none {
+    fill: none !important;
+  }
+
   .sm\:stroke-current {
     stroke: currentColor !important;
+  }
+
+  .sm\:stroke-none {
+    stroke: none !important;
   }
 
   .sm\:stroke-0 {
@@ -79295,8 +79311,16 @@ video {
     fill: currentColor !important;
   }
 
+  .md\:fill-none {
+    fill: none !important;
+  }
+
   .md\:stroke-current {
     stroke: currentColor !important;
+  }
+
+  .md\:stroke-none {
+    stroke: none !important;
   }
 
   .md\:stroke-0 {
@@ -107844,8 +107868,16 @@ video {
     fill: currentColor !important;
   }
 
+  .lg\:fill-none {
+    fill: none !important;
+  }
+
   .lg\:stroke-current {
     stroke: currentColor !important;
+  }
+
+  .lg\:stroke-none {
+    stroke: none !important;
   }
 
   .lg\:stroke-0 {
@@ -136393,8 +136425,16 @@ video {
     fill: currentColor !important;
   }
 
+  .xl\:fill-none {
+    fill: none !important;
+  }
+
   .xl\:stroke-current {
     stroke: currentColor !important;
+  }
+
+  .xl\:stroke-none {
+    stroke: none !important;
   }
 
   .xl\:stroke-0 {
@@ -164942,8 +164982,16 @@ video {
     fill: currentColor !important;
   }
 
+  .\32xl\:fill-none {
+    fill: none !important;
+  }
+
   .\32xl\:stroke-current {
     stroke: currentColor !important;
+  }
+
+  .\32xl\:stroke-none {
+    stroke: none !important;
   }
 
   .\32xl\:stroke-0 {

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -20321,8 +20321,16 @@ video {
   fill: currentColor;
 }
 
+.fill-none {
+  fill: none;
+}
+
 .stroke-current {
   stroke: currentColor;
+}
+
+.stroke-none {
+  stroke: none;
 }
 
 .stroke-0 {
@@ -46344,8 +46352,16 @@ video {
     fill: currentColor;
   }
 
+  .sm\:fill-none {
+    fill: none;
+  }
+
   .sm\:stroke-current {
     stroke: currentColor;
+  }
+
+  .sm\:stroke-none {
+    stroke: none;
   }
 
   .sm\:stroke-0 {
@@ -72337,8 +72353,16 @@ video {
     fill: currentColor;
   }
 
+  .md\:fill-none {
+    fill: none;
+  }
+
   .md\:stroke-current {
     stroke: currentColor;
+  }
+
+  .md\:stroke-none {
+    stroke: none;
   }
 
   .md\:stroke-0 {
@@ -98330,8 +98354,16 @@ video {
     fill: currentColor;
   }
 
+  .lg\:fill-none {
+    fill: none;
+  }
+
   .lg\:stroke-current {
     stroke: currentColor;
+  }
+
+  .lg\:stroke-none {
+    stroke: none;
   }
 
   .lg\:stroke-0 {
@@ -124323,8 +124355,16 @@ video {
     fill: currentColor;
   }
 
+  .xl\:fill-none {
+    fill: none;
+  }
+
   .xl\:stroke-current {
     stroke: currentColor;
+  }
+
+  .xl\:stroke-none {
+    stroke: none;
   }
 
   .xl\:stroke-0 {
@@ -150316,8 +150356,16 @@ video {
     fill: currentColor;
   }
 
+  .\32xl\:fill-none {
+    fill: none;
+  }
+
   .\32xl\:stroke-current {
     stroke: currentColor;
+  }
+
+  .\32xl\:stroke-none {
+    stroke: none;
   }
 
   .\32xl\:stroke-0 {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -22167,8 +22167,16 @@ video {
   fill: currentColor;
 }
 
+.fill-none {
+  fill: none;
+}
+
 .stroke-current {
   stroke: currentColor;
+}
+
+.stroke-none {
+  stroke: none;
 }
 
 .stroke-0 {
@@ -50746,8 +50754,16 @@ video {
     fill: currentColor;
   }
 
+  .sm\:fill-none {
+    fill: none;
+  }
+
   .sm\:stroke-current {
     stroke: currentColor;
+  }
+
+  .sm\:stroke-none {
+    stroke: none;
   }
 
   .sm\:stroke-0 {
@@ -79295,8 +79311,16 @@ video {
     fill: currentColor;
   }
 
+  .md\:fill-none {
+    fill: none;
+  }
+
   .md\:stroke-current {
     stroke: currentColor;
+  }
+
+  .md\:stroke-none {
+    stroke: none;
   }
 
   .md\:stroke-0 {
@@ -107844,8 +107868,16 @@ video {
     fill: currentColor;
   }
 
+  .lg\:fill-none {
+    fill: none;
+  }
+
   .lg\:stroke-current {
     stroke: currentColor;
+  }
+
+  .lg\:stroke-none {
+    stroke: none;
   }
 
   .lg\:stroke-0 {
@@ -136393,8 +136425,16 @@ video {
     fill: currentColor;
   }
 
+  .xl\:fill-none {
+    fill: none;
+  }
+
   .xl\:stroke-current {
     stroke: currentColor;
+  }
+
+  .xl\:stroke-none {
+    stroke: none;
   }
 
   .xl\:stroke-0 {
@@ -164942,8 +164982,16 @@ video {
     fill: currentColor;
   }
 
+  .\32xl\:fill-none {
+    fill: none;
+  }
+
   .\32xl\:stroke-current {
     stroke: currentColor;
+  }
+
+  .\32xl\:stroke-none {
+    stroke: none;
   }
 
   .\32xl\:stroke-0 {

--- a/__tests__/plugins/fill.test.js
+++ b/__tests__/plugins/fill.test.js
@@ -26,3 +26,29 @@ test('defining color as a function', () => {
     ],
   ])
 })
+
+test('defining none as a function', () => {
+  const config = {
+    theme: {
+      fill: {
+        none: ({ opacityVariable: _ }) => 'none',
+      },
+    },
+    variants: {
+      fill: [],
+    },
+  }
+
+  const { utilities } = invokePlugin(plugin(), config)
+
+  expect(utilities).toEqual([
+    [
+      {
+        '.fill-none': {
+          fill: 'none',
+        },
+      },
+      [],
+    ],
+  ])
+})

--- a/__tests__/plugins/stroke.test.js
+++ b/__tests__/plugins/stroke.test.js
@@ -26,3 +26,29 @@ test('defining color as a function', () => {
     ],
   ])
 })
+
+test('defining none as a function', () => {
+  const config = {
+    theme: {
+      stroke: {
+        none: ({ opacityVariable: _ }) => 'none',
+      },
+    },
+    variants: {
+      stroke: [],
+    },
+  }
+
+  const { utilities } = invokePlugin(plugin(), config)
+
+  expect(utilities).toEqual([
+    [
+      {
+        '.stroke-none': {
+          stroke: 'none',
+        },
+      },
+      [],
+    ],
+  ])
+})

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -146,7 +146,10 @@ module.exports = {
     divideColor: (theme) => theme('borderColor'),
     divideOpacity: (theme) => theme('borderOpacity'),
     divideWidth: (theme) => theme('borderWidth'),
-    fill: { current: 'currentColor' },
+    fill: { 
+      current: 'currentColor',
+      none: 'none',
+    },
     flex: {
       1: '1 1 0%',
       auto: '1 1 auto',
@@ -608,6 +611,7 @@ module.exports = {
     }),
     stroke: {
       current: 'currentColor',
+      none: 'none',
     },
     strokeWidth: {
       0: '0',


### PR DESCRIPTION
Added fill-none and stroke-none options:

### stubs\defaultConfig.stub.js

```
    fill: { 
      current: 'currentColor',
      none: 'none',
    },
```

```
    stroke: {
      current: 'currentColor',
      none: 'none',
    },
```

Added this also into the tests which it was able to pass:

```
Test Suites: 45 passed, 45 total
Tests:       8471 passed, 8471 total
Snapshots:   0 total
Time:        87.062 s
Ran all test suites.
```