### PR TITLE
Cleanup leftover layers

### DIFF
--- a/integrations/tailwindcss-cli/tests/cli.test.js
+++ b/integrations/tailwindcss-cli/tests/cli.test.js
@@ -258,7 +258,7 @@ describe('Build command', () => {
 
     expect(combined).toMatchInlineSnapshot(`
       "
-      tailwindcss v2.1.2
+      tailwindcss v2.2.4
 
       Usage:
          tailwindcss build [options]
@@ -348,7 +348,7 @@ describe('Init command', () => {
 
     expect(combined).toMatchInlineSnapshot(`
       "
-      tailwindcss v2.1.2
+      tailwindcss v2.2.4
 
       Usage:
          tailwindcss init [options]

--- a/src/jit/lib/expandTailwindAtRules.js
+++ b/src/jit/lib/expandTailwindAtRules.js
@@ -238,5 +238,12 @@ export default function expandTailwindAtRules(context) {
 
     // Clear the cache for the changed files
     context.changedContent = []
+
+    // Cleanup any leftover @layer atrules
+    root.walkAtRules('layer', (rule) => {
+      if (Object.keys(layerNodes).includes(rule.params)) {
+        rule.remove()
+      }
+    })
   }
 }


### PR DESCRIPTION
When we create the context we also collect all the `@layer` nodes, cache them and remove them from the final stylesheet. However once you are in a running process the context will only be created once (as long as the dependencies don't change). Therefore the `@layer` nodes are not collected and removed anymore.

We already inject the correct contents (because we had it cached) but we didn't cleanup leftover `@layer` rules. This PR will make sure that we do that cleanup.

Whenever somebody changes the contents of an `@layer`, then one of the dependencies changed and a new context is created, therefore the new contents will be handled correctly.

Fixes: #4851 