### PR TITLE
Add `break-before`, `break-inside` and `break-after` utilities

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -813,6 +813,21 @@ export let appearance = ({ addUtilities }) => {
 
 export let columns = createUtilityPlugin('columns', [['columns', ['columns']]])
 
+export let breakBefore = ({ addUtilities }) => {
+  addUtilities({
+    '.break-before-auto': { 'break-before': 'auto' },
+    '.break-before-avoid': { 'break-before': 'avoid' },
+    '.break-before-always': { 'break-before': 'always' },
+    '.break-before-all': { 'break-before': 'all' },
+    '.break-before-avoid-page': { 'break-before': 'avoid-page' },
+    '.break-before-page': { 'break-before': 'page' },
+    '.break-before-left': { 'break-before': 'left' },
+    '.break-before-right': { 'break-before': 'right' },
+    '.break-before-avoid-col': { 'break-before': 'avoid-column' },
+    '.break-before-column': { 'break-before': 'column' },
+  })
+}
+
 export let gridAutoColumns = createUtilityPlugin('gridAutoColumns', [
   ['auto-cols', ['gridAutoColumns']],
 ])

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -831,7 +831,7 @@ export let breakInside = ({ addUtilities }) => {
     '.break-inside-auto': { 'break-inside': 'auto' },
     '.break-inside-avoid': { 'break-inside': 'avoid' },
     '.break-inside-avoid-page': { 'break-inside': 'avoid-page' },
-    '.break-inside-avoid-col': { 'break-inside': 'avoid-column' },
+    '.break-inside-avoid-column': { 'break-inside': 'avoid-column' },
   })
 }
 

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -828,6 +828,15 @@ export let breakBefore = ({ addUtilities }) => {
   })
 }
 
+export let breakInside = ({ addUtilities }) => {
+  addUtilities({
+    '.break-inside-auto': { 'break-inside': 'auto' },
+    '.break-inside-avoid': { 'break-inside': 'avoid' },
+    '.break-inside-avoid-page': { 'break-inside': 'avoid-page' },
+    '.break-inside-avoid-col': { 'break-inside': 'avoid-column' },
+  })
+}
+
 export let gridAutoColumns = createUtilityPlugin('gridAutoColumns', [
   ['auto-cols', ['gridAutoColumns']],
 ])

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -817,13 +817,11 @@ export let breakBefore = ({ addUtilities }) => {
   addUtilities({
     '.break-before-auto': { 'break-before': 'auto' },
     '.break-before-avoid': { 'break-before': 'avoid' },
-    '.break-before-always': { 'break-before': 'always' },
     '.break-before-all': { 'break-before': 'all' },
     '.break-before-avoid-page': { 'break-before': 'avoid-page' },
     '.break-before-page': { 'break-before': 'page' },
     '.break-before-left': { 'break-before': 'left' },
     '.break-before-right': { 'break-before': 'right' },
-    '.break-before-avoid-col': { 'break-before': 'avoid-column' },
     '.break-before-column': { 'break-before': 'column' },
   })
 }
@@ -841,13 +839,11 @@ export let breakAfter = ({ addUtilities }) => {
   addUtilities({
     '.break-after-auto': { 'break-after': 'auto' },
     '.break-after-avoid': { 'break-after': 'avoid' },
-    '.break-after-always': { 'break-after': 'always' },
     '.break-after-all': { 'break-after': 'all' },
     '.break-after-avoid-page': { 'break-after': 'avoid-page' },
     '.break-after-page': { 'break-after': 'page' },
     '.break-after-left': { 'break-after': 'left' },
     '.break-after-right': { 'break-after': 'right' },
-    '.break-after-avoid-col': { 'break-after': 'avoid-column' },
     '.break-after-column': { 'break-after': 'column' },
   })
 }

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -837,6 +837,21 @@ export let breakInside = ({ addUtilities }) => {
   })
 }
 
+export let breakAfter = ({ addUtilities }) => {
+  addUtilities({
+    '.break-after-auto': { 'break-after': 'auto' },
+    '.break-after-avoid': { 'break-after': 'avoid' },
+    '.break-after-always': { 'break-after': 'always' },
+    '.break-after-all': { 'break-after': 'all' },
+    '.break-after-avoid-page': { 'break-after': 'avoid-page' },
+    '.break-after-page': { 'break-after': 'page' },
+    '.break-after-left': { 'break-after': 'left' },
+    '.break-after-right': { 'break-after': 'right' },
+    '.break-after-avoid-col': { 'break-after': 'avoid-column' },
+    '.break-after-column': { 'break-after': 'column' },
+  })
+}
+
 export let gridAutoColumns = createUtilityPlugin('gridAutoColumns', [
   ['auto-cols', ['gridAutoColumns']],
 ])

--- a/tests/basic-usage.test.css
+++ b/tests/basic-usage.test.css
@@ -323,7 +323,7 @@
 .break-before-page  {
   break-before: page;
 }
-.break-inside-avoid-col  {
+.break-inside-avoid-column  {
   break-inside: avoid-column;
 }
 .break-after-auto {

--- a/tests/basic-usage.test.css
+++ b/tests/basic-usage.test.css
@@ -320,6 +320,15 @@
 .columns-md {
   columns: 28rem;
 }
+.break-before-page  {
+  break-before: page;
+}
+.break-inside-avoid-col  {
+  break-inside: avoid-column;
+}
+.break-after-auto {
+  break-after: auto;
+}
 .auto-cols-min {
   grid-auto-columns: min-content;
 }

--- a/tests/basic-usage.test.html
+++ b/tests/basic-usage.test.html
@@ -62,6 +62,7 @@
     <div class="gap-x-2 gap-y-3 gap-4"></div>
     <div class="from-red-300 via-purple-200 to-blue-400"></div>
     <div class="columns-1 columns-md"></div>
+    <div class="break-before-page break-inside-avoid-col break-after-auto"></div>
     <div class="auto-cols-min"></div>
     <div class="grid-flow-row"></div>
     <div class="auto-rows-max"></div>

--- a/tests/basic-usage.test.html
+++ b/tests/basic-usage.test.html
@@ -62,7 +62,7 @@
     <div class="gap-x-2 gap-y-3 gap-4"></div>
     <div class="from-red-300 via-purple-200 to-blue-400"></div>
     <div class="columns-1 columns-md"></div>
-    <div class="break-before-page break-inside-avoid-col break-after-auto"></div>
+    <div class="break-before-page break-inside-avoid-column break-after-auto"></div>
     <div class="auto-cols-min"></div>
     <div class="grid-flow-row"></div>
     <div class="auto-rows-max"></div>


### PR DESCRIPTION
This PR adds new [fragmentation](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Fragmentation) utilities to Tailwind CSS, including `break-before`, `break-inside` and `break-after`.

## Purpose

The primary purpose of these classes is to set how column and page breaks should behave. For example, it's very common to want to use `break-after: avoid-column` when using [multi-column layouts](https://github.com/tailwindlabs/tailwindcss/pull/5457). These utilities are also useful when setting print page break styles.

## Example

Here is an example of how you might use these utilities in a multi-column layout:

```html
<div class="columns-2 space-y-2">
  <blockquote class="p-4 rounded bg-white border-2 border-gray-300 break-inside-avoid-column">Lorem ipsum dolor sit amet, consectetur adipiscing elit...</blockquote>
  <blockquote class="p-4 rounded bg-white border-2 border-gray-300 break-inside-avoid-column">Maecenas bibendum volutpat tortor, ac viverra lacus sem...</blockquote>
  <blockquote class="p-4 rounded bg-white border-2 border-gray-300 break-inside-avoid-column">Nulla ac mi erat. Integer porta lacus sit amet felis al...</blockquote>
  <blockquote class="p-4 rounded bg-white border-2 border-gray-300 break-inside-avoid-column">Nullam at aliquam velit, quis tempor lectus. In ferment...</blockquote>
  <blockquote class="p-4 rounded bg-white border-2 border-gray-300 break-inside-avoid-column">Aenean interdum risus quam, vitae accumsan dui consequa...</blockquote>
</div>
```

Here is the result *without* `break-inside-avoid-column`:

![image](https://user-images.githubusercontent.com/882133/133781284-9d6d2d95-0b0d-418a-b59b-64cba83db880.png)

And here is the result *with* `break-inside-avoid-column`:

![image](https://user-images.githubusercontent.com/882133/133781312-d6235a19-0d3c-44de-8ff4-c5984e311a51.png)

It's worth noting that `break-inside: avoid-column` was not supported in Firefox, [until recently](https://bugzilla.mozilla.org/show_bug.cgi?id=1722945), thanks to [Adam](https://twitter.com/adamwathan/status/1420452397718118403). 🙌

## Naming

The naming of these classes is anything but creative. I literally just combined the property name with the value. This does mean there are a few four word utilities, which is somewhat regrettable, I just don't see a way to avoid (pun intended) it.

## Browser compatibility and excluded values

The browser support for these new utilities is a bit of a mixed bag. Some of these utilities work within paged media (when printing), but don't work in multi-column layouts. To keep things simple, I included all the utilities that have a reasonable amount of browser support. The following properties and values didn't meet that criteria:

```css
break-inside: avoid-region;
break-before: always;
break-before: avoid-column;
break-before: avoid-region;
break-before: recto;
break-before: region;
break-before: verso;
break-after: always;
break-after: avoid-column;
break-after: avoid-region;
break-after: recto;
break-after: region;
break-after: verso;
```

## Complete class list

Here is a complete list of all the new classes and their corresponding CSS:

| Class | CSS |
| --- | --- |
| `break-before-auto` | `break-before: auto` |
| `break-before-avoid` | `break-before: avoid` |
| `break-before-all` | `break-before: all` |
| `break-before-avoid-page` | `break-before: avoid-page` |
| `break-before-page` | `break-before: page` |
| `break-before-left` | `break-before: left` |
| `break-before-right` | `break-before: right` |
| `break-before-column` | `break-before: column` |
| `break-inside-auto` | `break-inside: auto` |
| `break-inside-avoid` | `break-inside: avoid` |
| `break-inside-avoid-page` | `break-inside: avoid-page` |
| `break-inside-avoid-column` | `break-inside: avoid-column` |
| `break-after-auto` | `break-after: auto` |
| `break-after-avoid` | `break-after: avoid` |
| `break-after-all` | `break-after: all` |
| `break-after-avoid-page` | `break-after: avoid-page` |
| `break-after-page` | `break-after: page` |
| `break-after-left` | `break-after: left` |
| `break-after-right` | `break-after: right` |
| `break-after-column` | `break-after: column` |