### PR TITLE
Ignore raw content when registering dependencies

### DIFF
--- a/src/lib/purgeUnusedStyles.js
+++ b/src/lib/purgeUnusedStyles.js
@@ -63,7 +63,7 @@ export default function purgeUnusedUtilities(config, configChanged, registerDepe
 
   let content = Array.isArray(config.purge) ? config.purge : config.purge.content
 
-  for (let maybeGlob of content) {
+  for (let maybeGlob of content.filter((item) => typeof item === 'string')) {
     let { is, base } = parseGlob(maybeGlob)
 
     if (is.glob) {


### PR DESCRIPTION
The `purge` content array can contain raw content (e.g. `{ raw: '' }`) which should be ignored when registering dependencies.