### PR TITLE
Remove dependency on postcss-functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "normalize-path": "^3.0.0",
     "object-hash": "^2.1.1",
     "parse-glob": "^3.0.4",
-    "postcss-functions": "^3",
     "postcss-js": "^3.0.3",
     "postcss-nested": "5.0.5",
     "postcss-selector-parser": "^6.0.5",

--- a/src/lib/evaluateTailwindFunctions.js
+++ b/src/lib/evaluateTailwindFunctions.js
@@ -1,7 +1,8 @@
 import _ from 'lodash'
-import functions from 'postcss-functions'
 import didYouMean from 'didyoumean'
 import transformThemeValue from '../util/transformThemeValue'
+import buildMediaQuery from '../util/buildMediaQuery'
+import parseValue from 'postcss-value-parser'
 
 function findClosestExistingPath(theme, path) {
   const parts = _.toPath(path)
@@ -109,23 +110,70 @@ function validatePath(config, path, defaultValue) {
   }
 }
 
+function extractArgs(node, vNodes, functions) {
+  vNodes = vNodes.map((vNode) => resolveVNode(node, vNode, functions))
+
+  let args = ['']
+
+  for (let vNode of vNodes) {
+    if (vNode.type === 'div' && vNode.value === ',') {
+      args.push('')
+    } else {
+      args[args.length - 1] += parseValue.stringify(vNode)
+    }
+  }
+
+  return args
+}
+
+function resolveVNode(node, vNode, functions) {
+  if (vNode.type === 'function' && functions[vNode.value] !== undefined) {
+    let args = extractArgs(node, vNode.nodes, functions)
+    vNode.type = 'word'
+    vNode.value = functions[vNode.value](node, ...args)
+  }
+
+  return vNode
+}
+
+function resolveFunctions(node, input, functions) {
+  return parseValue(input)
+    .walk((vNode) => {
+      resolveVNode(node, vNode, functions)
+    })
+    .toString()
+}
+
+let nodeTypePropertyMap = {
+  atrule: 'params',
+  decl: 'value',
+}
+
 export default function (config) {
-  return (root) =>
-    functions({
-      functions: {
-        theme: (path, ...defaultValue) => {
-          const { isValid, value, error } = validatePath(
-            config,
-            path,
-            defaultValue.length ? defaultValue : undefined
-          )
+  let functions = {
+    theme: (node, path, ...defaultValue) => {
+      const { isValid, value, error } = validatePath(
+        config,
+        path,
+        defaultValue.length ? defaultValue : undefined
+      )
 
-          if (!isValid) {
-            throw root.error(error)
-          }
+      if (!isValid) {
+        throw node.error(error)
+      }
 
-          return value
-        },
-      },
-    })(root)
+      return value
+    },
+  }
+  return (root) => {
+    root.walk((node) => {
+      let property = nodeTypePropertyMap[node.type]
+
+      if (property === undefined) {
+        return
+      }
+
+      node[property] = resolveFunctions(node, node[property], functions)
+    })
+  }
 }

--- a/src/lib/evaluateTailwindFunctions.js
+++ b/src/lib/evaluateTailwindFunctions.js
@@ -1,7 +1,6 @@
 import _ from 'lodash'
 import didYouMean from 'didyoumean'
 import transformThemeValue from '../util/transformThemeValue'
-import buildMediaQuery from '../util/buildMediaQuery'
 import parseValue from 'postcss-value-parser'
 
 function findClosestExistingPath(theme, path) {

--- a/tests/themeFunction.test.js
+++ b/tests/themeFunction.test.js
@@ -68,6 +68,27 @@ test('a default value can be provided', () => {
   })
 })
 
+test('the default value can use the theme function', () => {
+  const input = `
+    .cookieMonster { color: theme('colors.blue', theme('colors.yellow')); }
+  `
+
+  const output = `
+    .cookieMonster { color: #f7cc50; }
+  `
+
+  return run(input, {
+    theme: {
+      colors: {
+        yellow: '#f7cc50',
+      },
+    },
+  }).then((result) => {
+    expect(result.css).toEqual(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('quotes are preserved around default values', () => {
   const input = `
     .heading { font-family: theme('fontFamily.sans', "Helvetica Neue"); }


### PR DESCRIPTION
This PR removes our dependency on `postcss-functions` by implementing the logic we need ourselves. The primary motivation for this is to be able to throw errors from the relevant node, instead of having to throw them from the root. Using `postcss-functions` we had no way to access the actual node where the function was being called to throw a helpful error, but by implementing it ourselves we can make sure to keep a reference to the node and make it available to the actual function.