### PR TITLE
Support forcing coercion type with arbitrary value syntax

### DIFF
--- a/src/jit/lib/generateRules.js
+++ b/src/jit/lib/generateRules.js
@@ -192,9 +192,13 @@ function* resolveMatchedPlugins(classCandidate, context) {
   }
 }
 
+function splitWithSeparator(input, separator) {
+  return input.split(new RegExp(`\\${separator}(?![^[]*\\])`, 'g'))
+}
+
 function* resolveMatches(candidate, context) {
   let separator = context.tailwindConfig.separator
-  let [classCandidate, ...variants] = candidate.split(separator).reverse()
+  let [classCandidate, ...variants] = splitWithSeparator(candidate, separator).reverse()
   let important = false
 
   if (classCandidate.startsWith('!')) {

--- a/src/jit/lib/setupContext.js
+++ b/src/jit/lib/setupContext.js
@@ -534,9 +534,9 @@ function buildPluginApi(tailwindConfig, context, { variantList, variantMap, offs
 
         function wrapped(modifier) {
           let { type = 'any' } = options
-          let value = coerceValue(type, modifier, options.values)
+          let [value, coercedType] = coerceValue(type, modifier, options.values)
 
-          if (value === undefined) {
+          if (type !== coercedType || value === undefined) {
             return []
           }
 

--- a/src/util/pluginUtils.js
+++ b/src/util/pluginUtils.js
@@ -204,13 +204,16 @@ let typeMap = {
   lookup: asLookupValue,
 }
 
+function splitAtFirst(input, delim) {
+  return (([first, ...rest]) => [first, rest.join(delim)])(input.split(delim))
+}
+
 export function coerceValue(type, modifier, values) {
   if (modifier.startsWith('[') && modifier.endsWith(']')) {
-    let innerModifier = modifier.slice(1, -1)
-    let parts = innerModifier.split(':')
+    let [explicitType, value] = splitAtFirst(modifier.slice(1, -1), ':')
 
-    if (parts.length > 1 && Object.keys(typeMap).includes(parts[0])) {
-      return [asValue(`[${parts.slice(1).join(':')}]`, values), parts[0]]
+    if (value.length > 0 && Object.keys(typeMap).includes(explicitType)) {
+      return [asValue(`[${value}]`, values), explicitType]
     }
   }
 

--- a/src/util/pluginUtils.js
+++ b/src/util/pluginUtils.js
@@ -205,5 +205,14 @@ let typeMap = {
 }
 
 export function coerceValue(type, modifier, values) {
-  return typeMap[type](modifier, values)
+  if (modifier.startsWith('[') && modifier.endsWith(']')) {
+    let innerModifier = modifier.slice(1, -1)
+    let parts = innerModifier.split(':')
+
+    if (parts.length > 1 && Object.keys(typeMap).includes(parts[0])) {
+      return [asValue(`[${parts.slice(1).join(':')}]`, values), parts[0]]
+    }
+  }
+
+  return [typeMap[type](modifier, values), type]
 }

--- a/tests/jit/arbitrary-values.test.css
+++ b/tests/jit/arbitrary-values.test.css
@@ -278,6 +278,9 @@
 .tracking-\[var\(--tracking\)\] {
   letter-spacing: var(--tracking);
 }
+.text-\[color\:var\(--color\)\] {
+  color: var(--color);
+}
 .placeholder-\[var\(--placeholder\)\]::placeholder {
   color: var(--placeholder);
 }

--- a/tests/jit/arbitrary-values.test.css
+++ b/tests/jit/arbitrary-values.test.css
@@ -269,6 +269,9 @@
 .text-\[2\.23rem\] {
   font-size: 2.23rem;
 }
+.text-\[length\:var\(--font-size\)\] {
+  font-size: var(--font-size);
+}
 .leading-\[var\(--leading\)\] {
   line-height: var(--leading);
 }

--- a/tests/jit/arbitrary-values.test.html
+++ b/tests/jit/arbitrary-values.test.html
@@ -54,6 +54,7 @@
     <div class="skew-x-[3px]"></div>
     <div class="skew-y-[3px]"></div>
     <div class="text-[2.23rem]"></div>
+    <div class="text-[length:var(--font-size)]"></div>
     <div class="duration-[2s]"></div>
     <div class="m-[7px]"></div>
     <div class="mx-[7px]"></div>

--- a/tests/jit/arbitrary-values.test.html
+++ b/tests/jit/arbitrary-values.test.html
@@ -55,6 +55,8 @@
     <div class="skew-y-[3px]"></div>
     <div class="text-[2.23rem]"></div>
     <div class="text-[length:var(--font-size)]"></div>
+    <div class="text-[color:var(--color)]"></div>
+    <div class="text-[angle:var(--angle)]"></div>
     <div class="duration-[2s]"></div>
     <div class="m-[7px]"></div>
     <div class="mx-[7px]"></div>


### PR DESCRIPTION
Resolves #4096.

This PR makes it possible to force the type of a coerced arbitrary value in order to get around collisions between utilities when using arbitrary values with JIT.

For example, in this example, it's impossible to know if this is a font-size utility or a color utility:

```html
<div class="text-[var(--mystery)]">
```

To make it possible for this to work, you can now prefix the arbitrary value with `{type}:` to provide a hint to the compiler about what the resulting value is going to be so it is passed to the correct plugin:

```html
<div class="text-[color:var(--mystery)] text-[length:var(--surprise)]">
```

The valid values match the types supported by `matchUtilities`:

- `length`
- `color`
- `angle`
- `list`

...which generally correspond to the official CSS data type names. We will probably keep refining this but I think it's a good start. May also alias `length` to `size` since `length` is unintuitive for things like font-size, although it is the correct term.