### PR TITLE
chore: remove duplicate prettier.config.js settings from .eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,6 @@
     "camelcase": ["error", { "allow": ["^unstable_"] }],
     "no-unused-vars": [2, { "args": "all", "argsIgnorePattern": "^_" }],
     "no-warning-comments": 0,
-    "prettier/prettier": ["error"]
+    "prettier/prettier": "error"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,18 +12,6 @@
     "camelcase": ["error", { "allow": ["^unstable_"] }],
     "no-unused-vars": [2, { "args": "all", "argsIgnorePattern": "^_" }],
     "no-warning-comments": 0,
-    "prettier/prettier": [
-      "error",
-      {
-        "semi": false,
-        "singleQuote": true,
-        "printWidth": 100,
-        "tabWidth": 2,
-        "useTabs": false,
-        "trailingComma": "es5",
-        "bracketSpacing": true,
-        "parser": "flow"
-      }
-    ]
+    "prettier/prettier": ["error"]
   }
 }


### PR DESCRIPTION
✅ chore: remove duplicate `prettier.config.js` settings from `.eslintrc.json`
✅ manually tested with visual inspection in VS Code and by running `npx eslint --fix .` as a way of fixing Prettier errors

### Good news everyone!
![image](https://user-images.githubusercontent.com/761231/127067026-560031fd-9ff5-438e-8943-441eb85bd806.png)

Turns out you **can** ask ESLint to read Prettier's configuration file, and the [`eslint-prettier`](https://github.com/prettier/prettier-eslint) plugin **will** process it correctly.

Unfortunately, it doesn't work right the other way -- VSCode's Prettier extension won't pull the settings out of the ESLint config.

The `.editorconfig` file is still needed for fixing line endings to LF *on save* on Windows and for specifying `utf-8`.

Still, [`"prettier/prettier": ["error"]`](https://github.com/prettier/eslint-plugin-prettier#options) is a lot cleaner in `.eslintrc.json` than the copy-paste that was in there before! 😁