### PR TITLE
Ensure invalid typehints are not generated

### DIFF
--- a/src/util/pluginUtils.js
+++ b/src/util/pluginUtils.js
@@ -284,8 +284,12 @@ let typeMap = {
   lookup: asLookupValue,
 }
 
+let supportedTypes = Object.keys(typeMap)
+
 function splitAtFirst(input, delim) {
-  return (([first, ...rest]) => [first, rest.join(delim)])(input.split(delim))
+  let idx = input.indexOf(delim)
+  if (idx === -1) return [undefined, input]
+  return [input.slice(0, idx), input.slice(idx + 1)]
 }
 
 export function coerceValue(type, modifier, values, tailwindConfig) {
@@ -294,7 +298,11 @@ export function coerceValue(type, modifier, values, tailwindConfig) {
   if (isArbitraryValue(modifier)) {
     let [explicitType, value] = splitAtFirst(modifier.slice(1, -1), ':')
 
-    if (value.length > 0 && Object.keys(typeMap).includes(explicitType)) {
+    if (explicitType !== undefined && !supportedTypes.includes(explicitType)) {
+      return []
+    }
+
+    if (value.length > 0 && supportedTypes.includes(explicitType)) {
       return [asValue(`[${value}]`, values, tailwindConfig), explicitType]
     }
 

--- a/tests/arbitrary-values.test.js
+++ b/tests/arbitrary-values.test.js
@@ -16,6 +16,20 @@ test('arbitrary values', () => {
   })
 })
 
+it('should not generate any css if an unknown typehint is used', () => {
+  let config = {
+    content: [
+      {
+        raw: html`<div class="inset-[hmm:12px]"></div>`,
+      },
+    ],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    return expect(result.css).toMatchFormattedCss(css``)
+  })
+})
+
 it('should convert _ to spaces', () => {
   let config = {
     content: [


### PR DESCRIPTION
This PR prevents generating unknown typehints. This is because in a lot of plugins we use the value as-is (`any` typehint, which is the default).

**input:**
```html
<div class="inset-[hmm:12px]"></div>
```

**output:**
```css
```

If we didn't have this fix, this would have generated: 

**output:**
```css
.outline-\[hmm\:12px\] {
    outline: hmm: 12px;
}
```

Which in turn makes the whole css document invalid and it will break your build. No bueno!