### PR TITLE
Update color warnings to match other warnings

### DIFF
--- a/colors.js
+++ b/colors.js
@@ -4,8 +4,16 @@ let warned = []
 
 function warn({ version, from, to }) {
   if (!warned.includes(from)) {
-    console.warn(chalk.bold.yellow('warn'), '-', `As of Tailwind CSS ${version}, \`${from}\` has been renamed to \`${to}\`.`)
-    console.warn(chalk.bold.yellow('warn'), '-', 'Please update your color palette to eliminate this warning.')
+    console.warn(
+      chalk.bold.yellow('warn'),
+      '-',
+      `As of Tailwind CSS ${version}, \`${from}\` has been renamed to \`${to}\`.`
+    )
+    console.warn(
+      chalk.bold.yellow('warn'),
+      '-',
+      'Please update your color palette to eliminate this warning.'
+    )
     warned.push(from)
   }
 }

--- a/colors.js
+++ b/colors.js
@@ -1,9 +1,11 @@
+const chalk = require('chalk')
+
 let warned = []
 
 function warn({ version, from, to }) {
   if (!warned.includes(from)) {
-    console.log(`warn - As of Tailwind CSS ${version}, \`${from}\` has been renamed to \`${to}\`.`)
-    console.log('warn - Please update your color palette to eliminate this warning.')
+    console.warn(chalk.bold.yellow('warn'), '-', `As of Tailwind CSS ${version}, \`${from}\` has been renamed to \`${to}\`.`)
+    console.warn(chalk.bold.yellow('warn'), '-', 'Please update your color palette to eliminate this warning.')
     warned.push(from)
   }
 }

--- a/colors.js
+++ b/colors.js
@@ -1,19 +1,13 @@
-const chalk = require('chalk')
+const log = require('./lib/util/log').default
 
 let warned = []
 
 function warn({ version, from, to }) {
   if (!warned.includes(from)) {
-    console.warn(
-      chalk.bold.yellow('warn'),
-      '-',
-      `As of Tailwind CSS ${version}, \`${from}\` has been renamed to \`${to}\`.`
-    )
-    console.warn(
-      chalk.bold.yellow('warn'),
-      '-',
-      'Please update your color palette to eliminate this warning.'
-    )
+    log.warn([
+      `As of Tailwind CSS ${version}, \`${from}\` has been renamed to \`${to}\`.`,
+      'Please update your color palette to eliminate this warning.',
+    ])
     warned.push(from)
   }
 }


### PR DESCRIPTION
Make the color deprecation warnings match the style of other warnings in tailwind

**Before:**
![warn](https://user-images.githubusercontent.com/9247037/131889318-1b19d7f8-a5a0-4365-8c9f-3263a8a0d89d.png)

**After:**
![new warnings](https://user-images.githubusercontent.com/9247037/132260707-d30319a9-9b03-4f88-a563-d65d996945f2.png)