### PR TITLE
Enable purging when --purge option is supplied in CLI

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -420,7 +420,10 @@ async function build() {
     let resolvedConfig = resolveConfigInternal(config)
 
     if (args['--purge']) {
-      resolvedConfig.purge = args['--purge'].split(/(?<!{[^}]+),/)
+      resolvedConfig.purge = {
+        enabled: true,
+        content: args['--purge'].split(/(?<!{[^}]+),/),
+      }
     }
 
     if (args['--jit']) {


### PR DESCRIPTION
Do not require NODE_ENV to be set to 'production' as well, as using
the `--purge` option in the CLI is explicit enough.
