### PR TITLE
Support arbitrary values for `transitionProperty`

### DIFF
--- a/src/plugins/transitionProperty.js
+++ b/src/plugins/transitionProperty.js
@@ -2,12 +2,13 @@ export default function () {
   return function ({ matchUtilities, theme, variants }) {
     let defaultTimingFunction = theme('transitionTimingFunction.DEFAULT')
     let defaultDuration = theme('transitionDuration.DEFAULT')
+    let transitionPropertyTheme = theme('transitionProperty')
 
     matchUtilities(
       {
         transition: (value) => {
           return {
-            'transition-property': value,
+            'transition-property': transitionPropertyTheme[value] ?? value.replace(/,/g, ', '),
             ...(value === 'none'
               ? {}
               : {
@@ -20,7 +21,7 @@ export default function () {
       {
         values: theme('transitionProperty'),
         variants: variants('transitionProperty'),
-        type: 'lookup',
+        type: 'any',
       }
     )
   }

--- a/tests/jit/arbitrary-values.test.css
+++ b/tests/jit/arbitrary-values.test.css
@@ -144,6 +144,21 @@
   --tw-skew-y: 3px;
   transform: var(--tw-transform);
 }
+.transition-\[left\] {
+  transition-property: left;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+.transition-\[width\2c height\] {
+  transition-property: width, height;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+.transition-\[color\2c opacity\2c height\2c left\2c width\] {
+  transition-property: color, opacity, height, left, width;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
 .grid-cols-\[200px\2c repeat\(auto-fill\2c minmax\(15\%\2c 100px\)\)\2c 300px\] {
   grid-template-columns: 200px repeat(auto-fill, minmax(15%, 100px)) 300px;
 }

--- a/tests/jit/arbitrary-values.test.html
+++ b/tests/jit/arbitrary-values.test.html
@@ -53,6 +53,7 @@
     <div class="rotate-[23deg] rotate-[2.3rad] rotate-[401grad] rotate-[1.5turn]"></div>
     <div class="skew-x-[3px]"></div>
     <div class="skew-y-[3px]"></div>
+    <div class="transition-[left] transition-[width,height] transition-[color,opacity,height,left,width]"></div>
     <div class="text-[2.23rem]"></div>
     <div class="text-[length:var(--font-size)]"></div>
     <div class="text-[color:var(--color)]"></div>


### PR DESCRIPTION
Transition property can be a great use case for the JIT arbitrary values blocks. As such, this commit makes that utility accept arbitrary values and apply those values to the `transition-property` property.

> Note: I'm not sure if this is how y'all would want to implement this. For context, on my team we've recently started using tailwindcss and are migrating our existing code. In some cases, we are transitioning arbitrary props, and we don't necessarily want to bloat the config for those transitions.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
