### PR TITLE
Unify config helpers into single object

### DIFF
--- a/src/util/resolveConfig.js
+++ b/src/util/resolveConfig.js
@@ -123,6 +123,12 @@ function resolveFunctionKeys(object) {
     return val === undefined ? defaultValue : val
   }
 
+  resolvePath.theme = resolvePath
+
+  for (let key in configUtils) {
+    resolvePath[key] = configUtils[key]
+  }
+
   return Object.keys(object).reduce((resolved, key) => {
     return {
       ...resolved,

--- a/tests/resolveConfig.test.js
+++ b/tests/resolveConfig.test.js
@@ -2215,3 +2215,62 @@ test('plugins are merged', () => {
     plugins: ['1', '2', '3'],
   })
 })
+
+test('all helpers can be destructured from the first function argument', () => {
+  const userConfig = {
+    theme: {
+      example: ({ theme, colors, negative, breakpoints }) => ({
+        weight: theme('fontWeight.bold'),
+        black: colors.black,
+        white: colors.white,
+        ...negative(theme('spacing')),
+        ...breakpoints(theme('screens')),
+      }),
+    },
+  }
+
+  const defaultConfig = {
+    prefix: '-',
+    important: false,
+    separator: ':',
+    theme: {
+      screens: {
+        sm: '640px',
+        md: '768px',
+      },
+      fontWeight: {
+        bold: 700,
+      },
+      spacing: {
+        0: '0px',
+        1: '1px',
+        2: '2px',
+        3: '3px',
+        4: '4px',
+      },
+    },
+    variants: {},
+  }
+
+  const result = resolveConfig([userConfig, defaultConfig])
+
+  expect(result).toMatchObject({
+    prefix: '-',
+    important: false,
+    separator: ':',
+    theme: {
+      example: {
+        weight: 700,
+        black: '#000',
+        white: '#fff',
+        '-1': '-1px',
+        '-2': '-2px',
+        '-3': '-3px',
+        '-4': '-4px',
+        'screen-sm': '640px',
+        'screen-md': '768px',
+      },
+    },
+    variants: {},
+  })
+})


### PR DESCRIPTION
This PR makes it possible to destructure all the config helpers from the first parameter so that you don't need to have an unused `theme` parameter just to access the second parameter.

```diff
- colors: (theme, { colors }) => ({ colors })
+ colors: ({ theme, colors }) => ({ colors })
```

This is not a breaking change, and `theme` is still accessible on its own as the first parameter (both examples above still work). However moving forward we will only document the second option.