### PR TITLE
Add `will-change` utilities

### DIFF
--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -165,4 +165,6 @@ export { default as transitionDelay } from './transitionDelay'
 export { default as transitionDuration } from './transitionDuration'
 export { default as transitionTimingFunction } from './transitionTimingFunction'
 
+export { default as willChange } from './willChange'
+
 export { default as content } from './content'

--- a/src/plugins/willChange.js
+++ b/src/plugins/willChange.js
@@ -1,0 +1,5 @@
+import createUtilityPlugin from '../util/createUtilityPlugin'
+
+export default function () {
+  return createUtilityPlugin('willChange', [['will-change', ['will-change']]])
+}

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -814,6 +814,12 @@ module.exports = {
       min: 'min-content',
       max: 'max-content',
     }),
+    willChange: {
+      'auto': 'auto',
+      'scroll': 'scroll-position',
+      'contents': 'contents',
+      'transform': 'transform',
+    },
     zIndex: {
       auto: 'auto',
       0: '0',

--- a/tests/arbitrary-values.test.css
+++ b/tests/arbitrary-values.test.css
@@ -446,6 +446,12 @@
 .duration-\[var\(--app-duration\)\] {
   transition-duration: var(--app-duration);
 }
+.will-change-\[top\2c left\] {
+  will-change: top, left;
+}
+.will-change-\[var\(--will-change\)\] {
+  will-change: var(--will-change);
+}
 .content-\[\'hello\'\] {
   content: 'hello';
 }

--- a/tests/arbitrary-values.test.html
+++ b/tests/arbitrary-values.test.html
@@ -115,6 +115,7 @@
     <div class="ring-offset-[19rem]"></div>
     <div class="ring-opacity-[var(--ring-opacity)]"></div>
     <div class="delay-[var(--delay)]"></div>
+    <div class="will-change-[top,left] will-change-[var(--will-change)]"></div>
     <div class="content-['hello']"></div>
     <div class="content-[attr(content-before)]"></div>
     <div class="accent-[#bada55]"></div>

--- a/tests/basic-usage.test.css
+++ b/tests/basic-usage.test.css
@@ -822,6 +822,12 @@
 .ease-in-out {
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
+.will-change-scroll {
+  will-change: scroll-position;
+}
+.will-change-transform {
+  will-change: transform;
+}
 .content-none {
   content: none;
 }

--- a/tests/basic-usage.test.html
+++ b/tests/basic-usage.test.html
@@ -168,6 +168,7 @@
     <div class="w-12"></div>
     <div class="break-words"></div>
     <div class="z-30"></div>
+    <div class="will-change-scroll will-change-transform"></div>
     <div class="content-none"></div>
     <div class="aspect-square aspect-video"></div>
   </body>


### PR DESCRIPTION
This PR adds new [will-change](https://developer.mozilla.org/en-US/docs/Web/CSS/will-change) utilities to Tailwind CSS. By default, the following classes are included:

| Class | CSS |
| --- | --- |
| `will-change-auto` | `will-change: auto` |
| `will-change-scroll` | `will-change: scroll-position` |
| `will-change-contents` | `will-change: contents` |
| `will-change-transform` | `will-change: transform` |

The available utilities can be customized under the `theme.willChange` section of your `tailwind.config.js` file.

These utilities also support arbitrary values, so if you need to use another value that doesn't make sense to include in your Tailwind config, you can do this using the square bracket notation:

```html
<div class="will-change-[top,left]">Example</div>
```