### PR TITLE
Add support for PurgeCSS contentFunction

### DIFF
--- a/src/jit/lib/setupWatchingContext.js
+++ b/src/jit/lib/setupWatchingContext.js
@@ -10,6 +10,7 @@ import normalizePath from 'normalize-path'
 import hash from '../../util/hashConfig'
 import log from '../../util/log'
 import getModuleDependencies from '../../lib/getModuleDependencies'
+import getPurgeContent from '../../lib/getPurgeContent'
 import resolveConfig from '../../../resolveConfig'
 import resolveConfigPath from '../../util/resolveConfigPath'
 import { getContext } from './setupContextUtils'
@@ -142,16 +143,12 @@ function getConfigDependencies(context) {
 
 let candidateFilesCache = new WeakMap()
 
-function getCandidateFiles(context, tailwindConfig) {
+function getCandidateFiles(context, tailwindConfig, root) {
   if (candidateFilesCache.has(context)) {
     return candidateFilesCache.get(context)
   }
 
-  let purgeContent = Array.isArray(tailwindConfig.purge)
-    ? tailwindConfig.purge
-    : tailwindConfig.purge.content
-
-  let candidateFiles = purgeContent
+  let candidateFiles = getPurgeContent(tailwindConfig, root)
     .filter((item) => typeof item === 'string')
     .map((purgePath) => normalizePath(path.resolve(purgePath)))
 
@@ -188,12 +185,8 @@ function getTailwindConfig(configOrPath) {
   return [newConfig, null, hash(newConfig), [userConfigPath]]
 }
 
-function resolvedChangedContent(context, candidateFiles) {
-  let changedContent = (
-    Array.isArray(context.tailwindConfig.purge)
-      ? context.tailwindConfig.purge
-      : context.tailwindConfig.purge.content
-  )
+function resolvedChangedContent(context, root, candidateFiles) {
+  let changedContent = getPurgeContent(context.tailwindConfig, root)
     .filter((item) => typeof item.raw === 'string')
     .concat(
       (context.tailwindConfig.purge?.safelist ?? []).map((content) => {
@@ -281,7 +274,7 @@ export default function setupWatchingContext(configOrPath) {
         contextDependencies
       )
 
-      let candidateFiles = getCandidateFiles(context, tailwindConfig)
+      let candidateFiles = getCandidateFiles(context, tailwindConfig, root)
       let contextConfigDependencies = getConfigDependencies(context)
 
       for (let file of configDependencies) {
@@ -319,7 +312,7 @@ export default function setupWatchingContext(configOrPath) {
       }
 
       if (tailwindDirectives.size > 0) {
-        for (let changedContent of resolvedChangedContent(context, candidateFiles)) {
+        for (let changedContent of resolvedChangedContent(context, root, candidateFiles)) {
           context.changedContent.push(changedContent)
         }
       }

--- a/src/lib/getPurgeContent.js
+++ b/src/lib/getPurgeContent.js
@@ -1,0 +1,7 @@
+export default function getPurgeContent(tailwindConfig, root) {
+  if (typeof tailwindConfig.purge?.options?.contentFunction === 'function') {
+    return tailwindConfig.purge.options.contentFunction(root.source.input.file)
+  }
+
+  return Array.isArray(tailwindConfig.purge) ? tailwindConfig.purge : tailwindConfig.purge.content
+}


### PR DESCRIPTION
PurgeCSS plugin allows to specify **contentFunction** in [options](https://purgecss.com/plugins/postcss.html#options) as an alternative for default **content** option.
It can be used to return different content paths for every processed CSS file.
This is a really useful feature for projects with a more modular approach to further reduce the size of the production build.

This PR aims to close the gap between AOT and JIT modes by adding **contentFunction** support to the latter.