### PR TITLE
add `TAILWIND_ENV` environment variable for better Angular support

### DIFF
--- a/src/lib/purgeUnusedStyles.js
+++ b/src/lib/purgeUnusedStyles.js
@@ -52,7 +52,7 @@ export default function purgeUnusedUtilities(config, configChanged, registerDepe
   const purgeEnabled = _.get(
     config,
     'purge.enabled',
-    config.purge !== false && config.purge !== undefined && process.env.NODE_ENV === 'production'
+    config.purge !== false && config.purge !== undefined && (process.env.NODE_ENV === 'production' || process.env.TAILWIND_ENV === 'production')
   )
 
   if (!purgeEnabled) {

--- a/src/lib/purgeUnusedStyles.js
+++ b/src/lib/purgeUnusedStyles.js
@@ -52,7 +52,9 @@ export default function purgeUnusedUtilities(config, configChanged, registerDepe
   const purgeEnabled = _.get(
     config,
     'purge.enabled',
-    config.purge !== false && config.purge !== undefined && (process.env.NODE_ENV === 'production' || process.env.TAILWIND_ENV === 'production')
+    config.purge !== false &&
+      config.purge !== undefined &&
+      (process.env.NODE_ENV === 'production' || process.env.TAILWIND_ENV === 'production')
   )
 
   if (!purgeEnabled) {

--- a/tests/purgeUnusedStyles.test.js
+++ b/tests/purgeUnusedStyles.test.js
@@ -85,6 +85,25 @@ function assertPurged(result) {
   expect(result.css).toContain('.whitespace-nowrap')
 }
 
+test('purges unused classes with TAILWIND_ENV production', () => {
+  process.env.TAILWIND_ENV = 'production'
+  suppressConsoleLogs(() => {
+    const inputPath = path.resolve(`${__dirname}/fixtures/tailwind-input.css`)
+    const input = fs.readFileSync(inputPath, 'utf8')
+
+    return postcss([
+      tailwind({
+        ...config,
+        purge: [path.resolve(`${__dirname}/fixtures/**/*.html`)],
+      }),
+    ])
+      .process(input, { from: withTestName(inputPath) })
+      .then((result) => {
+        assertPurged(result)
+      })
+  })
+  process.env.TAILWIND_ENV = undefined
+})
 test('purges unused classes', () => {
   return inProduction(
     suppressConsoleLogs(() => {


### PR DESCRIPTION
Hey, this PR adds `TAILWIND_ENV` environment variable that behaves the same as `NODE_ENV` for better Angular support, as Angular doesn't set `NODE_ENV`, you can read the reasoning of the Angular team in the following quote and more in [#20015 issue](https://github.com/angular/angular-cli/issues/20015):

> For the purge setting, it would be preferred if Tailwind itself provided a more fine-grained method to specify its production mode.  Two potential options for this are a programmatic option when initializing the plugin or a targeted environment variable (e.g., `TAILWIND_ENV`/`TAILWIND_MODE`/etc.).  The `NODE_ENV` environment variable has the potential to effect the behavior of every active dependency involved in the build system.
> If this is not viable, then loading the configuration file directly may be an option.  However, it would be preferred that the structure of the Tailwind configuration object remain opaque to the Angular CLI.  Not doing so presents supportability and sustainment concerns moving forward.  One potential concept (that would still need further analysis) may be to provide additional context properties when loading the configuration file (for example, `angular.configuration`, `angular.options`, etc.).  The `ngneat/tailwind` schematics could then use those when generating a Tailwind configuration file (`purge: { enabled: angular?.options.optimization?.styles?.minify }` or `purge: { enabled: angular?.configuration === 'production' }`).  This would limit the necessary knowledge for the Angular CLI to a JavaScript file that exports an object that is passed directly to the Tailwind plugin.  Again, this would still need further analysis.

_Originally posted by @clydin in https://github.com/angular/angular-cli/issues/20015#issuecomment-790861513_

Since Angular version 11.2.12 set `TAILWIND_MODE` by Angular CLI https://github.com/angular/angular-cli/pull/20574, so JIT works out of the box now, but purge still needs some specific configuration as:
@clydin thanks for adding that.

> To help clarify for others, as of Angular 11.2.12 or `"@angular-devkit/build-angular": "~0.1102.12"` the following code will work for setting Tailwind purge to be enabled for building and off for serving ('watch'). Be sure to also have Tailwind v2.1 or greater installed.

```
module.exports = {
  purge: {
    enabled: process.env.TAILWIND_MODE === 'build',
    content: [
      './src/**/*.{html,scss,ts}'
    ]
  },
  theme: {
    extend: {},
  },
  variants: {},
  plugins: [],
};
```

_Originally posted by @tthrash in https://github.com/angular/angular-cli/issues/20015#issuecomment-834742250_ 


As JIT still not the default mode, it would be really nice to help Angular CLI smooth integration with Tailwind purge mode.