### PR TITLE
Add `blur-none` with intent to deprecate `blur-0`

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -111,6 +111,7 @@ module.exports = {
     },
     blur: {
       0: '0',
+      none: '0',
       sm: '4px',
       DEFAULT: '8px',
       md: '12px',

--- a/tests/fixtures/tailwind-output-flagged.css
+++ b/tests/fixtures/tailwind-output-flagged.css
@@ -29200,6 +29200,10 @@ video {
   --tw-blur: blur(0);
 }
 
+.blur-none {
+  --tw-blur: blur(0);
+}
+
 .blur-sm {
   --tw-blur: blur(4px);
 }
@@ -29434,6 +29438,10 @@ video {
 }
 
 .backdrop-blur-0 {
+  --tw-backdrop-blur: blur(0);
+}
+
+.backdrop-blur-none {
   --tw-backdrop-blur: blur(0);
 }
 
@@ -58414,6 +58422,10 @@ video {
     --tw-blur: blur(0);
   }
 
+  .sm\:blur-none {
+    --tw-blur: blur(0);
+  }
+
   .sm\:blur-sm {
     --tw-blur: blur(4px);
   }
@@ -58648,6 +58660,10 @@ video {
   }
 
   .sm\:backdrop-blur-0 {
+    --tw-backdrop-blur: blur(0);
+  }
+
+  .sm\:backdrop-blur-none {
     --tw-backdrop-blur: blur(0);
   }
 
@@ -87569,6 +87585,10 @@ video {
     --tw-blur: blur(0);
   }
 
+  .md\:blur-none {
+    --tw-blur: blur(0);
+  }
+
   .md\:blur-sm {
     --tw-blur: blur(4px);
   }
@@ -87803,6 +87823,10 @@ video {
   }
 
   .md\:backdrop-blur-0 {
+    --tw-backdrop-blur: blur(0);
+  }
+
+  .md\:backdrop-blur-none {
     --tw-backdrop-blur: blur(0);
   }
 
@@ -116724,6 +116748,10 @@ video {
     --tw-blur: blur(0);
   }
 
+  .lg\:blur-none {
+    --tw-blur: blur(0);
+  }
+
   .lg\:blur-sm {
     --tw-blur: blur(4px);
   }
@@ -116958,6 +116986,10 @@ video {
   }
 
   .lg\:backdrop-blur-0 {
+    --tw-backdrop-blur: blur(0);
+  }
+
+  .lg\:backdrop-blur-none {
     --tw-backdrop-blur: blur(0);
   }
 
@@ -145879,6 +145911,10 @@ video {
     --tw-blur: blur(0);
   }
 
+  .xl\:blur-none {
+    --tw-blur: blur(0);
+  }
+
   .xl\:blur-sm {
     --tw-blur: blur(4px);
   }
@@ -146113,6 +146149,10 @@ video {
   }
 
   .xl\:backdrop-blur-0 {
+    --tw-backdrop-blur: blur(0);
+  }
+
+  .xl\:backdrop-blur-none {
     --tw-backdrop-blur: blur(0);
   }
 
@@ -175034,6 +175074,10 @@ video {
     --tw-blur: blur(0);
   }
 
+  .\32xl\:blur-none {
+    --tw-blur: blur(0);
+  }
+
   .\32xl\:blur-sm {
     --tw-blur: blur(4px);
   }
@@ -175268,6 +175312,10 @@ video {
   }
 
   .\32xl\:backdrop-blur-0 {
+    --tw-backdrop-blur: blur(0);
+  }
+
+  .\32xl\:backdrop-blur-none {
     --tw-backdrop-blur: blur(0);
   }
 

--- a/tests/fixtures/tailwind-output-no-color-opacity.css
+++ b/tests/fixtures/tailwind-output-no-color-opacity.css
@@ -26643,6 +26643,10 @@ video {
   --tw-blur: blur(0);
 }
 
+.blur-none {
+  --tw-blur: blur(0);
+}
+
 .blur-sm {
   --tw-blur: blur(4px);
 }
@@ -26877,6 +26881,10 @@ video {
 }
 
 .backdrop-blur-0 {
+  --tw-backdrop-blur: blur(0);
+}
+
+.backdrop-blur-none {
   --tw-backdrop-blur: blur(0);
 }
 
@@ -53301,6 +53309,10 @@ video {
     --tw-blur: blur(0);
   }
 
+  .sm\:blur-none {
+    --tw-blur: blur(0);
+  }
+
   .sm\:blur-sm {
     --tw-blur: blur(4px);
   }
@@ -53535,6 +53547,10 @@ video {
   }
 
   .sm\:backdrop-blur-0 {
+    --tw-backdrop-blur: blur(0);
+  }
+
+  .sm\:backdrop-blur-none {
     --tw-backdrop-blur: blur(0);
   }
 
@@ -79900,6 +79916,10 @@ video {
     --tw-blur: blur(0);
   }
 
+  .md\:blur-none {
+    --tw-blur: blur(0);
+  }
+
   .md\:blur-sm {
     --tw-blur: blur(4px);
   }
@@ -80134,6 +80154,10 @@ video {
   }
 
   .md\:backdrop-blur-0 {
+    --tw-backdrop-blur: blur(0);
+  }
+
+  .md\:backdrop-blur-none {
     --tw-backdrop-blur: blur(0);
   }
 
@@ -106499,6 +106523,10 @@ video {
     --tw-blur: blur(0);
   }
 
+  .lg\:blur-none {
+    --tw-blur: blur(0);
+  }
+
   .lg\:blur-sm {
     --tw-blur: blur(4px);
   }
@@ -106733,6 +106761,10 @@ video {
   }
 
   .lg\:backdrop-blur-0 {
+    --tw-backdrop-blur: blur(0);
+  }
+
+  .lg\:backdrop-blur-none {
     --tw-backdrop-blur: blur(0);
   }
 
@@ -133098,6 +133130,10 @@ video {
     --tw-blur: blur(0);
   }
 
+  .xl\:blur-none {
+    --tw-blur: blur(0);
+  }
+
   .xl\:blur-sm {
     --tw-blur: blur(4px);
   }
@@ -133332,6 +133368,10 @@ video {
   }
 
   .xl\:backdrop-blur-0 {
+    --tw-backdrop-blur: blur(0);
+  }
+
+  .xl\:backdrop-blur-none {
     --tw-backdrop-blur: blur(0);
   }
 
@@ -159697,6 +159737,10 @@ video {
     --tw-blur: blur(0);
   }
 
+  .\32xl\:blur-none {
+    --tw-blur: blur(0);
+  }
+
   .\32xl\:blur-sm {
     --tw-blur: blur(4px);
   }
@@ -159931,6 +159975,10 @@ video {
   }
 
   .\32xl\:backdrop-blur-0 {
+    --tw-backdrop-blur: blur(0);
+  }
+
+  .\32xl\:backdrop-blur-none {
     --tw-backdrop-blur: blur(0);
   }
 

--- a/tests/fixtures/tailwind-output.css
+++ b/tests/fixtures/tailwind-output.css
@@ -29200,6 +29200,10 @@ video {
   --tw-blur: blur(0);
 }
 
+.blur-none {
+  --tw-blur: blur(0);
+}
+
 .blur-sm {
   --tw-blur: blur(4px);
 }
@@ -29434,6 +29438,10 @@ video {
 }
 
 .backdrop-blur-0 {
+  --tw-backdrop-blur: blur(0);
+}
+
+.backdrop-blur-none {
   --tw-backdrop-blur: blur(0);
 }
 
@@ -58414,6 +58422,10 @@ video {
     --tw-blur: blur(0);
   }
 
+  .sm\:blur-none {
+    --tw-blur: blur(0);
+  }
+
   .sm\:blur-sm {
     --tw-blur: blur(4px);
   }
@@ -58648,6 +58660,10 @@ video {
   }
 
   .sm\:backdrop-blur-0 {
+    --tw-backdrop-blur: blur(0);
+  }
+
+  .sm\:backdrop-blur-none {
     --tw-backdrop-blur: blur(0);
   }
 
@@ -87569,6 +87585,10 @@ video {
     --tw-blur: blur(0);
   }
 
+  .md\:blur-none {
+    --tw-blur: blur(0);
+  }
+
   .md\:blur-sm {
     --tw-blur: blur(4px);
   }
@@ -87803,6 +87823,10 @@ video {
   }
 
   .md\:backdrop-blur-0 {
+    --tw-backdrop-blur: blur(0);
+  }
+
+  .md\:backdrop-blur-none {
     --tw-backdrop-blur: blur(0);
   }
 
@@ -116724,6 +116748,10 @@ video {
     --tw-blur: blur(0);
   }
 
+  .lg\:blur-none {
+    --tw-blur: blur(0);
+  }
+
   .lg\:blur-sm {
     --tw-blur: blur(4px);
   }
@@ -116958,6 +116986,10 @@ video {
   }
 
   .lg\:backdrop-blur-0 {
+    --tw-backdrop-blur: blur(0);
+  }
+
+  .lg\:backdrop-blur-none {
     --tw-backdrop-blur: blur(0);
   }
 
@@ -145879,6 +145911,10 @@ video {
     --tw-blur: blur(0);
   }
 
+  .xl\:blur-none {
+    --tw-blur: blur(0);
+  }
+
   .xl\:blur-sm {
     --tw-blur: blur(4px);
   }
@@ -146113,6 +146149,10 @@ video {
   }
 
   .xl\:backdrop-blur-0 {
+    --tw-backdrop-blur: blur(0);
+  }
+
+  .xl\:backdrop-blur-none {
     --tw-backdrop-blur: blur(0);
   }
 
@@ -175034,6 +175074,10 @@ video {
     --tw-blur: blur(0);
   }
 
+  .\32xl\:blur-none {
+    --tw-blur: blur(0);
+  }
+
   .\32xl\:blur-sm {
     --tw-blur: blur(4px);
   }
@@ -175268,6 +175312,10 @@ video {
   }
 
   .\32xl\:backdrop-blur-0 {
+    --tw-backdrop-blur: blur(0);
+  }
+
+  .\32xl\:backdrop-blur-none {
     --tw-backdrop-blur: blur(0);
   }
 


### PR DESCRIPTION
We always use `none` for other utilities where the values have string names like `sm` for example `shadow-none` and `rounded-none`, but for `blur` I chose `blur-0` for some idiotic reason even though the other values are `blur-sm`, `blur-lg`, etc. Can't have that.