### PR TITLE
Remove unnecessary formatting during tests

### DIFF
--- a/jest/customMatchers.js
+++ b/jest/customMatchers.js
@@ -29,8 +29,8 @@ expect.extend({
           return (
             this.utils.matcherHint('toMatchCss', undefined, undefined, options) +
             '\n\n' +
-            `Expected: not ${this.utils.printExpected(format(received))}\n` +
-            `Received: ${this.utils.printReceived(format(argument))}`
+            `Expected: not ${this.utils.printExpected(received)}\n` +
+            `Received: ${this.utils.printReceived(argument)}`
           )
         }
       : () => {

--- a/jest/customMatchers.js
+++ b/jest/customMatchers.js
@@ -34,10 +34,7 @@ expect.extend({
           )
         }
       : () => {
-          const actual = format(received)
-          const expected = format(argument)
-
-          const diffString = diff(expected, actual, {
+          const diffString = diff(argument, received, {
             expand: this.expand,
           })
 
@@ -46,8 +43,8 @@ expect.extend({
             '\n\n' +
             (diffString && diffString.includes('- Expect')
               ? `Difference:\n\n${diffString}`
-              : `Expected: ${this.utils.printExpected(expected)}\n` +
-                `Received: ${this.utils.printReceived(actual)}`)
+              : `Expected: ${this.utils.printExpected(argument)}\n` +
+                `Received: ${this.utils.printReceived(received)}`)
           )
         }
 
@@ -101,12 +98,6 @@ expect.extend({
   // Compare two CSS strings with all whitespace removed
   // This is probably naive but it's fast and works well enough.
   toMatchFormattedCss(received, argument) {
-    function format(input) {
-      return prettier.format(input, {
-        parser: 'css',
-        printWidth: 100,
-      })
-    }
     const options = {
       comment: 'stripped(received) === stripped(argument)',
       isNot: this.isNot,


### PR DESCRIPTION
When a test that uses fixture files fails, the process often takes about 40 minutes to complete ([the latest failing test](https://github.com/tailwindlabs/tailwindcss/runs/2898523298) took 42 minutes). This is because when it fails, all CSS from the files, which are over 100,000 lines in length, is run through prettier (see [the custom matcher](https://github.com/tailwindlabs/tailwindcss/blob/master/jest/customMatchers.js#L37)). After removing the formatting for failing tests, the time was reduced to 114 seconds. It also seems like this formatting should have been restricted to `toMatchFormattedCss` as it [has its own format function](https://github.com/tailwindlabs/tailwindcss/blob/master/jest/customMatchers.js#L104) that was an exact copy of the top-level one.

Note: I did not remove [the formatting from `toIncludeCss`](https://github.com/tailwindlabs/tailwindcss/blob/master/jest/customMatchers.js#L79) because I was unsure if would break the integration tests.