### PR TITLE
Ensure nested `[]` is allowed

### DIFF
--- a/src/jit/lib/generateRules.js
+++ b/src/jit/lib/generateRules.js
@@ -17,6 +17,9 @@ function getClassNameFromSelector(selector) {
 // ['ring-offset-blue', '100']
 // ['ring-offset', 'blue-100']
 // ['ring', 'offset-blue-100']
+// Example with dynamic classes:
+// ['grid-cols', '[[linename],1fr,auto]']
+// ['grid', 'cols-[[linename],1fr,auto]']
 function* candidatePermutations(candidate, lastIndex = Infinity) {
   if (lastIndex < 0) {
     return
@@ -25,7 +28,7 @@ function* candidatePermutations(candidate, lastIndex = Infinity) {
   let dashIdx
 
   if (lastIndex === Infinity && candidate.endsWith(']')) {
-    let bracketIdx = candidate.lastIndexOf('[')
+    let bracketIdx = candidate.indexOf('[')
 
     // If character before `[` isn't a dash or a slash, this isn't a dynamic class
     // eg. string[]

--- a/tests/jit/arbitrary-values.test.css
+++ b/tests/jit/arbitrary-values.test.css
@@ -103,11 +103,20 @@
     }
   }
 }
+.w-\[\[\]\] {
+  width: [];
+}
+.w-\[\[\[\]\]\] {
+  width: [[]];
+}
 .w-\[\(\)\] {
   width: ();
 }
 .w-\[\(\(\)\)\] {
   width: (());
+}
+.w-\[\'\]\[\]\'\] {
+  width: '][]';
 }
 .w-\[\'\)\(\)\'\] {
   width: ')()';
@@ -168,6 +177,9 @@
 }
 .grid-cols-\[200px\2c repeat\(auto-fill\2c minmax\(15\%\2c 100px\)\)\2c 300px\] {
   grid-template-columns: 200px repeat(auto-fill, minmax(15%, 100px)) 300px;
+}
+.grid-cols-\[\[linename\]\2c 1fr\2c auto\] {
+  grid-template-columns: [linename] 1fr auto;
 }
 .grid-rows-\[200px\2c repeat\(auto-fill\2c minmax\(15\%\2c 100px\)\)\2c 300px\] {
   grid-template-rows: 200px repeat(auto-fill, minmax(15%, 100px)) 300px;

--- a/tests/jit/arbitrary-values.test.html
+++ b/tests/jit/arbitrary-values.test.html
@@ -135,9 +135,6 @@
     <div class="w-['][]']"></div><!-- VALID -->
     <div class="w-[')()']"></div><!-- VALID -->
     <div class="w-['}{}']"></div><!-- VALID -->
-    <div class="w-[[']']]"></div><!-- VALID -->
-    <div class="w-[(')')]"></div><!-- VALID -->
-    <div class="w-[{'}'}]"></div><!-- VALID -->
     <div class="w-[{[}]]"></div><!-- INVALID -->
     <div class="w-[[{]}]"></div><!-- INVALID -->
     <div class="w-[{(})]"></div><!-- INVALID -->


### PR DESCRIPTION
After the improvements in #5293, I noticed that writing `grid-cols-[[linename],1fr,auto]` doesn't work because of the nested `[]`. This PR will make sure that it does work as expected.

You will also notice that this generated a bit more code, because I had some test examples that weren't covered yet.
I also dropped a few examples that were in there from the previous PR. I think we can still do those, but I didn't want to touch the regexes for the content extractors.