### PR TITLE
Add `overscroll-inline` utilities

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1235,6 +1235,14 @@ export let corePlugins = {
     })
   },
 
+  overscrollBehaviorInline: ({ addUtilities }) => {
+    addUtilities({
+      '.overscroll-inline-auto': { 'overscroll-behavior-inline': 'auto' },
+      '.overscroll-inline-contain': { 'overscroll-behavior-inline': 'contain' },
+      '.overscroll-inline-none': { 'overscroll-behavior-inline': 'none' },
+    })
+  },
+
   scrollBehavior: ({ addUtilities }) => {
     addUtilities({
       '.scroll-auto': { 'scroll-behavior': 'auto' },

--- a/tests/basic-usage.test.css
+++ b/tests/basic-usage.test.css
@@ -469,6 +469,9 @@
 .overscroll-contain {
   overscroll-behavior: contain;
 }
+.overscroll-inline-contain {
+  overscroll-behavior-inline: contain;
+}
 .truncate {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/tests/basic-usage.test.html
+++ b/tests/basic-usage.test.html
@@ -100,6 +100,7 @@
     <div class="outline-none outline-black"></div>
     <div class="overflow-hidden"></div>
     <div class="overscroll-contain"></div>
+    <div class="overscroll-inline-contain"></div>
     <div class="p-4 py-2 px-3 pt-1 pr-2 pb-3 pl-4"></div>
     <div class="place-content-start"></div>
     <div class="placeholder-green-300"></div>


### PR DESCRIPTION
This PR adds new `overscroll-inline` utilities:

| Utility                      | CSS                                    |
| ---------------------------- | -------------------------------------- |
| `overscroll-inline-auto`    | `overscroll-behavior-inline: auto;`    |
| `overscroll-inline-contain` | `overscroll-behavior-inline: contain;` |
| `overscroll-inline-none`    | `overscroll-behavior-inline: none;`    |
