### PR TITLE
Add fit-content utilities for (min/max) height and width

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -478,6 +478,7 @@ module.exports = {
       '5/6': '83.333333%',
       full: '100%',
       screen: '100vh',
+      fit: 'fit-content',
     }),
     inset: (theme, { negative }) => ({
       auto: 'auto',
@@ -564,6 +565,7 @@ module.exports = {
       ...theme('spacing'),
       full: '100%',
       screen: '100vh',
+      fit: 'fit-content',
     }),
     maxWidth: (theme, { breakpoints }) => ({
       none: 'none',
@@ -582,6 +584,7 @@ module.exports = {
       full: '100%',
       min: 'min-content',
       max: 'max-content',
+      fit: 'fit-content',
       prose: '65ch',
       ...breakpoints(theme('screens')),
     }),
@@ -589,12 +592,14 @@ module.exports = {
       0: '0px',
       full: '100%',
       screen: '100vh',
+      fit: 'fit-content',
     },
     minWidth: {
       0: '0px',
       full: '100%',
       min: 'min-content',
       max: 'max-content',
+      fit: 'fit-content',
     },
     objectPosition: {
       bottom: 'bottom',
@@ -846,6 +851,7 @@ module.exports = {
       screen: '100vw',
       min: 'min-content',
       max: 'max-content',
+      fit: 'fit-content',
     }),
     willChange: {
       auto: 'auto',


### PR DESCRIPTION
This PR adds [fit-content](https://developer.mozilla.org/en-US/docs/Web/CSS/fit-content) classes for (min/max) height and width.

I noticed only width seemed to have min or max content utilities currently. I'm not sure why height is missing them but I left it that way to keep this PR focussed. Happy to make a follow up if they are wanted too.

Couldn't find relevant tests for the existing utils for width and height so haven't added any for this. Feel free to point me in the right direction and I can add them.
