### PR TITLE
Ensure we log flag notices

### DIFF
--- a/src/processTailwindFeatures.js
+++ b/src/processTailwindFeatures.js
@@ -7,6 +7,7 @@ import resolveDefaultsAtRules from './lib/resolveDefaultsAtRules'
 import collapseAdjacentRules from './lib/collapseAdjacentRules'
 import detectNesting from './lib/detectNesting'
 import { createContext } from './lib/setupContextUtils'
+import { issueFlagNotices } from './featureFlags'
 
 export default function processTailwindFeatures(setupContext) {
   return function (root, result) {
@@ -31,6 +32,8 @@ export default function processTailwindFeatures(setupContext) {
         "The '-' character cannot be used as a custom separator in JIT mode due to parsing ambiguity. Please use another character like '_' instead."
       )
     }
+
+    issueFlagNotices(context.tailwindConfig)
 
     detectNesting(context)(root, result)
     expandTailwindAtRules(context)(root, result)


### PR DESCRIPTION
If you enable `experimental` or `future` features, then we want to log about this in the console so that people are aware that they have some special features going.
With the changes introduced in #5635 we enable the `optimizeUniversalDefaults` by default, but you can still turn it off. If you have it explicitly enabled in your config, then you will get this warning. If you rely on the default implementation internally, then you won't see the log.