### PR TITLE
Adds support for ESM `tailwind.config.js` files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@
 /docs
 /__tests__/fixtures/cli-utils.js
 /stubs/*
+/src/util/requireOrImportConfig.js

--- a/package.json
+++ b/package.json
@@ -94,6 +94,9 @@
           }
         }
       ]
+    ],
+    "exclude": [
+      "src/util/requireOrImportConfig.js"
     ]
   },
   "jest": {

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import processTailwindFeatures from './processTailwindFeatures'
 import formatCSS from './lib/formatCSS'
 import resolveConfig from './util/resolveConfig'
 import getAllConfigs from './util/getAllConfigs'
+import requireOrImportConfig from './util/requireOrImportConfig'
 import { supportedConfigFiles } from './constants'
 import defaultConfig from '../stubs/defaultConfig.stub.js'
 
@@ -45,7 +46,7 @@ function resolveConfigPath(filePath) {
   return undefined
 }
 
-const getConfigFunction = (config) => () => {
+const getConfigFunction = (config) => async () => {
   if (_.isUndefined(config)) {
     return resolveConfig([...getAllConfigs(defaultConfig)])
   }
@@ -59,7 +60,9 @@ const getConfigFunction = (config) => () => {
     }
   }
 
-  const configObject = _.isObject(config) ? _.get(config, 'config', config) : require(config)
+  const configObject = _.isObject(config)
+    ? _.get(config, 'config', config)
+    : await requireOrImportConfig(config)
 
   return resolveConfig([...getAllConfigs(configObject)])
 }

--- a/src/processTailwindFeatures.js
+++ b/src/processTailwindFeatures.js
@@ -25,8 +25,8 @@ let processedPlugins = null
 let getProcessedPlugins = null
 
 export default function (getConfig) {
-  return function (css) {
-    const config = getConfig()
+  return async function (css) {
+    const config = await getConfig()
     const configChanged = hash(previousConfig) !== hash(config)
     previousConfig = config
 

--- a/src/util/requireOrImportConfig.js
+++ b/src/util/requireOrImportConfig.js
@@ -3,8 +3,8 @@
 // Node v12.17+ exposes `import` within CJS files
 // in order to `require` ESM files.
 
-// This file is intentionally excluded from `babel`
-// to avoid transpiling the `import` statement
+// This file is intentionally excluded from `babel` (and `eslint`)
+// to avoid transpiling away the `import` statement
 
 Object.defineProperty(exports, "__esModule", {
   value: true

--- a/src/util/requireOrImportConfig.js
+++ b/src/util/requireOrImportConfig.js
@@ -1,0 +1,26 @@
+"use strict";
+
+// Node v12.17+ exposes `import` within CJS files
+// in order to `require` ESM files.
+
+// This file is intentionally excluded from `babel`
+// to avoid transpiling the `import` statement
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = requireOrImportConfig;
+
+function requireOrImportConfig(config) {
+  try {
+    return require(config)
+  } catch (e) {
+    if (e.code === 'ERR_REQUIRE_ESM') {
+      try {
+        return import(config).then(mdl => mdl.default)
+      } catch (e) {}
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
ESM adoption in Node is becoming more common—it would be really great for Tailwind to get out ahead of a lot of the issues people are about to run into as the ecosystem shifts to support ESM.

Currently, users who rely on Node ESM with ["type": "module"](https://nodejs.org/api/packages.html#packages_type) (officially supported since node@12.17.0) must use a `tailwind.config.cjs` file in CJS format (#3181) inside of their ESM project. This is great! But the best solution would be to allow ESM projects to use the normal `tailwind.config.js` file in ESM format, as requested in [discussion #2284](https://github.com/tailwindlabs/tailwindcss/discussions/2284).

I thought this would be a bigger problem, but it turned out to be fairly simple. The magic here is a [utility function](https://github.com/tailwindlabs/tailwindcss/blob/cbd91215393f86a18e0c38a7e1144b662a8c3410/src/util/requireOrImportConfig.js) that attempts to `require` the config path (will work for CJS files), `catch` any errors with `code: "ERR_REQUIRE_ESM"`, and then `import` the config path instead (will work for ESM files). Note that this util function is split into a separate file and excluded from the `babel` config, otherwise `babel` transpiles out the native `import` statement.

Two issues I'd love some assistance on:
- I don't really know how to write tests for this.
- There is probably additional logic that needs to be updated to accommodate ESM config files... `getModuleDependencies` and maybe others?