### PR TITLE
Add `target:` variant

### DIFF
--- a/src/jit/corePlugins.js
+++ b/src/jit/corePlugins.js
@@ -19,6 +19,7 @@ export default {
       ['even', 'nth-child(even)'],
       'visited',
       'checked',
+      'target',
       'empty',
       'read-only',
       'focus-within',

--- a/src/lib/substituteVariantsAtRules.js
+++ b/src/lib/substituteVariantsAtRules.js
@@ -135,6 +135,7 @@ const defaultVariantGenerators = (config) => ({
   odd: generatePseudoClassVariant('nth-child(odd)', 'odd'),
   even: generatePseudoClassVariant('nth-child(even)', 'even'),
   empty: generatePseudoClassVariant('empty'),
+  target: generatePseudoClassVariant('target'),
 })
 
 function prependStackableVariants(atRule, variants, stackableVariants) {

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -806,6 +806,7 @@ module.exports = {
     'even',
     'visited',
     'checked',
+    'target',
     'empty',
     'read-only',
     'group-hover',

--- a/tests/variantsAtRule.test.js
+++ b/tests/variantsAtRule.test.js
@@ -431,6 +431,27 @@ test('it can generate even variants', () => {
   })
 })
 
+test('it can generate target variants', () => {
+  const input = `
+    @variants target {
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+    }
+  `
+
+  const output = `
+    .banana { color: yellow; }
+    .chocolate { color: brown; }
+    .target\\:banana:target { color: yellow; }
+    .target\\:chocolate:target { color: brown; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('it can generate empty variants', () => {
   const input = `
     @variants empty {


### PR DESCRIPTION
Hey 👋!

This PR adds `target:` variant for the CSS selector `:target`.

---

**Why?**

A lot of sites has fixed nav on top of the page. When you navigate to an anchor link it gets covered up by a fixed header.

With `target:` variant we can target active anchor on the page. Step two is to add an offset, what is possieble by adding e.g., `scroll-margin-top: 20px`. When this PR would be accepted I would like to create also PR for the mentioned `scroll-margin-*` utilities. 

```html
<nav class="fixed h-20">
  <a href="#hello">Hello</a>
</nav>

<section id="hello" class="target:scroll-margin-top-24">
  Hello World
</section>
```

Demo: https://yie6f.csb.app/#target-2
Demo Code: https://codesandbox.io/s/scroll-margin-yie6f?file=/index.html