### PR TITLE
Detect ambiguity in arbitrary values

### DIFF
--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -309,12 +309,13 @@ function* resolveMatches(candidate, context) {
       }
 
       log.warn([
-        // TODO: Improve this warning message
-        `We found ${matches.length} plugins that generated output for "${candidate}".`,
         // TODO: Update URL
-        'You can be explicit by introducing typehints: https://tailwindcss.com/docs/just-in-time-mode#ambiguous-values',
+        `The class "${candidate}" is ambiguous and matches multiple utilities. Use a type hint (https://tailwindcss.com/docs/just-in-time-mode#ambiguous-values) to fix this.`,
         '',
         ...messages,
+        `If this is just part of your content and not a class, replace it with "${candidate
+          .replace('[', '&lsqb;')
+          .replace(']', '&rsqb;')}" to silence this warning.`,
       ])
       continue
     }

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -4,6 +4,7 @@ import parseObjectStyles from '../util/parseObjectStyles'
 import isPlainObject from '../util/isPlainObject'
 import prefixSelector from '../util/prefixSelector'
 import { updateAllClasses } from '../util/pluginUtils'
+import log from '../util/log'
 
 let classNameParser = selectorParser((selectors) => {
   return selectors.first.filter(({ type }) => type === 'class').pop().value
@@ -225,15 +226,19 @@ function* resolveMatches(candidate, context) {
 
   for (let matchedPlugins of resolveMatchedPlugins(classCandidate, context)) {
     let matches = []
+    let typesByMatches = new Map()
+
     let [plugins, modifier] = matchedPlugins
     let isOnlyPlugin = plugins.length === 1
 
     for (let [sort, plugin] of plugins) {
+      let matchesPerPlugin = []
+
       if (typeof plugin === 'function') {
         for (let ruleSet of [].concat(plugin(modifier, { isOnlyPlugin }))) {
           let [rules, options] = parseRules(ruleSet, context.postCssNodeCache)
           for (let rule of rules) {
-            matches.push([{ ...sort, options: { ...sort.options, ...options } }, rule])
+            matchesPerPlugin.push([{ ...sort, options: { ...sort.options, ...options } }, rule])
           }
         }
       }
@@ -242,12 +247,79 @@ function* resolveMatches(candidate, context) {
         let ruleSet = plugin
         let [rules, options] = parseRules(ruleSet, context.postCssNodeCache)
         for (let rule of rules) {
-          matches.push([{ ...sort, options: { ...sort.options, ...options } }, rule])
+          matchesPerPlugin.push([{ ...sort, options: { ...sort.options, ...options } }, rule])
         }
+      }
+
+      if (matchesPerPlugin.length > 0) {
+        typesByMatches.set(matchesPerPlugin, sort.options?.type)
+        matches.push(matchesPerPlugin)
       }
     }
 
-    matches = applyPrefix(matches, context)
+    // Only keep the result of the very first plugin if we are dealing with
+    // arbitrary values, to protect against ambiguity.
+    if (isArbitraryValue(modifier) && matches.length > 1) {
+      let typesPerPlugin = matches.map((match) => new Set([...(typesByMatches.get(match) ?? [])]))
+
+      // Remove duplicates, so that we can detect proper unique types for each plugin.
+      for (let pluginTypes of typesPerPlugin) {
+        for (let type of pluginTypes) {
+          let removeFromOwnGroup = false
+
+          for (let otherGroup of typesPerPlugin) {
+            if (pluginTypes === otherGroup) continue
+
+            if (otherGroup.has(type)) {
+              otherGroup.delete(type)
+              removeFromOwnGroup = true
+            }
+          }
+
+          if (removeFromOwnGroup) pluginTypes.delete(type)
+        }
+      }
+
+      let messages = []
+
+      for (let [idx, group] of typesPerPlugin.entries()) {
+        for (let type of group) {
+          let rules = matches[idx]
+            .map(([, rule]) => rule)
+            .flat()
+            .map((rule) =>
+              rule
+                .toString()
+                .split('\n')
+                .slice(1, -1) // Remove selector and closing '}'
+                .map((line) => line.trim())
+                .map((x) => `      ${x}`) // Re-indent
+                .join('\n')
+            )
+            .join('\n\n')
+
+          messages.push(
+            `  - Replace "${candidate}" with "${candidate.replace(
+              '[',
+              `[${type}:`
+            )}" for:\n${rules}\n`
+          )
+          break
+        }
+      }
+
+      log.warn([
+        // TODO: Improve this warning message
+        `We found ${matches.length} plugins that generated output for "${candidate}".`,
+        // TODO: Update URL
+        'You can be explicit by introducing typehints: https://tailwindcss.com/docs/just-in-time-mode#ambiguous-values',
+        '',
+        ...messages,
+      ])
+      continue
+    }
+
+    matches = applyPrefix(matches.flat(), context)
 
     if (important) {
       matches = applyImportant(matches, context)
@@ -315,6 +387,10 @@ function generateRules(candidates, context) {
     }
     return [sort | context.layerOrder[layer], rule]
   })
+}
+
+function isArbitraryValue(input) {
+  return input.startsWith('[') && input.endsWith(']')
 }
 
 export { resolveMatches, generateRules }

--- a/tests/arbitrary-values.test.js
+++ b/tests/arbitrary-values.test.js
@@ -197,3 +197,15 @@ it('should not convert escaped underscores with spaces', () => {
     `)
   })
 })
+
+it('should warn and not generate if arbitrary values are ambigu', () => {
+  // If we don't protect against this, then `bg-[200px_100px]` would both
+  // generate the background-size as well as the background-position utilities.
+  let config = {
+    content: [{ raw: html`<div class="bg-[200px_100px]"></div>` }],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    return expect(result.css).toMatchFormattedCss(css``)
+  })
+})


### PR DESCRIPTION
If you use arbitrary values for the `bg` utilities, then it could happen that you introduce some ambiguity. When you use arbitrary values, then we can detect the type of the input. For example `#ff00ff` is a color, `20%` is a percentage and so on.

```html
<div class="bg-[200px_100px]"></div>
```
The value here would be parsed as `length`. However, we have 2 plugins (`backgroundSize` and `backgroundPosition`) that can handle this plugin. Before this plugin this would have generated:
```css
.bg-\[200px_100px\] {
  background-size: 200px 100px
}
.bg-\[200px_100px\] {
  background-position: 200px 100px
}
```
This will also probably be squashed together like this:
```css
.bg-\[200px_100px\] {
  background-size: 200px 100px
  background-position: 200px 100px
}
```
This will not be the desired result, instead you can use `typehints` to explicitly tell what the value means. In this case, the `backgroundPosition` plugin implements a `position` type. This means that we can explicit here:

```html
<div class="bg-[length:200px_100px]"></div>
<div class="bg-[size:200px_100px]"></div>
```
This will now generate the correct results with a unique selector:
```css
.bg-\[length\:200px_100px\] {
  background-size: 200px 100px
}
.bg-\[position\:200px_100px\] {
  background-position: 200px 100px
}
```
---
That said, this PR will be able to detect the very first case `bg-[200px_100px]` and not generate css for that at all, instead it will show you a warning in the console:
```
The class "bg-[200px_100px]" is ambiguous and matches multiple utilities. Use a type hint (https://tailwindcss.com/docs/just-in-time-mode#ambiguous-values) to fix this.

  - Replace "bg-[200px_100px]" with "bg-[length:200px_100px]" for:
      background-size: 200px 100px

  - Replace "bg-[200px_100px]" with "bg-[position:200px_100px]" for:
      background-position: 200px 100px

If this is just part of your content and not a class, replace it with "bg-&lsqb;200px_100px&rsqb;" to silence this warning.
```
~**Note**: There is a high chance that the warning will be changed/simplified, but at least we can detect it!~