### PR TITLE
Try to use lowest impact selector when filling in defaults

### DIFF
--- a/tests/jit/resolve-defaults-at-rules.test.js
+++ b/tests/jit/resolve-defaults-at-rules.test.js
@@ -605,3 +605,104 @@ test('when a utility uses defaults but they do not exist', async () => {
     `)
   })
 })
+
+test('selectors are reduced to the lowest possible specificity', async () => {
+  let config = {
+    mode: 'jit',
+    purge: [
+      {
+        raw: '<div class="foo"></div>',
+      },
+    ],
+    theme: {},
+    plugins: [],
+    corePlugins: [],
+  }
+
+  let css = `
+    @defaults test {
+      --color: black;
+    }
+
+    /* --- */
+
+    .foo {
+      @defaults test;
+      background-color: var(--color);
+    }
+
+    #app {
+      @defaults test;
+      border-color: var(--color);
+    }
+
+    span#page {
+      @defaults test;
+      color: var(--color);
+    }
+
+    div[data-foo="bar"]#other {
+      @defaults test;
+      fill: var(--color);
+    }
+
+    div[data-bar="baz"] {
+      @defaults test;
+      stroke: var(--color);
+    }
+
+    article {
+      @defaults test;
+      --article: var(--color);
+    }
+
+    div[data-foo="bar"]#another::before {
+      @defaults test;
+      fill: var(--color);
+    }
+  `
+
+  return run(css, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(`
+      .foo,
+      [id="app"],
+      [id="page"],
+      [id="other"],
+      [data-bar="baz"],
+      article,
+      [id="another"]::before {
+        --color: black;
+      }
+
+      /* --- */
+
+      .foo {
+        background-color: var(--color);
+      }
+
+      #app {
+        border-color: var(--color);
+      }
+
+      span#page {
+        color: var(--color);
+      }
+
+      div[data-foo="bar"]#other {
+        fill: var(--color);
+      }
+
+      div[data-bar="baz"] {
+        stroke: var(--color);
+      }
+
+      article {
+        --article: var(--color);
+      }
+
+      div[data-foo="bar"]#another::before {
+        fill: var(--color);
+      }
+    `)
+  })
+})


### PR DESCRIPTION
This PR adjusts how `resolveDefaultsAtRules` works to try and make sure it always uses the lowest impact selector when filling in the defaults.

For example, if someone has a selector like `span.foo#app`, we will just use `.foo` since it has a good combination of low specificity + selecting the fewest elements. If they use `span#app`, we don't want `#app` because it has high specificity, but also don't want `span` because it would select a lot of false positives, so instead we use `[id="app"]` which has low specificity, and is likely to only target one element.