### PR TITLE
Add support for variant targets to specify which classes in selector should receive variant prefix

### DIFF
--- a/__tests__/variantTarget.test.js
+++ b/__tests__/variantTarget.test.js
@@ -1,6 +1,7 @@
 import postcss from 'postcss'
 import variantsAtRulesPlugin from '../src/lib/substituteVariantsAtRules'
 import responsiveAtRulesPlugin from '../src/lib/substituteResponsiveAtRules'
+import unwrapVariantTargets from '../src/lib/unwrapVariantTargets'
 import processPlugins from '../src/util/processPlugins'
 import resolveConfig from '../src/util/resolveConfig'
 import config from '../stubs/defaultConfig.stub.js'
@@ -10,12 +11,13 @@ function run(input, opts = config) {
   return postcss([
     variantsAtRulesPlugin(resolved, processPlugins(resolved.plugins, resolved)),
     responsiveAtRulesPlugin(resolved),
+    unwrapVariantTargets(),
   ]).process(input, {
     from: undefined,
   })
 }
 
-test('the dark variant uses the last class as target by default when the mode is set to media', () => {
+test('it targets the last class when selectors are wrapped in dark variants and the `darkMode` is set to media', () => {
   const input = `
     @variants dark {
       .banana .peel { color: yellow; }
@@ -35,7 +37,7 @@ test('the dark variant uses the last class as target by default when the mode is
   })
 })
 
-test('the dark variant uses the last class as target by default when the mode is set to class', () => {
+test('it targets the last class when selectors are wrapped in dark variants and the `darkMode` is set to class', () => {
   const input = `
     @variants dark {
       .banana .peel { color: yellow; }
@@ -53,7 +55,7 @@ test('the dark variant uses the last class as target by default when the mode is
   })
 })
 
-test('the motion-safe variant uses the last class as target by default', () => {
+test('it targets the last class when selectors are wrapped in motion-safe variants', () => {
   const input = `
     @variants motion-safe {
       .banana .peel { color: yellow; }
@@ -73,7 +75,7 @@ test('the motion-safe variant uses the last class as target by default', () => {
   })
 })
 
-test('the motion-reduce variant uses the last class as target by default', () => {
+test('it targets the last class when selectors are wrapped in motion-reduce variants', () => {
   const input = `
     @variants motion-reduce {
       .banana .peel { color: yellow; }
@@ -93,7 +95,7 @@ test('the motion-reduce variant uses the last class as target by default', () =>
   })
 })
 
-test('the hover variant uses the last class as target by default', () => {
+test('it targets the last class when selectors are wrapped in hover variants', () => {
   const input = `
     @variants hover {
       .banana .peel { color: yellow; }
@@ -111,7 +113,7 @@ test('the hover variant uses the last class as target by default', () => {
   })
 })
 
-test('the focus variant uses the last class as target by default', () => {
+test('it targets the last class when selectors are wrapped in focus variants', () => {
   const input = `
     @variants focus {
       .banana .peel { color: yellow; }
@@ -129,7 +131,7 @@ test('the focus variant uses the last class as target by default', () => {
   })
 })
 
-test('the focus-within variant uses the last class as target by default', () => {
+test('it targets the last class when selectors are wrapped in focus-within variants', () => {
   const input = `
     @variants focus-within {
       .banana .peel { color: yellow; }
@@ -147,7 +149,7 @@ test('the focus-within variant uses the last class as target by default', () => 
   })
 })
 
-test('the focus-visible variant uses the last class as target by default', () => {
+test('it targets the last class when selectors are wrapped in focus-visible variants', () => {
   const input = `
     @variants focus-visible {
       .banana .peel { color: yellow; }
@@ -165,7 +167,7 @@ test('the focus-visible variant uses the last class as target by default', () =>
   })
 })
 
-test('the active variant uses the last class as target by default', () => {
+test('it targets the last class when selectors are wrapped in active variants', () => {
   const input = `
     @variants active {
       .banana .peel { color: yellow; }
@@ -183,7 +185,7 @@ test('the active variant uses the last class as target by default', () => {
   })
 })
 
-test('the visited variant uses the last class as target by default', () => {
+test('it targets the last class when selectors are wrapped in visited variants', () => {
   const input = `
     @variants visited {
       .banana .peel { color: yellow; }
@@ -201,7 +203,7 @@ test('the visited variant uses the last class as target by default', () => {
   })
 })
 
-test('the disabled variant uses the last class as target by default', () => {
+test('it targets the last class when selectors are wrapped in disabled variants', () => {
   const input = `
     @variants disabled {
       .banana .peel { color: yellow; }
@@ -219,7 +221,7 @@ test('the disabled variant uses the last class as target by default', () => {
   })
 })
 
-test('the checked variant uses the last class as target by default', () => {
+test('it targets the last class when selectors are wrapped in checked variants', () => {
   const input = `
     @variants checked {
       .banana .peel { color: yellow; }
@@ -237,7 +239,7 @@ test('the checked variant uses the last class as target by default', () => {
   })
 })
 
-test('the first variant uses the last class as target by default', () => {
+test('it targets the last class when selectors are wrapped in first variants', () => {
   const input = `
     @variants first {
       .banana .peel { color: yellow; }
@@ -255,7 +257,7 @@ test('the first variant uses the last class as target by default', () => {
   })
 })
 
-test('the last variant uses the last class as target by default', () => {
+test('it targets the last class when selectors are wrapped in last variants', () => {
   const input = `
     @variants last {
       .banana .peel { color: yellow; }
@@ -273,7 +275,7 @@ test('the last variant uses the last class as target by default', () => {
   })
 })
 
-test('the odd variant uses the last class as target by default', () => {
+test('it targets the last class when selectors are wrapped in odd variants', () => {
   const input = `
     @variants odd {
       .banana .peel { color: yellow; }
@@ -291,7 +293,7 @@ test('the odd variant uses the last class as target by default', () => {
   })
 })
 
-test('the even variant uses the last class as target by default', () => {
+test('it targets the last class when selectors are wrapped in even variants', () => {
   const input = `
     @variants even {
       .banana .peel { color: yellow; }
@@ -309,7 +311,7 @@ test('the even variant uses the last class as target by default', () => {
   })
 })
 
-test('the responsive variant uses the last class as target by default', () => {
+test('it targets the last class when selectors are wrapped in responsive variants', () => {
   const input = `
     @responsive {
       .banana .peel { color: yellow; }
@@ -341,6 +343,360 @@ test('the responsive variant uses the last class as target by default', () => {
     },
     separator: ':',
   }).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+test('it uses the given target when selectors are wrapped in dark variants and the `darkMode` is set to media', () => {
+  const input = `
+    @variants dark {
+      [.banana] .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    @media (prefers-color-scheme: dark) {
+      .dark\\:banana .peel { color: yellow; }
+    }
+  `
+
+  return run(input, { darkMode: 'media' }).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it uses the given target when selectors are wrapped in dark variants and the `darkMode` is set to class', () => {
+  const input = `
+    @variants dark {
+      [.banana] .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .dark .dark\\:banana .peel { color: yellow; }
+  `
+
+  return run(input, { darkMode: 'class' }).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it uses the given target when selectors are wrapped in motion-safe variants', () => {
+  const input = `
+    @variants motion-safe {
+      [.banana] .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    @media (prefers-reduced-motion: no-preference) {
+      .motion-safe\\:banana .peel { color: yellow; }
+    }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it uses the given target when selectors are wrapped in motion-reduce variants', () => {
+  const input = `
+    @variants motion-reduce {
+      [.banana] .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    @media (prefers-reduced-motion: reduce) {
+      .motion-reduce\\:banana .peel { color: yellow; }
+    }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it uses the given target when selectors are wrapped in hover variants', () => {
+  const input = `
+    @variants hover {
+      [.banana] .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .hover\\:banana:hover .peel { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it uses the given target when selectors are wrapped in focus variants', () => {
+  const input = `
+    @variants focus {
+      [.banana] .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .focus\\:banana:focus .peel { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it uses the given target when selectors are wrapped in focus-within variants', () => {
+  const input = `
+    @variants focus-within {
+      [.banana] .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .focus-within\\:banana:focus-within .peel { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it uses the given target when selectors are wrapped in focus-visible variants', () => {
+  const input = `
+    @variants focus-visible {
+      [.banana] .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .focus-visible\\:banana:focus-visible .peel { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it uses the given target when selectors are wrapped in active variants', () => {
+  const input = `
+    @variants active {
+      [.banana] .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .active\\:banana:active .peel { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it uses the given target when selectors are wrapped in visited variants', () => {
+  const input = `
+    @variants visited {
+      [.banana] .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .visited\\:banana:visited .peel { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it uses the given target when selectors are wrapped in disabled variants', () => {
+  const input = `
+    @variants disabled {
+      [.banana] .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .disabled\\:banana:disabled .peel { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it uses the given target when selectors are wrapped in checked variants', () => {
+  const input = `
+    @variants checked {
+      [.banana] .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .checked\\:banana:checked .peel { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it uses the given target when selectors are wrapped in first variants', () => {
+  const input = `
+    @variants first {
+      [.banana] .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .first\\:banana:first-child .peel { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it uses the given target when selectors are wrapped in last variants', () => {
+  const input = `
+    @variants last {
+      [.banana] .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .last\\:banana:last-child .peel { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it uses the given target when selectors are wrapped in odd variants', () => {
+  const input = `
+    @variants odd {
+      [.banana] .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .odd\\:banana:nth-child(odd) .peel { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it uses the given target when selectors are wrapped in even variants', () => {
+  const input = `
+    @variants even {
+      [.banana] .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .even\\:banana:nth-child(even) .peel { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it uses the given target when selectors are wrapped in responsive variants', () => {
+  const input = `
+    @variants responsive {
+      [.banana] .peel { color: yellow; }
+    }
+
+    @tailwind screens;
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    @media (min-width: 500px) {
+      .sm\\:banana .peel { color: yellow; }
+    }
+    @media (min-width: 750px) {
+      .md\\:banana .peel { color: yellow; }
+    }
+    @media (min-width: 1000px) {
+      .lg\\:banana .peel { color: yellow; }
+    }
+  `
+
+  return run(input, {
+    theme: {
+      screens: {
+        sm: '500px',
+        md: '750px',
+        lg: '1000px',
+      },
+    },
+    separator: ':',
+  }).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('it uses the correct target even when multiple variants get stacked', () => {
+  const input = `
+    @variants motion-reduce, hover, group-hover {
+      [.banana] .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .hover\\:banana:hover .peel { color: yellow; }
+    .group:hover .group-hover\\:banana .peel { color: yellow; }
+    @media (prefers-reduced-motion: reduce) {
+      .motion-reduce\\:banana .peel { color: yellow; }
+      .motion-reduce\\:hover\\:banana:hover .peel { color: yellow; }
+      .group:hover .motion-reduce\\:group-hover\\:banana .peel { color: yellow; }
+    }
+  `
+
+  return run(input).then((result) => {
     expect(result.css).toMatchCss(output)
     expect(result.warnings().length).toBe(0)
   })

--- a/__tests__/variantTarget.test.js
+++ b/__tests__/variantTarget.test.js
@@ -1,0 +1,347 @@
+import postcss from 'postcss'
+import variantsAtRulesPlugin from '../src/lib/substituteVariantsAtRules'
+import responsiveAtRulesPlugin from '../src/lib/substituteResponsiveAtRules'
+import processPlugins from '../src/util/processPlugins'
+import resolveConfig from '../src/util/resolveConfig'
+import config from '../stubs/defaultConfig.stub.js'
+
+function run(input, opts = config) {
+  const resolved = resolveConfig([opts])
+  return postcss([
+    variantsAtRulesPlugin(resolved, processPlugins(resolved.plugins, resolved)),
+    responsiveAtRulesPlugin(resolved),
+  ]).process(input, {
+    from: undefined,
+  })
+}
+
+test('the dark variant uses the last class as target by default when the mode is set to media', () => {
+  const input = `
+    @variants dark {
+      .banana .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    @media (prefers-color-scheme: dark) {
+      .banana .dark\\:peel { color: yellow; }
+    }
+  `
+
+  return run(input, { darkMode: 'media' }).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('the dark variant uses the last class as target by default when the mode is set to class', () => {
+  const input = `
+    @variants dark {
+      .banana .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .dark .banana .dark\\:peel { color: yellow; }
+  `
+
+  return run(input, { darkMode: 'class' }).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('the motion-safe variant uses the last class as target by default', () => {
+  const input = `
+    @variants motion-safe {
+      .banana .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    @media (prefers-reduced-motion: no-preference) {
+      .banana .motion-safe\\:peel { color: yellow; }
+    }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('the motion-reduce variant uses the last class as target by default', () => {
+  const input = `
+    @variants motion-reduce {
+      .banana .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    @media (prefers-reduced-motion: reduce) {
+      .banana .motion-reduce\\:peel { color: yellow; }
+    }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('the hover variant uses the last class as target by default', () => {
+  const input = `
+    @variants hover {
+      .banana .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .banana .hover\\:peel:hover { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('the focus variant uses the last class as target by default', () => {
+  const input = `
+    @variants focus {
+      .banana .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .banana .focus\\:peel:focus { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('the focus-within variant uses the last class as target by default', () => {
+  const input = `
+    @variants focus-within {
+      .banana .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .banana .focus-within\\:peel:focus-within { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('the focus-visible variant uses the last class as target by default', () => {
+  const input = `
+    @variants focus-visible {
+      .banana .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .banana .focus-visible\\:peel:focus-visible { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('the active variant uses the last class as target by default', () => {
+  const input = `
+    @variants active {
+      .banana .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .banana .active\\:peel:active { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('the visited variant uses the last class as target by default', () => {
+  const input = `
+    @variants visited {
+      .banana .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .banana .visited\\:peel:visited { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('the disabled variant uses the last class as target by default', () => {
+  const input = `
+    @variants disabled {
+      .banana .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .banana .disabled\\:peel:disabled { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('the checked variant uses the last class as target by default', () => {
+  const input = `
+    @variants checked {
+      .banana .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .banana .checked\\:peel:checked { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('the first variant uses the last class as target by default', () => {
+  const input = `
+    @variants first {
+      .banana .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .banana .first\\:peel:first-child { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('the last variant uses the last class as target by default', () => {
+  const input = `
+    @variants last {
+      .banana .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .banana .last\\:peel:last-child { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('the odd variant uses the last class as target by default', () => {
+  const input = `
+    @variants odd {
+      .banana .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .banana .odd\\:peel:nth-child(odd) { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('the even variant uses the last class as target by default', () => {
+  const input = `
+    @variants even {
+      .banana .peel { color: yellow; }
+    }
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    .banana .even\\:peel:nth-child(even) { color: yellow; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('the responsive variant uses the last class as target by default', () => {
+  const input = `
+    @responsive {
+      .banana .peel { color: yellow; }
+    }
+
+    @tailwind screens;
+  `
+
+  const output = `
+    .banana .peel { color: yellow; }
+    @media (min-width: 500px) {
+      .banana .sm\\:peel { color: yellow; }
+    }
+    @media (min-width: 750px) {
+      .banana .md\\:peel { color: yellow; }
+    }
+    @media (min-width: 1000px) {
+      .banana .lg\\:peel { color: yellow; }
+    }
+  `
+
+  return run(input, {
+    theme: {
+      screens: {
+        sm: '500px',
+        md: '750px',
+        lg: '1000px',
+      },
+    },
+    separator: ':',
+  }).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})

--- a/src/lib/substituteResponsiveAtRules.js
+++ b/src/lib/substituteResponsiveAtRules.js
@@ -65,8 +65,13 @@ export default function (config) {
         _.tap(responsiveRules.clone(), (clonedRoot) => {
           clonedRoot.walkRules((rule) => {
             rule.selectors = _.map(rule.selectors, (selector) =>
-              buildSelectorVariant(selector, screen, separator, (message) => {
-                throw rule.error(message)
+              buildSelectorVariant({
+                selector,
+                variant: screen,
+                separator,
+                onError: (message) => {
+                  throw rule.error(message)
+                },
               })
             )
           })

--- a/src/lib/unwrapVariantTargets.js
+++ b/src/lib/unwrapVariantTargets.js
@@ -1,0 +1,29 @@
+import postcss from 'postcss'
+import selectorParser from 'postcss-selector-parser'
+
+export default function () {
+  return function (css) {
+    css.walkRules((rule) => {
+      if (rule.type != 'rule') {
+        return
+      }
+
+      const container = postcss.rule(rule.clone())
+
+      container.selectors = container.selectors.map((selector) =>
+        selectorParser((selectors) => {
+          selectors.first.walkAttributes((attributeNode) => {
+            if (attributeNode.attribute.startsWith('.')) {
+              const className = attributeNode.attribute.slice(1)
+              const classNode = selectorParser.className()
+              classNode.value = className
+              attributeNode.replaceWith(classNode)
+            }
+          })
+        }).processSync(selector)
+      )
+
+      rule.replaceWith(container)
+    })
+  }
+}

--- a/src/processTailwindFeatures.js
+++ b/src/processTailwindFeatures.js
@@ -5,6 +5,7 @@ import substituteTailwindAtRules from './lib/substituteTailwindAtRules'
 import evaluateTailwindFunctions from './lib/evaluateTailwindFunctions'
 import substituteVariantsAtRules from './lib/substituteVariantsAtRules'
 import substituteResponsiveAtRules from './lib/substituteResponsiveAtRules'
+import unwrapVariantTargets from './lib/unwrapVariantTargets'
 import convertLayerAtRulesToControlComments from './lib/convertLayerAtRulesToControlComments'
 import substituteScreenAtRules from './lib/substituteScreenAtRules'
 import substituteClassApplyAtRules from './lib/substituteClassApplyAtRules'
@@ -61,6 +62,7 @@ export default function (getConfig) {
       evaluateTailwindFunctions(config),
       substituteVariantsAtRules(config, getProcessedPlugins()),
       substituteResponsiveAtRules(config),
+      unwrapVariantTargets(),
       convertLayerAtRulesToControlComments(config),
       substituteScreenAtRules(config),
       substituteClassApplyAtRules(config, getProcessedPlugins, configChanged),


### PR DESCRIPTION
Fixes #3361

As discussed in the linked issue, this pull request aims to get things started by proposing an early (yet functional) implementation of the so-called *variant targets*. The changes also include:
- a normalization of how variants choose their default target;
- more consistent error reporting thanks to a more extensive usage of the `buildSelectorVariant` function.

The current syntax is as follows:
```css
@variants motion-reduce, hover, group-hover {
  [.banana] .peel { color: yellow; }
}
```

The above snippet yields (taken straight from the tests):
```css
.banana .peel { color: yellow; }
.hover\\:banana:hover .peel { color: yellow; }
.group:hover .group-hover\\:banana .peel { color: yellow; }
@media (prefers-reduced-motion: reduce) {
  .motion-reduce\\:banana .peel { color: yellow; }
  .motion-reduce\\:hover\\:banana:hover .peel { color: yellow; }
  .group:hover .motion-reduce\\:group-hover\\:banana .peel { color: yellow; }
}
```

I hope I didn't forget anything. Let me know if it needs more tweaking.