### PR TITLE
add help cursor

### DIFF
--- a/__tests__/fixtures/tailwind-output-flagged.css
+++ b/__tests__/fixtures/tailwind-output-flagged.css
@@ -10769,6 +10769,10 @@ video {
   cursor: move;
 }
 
+.cursor-help {
+  cursor: help;
+}
+
 .cursor-not-allowed {
   cursor: not-allowed;
 }
@@ -39361,6 +39365,10 @@ video {
     cursor: move;
   }
 
+  .sm\:cursor-help {
+    cursor: help;
+  }
+
   .sm\:cursor-not-allowed {
     cursor: not-allowed;
   }
@@ -67908,6 +67916,10 @@ video {
 
   .md\:cursor-move {
     cursor: move;
+  }
+
+  .md\:cursor-help {
+    cursor: help;
   }
 
   .md\:cursor-not-allowed {
@@ -96459,6 +96471,10 @@ video {
     cursor: move;
   }
 
+  .lg\:cursor-help {
+    cursor: help;
+  }
+
   .lg\:cursor-not-allowed {
     cursor: not-allowed;
   }
@@ -125008,6 +125024,10 @@ video {
     cursor: move;
   }
 
+  .xl\:cursor-help {
+    cursor: help;
+  }
+
   .xl\:cursor-not-allowed {
     cursor: not-allowed;
   }
@@ -153555,6 +153575,10 @@ video {
 
   .\32xl\:cursor-move {
     cursor: move;
+  }
+
+  .\32xl\:cursor-help {
+    cursor: help;
   }
 
   .\32xl\:cursor-not-allowed {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -10769,6 +10769,10 @@ video {
   cursor: move !important;
 }
 
+.cursor-help {
+  cursor: help !important;
+}
+
 .cursor-not-allowed {
   cursor: not-allowed !important;
 }
@@ -39361,6 +39365,10 @@ video {
     cursor: move !important;
   }
 
+  .sm\:cursor-help {
+    cursor: help !important;
+  }
+
   .sm\:cursor-not-allowed {
     cursor: not-allowed !important;
   }
@@ -67908,6 +67916,10 @@ video {
 
   .md\:cursor-move {
     cursor: move !important;
+  }
+
+  .md\:cursor-help {
+    cursor: help !important;
   }
 
   .md\:cursor-not-allowed {
@@ -96459,6 +96471,10 @@ video {
     cursor: move !important;
   }
 
+  .lg\:cursor-help {
+    cursor: help !important;
+  }
+
   .lg\:cursor-not-allowed {
     cursor: not-allowed !important;
   }
@@ -125008,6 +125024,10 @@ video {
     cursor: move !important;
   }
 
+  .xl\:cursor-help {
+    cursor: help !important;
+  }
+
   .xl\:cursor-not-allowed {
     cursor: not-allowed !important;
   }
@@ -153555,6 +153575,10 @@ video {
 
   .\32xl\:cursor-move {
     cursor: move !important;
+  }
+
+  .\32xl\:cursor-help {
+    cursor: help !important;
   }
 
   .\32xl\:cursor-not-allowed {

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -9207,6 +9207,10 @@ video {
   cursor: move;
 }
 
+.cursor-help {
+  cursor: help;
+}
+
 .cursor-not-allowed {
   cursor: not-allowed;
 }
@@ -35243,6 +35247,10 @@ video {
     cursor: move;
   }
 
+  .sm\:cursor-help {
+    cursor: help;
+  }
+
   .sm\:cursor-not-allowed {
     cursor: not-allowed;
   }
@@ -61234,6 +61242,10 @@ video {
 
   .md\:cursor-move {
     cursor: move;
+  }
+
+  .md\:cursor-help {
+    cursor: help;
   }
 
   .md\:cursor-not-allowed {
@@ -87229,6 +87241,10 @@ video {
     cursor: move;
   }
 
+  .lg\:cursor-help {
+    cursor: help;
+  }
+
   .lg\:cursor-not-allowed {
     cursor: not-allowed;
   }
@@ -113222,6 +113238,10 @@ video {
     cursor: move;
   }
 
+  .xl\:cursor-help {
+    cursor: help;
+  }
+
   .xl\:cursor-not-allowed {
     cursor: not-allowed;
   }
@@ -139213,6 +139233,10 @@ video {
 
   .\32xl\:cursor-move {
     cursor: move;
+  }
+
+  .\32xl\:cursor-help {
+    cursor: help;
   }
 
   .\32xl\:cursor-not-allowed {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -10769,6 +10769,10 @@ video {
   cursor: move;
 }
 
+.cursor-help {
+  cursor: help;
+}
+
 .cursor-not-allowed {
   cursor: not-allowed;
 }
@@ -39361,6 +39365,10 @@ video {
     cursor: move;
   }
 
+  .sm\:cursor-help {
+    cursor: help;
+  }
+
   .sm\:cursor-not-allowed {
     cursor: not-allowed;
   }
@@ -67908,6 +67916,10 @@ video {
 
   .md\:cursor-move {
     cursor: move;
+  }
+
+  .md\:cursor-help {
+    cursor: help;
   }
 
   .md\:cursor-not-allowed {
@@ -96459,6 +96471,10 @@ video {
     cursor: move;
   }
 
+  .lg\:cursor-help {
+    cursor: help;
+  }
+
   .lg\:cursor-not-allowed {
     cursor: not-allowed;
   }
@@ -125008,6 +125024,10 @@ video {
     cursor: move;
   }
 
+  .xl\:cursor-help {
+    cursor: help;
+  }
+
   .xl\:cursor-not-allowed {
     cursor: not-allowed;
   }
@@ -153555,6 +153575,10 @@ video {
 
   .\32xl\:cursor-move {
     cursor: move;
+  }
+
+  .\32xl\:cursor-help {
+    cursor: help;
   }
 
   .\32xl\:cursor-not-allowed {

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -141,6 +141,7 @@ module.exports = {
       wait: 'wait',
       text: 'text',
       move: 'move',
+      help: 'help',
       'not-allowed': 'not-allowed',
     },
     divideColor: (theme) => theme('borderColor'),


### PR DESCRIPTION
Adds on to #679 to also have a help cursor utility.

There are a bunch of other cursors laid out in MDN docs, not sure if any of those would also be of use.
https://developer.mozilla.org/en-US/docs/Web/CSS/cursor