### PR TITLE
Support `@apply` for classes outside of a `@layer`

### DIFF
--- a/src/lib/expandApplyAtRules.js
+++ b/src/lib/expandApplyAtRules.js
@@ -97,6 +97,7 @@ function processApply(root, context) {
     for (let util of candidates) {
       applyCandidates.add(util)
     }
+
     applies.push(rule)
   })
 

--- a/src/lib/expandApplyAtRules.js
+++ b/src/lib/expandApplyAtRules.js
@@ -211,7 +211,12 @@ function processApply(root, context) {
             })
           }
 
-          siblings.push([meta, root.nodes[0]])
+          // Insert it
+          siblings.push([
+            // Ensure that when we are sorting, that we take the layer order into account
+            { ...meta, sort: meta.sort | context.layerOrder[meta.layer] },
+            root.nodes[0],
+          ])
         }
       }
 

--- a/src/lib/expandTailwindAtRules.js
+++ b/src/lib/expandTailwindAtRules.js
@@ -109,6 +109,16 @@ function buildStylesheet(rules, context) {
     components: new Set(),
     utilities: new Set(),
     variants: new Set(),
+
+    // All the CSS that is not Tailwind related can be put in this bucket. This
+    // will make it easier to later use this information when we want to
+    // `@apply` for example. The main reason we do this here is because we
+    // still need to make sure the order is correct. Last but not least, we
+    // will make sure to always re-inject this section into the css, even if
+    // certain rules were not used. This means that it will look like a no-op
+    // from the user's perspective, but we gathered all the useful information
+    // we need.
+    user: new Set(),
   }
 
   for (let [sort, rule] of sortedRules) {
@@ -129,6 +139,11 @@ function buildStylesheet(rules, context) {
 
     if (sort & context.layerOrder.utilities) {
       returnValue.utilities.add(rule)
+      continue
+    }
+
+    if (sort & context.layerOrder.user) {
+      returnValue.user.add(rule)
       continue
     }
   }

--- a/tests/apply.test.js
+++ b/tests/apply.test.js
@@ -292,29 +292,26 @@ test('@apply classes from outside a @layer', async () => {
       }
 
       .bar {
-        font-weight: 700;
         --tw-text-opacity: 1;
         color: rgba(239, 68, 68, var(--tw-text-opacity));
+        font-weight: 700;
       }
 
       .bar:hover {
         --tw-text-opacity: 1;
-        color: rgba(16, 185, 129, var(--tw-text-opacity));
-      }
-
-      .baz {
-        font-weight: 700;
-        --tw-text-opacity: 1;
-        color: rgba(239, 68, 68, var(--tw-text-opacity));
-      }
-
-      .baz:hover {
-        --tw-text-opacity: 1;
-        color: rgba(16, 185, 129, var(--tw-text-opacity));
+        color: rgba(34, 197, 94, var(--tw-text-opacity));
       }
 
       .baz {
         text-decoration: underline;
+        --tw-text-opacity: 1;
+        color: rgba(239, 68, 68, var(--tw-text-opacity));
+        font-weight: 700;
+      }
+
+      .baz:hover {
+        --tw-text-opacity: 1;
+        color: rgba(34, 197, 94, var(--tw-text-opacity));
       }
 
       .keep-me-even-though-I-am-not-used-in-content {

--- a/tests/apply.test.js
+++ b/tests/apply.test.js
@@ -323,3 +323,85 @@ test('@apply classes from outside a @layer', async () => {
     `)
   })
 })
+
+test('@applying classes from outside a @layer respects the source order', async () => {
+  let config = {
+    content: [{ raw: html`<div class="container font-bold foo bar baz"></div>` }],
+  }
+
+  let input = css`
+    .baz {
+      @apply bar underline;
+    }
+
+    @tailwind components;
+
+    .keep-me-even-though-I-am-not-used-in-content {
+      color: green;
+    }
+
+    @tailwind utilities;
+
+    .foo {
+      @apply font-bold;
+    }
+
+    .bar {
+      @apply no-underline;
+    }
+  `
+
+  await run(input, config).then((result) => {
+    return expect(result.css).toMatchFormattedCss(css`
+      .baz {
+        text-decoration: underline;
+        text-decoration: none;
+      }
+
+      .container {
+        width: 100%;
+      }
+      @media (min-width: 640px) {
+        .container {
+          max-width: 640px;
+        }
+      }
+      @media (min-width: 768px) {
+        .container {
+          max-width: 768px;
+        }
+      }
+      @media (min-width: 1024px) {
+        .container {
+          max-width: 1024px;
+        }
+      }
+      @media (min-width: 1280px) {
+        .container {
+          max-width: 1280px;
+        }
+      }
+      @media (min-width: 1536px) {
+        .container {
+          max-width: 1536px;
+        }
+      }
+
+      .keep-me-even-though-I-am-not-used-in-content {
+        color: green;
+      }
+
+      .font-bold {
+        font-weight: 700;
+      }
+
+      .foo {
+        font-weight: 700;
+      }
+
+      .bar {
+        text-decoration: none;
+      }
+    `)
+  })
+})


### PR DESCRIPTION
This PR will allow you to apply classes that are not inside a `@layer` directive. This is an important part of making JIT the default for backwards compatibility reasons. In short:

The following already worked:
```css
@tailwind utilities;

.foo {
  @apply bg-red-500 hover:bg-red-600;
}
```

This got converted to the following output:
```css
.foo {
  --tw-bg-opacity: 1;
  background-color: rgba(239, 68, 68, var(--tw-bg-opacity));
}
.foo:hover {
   --tw-bg-opacity: 1;
  background-color: rgba(220, 38, 38, var(--tw-bg-opacity));
}
```

However, it was not possible to do this:

```css
@tailwind utilities;

.foo {
  @apply bg-red-500 hover:bg-red-600;
}

.bar {
  @apply hover:foo;
}
```

This resulted in the following output:
```
CssSyntaxError: The `hover:foo` class does not exist. If `hover:foo` is a custom class, make sure it is defined within a `@layer` directive.
```

But with this PR, it results in the following output:
```css
.foo {
  --tw-bg-opacity: 1;
  background-color: rgba(239, 68, 68, var(--tw-bg-opacity));
}
.foo:hover {
  --tw-bg-opacity: 1;
  background-color: rgba(220, 38, 38, var(--tw-bg-opacity));
}
.bar:hover {
  --tw-bg-opacity: 1;
  background-color: rgba(239, 68, 68, var(--tw-bg-opacity));
}
.bar:hover:hover {
  --tw-bg-opacity: 1;
  background-color: rgba(220, 38, 38, var(--tw-bg-opacity));
}
```

There is this weird issue that `.bar:hover:hover` exists, but I will fix that in another PR. (Note: this is an existing issue, and not a newly introduced issue)

---

Apart from the backwards compatibility aspect, the biggest difference is the behaviour whether you are using the class or not.

```css
@tailwind utilities;

.foo { /* This will _always_ exist in your output, even if you didn't use the "foo" class in your content. */
  
}

@layer components {
  .bar { /* This will _only_ exist in your output if you used the "bar" class in your content. */
  }
}
```
