### PR TITLE
Add `scroll-behavior` utilities

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1106,6 +1106,13 @@ export let overscrollBehavior = ({ addUtilities }) => {
   })
 }
 
+export let scrollBehavior = ({ addUtilities }) => {
+  addUtilities({
+    '.scroll-auto': { 'scroll-behavior': 'auto' },
+    '.scroll-smooth': { 'scroll-behavior': 'smooth' },
+  })
+}
+
 export let textOverflow = ({ addUtilities }) => {
   addUtilities({
     '.truncate': { overflow: 'hidden', 'text-overflow': 'ellipsis', 'white-space': 'nowrap' },

--- a/tests/raw-content.test.css
+++ b/tests/raw-content.test.css
@@ -364,6 +364,9 @@
 .overscroll-contain {
   overscroll-behavior: contain;
 }
+.scroll-smooth {
+  scroll-behavior: smooth;
+}
 .truncate {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/tests/raw-content.test.html
+++ b/tests/raw-content.test.html
@@ -96,6 +96,7 @@
     <div class="outline-none outline-black"></div>
     <div class="overflow-hidden"></div>
     <div class="overscroll-contain"></div>
+    <div class="scroll-smooth"></div>
     <div class="p-4 py-2 px-3 pt-1 pr-2 pb-3 pl-4"></div>
     <div class="place-content-start"></div>
     <div class="placeholder-green-300"></div>


### PR DESCRIPTION
This PR adds utilities for the [`scroll-behavior`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior) property.

I would recommend pushing people towards using this property responsibly in combination with the `motion-safe` variant. I don't believe we have to manually enable variants for plugins anymore but if we do let me know and I'll add `motion-safe` and `motion-reduce` to the defaults.
