### PR TITLE
Fix pathname parsing for tracked files

### DIFF
--- a/src/jit/lib/setupContextUtils.js
+++ b/src/jit/lib/setupContextUtils.js
@@ -317,7 +317,8 @@ function trackModified(files, fileModifiedMap) {
     if (!file) continue
 
     let parsed = url.parse(file)
-    let pathname = parsed.href.replace(parsed.hash, '').replace(parsed.search, '')
+    let pathname = parsed.hash ? parsed.href.replace(parsed.hash, '') : parsed.href
+    pathname = parsed.search ? pathname.replace(parsed.search, '') : pathname
     let newModified = fs.statSync(decodeURIComponent(pathname)).mtimeMs
 
     if (!fileModifiedMap.has(file) || newModified > fileModifiedMap.get(file)) {


### PR DESCRIPTION
The `trackModified` call in the tracking logic has a bug that incorrectly removes `null` from pathnames when it tries to remove `hash` or `search` values from the parsed path.

Currently:
```
let pathname = parsed.href.replace(parsed.hash, '').replace(parsed.search, '')
```
Where if `parsed.hash` or `parsed.search` are missing (which is mostly the case for FS files), the value is null
eg `{ hash: null, search: null}`
  - In which case, we essentially trim `null`
Converting `/mypath/nulldir/file.js` -> `/mypath/dir/filejs` and breaking builds  (see #4920) or potentially accessing the wrong files.

Fix checks if `hash` or `search` are set before replacing them

Fixes #4920

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
