### PR TITLE
Add `transform` and `extract` APIs

### DIFF
--- a/src/jit/lib/expandTailwindAtRules.js
+++ b/src/jit/lib/expandTailwindAtRules.js
@@ -18,8 +18,9 @@ const builtInExtractors = {
   },
 }
 
-builtInExtractors.svelte = (content) => {
-  return builtInExtractors.DEFAULT(content.replace(/(?:^|\s)class:/g, ' '))
+const builtInTransformers = {
+  DEFAULT: (content) => content,
+  svelte: (content) => content.replace(/(?:^|\s)class:/g, ' '),
 }
 
 function getExtractor(tailwindConfig, fileExtension) {
@@ -59,7 +60,12 @@ function getTransformer(tailwindConfig, fileExtension) {
     }
   }
 
-  return transformers[fileExtension] || transformers.DEFAULT || ((content) => content)
+  return (
+    transformers[fileExtension] ||
+    transformers.DEFAULT ||
+    builtInTransformers[fileExtension] ||
+    builtInTransformers.DEFAULT
+  )
 }
 
 // Scans template contents for possible classes. This is a hot path on initial build but

--- a/src/jit/lib/expandTailwindAtRules.js
+++ b/src/jit/lib/expandTailwindAtRules.js
@@ -1,5 +1,3 @@
-import fs from 'fs'
-import path from 'path'
 import * as sharedState from './sharedState'
 import { generateRules } from './generateRules'
 import bigSign from '../../util/bigSign'
@@ -11,38 +9,57 @@ let contentMatchCache = sharedState.contentMatchCache
 const BROAD_MATCH_GLOBAL_REGEXP = /[^<>"'`\s]*[^<>"'`\s:]/g
 const INNER_MATCH_GLOBAL_REGEXP = /[^<>"'`\s.(){}[\]#=%]*[^<>"'`\s.(){}[\]#=%:]/g
 
-function getDefaultExtractor(fileExtension) {
-  return function (content) {
-    if (fileExtension === 'svelte') {
-      content = content.replace(/(?:^|\s)class:/g, ' ')
-    }
+const builtInExtractors = {
+  DEFAULT: (content) => {
     let broadMatches = content.match(BROAD_MATCH_GLOBAL_REGEXP) || []
     let innerMatches = content.match(INNER_MATCH_GLOBAL_REGEXP) || []
 
     return [...broadMatches, ...innerMatches]
-  }
+  },
+}
+
+builtInExtractors.svelte = (content) => {
+  return builtInExtractors.DEFAULT(content.replace(/(?:^|\s)class:/g, ' '))
 }
 
 function getExtractor(tailwindConfig, fileExtension) {
-  const purgeOptions = tailwindConfig && tailwindConfig.purge && tailwindConfig.purge.options
+  let extractors = (tailwindConfig && tailwindConfig.purge && tailwindConfig.purge.extract) || {}
+  const purgeOptions =
+    (tailwindConfig && tailwindConfig.purge && tailwindConfig.purge.options) || {}
 
-  if (!fileExtension) {
-    return (purgeOptions && purgeOptions.defaultExtractor) || getDefaultExtractor()
+  if (typeof extractors === 'function') {
+    extractors = {
+      DEFAULT: extractors,
+    }
+  }
+  if (purgeOptions.defaultExtractor) {
+    extractors.DEFAULT = purgeOptions.defaultExtractor
+  }
+  for (let { extensions, extractor } of purgeOptions.extractors || []) {
+    for (let extension of extensions) {
+      extractors[extension] = extractor
+    }
   }
 
-  if (!purgeOptions) {
-    return getDefaultExtractor(fileExtension)
-  }
-
-  const fileSpecificExtractor = (purgeOptions.extractors || []).find((extractor) =>
-    extractor.extensions.includes(fileExtension)
+  return (
+    extractors[fileExtension] ||
+    extractors.DEFAULT ||
+    builtInExtractors[fileExtension] ||
+    builtInExtractors.DEFAULT
   )
+}
 
-  if (fileSpecificExtractor) {
-    return fileSpecificExtractor.extractor
+function getTransformer(tailwindConfig, fileExtension) {
+  let transformers =
+    (tailwindConfig && tailwindConfig.purge && tailwindConfig.purge.transform) || {}
+
+  if (typeof transformers === 'function') {
+    transformers = {
+      DEFAULT: transformers,
+    }
   }
 
-  return purgeOptions.defaultExtractor || getDefaultExtractor(fileExtension)
+  return transformers[fileExtension] || transformers.DEFAULT || ((content) => content)
 }
 
 // Scans template contents for possible classes. This is a hot path on initial build but
@@ -141,8 +158,9 @@ export default function expandTailwindAtRules(context) {
     env.DEBUG && console.time('Reading changed files')
 
     for (let { content, extension } of context.changedContent) {
+      let transformer = getTransformer(context.tailwindConfig, extension)
       let extractor = getExtractor(context.tailwindConfig, extension)
-      getClassCandidates(content, extractor, contentMatchCache, candidates, seen)
+      getClassCandidates(transformer(content), extractor, contentMatchCache, candidates, seen)
     }
 
     // ---

--- a/tests/jit/custom-extractors.test.js
+++ b/tests/jit/custom-extractors.test.js
@@ -65,3 +65,58 @@ test('extractors array', () => {
     expect(result.css).toMatchFormattedCss(expected)
   })
 })
+
+test('extract function', () => {
+  let config = {
+    mode: 'jit',
+    purge: {
+      content: [path.resolve(__dirname, './custom-extractors.test.html')],
+      extract: customExtractor,
+    },
+    corePlugins: { preflight: false },
+    theme: {},
+    plugins: [],
+  }
+
+  return run(css, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(expected)
+  })
+})
+
+test('extract.DEFAULT', () => {
+  let config = {
+    mode: 'jit',
+    purge: {
+      content: [path.resolve(__dirname, './custom-extractors.test.html')],
+      extract: {
+        DEFAULT: customExtractor,
+      },
+    },
+    corePlugins: { preflight: false },
+    theme: {},
+    plugins: [],
+  }
+
+  return run(css, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(expected)
+  })
+})
+
+test('extract.{extension}', () => {
+  let config = {
+    purge: {
+      content: [path.resolve(__dirname, './custom-extractors.test.html')],
+      extract: {
+        html: customExtractor,
+      },
+    },
+    mode: 'jit',
+    corePlugins: { preflight: false },
+    theme: {},
+    plugins: [],
+  }
+
+  return run(css, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(expected)
+  })
+})

--- a/tests/jit/custom-transformers.test.js
+++ b/tests/jit/custom-transformers.test.js
@@ -1,0 +1,93 @@
+import postcss from 'postcss'
+import path from 'path'
+
+function run(input, config = {}) {
+  jest.resetModules()
+  const tailwind = require('../../src/jit/index.js').default
+  return postcss(tailwind(config)).process(input, {
+    from: path.resolve(__filename),
+  })
+}
+
+function customTransformer(content) {
+  return content.replace(/uppercase/g, 'lowercase')
+}
+
+const css = `
+  @tailwind base;
+  @tailwind components;
+  @tailwind utilities;
+`
+
+test('transform function', () => {
+  let config = {
+    mode: 'jit',
+    purge: {
+      content: [{ raw: '<div class="uppercase"></div>' }],
+      transform: customTransformer,
+    },
+    corePlugins: { preflight: false, borderColor: false, ringWidth: false, boxShadow: false },
+    theme: {},
+    plugins: [],
+  }
+
+  return run(css, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(`
+      .lowercase {
+        text-transform: lowercase;
+      }
+    `)
+  })
+})
+
+test('transform.DEFAULT', () => {
+  let config = {
+    mode: 'jit',
+    purge: {
+      content: [{ raw: '<div class="uppercase"></div>' }],
+      transform: {
+        DEFAULT: customTransformer,
+      },
+    },
+    corePlugins: { preflight: false, borderColor: false, ringWidth: false, boxShadow: false },
+    theme: {},
+    plugins: [],
+  }
+
+  return run(css, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(`
+      .lowercase {
+        text-transform: lowercase;
+      }
+    `)
+  })
+})
+
+test('transform.{extension}', () => {
+  let config = {
+    mode: 'jit',
+    purge: {
+      content: [
+        { raw: '<div class="uppercase"></div>', extension: 'html' },
+        { raw: '<div class="uppercase"></div>', extension: 'php' },
+      ],
+      transform: {
+        html: customTransformer,
+      },
+    },
+    corePlugins: { preflight: false, borderColor: false, ringWidth: false, boxShadow: false },
+    theme: {},
+    plugins: [],
+  }
+
+  return run(css, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(`
+      .uppercase {
+        text-transform: uppercase;
+      }
+      .lowercase {
+        text-transform: lowercase;
+      }
+    `)
+  })
+})

--- a/tests/purgeUnusedStyles.test.js
+++ b/tests/purgeUnusedStyles.test.js
@@ -663,6 +663,187 @@ test('element selectors are preserved by default', () => {
   )
 })
 
+test('custom default extractor', () => {
+  return inProduction(
+    suppressConsoleLogs(() => {
+      const inputPath = path.resolve(`${__dirname}/fixtures/tailwind-input.css`)
+      const input = fs.readFileSync(inputPath, 'utf8')
+
+      return postcss([
+        tailwind({
+          ...config,
+          corePlugins: { preflight: false, ringWidth: false, boxShadow: false, borderColor: false },
+          purge: {
+            content: [
+              path.resolve(`${__dirname}/fixtures/**/*.html`),
+              { raw: '<div class="uppercase"></div>', extension: 'php' },
+            ],
+            extract: () => [],
+            mode: 'all',
+            preserveHtmlElements: false,
+            options: {
+              keyframes: true,
+            },
+          },
+        }),
+      ])
+        .process(input, { from: withTestName(inputPath) })
+        .then((result) => {
+          expect(result.css).toMatchFormattedCss('')
+        })
+    })
+  )
+})
+
+test('custom extension-specific extractor', () => {
+  return inProduction(
+    suppressConsoleLogs(() => {
+      const inputPath = path.resolve(`${__dirname}/fixtures/tailwind-input.css`)
+      const input = fs.readFileSync(inputPath, 'utf8')
+
+      return postcss([
+        tailwind({
+          ...config,
+          corePlugins: { preflight: false, ringWidth: false, boxShadow: false, borderColor: false },
+          purge: {
+            content: [
+              path.resolve(`${__dirname}/fixtures/**/*.html`),
+              { raw: '<div class="lowercase"></div>', extension: 'html' },
+              { raw: '<div class="uppercase"></div>', extension: 'php' },
+            ],
+            extract: {
+              html: () => [],
+            },
+            mode: 'all',
+            preserveHtmlElements: false,
+            options: {
+              keyframes: true,
+            },
+          },
+        }),
+      ])
+        .process(input, { from: withTestName(inputPath) })
+        .then((result) => {
+          expect(result.css).toMatchFormattedCss(`
+            .uppercase {
+              text-transform: uppercase;
+            }
+          `)
+        })
+    })
+  )
+})
+
+test('custom default transformer', () => {
+  return inProduction(
+    suppressConsoleLogs(() => {
+      const inputPath = path.resolve(`${__dirname}/fixtures/tailwind-input.css`)
+      const input = fs.readFileSync(inputPath, 'utf8')
+
+      return postcss([
+        tailwind({
+          ...config,
+          corePlugins: { preflight: false, ringWidth: false, boxShadow: false, borderColor: false },
+          purge: {
+            content: [{ raw: '<div class="uppercase"></div>', extension: 'html' }],
+            transform: (content) => content.replace(/uppercase/g, 'lowercase'),
+            mode: 'all',
+            preserveHtmlElements: false,
+            options: {
+              keyframes: true,
+            },
+          },
+        }),
+      ])
+        .process(input, { from: withTestName(inputPath) })
+        .then((result) => {
+          expect(result.css).toMatchFormattedCss(`
+            .lowercase {
+              text-transform: lowercase;
+            }
+          `)
+        })
+    })
+  )
+})
+
+test('custom explicit default transformer', () => {
+  return inProduction(
+    suppressConsoleLogs(() => {
+      const inputPath = path.resolve(`${__dirname}/fixtures/tailwind-input.css`)
+      const input = fs.readFileSync(inputPath, 'utf8')
+
+      return postcss([
+        tailwind({
+          ...config,
+          corePlugins: { preflight: false, ringWidth: false, boxShadow: false, borderColor: false },
+          purge: {
+            content: [{ raw: '<div class="uppercase"></div>', extension: 'html' }],
+            transform: {
+              DEFAULT: (content) => content.replace(/uppercase/g, 'lowercase'),
+            },
+            mode: 'all',
+            preserveHtmlElements: false,
+            options: {
+              keyframes: true,
+            },
+          },
+        }),
+      ])
+        .process(input, { from: withTestName(inputPath) })
+        .then((result) => {
+          expect(result.css).toMatchFormattedCss(`
+            .lowercase {
+              text-transform: lowercase;
+            }
+          `)
+        })
+    })
+  )
+})
+
+test('custom extension-specific transformer', () => {
+  return inProduction(
+    suppressConsoleLogs(() => {
+      const inputPath = path.resolve(`${__dirname}/fixtures/tailwind-input.css`)
+      const input = fs.readFileSync(inputPath, 'utf8')
+
+      return postcss([
+        tailwind({
+          ...config,
+          corePlugins: { preflight: false, ringWidth: false, boxShadow: false, borderColor: false },
+          purge: {
+            content: [
+              { raw: '<div class="uppercase"></div>', extension: 'html' },
+              { raw: '<div class="uppercase"></div>', extension: 'php' },
+            ],
+            transform: {
+              html: (content) => content.replace(/uppercase/g, 'lowercase'),
+            },
+            mode: 'all',
+            preserveHtmlElements: false,
+            options: {
+              keyframes: true,
+            },
+          },
+        }),
+      ])
+        .process(input, { from: withTestName(inputPath) })
+        .then((result) => {
+          expect(result.css).toMatchFormattedCss(`
+            .uppercase {
+              text-transform: uppercase;
+            }
+
+            .lowercase {
+              text-transform: lowercase;
+            }
+          `)
+        })
+    })
+  )
+})
+
 test('element selectors are preserved even when defaultExtractor is overridden', () => {
   return inProduction(
     suppressConsoleLogs(() => {


### PR DESCRIPTION
This PR adds `purge.transform` and `purge.extract` configuration options.

### `purge.extract`

This is an alternative way to define class extractors:

```js
purge: {
  extract: (content) => { /* ... */ },
}

// same as:
purge: {
  options: {
    defaultExtractor: (content) => { /* ... */ },
  },
}
```

```js
purge: {
  extract: {
    DEFAULT: (content) => { /* ... */ },
    html: (content) => { /* ... */ },
  },
}

// same as:
purge: {
  options: {
    defaultExtractor: (content) => { /* ... */ },
    extractors: [
      {
        extensions: ['html'],
        extractor: (content) => { /* ... */ },
      },
    ],
  },
}
```

### `purge.transform`

`purge.transform` is a new option that allows you to specify transformation functions that run on file contents before it is passed to the class extractor. One use-case for this is converting markdown to HTML:

```js
// One transformer for every file
purge: {
  transform: (content) => { /* ... */ },
}

// Transformer for .md files, and a (optional) default transformer for all other file types
purge: {
  transform: {
    DEFAULT: (content) => { /* ... */ },
    md: markdownToHtml,
  },
}
```

### Notes

- The Svelte transform (`content.replace(/(?:^|\s)class:/g, ' ')`) is now implemented as a **transformer**.
- `purge.options.defaultExtractor` and `purge.options.extractors` still work and override any extractors defined using `purge.extract`. One thing that I noticed about this is that when using a custom `defaultExtractor` the `purge.preserveHtmlElements` option is still respected, but this isn't the case with custom extractors defined in `purge.extractors`. This behaviour has been maintained but I'm wondering if this was intentional?