### PR TITLE
Ensure `peer` variants don't include multiple ~ characters

### DIFF
--- a/src/jit/corePlugins.js
+++ b/src/jit/corePlugins.js
@@ -201,11 +201,8 @@ export default {
             return null
           }
 
-          return applyPseudoToMarker(
-            variantSelector,
-            peerMarker,
-            state,
-            (marker, selector) => `${marker} ~ ${selector}`
+          return applyPseudoToMarker(variantSelector, peerMarker, state, (marker, selector) =>
+            selector.trim().startsWith('~') ? `${marker}${selector}` : `${marker} ~ ${selector}`
           )
         })
       )

--- a/tests/jit/variants.test.js
+++ b/tests/jit/variants.test.js
@@ -32,3 +32,29 @@ test('variants', () => {
     expect(result.css).toMatchFormattedCss(expected)
   })
 })
+
+test('stacked peer variants', async () => {
+  let config = {
+    mode: 'jit',
+    purge: [{ raw: 'peer-disabled:peer-focus:peer-hover:border-blue-500' }],
+    corePlugins: { preflight: false },
+    theme: {},
+    plugins: [],
+  }
+
+  let css = `
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  let expected = `
+    .peer:disabled:focus:hover ~ .peer-disabled\\:peer-focus\\:peer-hover\\:border-blue-500 {
+      --tw-border-opacity: 1;
+      border-color: rgba(59, 130, 246, var(--tw-border-opacity));
+    }
+  `
+
+  let result = await run(css, config)
+  expect(result.css).toIncludeCss(expected)
+})


### PR DESCRIPTION
This PR will ensure that the peer variants are generated correctly.
Currently, the generated `peer` variants will result in something like:

```css
.peer:disabled:focus:hover ~ ~ ~ .peer-disabled\\:peer-focus\\:peer-hover\\:border-blue-500 {}
```

But this PR will ensure that the result looks like this:
```css
.peer:disabled:focus:hover ~ .peer-disabled\\:peer-focus\\:peer-hover\\:border-blue-500 {}
```

While testing, I noticed that `prettier` properly reduces `~ ~ ~` to a single `~`. This sort of explains why the output in a production build for Next.js is "correct". The included minifiers will properly do this correctly as well, but it is incorrect in dev mode.

Fixes: #4726

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
