### PR TITLE
Ensure that we fallback to the first argument when `-i` is missing

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -351,6 +351,7 @@ async function build() {
   // TODO: Deprecate this in future versions
   if (!input && args['_'][1]) {
     console.error('[deprecation] Running tailwindcss without -i, please provide an input file.')
+    input = args['--input'] = args['_'][1]
   }
 
   if (input && !fs.existsSync((input = path.resolve(input)))) {


### PR DESCRIPTION
If you have a command like this:

```sh
npx tailwindcss app.css -o output.css
```

Then you would get a deprecation warning:

```
[deprecation] Running tailwindcss without -i, please provide an input file.
```

However, this is a deprecation **warning**, but the CLI won't work if you don't have a `-i`. For now we will fallback to the first argument (in this case `app.css`) as the input.