### PR TITLE
Error when dash is used as custom separator

### DIFF
--- a/src/jit/processTailwindFeatures.js
+++ b/src/jit/processTailwindFeatures.js
@@ -35,6 +35,12 @@ export default function processTailwindFeatures(setupContext) {
       },
     })(root, result)
 
+    if (context.tailwindConfig.separator === '-') {
+      throw new Error(
+        "The '-' character cannot be used as a custom separator in JIT mode due to parsing ambiguity. Please use another character like '_' instead."
+      )
+    }
+
     expandTailwindAtRules(context)(root, result)
     expandApplyAtRules(context)(root, result)
     evaluateTailwindFunctions(context)(root, result)

--- a/tests/jit/custom-separator.test.js
+++ b/tests/jit/custom-separator.test.js
@@ -29,3 +29,21 @@ test('custom separator', () => {
     expect(result.css).toMatchFormattedCss(expected)
   })
 })
+
+test('dash is not supported', () => {
+  let config = {
+    darkMode: 'class',
+    mode: 'jit',
+    purge: [{ raw: 'lg-hover-font-bold' }],
+    separator: '-',
+    corePlugins: {},
+    theme: {},
+    plugins: [],
+  }
+
+  let css = `@tailwind utilities`
+
+  return expect(run(css, config)).rejects.toThrowError(
+    "The '-' character cannot be used as a custom separator in JIT mode due to parsing ambiguity. Please use another character like '_' instead."
+  )
+})


### PR DESCRIPTION
Right now using a dash as a custom separator causes a bunch of errors because it's extremely difficult if not impossible to handle properly.

This PR throws an explicit error so the user has some idea what's actually going wrong, instead of having to Google around for other cryptic errors to figure out what the real source of the problem is.

If we can support this one day then we can get rid of this exception, but until we can actually support it it seems much better to error explicitly.