### PR TITLE
Allow color opacity for CSS custom properties

### DIFF
--- a/src/util/withAlphaVariable.js
+++ b/src/util/withAlphaVariable.js
@@ -45,19 +45,32 @@ export default function withAlphaVariable({ color, property, variable }) {
   }
 
   try {
+    let customProperty = false
+
+    // A var() with a comma always has a fallback. We will try to parse fallback as a color.
+    if (color.startsWith('var(') && color.includes(',')) {
+      // Get the var name by removing `var(` and everything after the comma.
+      customProperty = color.split(',')[0].substring(4)
+      // To get the fallback, we remove everything before the first comma,
+      // remove the comma and the trailing bracket and trim whitespace.
+      color = color.split(',').slice(1).join(',').slice(1, -1).trim()
+    }
+
     const isHSL = color.startsWith('hsl')
 
     const [i, j, k, a] = isHSL ? toHsla(color) : toRgba(color)
 
     if (a !== undefined) {
       return {
-        [property]: color,
+        [property]: customProperty ? `var(${customProperty}, ${color})` : color,
       }
     }
 
+    color = `${isHSL ? 'hsla' : 'rgba'}(${i}, ${j}, ${k}, var(${variable}))`
+
     return {
       [variable]: '1',
-      [property]: `${isHSL ? 'hsla' : 'rgba'}(${i}, ${j}, ${k}, var(${variable}))`,
+      [property]: customProperty ? `var(${customProperty}, ${color})` : color,
     }
   } catch (error) {
     return {

--- a/tests/withAlphaVariable.test.js
+++ b/tests/withAlphaVariable.test.js
@@ -119,6 +119,19 @@ test('it allows a closure to be passed', () => {
   })
 })
 
+test('it parses the color in the fallback of a custom property', () => {
+  expect(
+    withAlphaVariable({
+      color: 'var(--custom-property, #ff0000)',
+      property: 'color',
+      variable: '--tw-text-opacity',
+    })
+  ).toEqual({
+    '--tw-text-opacity': '1',
+    color: 'var(--custom-property, rgba(255, 0, 0, var(--tw-text-opacity)))',
+  })
+})
+
 test('it transforms rgb and hsl to rgba and hsla', () => {
   expect(
     withAlphaVariable({


### PR DESCRIPTION
When adding a color, you can use custom property with a fallback:
```js
theme: {
  extend: {
    colors: {
      primary: 'var(--primary, red)',
    },
  },
},
```
Unfortunately, when doing this, the `.bg-opacity` classes won't work anymore. With this change, we also process the fallback color.

This doesn't fix the issue when you set the custom property in CSS.