### PR TITLE
Force creating a version

### DIFF
--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -48,7 +48,7 @@ jobs:
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
 
       - name: "Version based on commit: 0.0.0-insiders.${{ steps.vars.outputs.sha_short }}"
-        run: npm version 0.0.0-insiders.${{ steps.vars.outputs.sha_short }}
+        run: npm version 0.0.0-insiders.${{ steps.vars.outputs.sha_short }} --force
 
       - name: Publish
         run: npm publish --tag insiders


### PR DESCRIPTION
Part 3! (Part 1: #5421, Part 2: #5422)

This fails because we usually use node 14 or 16, which has a
package-lock.json version of `2`. However on node 12, this version is
`1`. This means that after an npm install the package-lock.json is
touched and thus `npm version` fails because git is in a dirty
directory.

Adding a `--force` is not ideal, but also not really an issue since the
only thing that could change is the package-lock.json and this is not
published to npm anyways.
