### PR TITLE
Change text-lg line-height to `1.625rem`

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -271,7 +271,7 @@ module.exports = {
       xs: ['0.75rem', { lineHeight: '1rem' }],
       sm: ['0.875rem', { lineHeight: '1.25rem' }],
       base: ['1rem', { lineHeight: '1.5rem' }],
-      lg: ['1.125rem', { lineHeight: '1.75rem' }],
+      lg: ['1.125rem', { lineHeight: '1.625rem' }],
       xl: ['1.25rem', { lineHeight: '1.75rem' }],
       '2xl': ['1.5rem', { lineHeight: '2rem' }],
       '3xl': ['1.875rem', { lineHeight: '2.25rem' }],

--- a/tests/fixtures/tailwind-output-flagged.css
+++ b/tests/fixtures/tailwind-output-flagged.css
@@ -22222,7 +22222,7 @@ video {
 
 .text-lg {
   font-size: 1.125rem;
-  line-height: 1.75rem;
+  line-height: 1.625rem;
 }
 
 .text-xl {
@@ -51457,7 +51457,7 @@ video {
 
   .sm\:text-lg {
     font-size: 1.125rem;
-    line-height: 1.75rem;
+    line-height: 1.625rem;
   }
 
   .sm\:text-xl {
@@ -80620,7 +80620,7 @@ video {
 
   .md\:text-lg {
     font-size: 1.125rem;
-    line-height: 1.75rem;
+    line-height: 1.625rem;
   }
 
   .md\:text-xl {
@@ -109783,7 +109783,7 @@ video {
 
   .lg\:text-lg {
     font-size: 1.125rem;
-    line-height: 1.75rem;
+    line-height: 1.625rem;
   }
 
   .lg\:text-xl {
@@ -138946,7 +138946,7 @@ video {
 
   .xl\:text-lg {
     font-size: 1.125rem;
-    line-height: 1.75rem;
+    line-height: 1.625rem;
   }
 
   .xl\:text-xl {
@@ -168109,7 +168109,7 @@ video {
 
   .\32xl\:text-lg {
     font-size: 1.125rem;
-    line-height: 1.75rem;
+    line-height: 1.625rem;
   }
 
   .\32xl\:text-xl {

--- a/tests/fixtures/tailwind-output-no-color-opacity.css
+++ b/tests/fixtures/tailwind-output-no-color-opacity.css
@@ -20659,7 +20659,7 @@ video {
 
 .text-lg {
   font-size: 1.125rem;
-  line-height: 1.75rem;
+  line-height: 1.625rem;
 }
 
 .text-xl {
@@ -47338,7 +47338,7 @@ video {
 
   .sm\:text-lg {
     font-size: 1.125rem;
-    line-height: 1.75rem;
+    line-height: 1.625rem;
   }
 
   .sm\:text-xl {
@@ -73945,7 +73945,7 @@ video {
 
   .md\:text-lg {
     font-size: 1.125rem;
-    line-height: 1.75rem;
+    line-height: 1.625rem;
   }
 
   .md\:text-xl {
@@ -100552,7 +100552,7 @@ video {
 
   .lg\:text-lg {
     font-size: 1.125rem;
-    line-height: 1.75rem;
+    line-height: 1.625rem;
   }
 
   .lg\:text-xl {
@@ -127159,7 +127159,7 @@ video {
 
   .xl\:text-lg {
     font-size: 1.125rem;
-    line-height: 1.75rem;
+    line-height: 1.625rem;
   }
 
   .xl\:text-xl {
@@ -153766,7 +153766,7 @@ video {
 
   .\32xl\:text-lg {
     font-size: 1.125rem;
-    line-height: 1.75rem;
+    line-height: 1.625rem;
   }
 
   .\32xl\:text-xl {

--- a/tests/fixtures/tailwind-output.css
+++ b/tests/fixtures/tailwind-output.css
@@ -22222,7 +22222,7 @@ video {
 
 .text-lg {
   font-size: 1.125rem;
-  line-height: 1.75rem;
+  line-height: 1.625rem;
 }
 
 .text-xl {
@@ -51457,7 +51457,7 @@ video {
 
   .sm\:text-lg {
     font-size: 1.125rem;
-    line-height: 1.75rem;
+    line-height: 1.625rem;
   }
 
   .sm\:text-xl {
@@ -80620,7 +80620,7 @@ video {
 
   .md\:text-lg {
     font-size: 1.125rem;
-    line-height: 1.75rem;
+    line-height: 1.625rem;
   }
 
   .md\:text-xl {
@@ -109783,7 +109783,7 @@ video {
 
   .lg\:text-lg {
     font-size: 1.125rem;
-    line-height: 1.75rem;
+    line-height: 1.625rem;
   }
 
   .lg\:text-xl {
@@ -138946,7 +138946,7 @@ video {
 
   .xl\:text-lg {
     font-size: 1.125rem;
-    line-height: 1.75rem;
+    line-height: 1.625rem;
   }
 
   .xl\:text-xl {
@@ -168109,7 +168109,7 @@ video {
 
   .\32xl\:text-lg {
     font-size: 1.125rem;
-    line-height: 1.75rem;
+    line-height: 1.625rem;
   }
 
   .\32xl\:text-xl {

--- a/tests/jit/variants.test.css
+++ b/tests/jit/variants.test.css
@@ -62,7 +62,7 @@
 }
 .marker\:text-lg *::marker {
   font-size: 1.125rem;
-  line-height: 1.75rem;
+  line-height: 1.625rem;
 }
 .marker\:text-red-500 *::marker {
   --tw-text-opacity: 1;
@@ -70,7 +70,7 @@
 }
 .marker\:text-lg::marker {
   font-size: 1.125rem;
-  line-height: 1.75rem;
+  line-height: 1.625rem;
 }
 .marker\:text-red-500::marker {
   --tw-text-opacity: 1;


### PR DESCRIPTION
Howdy!

I noticed the `line-height` of `.text-lg` is quite large compared to the sibling font sizes:

![image](https://user-images.githubusercontent.com/11559216/122671091-5c2abf80-d1c5-11eb-9ad9-8ea9a756f68c.png)


This is also noticable if you plot the font-size vs line-height (red dot seems to be off the visual swirl):

![Line height versus Font size (4)](https://user-images.githubusercontent.com/11559216/122671344-67cab600-d1c6-11eb-85f8-4f526241a2f4.png)

By setting the line height to `1.625rem`, the line height feels more natural:

![image](https://user-images.githubusercontent.com/11559216/122671110-6f3d8f80-d1c5-11eb-9ebc-df45c0e0b90c.png)

![Line height versus Font size (3)](https://user-images.githubusercontent.com/11559216/122671294-3356fa00-d1c6-11eb-997d-ef3b826bebd6.png)

What do you think?
