### PR TITLE
Update color to v3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "tailwindcss",
       "version": "2.2.4",
       "license": "MIT",
       "dependencies": {
@@ -13,7 +12,7 @@
         "bytes": "^3.0.0",
         "chalk": "^4.1.1",
         "chokidar": "^3.5.2",
-        "color": "^3.1.3",
+        "color": "^3.2.0",
         "cosmiconfig": "^7.0.0",
         "detective": "^5.2.0",
         "didyoumean": "^1.2.2",
@@ -3243,12 +3242,12 @@
       }
     },
     "node_modules/color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",
-      "integrity": "sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.0.tgz",
+      "integrity": "sha512-4ximSqKXLTQmYLJuvrRHtpOqniR+ASoaVK+Rxdy6ZpfsLvUqtIM7oGGgopRG+O4p9NRv/AfuVD3jsvdxyXqozQ==",
       "dependencies": {
-        "color-convert": "^1.9.1",
-        "color-string": "^1.5.4"
+        "color-convert": "^2.0.1",
+        "color-string": "^1.6.0"
       }
     },
     "node_modules/color-convert": {
@@ -3268,26 +3267,13 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/color-string": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
-      "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
+      "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
-    },
-    "node_modules/color/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/color/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "node_modules/colord": {
       "version": "2.0.1",
@@ -12855,27 +12841,12 @@
       }
     },
     "color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",
-      "integrity": "sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.0.tgz",
+      "integrity": "sha512-4ximSqKXLTQmYLJuvrRHtpOqniR+ASoaVK+Rxdy6ZpfsLvUqtIM7oGGgopRG+O4p9NRv/AfuVD3jsvdxyXqozQ==",
       "requires": {
-        "color-convert": "^1.9.1",
-        "color-string": "^1.5.4"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-        }
+        "color-convert": "^2.0.1",
+        "color-string": "^1.6.0"
       }
     },
     "color-convert": {
@@ -12892,9 +12863,9 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "color-string": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
-      "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
+      "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"

--- a/package.json
+++ b/package.json
@@ -70,12 +70,11 @@
     "postcss": "^8.0.9"
   },
   "dependencies": {
-    "purgecss": "^4.0.3",
     "arg": "^5.0.0",
     "bytes": "^3.0.0",
     "chalk": "^4.1.1",
     "chokidar": "^3.5.2",
-    "color": "^3.1.3",
+    "color": "^3.2.0",
     "cosmiconfig": "^7.0.0",
     "detective": "^5.2.0",
     "didyoumean": "^1.2.2",
@@ -97,6 +96,7 @@
     "postcss-selector-parser": "^6.0.6",
     "postcss-value-parser": "^4.1.0",
     "pretty-hrtime": "^1.0.3",
+    "purgecss": "^4.0.3",
     "quick-lru": "^5.1.1",
     "reduce-css-calc": "^2.1.8",
     "resolve": "^1.20.0",


### PR DESCRIPTION
### Changes

Updates **`color`** from `v3.1.3` to `v3.2.0`, which includes support for space-separated HSL color values. See #4677 for more details. 