### PR TITLE
Remove lodash

### DIFF
--- a/defaultConfig.js
+++ b/defaultConfig.js
@@ -1,4 +1,4 @@
-const cloneDeep = require('lodash/cloneDeep')
-const defaultConfig = require('./stubs/defaultConfig.stub.js')
+let { cloneDeep } = require('./src/util/cloneDeep')
+let defaultConfig = require('./stubs/defaultConfig.stub.js')
 
 module.exports = cloneDeep(defaultConfig)

--- a/defaultTheme.js
+++ b/defaultTheme.js
@@ -1,4 +1,15 @@
-const cloneDeep = require('lodash/cloneDeep')
-const defaultConfig = require('./stubs/defaultConfig.stub.js')
+let defaultConfig = require('./stubs/defaultConfig.stub.js')
 
 module.exports = cloneDeep(defaultConfig.theme)
+
+function cloneDeep(value) {
+  if (Array.isArray(value)) {
+    return value.map((child) => cloneDeep(child))
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, cloneDeep(v)]))
+  }
+
+  return value
+}

--- a/defaultTheme.js
+++ b/defaultTheme.js
@@ -1,15 +1,4 @@
+let { cloneDeep } = require('./src/util/cloneDeep')
 let defaultConfig = require('./stubs/defaultConfig.stub.js')
 
 module.exports = cloneDeep(defaultConfig.theme)
-
-function cloneDeep(value) {
-  if (Array.isArray(value)) {
-    return value.map((child) => cloneDeep(child))
-  }
-
-  if (typeof value === 'object' && value !== null) {
-    return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, cloneDeep(v)]))
-  }
-
-  return value
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "tailwindcss",
       "version": "2.2.9",
       "license": "MIT",
       "dependencies": {
@@ -20,7 +19,6 @@
         "fast-glob": "^3.2.7",
         "glob-parent": "^6.0.1",
         "is-glob": "^4.0.1",
-        "lodash": "^4.17.21",
         "normalize-path": "^3.0.0",
         "object-hash": "^2.2.0",
         "postcss-js": "^3.0.3",
@@ -7031,7 +7029,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -15617,7 +15616,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "fast-glob": "^3.2.7",
     "glob-parent": "^6.0.1",
     "is-glob": "^4.0.1",
-    "lodash": "^4.17.21",
     "normalize-path": "^3.0.0",
     "object-hash": "^2.2.0",
     "postcss-js": "^3.0.3",

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import chalk from 'chalk'
 import log from './util/log'
 
@@ -9,11 +8,11 @@ const featureFlags = {
 
 export function flagEnabled(config, flag) {
   if (featureFlags.future.includes(flag)) {
-    return config.future === 'all' || _.get(config, ['future', flag], false)
+    return config.future === 'all' || (config?.future?.[flag] ?? false)
   }
 
   if (featureFlags.experimental.includes(flag)) {
-    return config.experimental === 'all' || _.get(config, ['experimental', flag], false)
+    return config.experimental === 'all' || (config?.experimental?.[flag] ?? false)
   }
 
   return false
@@ -24,7 +23,7 @@ function experimentalFlagsEnabled(config) {
     return featureFlags.experimental
   }
 
-  return Object.keys(_.get(config, 'experimental', {})).filter(
+  return Object.keys(config?.experimental ?? {}).filter(
     (flag) => featureFlags.experimental.includes(flag) && config.experimental[flag]
   )
 }

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -15,44 +15,7 @@ import bigSign from '../util/bigSign'
 import corePlugins from '../corePlugins'
 import * as sharedState from './sharedState'
 import { env } from './sharedState'
-
-function toPath(value) {
-  if (Array.isArray(value)) {
-    return value
-  }
-
-  let inBrackets = false
-  let parts = []
-  let chunk = ''
-
-  for (let i = 0; i < value.length; i++) {
-    let char = value[i]
-    if (char === '[') {
-      inBrackets = true
-      parts.push(chunk)
-      chunk = ''
-      continue
-    }
-    if (char === ']' && inBrackets) {
-      inBrackets = false
-      parts.push(chunk)
-      chunk = ''
-      continue
-    }
-    if (char === '.' && !inBrackets && chunk.length > 0) {
-      parts.push(chunk)
-      chunk = ''
-      continue
-    }
-    chunk = chunk + char
-  }
-
-  if (chunk.length > 0) {
-    parts.push(chunk)
-  }
-
-  return parts
-}
+import { toPath } from '../util/toPath'
 
 function insertInto(list, value, { before = [] } = {}) {
   before = [].concat(before)

--- a/src/lib/substituteResponsiveAtRules.js
+++ b/src/lib/substituteResponsiveAtRules.js
@@ -1,8 +1,12 @@
-import _ from 'lodash'
 import postcss from 'postcss'
 import cloneNodes from '../util/cloneNodes'
 import buildMediaQuery from '../util/buildMediaQuery'
 import buildSelectorVariant from '../util/buildSelectorVariant'
+
+function tap(value, cb) {
+  cb(value)
+  return value
+}
 
 function isLayer(node) {
   if (Array.isArray(node)) {
@@ -20,9 +24,9 @@ export default function (config) {
     // Wrap any `responsive` rules with a copy of their parent `layer` to
     // ensure the layer isn't lost when copying to the `screens` location.
     css.walkAtRules('layer', (layerAtRule) => {
-      const layer = layerAtRule.params
+      let layer = layerAtRule.params
       layerAtRule.walkAtRules('responsive', (responsiveAtRule) => {
-        const nestedlayerAtRule = postcss.atRule({
+        let nestedlayerAtRule = postcss.atRule({
           name: 'layer',
           params: layer,
         })
@@ -32,15 +36,15 @@ export default function (config) {
       })
     })
 
-    const {
+    let {
       theme: { screens },
       separator,
     } = config
-    const responsiveRules = postcss.root()
-    const finalRules = []
+    let responsiveRules = postcss.root()
+    let finalRules = []
 
     css.walkAtRules('responsive', (atRule) => {
-      const nodes = atRule.nodes
+      let nodes = atRule.nodes
       responsiveRules.append(...cloneNodes(nodes))
 
       // If the parent is already a `layer` (this is true for anything coming from
@@ -55,16 +59,16 @@ export default function (config) {
       atRule.remove()
     })
 
-    _.keys(screens).forEach((screen) => {
-      const mediaQuery = postcss.atRule({
+    for (let [screen, value] of Object.entries(screens ?? {})) {
+      let mediaQuery = postcss.atRule({
         name: 'media',
-        params: buildMediaQuery(screens[screen]),
+        params: buildMediaQuery(value),
       })
 
       mediaQuery.append(
-        _.tap(responsiveRules.clone(), (clonedRoot) => {
+        tap(responsiveRules.clone(), (clonedRoot) => {
           clonedRoot.walkRules((rule) => {
-            rule.selectors = _.map(rule.selectors, (selector) =>
+            rule.selectors = rule.selectors.map((selector) =>
               buildSelectorVariant(selector, screen, separator, (message) => {
                 throw rule.error(message)
               })
@@ -74,9 +78,9 @@ export default function (config) {
       )
 
       finalRules.push(mediaQuery)
-    })
+    }
 
-    const hasScreenRules = finalRules.some((i) => i.nodes.length !== 0)
+    let hasScreenRules = finalRules.some((i) => i.nodes.length !== 0)
 
     css.walkAtRules('tailwind', (atRule) => {
       if (atRule.params !== 'screens') {

--- a/src/lib/substituteResponsiveAtRules.js
+++ b/src/lib/substituteResponsiveAtRules.js
@@ -2,11 +2,7 @@ import postcss from 'postcss'
 import cloneNodes from '../util/cloneNodes'
 import buildMediaQuery from '../util/buildMediaQuery'
 import buildSelectorVariant from '../util/buildSelectorVariant'
-
-function tap(value, cb) {
-  cb(value)
-  return value
-}
+import { tap } from '../util/tap'
 
 function isLayer(node) {
   if (Array.isArray(node)) {

--- a/src/lib/substituteScreenAtRules.js
+++ b/src/lib/substituteScreenAtRules.js
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import buildMediaQuery from '../util/buildMediaQuery'
 
 export default function ({ tailwindConfig: { theme } }) {
@@ -6,7 +5,7 @@ export default function ({ tailwindConfig: { theme } }) {
     css.walkAtRules('screen', (atRule) => {
       const screen = atRule.params
 
-      if (!_.has(theme.screens, screen)) {
+      if (!theme.screens?.hasOwnProperty?.(screen)) {
         throw atRule.error(`No \`${screen}\` screen found.`)
       }
 

--- a/src/plugins/dropShadow.js
+++ b/src/plugins/dropShadow.js
@@ -1,10 +1,9 @@
-import _ from 'lodash'
 import nameClass from '../util/nameClass'
 
 export default function () {
   return function ({ addUtilities, theme, variants }) {
-    const utilities = _.fromPairs(
-      _.map(theme('dropShadow'), (value, modifier) => {
+    let utilities = Object.fromEntries(
+      Object.entries(theme('dropShadow') ?? {}).map(([modifier, value]) => {
         return [
           nameClass('drop-shadow', modifier),
           {

--- a/src/util/buildMediaQuery.js
+++ b/src/util/buildMediaQuery.js
@@ -1,7 +1,5 @@
-import _ from 'lodash'
-
 export default function buildMediaQuery(screens) {
-  if (_.isString(screens)) {
+  if (typeof screens === 'string') {
     screens = { min: screens }
   }
 
@@ -9,22 +7,15 @@ export default function buildMediaQuery(screens) {
     screens = [screens]
   }
 
-  return _(screens)
+  return screens
     .map((screen) => {
-      if (_.has(screen, 'raw')) {
+      if (screen?.hasOwnProperty?.('raw')) {
         return screen.raw
       }
 
-      return _(screen)
-        .map((value, feature) => {
-          feature = _.get(
-            {
-              min: 'min-width',
-              max: 'max-width',
-            },
-            feature,
-            feature
-          )
+      return Object.entries(screen)
+        .map(([feature, value]) => {
+          feature = { min: 'min-width', max: 'max-width' }[feature] ?? feature
           return `(${feature}: ${value})`
         })
         .join(' and ')

--- a/src/util/buildSelectorVariant.js
+++ b/src/util/buildSelectorVariant.js
@@ -1,10 +1,6 @@
 import parser from 'postcss-selector-parser'
+import { tap } from './tap'
 import { useMemo } from './useMemo'
-
-function tap(input, cb) {
-  cb(input)
-  return input
-}
 
 const buildSelectorVariant = useMemo(
   (selector, variantName, separator, onError = () => {}) => {

--- a/src/util/buildSelectorVariant.js
+++ b/src/util/buildSelectorVariant.js
@@ -1,6 +1,10 @@
 import parser from 'postcss-selector-parser'
-import tap from 'lodash/tap'
 import { useMemo } from './useMemo'
+
+function tap(input, cb) {
+  cb(input)
+  return input
+}
 
 const buildSelectorVariant = useMemo(
   (selector, variantName, separator, onError = () => {}) => {

--- a/src/util/cloneDeep.js
+++ b/src/util/cloneDeep.js
@@ -1,0 +1,11 @@
+export function cloneDeep(value) {
+  if (Array.isArray(value)) {
+    return value.map((child) => cloneDeep(child))
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, cloneDeep(v)]))
+  }
+
+  return value
+}

--- a/src/util/defaults.js
+++ b/src/util/defaults.js
@@ -1,0 +1,11 @@
+export function defaults(target, ...sources) {
+  for (let source of sources) {
+    for (let k in source) {
+      if (!target?.hasOwnProperty?.(k)) {
+        target[k] = source[k]
+      }
+    }
+  }
+
+  return target
+}

--- a/src/util/escapeClassName.js
+++ b/src/util/escapeClassName.js
@@ -1,9 +1,8 @@
 import parser from 'postcss-selector-parser'
-import get from 'lodash/get'
 import escapeCommas from './escapeCommas'
 
 export default function escapeClassName(className) {
-  const node = parser.className()
+  let node = parser.className()
   node.value = className
-  return escapeCommas(get(node, 'raws.value', node.value))
+  return escapeCommas(node?.raws?.value ?? node.value)
 }

--- a/src/util/generateVariantFunction.js
+++ b/src/util/generateVariantFunction.js
@@ -1,13 +1,12 @@
-import _ from 'lodash'
 import postcss from 'postcss'
 import selectorParser from 'postcss-selector-parser'
 import { useMemo } from './useMemo'
 
-const classNameParser = selectorParser((selectors) => {
+let classNameParser = selectorParser((selectors) => {
   return selectors.first.filter(({ type }) => type === 'class').pop().value
 })
 
-const getClassNameFromSelector = useMemo(
+let getClassNameFromSelector = useMemo(
   (selector) => classNameParser.transformSync(selector),
   (selector) => selector
 )
@@ -16,10 +15,10 @@ export default function generateVariantFunction(generator, options = {}) {
   return {
     options,
     handler: (container, config) => {
-      const cloned = postcss.root({ nodes: container.clone().nodes })
+      let cloned = postcss.root({ nodes: container.clone().nodes })
 
       container.before(
-        _.defaultTo(
+        (
           generator({
             container: cloned,
             separator: config.separator,
@@ -40,8 +39,7 @@ export default function generateVariantFunction(generator, options = {}) {
               })
               return cloned
             },
-          }),
-          cloned
+          }) ?? cloned
         ).nodes
       )
     },

--- a/src/util/parseObjectStyles.js
+++ b/src/util/parseObjectStyles.js
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import postcss from 'postcss'
 import postcssNested from 'postcss-nested'
 import postcssJs from 'postcss-js'
@@ -8,7 +7,7 @@ export default function parseObjectStyles(styles) {
     return parseObjectStyles([styles])
   }
 
-  return _.flatMap(styles, (style) => {
+  return styles.flatMap((style) => {
     return postcss([
       postcssNested({
         bubble: ['screen'],

--- a/src/util/prefixNegativeModifiers.js
+++ b/src/util/prefixNegativeModifiers.js
@@ -1,9 +1,7 @@
-import _ from 'lodash'
-
 export default function prefixNegativeModifiers(base, modifier) {
   if (modifier === '-') {
     return `-${base}`
-  } else if (_.startsWith(modifier, '-')) {
+  } else if (modifier.startsWith('-')) {
     return `-${base}-${modifier.slice(1)}`
   } else {
     return `${base}-${modifier}`

--- a/src/util/prefixSelector.js
+++ b/src/util/prefixSelector.js
@@ -1,5 +1,9 @@
 import parser from 'postcss-selector-parser'
-import tap from 'lodash/tap'
+
+function tap(value, cb) {
+  cb(value)
+  return value
+}
 
 export default function (prefix, selector) {
   const getPrefix =

--- a/src/util/prefixSelector.js
+++ b/src/util/prefixSelector.js
@@ -1,9 +1,5 @@
 import parser from 'postcss-selector-parser'
-
-function tap(value, cb) {
-  cb(value)
-  return value
-}
+import { tap } from './tap'
 
 export default function (prefix, selector) {
   const getPrefix =

--- a/src/util/processPlugins.js
+++ b/src/util/processPlugins.js
@@ -1,15 +1,16 @@
 import dlv from 'dlv'
 import postcss from 'postcss'
 import Node from 'postcss/lib/node'
-import escapeClassName from '../util/escapeClassName'
-import generateVariantFunction from '../util/generateVariantFunction'
-import parseObjectStyles from '../util/parseObjectStyles'
-import prefixSelector from '../util/prefixSelector'
-import wrapWithVariants from '../util/wrapWithVariants'
-import cloneNodes from '../util/cloneNodes'
+import escapeClassName from './escapeClassName'
+import generateVariantFunction from './generateVariantFunction'
+import parseObjectStyles from './parseObjectStyles'
+import prefixSelector from './prefixSelector'
+import wrapWithVariants from './wrapWithVariants'
+import cloneNodes from './cloneNodes'
 import transformThemeValue from './transformThemeValue'
-import nameClass from '../util/nameClass'
-import isKeyframeRule from '../util/isKeyframeRule'
+import nameClass from './nameClass'
+import isKeyframeRule from './isKeyframeRule'
+import { toPath } from './toPath'
 
 function defaults(target, ...sources) {
   for (let source of sources) {
@@ -21,11 +22,6 @@ function defaults(target, ...sources) {
   }
 
   return target
-}
-
-function toPath(path) {
-  if (Array.isArray(path)) return path
-  return path.split(/[\.\]\[]*/g)
 }
 
 function parseStyles(styles) {

--- a/src/util/processPlugins.js
+++ b/src/util/processPlugins.js
@@ -11,18 +11,7 @@ import transformThemeValue from './transformThemeValue'
 import nameClass from './nameClass'
 import isKeyframeRule from './isKeyframeRule'
 import { toPath } from './toPath'
-
-function defaults(target, ...sources) {
-  for (let source of sources) {
-    for (let k in source) {
-      if (!target?.hasOwnProperty?.(k)) {
-        target[k] = source[k]
-      }
-    }
-  }
-
-  return target
-}
+import { defaults } from './defaults'
 
 function parseStyles(styles) {
   if (!Array.isArray(styles)) {

--- a/src/util/processPlugins.js
+++ b/src/util/processPlugins.js
@@ -1,4 +1,5 @@
 import _ from 'lodash'
+import dlv from 'dlv'
 import postcss from 'postcss'
 import Node from 'postcss/lib/node'
 import isFunction from 'lodash/isFunction'
@@ -17,7 +18,7 @@ function parseStyles(styles) {
     return parseStyles([styles])
   }
 
-  return _.flatMap(styles, (style) => (style instanceof Node ? style : parseObjectStyles(style)))
+  return styles.flatMap((style) => (style instanceof Node ? style : parseObjectStyles(style)))
 }
 
 function wrapWithLayer(rules, layer) {
@@ -70,14 +71,14 @@ export default function (plugins, config) {
     )
   }
 
-  const getConfigValue = (path, defaultValue) => (path ? _.get(config, path, defaultValue) : config)
+  const getConfigValue = (path, defaultValue) => (path ? dlv(config, path, defaultValue) : config)
 
   plugins.forEach((plugin) => {
     if (plugin.__isOptionsFunction) {
       plugin = plugin()
     }
 
-    const handler = isFunction(plugin) ? plugin : _.get(plugin, 'handler', () => {})
+    const handler = isFunction(plugin) ? plugin : plugin?.handler ?? (() => {})
 
     handler({
       postcss,

--- a/src/util/tap.js
+++ b/src/util/tap.js
@@ -1,0 +1,4 @@
+export function tap(value, mutator) {
+  mutator(value)
+  return value
+}

--- a/src/util/toColorValue.js
+++ b/src/util/toColorValue.js
@@ -1,5 +1,3 @@
-import _ from 'lodash'
-
 export default function toColorValue(maybeFunction) {
-  return _.isFunction(maybeFunction) ? maybeFunction({}) : maybeFunction
+  return typeof maybeFunction === 'function' ? maybeFunction({}) : maybeFunction
 }

--- a/src/util/toPath.js
+++ b/src/util/toPath.js
@@ -1,0 +1,4 @@
+export function toPath(path) {
+  if (Array.isArray(path)) return path
+  return path.split(/[\.\]\[]+/g)
+}

--- a/src/util/withAlphaVariable.js
+++ b/src/util/withAlphaVariable.js
@@ -1,12 +1,11 @@
 import * as culori from 'culori'
-import _ from 'lodash'
 
 function isValidColor(color) {
   return culori.parse(color) !== undefined
 }
 
 export function withAlphaValue(color, alphaValue, defaultValue) {
-  if (_.isFunction(color)) {
+  if (typeof color === 'function') {
     return color({ opacityValue: alphaValue })
   }
 
@@ -40,7 +39,7 @@ export function withAlphaValue(color, alphaValue, defaultValue) {
 }
 
 export default function withAlphaVariable({ color, property, variable }) {
-  if (_.isFunction(color)) {
+  if (typeof color === 'function') {
     return {
       [variable]: '1',
       [property]: color({ opacityVariable: variable, opacityValue: `var(${variable})` }),

--- a/tests/to-path.test.js
+++ b/tests/to-path.test.js
@@ -1,0 +1,17 @@
+import { toPath } from '../src/util/toPath'
+
+it('should keep an array as an array', () => {
+  let input = ['a', 'b', '0', 'c']
+
+  expect(toPath(input)).toBe(input)
+})
+
+it.each`
+  input         | output
+  ${'a.b.c'}    | ${['a', 'b', 'c']}
+  ${'a[0].b.c'} | ${['a', '0', 'b', 'c']}
+  ${'.a'}       | ${['', 'a']}
+  ${'[].a'}     | ${['', 'a']}
+`('should convert "$input" to "$output"', ({ input, output }) => {
+  expect(toPath(input)).toEqual(output)
+})

--- a/tests/util/invokePlugin.js
+++ b/tests/util/invokePlugin.js
@@ -1,16 +1,16 @@
-import _ from 'lodash'
+import dlv from 'dlv'
 import escapeClassName from '../src/util/escapeClassName'
 
 export default function (plugin, config) {
   const addedUtilities = []
 
-  const getConfigValue = (path, defaultValue) => _.get(config, path, defaultValue)
+  const getConfigValue = (path, defaultValue) => dlv(config, path, defaultValue)
   const pluginApi = {
     config: getConfigValue,
     e: escapeClassName,
     theme: (path, defaultValue) => getConfigValue(`theme.${path}`, defaultValue),
     variants: (path, defaultValue) => {
-      if (_.isArray(config.variants)) {
+      if (Array.isArray(config.variants)) {
         return config.variants
       }
 
@@ -36,7 +36,7 @@ export default function (plugin, config) {
 
   return {
     utilities: addedUtilities.map(([utilities, variants]) => [
-      _.merge({}, ..._.castArray(utilities)),
+      Object.assign({}, ...(Array.isArray(utilities) ? utilities : [utilities])),
       variants,
     ]),
   }


### PR DESCRIPTION
This PR will get rid of the `lodash` dependency since it is rather big. I replaced most of the functions with plain built-ins. I've added a few extra utilities to mimic lodash' behaviour.
Some files (like the `resolveConfig`) can use some refactoring, however I tried to mainly focus on `lodash`'s removal.