### PR TITLE
Call color functions when using `theme('...')` on all color related sections.

### DIFF
--- a/src/util/transformThemeValue.js
+++ b/src/util/transformThemeValue.js
@@ -13,7 +13,6 @@ export default function transformThemeValue(themeSection) {
       'transitionTimingFunction',
       'backgroundImage',
       'backgroundSize',
-      'backgroundColor',
       'cursor',
       'animation',
     ].includes(themeSection)
@@ -21,7 +20,7 @@ export default function transformThemeValue(themeSection) {
     return (value) => (Array.isArray(value) ? value.join(', ') : value)
   }
 
-  if (themeSection === 'colors') {
+  if (['colors', 'textColor', 'backgroundColor', 'borderColor'].includes(themeSection)) {
     return (value) => (typeof value === 'function' ? value({}) : value)
   }
 

--- a/src/util/transformThemeValue.js
+++ b/src/util/transformThemeValue.js
@@ -20,7 +20,22 @@ export default function transformThemeValue(themeSection) {
     return (value) => (Array.isArray(value) ? value.join(', ') : value)
   }
 
-  if (['colors', 'textColor', 'backgroundColor', 'borderColor'].includes(themeSection)) {
+  if (
+    [
+      'backgroundColor',
+      'borderColor',
+      'caretColor',
+      'colors',
+      'divideColor',
+      'fill',
+      'gradientColorStops',
+      'placeholderColor',
+      'ringColor',
+      'ringOffsetColor',
+      'stroke',
+      'textColor',
+    ].includes(themeSection)
+  ) {
     return (value) => (typeof value === 'function' ? value({}) : value)
   }
 

--- a/tests/evaluateTailwindFunctions.test.js
+++ b/tests/evaluateTailwindFunctions.test.js
@@ -26,6 +26,42 @@ test('it looks up values in the theme using dot notation', () => {
   })
 })
 
+test('color can be a function', () => {
+  const input = `
+    .colors { color: theme('colors.fn'); }
+    .textColor { color: theme('textColor.fn'); }
+    .backgroundColor { color: theme('backgroundColor.fn'); }
+    .borderColor { color: theme('borderColor.fn'); }
+  `
+
+  const output = `
+    .colors { color: #f00; }
+    .textColor { color: #f00; }
+    .backgroundColor { color: #f00; }
+    .borderColor { color: #f00; }
+  `
+
+  return run(input, {
+    theme: {
+      colors: {
+        fn: () => `#f00`,
+      },
+      textColor: {
+        fn: () => '#f00',
+      },
+      backgroundColor: {
+        fn: () => '#f00',
+      },
+      borderColor: {
+        fn: () => '#f00',
+      },
+    },
+  }).then((result) => {
+    expect(result.css).toEqual(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('quotes are optional around the lookup path', () => {
   const input = `
     .banana { color: theme(colors.yellow); }

--- a/tests/evaluateTailwindFunctions.test.js
+++ b/tests/evaluateTailwindFunctions.test.js
@@ -28,33 +28,51 @@ test('it looks up values in the theme using dot notation', () => {
 
 test('color can be a function', () => {
   const input = `
-    .colors { color: theme('colors.fn'); }
-    .textColor { color: theme('textColor.fn'); }
-    .backgroundColor { color: theme('backgroundColor.fn'); }
-    .borderColor { color: theme('borderColor.fn'); }
+    .backgroundColor { color: theme('backgroundColor.fn') }
+    .borderColor { color: theme('borderColor.fn') }
+    .caretColor { color: theme('caretColor.fn') }
+    .colors { color: theme('colors.fn') }
+    .divideColor { color: theme('divideColor.fn') }
+    .fill { color: theme('fill.fn') }
+    .gradientColorStops { color: theme('gradientColorStops.fn') }
+    .placeholderColor { color: theme('placeholderColor.fn') }
+    .ringColor { color: theme('ringColor.fn') }
+    .ringOffsetColor { color: theme('ringOffsetColor.fn') }
+    .stroke { color: theme('stroke.fn') }
+    .textColor { color: theme('textColor.fn') }
   `
 
   const output = `
-    .colors { color: #f00; }
-    .textColor { color: #f00; }
-    .backgroundColor { color: #f00; }
-    .borderColor { color: #f00; }
+    .backgroundColor { color: #f00 }
+    .borderColor { color: #f00 }
+    .caretColor { color: #f00 }
+    .colors { color: #f00 }
+    .divideColor { color: #f00 }
+    .fill { color: #f00 }
+    .gradientColorStops { color: #f00 }
+    .placeholderColor { color: #f00 }
+    .ringColor { color: #f00 }
+    .ringOffsetColor { color: #f00 }
+    .stroke { color: #f00 }
+    .textColor { color: #f00 }
   `
+
+  const fn = () => `#f00`
 
   return run(input, {
     theme: {
-      colors: {
-        fn: () => `#f00`,
-      },
-      textColor: {
-        fn: () => '#f00',
-      },
-      backgroundColor: {
-        fn: () => '#f00',
-      },
-      borderColor: {
-        fn: () => '#f00',
-      },
+      backgroundColor: { fn },
+      borderColor: { fn },
+      caretColor: { fn },
+      colors: { fn },
+      divideColor: { fn },
+      fill: { fn },
+      gradientColorStops: { fn },
+      placeholderColor: { fn },
+      ringColor: { fn },
+      ringOffsetColor: { fn },
+      stroke: { fn },
+      textColor: { fn },
     },
   }).then((result) => {
     expect(result.css).toEqual(output)


### PR DESCRIPTION
We noticed we were able to do:

```css
.test {
  color: theme('colors.someFunction')
}
```

but we were unable to do:

```css
.test {
  color: theme('textColor.someFunction')
}
```

so this resolves that.

I left a few comments below because I feel like I'll need to adjust a bit.
