### PR TITLE
Add `[open]` variant

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -10,6 +10,7 @@ import toColorValue from './util/toColorValue'
 import isPlainObject from './util/isPlainObject'
 import transformThemeValue from './util/transformThemeValue'
 import {
+  applyAttributeToMarker,
   applyPseudoToMarker,
   updateLastClasses,
   updateAllClasses,
@@ -128,11 +129,11 @@ export default {
   pseudoClassVariants: ({ config, addVariant }) => {
     let pseudoVariants = [
       // Positional
-      ['first', 'first-child'],
-      ['last', 'last-child'],
-      ['only', 'only-child'],
-      ['odd', 'nth-child(odd)'],
-      ['even', 'nth-child(even)'],
+      ['first', ':first-child'],
+      ['last', ':last-child'],
+      ['only', ':only-child'],
+      ['odd', ':nth-child(odd)'],
+      ['even', ':nth-child(even)'],
       'first-of-type',
       'last-of-type',
       'only-of-type',
@@ -140,6 +141,7 @@ export default {
       // State
       'visited',
       'target',
+      ['open', '[open]'],
 
       // Forms
       'default',
@@ -167,19 +169,23 @@ export default {
     ]
 
     for (let variant of pseudoVariants) {
-      let [variantName, state] = Array.isArray(variant) ? variant : [variant, variant]
+      let [variantName, state] = Array.isArray(variant) ? variant : [variant, `:${variant}`]
 
       addVariant(
         variantName,
-        transformAllClasses((className, { withPseudo }) => {
-          return withPseudo(`${variantName}${config('separator')}${className}`, `:${state}`)
+        transformAllClasses((className, { withAttr, withPseudo }) => {
+          if (state.startsWith(':')) {
+            return withPseudo(`${variantName}${config('separator')}${className}`, state)
+          } else if (state.startsWith('[')) {
+            return withAttr(`${variantName}${config('separator')}${className}`, state)
+          }
         })
       )
     }
 
     let groupMarker = prefixSelector(config('prefix'), '.group')
     for (let variant of pseudoVariants) {
-      let [variantName, state] = Array.isArray(variant) ? variant : [variant, variant]
+      let [variantName, state] = Array.isArray(variant) ? variant : [variant, `:${variant}`]
       let groupVariantName = `group-${variantName}`
 
       addVariant(
@@ -194,19 +200,28 @@ export default {
             return null
           }
 
-          return applyPseudoToMarker(
-            variantSelector,
-            groupMarker,
-            state,
-            (marker, selector) => `${marker} ${selector}`
-          )
+          if (state.startsWith(':')) {
+            return applyPseudoToMarker(
+              variantSelector,
+              groupMarker,
+              state,
+              (marker, selector) => `${marker} ${selector}`
+            )
+          } else if (state.startsWith('[')) {
+            return applyAttributeToMarker(
+              variantSelector,
+              groupMarker,
+              state,
+              (marker, selector) => `${marker} ${selector}`
+            )
+          }
         })
       )
     }
 
     let peerMarker = prefixSelector(config('prefix'), '.peer')
     for (let variant of pseudoVariants) {
-      let [variantName, state] = Array.isArray(variant) ? variant : [variant, variant]
+      let [variantName, state] = Array.isArray(variant) ? variant : [variant, `:${variant}`]
       let peerVariantName = `peer-${variantName}`
 
       addVariant(

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -10,8 +10,7 @@ import toColorValue from './util/toColorValue'
 import isPlainObject from './util/isPlainObject'
 import transformThemeValue from './util/transformThemeValue'
 import {
-  applyAttributeToMarker,
-  applyPseudoToMarker,
+  applyStateToMarker,
   updateLastClasses,
   updateAllClasses,
   transformAllSelectors,
@@ -200,21 +199,12 @@ export default {
             return null
           }
 
-          if (state.startsWith(':')) {
-            return applyPseudoToMarker(
-              variantSelector,
-              groupMarker,
-              state,
-              (marker, selector) => `${marker} ${selector}`
-            )
-          } else if (state.startsWith('[')) {
-            return applyAttributeToMarker(
-              variantSelector,
-              groupMarker,
-              state,
-              (marker, selector) => `${marker} ${selector}`
-            )
-          }
+          return applyStateToMarker(
+            variantSelector,
+            groupMarker,
+            state,
+            (marker, selector) => `${marker} ${selector}`
+          )
         })
       )
     }
@@ -236,7 +226,7 @@ export default {
             return null
           }
 
-          return applyPseudoToMarker(variantSelector, peerMarker, state, (marker, selector) =>
+          return applyStateToMarker(variantSelector, peerMarker, state, (marker, selector) =>
             selector.trim().startsWith('~') ? `${marker}${selector}` : `${marker} ~ ${selector}`
           )
         })

--- a/src/util/pluginUtils.js
+++ b/src/util/pluginUtils.js
@@ -18,36 +18,19 @@ import {
   lineWidth,
 } from './dataTypes'
 
-export function applyAttributeToMarker(selector, marker, state, join) {
-  let markerIdx = selector.indexOf(marker + ':')
+export function applyStateToMarker(selector, marker, state, join) {
+  let markerIdx = selector.search(new RegExp(`${marker}[:[]`))
 
-  if (markerIdx !== -1) {
-    let existingMarker = selector.slice(markerIdx, selector.indexOf(' ', markerIdx))
-
-    selector = selector.replace(existingMarker, '')
-
-    return join(existingMarker.replace(marker + ':', `${marker}[${state.slice(1, -1)}]:`), selector)
+  if (markerIdx === -1) {
+    return join(marker + state, selector)
   }
 
-  return join(`${marker}[${state.slice(1, -1)}]`, selector)
-}
+  let markerSelector = selector.slice(markerIdx, selector.indexOf(' ', markerIdx))
 
-export function applyPseudoToMarker(selector, marker, state, join) {
-  let states = [state.slice(1)]
-
-  let markerIdx = selector.indexOf(marker + ':')
-
-  if (markerIdx !== -1) {
-    let existingMarker = selector.slice(markerIdx, selector.indexOf(' ', markerIdx))
-
-    states = states.concat(
-      selector.slice(markerIdx + marker.length + 1, existingMarker.length).split(':')
-    )
-
-    selector = selector.replace(existingMarker, '')
-  }
-
-  return join(`${[marker, ...states].join(':')}`, selector)
+  return join(
+    marker + state + markerSelector.slice(markerIdx + marker.length),
+    selector.replace(markerSelector, '')
+  )
 }
 
 export function updateAllClasses(selectors, updateClass) {

--- a/src/util/pluginUtils.js
+++ b/src/util/pluginUtils.js
@@ -18,8 +18,22 @@ import {
   lineWidth,
 } from './dataTypes'
 
+export function applyAttributeToMarker(selector, marker, state, join) {
+  let markerIdx = selector.indexOf(marker + ':')
+
+  if (markerIdx !== -1) {
+    let existingMarker = selector.slice(markerIdx, selector.indexOf(' ', markerIdx))
+
+    selector = selector.replace(existingMarker, '')
+
+    return join(existingMarker.replace(marker + ':', `${marker}[${state.slice(1, -1)}]:`), selector)
+  }
+
+  return join(`${marker}[${state.slice(1, -1)}]`, selector)
+}
+
 export function applyPseudoToMarker(selector, marker, state, join) {
-  let states = [state]
+  let states = [state.slice(1)]
 
   let markerIdx = selector.indexOf(marker + ':')
 
@@ -40,8 +54,12 @@ export function updateAllClasses(selectors, updateClass) {
   let parser = selectorParser((selectors) => {
     selectors.walkClasses((sel) => {
       let updatedClass = updateClass(sel.value, {
+        withAttr(className, attr) {
+          sel.parent.insertAfter(sel, selectorParser.attribute({ attribute: attr.slice(1, -1) }))
+          return className
+        },
         withPseudo(className, pseudo) {
-          sel.parent.insertAfter(sel, selectorParser.pseudo({ value: `${pseudo}` }))
+          sel.parent.insertAfter(sel, selectorParser.pseudo({ value: pseudo }))
           return className
         },
       })

--- a/tests/variants.test.css
+++ b/tests/variants.test.css
@@ -358,6 +358,11 @@
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
     var(--tw-shadow);
 }
+.group[open]:hover .group-open\:group-hover\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(0.5rem * var(--tw-space-x-reverse));
+  margin-left: calc(0.5rem * calc(1 - var(--tw-space-x-reverse)));
+}
 .group:focus .group-focus\:shadow-md {
   --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -1px rgb(0 0 0 / 0.06);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),

--- a/tests/variants.test.css
+++ b/tests/variants.test.css
@@ -127,6 +127,10 @@
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
     var(--tw-shadow);
 }
+.open\:bg-red-200[open] {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 202 202 / var(--tw-bg-opacity));
+}
 .default\:shadow-md:default {
   --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -1px rgb(0 0 0 / 0.06);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
@@ -200,6 +204,10 @@
 .file\:hover\:bg-blue-600::file-selector-button:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(37 99 235 / var(--tw-bg-opacity));
+}
+.open\:hover\:bg-red-200[open]:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 202 202 / var(--tw-bg-opacity));
 }
 .focus\:shadow-md:focus {
   --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -1px rgb(0 0 0 / 0.06);
@@ -276,6 +284,10 @@
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
     var(--tw-shadow);
 }
+.group[open] .group-open\:bg-red-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 202 202 / var(--tw-bg-opacity));
+}
 .group:default .group-default\:shadow-md {
   --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -1px rgb(0 0 0 / 0.06);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
@@ -350,6 +362,10 @@
   --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -1px rgb(0 0 0 / 0.06);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
     var(--tw-shadow);
+}
+.group[open]:focus .group-open\:group-focus\:bg-red-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 202 202 / var(--tw-bg-opacity));
 }
 .group:focus:hover .group-focus\:group-hover\:shadow-md {
   --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -1px rgb(0 0 0 / 0.06);

--- a/tests/variants.test.html
+++ b/tests/variants.test.html
@@ -22,6 +22,7 @@
     <div class="disabled:shadow-md"></div>
     <div class="active:shadow-md"></div>
     <div class="target:shadow-md"></div>
+    <div class="open:bg-red-200"></div>
     <div class="visited:shadow-md"></div>
     <div class="default:shadow-md"></div>
     <div class="checked:shadow-md"></div>
@@ -50,6 +51,7 @@
     <div class="after:flex after:uppercase"></div>
 
     <!-- Group variants -->
+    <div class="group-open:bg-red-200"></div>
     <div class="group-first:shadow-md"></div>
     <div class="group-last:shadow-md"></div>
     <div class="group-only:shadow-md"></div>
@@ -128,6 +130,7 @@
     <div class="2xl:shadow-md"></div>
 
     <!-- Stacked variants -->
+    <div class="open:hover:bg-red-200"></div>
     <div class="file:hover:bg-blue-600"></div>
     <div class="focus:hover:shadow-md"></div>
     <div class="sm:active:shadow-md"></div>
@@ -137,6 +140,7 @@
     <div class="2xl:dark:motion-safe:focus-within:shadow-md"></div>
 
     <!-- Stacked group variants -->
+    <div class="group-open:group-focus:bg-red-200"></div>
     <div class="group-focus:group-hover:shadow-md"></div>
     <div class="group-disabled:group-focus:group-hover:shadow-md"></div>
     <div class="dark:group-disabled:group-focus:group-hover:shadow-md"></div>

--- a/tests/variants.test.html
+++ b/tests/variants.test.html
@@ -141,6 +141,7 @@
 
     <!-- Stacked group variants -->
     <div class="group-open:group-focus:bg-red-200"></div>
+    <div class="group-open:group-hover:space-x-2"></div>
     <div class="group-focus:group-hover:shadow-md"></div>
     <div class="group-disabled:group-focus:group-hover:shadow-md"></div>
     <div class="dark:group-disabled:group-focus:group-hover:shadow-md"></div>


### PR DESCRIPTION
This PR adds a new `[open]` attribute selector variant to Tailwind CSS. This is based on the work started by @seanpdoyle in #4627. This can be useful for applying styles to `<details>` or `<dialog>` elements based on whether they are open.

```html
<details class="border-0 open:border-1" open>
  <!-- ... -->
</details>

<details class="border-0 open:border-1">
  <!-- ... -->
</details>
```

This can also be combined with `group` and `peer` variants:

```html
<details class="group peer" open>
  <summary>
    <span class="hidden group-open:inline">Close me, I'm open</span>
    <span class="inline group-open:hidden">Open me, I'm closed</span>
  </summary>
</details>

<span class="hidden peer-open:inline">I'm next to an open element</span>
<span class="inline peer-open:hidden">I'm next to a closed element</span>
```