### PR TITLE
Add min-content and max-content utilities for (min/max) height

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -504,6 +504,8 @@ module.exports = {
       '5/6': '83.333333%',
       full: '100%',
       screen: '100vh',
+      min: 'min-content',
+      max: 'max-content',
       fit: 'fit-content',
     }),
     inset: ({ theme }) => ({
@@ -582,6 +584,8 @@ module.exports = {
       ...theme('spacing'),
       full: '100%',
       screen: '100vh',
+      min: 'min-content',
+      max: 'max-content',
       fit: 'fit-content',
     }),
     maxWidth: ({ theme, breakpoints }) => ({
@@ -609,6 +613,8 @@ module.exports = {
       0: '0px',
       full: '100%',
       screen: '100vh',
+      min: 'min-content',
+      max: 'max-content',
       fit: 'fit-content',
     },
     minWidth: {


### PR DESCRIPTION
This PR adds [`min-content`](https://developer.mozilla.org/en-US/docs/Web/CSS/min-content) and [`max-content`](https://developer.mozilla.org/en-US/docs/Web/CSS/max-content) classes for (min/max) height.