### PR TITLE
Add Prettier configuration file (prettier.config.js)

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,9 +1,8 @@
 module.exports = {
-  editorconfig: true, // Read .editorconfig
-  // These settings are handled in .editorconfig:
-  // tabWidth: 2, // indent_size = 2
-  // useTabs: false, // indent_style = space
-  // endOfLine: 'lf', // end_of_line = lf
+  // These settings are duplicated in .editorconfig:
+  tabWidth: 2, // indent_size = 2
+  useTabs: false, // indent_style = space
+  endOfLine: 'lf', // end_of_line = lf
   semi: false, // default: true
   singleQuote: true, // default: false
   printWidth: 100, // default: 80

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,13 +1,14 @@
 module.exports = {
-  editorconfig: true,
+  editorconfig: true, // Read .editorconfig
+  // These settings are handled in .editorconfig:
+  // tabWidth: 2, // indent_size = 2
+  // useTabs: false, // indent_style = space
+  // endOfLine: 'lf', // end_of_line = lf
   semi: false, // default: true
   singleQuote: true, // default: false
   printWidth: 80, // default: 100
-  tabWidth: 2,
-  useTabs: false,
   trailingComma: 'es5',
   bracketSpacing: true,
-  endOfLine: 'lf',
   overrides: [
     {
       files: '*.js',
@@ -17,16 +18,3 @@ module.exports = {
     },
   ],
 }
-
-/* .editorconfig
-
-root = true
-
-[*]
-indent_style = space
-indent_size = 2
-end_of_line = lf
-charset = utf-8
-trim_trailing_whitespace = true
-insert_final_newline = true
-*/

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -17,3 +17,16 @@ module.exports = {
     },
   ],
 }
+
+/* .editorconfig
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+*/

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -6,7 +6,7 @@ module.exports = {
   // endOfLine: 'lf', // end_of_line = lf
   semi: false, // default: true
   singleQuote: true, // default: false
-  printWidth: 80, // default: 100
+  printWidth: 100, // default: 80
   trailingComma: 'es5',
   bracketSpacing: true,
   overrides: [

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+  editorconfig: true,
+  semi: false, // default: true
+  singleQuote: true, // default: false
+  printWidth: 80, // default: 100
+  tabWidth: 2,
+  useTabs: false,
+  trailingComma: 'es5',
+  bracketSpacing: true,
+  endOfLine: 'lf',
+  overrides: [
+    {
+      files: '*.js',
+      options: {
+        parser: 'flow',
+      },
+    },
+  ],
+}


### PR DESCRIPTION
A Prettier configuration file is needed for those of us who aren't using the [Airbnb style guide](https://github.com/airbnb/javascript#strings) as our default Prettier configuration.

The EditorConfig configuration file _.editorconfig_ doesn't cover all of the custom Prettier settings specified in the _.eslintrc.json_ file.

This _prettier.config.js_ file includes the `editorconfig: true` setting to read _.editorconfig_ automatically as well as comments about settings that vary from Prettier's defaults.

## What does this do?
This pull request fixes the _eslint(prettier/prettier)_ errors while coding using the Prettier extension for VSCode without needing to run the `npm run style -- --fix` command.

Currently, only users with a custom Prettier configuration in VS Code matching Airbnb's style guide won't see ESLint errors in every TailwindCSS file. Everybody else with Prettier configured will see errors until they run the ESLint --fix command.