### PR TITLE
Ignore `[type="hidden"]` elements when spacing

### DIFF
--- a/src/plugins/divideColor.js
+++ b/src/plugins/divideColor.js
@@ -8,18 +8,19 @@ export default function () {
         divide: (value) => {
           if (!corePlugins('divideOpacity')) {
             return {
-              ['& > :not([hidden]) ~ :not([hidden])']: {
+              ['& > :not([hidden]):not([type="hidden"]) ~ :not([hidden]):not([type="hidden"])']: {
                 'border-color': value,
               },
             }
           }
 
           return {
-            ['& > :not([hidden]) ~ :not([hidden])']: withAlphaVariable({
-              color: value,
-              property: 'border-color',
-              variable: '--tw-divide-opacity',
-            }),
+            ['& > :not([hidden]):not([type="hidden"]) ~ :not([hidden]):not([type="hidden"])']:
+              withAlphaVariable({
+                color: value,
+                property: 'border-color',
+                variable: '--tw-divide-opacity',
+              }),
           }
         },
       },

--- a/src/plugins/divideOpacity.js
+++ b/src/plugins/divideOpacity.js
@@ -4,7 +4,7 @@ export default function () {
       {
         'divide-opacity': (value) => {
           return {
-            [`& > :not([hidden]) ~ :not([hidden])`]: {
+            [`& > :not([hidden]):not([type="hidden"]) ~ :not([hidden]):not([type="hidden"])`]: {
               '--tw-divide-opacity': value,
             },
           }

--- a/src/plugins/divideStyle.js
+++ b/src/plugins/divideStyle.js
@@ -2,21 +2,26 @@ export default function () {
   return function ({ addUtilities, variants }) {
     addUtilities(
       {
-        '.divide-solid > :not([hidden]) ~ :not([hidden])': {
-          'border-style': 'solid',
-        },
-        '.divide-dashed > :not([hidden]) ~ :not([hidden])': {
-          'border-style': 'dashed',
-        },
-        '.divide-dotted > :not([hidden]) ~ :not([hidden])': {
-          'border-style': 'dotted',
-        },
-        '.divide-double > :not([hidden]) ~ :not([hidden])': {
-          'border-style': 'double',
-        },
-        '.divide-none > :not([hidden]) ~ :not([hidden])': {
-          'border-style': 'none',
-        },
+        '.divide-solid > :not([hidden]):not([type="hidden"]) ~ :not([hidden]):not([type="hidden"])':
+          {
+            'border-style': 'solid',
+          },
+        '.divide-dashed > :not([hidden]):not([type="hidden"]) ~ :not([hidden]):not([type="hidden"])':
+          {
+            'border-style': 'dashed',
+          },
+        '.divide-dotted > :not([hidden]):not([type="hidden"]) ~ :not([hidden]):not([type="hidden"])':
+          {
+            'border-style': 'dotted',
+          },
+        '.divide-double > :not([hidden]):not([type="hidden"]) ~ :not([hidden]):not([type="hidden"])':
+          {
+            'border-style': 'double',
+          },
+        '.divide-none > :not([hidden]):not([type="hidden"]) ~ :not([hidden]):not([type="hidden"])':
+          {
+            'border-style': 'none',
+          },
       },
       variants('divideStyle')
     )

--- a/src/plugins/divideWidth.js
+++ b/src/plugins/divideWidth.js
@@ -6,7 +6,7 @@ export default function () {
           value = value === '0' ? '0px' : value
 
           return {
-            '& > :not([hidden]) ~ :not([hidden])': {
+            '& > :not([hidden]):not([type="hidden"]) ~ :not([hidden]):not([type="hidden"])': {
               '--tw-divide-x-reverse': '0',
               'border-right-width': `calc(${value} * var(--tw-divide-x-reverse))`,
               'border-left-width': `calc(${value} * calc(1 - var(--tw-divide-x-reverse)))`,
@@ -34,12 +34,14 @@ export default function () {
 
     addUtilities(
       {
-        '.divide-y-reverse > :not([hidden]) ~ :not([hidden])': {
-          '--tw-divide-y-reverse': '1',
-        },
-        '.divide-x-reverse > :not([hidden]) ~ :not([hidden])': {
-          '--tw-divide-x-reverse': '1',
-        },
+        '.divide-y-reverse > :not([hidden]):not([type="hidden"]) ~ :not([hidden]):not([type="hidden"])':
+          {
+            '--tw-divide-y-reverse': '1',
+          },
+        '.divide-x-reverse > :not([hidden]):not([type="hidden"]) ~ :not([hidden]):not([type="hidden"])':
+          {
+            '--tw-divide-x-reverse': '1',
+          },
       },
       variants('divideWidth')
     )

--- a/src/plugins/space.js
+++ b/src/plugins/space.js
@@ -6,7 +6,7 @@ export default function () {
           value = value === '0' ? '0px' : value
 
           return {
-            '& > :not([hidden]) ~ :not([hidden])': {
+            '& > :not([hidden]):not([type="hidden"]) ~ :not([hidden]):not([type="hidden"])': {
               '--tw-space-x-reverse': '0',
               'margin-right': `calc(${value} * var(--tw-space-x-reverse))`,
               'margin-left': `calc(${value} * calc(1 - var(--tw-space-x-reverse)))`,
@@ -17,7 +17,7 @@ export default function () {
           value = value === '0' ? '0px' : value
 
           return {
-            '& > :not([hidden]) ~ :not([hidden])': {
+            '& > :not([hidden]):not([type="hidden"]) ~ :not([hidden]):not([type="hidden"])': {
               '--tw-space-y-reverse': '0',
               'margin-top': `calc(${value} * calc(1 - var(--tw-space-y-reverse)))`,
               'margin-bottom': `calc(${value} * var(--tw-space-y-reverse))`,
@@ -34,12 +34,14 @@ export default function () {
 
     addUtilities(
       {
-        '.space-y-reverse > :not([hidden]) ~ :not([hidden])': {
-          '--tw-space-y-reverse': '1',
-        },
-        '.space-x-reverse > :not([hidden]) ~ :not([hidden])': {
-          '--tw-space-x-reverse': '1',
-        },
+        '.space-y-reverse > :not([hidden]):not([type="hidden"]) ~ :not([hidden]):not([type="hidden"])':
+          {
+            '--tw-space-y-reverse': '1',
+          },
+        '.space-x-reverse > :not([hidden]):not([type="hidden"]) ~ :not([hidden]):not([type="hidden"])':
+          {
+            '--tw-space-x-reverse': '1',
+          },
       },
       variants('space')
     )


### PR DESCRIPTION
For spacing and divide utilities, ignore `<input type="hidden">`
elements.

This is useful within Rails-generated `<form>` elements, since the CSRF
token and `_method` override elements are automatically injected. This
can introduce unwanted spacing. For example, when a `<form>` declares a
`space-y-*` style, there are spacers added for each of the elements.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
