### PR TITLE
add hidden inputs to not clause in flex space

### DIFF
--- a/src/plugins/space.js
+++ b/src/plugins/space.js
@@ -7,12 +7,12 @@ export default function () {
       (_size, modifier) => {
         const size = _size === '0' ? '0px' : _size
         return {
-          [`${nameClass('space-y', modifier)} > :not([hidden]) ~ :not([hidden])`]: {
+          [`${nameClass('space-y', modifier)} > :not([hidden]):not([type="hidden"]) ~ :not([hidden]):not([type="hidden"])`]: {
             '--tw-space-y-reverse': '0',
             'margin-top': `calc(${size} * calc(1 - var(--tw-space-y-reverse)))`,
             'margin-bottom': `calc(${size} * var(--tw-space-y-reverse))`,
           },
-          [`${nameClass('space-x', modifier)} > :not([hidden]) ~ :not([hidden])`]: {
+          [`${nameClass('space-x', modifier)} > :not([hidden]):not([type="hidden"]) ~ :not([hidden]):not([type="hidden"])`]: {
             '--tw-space-x-reverse': '0',
             'margin-right': `calc(${size} * var(--tw-space-x-reverse))`,
             'margin-left': `calc(${size} * calc(1 - var(--tw-space-x-reverse)))`,
@@ -25,10 +25,10 @@ export default function () {
       return [
         ..._.flatMap(theme('space'), generator),
         {
-          '.space-y-reverse > :not([hidden]) ~ :not([hidden])': {
+          '.space-y-reverse > :not([hidden]):not([type="hidden"]) ~ :not([hidden]):not([type="hidden"])': {
             '--tw-space-y-reverse': '1',
           },
-          '.space-x-reverse > :not([hidden]) ~ :not([hidden])': {
+          '.space-x-reverse > :not([hidden]):not([type="hidden"]) ~ :not([hidden]):not([type="hidden"])': {
             '--tw-space-x-reverse': '1',
           },
         },


### PR DESCRIPTION
thought I'd accompany my issue #3350 with a possible solution

> ### Describe the problem:
> 
> when using `flex space-x-8` when there is a `<input type="hidden" />` as a the first child, a margin is applied to the first visible child element
> 
> ## expected
> no extra spacing
> 
> ### Link to a minimal reproduction:
> 
> https://play.tailwindcss.com/OTcySBQoic