### PR TITLE
Setup integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,46 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Use cached node_modules
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: nodeModules-${{ hashFiles('**/package-lock.json') }}-${{ matrix.node-version }}
+          restore-keys: |
+            nodeModules-
+
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm install
+        env:
+          CI: true
+
+      - name: Build Tailwind CSS
+        run: npm run prepublishOnly
+
+      - name: Install dependencies of each integration
+        run: npm run install:integrations
+
+      - name: Test all integrations
+        run: npm run test:integrations

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        integration: [parcel, vite]
+        integration: [parcel, postcss-cli, rollup, tailwindcss-cli, vite, webpack-4, webpack-5]
         node-version: [16]
 
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -40,33 +40,8 @@ jobs:
       - name: Build Tailwind CSS
         run: npm run prepublishOnly
 
-      - name: Use cached node_modules for the shared integrations folder
-        id: integrations-cache
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: nodeModules-${{ hashFiles('**/package-lock.json') }}-${{ matrix.node-version }}-integrations
-          restore-keys: |
-            nodeModules-
-
       - name: Install shared dependencies
-        if: steps.integrations-cache.outputs.cache-hit != 'true'
-        run: npm install --prefix ./integrations
-        env:
-          CI: true
-
-      - name: Use cached node_modules for ${{ matrix.integration }}
-        id: integration-cache
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: nodeModules-${{ hashFiles('**/package-lock.json') }}-${{ matrix.node-version }}-${{ matrix.integration }}
-          restore-keys: |
-            nodeModules-
-
-      - name: Install dependencies for ${{ matrix.integration }}
-        if: steps.integration-cache.outputs.cache-hit != 'true'
-        run: npm install --prefix ./integrations/${{ matrix.integration }}
+        run: npm run install:integrations
         env:
           CI: true
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,6 +12,7 @@ jobs:
 
     strategy:
       matrix:
+        integration: [parcel, vite]
         node-version: [16]
 
     steps:
@@ -39,8 +40,35 @@ jobs:
       - name: Build Tailwind CSS
         run: npm run prepublishOnly
 
-      - name: Install dependencies of each integration
-        run: npm run install:integrations
+      - name: Use cached node_modules for the shared integrations folder
+        id: integrations-cache
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: nodeModules-${{ hashFiles('**/package-lock.json') }}-${{ matrix.node-version }}-integrations
+          restore-keys: |
+            nodeModules-
 
-      - name: Test all integrations
-        run: npm run test:integrations
+      - name: Install shared dependencies
+        if: steps.integrations-cache.outputs.cache-hit != 'true'
+        run: npm install --prefix ./integrations
+        env:
+          CI: true
+
+      - name: Use cached node_modules for ${{ matrix.integration }}
+        id: integration-cache
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: nodeModules-${{ hashFiles('**/package-lock.json') }}-${{ matrix.node-version }}-${{ matrix.integration }}
+          restore-keys: |
+            nodeModules-
+
+      - name: Install dependencies for ${{ matrix.integration }}
+        if: steps.integration-cache.outputs.cache-hit != 'true'
+        run: npm install --prefix ./integrations/${{ matrix.integration }}
+        env:
+          CI: true
+
+      - name: Test ${{ matrix.integration }}
+        run: npm test --prefix ./integrations/${{ matrix.integration }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,17 +22,17 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Use cached node_modules
-        id: cache
+      - name: Use cached node_modules (tailwindcss)
+        id: cache-tailwindcss
         uses: actions/cache@v2
         with:
           path: node_modules
-          key: nodeModules-${{ hashFiles('**/package-lock.json') }}-${{ matrix.node-version }}
+          key: nodeModules-${{ hashFiles('**/package-lock.json') }}-${{ matrix.node-version }}-tailwindcss
           restore-keys: |
             nodeModules-
 
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache-tailwindcss.outputs.cache-hit != 'true'
         run: npm install
         env:
           CI: true
@@ -40,7 +40,17 @@ jobs:
       - name: Build Tailwind CSS
         run: npm run prepublishOnly
 
+      - name: Use cached node_modules (integrations)
+        id: cache-integrations
+        uses: actions/cache@v2
+        with:
+          path: ./integrations/**/node_modules
+          key: nodeModules-${{ hashFiles('**/package-lock.json') }}-${{ matrix.node-version }}-${{ matrix.integration }}-integrations
+          restore-keys: |
+            nodeModules-
+
       - name: Install shared dependencies
+        if: steps.cache-integrations.outputs.cache-hit != 'true'
         run: npm run install:integrations
         env:
           CI: true

--- a/integrations/execute.js
+++ b/integrations/execute.js
@@ -8,6 +8,15 @@ afterEach(() => {
   runningProcessess.splice(0).forEach((runningProcess) => runningProcess.stop())
 })
 
+function debounce(fn, ms) {
+  let state = { timer: undefined }
+
+  return (...args) => {
+    if (state.timer) clearTimeout(state.timer)
+    state.timer = setTimeout(() => fn(...args), ms)
+  }
+}
+
 module.exports = function $(command, options = {}) {
   let abortController = new AbortController()
   let cwd = resolveToolRoot()
@@ -37,13 +46,13 @@ module.exports = function $(command, options = {}) {
     }
   }
 
-  function notifyNextStdoutActor() {
+  let notifyNextStdoutActor = debounce(() => {
     return notifyNext(stdoutActors, stdoutMessages)
-  }
+  }, 200)
 
-  function notifyNextStderrActor() {
+  let notifyNextStderrActor = debounce(() => {
     return notifyNext(stderrActors, stderrMessages)
-  }
+  }, 200)
 
   let runningProcess = new Promise((resolve, reject) => {
     let child = spawn(command, args, {

--- a/integrations/execute.js
+++ b/integrations/execute.js
@@ -74,6 +74,12 @@ module.exports = function $(command, options = {}) {
       combined += data
     })
 
+    child.on('error', (err) => {
+      if (err.name !== 'AbortError') {
+        throw err
+      }
+    })
+
     child.on('close', (code, signal) => {
       ;(signal === 'SIGTERM' ? resolve : code === 0 ? resolve : reject)({
         code,

--- a/integrations/package-lock.json
+++ b/integrations/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "integrations",
       "version": "0.0.0",
       "devDependencies": {
         "isomorphic-fetch": "^3.0.0",

--- a/integrations/package.json
+++ b/integrations/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "test": "jest --runInBand"
+    "test": "jest --runInBand --forceExit"
   },
   "jest": {
     "testTimeout": 30000,

--- a/integrations/parcel/package-lock.json
+++ b/integrations/parcel/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "parcel",
       "version": "0.0.0",
       "devDependencies": {
         "parcel": "nightly"

--- a/integrations/parcel/package.json
+++ b/integrations/parcel/package.json
@@ -8,7 +8,7 @@
     "test": "jest --runInBand --forceExit"
   },
   "jest": {
-    "testTimeout": 30000,
+    "testTimeout": 10000,
     "displayName": "parcel",
     "setupFilesAfterEnv": [
       "<rootDir>/../../jest/customMatchers.js"

--- a/integrations/parcel/package.json
+++ b/integrations/parcel/package.json
@@ -5,9 +5,10 @@
   "scripts": {
     "build": "parcel build ./src/index.html --no-cache",
     "dev": "parcel watch ./src/index.html --no-cache",
-    "test": "jest --runInBand"
+    "test": "jest --runInBand --forceExit"
   },
   "jest": {
+    "testTimeout": 30000,
     "displayName": "parcel",
     "setupFilesAfterEnv": [
       "<rootDir>/../../jest/customMatchers.js"

--- a/integrations/parcel/tests/integration.test.js
+++ b/integrations/parcel/tests/integration.test.js
@@ -80,7 +80,7 @@ describe.skip('watcher', () => {
       css`
         .bg-red-500 {
           --tw-bg-opacity: 1;
-          background-color: rgba(239, 68, 68, var(--tw-bg-opacity));
+          background-color: rgb(239 68 68 / var(--tw-bg-opacity));
         }
         .font-bold {
           font-weight: 700;
@@ -240,7 +240,7 @@ describe.skip('watcher', () => {
         .btn {
           border-radius: 0.25rem;
           --tw-bg-opacity: 1;
-          background-color: rgba(239, 68, 68, var(--tw-bg-opacity));
+          background-color: rgb(239 68 68 / var(--tw-bg-opacity));
           padding-left: 0.5rem;
           padding-right: 0.5rem;
           padding-top: 0.25rem;

--- a/integrations/postcss-cli/package-lock.json
+++ b/integrations/postcss-cli/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "postcss-cli",
       "version": "0.0.0",
       "devDependencies": {
         "postcss": "^8.2.15",

--- a/integrations/postcss-cli/package.json
+++ b/integrations/postcss-cli/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "build": "NODE_ENV=production postcss ./src/index.css -o ./dist/main.css",
+    "build": "NODE_ENV=production postcss ./src/index.css -o ./dist/main.css --verbose",
     "test": "jest --runInBand --forceExit"
   },
   "jest": {

--- a/integrations/postcss-cli/package.json
+++ b/integrations/postcss-cli/package.json
@@ -4,9 +4,10 @@
   "version": "0.0.0",
   "scripts": {
     "build": "NODE_ENV=production postcss ./src/index.css -o ./dist/main.css",
-    "test": "jest --runInBand"
+    "test": "jest --runInBand --forceExit"
   },
   "jest": {
+    "testTimeout": 30000,
     "displayName": "PostCSS CLI",
     "setupFilesAfterEnv": [
       "<rootDir>/../../jest/customMatchers.js"

--- a/integrations/postcss-cli/package.json
+++ b/integrations/postcss-cli/package.json
@@ -7,7 +7,7 @@
     "test": "jest --runInBand --forceExit"
   },
   "jest": {
-    "testTimeout": 30000,
+    "testTimeout": 10000,
     "displayName": "PostCSS CLI",
     "setupFilesAfterEnv": [
       "<rootDir>/../../jest/customMatchers.js"

--- a/integrations/postcss-cli/tests/integration.test.js
+++ b/integrations/postcss-cli/tests/integration.test.js
@@ -31,7 +31,7 @@ describe('watcher', () => {
   test('classes are generated when the html file changes', async () => {
     await writeInputFile('index.html', html`<div class="font-bold"></div>`)
 
-    let runningProcess = $('postcss ./src/index.css -o ./dist/main.css -w', {
+    let runningProcess = $('postcss ./src/index.css -o ./dist/main.css -w --verbose', {
       env: { TAILWIND_MODE: 'watch' },
     })
 
@@ -85,7 +85,7 @@ describe('watcher', () => {
   test('classes are generated when the tailwind.config.js file changes', async () => {
     await writeInputFile('index.html', html`<div class="font-bold md:font-medium"></div>`)
 
-    let runningProcess = $('postcss ./src/index.css -o ./dist/main.css -w', {
+    let runningProcess = $('postcss ./src/index.css -o ./dist/main.css -w --verbose', {
       env: { TAILWIND_MODE: 'watch' },
     })
 
@@ -148,7 +148,7 @@ describe('watcher', () => {
   test('classes are generated when the index.css file changes', async () => {
     await writeInputFile('index.html', html`<div class="font-bold btn"></div>`)
 
-    let runningProcess = $('postcss ./src/index.css -o ./dist/main.css -w', {
+    let runningProcess = $('postcss ./src/index.css -o ./dist/main.css -w --verbose', {
       env: { TAILWIND_MODE: 'watch' },
     })
 

--- a/integrations/postcss-cli/tests/integration.test.js
+++ b/integrations/postcss-cli/tests/integration.test.js
@@ -68,7 +68,7 @@ describe('watcher', () => {
       css`
         .bg-red-500 {
           --tw-bg-opacity: 1;
-          background-color: rgba(239, 68, 68, var(--tw-bg-opacity));
+          background-color: rgb(239 68 68 / var(--tw-bg-opacity));
         }
         .font-bold {
           font-weight: 700;
@@ -216,7 +216,7 @@ describe('watcher', () => {
         .btn {
           border-radius: 0.25rem;
           --tw-bg-opacity: 1;
-          background-color: rgba(239, 68, 68, var(--tw-bg-opacity));
+          background-color: rgb(239 68 68 / var(--tw-bg-opacity));
           padding-left: 0.5rem;
           padding-right: 0.5rem;
           padding-top: 0.25rem;

--- a/integrations/postcss-cli/tests/integration.test.js
+++ b/integrations/postcss-cli/tests/integration.test.js
@@ -1,13 +1,14 @@
 let $ = require('../../execute')
 let { css, html, javascript } = require('../../syntax')
 
-let {
-  readOutputFile,
-  appendToInputFile,
-  writeInputFile,
-  waitForOutputFileCreation,
-  waitForOutputFileChange,
-} = require('../../io')({ output: 'dist', input: 'src' })
+let { readOutputFile, appendToInputFile, writeInputFile } = require('../../io')({
+  output: 'dist',
+  input: 'src',
+})
+
+function ready(message) {
+  return message.includes('Finished')
+}
 
 describe('static build', () => {
   it('should be possible to generate tailwind output', async () => {
@@ -34,8 +35,7 @@ describe('watcher', () => {
     let runningProcess = $('postcss ./src/index.css -o ./dist/main.css -w --verbose', {
       env: { TAILWIND_MODE: 'watch' },
     })
-
-    await waitForOutputFileCreation('main.css')
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('main.css')).toIncludeCss(
       css`
@@ -45,9 +45,8 @@ describe('watcher', () => {
       `
     )
 
-    await waitForOutputFileChange('main.css', async () => {
-      await appendToInputFile('index.html', html`<div class="font-normal"></div>`)
-    })
+    await appendToInputFile('index.html', html`<div class="font-normal"></div>`)
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('main.css')).toIncludeCss(
       css`
@@ -60,9 +59,8 @@ describe('watcher', () => {
       `
     )
 
-    await waitForOutputFileChange('main.css', async () => {
-      await appendToInputFile('index.html', html`<div class="bg-red-500"></div>`)
-    })
+    await appendToInputFile('index.html', html`<div class="bg-red-500"></div>`)
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('main.css')).toIncludeCss(
       css`
@@ -89,7 +87,7 @@ describe('watcher', () => {
       env: { TAILWIND_MODE: 'watch' },
     })
 
-    await waitForOutputFileCreation('main.css')
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('main.css')).toIncludeCss(
       css`
@@ -104,10 +102,9 @@ describe('watcher', () => {
       `
     )
 
-    await waitForOutputFileChange('main.css', async () => {
-      await writeInputFile(
-        '../tailwind.config.js',
-        javascript`
+    await writeInputFile(
+      '../tailwind.config.js',
+      javascript`
           module.exports = {
             content: ['./src/index.html'],
             theme: {
@@ -126,8 +123,8 @@ describe('watcher', () => {
             plugins: [],
           }
       `
-      )
-    })
+    )
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('main.css')).toIncludeCss(
       css`
@@ -152,7 +149,7 @@ describe('watcher', () => {
       env: { TAILWIND_MODE: 'watch' },
     })
 
-    await waitForOutputFileCreation('main.css')
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('main.css')).toIncludeCss(
       css`
@@ -162,22 +159,21 @@ describe('watcher', () => {
       `
     )
 
-    await waitForOutputFileChange('main.css', async () => {
-      await writeInputFile(
-        'index.css',
-        css`
-          @tailwind base;
-          @tailwind components;
-          @tailwind utilities;
+    await writeInputFile(
+      'index.css',
+      css`
+        @tailwind base;
+        @tailwind components;
+        @tailwind utilities;
 
-          @layer components {
-            .btn {
-              @apply px-2 py-1 rounded;
-            }
+        @layer components {
+          .btn {
+            @apply px-2 py-1 rounded;
           }
-        `
-      )
-    })
+        }
+      `
+    )
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('main.css')).toIncludeCss(
       css`
@@ -194,22 +190,21 @@ describe('watcher', () => {
       `
     )
 
-    await waitForOutputFileChange('main.css', async () => {
-      await writeInputFile(
-        'index.css',
-        css`
-          @tailwind base;
-          @tailwind components;
-          @tailwind utilities;
+    await writeInputFile(
+      'index.css',
+      css`
+        @tailwind base;
+        @tailwind components;
+        @tailwind utilities;
 
-          @layer components {
-            .btn {
-              @apply px-2 py-1 rounded bg-red-500;
-            }
+        @layer components {
+          .btn {
+            @apply px-2 py-1 rounded bg-red-500;
           }
-        `
-      )
-    })
+        }
+      `
+    )
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('main.css')).toIncludeCss(
       css`

--- a/integrations/rollup/package.json
+++ b/integrations/rollup/package.json
@@ -4,13 +4,12 @@
   "version": "0.0.0",
   "scripts": {
     "build": "rollup -c",
-    "test": "jest --runInBand"
+    "test": "jest --runInBand --forceExit"
   },
   "jest": {
+    "testTimeout": 30000,
     "displayName": "rollup.js",
-    "setupFilesAfterEnv": [
-      "<rootDir>/../../jest/customMatchers.js"
-    ]
+    "setupFilesAfterEnv": ["<rootDir>/../../jest/customMatchers.js"]
   },
   "devDependencies": {
     "rollup": "^2.48.0",

--- a/integrations/rollup/package.json
+++ b/integrations/rollup/package.json
@@ -7,7 +7,7 @@
     "test": "jest --runInBand --forceExit"
   },
   "jest": {
-    "testTimeout": 30000,
+    "testTimeout": 10000,
     "displayName": "rollup.js",
     "setupFilesAfterEnv": ["<rootDir>/../../jest/customMatchers.js"]
   },

--- a/integrations/rollup/tests/integration.test.js
+++ b/integrations/rollup/tests/integration.test.js
@@ -66,7 +66,7 @@ describe.each([{ TAILWIND_MODE: 'watch' }, { TAILWIND_MODE: undefined }])('watch
       css`
         .bg-red-500 {
           --tw-bg-opacity: 1;
-          background-color: rgba(239, 68, 68, var(--tw-bg-opacity));
+          background-color: rgb(239 68 68 / var(--tw-bg-opacity));
         }
         .font-bold {
           font-weight: 700;
@@ -210,7 +210,7 @@ describe.each([{ TAILWIND_MODE: 'watch' }, { TAILWIND_MODE: undefined }])('watch
         .btn {
           border-radius: 0.25rem;
           --tw-bg-opacity: 1;
-          background-color: rgba(239, 68, 68, var(--tw-bg-opacity));
+          background-color: rgb(239 68 68 / var(--tw-bg-opacity));
           padding-left: 0.5rem;
           padding-right: 0.5rem;
           padding-top: 0.25rem;

--- a/integrations/rollup/tests/integration.test.js
+++ b/integrations/rollup/tests/integration.test.js
@@ -1,13 +1,14 @@
 let $ = require('../../execute')
 let { css, html, javascript } = require('../../syntax')
 
-let {
-  readOutputFile,
-  appendToInputFile,
-  writeInputFile,
-  waitForOutputFileCreation,
-  waitForOutputFileChange,
-} = require('../../io')({ output: 'dist', input: 'src' })
+let { readOutputFile, appendToInputFile, writeInputFile } = require('../../io')({
+  output: 'dist',
+  input: 'src',
+})
+
+function ready(message) {
+  return message.includes('created')
+}
 
 describe('static build', () => {
   it('should be possible to generate tailwind output', async () => {
@@ -32,8 +33,7 @@ describe.each([{ TAILWIND_MODE: 'watch' }, { TAILWIND_MODE: undefined }])('watch
     await writeInputFile('index.html', html`<div class="font-bold"></div>`)
 
     let runningProcess = $('rollup -c --watch', { env })
-
-    await waitForOutputFileCreation('index.css')
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('index.css')).toIncludeCss(
       css`
@@ -43,9 +43,8 @@ describe.each([{ TAILWIND_MODE: 'watch' }, { TAILWIND_MODE: undefined }])('watch
       `
     )
 
-    await waitForOutputFileChange('index.css', async () => {
-      await appendToInputFile('index.html', html`<div class="font-normal"></div>`)
-    })
+    await appendToInputFile('index.html', html`<div class="font-normal"></div>`)
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('index.css')).toIncludeCss(
       css`
@@ -58,9 +57,8 @@ describe.each([{ TAILWIND_MODE: 'watch' }, { TAILWIND_MODE: undefined }])('watch
       `
     )
 
-    await waitForOutputFileChange('index.css', async () => {
-      await appendToInputFile('index.html', html`<div class="bg-red-500"></div>`)
-    })
+    await appendToInputFile('index.html', html`<div class="bg-red-500"></div>`)
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('index.css')).toIncludeCss(
       css`
@@ -84,8 +82,7 @@ describe.each([{ TAILWIND_MODE: 'watch' }, { TAILWIND_MODE: undefined }])('watch
     await writeInputFile('index.html', html`<div class="font-bold md:font-medium"></div>`)
 
     let runningProcess = $('rollup -c --watch', { env })
-
-    await waitForOutputFileCreation('index.css')
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('index.css')).toIncludeCss(
       css`
@@ -100,10 +97,9 @@ describe.each([{ TAILWIND_MODE: 'watch' }, { TAILWIND_MODE: undefined }])('watch
       `
     )
 
-    await waitForOutputFileChange('index.css', async () => {
-      await writeInputFile(
-        '../tailwind.config.js',
-        javascript`
+    await writeInputFile(
+      '../tailwind.config.js',
+      javascript`
           module.exports = {
             content: ['./src/index.html'],
             theme: {
@@ -122,8 +118,8 @@ describe.each([{ TAILWIND_MODE: 'watch' }, { TAILWIND_MODE: undefined }])('watch
             plugins: [],
           }
       `
-      )
-    })
+    )
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('index.css')).toIncludeCss(
       css`
@@ -145,8 +141,7 @@ describe.each([{ TAILWIND_MODE: 'watch' }, { TAILWIND_MODE: undefined }])('watch
     await writeInputFile('index.html', html`<div class="font-bold btn"></div>`)
 
     let runningProcess = $('rollup -c --watch', { env })
-
-    await waitForOutputFileCreation('index.css')
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('index.css')).toIncludeCss(
       css`
@@ -156,22 +151,21 @@ describe.each([{ TAILWIND_MODE: 'watch' }, { TAILWIND_MODE: undefined }])('watch
       `
     )
 
-    await waitForOutputFileChange('index.css', async () => {
-      await writeInputFile(
-        'index.css',
-        css`
-          @tailwind base;
-          @tailwind components;
-          @tailwind utilities;
+    await writeInputFile(
+      'index.css',
+      css`
+        @tailwind base;
+        @tailwind components;
+        @tailwind utilities;
 
-          @layer components {
-            .btn {
-              @apply px-2 py-1 rounded;
-            }
+        @layer components {
+          .btn {
+            @apply px-2 py-1 rounded;
           }
-        `
-      )
-    })
+        }
+      `
+    )
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('index.css')).toIncludeCss(
       css`
@@ -188,22 +182,21 @@ describe.each([{ TAILWIND_MODE: 'watch' }, { TAILWIND_MODE: undefined }])('watch
       `
     )
 
-    await waitForOutputFileChange('index.css', async () => {
-      await writeInputFile(
-        'index.css',
-        css`
-          @tailwind base;
-          @tailwind components;
-          @tailwind utilities;
+    await writeInputFile(
+      'index.css',
+      css`
+        @tailwind base;
+        @tailwind components;
+        @tailwind utilities;
 
-          @layer components {
-            .btn {
-              @apply px-2 py-1 rounded bg-red-500;
-            }
+        @layer components {
+          .btn {
+            @apply px-2 py-1 rounded bg-red-500;
           }
-        `
-      )
-    })
+        }
+      `
+    )
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('index.css')).toIncludeCss(
       css`

--- a/integrations/tailwindcss-cli/package-lock.json
+++ b/integrations/tailwindcss-cli/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "tailwindcss-cli",
       "version": "0.0.0"
     }
   }

--- a/integrations/tailwindcss-cli/package.json
+++ b/integrations/tailwindcss-cli/package.json
@@ -4,9 +4,10 @@
   "version": "0.0.0",
   "scripts": {
     "build": "NODE_ENV=production node ../../lib/cli.js -i ./src/index.css -o ./dist/main.css",
-    "test": "jest --runInBand"
+    "test": "jest --runInBand --forceExit"
   },
   "jest": {
+    "testTimeout": 30000,
     "displayName": "Tailwind CSS CLI",
     "setupFilesAfterEnv": [
       "<rootDir>/../../jest/customMatchers.js"

--- a/integrations/tailwindcss-cli/package.json
+++ b/integrations/tailwindcss-cli/package.json
@@ -7,7 +7,7 @@
     "test": "jest --runInBand --forceExit"
   },
   "jest": {
-    "testTimeout": 30000,
+    "testTimeout": 10000,
     "displayName": "Tailwind CSS CLI",
     "setupFilesAfterEnv": [
       "<rootDir>/../../jest/customMatchers.js"

--- a/integrations/tailwindcss-cli/tests/cli.test.js
+++ b/integrations/tailwindcss-cli/tests/cli.test.js
@@ -187,7 +187,7 @@ describe('Build command', () => {
 
         .btn-after {
           --tw-bg-opacity: 1;
-          background-color: rgba(239, 68, 68, var(--tw-bg-opacity));
+          background-color: rgb(239 68 68 / var(--tw-bg-opacity));
           padding-left: 0.5rem;
           padding-right: 0.5rem;
           padding-top: 0.25rem;
@@ -238,7 +238,7 @@ describe('Build command', () => {
 
         .btn-after {
           --tw-bg-opacity: 1;
-          background-color: rgba(239, 68, 68, var(--tw-bg-opacity));
+          background-color: rgb(239 68 68 / var(--tw-bg-opacity));
           padding-left: 0.5rem;
           padding-right: 0.5rem;
           padding-top: 0.25rem;

--- a/integrations/tailwindcss-cli/tests/integration.test.js
+++ b/integrations/tailwindcss-cli/tests/integration.test.js
@@ -58,12 +58,12 @@ describe('static build', () => {
       css`
         .bg-red-500 {
           --tw-bg-opacity: 1;
-          background-color: rgba(239, 68, 68, var(--tw-bg-opacity));
+          background-color: rgb(239 68 68 / var(--tw-bg-opacity));
         }
 
         .bg-red-600 {
           --tw-bg-opacity: 1;
-          background-color: rgba(220, 38, 38, var(--tw-bg-opacity));
+          background-color: rgb(220 38 38 / var(--tw-bg-opacity));
         }
 
         .font-bold {
@@ -113,7 +113,7 @@ describe('watcher', () => {
       css`
         .bg-red-500 {
           --tw-bg-opacity: 1;
-          background-color: rgba(239, 68, 68, var(--tw-bg-opacity));
+          background-color: rgb(239 68 68 / var(--tw-bg-opacity));
         }
         .font-bold {
           font-weight: 700;
@@ -312,7 +312,7 @@ describe('watcher', () => {
         .btn {
           border-radius: 0.25rem;
           --tw-bg-opacity: 1;
-          background-color: rgba(239, 68, 68, var(--tw-bg-opacity));
+          background-color: rgb(239 68 68 / var(--tw-bg-opacity));
           padding-left: 0.5rem;
           padding-right: 0.5rem;
           padding-top: 0.25rem;

--- a/integrations/tailwindcss-cli/tests/integration.test.js
+++ b/integrations/tailwindcss-cli/tests/integration.test.js
@@ -1,13 +1,14 @@
 let $ = require('../../execute')
 let { css, html, javascript } = require('../../syntax')
 
-let {
-  readOutputFile,
-  appendToInputFile,
-  writeInputFile,
-  waitForOutputFileCreation,
-  waitForOutputFileChange,
-} = require('../../io')({ output: 'dist', input: 'src' })
+let { readOutputFile, appendToInputFile, writeInputFile } = require('../../io')({
+  output: 'dist',
+  input: 'src',
+})
+
+function ready(message) {
+  return message.includes('Done in')
+}
 
 describe('static build', () => {
   it('should be possible to generate tailwind output', async () => {
@@ -77,8 +78,7 @@ describe('watcher', () => {
     await writeInputFile('index.html', html`<div class="font-bold"></div>`)
 
     let runningProcess = $('node ../../lib/cli.js -i ./src/index.css -o ./dist/main.css -w')
-
-    await waitForOutputFileCreation('main.css')
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('main.css')).toIncludeCss(
       css`
@@ -88,9 +88,8 @@ describe('watcher', () => {
       `
     )
 
-    await waitForOutputFileChange('main.css', async () => {
-      await appendToInputFile('index.html', html`<div class="font-normal"></div>`)
-    })
+    await appendToInputFile('index.html', html`<div class="font-normal"></div>`)
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('main.css')).toIncludeCss(
       css`
@@ -103,9 +102,8 @@ describe('watcher', () => {
       `
     )
 
-    await waitForOutputFileChange('main.css', async () => {
-      await appendToInputFile('index.html', html`<div class="bg-red-500"></div>`)
-    })
+    await appendToInputFile('index.html', html`<div class="bg-red-500"></div>`)
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('main.css')).toIncludeCss(
       css`
@@ -143,8 +141,7 @@ describe('watcher', () => {
     )
 
     let runningProcess = $('node ../../lib/cli.js -i ./src/index.css -o ./dist/main.css -w')
-
-    await waitForOutputFileCreation('main.css')
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('main.css')).toIncludeCss(
       css`
@@ -154,9 +151,8 @@ describe('watcher', () => {
       `
     )
 
-    await waitForOutputFileChange('main.css', async () => {
-      await appendToInputFile('index.html', html`<div class="font-normal"></div>`)
-    })
+    await appendToInputFile('index.html', html`<div class="font-normal"></div>`)
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('main.css')).not.toIncludeCss(css`
       @layer base {
@@ -184,8 +180,7 @@ describe('watcher', () => {
     await writeInputFile('index.html', html`<div class="font-bold md:font-medium"></div>`)
 
     let runningProcess = $('node ../../lib/cli.js -i ./src/index.css -o ./dist/main.css -w')
-
-    await waitForOutputFileCreation('main.css')
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('main.css')).toIncludeCss(
       css`
@@ -200,10 +195,9 @@ describe('watcher', () => {
       `
     )
 
-    await waitForOutputFileChange('main.css', async () => {
-      await writeInputFile(
-        '../tailwind.config.js',
-        javascript`
+    await writeInputFile(
+      '../tailwind.config.js',
+      javascript`
           module.exports = {
             content: ['./src/index.html'],
             theme: {
@@ -222,8 +216,8 @@ describe('watcher', () => {
             plugins: [],
           }
       `
-      )
-    })
+    )
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('main.css')).toIncludeCss(
       css`
@@ -245,8 +239,7 @@ describe('watcher', () => {
     await writeInputFile('index.html', html`<div class="font-bold btn"></div>`)
 
     let runningProcess = $('node ../../lib/cli.js -i ./src/index.css -o ./dist/main.css -w')
-
-    await waitForOutputFileCreation('main.css')
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('main.css')).toIncludeCss(
       css`
@@ -256,22 +249,21 @@ describe('watcher', () => {
       `
     )
 
-    await waitForOutputFileChange('main.css', async () => {
-      await writeInputFile(
-        'index.css',
-        css`
-          @tailwind base;
-          @tailwind components;
-          @tailwind utilities;
+    await writeInputFile(
+      'index.css',
+      css`
+        @tailwind base;
+        @tailwind components;
+        @tailwind utilities;
 
-          @layer components {
-            .btn {
-              @apply px-2 py-1 rounded;
-            }
+        @layer components {
+          .btn {
+            @apply px-2 py-1 rounded;
           }
-        `
-      )
-    })
+        }
+      `
+    )
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('main.css')).toIncludeCss(
       css`
@@ -288,22 +280,21 @@ describe('watcher', () => {
       `
     )
 
-    await waitForOutputFileChange('main.css', async () => {
-      await writeInputFile(
-        'index.css',
-        css`
-          @tailwind base;
-          @tailwind components;
-          @tailwind utilities;
+    await writeInputFile(
+      'index.css',
+      css`
+        @tailwind base;
+        @tailwind components;
+        @tailwind utilities;
 
-          @layer components {
-            .btn {
-              @apply px-2 py-1 rounded bg-red-500;
-            }
+        @layer components {
+          .btn {
+            @apply px-2 py-1 rounded bg-red-500;
           }
-        `
-      )
-    })
+        }
+      `
+    )
+    await runningProcess.onStderr(ready)
 
     expect(await readOutputFile('main.css')).toIncludeCss(
       css`

--- a/integrations/tailwindcss-cli/tests/integration.test.js
+++ b/integrations/tailwindcss-cli/tests/integration.test.js
@@ -48,11 +48,9 @@ describe('static build', () => {
       `
     )
 
-    $('node ../../lib/cli.js -i ./src/index.css -o ./dist/main.css', {
+    await $('node ../../lib/cli.js -i ./src/index.css -o ./dist/main.css', {
       env: { NODE_ENV: 'production' },
     })
-
-    await waitForOutputFileCreation('main.css')
 
     expect(await readOutputFile('main.css')).toIncludeCss(
       css`

--- a/integrations/vite/package-lock.json
+++ b/integrations/vite/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "vite",
       "version": "0.0.0",
       "devDependencies": {
         "vite": "^2.3.3"

--- a/integrations/vite/package.json
+++ b/integrations/vite/package.json
@@ -9,7 +9,7 @@
     "test": "jest --runInBand --forceExit"
   },
   "jest": {
-    "testTimeout": 30000,
+    "testTimeout": 10000,
     "displayName": "vite",
     "setupFilesAfterEnv": [
       "<rootDir>/../../jest/customMatchers.js"

--- a/integrations/vite/package.json
+++ b/integrations/vite/package.json
@@ -6,9 +6,10 @@
   "browser": "./src/index.js",
   "scripts": {
     "build": "vite build",
-    "test": "jest --runInBand"
+    "test": "jest --runInBand --forceExit"
   },
   "jest": {
+    "testTimeout": 30000,
     "displayName": "vite",
     "setupFilesAfterEnv": [
       "<rootDir>/../../jest/customMatchers.js"

--- a/integrations/vite/tests/integration.test.js
+++ b/integrations/vite/tests/integration.test.js
@@ -87,7 +87,7 @@ describe('watcher', () => {
       css`
         .bg-red-500 {
           --tw-bg-opacity: 1;
-          background-color: rgba(239, 68, 68, var(--tw-bg-opacity));
+          background-color: rgb(239 68 68 / var(--tw-bg-opacity));
         }
         .font-bold {
           font-weight: 700;
@@ -242,7 +242,7 @@ describe('watcher', () => {
         .btn {
           border-radius: 0.25rem;
           --tw-bg-opacity: 1;
-          background-color: rgba(239, 68, 68, var(--tw-bg-opacity));
+          background-color: rgb(239 68 68 / var(--tw-bg-opacity));
           padding-left: 0.5rem;
           padding-right: 0.5rem;
           padding-top: 0.25rem;

--- a/integrations/webpack-4/package-lock.json
+++ b/integrations/webpack-4/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "webpack-4",
       "version": "0.0.0",
       "devDependencies": {
         "css-loader": "^5.2.4",

--- a/integrations/webpack-4/package.json
+++ b/integrations/webpack-4/package.json
@@ -7,9 +7,10 @@
   "scripts": {
     "build": "webpack --mode=production",
     "dev": "webpack --mode=development --watch",
-    "test": "jest --runInBand"
+    "test": "jest --runInBand --forceExit"
   },
   "jest": {
+    "testTimeout": 30000,
     "displayName": "webpack 4",
     "setupFilesAfterEnv": [
       "<rootDir>/../../jest/customMatchers.js"

--- a/integrations/webpack-4/package.json
+++ b/integrations/webpack-4/package.json
@@ -10,7 +10,7 @@
     "test": "jest --runInBand --forceExit"
   },
   "jest": {
-    "testTimeout": 30000,
+    "testTimeout": 10000,
     "displayName": "webpack 4",
     "setupFilesAfterEnv": [
       "<rootDir>/../../jest/customMatchers.js"

--- a/integrations/webpack-4/tests/integration.test.js
+++ b/integrations/webpack-4/tests/integration.test.js
@@ -64,7 +64,7 @@ describe.each([{ TAILWIND_MODE: 'watch' }, { TAILWIND_MODE: undefined }])('watch
       css`
         .bg-red-500 {
           --tw-bg-opacity: 1;
-          background-color: rgba(239, 68, 68, var(--tw-bg-opacity));
+          background-color: rgb(239 68 68 / var(--tw-bg-opacity));
         }
         .font-bold {
           font-weight: 700;
@@ -208,7 +208,7 @@ describe.each([{ TAILWIND_MODE: 'watch' }, { TAILWIND_MODE: undefined }])('watch
         .btn {
           border-radius: 0.25rem;
           --tw-bg-opacity: 1;
-          background-color: rgba(239, 68, 68, var(--tw-bg-opacity));
+          background-color: rgb(239 68 68 / var(--tw-bg-opacity));
           padding-left: 0.5rem;
           padding-right: 0.5rem;
           padding-top: 0.25rem;

--- a/integrations/webpack-5/package-lock.json
+++ b/integrations/webpack-5/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "webpack-5",
       "version": "0.0.0",
       "devDependencies": {
         "css-loader": "^5.2.4",

--- a/integrations/webpack-5/package.json
+++ b/integrations/webpack-5/package.json
@@ -10,7 +10,7 @@
     "test": "jest --runInBand --forceExit"
   },
   "jest": {
-    "testTimeout": 30000,
+    "testTimeout": 10000,
     "displayName": "webpack 5",
     "setupFilesAfterEnv": [
       "<rootDir>/../../jest/customMatchers.js"

--- a/integrations/webpack-5/package.json
+++ b/integrations/webpack-5/package.json
@@ -7,9 +7,10 @@
   "scripts": {
     "build": "webpack --mode=production",
     "dev": "webpack --mode=development",
-    "test": "jest"
+    "test": "jest --runInBand --forceExit"
   },
   "jest": {
+    "testTimeout": 30000,
     "displayName": "webpack 5",
     "setupFilesAfterEnv": [
       "<rootDir>/../../jest/customMatchers.js"

--- a/integrations/webpack-5/tests/integration.test.js
+++ b/integrations/webpack-5/tests/integration.test.js
@@ -64,7 +64,7 @@ describe.each([{ TAILWIND_MODE: 'watch' }, { TAILWIND_MODE: undefined }])('watch
       css`
         .bg-red-500 {
           --tw-bg-opacity: 1;
-          background-color: rgba(239, 68, 68, var(--tw-bg-opacity));
+          background-color: rgb(239 68 68 / var(--tw-bg-opacity));
         }
         .font-bold {
           font-weight: 700;
@@ -208,7 +208,7 @@ describe.each([{ TAILWIND_MODE: 'watch' }, { TAILWIND_MODE: undefined }])('watch
         .btn {
           border-radius: 0.25rem;
           --tw-bg-opacity: 1;
-          background-color: rgba(239, 68, 68, var(--tw-bg-opacity));
+          background-color: rgb(239 68 68 / var(--tw-bg-opacity));
           padding-left: 0.5rem;
           padding-right: 0.5rem;
           padding-top: 0.25rem;
@@ -253,12 +253,12 @@ describe.each([{ TAILWIND_MODE: 'watch' }, { TAILWIND_MODE: undefined }])('watch
       css`
         .bg-red-500 {
           --tw-bg-opacity: 1;
-          background-color: rgba(239, 68, 68, var(--tw-bg-opacity));
+          background-color: rgb(239 68 68 / var(--tw-bg-opacity));
         }
 
         .bg-red-600 {
           --tw-bg-opacity: 1;
-          background-color: rgba(220, 38, 38, var(--tw-bg-opacity));
+          background-color: rgb(220 38 38 / var(--tw-bg-opacity));
         }
 
         .font-bold {


### PR DESCRIPTION
Finally got the integration tests working on CI! Turns out that there are a few gotchas... fs events are not really reliable, because if you stream to a file, then the first time you touch the file you immediately get a change even if the file is not finished yet. Instead we now use polling and the `awaitWriteFinish` options from chokidar with the `stabilityThreshold` set to a pretty high number to be very sure!

For a few integrations we look at the terminal output (stdout/stderr), and rely on a message like `done in`, that way we don't have to rely on the extra polling time of the output. This results in faster tests, which is always nice to see. There is a catch though, turns out that webpack-4 and webpack-5 write the `successfully compiled in` message, before it is fully done writing to disk.