### PR TITLE
Support border-opacity with default border color

### DIFF
--- a/src/plugins/borderColor.js
+++ b/src/plugins/borderColor.js
@@ -3,13 +3,21 @@ import withAlphaVariable from '../util/withAlphaVariable'
 
 export default function () {
   return function ({ addBase, matchUtilities, theme, variants, corePlugins }) {
-    addBase({
-      '*, ::before, ::after': withAlphaVariable({
-        color: theme('borderColor.DEFAULT', 'currentColor'),
-        property: 'border-color',
-        variable: '--tw-border-opacity',
-      }),
-    })
+    if (!corePlugins('borderOpacity')) {
+      addBase({
+        '*, ::before, ::after': {
+          'border-color': theme('borderColor.DEFAULT', 'currentColor'),
+        },
+      })
+    } else {
+      addBase({
+        '*, ::before, ::after': withAlphaVariable({
+          color: theme('borderColor.DEFAULT', 'currentColor'),
+          property: 'border-color',
+          variable: '--tw-border-opacity',
+        }),
+      })
+    }
 
     matchUtilities(
       {

--- a/src/plugins/borderColor.js
+++ b/src/plugins/borderColor.js
@@ -2,7 +2,15 @@ import flattenColorPalette from '../util/flattenColorPalette'
 import withAlphaVariable from '../util/withAlphaVariable'
 
 export default function () {
-  return function ({ matchUtilities, theme, variants, corePlugins }) {
+  return function ({ addBase, matchUtilities, theme, variants, corePlugins }) {
+    addBase({
+      '*, ::before, ::after': withAlphaVariable({
+        color: theme('borderColor.DEFAULT', 'currentColor'),
+        property: 'border-color',
+        variable: '--tw-border-opacity',
+      }),
+    })
+
     matchUtilities(
       {
         border: (value) => {

--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -110,7 +110,7 @@ body {
   box-sizing: border-box; /* 1 */
   border-width: 0; /* 2 */
   border-style: solid; /* 2 */
-  border-color: theme('borderColor.DEFAULT', currentColor); /* 2 */
+  border-color: currentColor; /* 2 */
 }
 
 /*

--- a/tests/fixtures/tailwind-output-flagged.css
+++ b/tests/fixtures/tailwind-output-flagged.css
@@ -410,7 +410,7 @@ body {
   box-sizing: border-box; /* 1 */
   border-width: 0; /* 2 */
   border-style: solid; /* 2 */
-  border-color: #e5e7eb; /* 2 */
+  border-color: currentColor; /* 2 */
 }
 
 /*
@@ -537,6 +537,11 @@ img,
 video {
   max-width: 100%;
   height: auto;
+}
+
+*, ::before, ::after {
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
 }
 
 .container {

--- a/tests/fixtures/tailwind-output-no-color-opacity.css
+++ b/tests/fixtures/tailwind-output-no-color-opacity.css
@@ -410,7 +410,7 @@ body {
   box-sizing: border-box; /* 1 */
   border-width: 0; /* 2 */
   border-style: solid; /* 2 */
-  border-color: #e5e7eb; /* 2 */
+  border-color: currentColor; /* 2 */
 }
 
 /*
@@ -537,6 +537,11 @@ img,
 video {
   max-width: 100%;
   height: auto;
+}
+
+*, ::before, ::after {
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
 }
 
 .container {

--- a/tests/fixtures/tailwind-output-no-color-opacity.css
+++ b/tests/fixtures/tailwind-output-no-color-opacity.css
@@ -540,8 +540,7 @@ video {
 }
 
 *, ::before, ::after {
-  --tw-border-opacity: 1;
-  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+  border-color: #e5e7eb;
 }
 
 .container {

--- a/tests/fixtures/tailwind-output.css
+++ b/tests/fixtures/tailwind-output.css
@@ -410,7 +410,7 @@ body {
   box-sizing: border-box; /* 1 */
   border-width: 0; /* 2 */
   border-style: solid; /* 2 */
-  border-color: #e5e7eb; /* 2 */
+  border-color: currentColor; /* 2 */
 }
 
 /*
@@ -537,6 +537,11 @@ img,
 video {
   max-width: 100%;
   height: auto;
+}
+
+*, ::before, ::after {
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
 }
 
 .container {

--- a/tests/jit/apply.test.css
+++ b/tests/jit/apply.test.css
@@ -1,3 +1,9 @@
+*,
+::before,
+::after {
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+}
 * {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);

--- a/tests/jit/arbitrary-values.test.css
+++ b/tests/jit/arbitrary-values.test.css
@@ -1,3 +1,9 @@
+*,
+::before,
+::after {
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+}
 * {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);

--- a/tests/jit/basic-usage.test.css
+++ b/tests/jit/basic-usage.test.css
@@ -1,3 +1,9 @@
+*,
+::before,
+::after {
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+}
 * {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);

--- a/tests/jit/collapse-adjacent-rules.test.css
+++ b/tests/jit/collapse-adjacent-rules.test.css
@@ -1,3 +1,9 @@
+*,
+::before,
+::after {
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+}
 * {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);

--- a/tests/jit/custom-extractors.test.css
+++ b/tests/jit/custom-extractors.test.css
@@ -1,3 +1,9 @@
+*,
+::before,
+::after {
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+}
 * {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);

--- a/tests/jit/import-syntax.test.css
+++ b/tests/jit/import-syntax.test.css
@@ -1,3 +1,9 @@
+*,
+::before,
+::after {
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+}
 * {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);

--- a/tests/jit/important-boolean.test.css
+++ b/tests/jit/important-boolean.test.css
@@ -1,3 +1,9 @@
+*,
+::before,
+::after {
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+}
 * {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);

--- a/tests/jit/important-modifier-prefix.test.css
+++ b/tests/jit/important-modifier-prefix.test.css
@@ -1,3 +1,9 @@
+*,
+::before,
+::after {
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+}
 * {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);

--- a/tests/jit/important-modifier.test.css
+++ b/tests/jit/important-modifier.test.css
@@ -1,3 +1,9 @@
+*,
+::before,
+::after {
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+}
 * {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);

--- a/tests/jit/important-selector.test.css
+++ b/tests/jit/important-selector.test.css
@@ -1,3 +1,9 @@
+*,
+::before,
+::after {
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+}
 * {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);

--- a/tests/jit/kitchen-sink.test.css
+++ b/tests/jit/kitchen-sink.test.css
@@ -126,6 +126,12 @@
     }
   }
 }
+*,
+::before,
+::after {
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+}
 * {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);

--- a/tests/jit/opacity.test.css
+++ b/tests/jit/opacity.test.css
@@ -1,3 +1,9 @@
+*,
+::before,
+::after {
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+}
 * {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);

--- a/tests/jit/opacity.test.css
+++ b/tests/jit/opacity.test.css
@@ -1,8 +1,7 @@
 *,
 ::before,
 ::after {
-  --tw-border-opacity: 1;
-  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+  border-color: #e5e7eb;
 }
 * {
   --tw-shadow: 0 0 #0000;

--- a/tests/jit/prefix.test.css
+++ b/tests/jit/prefix.test.css
@@ -1,3 +1,9 @@
+*,
+::before,
+::after {
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+}
 * {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
@@ -73,7 +79,7 @@
 .tw-group:hover .group-hover\:focus-within\:tw-text-left:focus-within {
   text-align: left;
 }
-[dir="rtl"] .rtl\:active\:tw-text-center:active {
+[dir='rtl'] .rtl\:active\:tw-text-center:active {
   text-align: center;
 }
 @media (prefers-reduced-motion: no-preference) {

--- a/tests/jit/raw-content.test.css
+++ b/tests/jit/raw-content.test.css
@@ -1,3 +1,9 @@
+*,
+::before,
+::after {
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+}
 * {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);

--- a/tests/jit/raw-content.test.js
+++ b/tests/jit/raw-content.test.js
@@ -71,6 +71,12 @@ test('raw content with extension', () => {
 
   return run(tailwind, css, config).then((result) => {
     expect(result.css).toMatchFormattedCss(`
+      *,
+      ::before,
+      ::after {
+        --tw-border-opacity: 1;
+        border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+      }
       * {
         --tw-shadow: 0 0 #0000;
         --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);

--- a/tests/jit/relative-purge-paths.test.css
+++ b/tests/jit/relative-purge-paths.test.css
@@ -1,3 +1,9 @@
+*,
+::before,
+::after {
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+}
 * {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);

--- a/tests/jit/responsive-and-variants-atrules.test.css
+++ b/tests/jit/responsive-and-variants-atrules.test.css
@@ -1,3 +1,9 @@
+*,
+::before,
+::after {
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+}
 * {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);

--- a/tests/jit/svelte-syntax.test.css
+++ b/tests/jit/svelte-syntax.test.css
@@ -1,3 +1,9 @@
+*,
+::before,
+::after {
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+}
 * {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);

--- a/tests/jit/variants.test.css
+++ b/tests/jit/variants.test.css
@@ -1,3 +1,9 @@
+*,
+::before,
+::after {
+  --tw-border-opacity: 1;
+  border-color: rgba(229, 231, 235, var(--tw-border-opacity));
+}
 * {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);


### PR DESCRIPTION
Resolves #4261.

This PR moves the rules for adding the default border color out of preflight directly and into the `borderColor` plugin using `addBase`, making it possible to use our `withAlphaVariable` helper to ensure that `borderOpacity` utilities work with the default `border` class without adding a specific `border-color` utility. I think this actually makes way more sense anyways.

There are ways in which this is a breaking change but I am really not convinced it's a problem. It would only be a breaking change for people using Preflight without using the rest of Tailwind, or for people using Tailwind with the `borderColor` core plugin disabled for some reason but still expecting to be able to use `border` to get a border with the default border color. If this is even one person I would be amazed.

