### PR TITLE
Add `border-x` and `border-y` width and color utilities

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1286,6 +1286,10 @@ export default {
     [
       ['border', [['@defaults border-width', {}], 'border-width']],
       [
+        ['border-x', [['@defaults border-width', {}], 'border-left-width', 'border-right-width']],
+        ['border-y', [['@defaults border-width', {}], 'border-top-width', 'border-bottom-width']],
+      ],
+      [
         ['border-t', [['@defaults border-width', {}], 'border-top-width']],
         ['border-r', [['@defaults border-width', {}], 'border-right-width']],
         ['border-b', [['@defaults border-width', {}], 'border-bottom-width']],
@@ -1343,6 +1347,43 @@ export default {
       {
         values: (({ DEFAULT: _, ...colors }) => colors)(flattenColorPalette(theme('borderColor'))),
         type: ['color'],
+      }
+    )
+
+    matchUtilities(
+      {
+        'border-x': (value) => {
+          if (!corePlugins('borderOpacity')) {
+            return {
+              'border-left-color': toColorValue(value),
+              'border-right-color': toColorValue(value),
+            }
+          }
+
+          return withAlphaVariable({
+            color: value,
+            property: ['border-left-color', 'border-right-color'],
+            variable: '--tw-border-opacity',
+          })
+        },
+        'border-y': (value) => {
+          if (!corePlugins('borderOpacity')) {
+            return {
+              'border-top-color': toColorValue(value),
+              'border-bottom-color': toColorValue(value),
+            }
+          }
+
+          return withAlphaVariable({
+            color: value,
+            property: ['border-top-color', 'border-bottom-color'],
+            variable: '--tw-border-opacity',
+          })
+        },
+      },
+      {
+        values: (({ DEFAULT: _, ...colors }) => colors)(flattenColorPalette(theme('borderColor'))),
+        type: 'color',
       }
     )
 

--- a/src/util/withAlphaVariable.js
+++ b/src/util/withAlphaVariable.js
@@ -15,30 +15,35 @@ export function withAlphaValue(color, alphaValue, defaultValue) {
 }
 
 export default function withAlphaVariable({ color, property, variable }) {
+  let properties = [].concat(property)
   if (typeof color === 'function') {
     return {
       [variable]: '1',
-      [property]: color({ opacityVariable: variable, opacityValue: `var(${variable})` }),
+      ...Object.fromEntries(
+        properties.map((p) => {
+          return [p, color({ opacityVariable: variable, opacityValue: `var(${variable})` })]
+        })
+      ),
     }
   }
 
   const parsed = parseColor(color)
 
   if (parsed === null) {
-    return {
-      [property]: color,
-    }
+    return Object.fromEntries(properties.map((p) => [p, color]))
   }
 
   if (parsed.alpha !== undefined) {
     // Has an alpha value, return color as-is
-    return {
-      [property]: color,
-    }
+    return Object.fromEntries(properties.map((p) => [p, color]))
   }
 
   return {
     [variable]: '1',
-    [property]: formatColor({ ...parsed, alpha: `var(${variable})` }),
+    ...Object.fromEntries(
+      properties.map((p) => {
+        return [p, formatColor({ ...parsed, alpha: `var(${variable})` })]
+      })
+    ),
   }
 }

--- a/tests/basic-usage.test.css
+++ b/tests/basic-usage.test.css
@@ -486,6 +486,14 @@
 .border-2 {
   border-width: 2px;
 }
+.border-x-4 {
+  border-left-width: 4px;
+  border-right-width: 4px;
+}
+.border-y-4 {
+  border-top-width: 4px;
+  border-bottom-width: 4px;
+}
 .border-t {
   border-top-width: 1px;
 }
@@ -501,6 +509,16 @@
 .border-black {
   --tw-border-opacity: 1;
   border-color: rgb(0 0 0 / var(--tw-border-opacity));
+}
+.border-x-black {
+  --tw-border-opacity: 1;
+  border-left-color: rgb(0 0 0 / var(--tw-border-opacity));
+  border-right-color: rgb(0 0 0 / var(--tw-border-opacity));
+}
+.border-y-black {
+  --tw-border-opacity: 1;
+  border-top-color: rgb(0 0 0 / var(--tw-border-opacity));
+  border-bottom-color: rgb(0 0 0 / var(--tw-border-opacity));
 }
 .border-t-black {
   --tw-border-opacity: 1;

--- a/tests/basic-usage.test.html
+++ b/tests/basic-usage.test.html
@@ -25,12 +25,12 @@
     <div class="bg-cover"></div>
     <div class="bg-origin-border bg-origin-padding bg-origin-content"></div>
     <div class="border-collapse"></div>
-    <div class="border-black border-t-black border-r-black border-b-black border-l-black"></div>
+    <div class="border-black border-t-black border-r-black border-b-black border-l-black border-x-black border-y-black"></div>
     <div class="border-opacity-10"></div>
     <div class="rounded-md"></div>
     <div class="border-solid border-hidden"></div>
     <div class="border"></div>
-    <div class="border-2 border-t border-b-4"></div>
+    <div class="border-2 border-t border-b-4 border-x-4 border-y-4"></div>
     <div class="shadow"></div>
     <div class="shadow-md"></div>
     <div class="shadow-lg"></div>


### PR DESCRIPTION
This PR adds new `border-x-{width}`, `border-y-{width}`, `border-x-{color}`, and `border-y-{color}` utilities to style the border on two sides of an element at the same time.

Added @DavydeVries as a co-author for his original work on #1159 which we closed at the time due to file size considerations 🙏 
