### PR TITLE
Add `--no-git-tag-version` flag (Part 4)

### DIFF
--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -48,7 +48,7 @@ jobs:
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
 
       - name: "Version based on commit: 0.0.0-insiders.${{ steps.vars.outputs.sha_short }}"
-        run: npm version 0.0.0-insiders.${{ steps.vars.outputs.sha_short }} --force
+        run: npm version 0.0.0-insiders.${{ steps.vars.outputs.sha_short }} --force --no-git-tag-version
 
       - name: Publish
         run: npm publish --tag insiders


### PR DESCRIPTION
... I told you this might take a few tries... Part 4! (Previously: #5423)

When you run `npm version`, it also tries to make a git commit and a git
tag. However, we are not doing anything with this and CI doesn't know
who the committer is.
