### PR TITLE
Resolve purge paths relative to the current working directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve animation value parsing ([#4250](https://github.com/tailwindlabs/tailwindcss/pull/4250))
 - Ignore unknown object types when hashing config ([82f4eaa](https://github.com/tailwindlabs/tailwindcss/commit/82f4eaa6832ef8a4e3fd90869e7068efdf6e34f2))
 - Ensure variants are grouped properly for plugins with order-dependent utilities ([#4273](https://github.com/tailwindlabs/tailwindcss/pull/4273))
-- Resolve purge paths relative to `tailwind.config.js` instead of the current working directory ([#4214](https://github.com/tailwindlabs/tailwindcss/pull/4214))
 - JIT: Fix temp file storage when node temp directories are kept on a different drive than the project itself ([#4044](https://github.com/tailwindlabs/tailwindcss/pull/4044))
 - Support border-opacity utilities alongside default `border` utility ([#4277](https://github.com/tailwindlabs/tailwindcss/pull/4277))
 - JIT: Fix source maps for expanded `@tailwind` directives ([2f15411](https://github.com/tailwindlabs/tailwindcss/commit/2f1541123dea29d8a2ab0f1411bf60c79eeb96b4))

--- a/src/index.js
+++ b/src/index.js
@@ -92,7 +92,7 @@ module.exports = function tailwindcss(config) {
 
   return {
     postcssPlugin: 'tailwindcss',
-    plugins: [...plugins, processTailwindFeatures(getConfig, resolvedConfigPath), formatCSS],
+    plugins: [...plugins, processTailwindFeatures(getConfig), formatCSS],
   }
 }
 

--- a/src/jit/lib/setupTrackingContext.js
+++ b/src/jit/lib/setupTrackingContext.js
@@ -21,7 +21,7 @@ let configPathCache = new LRU({ maxSize: 100 })
 
 let candidateFilesCache = new WeakMap()
 
-function getCandidateFiles(context, userConfigPath, tailwindConfig) {
+function getCandidateFiles(context, tailwindConfig) {
   if (candidateFilesCache.has(context)) {
     return candidateFilesCache.get(context)
   }
@@ -30,10 +30,9 @@ function getCandidateFiles(context, userConfigPath, tailwindConfig) {
     ? tailwindConfig.purge
     : tailwindConfig.purge.content
 
-  let basePath = userConfigPath === null ? process.cwd() : path.dirname(userConfigPath)
   let candidateFiles = purgeContent
     .filter((item) => typeof item === 'string')
-    .map((purgePath) => normalizePath(path.resolve(basePath, purgePath)))
+    .map((purgePath) => normalizePath(path.resolve(purgePath)))
 
   return candidateFilesCache.set(context, candidateFiles).get(context)
 }
@@ -172,7 +171,7 @@ export default function setupTrackingContext(configOrPath) {
         contextDependencies
       )
 
-      let candidateFiles = getCandidateFiles(context, userConfigPath, tailwindConfig)
+      let candidateFiles = getCandidateFiles(context, tailwindConfig)
 
       // If there are no @tailwind rules, we don't consider this CSS file or it's dependencies
       // to be dependencies of the context. Can reuse the context even if they change.

--- a/src/jit/lib/setupWatchingContext.js
+++ b/src/jit/lib/setupWatchingContext.js
@@ -142,7 +142,7 @@ function getConfigDependencies(context) {
 
 let candidateFilesCache = new WeakMap()
 
-function getCandidateFiles(context, userConfigPath, tailwindConfig) {
+function getCandidateFiles(context, tailwindConfig) {
   if (candidateFilesCache.has(context)) {
     return candidateFilesCache.get(context)
   }
@@ -151,10 +151,9 @@ function getCandidateFiles(context, userConfigPath, tailwindConfig) {
     ? tailwindConfig.purge
     : tailwindConfig.purge.content
 
-  let basePath = userConfigPath === null ? process.cwd() : path.dirname(userConfigPath)
   let candidateFiles = purgeContent
     .filter((item) => typeof item === 'string')
-    .map((purgePath) => normalizePath(path.resolve(basePath, purgePath)))
+    .map((purgePath) => normalizePath(path.resolve(purgePath)))
 
   return candidateFilesCache.set(context, candidateFiles).get(context)
 }
@@ -282,7 +281,7 @@ export default function setupWatchingContext(configOrPath) {
         contextDependencies
       )
 
-      let candidateFiles = getCandidateFiles(context, userConfigPath, tailwindConfig)
+      let candidateFiles = getCandidateFiles(context, tailwindConfig)
       let contextConfigDependencies = getConfigDependencies(context)
 
       for (let file of configDependencies) {

--- a/src/lib/purgeUnusedStyles.js
+++ b/src/lib/purgeUnusedStyles.js
@@ -48,12 +48,7 @@ function getTransformer(config, fileExtension) {
   return transformers[fileExtension] || transformers.DEFAULT || ((content) => content)
 }
 
-export default function purgeUnusedUtilities(
-  config,
-  configChanged,
-  resolvedConfigPath,
-  registerDependency
-) {
+export default function purgeUnusedUtilities(config, configChanged, registerDependency) {
   const purgeEnabled = _.get(
     config,
     'purge.enabled',
@@ -130,9 +125,7 @@ export default function purgeUnusedUtilities(
     Array.isArray(config.purge) ? config.purge : config.purge.content || purgeOptions.content || []
   ).map((item) => {
     if (typeof item === 'string') {
-      return normalizePath(
-        path.resolve(resolvedConfigPath ? path.dirname(resolvedConfigPath) : process.cwd(), item)
-      )
+      return normalizePath(path.resolve(item))
     }
     return item
   })

--- a/src/processTailwindFeatures.js
+++ b/src/processTailwindFeatures.js
@@ -24,7 +24,7 @@ let previousConfig = null
 let processedPlugins = null
 let getProcessedPlugins = null
 
-export default function (getConfig, resolvedConfigPath) {
+export default function (getConfig) {
   return function (css, result) {
     const config = getConfig()
     const configChanged = hash(previousConfig) !== hash(config)
@@ -73,7 +73,7 @@ export default function (getConfig, resolvedConfigPath) {
       substituteScreenAtRules({ tailwindConfig: config }),
       substituteClassApplyAtRules(config, getProcessedPlugins, configChanged),
       applyImportantConfiguration(config),
-      purgeUnusedStyles(config, configChanged, resolvedConfigPath, registerDependency),
+      purgeUnusedStyles(config, configChanged, registerDependency),
     ]).process(css, { from: _.get(css, 'source.input.file') })
   }
 }

--- a/tests/fixtures/custom-purge-config.js
+++ b/tests/fixtures/custom-purge-config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  purge: ['./*.html'],
+  purge: ['./tests/fixtures/*.html'],
   theme: {
     extend: {
       colors: {

--- a/tests/jit/relative-purge-paths.config.js
+++ b/tests/jit/relative-purge-paths.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-  mode: 'jit',
-  purge: ['./tests/jit/relative-purge-paths.test.html'],
-  corePlugins: { preflight: false },
-  theme: {},
-  plugins: [],
-}

--- a/tests/jit/relative-purge-paths.config.js
+++ b/tests/jit/relative-purge-paths.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   mode: 'jit',
-  purge: ['./relative-purge-paths.test.html'],
+  purge: ['./tests/jit/relative-purge-paths.test.html'],
   corePlugins: { preflight: false },
   theme: {},
   plugins: [],

--- a/tests/jit/relative-purge-paths.test.js
+++ b/tests/jit/relative-purge-paths.test.js
@@ -10,13 +10,21 @@ function run(input, config = {}) {
 }
 
 test('relative purge paths', () => {
+  let config = {
+    purge: ['./tests/jit/relative-purge-paths.test.html'],
+    mode: 'jit',
+    corePlugins: { preflight: false },
+    theme: {},
+    plugins: [],
+  }
+
   let css = `
     @tailwind base;
     @tailwind components;
     @tailwind utilities;
   `
 
-  return run(css, path.resolve(__dirname, './relative-purge-paths.config.js')).then((result) => {
+  return run(css, config).then((result) => {
     let expectedPath = path.resolve(__dirname, './relative-purge-paths.test.css')
     let expected = fs.readFileSync(expectedPath, 'utf8')
 

--- a/tests/purgeUnusedStyles.test.js
+++ b/tests/purgeUnusedStyles.test.js
@@ -105,7 +105,7 @@ test('purges unused classes', () => {
   )
 })
 
-test('purge patterns are resolved relative to the config file', () => {
+test('purge patterns are resolved relative to the current working directory', () => {
   return inProduction(
     suppressConsoleLogs(() => {
       const inputPath = path.resolve(`${__dirname}/fixtures/tailwind-input.css`)


### PR DESCRIPTION
Part of #4214 made it so that purge paths are resolved relative to the Tailwind config file. This PR makes it so that purge paths are resolved relative to the current working directory (CWD) instead. **Resolving relative to the CWD was the original behaviour, and the current behaviour of the latest stable release (`v2.1.4`).** The alternative behaviour has only existed in `canary` releases.