### PR TITLE
Handle proper fallbacks in config

### DIFF
--- a/integrations/tailwindcss-cli/tests/integration.test.js
+++ b/integrations/tailwindcss-cli/tests/integration.test.js
@@ -34,9 +34,9 @@ describe('static build', () => {
       javascript`
         module.exports = {
           content: {
-            content: ['./src/index.html'],
-            safelist: ['bg-red-500','bg-red-600']
+            files: ['./src/index.html'],
           },
+          safelist: ['bg-red-500','bg-red-600'],
           theme: {
             extend: {
             },

--- a/integrations/webpack-5/tests/integration.test.js
+++ b/integrations/webpack-5/tests/integration.test.js
@@ -230,9 +230,9 @@ describe.each([{ TAILWIND_MODE: 'watch' }, { TAILWIND_MODE: undefined }])('watch
       javascript`
         module.exports = {
           content: {
-            content: ['./src/index.html'],
-            safelist: ['bg-red-500','bg-red-600']
+            files: ['./src/index.html'],
           },
+          safelist: ['bg-red-500','bg-red-600'],
           theme: {
             extend: {
             },

--- a/src/cli.js
+++ b/src/cli.js
@@ -437,7 +437,7 @@ async function build() {
   }
 
   function extractContent(config) {
-    return config.content.content.concat(config.content.safelist)
+    return config.content.files
   }
 
   function extractFileGlobs(config) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -467,7 +467,7 @@ async function build() {
     for (let file of files) {
       changedContent.push({
         content: fs.readFileSync(path.resolve(file), 'utf8'),
-        extension: path.extname(file),
+        extension: path.extname(file).slice(1),
       })
     }
 
@@ -729,7 +729,7 @@ async function build() {
         chain = chain.then(async () => {
           changedContent.push({
             content: fs.readFileSync(path.resolve(file), 'utf8'),
-            extension: path.extname(file),
+            extension: path.extname(file).slice(1),
           })
 
           await rebuild(config)
@@ -741,7 +741,7 @@ async function build() {
       chain = chain.then(async () => {
         changedContent.push({
           content: fs.readFileSync(path.resolve(file), 'utf8'),
-          extension: path.extname(file),
+          extension: path.extname(file).slice(1),
         })
 
         await rebuild(config)

--- a/src/cli.js
+++ b/src/cli.js
@@ -436,12 +436,8 @@ async function build() {
     return resolvedConfig
   }
 
-  function extractContent(config) {
-    return config.content.files
-  }
-
   function extractFileGlobs(config) {
-    return extractContent(config)
+    return config.content.files
       .filter((file) => {
         // Strings in this case are files / globs. If it is something else,
         // like an object it's probably a raw content object. But this object
@@ -452,7 +448,7 @@ async function build() {
   }
 
   function extractRawContent(config) {
-    return extractContent(config).filter((file) => {
+    return config.content.files.filter((file) => {
       return typeof file === 'object' && file !== null
     })
   }

--- a/src/lib/expandTailwindAtRules.js
+++ b/src/lib/expandTailwindAtRules.js
@@ -35,21 +35,6 @@ const builtInTransformers = {
 
 function getExtractor(tailwindConfig, fileExtension) {
   let extractors = tailwindConfig.content.extract
-  let contentOptions = tailwindConfig.content.options
-
-  if (typeof extractors === 'function') {
-    extractors = {
-      DEFAULT: extractors,
-    }
-  }
-  if (contentOptions.defaultExtractor) {
-    extractors.DEFAULT = contentOptions.defaultExtractor
-  }
-  for (let { extensions, extractor } of contentOptions.extractors || []) {
-    for (let extension of extensions) {
-      extractors[extension] = extractor
-    }
-  }
 
   return (
     extractors[fileExtension] ||
@@ -61,12 +46,6 @@ function getExtractor(tailwindConfig, fileExtension) {
 
 function getTransformer(tailwindConfig, fileExtension) {
   let transformers = tailwindConfig.content.transform
-
-  if (typeof transformers === 'function') {
-    transformers = {
-      DEFAULT: transformers,
-    }
-  }
 
   return (
     transformers[fileExtension] ||

--- a/src/lib/setupTrackingContext.js
+++ b/src/lib/setupTrackingContext.js
@@ -79,7 +79,7 @@ function getTailwindConfig(configOrPath) {
 function resolvedChangedContent(context, candidateFiles, fileModifiedMap) {
   let changedContent = context.tailwindConfig.content.files
     .filter((item) => typeof item.raw === 'string')
-    .map(({ raw, extension }) => ({ content: raw, extension }))
+    .map(({ raw, extension = 'html' }) => ({ content: raw, extension }))
 
   for (let changedFile of resolveChangedFiles(candidateFiles, fileModifiedMap)) {
     let content = fs.readFileSync(changedFile, 'utf8')

--- a/src/lib/setupTrackingContext.js
+++ b/src/lib/setupTrackingContext.js
@@ -26,7 +26,7 @@ function getCandidateFiles(context, tailwindConfig) {
     return candidateFilesCache.get(context)
   }
 
-  let candidateFiles = tailwindConfig.content.content
+  let candidateFiles = tailwindConfig.content.files
     .filter((item) => typeof item === 'string')
     .map((contentPath) => normalizePath(contentPath))
 
@@ -77,7 +77,7 @@ function getTailwindConfig(configOrPath) {
 }
 
 function resolvedChangedContent(context, candidateFiles, fileModifiedMap) {
-  let changedContent = context.tailwindConfig.content.content
+  let changedContent = context.tailwindConfig.content.files
     .filter((item) => typeof item.raw === 'string')
     .map(({ raw, extension }) => ({ content: raw, extension }))
 

--- a/src/lib/setupTrackingContext.js
+++ b/src/lib/setupTrackingContext.js
@@ -79,8 +79,6 @@ function getTailwindConfig(configOrPath) {
 function resolvedChangedContent(context, candidateFiles, fileModifiedMap) {
   let changedContent = context.tailwindConfig.content.content
     .filter((item) => typeof item.raw === 'string')
-    .concat(context.tailwindConfig.content.safelist)
-    .concat(context.safelist())
     .map(({ raw, extension }) => ({ content: raw, extension }))
 
   for (let changedFile of resolveChangedFiles(candidateFiles, fileModifiedMap)) {

--- a/src/lib/setupWatchingContext.js
+++ b/src/lib/setupWatchingContext.js
@@ -187,7 +187,7 @@ function getTailwindConfig(configOrPath) {
 function resolvedChangedContent(context, candidateFiles) {
   let changedContent = context.tailwindConfig.content.files
     .filter((item) => typeof item.raw === 'string')
-    .map(({ raw, extension }) => ({ content: raw, extension }))
+    .map(({ raw, extension = 'html' }) => ({ content: raw, extension }))
 
   for (let changedFile of resolveChangedFiles(context, candidateFiles)) {
     let content = fs.readFileSync(changedFile, 'utf8')

--- a/src/lib/setupWatchingContext.js
+++ b/src/lib/setupWatchingContext.js
@@ -147,7 +147,7 @@ function getCandidateFiles(context, tailwindConfig) {
     return candidateFilesCache.get(context)
   }
 
-  let candidateFiles = tailwindConfig.content.content
+  let candidateFiles = tailwindConfig.content.files
     .filter((item) => typeof item === 'string')
     .map((contentPath) => normalizePath(contentPath))
 
@@ -185,7 +185,7 @@ function getTailwindConfig(configOrPath) {
 }
 
 function resolvedChangedContent(context, candidateFiles) {
-  let changedContent = context.tailwindConfig.content.content
+  let changedContent = context.tailwindConfig.content.files
     .filter((item) => typeof item.raw === 'string')
     .map(({ raw, extension }) => ({ content: raw, extension }))
 

--- a/src/lib/setupWatchingContext.js
+++ b/src/lib/setupWatchingContext.js
@@ -187,8 +187,6 @@ function getTailwindConfig(configOrPath) {
 function resolvedChangedContent(context, candidateFiles) {
   let changedContent = context.tailwindConfig.content.content
     .filter((item) => typeof item.raw === 'string')
-    .concat(context.tailwindConfig.content.safelist)
-    .concat(context.safelist())
     .map(({ raw, extension }) => ({ content: raw, extension }))
 
   for (let changedFile of resolveChangedFiles(context, candidateFiles)) {

--- a/src/lib/sharedState.js
+++ b/src/lib/sharedState.js
@@ -1,5 +1,3 @@
-import LRU from 'quick-lru'
-
 export const env = {
   TAILWIND_MODE: process.env.TAILWIND_MODE,
   NODE_ENV: process.env.NODE_ENV,
@@ -10,4 +8,3 @@ export const env = {
 export const contextMap = new Map()
 export const configContextMap = new Map()
 export const contextSourcesMap = new Map()
-export const contentMatchCache = new LRU({ maxSize: 25000 })

--- a/src/util/normalizeConfig.js
+++ b/src/util/normalizeConfig.js
@@ -1,0 +1,149 @@
+import log from './log'
+
+function validate(config, options) {
+  if (!config) return false
+
+  for (let [k, v] of Object.entries(config)) {
+    let types = options[k]
+
+    if (!types) return false
+
+    // Property SHOULD exist, this catches unused keys like `options`
+    if (!types.includes(undefined) && !options.hasOwnProperty(k)) {
+      return false
+    }
+
+    if (
+      !types.some((type) => {
+        if (type === undefined) return true
+        return v instanceof type
+      })
+    ) {
+      return false
+    }
+  }
+
+  for (let [k, types] of Object.entries(options)) {
+    let value = config[k]
+    if (
+      !types.some((type) => {
+        if (type === undefined) return true
+        return value instanceof type
+      })
+    ) {
+      return false
+    }
+  }
+
+  return true
+}
+
+export function normalizeConfig(config) {
+  // Quick structure validation
+  let valid = validate(config.content, {
+    files: [Array],
+    extract: [undefined, Function, Object],
+  })
+
+  if (!valid) {
+    log.warn('purge-deprecation', [
+      'The `purge` option in your tailwind.config.js file has been deprecated.',
+      'Please rename this to `content` instead.',
+    ])
+  }
+
+  // Normalize the `safelist`
+  config.safelist = (() => {
+    let { content, purge, safelist } = config
+
+    if (Array.isArray(safelist)) return safelist
+    if (Array.isArray(content?.safelist)) return content.safelist
+    if (Array.isArray(purge?.safelist)) return purge.safelist
+    if (Array.isArray(purge?.options?.safelist)) return purge.options.safelist
+
+    return []
+  })()
+
+  // Normalize the `content`
+  config.content = {
+    files: (() => {
+      let { content, purge } = config
+
+      if (Array.isArray(purge)) return purge
+      if (Array.isArray(purge?.content)) return purge.content
+      if (Array.isArray(content)) return content
+      if (Array.isArray(content?.content)) return content.content
+      if (Array.isArray(content?.files)) return content.files
+
+      return []
+    })(),
+
+    extract: (() => {
+      let extract = (() => {
+        if (config.purge?.extract) return config.purge.extract
+        if (config.content?.extract) return config.content.extract
+
+        if (config.purge?.extract?.DEFAULT) return config.purge.extract.DEFAULT
+        if (config.content?.extract?.DEFAULT) return config.content.extract.DEFAULT
+
+        if (config.purge?.options?.defaultExtractor) return config.purge.options.defaultExtractor
+        if (config.content?.options?.defaultExtractor)
+          return config.content.options.defaultExtractor
+
+        if (config.purge?.options?.extractors) return config.purge.options.extractors
+        if (config.content?.options?.extractors) return config.content.options.extractors
+
+        return {}
+      })()
+
+      let extractors = {}
+
+      // Functions
+      if (typeof extract === 'function') {
+        extractors.DEFAULT = extract
+      }
+
+      // Arrays
+      else if (Array.isArray(extract)) {
+        for (let { extensions, extractor } of extract ?? []) {
+          for (let extension of extensions) {
+            extractors[extension] = extractor
+          }
+        }
+      }
+
+      // Objects
+      else if (typeof extract === 'object' && extract !== null) {
+        Object.assign(extractors, extract)
+      }
+
+      return extractors
+    })(),
+
+    transform: (() => {
+      let transform = (() => {
+        if (config.purge?.transform) return config.purge.transform
+        if (config.content?.transform) return config.content.transform
+
+        if (config.purge?.transform?.DEFAULT) return config.purge.transform.DEFAULT
+        if (config.content?.transform?.DEFAULT) return config.content.transform.DEFAULT
+
+        return {}
+      })()
+
+      let transformers = {}
+
+      if (typeof transform === 'function') {
+        transformers.DEFAULT = transform
+      }
+
+      if (typeof transform === 'object' && transform !== null) {
+        Object.assign(transformers, transform)
+      }
+
+      return transformers
+    })(),
+  }
+
+  return config
+}

--- a/src/util/normalizeConfig.js
+++ b/src/util/normalizeConfig.js
@@ -1,49 +1,126 @@
 import log from './log'
 
-function validate(config, options) {
-  if (!config) return false
-
-  for (let [k, v] of Object.entries(config)) {
-    let types = options[k]
-
-    if (!types) return false
-
-    // Property SHOULD exist, this catches unused keys like `options`
-    if (!types.includes(undefined) && !options.hasOwnProperty(k)) {
-      return false
-    }
-
-    if (
-      !types.some((type) => {
-        if (type === undefined) return true
-        return v instanceof type
-      })
-    ) {
-      return false
-    }
-  }
-
-  for (let [k, types] of Object.entries(options)) {
-    let value = config[k]
-    if (
-      !types.some((type) => {
-        if (type === undefined) return true
-        return value instanceof type
-      })
-    ) {
-      return false
-    }
-  }
-
-  return true
-}
-
 export function normalizeConfig(config) {
   // Quick structure validation
-  let valid = validate(config.content, {
-    files: [Array],
-    extract: [undefined, Function, Object],
-  })
+  /**
+   * type FilePath = string
+   * type RawFile = { raw: string, extension?: string }
+   * type ExtractorFn = (content: string) => Array<string>
+   * type TransformerFn = (content: string) => string
+   *
+   * type Content =
+   *   | Array<FilePath | RawFile>
+   *   | {
+   *       files: Array<FilePath | RawFile>,
+   *       extract?: ExtractorFn | { [extension: string]: ExtractorFn }
+   *       transform?: TransformerFn | { [extension: string]: TransformerFn }
+   *   }
+   */
+  let valid = (() => {
+    // `config.purge` should not exist anymore
+    if (config.purge) return false
+
+    // `config.content` should exist
+    if (!config.content) return false
+
+    // `config.content` should be an object or an array
+    if (
+      !Array.isArray(config.content) ||
+      !(typeof config.content === 'object' && config.content !== null)
+    ) {
+      return false
+    }
+
+    // When `config.content` is an array, it should consist of FilePaths or RawFiles
+    if (Array.isArray(config.content)) {
+      return config.content.every((path) => {
+        // `path` can be a string
+        if (typeof path === 'string') return true
+
+        // `path` can be an object { raw: string, extension?: string }
+        if (
+          // `raw` must be a string
+          typeof path?.raw === 'string' &&
+          // `extension` (if provided) should also be a string
+          path?.extension !== undefined &&
+          typeof path?.extension === 'string'
+        ) {
+          return true
+        }
+
+        return false
+      })
+    }
+
+    // When `config.content` is an object
+    if (typeof config.content === 'object' && config.content !== null) {
+      // Only `files`, `extract` and `transform` can exist in `config.content`
+      if (
+        Object.keys(config.content).some((key) => !['files', 'extract', 'transform'].includes(key))
+      ) {
+        return false
+      }
+
+      // `config.content.files` should exist of FilePaths or RawFiles
+      if (Array.isArray(config.content.files)) {
+        if (
+          !config.content.files.every((path) => {
+            // `path` can be a string
+            if (typeof path === 'string') return true
+
+            // `path` can be an object { raw: string, extension?: string }
+            if (
+              // `raw` must be a string
+              typeof path?.raw === 'string' &&
+              // `extension` (if provided) should also be a string
+              path?.extension !== undefined &&
+              typeof path?.extension === 'string'
+            ) {
+              return true
+            }
+
+            return false
+          })
+        ) {
+          return false
+        }
+
+        // `config.content.extract` is optional, and can be a Function or a Record<String, Function>
+        if (typeof config.content.extract === 'object') {
+          for (let value of Object.values(config.content.extract)) {
+            if (typeof value !== 'function') {
+              return false
+            }
+          }
+          return false
+        } else if (
+          !(config.content.extract === undefined || typeof config.content.extract === 'function')
+        ) {
+          return false
+        }
+
+        // `config.content.transform` is optional, and can be a Function or a Record<String, Function>
+        if (typeof config.content.transform === 'object') {
+          for (let value of Object.values(config.content.transform)) {
+            if (typeof value !== 'function') {
+              return false
+            }
+          }
+          return false
+        } else if (
+          !(
+            config.content.transform === undefined || typeof config.content.transform === 'function'
+          )
+        ) {
+          return false
+        }
+      }
+
+      return true
+    }
+
+    return false
+  })()
 
   if (!valid) {
     log.warn('purge-deprecation', [
@@ -86,10 +163,6 @@ export function normalizeConfig(config) {
         if (config.purge?.extract?.DEFAULT) return config.purge.extract.DEFAULT
         if (config.content?.extract?.DEFAULT) return config.content.extract.DEFAULT
 
-        if (config.purge?.options?.defaultExtractor) return config.purge.options.defaultExtractor
-        if (config.content?.options?.defaultExtractor)
-          return config.content.options.defaultExtractor
-
         if (config.purge?.options?.extractors) return config.purge.options.extractors
         if (config.content?.options?.extractors) return config.content.options.extractors
 
@@ -97,6 +170,18 @@ export function normalizeConfig(config) {
       })()
 
       let extractors = {}
+
+      extractors.DEFAULT = (() => {
+        if (config.purge?.options?.defaultExtractor) {
+          return config.purge.options.defaultExtractor
+        }
+
+        if (config.content?.options?.defaultExtractor) {
+          return config.content.options.defaultExtractor
+        }
+
+        return undefined
+      })()
 
       // Functions
       if (typeof extract === 'function') {

--- a/src/util/resolveConfig.js
+++ b/src/util/resolveConfig.js
@@ -3,9 +3,9 @@ import corePluginList from '../corePluginList'
 import configurePlugins from './configurePlugins'
 import defaultConfig from '../../stubs/defaultConfig.stub'
 import colors from '../public/colors'
-import log from './log'
 import { defaults } from './defaults'
 import { toPath } from './toPath'
+import { normalizeConfig } from './normalizeConfig'
 
 function isFunction(input) {
   return typeof input === 'function'
@@ -220,56 +220,4 @@ export default function resolveConfig(configs) {
       ...allConfigs
     )
   )
-}
-
-function normalizeConfig(config) {
-  log.warn('purge-deprecation', [
-    'The `purge` option in your tailwind.config.js file has been deprecated.',
-    'Please rename this to `content` instead.',
-  ])
-
-  config.content = {
-    content: (() => {
-      let { content, purge } = config
-
-      if (Array.isArray(purge)) return purge
-      if (Array.isArray(purge?.content)) return purge.content
-      if (Array.isArray(content)) return content
-      if (Array.isArray(content?.content)) return content.content
-
-      return []
-    })(),
-    safelist: (() => {
-      let { content, purge } = config
-
-      let [safelistKey, safelistPaths] = (() => {
-        if (Array.isArray(content?.safelist)) return ['content.safelist', content.safelist]
-        if (Array.isArray(purge?.safelist)) return ['purge.safelist', purge.safelist]
-        if (Array.isArray(purge?.options?.safelist))
-          return ['purge.options.safelist', purge.options.safelist]
-        return [null, []]
-      })()
-
-      return safelistPaths.map((content) => {
-        if (typeof content === 'string') {
-          return { raw: content, extension: 'html' }
-        }
-
-        if (content instanceof RegExp) {
-          throw new Error(
-            `Values inside '${safelistKey}' can only be of type 'string', found 'regex'.`
-          )
-        }
-
-        throw new Error(
-          `Values inside '${safelistKey}' can only be of type 'string', found '${typeof content}'.`
-        )
-      })
-    })(),
-    extract: config.content?.extract || config.purge?.extract || {},
-    options: config.content?.options || config.purge?.options || {},
-    transform: config.content?.transform || config.purge?.transform || {},
-  }
-
-  return config
 }

--- a/tests/color-opacity-modifiers.test.js
+++ b/tests/color-opacity-modifiers.test.js
@@ -62,12 +62,7 @@ test('missing alpha generates nothing', async () => {
 
 test('arbitrary color with opacity from scale', async () => {
   let config = {
-    mode: 'jit',
-    purge: [
-      {
-        raw: 'bg-[wheat]/50',
-      },
-    ],
+    content: [{ raw: 'bg-[wheat]/50' }],
     theme: {},
     plugins: [],
   }
@@ -85,12 +80,7 @@ test('arbitrary color with opacity from scale', async () => {
 
 test('arbitrary color with arbitrary opacity', async () => {
   let config = {
-    mode: 'jit',
-    purge: [
-      {
-        raw: 'bg-[#bada55]/[0.2]',
-      },
-    ],
+    content: [{ raw: 'bg-[#bada55]/[0.2]' }],
     theme: {},
     plugins: [],
   }
@@ -108,12 +98,7 @@ test('arbitrary color with arbitrary opacity', async () => {
 
 test('undefined theme color with opacity from scale', async () => {
   let config = {
-    mode: 'jit',
-    purge: [
-      {
-        raw: 'bg-garbage/50',
-      },
-    ],
+    content: [{ raw: 'bg-garbage/50' }],
     theme: {},
     plugins: [],
   }

--- a/tests/custom-extractors.test.js
+++ b/tests/custom-extractors.test.js
@@ -11,80 +11,84 @@ function customExtractor(content) {
 let expectedPath = path.resolve(__dirname, './custom-extractors.test.css')
 let expected = fs.readFileSync(expectedPath, 'utf8')
 
-test('defaultExtractor', () => {
-  let config = {
-    content: {
-      content: [path.resolve(__dirname, './custom-extractors.test.html')],
-      options: {
-        defaultExtractor: customExtractor,
+describe('modern', () => {
+  test('extract.DEFAULT', () => {
+    let config = {
+      content: {
+        files: [path.resolve(__dirname, './custom-extractors.test.html')],
+        extract: {
+          DEFAULT: customExtractor,
+        },
       },
-    },
-  }
+    }
 
-  return run('@tailwind utilities', config).then((result) => {
-    expect(result.css).toMatchFormattedCss(expected)
+    return run('@tailwind utilities', config).then((result) => {
+      expect(result.css).toMatchFormattedCss(expected)
+    })
+  })
+
+  test('extract.{extension}', () => {
+    let config = {
+      content: {
+        files: [path.resolve(__dirname, './custom-extractors.test.html')],
+        extract: {
+          html: customExtractor,
+        },
+      },
+    }
+
+    return run('@tailwind utilities', config).then((result) => {
+      expect(result.css).toMatchFormattedCss(expected)
+    })
   })
 })
 
-test('extractors array', () => {
-  let config = {
-    content: {
-      content: [path.resolve(__dirname, './custom-extractors.test.html')],
-      options: {
-        extractors: [
-          {
-            extractor: customExtractor,
-            extensions: ['html'],
-          },
-        ],
+describe('legacy', () => {
+  test('defaultExtractor', () => {
+    let config = {
+      content: {
+        content: [path.resolve(__dirname, './custom-extractors.test.html')],
+        options: {
+          defaultExtractor: customExtractor,
+        },
       },
-    },
-  }
+    }
 
-  return run('@tailwind utilities', config).then((result) => {
-    expect(result.css).toMatchFormattedCss(expected)
+    return run('@tailwind utilities', config).then((result) => {
+      expect(result.css).toMatchFormattedCss(expected)
+    })
   })
-})
 
-test('extract function', () => {
-  let config = {
-    content: {
-      content: [path.resolve(__dirname, './custom-extractors.test.html')],
-      extract: customExtractor,
-    },
-  }
-
-  return run('@tailwind utilities', config).then((result) => {
-    expect(result.css).toMatchFormattedCss(expected)
-  })
-})
-
-test('extract.DEFAULT', () => {
-  let config = {
-    content: {
-      content: [path.resolve(__dirname, './custom-extractors.test.html')],
-      extract: {
-        DEFAULT: customExtractor,
+  test('extractors array', () => {
+    let config = {
+      content: {
+        content: [path.resolve(__dirname, './custom-extractors.test.html')],
+        options: {
+          extractors: [
+            {
+              extractor: customExtractor,
+              extensions: ['html'],
+            },
+          ],
+        },
       },
-    },
-  }
+    }
 
-  return run('@tailwind utilities', config).then((result) => {
-    expect(result.css).toMatchFormattedCss(expected)
+    return run('@tailwind utilities', config).then((result) => {
+      expect(result.css).toMatchFormattedCss(expected)
+    })
   })
-})
 
-test('extract.{extension}', () => {
-  let config = {
-    content: {
-      content: [path.resolve(__dirname, './custom-extractors.test.html')],
-      extract: {
-        html: customExtractor,
+  test('extract function', () => {
+    let config = {
+      content: {
+        content: [path.resolve(__dirname, './custom-extractors.test.html')],
+        extract: customExtractor,
       },
-    },
-  }
+    }
 
-  return run('@tailwind utilities', config).then((result) => {
-    expect(result.css).toMatchFormattedCss(expected)
+    return run('@tailwind utilities', config).then((result) => {
+      expect(result.css).toMatchFormattedCss(expected)
+    })
   })
 })

--- a/tests/custom-extractors.test.js
+++ b/tests/custom-extractors.test.js
@@ -41,13 +41,26 @@ describe('modern', () => {
       expect(result.css).toMatchFormattedCss(expected)
     })
   })
+
+  test('extract function', () => {
+    let config = {
+      content: {
+        files: [path.resolve(__dirname, './custom-extractors.test.html')],
+        extract: customExtractor,
+      },
+    }
+
+    return run('@tailwind utilities', config).then((result) => {
+      expect(result.css).toMatchFormattedCss(expected)
+    })
+  })
 })
 
 describe('legacy', () => {
   test('defaultExtractor', () => {
     let config = {
       content: {
-        content: [path.resolve(__dirname, './custom-extractors.test.html')],
+        files: [path.resolve(__dirname, './custom-extractors.test.html')],
         options: {
           defaultExtractor: customExtractor,
         },
@@ -62,7 +75,7 @@ describe('legacy', () => {
   test('extractors array', () => {
     let config = {
       content: {
-        content: [path.resolve(__dirname, './custom-extractors.test.html')],
+        files: [path.resolve(__dirname, './custom-extractors.test.html')],
         options: {
           extractors: [
             {
@@ -71,19 +84,6 @@ describe('legacy', () => {
             },
           ],
         },
-      },
-    }
-
-    return run('@tailwind utilities', config).then((result) => {
-      expect(result.css).toMatchFormattedCss(expected)
-    })
-  })
-
-  test('extract function', () => {
-    let config = {
-      content: {
-        content: [path.resolve(__dirname, './custom-extractors.test.html')],
-        extract: customExtractor,
       },
     }
 

--- a/tests/custom-transformers.test.js
+++ b/tests/custom-transformers.test.js
@@ -7,7 +7,7 @@ function customTransformer(content) {
 test('transform function', () => {
   let config = {
     content: {
-      content: [{ raw: html`<div class="uppercase"></div>` }],
+      files: [{ raw: html`<div class="uppercase"></div>` }],
       transform: customTransformer,
     },
   }
@@ -24,7 +24,7 @@ test('transform function', () => {
 test('transform.DEFAULT', () => {
   let config = {
     content: {
-      content: [{ raw: html`<div class="uppercase"></div>` }],
+      files: [{ raw: html`<div class="uppercase"></div>` }],
       transform: {
         DEFAULT: customTransformer,
       },
@@ -43,7 +43,7 @@ test('transform.DEFAULT', () => {
 test('transform.{extension}', () => {
   let config = {
     content: {
-      content: [
+      files: [
         { raw: html`<div class="uppercase"></div>`, extension: 'html' },
         { raw: html`<div class="uppercase"></div>`, extension: 'php' },
       ],

--- a/tests/normalize-config.test.js
+++ b/tests/normalize-config.test.js
@@ -1,0 +1,48 @@
+import { run, css } from './util/run'
+
+it.each`
+  config
+  ${{ purge: [{ raw: 'text-center' }] }}
+  ${{ purge: { content: [{ raw: 'text-center' }] } }}
+  ${{ content: { content: [{ raw: 'text-center' }] } }}
+`('should normalize content $config', ({ config }) => {
+  return run('@tailwind utilities', config).then((result) => {
+    return expect(result.css).toMatchFormattedCss(css`
+      .text-center {
+        text-align: center;
+      }
+    `)
+  })
+})
+
+it.each`
+  config
+  ${{ purge: { safelist: ['text-center'] } }}
+  ${{ purge: { options: { safelist: ['text-center'] } } }}
+  ${{ content: { safelist: ['text-center'] } }}
+`('should normalize safelist $config', ({ config }) => {
+  return run('@tailwind utilities', config).then((result) => {
+    return expect(result.css).toMatchFormattedCss(css`
+      .text-center {
+        text-align: center;
+      }
+    `)
+  })
+})
+
+it.each`
+  config
+  ${{ content: [{ raw: 'text-center' }], purge: { extract: () => ['font-bold'] } }}
+  ${{ content: [{ raw: 'text-center' }], purge: { extract: { DEFAULT: () => ['font-bold'] } } }}
+  ${{ content: [{ raw: 'text-center' }], purge: { options: { defaultExtractor: () => ['font-bold'] } } }}
+  ${{ content: [{ raw: 'text-center' }], purge: { options: { extractors: [{ extractor: () => ['font-bold'], extensions: ['html'] }] } } }}
+  ${{ content: [{ raw: 'text-center' }], purge: { extract: { html: () => ['font-bold'] } } }}
+`('should normalize extractors $config', ({ config }) => {
+  return run('@tailwind utilities', config).then((result) => {
+    return expect(result.css).toMatchFormattedCss(css`
+      .font-bold {
+        font-weight: 700;
+      }
+    `)
+  })
+})

--- a/tests/normalize-config.test.js
+++ b/tests/normalize-config.test.js
@@ -46,3 +46,52 @@ it.each`
     `)
   })
 })
+
+it('should still be possible to use the "old" v2 config', () => {
+  let config = {
+    purge: {
+      content: [
+        { raw: 'text-svelte', extension: 'svelte' },
+        { raw: '# My Big Heading', extension: 'md' },
+      ],
+      options: {
+        defaultExtractor(content) {
+          return content.split(' ').concat(['font-bold'])
+        },
+      },
+      extract: {
+        svelte(content) {
+          return content.replace('svelte', 'center').split(' ')
+        },
+      },
+      transform: {
+        md() {
+          return 'text-4xl'
+        },
+      },
+    },
+    theme: {
+      extends: {},
+    },
+    variants: {
+      extends: {},
+    },
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    return expect(result.css).toMatchFormattedCss(css`
+      .text-center {
+        text-align: center;
+      }
+
+      .text-4xl {
+        font-size: 2.25rem;
+        line-height: 2.5rem;
+      }
+
+      .font-bold {
+        font-weight: 700;
+      }
+    `)
+  })
+})

--- a/tests/raw-content.test.js
+++ b/tests/raw-content.test.js
@@ -29,19 +29,14 @@ test('raw content with extension', () => {
   let tailwind = require('../src')
   let config = {
     content: {
-      content: [
+      files: [
         {
           raw: fs.readFileSync(path.resolve(__dirname, './raw-content.test.html'), 'utf8'),
           extension: 'html',
         },
       ],
-      options: {
-        extractors: [
-          {
-            extractor: () => ['invisible'],
-            extensions: ['html'],
-          },
-        ],
+      extract: {
+        html: () => ['invisible'],
       },
     },
     corePlugins: { preflight: false },

--- a/tests/resolveConfig.test.js
+++ b/tests/resolveConfig.test.js
@@ -10,6 +10,7 @@ test('prefix key overrides default prefix', () => {
     prefix: '',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       screens: {
         mobile: '400px',
@@ -40,6 +41,7 @@ test('important key overrides default important', () => {
     prefix: '',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       screens: {
         mobile: '400px',
@@ -70,6 +72,7 @@ test('important (selector) key overrides default important', () => {
     prefix: '',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       screens: {
         mobile: '400px',
@@ -100,6 +103,7 @@ test('separator key overrides default separator', () => {
     prefix: '',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       screens: {
         mobile: '400px',
@@ -134,6 +138,7 @@ test('theme key is merged instead of replaced', () => {
     prefix: '-',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       colors: {
         'grey-darker': '#606f7b',
@@ -197,6 +202,7 @@ test('theme key is deeply merged instead of replaced', () => {
     prefix: '-',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       colors: {
         grey: {
@@ -235,6 +241,7 @@ test('missing top level keys are pulled from the default config', () => {
     prefix: '-',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       colors: { green: '#00ff00' },
       screens: {
@@ -273,6 +280,7 @@ test('functions in the default theme section are lazily evaluated', () => {
     prefix: '-',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       colors: {
         cyan: 'cyan',
@@ -333,6 +341,7 @@ test('functions in the user theme section are lazily evaluated', () => {
     prefix: '-',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       colors: {
         cyan: 'cyan',
@@ -391,6 +400,7 @@ test('theme values in the extend section extend the existing theme', () => {
     prefix: '-',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       colors: {
         cyan: 'cyan',
@@ -461,6 +471,7 @@ test('theme values in the extend section extend the user theme', () => {
     prefix: '-',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       opacity: {
         0: '0',
@@ -535,6 +546,7 @@ test('theme values in the extend section can extend values that are depended on 
     prefix: '-',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       colors: {
         cyan: 'cyan',
@@ -588,6 +600,7 @@ test('theme values in the extend section are not deeply merged when they are sim
     prefix: '-',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       fonts: {
         sans: ['system-ui', 'Helvetica Neue', 'sans-serif'],
@@ -636,6 +649,7 @@ test('theme values in the extend section are deeply merged, when they are arrays
     prefix: '-',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       typography: {
         ArrayArray: {
@@ -696,6 +710,7 @@ test('the theme function can use a default value if the key is missing', () => {
     prefix: '-',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       colors: {
         cyan: 'cyan',
@@ -750,6 +765,7 @@ test('the theme function can resolve function values', () => {
     prefix: '-',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       colors: {
         red: 'red',
@@ -808,6 +824,7 @@ test('the theme function can resolve deep function values', () => {
     prefix: '-',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       spacing: {
         0: '0',
@@ -864,6 +881,7 @@ test('theme values in the extend section are lazily evaluated', () => {
     prefix: '-',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       colors: {
         cyan: 'cyan',
@@ -924,6 +942,7 @@ test('lazily evaluated values have access to the config utils', () => {
     prefix: '-',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       spacing: {
         1: '1px',
@@ -1010,6 +1029,7 @@ test('the original theme is not mutated', () => {
     prefix: '-',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       colors: {
         cyan: 'cyan',
@@ -1058,6 +1078,7 @@ test('custom properties are multiplied by -1 for negative values', () => {
     prefix: '-',
     important: false,
     separator: ':',
+    content: [],
     theme: {},
   }
 
@@ -1165,6 +1186,7 @@ test('more than two config objects can be resolved', () => {
     prefix: '-',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       fontFamily: {
         body: ['Arial', 'sans-serif'],
@@ -1233,6 +1255,7 @@ test('plugin config modifications are applied', () => {
     prefix: '',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       screens: {
         mobile: '400px',
@@ -1271,6 +1294,7 @@ test('user config takes precedence over plugin config modifications', () => {
     prefix: '',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       screens: {
         mobile: '400px',
@@ -1321,6 +1345,7 @@ test('plugin config can register plugins that also have config', () => {
     prefix: '',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       screens: {
         mobile: '400px',
@@ -1366,6 +1391,7 @@ test('plugin configs take precedence over plugin configs registered by that plug
     prefix: '',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       screens: {
         mobile: '400px',
@@ -1416,6 +1442,7 @@ test('plugin theme extensions are added even if user overrides top-level theme c
     prefix: '',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       width: {
         sm: '1rem',
@@ -1477,6 +1504,7 @@ test('user theme extensions take precedence over plugin theme extensions with th
     prefix: '',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       width: {
         sm: '1rem',
@@ -1549,6 +1577,7 @@ test('extensions are applied in the right order', () => {
   }
 
   const defaultConfig = {
+    content: [],
     theme: {
       colors: {
         grey: {
@@ -1583,6 +1612,7 @@ test('core plugin configuration builds on the default list when starting with an
     prefix: '',
     important: false,
     separator: ':',
+    content: [],
     theme: {},
     corePlugins: {},
   }
@@ -1608,6 +1638,7 @@ test('core plugins that are disabled by default can be enabled', () => {
     prefix: '',
     important: false,
     separator: ':',
+    content: [],
     theme: {},
     corePlugins: { display: false },
   }
@@ -1631,6 +1662,7 @@ test('core plugin configurations stack', () => {
     prefix: '',
     important: false,
     separator: ':',
+    content: [],
     theme: {},
     corePlugins: ['float', 'display', 'padding'],
   }
@@ -1660,6 +1692,7 @@ test('plugins are merged', () => {
     prefix: '',
     important: false,
     separator: ':',
+    content: [],
     theme: {},
   }
 
@@ -1691,6 +1724,7 @@ test('all helpers can be destructured from the first function argument', () => {
     prefix: '-',
     important: false,
     separator: ':',
+    content: [],
     theme: {
       screens: {
         sm: '640px',


### PR DESCRIPTION
This PR will normalize the config from the old structures to the new structure. If we detect that anything is old/incorrect, we are still able to normalize it but we will also warn in the console. 

We will have to improve the warning to include a link to a discussion / website to talk about the new structure.
If you happen to see this PR, here is the new structure:

```js
module.exports = {
  content: { // Or content: ['/path-to-files', '/path-to-files-with-globs/**.js', { raw: 'text-center' }]
    files: [/* Same as above... */],
    extract: { // Or a function immediately for the DEFAULT case
      DEFAULT: (content) => ['list', 'of', 'candidates']
      html: (content) => ['list', 'of', 'candidates']
    },
    transform: { // Or a function immediately for the DEFAULT case
      DEFAULT: (content) => content,
      md: (content) => parseMarkdown(content)
    }
  },
  safelist: [
    'mt-20', // Raw strings
    { pattern: /bg-red/, variants: ['hover', 'focus'] }
  ]
}
```

---

**TODO:**
- [x] upgrade existing tests to "new" syntax
- [x] add a "old" tailwind config to make sure that everything still works in v3 + warning