### PR TITLE
Improve release workflows part 2

### DIFF
--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -35,6 +35,9 @@ jobs:
         env:
           CI: true
 
+      - name: Build
+        run: npm run prepublishOnly
+
       - name: Test
         run: npm test
         env:

--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -47,8 +47,8 @@ jobs:
         id: vars
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
 
-      - name: "Version based on commit: 0.0.0-${{ steps.vars.outputs.sha_short }}"
-        run: npm version 0.0.0-${{ steps.vars.outputs.sha_short }}
+      - name: "Version based on commit: 0.0.0-insiders.${{ steps.vars.outputs.sha_short }}"
+        run: npm version 0.0.0-insiders.${{ steps.vars.outputs.sha_short }}
 
       - name: Publish
         run: npm publish --tag insiders

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
         env:
           CI: true
 
+      - name: Build
+        run: npm run prepublishOnly
+
       - name: Test
         run: npm test
         env:


### PR DESCRIPTION
I knew it would take multiple tries... this is a continuation of #5421 

- ensure we build before the tests (our tests require it)
- improve insiders version name
