### PR TITLE
Improve accessibility of default link focus styles in Firefox

### DIFF
--- a/src/plugins/css/preflight.css
+++ b/src/plugins/css/preflight.css
@@ -140,6 +140,18 @@ button,
   cursor: pointer;
 }
 
+/**
+ * Override legacy focus reset from Normalize with modern Firefox focus styles.
+ *
+ * This is actually an improvement over the new defaults in Firefox in our testing,
+ * as it triggers the better focus styles even for links, which still use a dotted
+ * outline in Firefox by default.
+ */
+ 
+:-moz-focusring {
+	outline: auto;
+}
+
 table {
   border-collapse: collapse;
 }

--- a/tests/fixtures/tailwind-output-flagged.css
+++ b/tests/fixtures/tailwind-output-flagged.css
@@ -440,6 +440,18 @@ button,
   cursor: pointer;
 }
 
+/**
+ * Override legacy focus reset from Normalize with modern Firefox focus styles.
+ *
+ * This is actually an improvement over the new defaults in Firefox in our testing,
+ * as it triggers the better focus styles even for links, which still use a dotted
+ * outline in Firefox by default.
+ */
+
+:-moz-focusring {
+  outline: auto;
+}
+
 table {
   border-collapse: collapse;
 }

--- a/tests/fixtures/tailwind-output-no-color-opacity.css
+++ b/tests/fixtures/tailwind-output-no-color-opacity.css
@@ -440,6 +440,18 @@ button,
   cursor: pointer;
 }
 
+/**
+ * Override legacy focus reset from Normalize with modern Firefox focus styles.
+ *
+ * This is actually an improvement over the new defaults in Firefox in our testing,
+ * as it triggers the better focus styles even for links, which still use a dotted
+ * outline in Firefox by default.
+ */
+
+:-moz-focusring {
+  outline: auto;
+}
+
 table {
   border-collapse: collapse;
 }

--- a/tests/fixtures/tailwind-output.css
+++ b/tests/fixtures/tailwind-output.css
@@ -440,6 +440,18 @@ button,
   cursor: pointer;
 }
 
+/**
+ * Override legacy focus reset from Normalize with modern Firefox focus styles.
+ *
+ * This is actually an improvement over the new defaults in Firefox in our testing,
+ * as it triggers the better focus styles even for links, which still use a dotted
+ * outline in Firefox by default.
+ */
+
+:-moz-focusring {
+  outline: auto;
+}
+
 table {
   border-collapse: collapse;
 }


### PR DESCRIPTION
Firefox 89 introduced new focus styles for form controls that are a big improvement in terms of accessibility, but by default it doesn't carry those improvements over to links, which still have a very subtle dotted border.

All this does is replace this old legacy rule from normalize.css:

```css
:-moz-focusring {
	outline: 1px dotted ButtonText;
}
```

...with this:

```css
:-moz-focusring {
	outline: auto;
}
```

The Firefox team is considering just doing this by default, as you can read here:

https://bugzilla.mozilla.org/show_bug.cgi?id=1708244#c3

**Before:**

<img width="715" alt="image" src="https://user-images.githubusercontent.com/4323180/126993781-21b44131-8c18-4692-9d0f-40f578ccfa42.png">

**After:**

<img width="705" alt="image" src="https://user-images.githubusercontent.com/4323180/126993795-64d432b5-bd4b-4f97-b495-e488aa74abce.png">

**Before on dark backgrounds:**

<img width="710" alt="image" src="https://user-images.githubusercontent.com/4323180/126996323-effa28c9-ea07-4b7c-a591-0bda47c86cbc.png">

**After on dark backgrounds:**

<img width="724" alt="image" src="https://user-images.githubusercontent.com/4323180/126996354-71d58b62-962d-4550-bceb-428fd4e5bc3f.png">

