### PR TITLE
Abort the watcher if stdin is closed to avoid zombie processes

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -784,6 +784,9 @@ async function build() {
   }
 
   if (shouldWatch) {
+    /* Abort the watcher if stdin is closed to avoid zombie processes */
+    process.stdin.on('end', () => process.exit(0));
+    process.stdin.resume();
     startWatcher()
   } else {
     buildOnce()

--- a/src/cli.js
+++ b/src/cli.js
@@ -785,8 +785,8 @@ async function build() {
 
   if (shouldWatch) {
     /* Abort the watcher if stdin is closed to avoid zombie processes */
-    process.stdin.on('end', () => process.exit(0));
-    process.stdin.resume();
+    process.stdin.on('end', () => process.exit(0))
+    process.stdin.resume()
     startWatcher()
   } else {
     buildOnce()


### PR DESCRIPTION
This is the same behaviour as found in postcss --watch:

https://github.com/postcss/postcss-cli/blob/f0e262ed484436a669d81b66424ef6017058950c/index.js#L55-L56