### PR TITLE
fix: do not return the userConfigPath if its null

### DIFF
--- a/src/jit/lib/setupWatchingContext.js
+++ b/src/jit/lib/setupWatchingContext.js
@@ -185,7 +185,7 @@ function getTailwindConfig(configOrPath) {
     configOrPath.config === undefined ? configOrPath : configOrPath.config
   )
 
-  return [newConfig, null, hash(newConfig), [userConfigPath]]
+  return [newConfig, null, hash(newConfig), []]
 }
 
 function resolvedChangedContent(context, candidateFiles) {


### PR DESCRIPTION
This prevents adding a null config path to the postcss dependencies.
It happens when you use a config object instead of a config file with watch in jit mode with postcss-cli.
```js
// postcss.config.js
module.exports = {
  plugins: [
    require('tailwindcss')({
      mode: 'jit', 
      purge: ['./src/**/*'],
      theme: {/**/}
    })
  ]
}
```

```sh
TAILWIND_MODE=watch yarn postcss --watch ./src/css/* --dir ./public/css/
```
->
`TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received null`