### PR TITLE
Fix media queries with jit and postcss7

### DIFF
--- a/jit/lib/generateRules.js
+++ b/jit/lib/generateRules.js
@@ -109,7 +109,12 @@ function applyVariant(variant, matches, context) {
         continue
       }
 
-      let container = postcss.root({ nodes: [rule] })
+      let container = postcss.root()
+      if (typeof rule.clone === 'function') {
+        container.append(rule.clone())
+      } else {
+        container.append(rule)
+      }
 
       function modifySelectors(modifierFunction) {
         container.each((rule) => {


### PR DESCRIPTION
When using @tailwindcss/postcss7-compat and jit, media queries are not generated.

The problem is that this chunk of code: https://github.com/postcss/postcss/blob/8.2.10/lib/node.js#L44-L48
is missing in postcss 7: https://github.com/postcss/postcss/blob/7.0.35/lib/node.es6#L37
Which means that the parent of the rule is not set correctly, which then causes this bug.

This fixes #4034.