### PR TITLE
Add `glob` property to `dir-dependency` messages

### DIFF
--- a/src/jit/lib/setupWatchingContext.js
+++ b/src/jit/lib/setupWatchingContext.js
@@ -308,7 +308,7 @@ export default function setupWatchingContext(configOrPath) {
       let contextConfigDependencies = getConfigDependencies(context)
 
       for (let file of configDependencies) {
-        registerDependency({ file })
+        registerDependency({ type: 'dependency', file })
       }
 
       context.disposables.push((oldContext) => {
@@ -338,7 +338,7 @@ export default function setupWatchingContext(configOrPath) {
       // to trigger rebuilds.
       let touchFile = getTouchFile(context)
       if (touchFile) {
-        registerDependency({ file: touchFile })
+        registerDependency({ type: 'dependency', file: touchFile })
       }
 
       if (tailwindDirectives.size > 0) {

--- a/src/jit/lib/setupWatchingContext.js
+++ b/src/jit/lib/setupWatchingContext.js
@@ -308,7 +308,7 @@ export default function setupWatchingContext(configOrPath) {
       let contextConfigDependencies = getConfigDependencies(context)
 
       for (let file of configDependencies) {
-        registerDependency(file)
+        registerDependency({ file })
       }
 
       context.disposables.push((oldContext) => {
@@ -338,7 +338,7 @@ export default function setupWatchingContext(configOrPath) {
       // to trigger rebuilds.
       let touchFile = getTouchFile(context)
       if (touchFile) {
-        registerDependency(touchFile)
+        registerDependency({ file: touchFile })
       }
 
       if (tailwindDirectives.size > 0) {

--- a/src/jit/processTailwindFeatures.js
+++ b/src/jit/processTailwindFeatures.js
@@ -8,26 +8,17 @@ import { createContext } from './lib/setupContextUtils'
 
 export default function processTailwindFeatures(setupContext) {
   return function (root, result) {
-    function registerDependency(dependency) {
-      // rollup-plugin-postcss does not support dir-dependency messages
-      // but directories can be watched in the same way as files
-      if (dependency.dir && process.env.ROLLUP_WATCH === 'true') {
-        dependency = { file: dependency.dir }
-      }
-
-      result.messages.push({
-        type: dependency.dir ? 'dir-dependency' : 'dependency',
-        plugin: 'tailwindcss',
-        parent: result.opts.from,
-        ...dependency,
-      })
-    }
-
     let tailwindDirectives = normalizeTailwindDirectives(root)
 
     let context = setupContext({
       tailwindDirectives,
-      registerDependency,
+      registerDependency(dependency) {
+        result.messages.push({
+          plugin: 'tailwindcss',
+          parent: result.opts.from,
+          ...dependency,
+        })
+      },
       createContext(tailwindConfig, changedContent) {
         return createContext(tailwindConfig, changedContent, tailwindDirectives, root)
       },

--- a/src/jit/processTailwindFeatures.js
+++ b/src/jit/processTailwindFeatures.js
@@ -8,12 +8,18 @@ import { createContext } from './lib/setupContextUtils'
 
 export default function processTailwindFeatures(setupContext) {
   return function (root, result) {
-    function registerDependency(fileName, type = 'dependency') {
+    function registerDependency(dependency) {
+      // rollup-plugin-postcss does not support dir-dependency messages
+      // but directories can be watched in the same way as files
+      if (dependency.dir && process.env.ROLLUP_WATCH === 'true') {
+        dependency = { file: dependency.dir }
+      }
+
       result.messages.push({
-        type,
+        type: dependency.dir ? 'dir-dependency' : 'dependency',
         plugin: 'tailwindcss',
         parent: result.opts.from,
-        [type === 'dir-dependency' ? 'dir' : 'file']: fileName,
+        ...dependency,
       })
     }
 

--- a/src/util/parseDependency.js
+++ b/src/util/parseDependency.js
@@ -1,0 +1,45 @@
+import isGlob from 'is-glob'
+import globParent from 'glob-parent'
+import path from 'path'
+
+// Based on `glob-base`
+// https://github.com/micromatch/glob-base/blob/master/index.js
+function parseGlob(pattern) {
+  let glob = pattern
+  let base = globParent(pattern)
+
+  if (base !== '.') {
+    glob = pattern.substr(base.length)
+    if (glob.charAt(0) === '/') {
+      glob = glob.substr(1)
+    }
+  }
+
+  if (glob.substr(0, 2) === './') {
+    glob = glob.substr(2)
+  }
+  if (glob.charAt(0) === '/') {
+    glob = glob.substr(1)
+  }
+
+  return { base, glob }
+}
+
+export default function parseDependency(normalizedFileOrGlob) {
+  let message
+
+  if (isGlob(normalizedFileOrGlob)) {
+    let { base, glob } = parseGlob(normalizedFileOrGlob)
+    message = { type: 'dir-dependency', dir: path.resolve(base), glob }
+  } else {
+    message = { type: 'dependency', file: path.resolve(normalizedFileOrGlob) }
+  }
+
+  // rollup-plugin-postcss does not support dir-dependency messages
+  // but directories can be watched in the same way as files
+  if (message.type === 'dir-dependency' && process.env.ROLLUP_WATCH === 'true') {
+    message = { type: 'dependency', file: message.dir }
+  }
+
+  return message
+}


### PR DESCRIPTION
This PR adds a `glob` property to `dir-dependency` messages to indicate to runners that files inside the directory should only be considered dependencies if they match the glob pattern.

For example if you have `/src/**/*.html` as a `purge` glob the following PostCSS message is registered:

```js
{
  type: 'dir-dependency',
  dir: '/src',
  glob: '**/*.html',
}
```

**Some runners may ignore this property and simply register the entire directory as a dependency,** but for those that don't efficiency is improved (i.e. editing a`.js` file in `/src` would not trigger a rebuild)

Relevant documentation: https://github.com/postcss/postcss/blob/main/docs/guidelines/plugin.md#3-dependencies