### PR TITLE
Account for Svelte class bindings at the start of a line

### DIFF
--- a/jit/lib/expandTailwindAtRules.js
+++ b/jit/lib/expandTailwindAtRules.js
@@ -15,7 +15,7 @@ const INNER_MATCH_GLOBAL_REGEXP = /[^<>"'`\s.(){}[\]#=%]*[^<>"'`\s.(){}[\]#=%:]/
 function getDefaultExtractor(fileExtension) {
   return function (content) {
     if (fileExtension === 'svelte') {
-      content = content.replace(/\sclass:/g, ' ')
+      content = content.replace(/(?:^|\s)class:/g, ' ')
     }
     let broadMatches = content.match(BROAD_MATCH_GLOBAL_REGEXP) || []
     let innerMatches = content.match(INNER_MATCH_GLOBAL_REGEXP) || []

--- a/jit/tests/svelte-syntax.test.css
+++ b/jit/tests/svelte-syntax.test.css
@@ -7,6 +7,10 @@
   --tw-ring-offset-shadow: 0 0 #0000;
   --tw-ring-shadow: 0 0 #0000;
 }
+.bg-red-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgba(239, 68, 68, var(--tw-bg-opacity));
+}
 @media (min-width: 1024px) {
   .lg\:hover\:bg-blue-500:hover {
     --tw-bg-opacity: 1;

--- a/jit/tests/svelte-syntax.test.svelte
+++ b/jit/tests/svelte-syntax.test.svelte
@@ -3,3 +3,9 @@
 </script>
 
 <button class:lg:hover:bg-blue-500={current === 'foo'}>Click me</button>
+
+<button
+  class:bg-red-500={current === 'foo'}
+>
+  Click me
+</button>


### PR DESCRIPTION
Fixes #4181

This PR updates the Svelte class binding regular expression so that it catches instances at the start of a line. 

Consider the following example:

```html
<button
  class:bg-red-500={current === 'foo'}
>
  Click me
</button>
```

Because the class extractor runs for each **trimmed** line separately, in this case it runs against `class:bg-red-500={current === 'foo'}`. The regular expression did not match the class binding because there is no whitespace before it.

The regular expression has been updated to look for either whitespace or the start of the string, which fixes the issue.