### PR TITLE
Add variant for `::file-selector-button` pseudo element

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -73,13 +73,10 @@ export let pseudoElementVariants = ({ config, addVariant }) => {
   ])
 
   addVariant(
-    'file-selector-button',
+    'file',
     transformAllSelectors((selector) => {
       return updateAllClasses(selector, (className, { withPseudo }) => {
-        return withPseudo(
-          `file-selector-button${config('separator')}${className}`,
-          '::file-selector-button'
-        )
+        return withPseudo(`file${config('separator')}${className}`, '::file-selector-button')
       })
     })
   )

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -73,6 +73,18 @@ export let pseudoElementVariants = ({ config, addVariant }) => {
   ])
 
   addVariant(
+    'file-selector-button',
+    transformAllSelectors((selector) => {
+      return updateAllClasses(selector, (className, { withPseudo }) => {
+        return withPseudo(
+          `file-selector-button${config('separator')}${className}`,
+          '::file-selector-button'
+        )
+      })
+    })
+  )
+
+  addVariant(
     'before',
     transformAllSelectors(
       (selector) => {

--- a/tests/variants.test.css
+++ b/tests/variants.test.css
@@ -52,6 +52,14 @@
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
+.file-selector-button\:bg-blue-500::file-selector-button {
+  --tw-bg-opacity: 1;
+  background-color: rgb(59 130 246 / var(--tw-bg-opacity));
+}
+.file-selector-button\:text-white::file-selector-button {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity));
+}
 .before\:block::before {
   content: '';
   display: block;

--- a/tests/variants.test.css
+++ b/tests/variants.test.css
@@ -52,11 +52,11 @@
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
-.file-selector-button\:bg-blue-500::file-selector-button {
+.file\:bg-blue-500::file-selector-button {
   --tw-bg-opacity: 1;
   background-color: rgb(59 130 246 / var(--tw-bg-opacity));
 }
-.file-selector-button\:text-white::file-selector-button {
+.file\:text-white::file-selector-button {
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
@@ -196,6 +196,10 @@
   --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -1px rgb(0 0 0 / 0.06);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
     var(--tw-shadow);
+}
+.file\:hover\:bg-blue-600::file-selector-button:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(37 99 235 / var(--tw-bg-opacity));
 }
 .focus\:shadow-md:focus {
   --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -1px rgb(0 0 0 / 0.06);

--- a/tests/variants.test.html
+++ b/tests/variants.test.html
@@ -45,6 +45,7 @@
       <li class="marker:text-red-500 marker:text-lg"></li>
     </ul>
     <div class="selection:bg-blue-500 selection:text-white"></div>
+    <div class="file-selector-button:bg-blue-500 file-selector-button:text-white"></div>
     <div class="before:block before:bg-red-500"></div>
     <div class="after:flex after:uppercase"></div>
 

--- a/tests/variants.test.html
+++ b/tests/variants.test.html
@@ -45,7 +45,7 @@
       <li class="marker:text-red-500 marker:text-lg"></li>
     </ul>
     <div class="selection:bg-blue-500 selection:text-white"></div>
-    <div class="file-selector-button:bg-blue-500 file-selector-button:text-white"></div>
+    <div class="file:bg-blue-500 file:text-white"></div>
     <div class="before:block before:bg-red-500"></div>
     <div class="after:flex after:uppercase"></div>
 
@@ -128,6 +128,7 @@
     <div class="2xl:shadow-md"></div>
 
     <!-- Stacked variants -->
+    <div class="file:hover:bg-blue-600"></div>
     <div class="focus:hover:shadow-md"></div>
     <div class="sm:active:shadow-md"></div>
     <div class="md:group-focus:shadow-md"></div>


### PR DESCRIPTION
This PR adds a variant for the [`::file-selector-button`](https://developer.mozilla.org/en-US/docs/Web/CSS/::file-selector-button)  pseudo element, which is supported by the latest versions of all three engines.

I think I've added to the relevant tests but feel free to point out any others that are required.
