### PR TITLE
Avoid different chunks' content after each build for Vue components with @apply

### DIFF
--- a/src/lib/substituteClassApplyAtRules.js
+++ b/src/lib/substituteClassApplyAtRules.js
@@ -350,7 +350,7 @@ export default function substituteClassApplyAtRules(config, getProcessedPlugins,
               substituteScreenAtRules(config),
             ])
               .process(requiredTailwindAtRules.map((rule) => `@tailwind ${rule};`).join('\n'), {
-                from: undefined,
+                from: __filename,
               })
               .then((result) => {
                 defaultTailwindTree.set(lookupKey, result)


### PR DESCRIPTION
When we use `@apply` in the styles of the Vue component, the resulting chunks' content is different after each build (the reason why I want chunks' content to be the same after each build described here: #3349).

And the difference lays here:

![](https://user-images.githubusercontent.com/22997803/104469489-3f101600-55c1-11eb-988a-1019050be6c6.png)

That's because PostCSS generates random `Input#id` if `from` is not provided (https://postcss.org/api/#input-id).

So in order to fix the problem described above, `from` needs to be provided. That's what this PR does.

I was wondering about the best value for the `from` option and had decided to use `__filename` since the idea of the `from` option is to help users to find the source of the CSS (thanks @ai: https://github.com/postcss/postcss/issues/1512#issuecomment-760355857)

_Fixes #3349_