### PR TITLE
Ensure variants are grouped properly for plugins with order-dependent utilities

### DIFF
--- a/src/plugins/display.js
+++ b/src/plugins/display.js
@@ -62,11 +62,6 @@ export default function () {
         '.list-item': {
           display: 'list-item',
         },
-      },
-      variants('display')
-    )
-    addUtilities(
-      {
         '.hidden': {
           display: 'none',
         },

--- a/src/plugins/fontVariantNumeric.js
+++ b/src/plugins/fontVariantNumeric.js
@@ -11,11 +11,6 @@ export default function () {
           'font-variant-numeric':
             'var(--tw-ordinal) var(--tw-slashed-zero) var(--tw-numeric-figure) var(--tw-numeric-spacing) var(--tw-numeric-fraction)',
         },
-      },
-      variants('fontVariantNumeric')
-    )
-    addUtilities(
-      {
         '.normal-nums': {
           'font-variant-numeric': 'normal',
         },

--- a/src/plugins/textOverflow.js
+++ b/src/plugins/textOverflow.js
@@ -7,12 +7,6 @@ export default function () {
           'text-overflow': 'ellipsis',
           'white-space': 'nowrap',
         },
-      },
-      variants('textOverflow')
-    )
-
-    addUtilities(
-      {
         '.overflow-ellipsis': { 'text-overflow': 'ellipsis' },
         '.overflow-clip': { 'text-overflow': 'clip' },
       },


### PR DESCRIPTION
Fixes #4038.

Prior to this we were using multiple `addUtilities` calls within one plugin sometimes to make sure that certain things were guaranteed to be in a certain order in JIT mode. It turns out that wasn't even necessary because we were already counting each utility in every `addUtilities` call toward the total sort count, not just counting the `addUtilities` calls themselves.

This PR collapses anywhere where we had multiple calls, as multiple calls were resulting in variants for the first call showing up in the output before non-variant utilities for subsequent calls.

Before:

```css
.block {
  display: block
}

@media (prefers-color-scheme: dark) {
  .dark\:block {
    display: block;
  }
}

.hidden {
  display: none;
}
```

After:

```css
.block {
  display: block
}

.hidden {
  display: none;
}

@media (prefers-color-scheme: dark) {
  .dark\:block {
    display: block;
  }
}
```