### PR TITLE
Add `listStylePosition` to `defaultConfig.stub.js`

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -549,6 +549,10 @@ module.exports = {
       9: '2.25rem',
       10: '2.5rem',
     },
+    listStylePosition: {
+      inside: 'inside',
+      outside: 'outside',
+    },
     listStyleType: {
       none: 'none',
       disc: 'disc',


### PR DESCRIPTION
Hi,

I am using https://github.com/spatie/tailwind-safelist-generator plugin and noticed i couldn't safelist the `list-style-position` utility like this...

```javascript
    require('tailwind-safelist-generator')({
      path: 'tailwind-safelist.txt',
      patterns: [
        'list-{listStylePosition}',
      ]
   }),
```


This PR is a stab in the dark really, but it fixed the issue for me. I dont know the internals of Tailwind well enough to know if it's omission from `defaultConfig.stub.js` was intentional or an oversight.

Thanks 👍 

