### PR TITLE
Use `purge.options.safelist` as a fallback in JIT mode

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -434,7 +434,17 @@ async function build() {
     let content = Array.isArray(config.purge) ? config.purge : config.purge.content
 
     return content.concat(
-      (config.purge?.safelist ?? []).map((content) => {
+      (() => {
+        if (config.purge?.safelist) {
+          return config.purge.safelist
+        }
+
+        if (Array.isArray(config.purge?.options?.safelist)) {
+          return config.purge.options.safelist
+        }
+
+        return []
+      })().map((content) => {
         if (typeof content === 'string') {
           return { raw: content, extension: 'html' }
         }

--- a/src/jit/lib/setupTrackingContext.js
+++ b/src/jit/lib/setupTrackingContext.js
@@ -88,7 +88,17 @@ function resolvedChangedContent(context, candidateFiles, fileModifiedMap) {
   )
     .filter((item) => typeof item.raw === 'string')
     .concat(
-      (context.tailwindConfig.purge?.safelist ?? []).map((content) => {
+      (() => {
+        if (context.tailwindConfig.purge?.safelist) {
+          return context.tailwindConfig.purge.safelist
+        }
+
+        if (Array.isArray(context.tailwindConfig.purge?.options?.safelist)) {
+          return context.tailwindConfig.purge.options.safelist
+        }
+
+        return []
+      })().map((content) => {
         if (typeof content === 'string') {
           return { raw: content, extension: 'html' }
         }

--- a/src/jit/lib/setupWatchingContext.js
+++ b/src/jit/lib/setupWatchingContext.js
@@ -196,7 +196,17 @@ function resolvedChangedContent(context, candidateFiles) {
   )
     .filter((item) => typeof item.raw === 'string')
     .concat(
-      (context.tailwindConfig.purge?.safelist ?? []).map((content) => {
+      (() => {
+        if (context.tailwindConfig.purge?.safelist) {
+          return context.tailwindConfig.purge.safelist
+        }
+
+        if (Array.isArray(context.tailwindConfig.purge?.options?.safelist)) {
+          return context.tailwindConfig.purge.options.safelist
+        }
+
+        return []
+      })().map((content) => {
         if (typeof content === 'string') {
           return { raw: content, extension: 'html' }
         }


### PR DESCRIPTION
Currently, for AOT mode you can use the following:

- purge.safelist
- purge.options.safelist

But for JIT mode, you can only use:

- purge.safelist

This commit will ensure that you can use these in both cases:

- purge.safelist
- purge.options.safelist

This should make transitioning to JIT a little bit smoother.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
