### PR TITLE
Add support for transform, filter, backdrop-filter, box-shadow and ring to pseudo-elements

### DIFF
--- a/src/plugins/backdropFilter.js
+++ b/src/plugins/backdropFilter.js
@@ -2,7 +2,7 @@ export default function () {
   return function ({ config, addBase, addUtilities, variants }) {
     if (config('mode') === 'jit') {
       addBase({
-        '*': {
+        '*, ::before, ::after': {
           '--tw-backdrop-blur': 'var(--tw-empty,/*!*/ /*!*/)',
           '--tw-backdrop-brightness': 'var(--tw-empty,/*!*/ /*!*/)',
           '--tw-backdrop-contrast': 'var(--tw-empty,/*!*/ /*!*/)',

--- a/src/plugins/boxShadow.js
+++ b/src/plugins/boxShadow.js
@@ -2,7 +2,7 @@ import transformThemeValue from '../util/transformThemeValue'
 
 let transformValue = transformThemeValue('boxShadow')
 let shadowReset = {
-  '*': {
+  '*, ::before, ::after': {
     '--tw-shadow': '0 0 #0000',
   },
 }

--- a/src/plugins/filter.js
+++ b/src/plugins/filter.js
@@ -2,7 +2,7 @@ export default function () {
   return function ({ config, addBase, addUtilities, variants }) {
     if (config('mode') === 'jit') {
       addBase({
-        '*': {
+        '*, ::before, ::after': {
           '--tw-blur': 'var(--tw-empty,/*!*/ /*!*/)',
           '--tw-brightness': 'var(--tw-empty,/*!*/ /*!*/)',
           '--tw-contrast': 'var(--tw-empty,/*!*/ /*!*/)',

--- a/src/plugins/ringWidth.js
+++ b/src/plugins/ringWidth.js
@@ -10,7 +10,7 @@ export default function () {
     )
 
     let ringReset = {
-      '*': {
+      '*, ::before, ::after': {
         '--tw-ring-inset': 'var(--tw-empty,/*!*/ /*!*/)',
         '--tw-ring-offset-width': theme('ringOffsetWidth.DEFAULT', '0px'),
         '--tw-ring-offset-color': theme('ringOffsetColor.DEFAULT', '#fff'),

--- a/src/plugins/transform.js
+++ b/src/plugins/transform.js
@@ -2,7 +2,7 @@ export default function () {
   return function ({ config, addBase, addUtilities, variants }) {
     if (config('mode') === 'jit') {
       addBase({
-        '*': {
+        '*, ::before, ::after': {
           '--tw-translate-x': '0',
           '--tw-translate-y': '0',
           '--tw-rotate': '0',

--- a/tests/fixtures/tailwind-output-flagged.css
+++ b/tests/fixtures/tailwind-output-flagged.css
@@ -26299,7 +26299,7 @@ video {
   mix-blend-mode: luminosity;
 }
 
-* {
+*, ::before, ::after {
   --tw-shadow: 0 0 #0000;
 }
 
@@ -26548,7 +26548,7 @@ video {
   outline-offset: 2px;
 }
 
-* {
+*, ::before, ::after {
   --tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
   --tw-ring-offset-width: 0px;
   --tw-ring-offset-color: #fff;

--- a/tests/fixtures/tailwind-output-no-color-opacity.css
+++ b/tests/fixtures/tailwind-output-no-color-opacity.css
@@ -23742,7 +23742,7 @@ video {
   mix-blend-mode: luminosity;
 }
 
-* {
+*, ::before, ::after {
   --tw-shadow: 0 0 #0000;
 }
 
@@ -23991,7 +23991,7 @@ video {
   outline-offset: 2px;
 }
 
-* {
+*, ::before, ::after {
   --tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
   --tw-ring-offset-width: 0px;
   --tw-ring-offset-color: #fff;

--- a/tests/fixtures/tailwind-output.css
+++ b/tests/fixtures/tailwind-output.css
@@ -26299,7 +26299,7 @@ video {
   mix-blend-mode: luminosity;
 }
 
-* {
+*, ::before, ::after {
   --tw-shadow: 0 0 #0000;
 }
 
@@ -26548,7 +26548,7 @@ video {
   outline-offset: 2px;
 }
 
-* {
+*, ::before, ::after {
   --tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
   --tw-ring-offset-width: 0px;
   --tw-ring-offset-color: #fff;

--- a/tests/jit/basic-usage.test.css
+++ b/tests/jit/basic-usage.test.css
@@ -1,4 +1,6 @@
-* {
+*,
+::before,
+::after {
   --tw-translate-x: 0;
   --tw-translate-y: 0;
   --tw-rotate: 0;
@@ -9,14 +11,8 @@
   --tw-transform: translateX(var(--tw-translate-x)) translateY(var(--tw-translate-y))
     rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
     scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-*,
-::before,
-::after {
   --tw-border-opacity: 1;
   border-color: rgba(229, 231, 235, var(--tw-border-opacity));
-}
-* {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
   --tw-ring-offset-width: 0px;

--- a/tests/jit/collapse-adjacent-rules.test.css
+++ b/tests/jit/collapse-adjacent-rules.test.css
@@ -1,4 +1,6 @@
-* {
+*,
+::before,
+::after {
   --tw-translate-x: 0;
   --tw-translate-y: 0;
   --tw-rotate: 0;
@@ -9,14 +11,8 @@
   --tw-transform: translateX(var(--tw-translate-x)) translateY(var(--tw-translate-y))
     rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
     scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-*,
-::before,
-::after {
   --tw-border-opacity: 1;
   border-color: rgba(229, 231, 235, var(--tw-border-opacity));
-}
-* {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
   --tw-ring-offset-width: 0px;

--- a/tests/jit/import-syntax.test.css
+++ b/tests/jit/import-syntax.test.css
@@ -1,4 +1,6 @@
-* {
+*,
+::before,
+::after {
   --tw-translate-x: 0;
   --tw-translate-y: 0;
   --tw-rotate: 0;
@@ -9,14 +11,8 @@
   --tw-transform: translateX(var(--tw-translate-x)) translateY(var(--tw-translate-y))
     rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
     scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-*,
-::before,
-::after {
   --tw-border-opacity: 1;
   border-color: rgba(229, 231, 235, var(--tw-border-opacity));
-}
-* {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
   --tw-ring-offset-width: 0px;

--- a/tests/jit/important-boolean.test.css
+++ b/tests/jit/important-boolean.test.css
@@ -1,4 +1,6 @@
-* {
+*,
+::before,
+::after {
   --tw-translate-x: 0;
   --tw-translate-y: 0;
   --tw-rotate: 0;
@@ -9,14 +11,8 @@
   --tw-transform: translateX(var(--tw-translate-x)) translateY(var(--tw-translate-y))
     rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
     scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-*,
-::before,
-::after {
   --tw-border-opacity: 1;
   border-color: rgba(229, 231, 235, var(--tw-border-opacity));
-}
-* {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
   --tw-ring-offset-width: 0px;

--- a/tests/jit/important-modifier-prefix.test.css
+++ b/tests/jit/important-modifier-prefix.test.css
@@ -1,4 +1,6 @@
-* {
+*,
+::before,
+::after {
   --tw-translate-x: 0;
   --tw-translate-y: 0;
   --tw-rotate: 0;
@@ -9,14 +11,8 @@
   --tw-transform: translateX(var(--tw-translate-x)) translateY(var(--tw-translate-y))
     rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
     scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-*,
-::before,
-::after {
   --tw-border-opacity: 1;
   border-color: rgba(229, 231, 235, var(--tw-border-opacity));
-}
-* {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
   --tw-ring-offset-width: 0px;

--- a/tests/jit/important-modifier.test.css
+++ b/tests/jit/important-modifier.test.css
@@ -1,4 +1,6 @@
-* {
+*,
+::before,
+::after {
   --tw-translate-x: 0;
   --tw-translate-y: 0;
   --tw-rotate: 0;
@@ -9,14 +11,8 @@
   --tw-transform: translateX(var(--tw-translate-x)) translateY(var(--tw-translate-y))
     rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
     scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-*,
-::before,
-::after {
   --tw-border-opacity: 1;
   border-color: rgba(229, 231, 235, var(--tw-border-opacity));
-}
-* {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
   --tw-ring-offset-width: 0px;

--- a/tests/jit/important-selector.test.css
+++ b/tests/jit/important-selector.test.css
@@ -1,4 +1,6 @@
-* {
+*,
+::before,
+::after {
   --tw-translate-x: 0;
   --tw-translate-y: 0;
   --tw-rotate: 0;
@@ -9,14 +11,8 @@
   --tw-transform: translateX(var(--tw-translate-x)) translateY(var(--tw-translate-y))
     rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
     scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-*,
-::before,
-::after {
   --tw-border-opacity: 1;
   border-color: rgba(229, 231, 235, var(--tw-border-opacity));
-}
-* {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
   --tw-ring-offset-width: 0px;

--- a/tests/jit/kitchen-sink.test.css
+++ b/tests/jit/kitchen-sink.test.css
@@ -126,7 +126,9 @@
     }
   }
 }
-* {
+*,
+::before,
+::after {
   --tw-translate-x: 0;
   --tw-translate-y: 0;
   --tw-rotate: 0;
@@ -137,14 +139,8 @@
   --tw-transform: translateX(var(--tw-translate-x)) translateY(var(--tw-translate-y))
     rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
     scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-*,
-::before,
-::after {
   --tw-border-opacity: 1;
   border-color: rgba(229, 231, 235, var(--tw-border-opacity));
-}
-* {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
   --tw-ring-offset-width: 0px;
@@ -291,7 +287,9 @@ div {
 .custom-component {
   background: #123456;
 }
-* {
+*,
+::before,
+::after {
   padding: 5px;
 }
 .foo .bg-black {
@@ -354,7 +352,9 @@ div {
 .custom-util {
   background: #abcdef;
 }
-* {
+*,
+::before,
+::after {
   margin: 10px;
 }
 .first\:pt-0:first-child {

--- a/tests/jit/kitchen-sink.test.js
+++ b/tests/jit/kitchen-sink.test.js
@@ -76,7 +76,9 @@ test('it works', () => {
     .custom-util {
       background: #abcdef;
     }
-    * {
+    *,
+::before,
+::after {
       margin: 10px;
     }
   }
@@ -87,7 +89,9 @@ test('it works', () => {
     .custom-component {
       background: #123456;
     }
-    * {
+    *,
+::before,
+::after {
       padding: 5px;
     }
     .foo .bg-black {

--- a/tests/jit/prefix.test.css
+++ b/tests/jit/prefix.test.css
@@ -1,4 +1,6 @@
-* {
+*,
+::before,
+::after {
   --tw-translate-x: 0;
   --tw-translate-y: 0;
   --tw-rotate: 0;
@@ -9,14 +11,8 @@
   --tw-transform: translateX(var(--tw-translate-x)) translateY(var(--tw-translate-y))
     rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
     scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-*,
-::before,
-::after {
   --tw-border-opacity: 1;
   border-color: rgba(229, 231, 235, var(--tw-border-opacity));
-}
-* {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
   --tw-ring-offset-width: 0px;

--- a/tests/jit/relative-purge-paths.test.css
+++ b/tests/jit/relative-purge-paths.test.css
@@ -1,4 +1,6 @@
-* {
+*,
+::before,
+::after {
   --tw-translate-x: 0;
   --tw-translate-y: 0;
   --tw-rotate: 0;
@@ -9,14 +11,8 @@
   --tw-transform: translateX(var(--tw-translate-x)) translateY(var(--tw-translate-y))
     rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
     scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-*,
-::before,
-::after {
   --tw-border-opacity: 1;
   border-color: rgba(229, 231, 235, var(--tw-border-opacity));
-}
-* {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
   --tw-ring-offset-width: 0px;

--- a/tests/jit/variants.test.css
+++ b/tests/jit/variants.test.css
@@ -1,4 +1,6 @@
-* {
+*,
+::before,
+::after {
   --tw-translate-x: 0;
   --tw-translate-y: 0;
   --tw-rotate: 0;
@@ -9,14 +11,8 @@
   --tw-transform: translateX(var(--tw-translate-x)) translateY(var(--tw-translate-y))
     rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
     scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-*,
-::before,
-::after {
   --tw-border-opacity: 1;
   border-color: rgba(229, 231, 235, var(--tw-border-opacity));
-}
-* {
   --tw-shadow: 0 0 #0000;
   --tw-ring-inset: var(--tw-empty, /*!*/ /*!*/);
   --tw-ring-offset-width: 0px;


### PR DESCRIPTION
This PR ensures that the `before` and `after` pseudo-elements work with filters, backdrop-filters, transforms, and shadows in the JIT engine by updating the universal base rule for those plugins to include `::before` and `::after`.

I considered updating all of this stuff to include other pseudo-elements like `first-letter`, `first-line`, etc., but those pseudo-elements don't actually support that many CSS properties and I kind of expect it's going to be a long time before someone is building something that needs support for that and actually bumps into it not working. Will wait for a proper motivating example before getting carried away.