### PR TITLE
Fix negative content patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix defining colors as functions when color opacity plugins are disabled ([#5470](https://github.com/tailwindlabs/tailwindcss/pull/5470))
+- Fix using negated `content` globs ([#5625](https://github.com/tailwindlabs/tailwindcss/pull/5625))
 
 ## [2.2.16] - 2021-09-26
 

--- a/src/lib/setupTrackingContext.js
+++ b/src/lib/setupTrackingContext.js
@@ -28,7 +28,7 @@ function getCandidateFiles(context, tailwindConfig) {
 
   let candidateFiles = tailwindConfig.content.content
     .filter((item) => typeof item === 'string')
-    .map((contentPath) => normalizePath(path.resolve(contentPath)))
+    .map((contentPath) => normalizePath(contentPath))
 
   return candidateFilesCache.set(context, candidateFiles).get(context)
 }
@@ -159,7 +159,10 @@ export default function setupTrackingContext(configOrPath) {
 
         // Add template paths as postcss dependencies.
         for (let fileOrGlob of candidateFiles) {
-          registerDependency(parseDependency(fileOrGlob))
+          let dependency = parseDependency(fileOrGlob)
+          if (dependency) {
+            registerDependency(dependency)
+          }
         }
 
         for (let changedContent of resolvedChangedContent(

--- a/src/lib/setupWatchingContext.js
+++ b/src/lib/setupWatchingContext.js
@@ -149,7 +149,7 @@ function getCandidateFiles(context, tailwindConfig) {
 
   let candidateFiles = tailwindConfig.content.content
     .filter((item) => typeof item === 'string')
-    .map((contentPath) => normalizePath(path.resolve(contentPath)))
+    .map((contentPath) => normalizePath(contentPath))
 
   return candidateFilesCache.set(context, candidateFiles).get(context)
 }

--- a/src/util/parseDependency.js
+++ b/src/util/parseDependency.js
@@ -26,6 +26,10 @@ function parseGlob(pattern) {
 }
 
 export default function parseDependency(normalizedFileOrGlob) {
+  if (normalizedFileOrGlob.startsWith('!')) {
+    return null
+  }
+
   let message
 
   if (isGlob(normalizedFileOrGlob)) {

--- a/tests/negated-content-ignore.test.html
+++ b/tests/negated-content-ignore.test.html
@@ -1,0 +1,1 @@
+<div class="lowercase"></div>

--- a/tests/negated-content-include.test.html
+++ b/tests/negated-content-include.test.html
@@ -1,0 +1,1 @@
+<div class="uppercase"></div>

--- a/tests/negated-content.test.js
+++ b/tests/negated-content.test.js
@@ -1,0 +1,26 @@
+import * as path from 'path'
+import { run, css } from './util/run'
+
+it('should be possible to use negated content patterns', () => {
+  let config = {
+    content: [
+      path.resolve(__dirname, './negated-content-*.test.html'),
+      '!' + path.resolve(__dirname, './negated-content-ignore.test.html'),
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .uppercase {
+        text-transform: uppercase;
+      }
+    `)
+  })
+})


### PR DESCRIPTION
This PR implements a fix for negative content patterns, e.g.

```js
module.exports = {
  content: [
    './src/**/*.html',
    '!./src/ignore-me.html',
  ],
}
```

This is achieved by removing the `path.resolve` call. This would turn an input like `!file` into `/Users/me/project/!file` which is incorrect.

_For context, `path.resolve` was originally used to work around [a bug](https://github.com/mrmlnc/fast-glob/issues/310) in `fast-glob` which has since been resolved._

Additionally, negative patterns are skipped when registering PostCSS dependencies.