### PR TITLE
Ensure purge tests work even for version mismatches

### DIFF
--- a/tests/purgeUnusedStyles.test.js
+++ b/tests/purgeUnusedStyles.test.js
@@ -20,6 +20,16 @@ function suppressConsoleLogs(cb, type = 'warn') {
   }
 }
 
+function dropTailwindHeader(css) {
+  let [header, ...lines] = css.split('\n')
+
+  expect(
+    /\/*! tailwindcss v\d*\.\d*\.\d* \| MIT License \| https:\/\/tailwindcss.com \*\//g.test(header)
+  ).toBe(true)
+
+  return lines.join('\n')
+}
+
 function extractRules(root) {
   let rules = []
 
@@ -450,7 +460,7 @@ test(
           'utf8'
         )
 
-        expect(result.css).toMatchCss(expected)
+        expect(dropTailwindHeader(result.css)).toMatchCss(dropTailwindHeader(expected))
       })
   })
 )
@@ -477,7 +487,7 @@ test('does not purge if the array is empty', () => {
             'utf8'
           )
 
-          expect(result.css).toMatchCss(expected)
+          expect(dropTailwindHeader(result.css)).toMatchCss(dropTailwindHeader(expected))
         })
     })
   )
@@ -502,7 +512,7 @@ test('does not purge if explicitly disabled', () => {
             'utf8'
           )
 
-          expect(result.css).toMatchCss(expected)
+          expect(dropTailwindHeader(result.css)).toMatchCss(dropTailwindHeader(expected))
         })
     })
   )
@@ -527,7 +537,7 @@ test('does not purge if purge is simply false', () => {
             'utf8'
           )
 
-          expect(result.css).toMatchCss(expected)
+          expect(dropTailwindHeader(result.css)).toMatchCss(dropTailwindHeader(expected))
         })
     })
   )


### PR DESCRIPTION
We applied the same treatment for the sanity tests, where we ignore the
first line (the tailwind header).

An odd issue I have found is that diffing of big css files is _very_
slow. When te tests pass, then the first test takes `3302 ms`, however,
when it fails it takes `477482 ms` on my machine. That's almost 8
minutes.
