### PR TITLE
Add `scroll-snap` utilities

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -813,6 +813,76 @@ export default {
     })
   },
 
+  scrollSnapType: ({ addUtilities, addBase }) => {
+    addBase({
+      '@defaults scroll-snap-type': {
+        '--tw-scroll-snap-strictness': 'proximity',
+      },
+    })
+
+    addUtilities({
+      '.snap-none': { 'scroll-snap-type': 'none' },
+      '.snap-x': {
+        '@defaults scroll-snap-type': {},
+        'scroll-snap-type': 'x var(--tw-scroll-snap-strictness)',
+      },
+      '.snap-y': {
+        '@defaults scroll-snap-type': {},
+        'scroll-snap-type': 'y var(--tw-scroll-snap-strictness)',
+      },
+      '.snap-both': {
+        '@defaults scroll-snap-type': {},
+        'scroll-snap-type': 'both var(--tw-scroll-snap-strictness)',
+      },
+      '.snap-mandatory': { '--tw-scroll-snap-strictness': 'mandatory' },
+      '.snap-proximity': { '--tw-scroll-snap-strictness': 'proximity' },
+    })
+  },
+
+  scrollSnapAlign: ({ addUtilities }) => {
+    addUtilities({
+      '.snap-start': { 'scroll-snap-align': 'start' },
+      '.snap-end': { 'scroll-snap-align': 'end' },
+      '.snap-center': { 'scroll-snap-align': 'center' },
+      '.snap-align-none': { 'scroll-snap-align': 'none' },
+    })
+  },
+
+  scrollSnapStop: ({ addUtilities }) => {
+    addUtilities({
+      '.snap-normal': { 'scroll-snap-stop': 'normal' },
+      '.snap-always': { 'scroll-snap-stop': 'always' },
+    })
+  },
+
+  scrollMargin: createUtilityPlugin('scrollMargin', [
+    ['scroll-m', ['scroll-margin']],
+    [
+      ['scroll-mx', ['scroll-margin-left', 'scroll-margin-right']],
+      ['scroll-my', ['scroll-margin-top', 'scroll-margin-bottom']],
+    ],
+    [
+      ['scroll-mt', ['scroll-margin-top']],
+      ['scroll-mr', ['scroll-margin-right']],
+      ['scroll-mb', ['scroll-margin-bottom']],
+      ['scroll-ml', ['scroll-margin-left']],
+    ],
+  ]),
+
+  scrollPadding: createUtilityPlugin('scrollPadding', [
+    ['scroll-p', ['scroll-padding']],
+    [
+      ['scroll-px', ['scroll-padding-left', 'scroll-padding-right']],
+      ['scroll-py', ['scroll-padding-top', 'scroll-padding-bottom']],
+    ],
+    [
+      ['scroll-pt', ['scroll-padding-top']],
+      ['scroll-pr', ['scroll-padding-right']],
+      ['scroll-pb', ['scroll-padding-bottom']],
+      ['scroll-pl', ['scroll-padding-left']],
+    ],
+  ]),
+
   listStylePosition: ({ addUtilities }) => {
     addUtilities({
       '.list-inside': { 'list-style-position': 'inside' },

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -711,6 +711,11 @@ module.exports = {
       125: '1.25',
       150: '1.5',
     },
+    scrollMargin: (theme, { negative }) => ({
+      ...theme('spacing'),
+      ...negative(theme('spacing')),
+    }),
+    scrollPadding: (theme) => theme('spacing'),
     sepia: {
       0: '0',
       DEFAULT: '100%',

--- a/tests/arbitrary-values.test.css
+++ b/tests/arbitrary-values.test.css
@@ -307,6 +307,58 @@
 .cursor-\[var\(--value\)\] {
   cursor: var(--value);
 }
+.scroll-m-\[7px\] {
+  scroll-margin: 7px;
+}
+.scroll-mx-\[7px\] {
+  scroll-margin-left: 7px;
+  scroll-margin-right: 7px;
+}
+.scroll-my-\[7px\] {
+  scroll-margin-top: 7px;
+  scroll-margin-bottom: 7px;
+}
+.scroll-mt-\[7px\] {
+  scroll-margin-top: 7px;
+}
+.scroll-mr-\[7px\] {
+  scroll-margin-right: 7px;
+}
+.scroll-mb-\[7px\] {
+  scroll-margin-bottom: 7px;
+}
+.scroll-ml-\[7px\] {
+  scroll-margin-left: 7px;
+}
+.scroll-mt-\[var\(--scroll-margin\)\] {
+  scroll-margin-top: var(--scroll-margin);
+}
+.scroll-p-\[7px\] {
+  scroll-padding: 7px;
+}
+.scroll-px-\[7px\] {
+  scroll-padding-left: 7px;
+  scroll-padding-right: 7px;
+}
+.scroll-py-\[7px\] {
+  scroll-padding-top: 7px;
+  scroll-padding-bottom: 7px;
+}
+.scroll-pt-\[7px\] {
+  scroll-padding-top: 7px;
+}
+.scroll-pr-\[7px\] {
+  scroll-padding-right: 7px;
+}
+.scroll-pb-\[7px\] {
+  scroll-padding-bottom: 7px;
+}
+.scroll-pl-\[7px\] {
+  scroll-padding-left: 7px;
+}
+.scroll-pt-\[var\(--scroll-padding\)\] {
+  scroll-padding-top: var(--scroll-padding);
+}
 .list-\[\'\\1f44d\'\] {
   list-style-type: '\1F44D';
 }

--- a/tests/arbitrary-values.test.html
+++ b/tests/arbitrary-values.test.html
@@ -103,6 +103,24 @@
     <div class="animate-[pong_1s_cubic-bezier(0,0,0.2,1)_infinite]"></div>
     <div class="animate-[var(--value)]"></div>
 
+    <div class="scroll-m-[7px]"></div>
+    <div class="scroll-mx-[7px]"></div>
+    <div class="scroll-my-[7px]"></div>
+    <div class="scroll-mt-[7px]"></div>
+    <div class="scroll-mr-[7px]"></div>
+    <div class="scroll-mb-[7px]"></div>
+    <div class="scroll-ml-[7px]"></div>
+    <div class="scroll-mt-[var(--scroll-margin)]"></div>
+
+    <div class="scroll-p-[7px]"></div>
+    <div class="scroll-px-[7px]"></div>
+    <div class="scroll-py-[7px]"></div>
+    <div class="scroll-pt-[7px]"></div>
+    <div class="scroll-pr-[7px]"></div>
+    <div class="scroll-pb-[7px]"></div>
+    <div class="scroll-pl-[7px]"></div>
+    <div class="scroll-pt-[var(--scroll-padding)]"></div>
+
     <div class="cursor-[pointer]"></div>
     <div class="cursor-[url(hand.cur)_2_2,pointer]"></div>
     <div class="cursor-[var(--value)]"></div>

--- a/tests/basic-usage.test.css
+++ b/tests/basic-usage.test.css
@@ -11,6 +11,7 @@
   --tw-transform: translateX(var(--tw-translate-x)) translateY(var(--tw-translate-y))
     rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
     scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  --tw-scroll-snap-strictness: proximity;
   --tw-border-opacity: 1;
   border-color: rgb(229 231 235 / var(--tw-border-opacity));
   --tw-ring-offset-shadow: 0 0 #0000;
@@ -310,6 +311,24 @@
 }
 .resize-none {
   resize: none;
+}
+.snap-x {
+  scroll-snap-type: x var(--tw-scroll-snap-strictness);
+}
+.snap-mandatory {
+  --tw-scroll-snap-strictness: mandatory;
+}
+.snap-center {
+  scroll-snap-align: center;
+}
+.snap-always {
+  scroll-snap-stop: always;
+}
+.scroll-mt-6 {
+  scroll-margin-top: 1.5rem;
+}
+.scroll-p-6 {
+  scroll-padding: 1.5rem;
 }
 .list-inside {
   list-style-position: inside;

--- a/tests/basic-usage.test.html
+++ b/tests/basic-usage.test.html
@@ -110,6 +110,10 @@
     <div class="pointer-events-none"></div>
     <div class="absolute"></div>
     <div class="resize-none"></div>
+    <div class="snap-x snap-mandatory"></div>
+    <div class="snap-center snap-always"></div>
+    <div class="scroll-mt-6"></div>
+    <div class="scroll-p-6"></div>
     <div class="ring-white"></div>
     <div class="ring-offset-blue-300"></div>
     <div class="ring-offset-2"></div>


### PR DESCRIPTION
This PR adds new [scroll-snap](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Scroll_Snap) utilities to Tailwind CSS.

## scroll-snap-type

The [scroll-snap-type](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-type) utilities are used to enable scroll snapping on a container.

This can be enabled on the horizontal axis (`.snap-x`), vertical axis (`.snap-y`), or both (`.snap-both`). You can also control how the snapping behaves, by either forcing a snap point (`.snap-mandatory`), or being less strict and only having it snap if the scroll position is close to a snap point (`.snap-proximity`).

These classes are designed to be composable, meaning if you omit a strictness class, it will default to `proximity`.

```html
<div class="snap-x">
  <!-- proximity strictness (default) -->
</div>

<div class="snap-x snap-mandatory">
  <!-- mandatory strictness -->
</div>
```

| Class | CSS |
| --- | --- |
| `.snap-none` | `scroll-snap-type: none` |
| `.snap-x` | `scroll-snap-type: x var(--tw-scroll-snap-strictness)` |
| `.snap-y` | `scroll-snap-type: y var(--tw-scroll-snap-strictness)` |
| `.snap-both` | `scroll-snap-type: both var(--tw-scroll-snap-strictness)` |
| `.snap-mandatory` | `--tw-scroll-snap-strictness: mandatory` |
| `.snap-proximity` | `--tw-scroll-snap-strictness: proximity` |

## scroll-snap-align

The [scroll-snap-align](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-align) utilities are used to enable scroll snapping as well as set the scroll snap point (alignment) on each child within a snap container.

You can set the alignment to the start of the element (`.snap-start`), the end of the element (`.snap-end`) or the center of the element (`.snap-center`). This value can be different for each of the children within the snap container.

```html
<div class="snap-x snap-mandatory">
  <div class="snap-start"></div>
  <div class="snap-center"></div>
  <div class="snap-end"></div>
</div>
```

It's also possible to omit a child element, which will cause that element to be "skipped" when scrolling.

```html
<div class="snap-x snap-mandatory">
  <div class="snap-start"></div>
  <div><!-- This element will be skipped --></div>
  <div class="snap-start"></div>
</div>
```

You can also disable scroll snapping on a child element using the `.snap-align-none` utility.

```html
<div class="snap-x snap-mandatory">
  <div class="snap-start"></div>
  <div class="snap-start md:snap-align-none">
    <!-- This element will be skipped on medium screens and larger -->
  </div>
  <div class="snap-start"></div>
</div>
```

The name here is somewhat unfortunate. It would have been nicer to use `.snap-none`, but that was already used to disable the `scroll-snap-type` utilities.

| Class | CSS |
| --- | --- |
| `.snap-start` | `scroll-snap-align: start` |
| `.snap-end` | `scroll-snap-align: end` |
| `.snap-center` | `scroll-snap-align: center` |
| `.snap-align-none` | `scroll-snap-align: none` |

## scroll-snap-stop

The [scroll-snap-stop](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-stop) utilities are used to set whether it's possible to scroll past ("pass over") an element's snap position. There are only two options here: the default browser behaviour (`.snap-normal`), and the option to prevent scrolling past a snap position (`.snap-always`).

```html
<div class="snap-x snap-mandatory">
  <div class="snap-start snap-always"></div>
  <div class="snap-start snap-always"></div>
  <div class="snap-start snap-always"></div>
</div>
```

It's worth noting that this feature isn't supported by Firefox yet ([see here](https://bugzilla.mozilla.org/show_bug.cgi?id=1312165)).

| Class | CSS |
| --- | --- |
| `.snap-normal` | `scroll-snap-stop: normal` |
| `.snap-always` | `scroll-snap-stop: always` |

## scroll-margin

The [scroll-margin](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin) utilities are used to set the scroll margin position of an element. This is very similar to how the `margin` property works, except it only applies to the scroll position.

One handy use-case for this feature is setting the scroll margin top on an anchor link. This allows you to add some scroll spacing above an element when linking to it.

```html
<div id="faqs" class="scroll-pt-8">
  <h1>FAQs</h1>
  <div></div>
  <div></div>
  <div></div>
</div>
```

Like the margin utilities, these values extend the `spacing` scale, so you have all the same values available as you do with [margin](https://tailwindcss.com/docs/margin). Here's a list of all the `2rem` values:

| Class | CSS |
| --- | --- |
| `.scroll-m-8` | `scroll-margin: 2rem` |
| `.scroll-mt-8` | `scroll-margin-top: 2rem` |
| `.scroll-mr-8` | `scroll-margin-right: 2rem` |
| `.scroll-ml-8` | `scroll-margin-left: 2rem` |
| `.scroll-mb-8` | `scroll-margin-bottom: 2rem` |
| `.scroll-my-8` | `scroll-margin-top: 2rem`<br />`scroll-margin-bottom: 2rem` |
| `.scroll-mx-8` | `scroll-margin-left: 2rem`<br />`scroll-margin-right: 2rem` |

## scroll-padding

The [scroll-padding](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding) utilities are used to set the scroll padding of an element. This is very similar to how the `padding` property works, except it only applies to the scroll position.

```html
<div class="snap-x snap-mandatory scroll-pl-6">
  <div class="snap-start"></div>
  <div class="snap-start"></div>
  <div class="snap-start"></div>
</div>
```

Like the padding utilities, these values extend the `spacing` scale, so you have all the same values available as you do with [padding](https://tailwindcss.com/docs/padding). Here's a list of all the `2rem` values:

| Class | CSS |
| --- | --- |
| `.scroll-p-8` | `scroll-padding: 2rem` |
| `.scroll-pt-8` | `scroll-padding-top: 2rem` |
| `.scroll-pr-8` | `scroll-padding-right: 2rem` |
| `.scroll-pl-8` | `scroll-padding-left: 2rem` |
| `.scroll-pb-8` | `scroll-padding-bottom: 2rem` |
| `.scroll-py-8` | `scroll-padding-top: 2rem`<br />`scroll-padding-bottom: 2rem` |
| `.scroll-px-8` | `scroll-padding-left: 2rem`<br />`scroll-padding-right: 2rem` |
