### PR TITLE
Reset button's border-radius to 0 for Edge

### DIFF
--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -162,6 +162,14 @@ textarea {
 }
 
 /*
+Remove the default border radius in Edge.
+*/
+
+button {
+  border-radius: 0;
+}
+
+/*
 Remove the inheritance of text transform in Edge and Firefox.
 */
 


### PR DESCRIPTION
I tested with the following playground: https://play.tailwindcss.com/ZcBGbScwwM

On Mac:
- Edge (version 94) has rounded corners by default.
![image](https://user-images.githubusercontent.com/2352663/135449141-c024e61d-ecf2-4e9b-81e2-572483511b79.png)
 
- Safari, Chrome and Firefox do not.

On Windows:
- Edge has rounded corners
- Chrome and Firefox do not.

I have not been able to find when Chromium-based browsers changed the default. I only found an issue in the chromium tracker about the devtools that don't show it: https://bugs.chromium.org/p/chromium/issues/detail?id=1146551
Refs: https://github.com/tailwindlabs/tailwindcss/commit/331454f62dd1bdaf57dae266097255fc8f8c70b1