### PR TITLE
Use `dir-dependency` messages

### DIFF
--- a/src/jit/index.js
+++ b/src/jit/index.js
@@ -26,7 +26,7 @@ export default function (configOrPath = {}) {
           type,
           plugin: 'tailwindcss-jit',
           parent: result.opts.from,
-          file: fileName,
+          [type === 'dir-dependency' ? 'dir' : 'file']: fileName,
         })
       }
 

--- a/src/jit/lib/expandTailwindAtRules.js
+++ b/src/jit/lib/expandTailwindAtRules.js
@@ -156,10 +156,12 @@ export default function expandTailwindAtRules(context, registerDependency, tailw
         } = parseGlob(maybeGlob)
 
         if (isGlob) {
-          // register base dir as `dependency` _and_ `context-dependency` for
-          // increased compatibility
-          registerDependency(path.resolve(base))
-          registerDependency(path.resolve(base), 'context-dependency')
+          // rollup-plugin-postcss does not support dir-dependency messages
+          // but directories can be watched in the same way as files
+          registerDependency(
+            path.resolve(base),
+            process.env.ROLLUP_WATCH === 'true' ? 'dependency' : 'dir-dependency'
+          )
         } else {
           registerDependency(path.resolve(maybeGlob))
         }


### PR DESCRIPTION
This PR registers directory dependencies using the `dir-dependency` message type.

[Relevant documentation](https://github.com/postcss/postcss/blob/main/docs/guidelines/plugin.md#31-use-messages-to-specify-dependencies)