### PR TITLE
Add `screen` function

### DIFF
--- a/src/lib/evaluateTailwindFunctions.js
+++ b/src/lib/evaluateTailwindFunctions.js
@@ -2,6 +2,7 @@ import _ from 'lodash'
 import didYouMean from 'didyoumean'
 import transformThemeValue from '../util/transformThemeValue'
 import parseValue from 'postcss-value-parser'
+import buildMediaQuery from '../util/buildMediaQuery'
 
 function findClosestExistingPath(theme, path) {
   const parts = _.toPath(path)
@@ -162,6 +163,15 @@ export default function (config) {
       }
 
       return value
+    },
+    screen: (node, screen) => {
+      screen = _.trim(screen, `'"`)
+
+      if (config.theme.screens[screen] === undefined) {
+        throw node.error(`The '${screen}' screen does not exist in your theme.`)
+      }
+
+      return buildMediaQuery(config.theme.screens[screen])
     },
   }
   return (root) => {

--- a/tests/evaluateTailwindFunctions.test.js
+++ b/tests/evaluateTailwindFunctions.test.js
@@ -401,3 +401,129 @@ test('transition-duration values are joined when an array', () => {
     expect(result.warnings().length).toBe(0)
   })
 })
+
+test('basic screen function calls are expanded', () => {
+  const input = `
+    @media screen(sm) {
+      .foo {}
+    }
+  `
+
+  const output = `
+  @media (min-width: 600px) {
+    .foo {}
+  }
+  `
+
+  return run(input, {
+    theme: { screens: { sm: '600px' } },
+  }).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('screen function supports max-width screens', () => {
+  const input = `
+    @media screen(sm) {
+      .foo {}
+    }
+  `
+
+  const output = `
+  @media (max-width: 600px) {
+    .foo {}
+  }
+  `
+
+  return run(input, {
+    theme: { screens: { sm: { max: '600px' } } },
+  }).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('screen function supports min-width screens', () => {
+  const input = `
+    @media screen(sm) {
+      .foo {}
+    }
+  `
+
+  const output = `
+  @media (min-width: 600px) {
+    .foo {}
+  }
+  `
+
+  return run(input, {
+    theme: { screens: { sm: { min: '600px' } } },
+  }).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('screen function supports min-width and max-width screens', () => {
+  const input = `
+    @media screen(sm) {
+      .foo {}
+    }
+  `
+
+  const output = `
+  @media (min-width: 600px) and (max-width: 700px) {
+    .foo {}
+  }
+  `
+
+  return run(input, {
+    theme: { screens: { sm: { min: '600px', max: '700px' } } },
+  }).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('screen function supports raw screens', () => {
+  const input = `
+    @media screen(mono) {
+      .foo {}
+    }
+  `
+
+  const output = `
+  @media monochrome {
+    .foo {}
+  }
+  `
+
+  return run(input, {
+    theme: { screens: { mono: { raw: 'monochrome' } } },
+  }).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('screen arguments can be quoted', () => {
+  const input = `
+    @media screen('sm') {
+      .foo {}
+    }
+  `
+
+  const output = `
+  @media (min-width: 600px) {
+    .foo {}
+  }
+  `
+
+  return run(input, {
+    theme: { screens: { sm: '600px' } },
+  }).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})


### PR DESCRIPTION
This PR adds a new `screen` function to complement the existing `theme` function:

```css
/* Input */
@media screen(sm) {
  ...
}

/* Output */
@media (min-width: 640px) {
  ...
}
```

This isn't really that useful on its own (we already have the `@screen` directive) but it's a useful part of solving the bigger problem of making Tailwind CSS more easily compatible with `postcss-nested` and `postcss-nesting`.

Adding this function will make it possible for us to release our own wrapper libraries around those two plugins that make them behave properly with Tailwind.

This is necessary for `postcss-nesting` because it doesn't support the ability to bubble custom at-rules, and necessary for `postcss-nested` because it has been migrated to the new visitor API which causes it to run in a non-deterministic order relative to other plugins, forcing Tailwind to be "nesting-aware" if it were to ever work properly. `postcss-nested` also has several bugs that cause bubbling to not work correctly in several situations for custom at-rules.

By providing this helper function, we can write wrappers around those libraries that translate `@screen sm` to `@media screen(sm)`, which will make bubbling work correctly. The wrappers can also be used to force the plugins to run in a deterministic order by wrapping the visitor API implementations with a layer that only uses `Once` rather than node type events.

