### PR TITLE
Ensure CLI keeps running on error

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -705,6 +705,13 @@ async function build() {
             let end = process.hrtime.bigint()
             console.error('Done in', (end - start) / BigInt(1e6) + 'ms.')
           })
+          .catch((err) => {
+            if (err.name === 'CssSyntaxError') {
+              console.error(err.toString())
+            } else {
+              console.error(err)
+            }
+          })
       }
 
       let css = input


### PR DESCRIPTION
When the new CLI was in watch mode, the full process would stop when encountering an issue of some sorts.
Now we will ensure that we print the error and keep the process running.

Before:
<img width="1374" alt="My terminal showing a crashed CLI with a rather 'ugly' representation of the error" src="https://user-images.githubusercontent.com/1834413/122561522-42ad3a80-d042-11eb-9305-25dc2426294b.png">

After:
<img width="1330" alt="My terminal showing a 'pretty' error representation, but more importantly the CLI keeps running" src="https://user-images.githubusercontent.com/1834413/122561417-1ee9f480-d042-11eb-8024-6b6d4a2140af.png">
