### PR TITLE
Support arbitrary values for the `gridColumn` plugin

### DIFF
--- a/src/plugins/gridColumn.js
+++ b/src/plugins/gridColumn.js
@@ -1,5 +1,8 @@
+import { asList } from '../util/pluginUtils'
 import createUtilityPlugin from '../util/createUtilityPlugin'
 
 export default function () {
-  return createUtilityPlugin('gridColumn', [['col', ['gridColumn']]])
+  return createUtilityPlugin('gridColumn', [['col', ['gridColumn']]], {
+    resolveArbitraryValue: asList,
+  })
 }

--- a/tests/jit/arbitrary-values.test.css
+++ b/tests/jit/arbitrary-values.test.css
@@ -7,12 +7,25 @@
 .col-\[7\] {
   grid-column: 7;
 }
+.col-\[span\2c 7\2c \/\2c span\2c 7\] {
+  grid-column: span 7 / span 7;
+}
+.col-\[span\2c calc\(9-2\)\2c \/\2c span\2c calc\(1\+6\)\] {
+  grid-column: span calc(9 - 2) / span calc(1 + 6);
+}
+.col-\[span\2c var\(--columns\)\2c \/\2c span\2c var\(--columns\)\] {
+  grid-column: span var(--columns) / span var(--columns);
+}
+.col-\[span\2c calc\(var\(--range-up\)-var\(--range-down\)\)\2c \/\2c span\2c 3\] {
+  grid-column: span calc(var(--range-up) - var(--range-down)) / span 3;
+}
 .col-start-\[7\] {
   grid-column-start: 7;
 }
 .col-end-\[7\] {
   grid-column-end: 7;
 }
+
 .row-\[7\] {
   grid-row: 7;
 }

--- a/tests/jit/arbitrary-values.test.html
+++ b/tests/jit/arbitrary-values.test.html
@@ -44,6 +44,10 @@
     <div class="col-[7]"></div>
     <div class="col-end-[7]"></div>
     <div class="col-start-[7]"></div>
+    <div class="col-[span,7,/,span,7]"></div>
+    <div class="col-[span,calc(9-2),/,span,calc(1+6)]"></div>
+    <div class="col-[span,var(--columns),/,span,var(--columns)]"></div>
+    <div class="col-[span,calc(var(--range-up)-var(--range-down)),/,span,3]"></div>
     <div class="flex-[var(--flex)]"></div>
     <div class="flex-grow-[var(--grow)]"></div>
     <div class="flex-shrink-[var(--shrink)]"></div>


### PR DESCRIPTION
This PR brings support for passing arbitrary values to the `gridColumn` plugin.

The following class in your markup...

```html
<div class="col-[span,18,/,span,18]"></div>
```

...will generate the following CSS property:

```css
/* --> grid-column: span 18 / span 18; */
```

## Supports `cacl()` and CSS variables

You can also use `calc()` operations...

```html
<div class="col-[span,calc(9-2),/,span,calc(1+6)]"></div>
```

```css
/* --> grid-column: span calc(9 - 2) / span calc(1 + 6); */
```

...as well as CSS variables:

```html
<div class="col-[span,var(--columns),/,span,var(--columns)]"></div>
```

```css
/* --> grid-column: span var(--columns) / span var(--columns); */
```

If you really feel adventurous, you can even use both together!

```html
<div class="col-[span,calc(var(--range-up)-var(--range-down)),/,span,3]"></div>
```

```css
/* --> grid-column: span calc(var(--range-up) - var(--range-down)) / span 3; */
```

---

## Important note around the `/` character

While you can ommit the commas around the `/` separator in certain situations, it's not always safe to do so.

The first example used above would work like this...

```html
<div class="col-[span,18/span,18]"></div>
```

```css
/* --> grid-column: span 18 / span 18; */
```

... but if the `/` character is used immediately after a `calc()` operation, **you _must_ use the separating commas** to avoid formatting problems with calc operations.

This class will work...

```html
<div class="col-[span,calc(9-2),/,span,calc(1+6)]"></div>
```

```css
grid-column: span calc(9 - 2) / span calc(1 + 6);
```

...but the same without wrapping the `/` in commas **will not work**:

```html
<div class="col-[span,calc(9-2),/,span,calc(1+6)]"></div>
```

```css
grid-column: span calc(9-2) / span calc(1 + 6);
```

Notice the missing spaces inside the `calc(9-2)`, which is not valid CSS. 

I believe this is due to the fact that `/` is an `operator`, and it shouldn't come immediately after the `calc()` operation. The same happens if you would use a `*` or `+` immediately after.

Wrapping the `/` in commas generates a space explicitly, and works in all scenarios.