### PR TITLE
Added support for display : inline-table

### DIFF
--- a/__tests__/fixtures/tailwind-output-flagged.css
+++ b/__tests__/fixtures/tailwind-output-flagged.css
@@ -10804,6 +10804,10 @@ video {
   display: table;
 }
 
+.inline-table {
+  display: inline-table;
+}
+
 .table-caption {
   display: table-caption;
 }
@@ -10854,10 +10858,6 @@ video {
 
 .hidden {
   display: none;
-}
-
-.inline-table {
-  display: inline-table;
 }
 
 .flex-row {
@@ -39404,6 +39404,10 @@ video {
     display: table;
   }
 
+  .sm\:inline-table {
+    display: inline-table;
+  }
+
   .sm\:table-caption {
     display: table-caption;
   }
@@ -39454,10 +39458,6 @@ video {
 
   .sm\:hidden {
     display: none;
-  }
-
-  .sm\:inline-table {
-    display: inline-table;
   }
 
   .sm\:flex-row {
@@ -67961,6 +67961,10 @@ video {
     display: table;
   }
 
+  .md\:inline-table {
+    display: inline-table;
+  }
+
   .md\:table-caption {
     display: table-caption;
   }
@@ -68011,10 +68015,6 @@ video {
 
   .md\:hidden {
     display: none;
-  }
-
-  .md\:inline-table {
-    display: inline-table;
   }
 
   .md\:flex-row {
@@ -96518,6 +96518,10 @@ video {
     display: table;
   }
 
+  .lg\:inline-table {
+    display: inline-table;
+  }
+
   .lg\:table-caption {
     display: table-caption;
   }
@@ -96568,10 +96572,6 @@ video {
 
   .lg\:hidden {
     display: none;
-  }
-
-  .lg\:inline-table {
-    display: inline-table;
   }
 
   .lg\:flex-row {
@@ -125075,6 +125075,10 @@ video {
     display: table;
   }
 
+  .xl\:inline-table {
+    display: inline-table;
+  }
+
   .xl\:table-caption {
     display: table-caption;
   }
@@ -125125,10 +125129,6 @@ video {
 
   .xl\:hidden {
     display: none;
-  }
-
-  .xl\:inline-table {
-    display: inline-table;
   }
 
   .xl\:flex-row {
@@ -153632,6 +153632,10 @@ video {
     display: table;
   }
 
+  .\32xl\:inline-table {
+    display: inline-table;
+  }
+
   .\32xl\:table-caption {
     display: table-caption;
   }
@@ -153682,10 +153686,6 @@ video {
 
   .\32xl\:hidden {
     display: none;
-  }
-
-  .\32xl\:inline-table {
-    display: inline-table;
   }
 
   .\32xl\:flex-row {

--- a/__tests__/fixtures/tailwind-output-flagged.css
+++ b/__tests__/fixtures/tailwind-output-flagged.css
@@ -10856,6 +10856,10 @@ video {
   display: none;
 }
 
+.inline-table {
+  display: inline-table;
+}
+
 .flex-row {
   flex-direction: row;
 }
@@ -39452,6 +39456,10 @@ video {
     display: none;
   }
 
+  .sm\:inline-table {
+    display: inline-table;
+  }
+
   .sm\:flex-row {
     flex-direction: row;
   }
@@ -68003,6 +68011,10 @@ video {
 
   .md\:hidden {
     display: none;
+  }
+
+  .md\:inline-table {
+    display: inline-table;
   }
 
   .md\:flex-row {
@@ -96558,6 +96570,10 @@ video {
     display: none;
   }
 
+  .lg\:inline-table {
+    display: inline-table;
+  }
+
   .lg\:flex-row {
     flex-direction: row;
   }
@@ -125111,6 +125127,10 @@ video {
     display: none;
   }
 
+  .xl\:inline-table {
+    display: inline-table;
+  }
+
   .xl\:flex-row {
     flex-direction: row;
   }
@@ -153662,6 +153682,10 @@ video {
 
   .\32xl\:hidden {
     display: none;
+  }
+
+  .\32xl\:inline-table {
+    display: inline-table;
   }
 
   .\32xl\:flex-row {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -10856,6 +10856,10 @@ video {
   display: none !important;
 }
 
+.inline-table {
+  display: inline-table !important;
+}
+
 .flex-row {
   flex-direction: row !important;
 }
@@ -39452,6 +39456,10 @@ video {
     display: none !important;
   }
 
+  .sm\:inline-table {
+    display: inline-table !important;
+  }
+
   .sm\:flex-row {
     flex-direction: row !important;
   }
@@ -68003,6 +68011,10 @@ video {
 
   .md\:hidden {
     display: none !important;
+  }
+
+  .md\:inline-table {
+    display: inline-table !important;
   }
 
   .md\:flex-row {
@@ -96558,6 +96570,10 @@ video {
     display: none !important;
   }
 
+  .lg\:inline-table {
+    display: inline-table !important;
+  }
+
   .lg\:flex-row {
     flex-direction: row !important;
   }
@@ -125111,6 +125127,10 @@ video {
     display: none !important;
   }
 
+  .xl\:inline-table {
+    display: inline-table !important;
+  }
+
   .xl\:flex-row {
     flex-direction: row !important;
   }
@@ -153662,6 +153682,10 @@ video {
 
   .\32xl\:hidden {
     display: none !important;
+  }
+
+  .\32xl\:inline-table {
+    display: inline-table !important;
   }
 
   .\32xl\:flex-row {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -10804,6 +10804,10 @@ video {
   display: table !important;
 }
 
+.inline-table {
+  display: inline-table !important;
+}
+
 .table-caption {
   display: table-caption !important;
 }
@@ -10854,10 +10858,6 @@ video {
 
 .hidden {
   display: none !important;
-}
-
-.inline-table {
-  display: inline-table !important;
 }
 
 .flex-row {
@@ -39404,6 +39404,10 @@ video {
     display: table !important;
   }
 
+  .sm\:inline-table {
+    display: inline-table !important;
+  }
+
   .sm\:table-caption {
     display: table-caption !important;
   }
@@ -39454,10 +39458,6 @@ video {
 
   .sm\:hidden {
     display: none !important;
-  }
-
-  .sm\:inline-table {
-    display: inline-table !important;
   }
 
   .sm\:flex-row {
@@ -67961,6 +67961,10 @@ video {
     display: table !important;
   }
 
+  .md\:inline-table {
+    display: inline-table !important;
+  }
+
   .md\:table-caption {
     display: table-caption !important;
   }
@@ -68011,10 +68015,6 @@ video {
 
   .md\:hidden {
     display: none !important;
-  }
-
-  .md\:inline-table {
-    display: inline-table !important;
   }
 
   .md\:flex-row {
@@ -96518,6 +96518,10 @@ video {
     display: table !important;
   }
 
+  .lg\:inline-table {
+    display: inline-table !important;
+  }
+
   .lg\:table-caption {
     display: table-caption !important;
   }
@@ -96568,10 +96572,6 @@ video {
 
   .lg\:hidden {
     display: none !important;
-  }
-
-  .lg\:inline-table {
-    display: inline-table !important;
   }
 
   .lg\:flex-row {
@@ -125075,6 +125075,10 @@ video {
     display: table !important;
   }
 
+  .xl\:inline-table {
+    display: inline-table !important;
+  }
+
   .xl\:table-caption {
     display: table-caption !important;
   }
@@ -125125,10 +125129,6 @@ video {
 
   .xl\:hidden {
     display: none !important;
-  }
-
-  .xl\:inline-table {
-    display: inline-table !important;
   }
 
   .xl\:flex-row {
@@ -153632,6 +153632,10 @@ video {
     display: table !important;
   }
 
+  .\32xl\:inline-table {
+    display: inline-table !important;
+  }
+
   .\32xl\:table-caption {
     display: table-caption !important;
   }
@@ -153682,10 +153686,6 @@ video {
 
   .\32xl\:hidden {
     display: none !important;
-  }
-
-  .\32xl\:inline-table {
-    display: inline-table !important;
   }
 
   .\32xl\:flex-row {

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -9242,6 +9242,10 @@ video {
   display: table;
 }
 
+.inline-table {
+  display: inline-table;
+}
+
 .table-caption {
   display: table-caption;
 }
@@ -9292,10 +9296,6 @@ video {
 
 .hidden {
   display: none;
-}
-
-.inline-table {
-  display: inline-table;
 }
 
 .flex-row {
@@ -35286,6 +35286,10 @@ video {
     display: table;
   }
 
+  .sm\:inline-table {
+    display: inline-table;
+  }
+
   .sm\:table-caption {
     display: table-caption;
   }
@@ -35336,10 +35340,6 @@ video {
 
   .sm\:hidden {
     display: none;
-  }
-
-  .sm\:inline-table {
-    display: inline-table;
   }
 
   .sm\:flex-row {
@@ -61287,6 +61287,10 @@ video {
     display: table;
   }
 
+  .md\:inline-table {
+    display: inline-table;
+  }
+
   .md\:table-caption {
     display: table-caption;
   }
@@ -61337,10 +61341,6 @@ video {
 
   .md\:hidden {
     display: none;
-  }
-
-  .md\:inline-table {
-    display: inline-table;
   }
 
   .md\:flex-row {
@@ -87288,6 +87288,10 @@ video {
     display: table;
   }
 
+  .lg\:inline-table {
+    display: inline-table;
+  }
+
   .lg\:table-caption {
     display: table-caption;
   }
@@ -87338,10 +87342,6 @@ video {
 
   .lg\:hidden {
     display: none;
-  }
-
-  .lg\:inline-table {
-    display: inline-table;
   }
 
   .lg\:flex-row {
@@ -113289,6 +113289,10 @@ video {
     display: table;
   }
 
+  .xl\:inline-table {
+    display: inline-table;
+  }
+
   .xl\:table-caption {
     display: table-caption;
   }
@@ -113339,10 +113343,6 @@ video {
 
   .xl\:hidden {
     display: none;
-  }
-
-  .xl\:inline-table {
-    display: inline-table;
   }
 
   .xl\:flex-row {
@@ -139290,6 +139290,10 @@ video {
     display: table;
   }
 
+  .\32xl\:inline-table {
+    display: inline-table;
+  }
+
   .\32xl\:table-caption {
     display: table-caption;
   }
@@ -139340,10 +139344,6 @@ video {
 
   .\32xl\:hidden {
     display: none;
-  }
-
-  .\32xl\:inline-table {
-    display: inline-table;
   }
 
   .\32xl\:flex-row {

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -9294,6 +9294,10 @@ video {
   display: none;
 }
 
+.inline-table {
+  display: inline-table;
+}
+
 .flex-row {
   flex-direction: row;
 }
@@ -35334,6 +35338,10 @@ video {
     display: none;
   }
 
+  .sm\:inline-table {
+    display: inline-table;
+  }
+
   .sm\:flex-row {
     flex-direction: row;
   }
@@ -61329,6 +61337,10 @@ video {
 
   .md\:hidden {
     display: none;
+  }
+
+  .md\:inline-table {
+    display: inline-table;
   }
 
   .md\:flex-row {
@@ -87328,6 +87340,10 @@ video {
     display: none;
   }
 
+  .lg\:inline-table {
+    display: inline-table;
+  }
+
   .lg\:flex-row {
     flex-direction: row;
   }
@@ -113325,6 +113341,10 @@ video {
     display: none;
   }
 
+  .xl\:inline-table {
+    display: inline-table;
+  }
+
   .xl\:flex-row {
     flex-direction: row;
   }
@@ -139320,6 +139340,10 @@ video {
 
   .\32xl\:hidden {
     display: none;
+  }
+
+  .\32xl\:inline-table {
+    display: inline-table;
   }
 
   .\32xl\:flex-row {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -10804,6 +10804,10 @@ video {
   display: table;
 }
 
+.inline-table {
+  display: inline-table;
+}
+
 .table-caption {
   display: table-caption;
 }
@@ -10854,10 +10858,6 @@ video {
 
 .hidden {
   display: none;
-}
-
-.inline-table {
-  display: inline-table;
 }
 
 .flex-row {
@@ -39404,6 +39404,10 @@ video {
     display: table;
   }
 
+  .sm\:inline-table {
+    display: inline-table;
+  }
+
   .sm\:table-caption {
     display: table-caption;
   }
@@ -39454,10 +39458,6 @@ video {
 
   .sm\:hidden {
     display: none;
-  }
-
-  .sm\:inline-table {
-    display: inline-table;
   }
 
   .sm\:flex-row {
@@ -67961,6 +67961,10 @@ video {
     display: table;
   }
 
+  .md\:inline-table {
+    display: inline-table;
+  }
+
   .md\:table-caption {
     display: table-caption;
   }
@@ -68011,10 +68015,6 @@ video {
 
   .md\:hidden {
     display: none;
-  }
-
-  .md\:inline-table {
-    display: inline-table;
   }
 
   .md\:flex-row {
@@ -96518,6 +96518,10 @@ video {
     display: table;
   }
 
+  .lg\:inline-table {
+    display: inline-table;
+  }
+
   .lg\:table-caption {
     display: table-caption;
   }
@@ -96568,10 +96572,6 @@ video {
 
   .lg\:hidden {
     display: none;
-  }
-
-  .lg\:inline-table {
-    display: inline-table;
   }
 
   .lg\:flex-row {
@@ -125075,6 +125075,10 @@ video {
     display: table;
   }
 
+  .xl\:inline-table {
+    display: inline-table;
+  }
+
   .xl\:table-caption {
     display: table-caption;
   }
@@ -125125,10 +125129,6 @@ video {
 
   .xl\:hidden {
     display: none;
-  }
-
-  .xl\:inline-table {
-    display: inline-table;
   }
 
   .xl\:flex-row {
@@ -153632,6 +153632,10 @@ video {
     display: table;
   }
 
+  .\32xl\:inline-table {
+    display: inline-table;
+  }
+
   .\32xl\:table-caption {
     display: table-caption;
   }
@@ -153682,10 +153686,6 @@ video {
 
   .\32xl\:hidden {
     display: none;
-  }
-
-  .\32xl\:inline-table {
-    display: inline-table;
   }
 
   .\32xl\:flex-row {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -10856,6 +10856,10 @@ video {
   display: none;
 }
 
+.inline-table {
+  display: inline-table;
+}
+
 .flex-row {
   flex-direction: row;
 }
@@ -39452,6 +39456,10 @@ video {
     display: none;
   }
 
+  .sm\:inline-table {
+    display: inline-table;
+  }
+
   .sm\:flex-row {
     flex-direction: row;
   }
@@ -68003,6 +68011,10 @@ video {
 
   .md\:hidden {
     display: none;
+  }
+
+  .md\:inline-table {
+    display: inline-table;
   }
 
   .md\:flex-row {
@@ -96558,6 +96570,10 @@ video {
     display: none;
   }
 
+  .lg\:inline-table {
+    display: inline-table;
+  }
+
   .lg\:flex-row {
     flex-direction: row;
   }
@@ -125111,6 +125127,10 @@ video {
     display: none;
   }
 
+  .xl\:inline-table {
+    display: inline-table;
+  }
+
   .xl\:flex-row {
     flex-direction: row;
   }
@@ -153662,6 +153682,10 @@ video {
 
   .\32xl\:hidden {
     display: none;
+  }
+
+  .\32xl\:inline-table {
+    display: inline-table;
   }
 
   .\32xl\:flex-row {

--- a/src/plugins/display.js
+++ b/src/plugins/display.js
@@ -59,6 +59,9 @@ export default function () {
         '.hidden': {
           display: 'none',
         },
+        '.inline-table': {
+          display: 'inline-table',
+        },
       },
       variants('display')
     )

--- a/src/plugins/display.js
+++ b/src/plugins/display.js
@@ -20,6 +20,9 @@ export default function () {
         '.table': {
           display: 'table',
         },
+        '.inline-table': {
+          display: 'inline-table',
+        },
         '.table-caption': {
           display: 'table-caption',
         },
@@ -58,9 +61,6 @@ export default function () {
         },
         '.hidden': {
           display: 'none',
-        },
-        '.inline-table': {
-          display: 'inline-table',
         },
       },
       variants('display')


### PR DESCRIPTION
I was missing a class for the `display : inline-table` property. I've added it underneath the other display classes and updated the tests to get back to green.

If you accept this request, hopefully it can also be added to V1 as the project I was missing it in still has to support IE11.