### PR TITLE
Improve extractor for arbitrary values with quotes

### DIFF
--- a/src/jit/lib/expandTailwindAtRules.js
+++ b/src/jit/lib/expandTailwindAtRules.js
@@ -6,7 +6,13 @@ import cloneNodes from '../../util/cloneNodes'
 let env = sharedState.env
 let contentMatchCache = sharedState.contentMatchCache
 
-const BROAD_MATCH_GLOBAL_REGEXP = /([^<>"'`\s]*\[[^<>\s]+\])|([^<>"'`\s]*[^<>"'`\s:])/g
+const PATTERNS = [
+  "([^<>\"'`\\s]*\\['[^<>\"'`\\s]*'\\])", // `content-['hello']` but not `content-['hello']']`
+  '([^<>"\'`\\s]*\\["[^<>"\'`\\s]*"\\])', // `content-["hello"]` but not `content-["hello"]"]`
+  '([^<>"\'`\\s]*\\[[^<>"\'`\\s]+\\])', // `fill-[#bada55]`
+  '([^<>"\'`\\s]*[^<>"\'`\\s:])', // `px-1.5`, `uppercase` but not `uppercase:`
+].join('|')
+const BROAD_MATCH_GLOBAL_REGEXP = new RegExp(PATTERNS, 'g')
 const INNER_MATCH_GLOBAL_REGEXP = /[^<>"'`\s.(){}[\]#=%]*[^<>"'`\s.(){}[\]#=%:]/g
 
 const builtInExtractors = {

--- a/tests/jit/extractor-edge-cases.test.js
+++ b/tests/jit/extractor-edge-cases.test.js
@@ -1,0 +1,57 @@
+import postcss from 'postcss'
+import path from 'path'
+import tailwind from '../../src/jit/index.js'
+
+function run(input, config = {}) {
+  const { currentTestName } = expect.getState()
+
+  return postcss(tailwind(config)).process(input, {
+    from: `${path.resolve(__filename)}?test=${currentTestName}`,
+  })
+}
+
+test('PHP arrays', async () => {
+  let config = {
+    mode: 'jit',
+    purge: [
+      {
+        raw: `<h1 class="<?php echo wrap(['class' => "max-w-[16rem]"]); ?>">Hello world</h1>`,
+      },
+    ],
+    theme: {},
+    plugins: [],
+  }
+
+  let css = `@tailwind utilities`
+
+  return run(css, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(`
+      .max-w-\\[16rem\\] {
+        max-width: 16rem;
+      }
+    `)
+  })
+})
+
+test('arbitrary values with quotes', async () => {
+  let config = {
+    mode: 'jit',
+    purge: [
+      {
+        raw: `<div class="content-['hello]']"></div>`,
+      },
+    ],
+    theme: {},
+    plugins: [],
+  }
+
+  let css = `@tailwind utilities`
+
+  return run(css, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(`
+      .content-\\[\\'hello\\]\\'\\] {
+        content: 'hello]';
+      }
+    `)
+  })
+})


### PR DESCRIPTION
Fixes #4801.

This PR improves our default extractor regex to handle arbitrary values that are wrapped in quotes more precisely.

Previously, given this input:

```html
<h1 class="<?php echo wrap(['class' => 'max-w-[16rem]']); ?>">Hello world</h1>
```

...we would find a class named `max-w-[16rem]']`. This PR makes sure we find `max-w-[16rem]` instead, while preserving the ability to match things like `content-['hello']` and even `content-[']']`.

We don't match this properly yet: `content-['hello[]']`, but we also didn't before this PR, so this is still purely an improvement over what was there before.

Since the regex is getting long, I've also broken it up into 4 parts with a few comments for each piece to explain what it's for.