### PR TITLE
Fix CLI `--purge` option when using commas

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -345,7 +345,7 @@ async function build() {
     let resolvedConfig = resolveConfigInternal(config)
 
     if (args['--purge']) {
-      resolvedConfig.purge = args['--purge'].split(',')
+      resolvedConfig.purge = args['--purge'].split(/(?<!{[^}]+),/)
     }
 
     if (args['--jit']) {


### PR DESCRIPTION
### Example

```js
let input = '**/*.{html,js},foo/bar.html'

input.split(',') // ['**/*.{html', 'js}', 'foo/bar.html']

input.split(/(?<!{[^}]+),/) // ['**/*.{html,js}', 'foo/bar.html']
```