### PR TITLE
JIT: Add caret-color utilities

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1,7 +1,7 @@
 import * as plugins from './plugins/index.js'
 import configurePlugins from './util/configurePlugins'
 
-const jitOnlyPlugins = ['content']
+const jitOnlyPlugins = ['caretColor', 'content']
 
 export default function ({ corePlugins: corePluginConfig }) {
   corePluginConfig = corePluginConfig.filter((pluginName) => !jitOnlyPlugins.includes(pluginName))

--- a/src/plugins/caretColor.js
+++ b/src/plugins/caretColor.js
@@ -1,0 +1,19 @@
+import flattenColorPalette from '../util/flattenColorPalette'
+import toColorValue from '../util/toColorValue'
+
+export default function () {
+  return function ({ matchUtilities, theme, variants }) {
+    matchUtilities(
+      {
+        caret: (value) => {
+          return { 'caret-color': toColorValue(value) }
+        },
+      },
+      {
+        values: flattenColorPalette(theme('caretColor')),
+        variants: variants('caretColor'),
+        type: ['color', 'any'],
+      }
+    )
+  }
+}

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -123,6 +123,7 @@ export { default as textDecoration } from './textDecoration'
 export { default as fontSmoothing } from './fontSmoothing'
 export { default as placeholderColor } from './placeholderColor'
 export { default as placeholderOpacity } from './placeholderOpacity'
+export { default as caretColor } from './caretColor'
 
 export { default as opacity } from './opacity'
 export { default as backgroundBlendMode } from './backgroundBlendMode'

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -165,6 +165,7 @@ module.exports = {
       inner: 'inset 0 2px 4px 0 rgba(0, 0, 0, 0.06)',
       none: 'none',
     },
+    caretColor: (theme) => theme('colors'),
     contrast: {
       0: '0',
       50: '.5',

--- a/tests/jit/basic-usage.test.css
+++ b/tests/jit/basic-usage.test.css
@@ -604,6 +604,9 @@
 .placeholder-opacity-60::placeholder {
   --tw-placeholder-opacity: 0.6;
 }
+.caret-red-600 {
+  caret-color: #dc2626;
+}
 .opacity-90 {
   opacity: 0.9;
 }

--- a/tests/jit/basic-usage.test.html
+++ b/tests/jit/basic-usage.test.html
@@ -100,6 +100,7 @@
     <div class="place-content-start"></div>
     <div class="placeholder-green-300"></div>
     <div class="placeholder-opacity-60"></div>
+    <div class="caret-red-600"></div>
     <div class="place-items-end"></div>
     <div class="place-self-center"></div>
     <div class="pointer-events-none"></div>


### PR DESCRIPTION
This PR adds utilities for the `caret-color` property to the JIT engine only, since adding color-related utilities has a large impact on file size.

```html
<input class="caret-red-500">
```

These utilities share your main color palette by default, and can be customized using the `caretColor` key in the `theme` section of your config.

Originally PR'd by @Naturalclar but got out of date after some of the major internal restructuring we've done recently, so I've reworked it and added them as a co-author to preserve credit ❤️ 
