### PR TITLE
Explicit mention of `Tailwind CSS` experimental

### DIFF
--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -39,7 +39,7 @@ export function issueFlagNotices(config) {
       .join(', ')
 
     log.warn([
-      `You have enabled experimental features: ${changes}`,
+      `You have enabled Tailwind CSS experimental features: ${changes}`,
       'Experimental features are not covered by semver, may introduce breaking changes, and can change at any time.',
     ])
   }


### PR DESCRIPTION
I noticed in my Next.js project that other tooling libraries (including Next.js) display similar warning, which can sometimes lead to confusion as to which tool has the experimental feature ON. No dramatic changes here, just explicit mention of Tailwind CSS in the console.

