### PR TITLE
Cleanup old contexts in config hash map

### DIFF
--- a/src/jit/lib/setupContextUtils.js
+++ b/src/jit/lib/setupContextUtils.js
@@ -558,6 +558,11 @@ export function getContext(
       contextSourcesMap.get(oldContext).delete(sourcePath)
       if (contextSourcesMap.get(oldContext).size === 0) {
         contextSourcesMap.delete(oldContext)
+        for (let [tailwindConfigHash, context] of configContextMap) {
+          if (context === oldContext) {
+            configContextMap.delete(tailwindConfigHash)
+          }
+        }
         for (let disposable of oldContext.disposables.splice(0)) {
           disposable(oldContext)
         }


### PR DESCRIPTION
This PR ensures that stale contexts are deleted from `configContextMap` when no longer needed.