### PR TITLE
Drop unused tailwindDirectives argument

### DIFF
--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -456,7 +456,7 @@ function collectLayerPlugins(root) {
   return layerPlugins
 }
 
-function resolvePlugins(context, tailwindDirectives, root) {
+function resolvePlugins(context, root) {
   let corePluginList = Object.entries(corePlugins)
     .map(([name, plugin]) => {
       if (!context.tailwindConfig.corePlugins.includes(name)) {
@@ -475,7 +475,7 @@ function resolvePlugins(context, tailwindDirectives, root) {
     return typeof plugin === 'function' ? plugin : plugin.handler
   })
 
-  let layerPlugins = collectLayerPlugins(root, tailwindDirectives)
+  let layerPlugins = collectLayerPlugins(root)
 
   // TODO: This is a workaround for backwards compatibility, since custom variants
   // were historically sorted before screen/stackable variants.
@@ -667,12 +667,7 @@ function registerPlugins(plugins, context) {
   }
 }
 
-export function createContext(
-  tailwindConfig,
-  changedContent = [],
-  tailwindDirectives = new Set(),
-  root = postcss.root()
-) {
+export function createContext(tailwindConfig, changedContent = [], root = postcss.root()) {
   let context = {
     disposables: [],
     ruleCache: new Set(),
@@ -687,7 +682,7 @@ export function createContext(
     stylesheetCache: null,
   }
 
-  let resolvedPlugins = resolvePlugins(context, tailwindDirectives, root)
+  let resolvedPlugins = resolvePlugins(context, root)
   registerPlugins(resolvedPlugins, context)
 
   return context
@@ -698,7 +693,6 @@ let configContextMap = sharedState.configContextMap
 let contextSourcesMap = sharedState.contextSourcesMap
 
 export function getContext(
-  tailwindDirectives,
   root,
   result,
   tailwindConfig,
@@ -760,7 +754,7 @@ export function getContext(
 
   env.DEBUG && console.log('Setting up new context...')
 
-  let context = createContext(tailwindConfig, [], tailwindDirectives, root)
+  let context = createContext(tailwindConfig, [], root)
 
   trackModified([...contextDependencies], getFileModifiedMap(context))
 

--- a/src/lib/setupTrackingContext.js
+++ b/src/lib/setupTrackingContext.js
@@ -139,7 +139,6 @@ export default function setupTrackingContext(configOrPath) {
       }
 
       let [context] = getContext(
-        tailwindDirectives,
         root,
         result,
         tailwindConfig,

--- a/src/lib/setupWatchingContext.js
+++ b/src/lib/setupWatchingContext.js
@@ -249,7 +249,6 @@ export default function setupWatchingContext(configOrPath) {
       }
 
       let [context, isNewContext] = getContext(
-        tailwindDirectives,
         root,
         result,
         tailwindConfig,

--- a/src/processTailwindFeatures.js
+++ b/src/processTailwindFeatures.js
@@ -22,7 +22,7 @@ export default function processTailwindFeatures(setupContext) {
         })
       },
       createContext(tailwindConfig, changedContent) {
-        return createContext(tailwindConfig, changedContent, tailwindDirectives, root)
+        return createContext(tailwindConfig, changedContent, root)
       },
     })(root, result)
 


### PR DESCRIPTION
Something I noticed while working on #5617 is that we had an unused variable spread across a chain of functions.
Of course not the highest priority, but saw it so wanted to clean it.