### PR TITLE
Add `.list-item` display utility

### DIFF
--- a/__tests__/fixtures/tailwind-output-flagged.css
+++ b/__tests__/fixtures/tailwind-output-flagged.css
@@ -10864,6 +10864,10 @@ video {
   display: contents;
 }
 
+.list-item {
+  display: list-item;
+}
+
 .hidden {
   display: none;
 }
@@ -39472,6 +39476,10 @@ video {
     display: contents;
   }
 
+  .sm\:list-item {
+    display: list-item;
+  }
+
   .sm\:hidden {
     display: none;
   }
@@ -68035,6 +68043,10 @@ video {
 
   .md\:contents {
     display: contents;
+  }
+
+  .md\:list-item {
+    display: list-item;
   }
 
   .md\:hidden {
@@ -96602,6 +96614,10 @@ video {
     display: contents;
   }
 
+  .lg\:list-item {
+    display: list-item;
+  }
+
   .lg\:hidden {
     display: none;
   }
@@ -125167,6 +125183,10 @@ video {
     display: contents;
   }
 
+  .xl\:list-item {
+    display: list-item;
+  }
+
   .xl\:hidden {
     display: none;
   }
@@ -153730,6 +153750,10 @@ video {
 
   .\32xl\:contents {
     display: contents;
+  }
+
+  .\32xl\:list-item {
+    display: list-item;
   }
 
   .\32xl\:hidden {

--- a/__tests__/fixtures/tailwind-output-important.css
+++ b/__tests__/fixtures/tailwind-output-important.css
@@ -10864,6 +10864,10 @@ video {
   display: contents !important;
 }
 
+.list-item {
+  display: list-item !important;
+}
+
 .hidden {
   display: none !important;
 }
@@ -39472,6 +39476,10 @@ video {
     display: contents !important;
   }
 
+  .sm\:list-item {
+    display: list-item !important;
+  }
+
   .sm\:hidden {
     display: none !important;
   }
@@ -68035,6 +68043,10 @@ video {
 
   .md\:contents {
     display: contents !important;
+  }
+
+  .md\:list-item {
+    display: list-item !important;
   }
 
   .md\:hidden {
@@ -96602,6 +96614,10 @@ video {
     display: contents !important;
   }
 
+  .lg\:list-item {
+    display: list-item !important;
+  }
+
   .lg\:hidden {
     display: none !important;
   }
@@ -125167,6 +125183,10 @@ video {
     display: contents !important;
   }
 
+  .xl\:list-item {
+    display: list-item !important;
+  }
+
   .xl\:hidden {
     display: none !important;
   }
@@ -153730,6 +153750,10 @@ video {
 
   .\32xl\:contents {
     display: contents !important;
+  }
+
+  .\32xl\:list-item {
+    display: list-item !important;
   }
 
   .\32xl\:hidden {

--- a/__tests__/fixtures/tailwind-output-no-color-opacity.css
+++ b/__tests__/fixtures/tailwind-output-no-color-opacity.css
@@ -9302,6 +9302,10 @@ video {
   display: contents;
 }
 
+.list-item {
+  display: list-item;
+}
+
 .hidden {
   display: none;
 }
@@ -35354,6 +35358,10 @@ video {
     display: contents;
   }
 
+  .sm\:list-item {
+    display: list-item;
+  }
+
   .sm\:hidden {
     display: none;
   }
@@ -61361,6 +61369,10 @@ video {
 
   .md\:contents {
     display: contents;
+  }
+
+  .md\:list-item {
+    display: list-item;
   }
 
   .md\:hidden {
@@ -87372,6 +87384,10 @@ video {
     display: contents;
   }
 
+  .lg\:list-item {
+    display: list-item;
+  }
+
   .lg\:hidden {
     display: none;
   }
@@ -113381,6 +113397,10 @@ video {
     display: contents;
   }
 
+  .xl\:list-item {
+    display: list-item;
+  }
+
   .xl\:hidden {
     display: none;
   }
@@ -139388,6 +139408,10 @@ video {
 
   .\32xl\:contents {
     display: contents;
+  }
+
+  .\32xl\:list-item {
+    display: list-item;
   }
 
   .\32xl\:hidden {

--- a/__tests__/fixtures/tailwind-output.css
+++ b/__tests__/fixtures/tailwind-output.css
@@ -10864,6 +10864,10 @@ video {
   display: contents;
 }
 
+.list-item {
+  display: list-item;
+}
+
 .hidden {
   display: none;
 }
@@ -39472,6 +39476,10 @@ video {
     display: contents;
   }
 
+  .sm\:list-item {
+    display: list-item;
+  }
+
   .sm\:hidden {
     display: none;
   }
@@ -68035,6 +68043,10 @@ video {
 
   .md\:contents {
     display: contents;
+  }
+
+  .md\:list-item {
+    display: list-item;
   }
 
   .md\:hidden {
@@ -96602,6 +96614,10 @@ video {
     display: contents;
   }
 
+  .lg\:list-item {
+    display: list-item;
+  }
+
   .lg\:hidden {
     display: none;
   }
@@ -125167,6 +125183,10 @@ video {
     display: contents;
   }
 
+  .xl\:list-item {
+    display: list-item;
+  }
+
   .xl\:hidden {
     display: none;
   }
@@ -153730,6 +153750,10 @@ video {
 
   .\32xl\:contents {
     display: contents;
+  }
+
+  .\32xl\:list-item {
+    display: list-item;
   }
 
   .\32xl\:hidden {

--- a/src/plugins/display.js
+++ b/src/plugins/display.js
@@ -59,6 +59,9 @@ export default function () {
         '.contents': {
           display: 'contents',
         },
+        '.list-item': {
+          display: 'list-item',
+        },
       },
       variants('display')
     )


### PR DESCRIPTION
This PR adds `.list-item` display utility.

It is the **default value** for the list item.

Adding a `display: list-item` to the element is useful in situations where you conditionally show/hide an item in the list, or toggling between `flex` and default behavior.

Also useful when creating fake lists.

E.g.: *(This is just an example, I know it can be done like `predicate ? '' : 'hidden'`)*
 
```jsx
<ul>
  <li>A</li>
  <li className={predicate ? 'list-item' : 'hidden'}>B</li>
  <li>C</li>
</ul>
```

```html
<div>
  <div class="list-item">A</div>
  <div class="list-item">B</div>
</div>
```

Links:
[MDN: display-listitem ](https://developer.mozilla.org/en-US/docs/Web/CSS/display-listitem)