### PR TITLE
Implement createSimpleStaticUtilityPlugin for gridTemplateColumns

### DIFF
--- a/jit/corePlugins/gridTemplateColumns.js
+++ b/jit/corePlugins/gridTemplateColumns.js
@@ -1,15 +1,17 @@
-const { asList, nameClass } = require('../pluginUtils')
+const { createSimpleStaticUtilityPlugin } = require('../pluginUtils')
 
-module.exports = function ({ matchUtilities }) {
-  matchUtilities({
-    'grid-cols': (modifier, { theme }) => {
-      let value = asList(modifier, theme.gridTemplateColumns)
-
-      if (value === undefined) {
-        return []
-      }
-
-      return { [nameClass('grid-cols', modifier)]: { 'grid-template-columns': value } }
-    },
-  })
-}
+module.exports = createSimpleStaticUtilityPlugin({
+  '.grid-cols-1': { gridTemplateColumns: 'repeat(1, minmax(0, 1fr))' },
+  '.grid-cols-2': { gridTemplateColumns: 'repeat(2, minmax(0, 1fr))' },
+  '.grid-cols-3': { gridTemplateColumns: 'repeat(3, minmax(0, 1fr))' },
+  '.grid-cols-4': { gridTemplateColumns: 'repeat(4, minmax(0, 1fr))' },
+  '.grid-cols-5': { gridTemplateColumns: 'repeat(5, minmax(0, 1fr))' },
+  '.grid-cols-6': { gridTemplateColumns: 'repeat(6, minmax(0, 1fr))' },
+  '.grid-cols-7': { gridTemplateColumns: 'repeat(7, minmax(0, 1fr))' },
+  '.grid-cols-8': { gridTemplateColumns: 'repeat(8, minmax(0, 1fr))' },
+  '.grid-cols-9': { gridTemplateColumns: 'repeat(9, minmax(0, 1fr))' },
+  '.grid-cols-10': { gridTemplateColumns: 'repeat(10, minmax(0, 1fr))' },
+  '.grid-cols-11': { gridTemplateColumns: 'repeat(11, minmax(0, 1fr))' },
+  '.grid-cols-12': { gridTemplateColumns: 'repeat(12, minmax(0, 1fr))' },
+  '.grid-cols-none': { gridTemplateColumns: 'none' } 
+})


### PR DESCRIPTION
Enable JIT styling for grid-cols-X.

Figure there's likely a reason certain things were excluded from the initial JIT release but if the difference between JIT classes and non-JIT classes is really just their implementation of the JIT functions or not then I don't see it being much of a stretch for me to expand off of it and convert some of the other utilities over.

Hence why only this one file is included in this PR, it's the one I need to kill off styled components from my codebase, and because it's a small enough diff that if there's a legitimate reason as to why every component is not being translated into JIT, I wouldn't feel any significant loss from seeing this PR declined.
