### PR TITLE
Add `group-focus-within` to `variantOrder`

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -724,6 +724,7 @@ module.exports = {
     'visited',
     'checked',
     'group-hover',
+    'group-focus-within'
     'group-focus',
     'focus-within',
     'hover',

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -724,7 +724,7 @@ module.exports = {
     'visited',
     'checked',
     'group-hover',
-    'group-focus-within'
+    'group-focus-within',
     'group-focus',
     'focus-within',
     'hover',


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->

There are [existing tests](https://github.com/tailwindlabs/tailwindcss/blob/fea75a0c8d9f4ced6273a6f6110f73e283f7cfc0/jit/tests/variants.test.css#L110) for `group-focus-within` variants. Unfortunately, it seems that the variant in question isn’t yet added into `variantOrder`, which may cause CSS rule precedence issues.

I think that `group-focus-within` should override `group-hover` styles for convenience. Unlike in the case of `focus-within` and `hover`, it felt more natural to priorize `group-focus-within` over `group-hover` in the case of a text editor with a hovering toolbar on top.  That’s just an example, though, and it may not be the preferred case in general.

Thank you for maintaining this project! 😊
