### PR TITLE
Generate plugin list file

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@
 /peers
 /tests/fixtures/cli-utils.js
 /stubs/*
+/src/corePluginList.js

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ yarn-error.log
 
 # Perf related files
 isolate*.log
+
+# Generated files
+/src/corePluginList.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "tailwindcss",
       "version": "2.2.2",
       "license": "MIT",
       "dependencies": {
@@ -11873,7 +11872,8 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/aspect-ratio/-/aspect-ratio-0.2.1.tgz",
       "integrity": "sha512-aDFi80aHQ3JM3symJ5iKU70lm151ugIGFCI0yRZGpyjgQSDS+Fbe93QwypC1tCEllQE8p0S7TUu20ih1b9IKLA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -12030,7 +12030,8 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-node": {
       "version": "1.8.2",
@@ -13031,7 +13032,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-2.0.1.tgz",
       "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "csso": {
       "version": "4.2.0",
@@ -13513,7 +13515,8 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
       "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-prettier": {
       "version": "3.4.0",
@@ -15149,7 +15152,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "27.0.1",
@@ -16368,25 +16372,29 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
       "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-duplicates": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz",
       "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz",
       "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz",
       "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-js": {
       "version": "3.0.3",
@@ -16485,7 +16493,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz",
       "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "5.0.1",
@@ -18073,7 +18082,8 @@
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
       "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
   "packages": {
     "": {
       "version": "2.2.2",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@fullhuman/postcss-purgecss": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "postbabelify": "ncc build lib/cli-peer-dependencies.js -o peers",
     "rebuild-fixtures": "npm run babelify && babel-node scripts/rebuildFixtures.js",
     "prepublishOnly": "npm install --force && npm run babelify && babel-node scripts/build.js && node scripts/build-plugins.js",
+    "prepare": "babel-node scripts/create-plugin-list.js",
     "style": "eslint .",
     "test": "cross-env TAILWIND_MODE=build jest",
     "test:integrations": "npm run test --prefix ./integrations",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "style": "eslint .",
     "test": "cross-env TAILWIND_MODE=build jest",
     "test:integrations": "npm run test --prefix ./integrations",
-    "install": "npm run generate:plugin-list",
+    "postinstall": "npm run generate:plugin-list",
     "install:integrations": "node scripts/install-integrations.js",
     "posttest": "npm run style",
     "compat": "node scripts/compat.js --prepare",

--- a/package.json
+++ b/package.json
@@ -18,19 +18,20 @@
     "David Hemphill <davidlee.hemphill@gmail.com>"
   ],
   "scripts": {
-    "prebabelify": "rimraf lib",
+    "prebabelify": "npm run generate:plugin-list && rimraf lib",
     "babelify": "babel src --out-dir lib --copy-files",
     "postbabelify": "ncc build lib/cli-peer-dependencies.js -o peers",
     "rebuild-fixtures": "npm run babelify && babel-node scripts/rebuildFixtures.js",
     "prepublishOnly": "npm install --force && npm run babelify && babel-node scripts/build.js && node scripts/build-plugins.js",
-    "prepare": "babel-node scripts/create-plugin-list.js",
     "style": "eslint .",
     "test": "cross-env TAILWIND_MODE=build jest",
     "test:integrations": "npm run test --prefix ./integrations",
+    "install": "npm run generate:plugin-list",
     "install:integrations": "node scripts/install-integrations.js",
     "posttest": "npm run style",
     "compat": "node scripts/compat.js --prepare",
-    "compat:restore": "node scripts/compat.js --restore"
+    "compat:restore": "node scripts/compat.js --restore",
+    "generate:plugin-list": "babel-node scripts/create-plugin-list.js"
   },
   "files": [
     "dist/*.css",

--- a/scripts/create-plugin-list.js
+++ b/scripts/create-plugin-list.js
@@ -5,6 +5,6 @@ import path from 'path'
 const corePluginList = Object.keys(corePlugins)
 
 fs.writeFileSync(
-  path.join(__dirname, '..', 'src', 'corePluginList.js'),
+  path.join(process.cwd(), 'src', 'corePluginList.js'),
   `export default ${JSON.stringify(corePluginList)}`
 )

--- a/scripts/create-plugin-list.js
+++ b/scripts/create-plugin-list.js
@@ -1,0 +1,10 @@
+import * as corePlugins from '../src/plugins'
+import fs from 'fs'
+import path from 'path'
+
+const corePluginList = Object.keys(corePlugins)
+
+fs.writeFileSync(
+  path.join(__dirname, '..', 'src', 'corePluginList.js'),
+  `export default ${JSON.stringify(corePluginList)}`
+)

--- a/src/util/resolveConfig.js
+++ b/src/util/resolveConfig.js
@@ -10,7 +10,7 @@ import toPath from 'lodash/toPath'
 import head from 'lodash/head'
 import isPlainObject from 'lodash/isPlainObject'
 import negateValue from './negateValue'
-import * as corePlugins from '../plugins'
+import corePluginList from '../corePluginList'
 import configurePlugins from './configurePlugins'
 import defaultConfig from '../../stubs/defaultConfig.stub'
 import colors from '../../colors'
@@ -243,7 +243,7 @@ function resolveCorePlugins(corePluginConfigs) {
       return corePluginConfig({ corePlugins: resolved })
     }
     return configurePlugins(corePluginConfig, resolved)
-  }, Object.keys(corePlugins))
+  }, corePluginList)
 
   return result
 }

--- a/tests/resolveConfig.test.js
+++ b/tests/resolveConfig.test.js
@@ -1,7 +1,5 @@
-import * as corePlugins from '../src/plugins'
 import resolveConfig from '../src/util/resolveConfig'
-
-const corePluginList = Object.keys(corePlugins)
+import corePluginList from '../src/corePluginList'
 
 test('prefix key overrides default prefix', () => {
   const userConfig = {


### PR DESCRIPTION
Removes the importing of all plugins in `src/util/resolveConfig` to avoid importing CSS.
Import the built plugin list file instead.
resolves #4681

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
