### PR TITLE
Improved arbitrary calc support for CSS variables

### DIFF
--- a/jit/pluginUtils.js
+++ b/jit/pluginUtils.js
@@ -112,7 +112,7 @@ function asValue(modifier, lookup = {}, { validate = () => true, transform = (v)
   }
 
   // add spaces around operators inside calc() that do not follow an operator or (
-  return transform(value).replace(/(?<=^calc\(.+?)(?<![-+*/(])([-+*/])/g, ' $1 ')
+  return transform(value).replace(/(?<=^calc\(.+?)(?!\b-\d)(?<![-+*/(])([-+*/])/g, ' $1 ')
 }
 
 function asUnit(modifier, units, lookup = {}) {
@@ -121,7 +121,7 @@ function asUnit(modifier, units, lookup = {}) {
       let unitsPattern = `(?:${units.join('|')})`
       return (
         new RegExp(`${unitsPattern}$`).test(value) ||
-        new RegExp(`^calc\\(.+?${unitsPattern}`).test(value)
+        new RegExp(`calc\\(.+?${unitsPattern}`).test(value)
       )
     },
     transform: (value) => {

--- a/jit/pluginUtils.js
+++ b/jit/pluginUtils.js
@@ -112,7 +112,7 @@ function asValue(modifier, lookup = {}, { validate = () => true, transform = (v)
   }
 
   // add spaces around operators inside calc() that do not follow an operator or (
-  return transform(value).replace(/(?<=^calc\(.+?)(?!\b-\d)(?<![-+*/(])([-+*/])/g, ' $1 ')
+  return transform(value).replace(/(?<=calc\(.+?)(?!\b-\b)(?<![-+*/(])([-+*/])/g, ' $1 ')
 }
 
 function asUnit(modifier, units, lookup = {}) {


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->

Hi, this PR does 2 things:
- Prevent adding space to dashy css variables
- Allows calc functions as fallback value of css variables (or anywhere in arbitrary values)

Classes for testing:
```css
/* test */
"w-[calc(var(--width-10px,calc(-20px-(-30px--40px)))-50px)]";
/* expected */
width: calc(var(--width-10px,calc(-20px - (-30px - -40px))) - 50px)
/* without this pr */
width: calc(var(--width - 10px,calc(-20px - (-30px - -40px))) - 50px)

/* test */
"w-[var(--width-10px,calc(-20px-(-30px--40px)))]";
/* expected */
width: var(--width-10px,calc(-20px - (-30px - -40px)))
/* without this pr */
width: var(--width-10px,calc(-20px-(-30px--40px)))
```

I didn't read source code very carefully and didn't clone this repo to my local machine yet to run tests. I would be happy to update tests if required but I didn't find any clear documentation how to run jit tests properly. Cloning tailwind-jit repo was an option but I didn't want to go for it now. I thought asking for it here would be better. 