### PR TITLE
Add `accent-color` utilities

### DIFF
--- a/src/plugins/accentColor.js
+++ b/src/plugins/accentColor.js
@@ -5,7 +5,7 @@ export default function () {
   return function ({ matchUtilities, theme, variants }) {
     matchUtilities(
       {
-        caret: (value) => {
+        accent: (value) => {
           return { 'accent-color': toColorValue(value) }
         },
       },

--- a/src/plugins/accentColor.js
+++ b/src/plugins/accentColor.js
@@ -1,0 +1,19 @@
+import flattenColorPalette from '../util/flattenColorPalette'
+import toColorValue from '../util/toColorValue'
+
+export default function () {
+  return function ({ matchUtilities, theme, variants }) {
+    matchUtilities(
+      {
+        caret: (value) => {
+          return { 'accent-color': toColorValue(value) }
+        },
+      },
+      {
+        values: flattenColorPalette(theme('accentColor')),
+        variants: variants('accentColor'),
+        type: 'color',
+      }
+    )
+  }
+}

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -125,6 +125,7 @@ export { default as fontSmoothing } from './fontSmoothing'
 export { default as placeholderColor } from './placeholderColor'
 export { default as placeholderOpacity } from './placeholderOpacity'
 export { default as caretColor } from './caretColor'
+export { default as accentColor } from './accentColor'
 
 export { default as opacity } from './opacity'
 export { default as backgroundBlendMode } from './backgroundBlendMode'

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -172,7 +172,10 @@ module.exports = {
       none: 'none',
     },
     caretColor: (theme) => theme('colors'),
-    accentColor: (theme) => theme('colors'),
+    accentColor: (theme) => ({
+      ...theme('colors'),
+      auto: 'auto',
+    }),
     contrast: {
       0: '0',
       50: '.5',

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -172,6 +172,7 @@ module.exports = {
       none: 'none',
     },
     caretColor: (theme) => theme('colors'),
+    accentColor: (theme) => theme('colors'),
     contrast: {
       0: '0',
       50: '.5',

--- a/tests/basic-usage.test.css
+++ b/tests/basic-usage.test.css
@@ -649,6 +649,9 @@
 .caret-red-600 {
   caret-color: #dc2626;
 }
+.accent-red-600 {
+  accent-color: #dc2626;
+}
 .opacity-90 {
   opacity: 0.9;
 }

--- a/tests/basic-usage.test.html
+++ b/tests/basic-usage.test.html
@@ -101,6 +101,7 @@
     <div class="placeholder-green-300"></div>
     <div class="placeholder-opacity-60"></div>
     <div class="caret-red-600"></div>
+    <div class="accent-red-600"></div>
     <div class="place-items-end"></div>
     <div class="place-self-center"></div>
     <div class="pointer-events-none"></div>


### PR DESCRIPTION
This PR adds utilities for the [`accent-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/accent-color) property.

Example usage:

`<input type="checkbox" class="accent-red-500">`