### PR TITLE
Allow to set utility property value via custom transform function

### DIFF
--- a/src/util/createUtilityPlugin.js
+++ b/src/util/createUtilityPlugin.js
@@ -25,7 +25,7 @@ export default function createUtilityPlugin(
             [classPrefix]: (value) => {
               return properties.reduce((obj, name) => {
                 if (Array.isArray(name)) {
-                  return Object.assign(obj, { [name[0]]: name[1] })
+                  return Object.assign(obj, { [name[0]]: name[1] instanceof Function ? name[1](value) : name[1] })
                 }
                 return Object.assign(obj, { [name]: transformValue(value) })
               }, {})


### PR DESCRIPTION
Small change to the `createUtilityPlugin` function to allow setting the property value via a custom transform function. This can be pretty handy especially in JIT mode when the given value needs to be transformed in a special way.

Example:

```
createUtilityPlugin("screens", [
  [
    ["sr-screen-from", [["--sr-screen-from", (v) => String(toUnitlessPixelValue(v))]]],
    ["sr-screen-to", [["--sr-screen-to", (v) => String(toUnitlessPixelValue(v))]]],
  ],
]);
```

So this allows to use classes like `sr-screen-from-md` or `sr-screen-from-[500px]`, which define variables like `--sr-screen-from: 768` or `--sr-screen-from: 500` I need for further `calc` functions.