### PR TITLE
Improve production build performance for the case of many small non-tailwind stylesheets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
-        "@fullhuman/postcss-purgecss": "^4.0.3",
         "arg": "^5.0.0",
         "bytes": "^3.0.0",
         "chalk": "^4.1.1",
@@ -36,6 +35,7 @@
         "postcss-selector-parser": "^6.0.6",
         "postcss-value-parser": "^4.1.0",
         "pretty-hrtime": "^1.0.3",
+        "purgecss": "^4.0.3",
         "quick-lru": "^5.1.1",
         "reduce-css-calc": "^2.1.8",
         "resolve": "^1.20.0"
@@ -1502,17 +1502,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@fullhuman/postcss-purgecss": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-4.0.3.tgz",
-      "integrity": "sha512-/EnQ9UDWGGqHkn1UKAwSgh+gJHPKmD+Z+5dQ4gWT4qq2NUyez3zqAfZNwFH3eSgmgO+wjTXfhlLchx2M9/K+7Q==",
-      "dependencies": {
-        "purgecss": "^4.0.3"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -11337,14 +11326,6 @@
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
         }
-      }
-    },
-    "@fullhuman/postcss-purgecss": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-4.0.3.tgz",
-      "integrity": "sha512-/EnQ9UDWGGqHkn1UKAwSgh+gJHPKmD+Z+5dQ4gWT4qq2NUyez3zqAfZNwFH3eSgmgO+wjTXfhlLchx2M9/K+7Q==",
-      "requires": {
-        "purgecss": "^4.0.3"
       }
     },
     "@istanbuljs/load-nyc-config": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "postcss": "^8.0.9"
   },
   "dependencies": {
-    "@fullhuman/postcss-purgecss": "^4.0.3",
+    "purgecss": "^4.0.3",
     "arg": "^5.0.0",
     "bytes": "^3.0.0",
     "chalk": "^4.1.1",

--- a/package.postcss7.json
+++ b/package.postcss7.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@fullhuman/postcss-purgecss": "^3.1.3",
+    "purgecss": "^4.0.3",
     "autoprefixer": "^9",
     "postcss": "^7",
     "postcss-functions": "^3",

--- a/src/lib/purgeUnusedStyles.js
+++ b/src/lib/purgeUnusedStyles.js
@@ -205,6 +205,10 @@ export default function purgeUnusedUtilities(
         safelist: standardizeSafelist(purgeOptions.safelist),
       }
 
+      if (purgeCSS.options.variables) {
+        purgeCSS.variablesStructure.safelist = purgeCSS.options.safelist.variables || []
+      }
+
       const fileFormatContents = content.filter((o) => typeof o === 'string')
       const rawFormatContents = content.filter((o) => typeof o === 'object')
 

--- a/tests/purgeUnusedStyles.test.js
+++ b/tests/purgeUnusedStyles.test.js
@@ -639,6 +639,67 @@ test(
   })
 )
 
+test('purges unused css variables in "all" mode', () => {
+  return inProduction(
+    suppressConsoleLogs(() => {
+      return postcss([
+        tailwind({
+          ...config,
+          purge: {
+            mode: 'all',
+            content: [path.resolve(`${__dirname}/fixtures/**/*.html`)],
+            options: {
+              variables: true,
+            },
+          },
+        }),
+      ])
+        .process(
+          `
+        :root {
+          --unused-var: 1;
+        }
+        `
+        )
+        .then((result) => {
+          expect(result.css).not.toContain('--unused-var')
+        })
+    })
+  )
+})
+
+test('respects safelist.variables in "all" mode', () => {
+  return inProduction(
+    suppressConsoleLogs(() => {
+      return postcss([
+        tailwind({
+          ...config,
+          purge: {
+            mode: 'all',
+            content: [path.resolve(`${__dirname}/fixtures/**/*.html`)],
+            options: {
+              variables: true,
+              safelist: {
+                variables: ['--unused-var'],
+              },
+            },
+          },
+        }),
+      ])
+        .process(
+          `
+        :root {
+          --unused-var: 1;
+        }
+        `
+        )
+        .then((result) => {
+          expect(result.css).toContain('--unused-var')
+        })
+    })
+  )
+})
+
 test('element selectors are preserved by default', () => {
   return inProduction(
     suppressConsoleLogs(() => {


### PR DESCRIPTION
Hi there!
We decided to use tailwind as a base of our design system. Our codebase is legacy-ish Vue 2 SPA with pretty liberal use of `<style>` blocks in our components, built with webpack (this info will be important later). Tailwind worked great and was delightful to work with. That is, until we got to production build part. 

Turns out, just adding tailwind to our postcss plugins list added a couple of minutes to our build times. Actual usage did not seem to matter: commenting out every `@apply` and `@tailwind` rule did not seem to change anything: build with tailwind plugin included still was couple of minutes slower than without it. Further investigation pointed out at `purge` option as the culprit. Removing it seemed to bring out build times in line with what we expected, but we'd very much like to keep it. Of course, purging unused styles takes time, but minutes still seemed excessive, especially considering that `tailwind-cli` with the same config successfully generates the stylesheet in a couple of seconds.

As it turns out, tailwind plugin runs purgecss on every source stylesheet. Which, in case of legacy-ish code base with a lot of tiny stylesheets, is quite a lot. Sure, if said file does not have `@tailwind` directive, it will get wrapped in `purgecss ignore` block, but extraction of used rules from html and js will still be done from scratch for every one of those tiny stylesheets.

This PR changes the plugin to completely skip `purgecss` in `layers` mode if the source file did not include any tailwind layers. For that, I had to switch from `postcss-purgecss` plugin to calling `purgecss` manually — it does not seem like there is a way to decorate `postcss-purgecss` plugin to call it conditionally for both PostCSS 7 and 8. I guess, the upside of this is that latest purgecss could also be used in compat build. 

Some benchmarks of this PR on our codebase:
Before: `pnpm build  421.86s user 29.51s system 169% cpu 4:25.98 total`
After: `pnpm build  285.95s user 16.38s system 214% cpu 2:21.21 total`

As you can see, it saves 2 minutes for us. It might be also very useful for other people in similar situations: integrating tailwind into existing codebase with modularized css.  
