### PR TITLE
Use tracking context by default

### DIFF
--- a/integrations/rollup/tests/integration.test.js
+++ b/integrations/rollup/tests/integration.test.js
@@ -27,10 +27,7 @@ describe('static build', () => {
   })
 })
 
-describe.each([
-  { TAILWIND_MODE: 'watch' },
-  { TAILWIND_MODE: 'watch', TAILWIND_DISABLE_TOUCH: true },
-])('watcher %p', (env) => {
+describe.each([{ TAILWIND_MODE: 'watch' }, { TAILWIND_MODE: undefined }])('watcher %p', (env) => {
   test(`classes are generated when the html file changes`, async () => {
     await writeInputFile('index.html', html`<div class="font-bold"></div>`)
 

--- a/integrations/webpack-4/tests/integration.test.js
+++ b/integrations/webpack-4/tests/integration.test.js
@@ -25,10 +25,7 @@ describe('static build', () => {
   })
 })
 
-describe.each([
-  { TAILWIND_MODE: 'watch' },
-  { TAILWIND_MODE: 'watch', TAILWIND_DISABLE_TOUCH: true },
-])('watcher %p', (env) => {
+describe.each([{ TAILWIND_MODE: 'watch' }, { TAILWIND_MODE: undefined }])('watcher %p', (env) => {
   test(`classes are generated when the html file changes`, async () => {
     await writeInputFile('index.html', html`<div class="font-bold"></div>`)
 

--- a/integrations/webpack-5/tests/integration.test.js
+++ b/integrations/webpack-5/tests/integration.test.js
@@ -25,10 +25,7 @@ describe('static build', () => {
   })
 })
 
-describe.each([
-  { TAILWIND_MODE: 'watch' },
-  { TAILWIND_MODE: 'watch', TAILWIND_DISABLE_TOUCH: true },
-])('watcher %p', (env) => {
+describe.each([{ TAILWIND_MODE: 'watch' }, { TAILWIND_MODE: undefined }])('watcher %p', (env) => {
   test(`classes are generated when the html file changes`, async () => {
     await writeInputFile('index.html', html`<div class="font-bold"></div>`)
 

--- a/src/jit/index.js
+++ b/src/jit/index.js
@@ -24,9 +24,10 @@ export default function (configOrPath = {}) {
 
       let tailwindDirectives = normalizeTailwindDirectives(root)
 
-      let context = env.TAILWIND_DISABLE_TOUCH
-        ? setupTrackingContext(configOrPath, tailwindDirectives, registerDependency)(result, root)
-        : setupWatchingContext(configOrPath, tailwindDirectives, registerDependency)(result, root)
+      let context =
+        env.TAILWIND_MODE === 'watch'
+          ? setupWatchingContext(configOrPath, tailwindDirectives, registerDependency)(result, root)
+          : setupTrackingContext(configOrPath, tailwindDirectives, registerDependency)(result, root)
 
       processTailwindFeatures(context)(root, result)
     },


### PR DESCRIPTION
This PR switches the JIT engine to use the tracking context by default, which relies on native dependency tracking within build runners instead of running our own chokidar instance. This is slightly slower but much more reliable and not prone to race conditions. This is basically just setting `TAILWIND_DISABLE_TOUCH=true` by default, and removing any actual conditions around that flag.

This depends on the new PostCSS `dir-dependency` message type which is not supported by all build tools yet, but is very close. Webpack 4 and 5 both support it already, Snowpack supports it, and we have open pull requests for adding support to Parcel and postcss-cli.

After this is released, you will still be able to use the chokidar-driven dependency tracking system by setting `TAILWIND_MODE=watch`.