### PR TITLE
Ensure integration tests are up to date

### DIFF
--- a/integrations/tailwindcss-cli/tests/cli.test.js
+++ b/integrations/tailwindcss-cli/tests/cli.test.js
@@ -12,7 +12,7 @@ let EXECUTABLE = 'node ../../lib/cli.js'
 
 describe('Build command', () => {
   test('--output', async () => {
-    await writeInputFile('index.html', html`<div class="font-bold"></div>`)
+    await writeInputFile('index.html', html`<div class="font-bold shadow"></div>`)
 
     await $(`${EXECUTABLE} --output ./dist/main.css`)
 

--- a/integrations/tailwindcss-cli/tests/cli.test.js
+++ b/integrations/tailwindcss-cli/tests/cli.test.js
@@ -258,7 +258,7 @@ describe('Build command', () => {
 
     expect(combined).toMatchInlineSnapshot(`
       "
-      tailwindcss v2.2.4
+      tailwindcss v2.2.8
 
       Usage:
          tailwindcss build [options]
@@ -348,7 +348,7 @@ describe('Init command', () => {
 
     expect(combined).toMatchInlineSnapshot(`
       "
-      tailwindcss v2.2.4
+      tailwindcss v2.2.8
 
       Usage:
          tailwindcss init [options]


### PR DESCRIPTION
- update (old) incorrect snapshots
- add `shadow` so that we can test `@tailwind base`

---

Wanted to ensure that these are up to date, which will help us when we start refactoring the code in the next cycle so that we guarantee that our integrations don't break.

<img width="739" alt="screenshot of integration tests passing" src="https://user-images.githubusercontent.com/1834413/131136729-2c82b36b-80e5-4cd1-9e6e-08951d1e6b5a.png">
