### PR TITLE
Normalize CLI content globs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix defining colors as functions when color opacity plugins are disabled ([#5470](https://github.com/tailwindlabs/tailwindcss/pull/5470))
 - Fix using negated `content` globs ([#5625](https://github.com/tailwindlabs/tailwindcss/pull/5625))
+- Fix using backslashes in `content` globs ([#5628](https://github.com/tailwindlabs/tailwindcss/pull/5628))
 
 ## [2.2.16] - 2021-09-26
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -15,6 +15,7 @@ import fastGlob from 'fast-glob'
 import getModuleDependencies from './lib/getModuleDependencies'
 import log from './util/log'
 import packageJson from '../package.json'
+import normalizePath from 'normalize-path'
 
 let env = {
   DEBUG: process.env.DEBUG !== undefined,
@@ -437,12 +438,14 @@ async function build() {
   }
 
   function extractFileGlobs(config) {
-    return extractContent(config).filter((file) => {
-      // Strings in this case are files / globs. If it is something else,
-      // like an object it's probably a raw content object. But this object
-      // is not watchable, so let's remove it.
-      return typeof file === 'string'
-    })
+    return extractContent(config)
+      .filter((file) => {
+        // Strings in this case are files / globs. If it is something else,
+        // like an object it's probably a raw content object. But this object
+        // is not watchable, so let's remove it.
+        return typeof file === 'string'
+      })
+      .map((glob) => normalizePath(glob))
   }
 
   function extractRawContent(config) {


### PR DESCRIPTION
This PR ensures that the `content` globs are normalized when using the CLI, [like they are when not using the CLI](https://github.com/tailwindlabs/tailwindcss/blob/master/src/lib/setupTrackingContext.js#L31).

`fast-glob` [expects patterns to always use forward-slashes](https://github.com/mrmlnc/fast-glob#pattern-syntax), but when using something like `path.resolve` on Windows your pattern might end up with back-slashes and not working, e.g.

```js
module.exports = {
  content: [require('path').resolve(__dirname, 'index.html')], // C:\Users\Me\Project\index.html
}
```

This doesn't currently work when using the CLI on Windows, but this PR fixes that.