### PR TITLE
Group variant stacking

### DIFF
--- a/src/jit/corePlugins.js
+++ b/src/jit/corePlugins.js
@@ -164,32 +164,8 @@ export default {
       addVariant(
         groupVariantName,
         transformAllSelectors((selector) => {
-          // Stack group variants
-          let existingGroupStates = []
-          if (selector.indexOf(baseGroupSelector + ':') !== -1) {
-            let idx = selector.indexOf(baseGroupSelector + ':')
-
-            let endIdx = selector.indexOf(' ', idx)
-
-            let before = selector.slice(0, idx)
-            let baseGroupWithStates = selector.slice(idx, endIdx + 1)
-            let after = selector.slice(endIdx + 1)
-
-            // Find the existing states on the main `.group`
-            let parts = baseGroupWithStates
-              .replace(baseGroupSelector, '')
-              .split(':')
-              .map((part) => part.trim())
-              .filter(Boolean)
-
-            // Keep the existing states
-            existingGroupStates.push(...parts)
-
-            // Change the selector by removing the base .group
-            selector = before + after
-          }
-
           let variantSelector = updateAllClasses(selector, (className) => {
+            if (`.${className}` === baseGroupSelector) return className
             return `${groupVariantName}${config('separator')}${className}`
           })
 
@@ -197,12 +173,28 @@ export default {
             return null
           }
 
-          let groupSelector = prefixSelector(
-            config('prefix'),
-            `.group:${[state].concat(existingGroupStates).join(':')}`
-          )
+          let states = [state]
 
-          return `${groupSelector} ${variantSelector}`
+          // Stack group variants
+          let baseGroupIdx = variantSelector.indexOf(baseGroupSelector + ':')
+          if (baseGroupIdx !== -1) {
+            let groupClassName = variantSelector.slice(
+              baseGroupIdx,
+              variantSelector.indexOf(' ', baseGroupIdx)
+            )
+
+            // Pick all the states
+            states = states.concat(
+              variantSelector
+                .slice(baseGroupIdx + baseGroupSelector.length + 1, groupClassName.length)
+                .split(':')
+            )
+
+            // Remove the base `.group:...`
+            variantSelector = variantSelector.replace(groupClassName, '')
+          }
+
+          return `${[baseGroupSelector, ...states].join(':')} ${variantSelector}`
         })
       )
     }

--- a/tests/jit/variants.test.css
+++ b/tests/jit/variants.test.css
@@ -347,6 +347,11 @@
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
     var(--tw-shadow);
 }
+.group:focus:hover .group-focus\:group-hover\:shadow-md {
+  --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
+    var(--tw-shadow);
+}
 .group:focus-visible .group-focus-visible\:shadow-md {
   --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
@@ -358,6 +363,17 @@
     var(--tw-shadow);
 }
 .group:disabled .group-disabled\:shadow-md {
+  --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
+    var(--tw-shadow);
+}
+.group:disabled:focus:hover .group-disabled\:group-focus\:group-hover\:shadow-md {
+  --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
+    var(--tw-shadow);
+}
+.group:disabled:focus:hover
+  .group-disabled\:group-focus\:group-hover\:first\:shadow-md:first-child {
   --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
     var(--tw-shadow);
@@ -387,6 +403,11 @@
   }
 }
 .dark .dark\:shadow-md {
+  --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
+    var(--tw-shadow);
+}
+.dark .group:disabled:focus:hover .dark\:group-disabled\:group-focus\:group-hover\:shadow-md {
   --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
     var(--tw-shadow);

--- a/tests/jit/variants.test.html
+++ b/tests/jit/variants.test.html
@@ -103,5 +103,11 @@
     <div class="lg:dark:shadow-md"></div>
     <div class="xl:dark:disabledshadow-md"></div>
     <div class="2xl:dark:motion-safe:focus-within:shadow-md"></div>
+
+    <!-- Stacked group variants -->
+    <div class="group-focus:group-hover:shadow-md"></div>
+    <div class="group-disabled:group-focus:group-hover:shadow-md"></div>
+    <div class="dark:group-disabled:group-focus:group-hover:shadow-md"></div>
+    <div class="group-disabled:group-focus:group-hover:first:shadow-md"></div>
   </body>
 </html>


### PR DESCRIPTION
This PR will make it possible to stack `group` variants together. It will make sure that all the states like `focus` and `hover` are applied to the `.group` correctly.

HTML:
```html
<div class="group">
  <div class="group-focus:group-hover:font-bold"></div>
</div>
```

Will generate:
```css
.group:focus:hover .group-focus\:group-hover\:font-bold {
  font-weight: 700;
}
```
---
This is a `jit` only feature.