### PR TITLE
Adds fit-content height variant as h-fit

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -363,6 +363,7 @@ module.exports = {
       '5/6': '83.333333%',
       full: '100%',
       screen: '100vh',
+      fit: 'fit-content',
     }),
     inset: (theme, { negative }) => ({
       auto: 'auto',


### PR DESCRIPTION
When working on my own projects, I often needed the `height: fit-content` style. I believe that this would be of use for many others in the default config.