### PR TITLE
Fix `object-position` arbitrary values

### DIFF
--- a/src/plugins/objectPosition.js
+++ b/src/plugins/objectPosition.js
@@ -1,5 +1,8 @@
 import createUtilityPlugin from '../util/createUtilityPlugin'
+import { asList } from '../util/pluginUtils'
 
 export default function () {
-  return createUtilityPlugin('objectPosition', [['object', ['object-position']]])
+  return createUtilityPlugin('objectPosition', [['object', ['object-position']]], {
+    resolveArbitraryValue: asList,
+  })
 }

--- a/tests/jit/arbitrary-values.test.css
+++ b/tests/jit/arbitrary-values.test.css
@@ -260,6 +260,12 @@
 .stroke-\[\#da5b66\] {
   stroke: #da5b66;
 }
+.object-\[50\%\2c 50\%\] {
+  object-position: 50% 50%;
+}
+.object-\[top\2c right\] {
+  object-position: top right;
+}
 .object-\[var\(--position\)\] {
   object-position: var(--position);
 }

--- a/tests/jit/arbitrary-values.test.html
+++ b/tests/jit/arbitrary-values.test.html
@@ -97,6 +97,8 @@
     <div class="from-[var(--color)] via-[var(--color)] to-[var(--color)]"></div>
     <div class="fill-[#da5b66]"></div>
     <div class="fill-[var(--color)]"></div>
+    <div class="object-[50%,50%]"></div>
+    <div class="object-[top,right]"></div>
     <div class="object-[var(--position)]"></div>
     <div class="stroke-[#da5b66]"></div>
     <div class="leading-[var(--leading)]"></div>


### PR DESCRIPTION
Fixes #5177

**Before**

```css
.object-\[50\%\2c 50\%\] {
  object-position: 50%, 50%;
}
```

**After**

```css
.object-\[50\%\2c 50\%\] {
  object-position: 50% 50%;
}
```