### PR TITLE
Add `[open]` variant

### DIFF
--- a/src/jit/corePlugins.js
+++ b/src/jit/corePlugins.js
@@ -211,6 +211,17 @@ export default {
       )
     }
   },
+  booleanAttributeVariants: function ({ addVariant }) {
+    let booleanAttributeVariants = ['open']
+
+    for (let variant of booleanAttributeVariants) {
+      addVariant(variant, ({ config, modifySelectors }) => {
+        modifySelectors(({ className }) => {
+          return `.${e(`${variant}${config('separator')}${className}`)}[${variant}]`
+        })
+      })
+    }
+  },
   directionVariants: function ({ config, addVariant }) {
     addVariant(
       'ltr',

--- a/src/jit/lib/setupContextUtils.js
+++ b/src/jit/lib/setupContextUtils.js
@@ -404,7 +404,11 @@ function resolvePlugins(context, tailwindDirectives, root) {
 
   // TODO: This is a workaround for backwards compatibility, since custom variants
   // were historically sorted before screen/stackable variants.
-  let beforeVariants = [corePlugins['pseudoElementVariants'], corePlugins['pseudoClassVariants']]
+  let beforeVariants = [
+    corePlugins['pseudoElementVariants'],
+    corePlugins['pseudoClassVariants'],
+    corePlugins['booleanAttributeVariants'],
+  ]
   let afterVariants = [
     corePlugins['directionVariants'],
     corePlugins['reducedMotionVariants'],

--- a/tests/variantsAtRule.test.js
+++ b/tests/variantsAtRule.test.js
@@ -590,6 +590,27 @@ test('it can generate read-only variants', () => {
   })
 })
 
+test('it can generate open variants', () => {
+  const input = `
+    @variants open {
+      .banana { color: yellow; }
+      .chocolate { color: brown; }
+    }
+  `
+
+  const output = `
+    .banana { color: yellow; }
+    .chocolate { color: brown; }
+    .open\\:banana[open] { color: yellow; }
+    .open\\:chocolate[open] { color: brown; }
+  `
+
+  return run(input).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('it can generate hover, active and focus variants for multiple classes in one rule', () => {
   const input = `
     @variants hover, focus, active {


### PR DESCRIPTION
The `[open]` pseudo-selector can be used to style an element that
declares the `[open]` attribute (like `<details>` or `<dialog>`).

For example:

```html
<details class="border-0 open:border-1" open>
  <!-- ... -->
</details>

<details class="border-0 open:border-1">
  <!-- ... -->
</details>
```

The first `<details>` element is expanded, and so the `open:` variant
will be active (i.e. `border-1`), and the second element's will be
inactive (i.e. `border-0`).

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
