### PR TITLE
Add inline-start and inline-end rules for padding and margin

### DIFF
--- a/src/plugins/margin.js
+++ b/src/plugins/margin.js
@@ -13,5 +13,9 @@ export default function () {
       ['mb', ['margin-bottom']],
       ['ml', ['margin-left']],
     ],
+    [
+      ['mis', ['margin-inline-start']],
+      ['mie', ['padding-inline-end']],
+    ],
   ])
 }

--- a/src/plugins/padding.js
+++ b/src/plugins/padding.js
@@ -13,5 +13,9 @@ export default function () {
       ['pb', ['padding-bottom']],
       ['pl', ['padding-left']],
     ],
+    [
+      ['pis', ['padding-inline-start']],
+      ['pie', ['padding-inline-end']],
+    ],
   ])
 }


### PR DESCRIPTION
Hi

Thanks for this great module! For better handling of both RTL and LTR pages, we use `inline-start` and `inline-end` rules instead of `padding-left` and `padding-right`, and its converts automatically to `padding-left` and `padding-right` based on the page tag's direction. I saw the `tailwindcss-dir` plugin, it requires more code, and in most cases, we just need to change the direction, not set different values for padding and margin in RTL and LTR directions.

So I added `pie`, `pis`, `mis`, and `mie` classes to handle this, and I think this change will make it easy to use in multi-direction pages.