### PR TITLE
Hotfix: Use universal selector again

### DIFF
--- a/src/jit/lib/resolveDefaultsAtRules.js
+++ b/src/jit/lib/resolveDefaultsAtRules.js
@@ -89,7 +89,11 @@ export default function resolveDefaultsAtRules() {
       }
 
       let universalRule = postcss.rule()
-      universalRule.selectors = [...selectors]
+
+      // TODO: Fix this, this is a hotfix
+      // universalRule.selectors = [...selectors]
+      universalRule.selectors = ['*', '::before', '::after']
+
       universalRule.append(universal.nodes)
       universal.before(universalRule)
       universal.remove()


### PR DESCRIPTION
Temporarily fixes a bunch of issues folks are discovering, like #5059, #5043, and #5039. 

Tests will fail but it's too much work to update them, then update them back when we implement this again but better.