### PR TITLE
Expose completions API

### DIFF
--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -624,6 +624,36 @@ function registerPlugins(plugins, context) {
 
     return output.map((value) => ({ raw: value, extension: 'html' }))
   }
+
+  // Generate a list of strings for autocompletion purposes. Colors will have a
+  // tuple with options, e.g.:
+  // ['uppercase', 'lowercase', ['bg-red', { color: 'rgb(255 0 0)' }]]
+  context.completions = function () {
+    // TODO: Try and detect color from components?
+    // TODO: Should we provide a simple "public api" file with functions?
+    let output = []
+
+    for (let util of classList) {
+      if (Array.isArray(util)) {
+        let [utilName, options] = util
+        let isColor = [].concat(options.type).includes('color')
+
+        if (isColor) {
+          for (let [value, color] of Object.entries(options?.values ?? {})) {
+            output.push([formatClass(utilName, value), { color }])
+          }
+        } else {
+          for (let value of Object.keys(options?.values ?? {})) {
+            output.push(formatClass(utilName, value))
+          }
+        }
+      } else {
+        output.push(util)
+      }
+    }
+
+    return output
+  }
 }
 
 export function createContext(

--- a/tests/completions.test.js
+++ b/tests/completions.test.js
@@ -1,0 +1,25 @@
+import resolveConfig from '../resolveConfig'
+import { createContext } from '../src/lib/setupContextUtils'
+
+it('should generate completions for every possible class, without variants', () => {
+  let config = {}
+
+  let context = createContext(resolveConfig(config))
+  expect(context.completions()).toBeInstanceOf(Array)
+
+  // Verify we have a `container` for the 'components' section.
+  expect(context.completions()).toContain('container')
+
+  // Verify we handle the DEFAULT case correctly
+  expect(context.completions()).toContain('border')
+
+  // Verify we handle negative values correctly
+  expect(context.completions()).toContain('-inset-1/4')
+
+  // Verify we list extra information for colors (!tuples)
+  let fromBlack = context
+    .completions()
+    .find((value) => Array.isArray(value) && value[0] === 'from-black')
+
+  expect(fromBlack).toMatchObject(['from-black', { color: '#000' }])
+})


### PR DESCRIPTION
The vscode extension wants to provide code completions, in AOT mode it used the final CSS to provide that, this AOT mode is now gone so we need another way of handling that.
This PR will also add a `completions` function on the context (which the extension already has access to). This will result in a list of all the `base` utilities without any variants.
It will also provide additional information about the type (currently only for colors). The result looks like this:

```js
['uppercase', 'lowercase', ['bg-red', { color: 'rgb(255 0 0)' }]]
```