### PR TITLE
Add utilities for `scrollbar-width`

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1272,6 +1272,19 @@ export let corePlugins = {
     })
   },
 
+  scrollbarWidth: ({ addUtilities }) => {
+    addUtilities({
+      '.scrollbar-auto': { 'scrollbar-width': 'auto' },
+      '.scrollbar-thin': { 'scrollbar-width': 'thin' },
+      '.scrollbar-none': {
+        'scrollbar-width': 'none',
+        '&::-webkit-scrollbar': {
+          display: 'none',
+        },
+      },
+    })
+  },
+
   textOverflow: ({ addUtilities }) => {
     addUtilities({
       '.truncate': { overflow: 'hidden', 'text-overflow': 'ellipsis', 'white-space': 'nowrap' },

--- a/tests/raw-content.test.css
+++ b/tests/raw-content.test.css
@@ -367,6 +367,15 @@
 .scroll-smooth {
   scroll-behavior: smooth;
 }
+.scrollbar-thin {
+  scrollbar-width: thin;
+}
+.scrollbar-none {
+  scrollbar-width: none;
+}
+.scrollbar-none::-webkit-scrollbar {
+  display: none;
+}
 .truncate {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/tests/raw-content.test.html
+++ b/tests/raw-content.test.html
@@ -97,6 +97,8 @@
     <div class="overflow-hidden"></div>
     <div class="overscroll-contain"></div>
     <div class="scroll-smooth"></div>
+    <div class="scrollbar-thin"></div>
+    <div class="scrollbar-none"></div>
     <div class="p-4 py-2 px-3 pt-1 pr-2 pb-3 pl-4"></div>
     <div class="place-content-start"></div>
     <div class="placeholder-green-300"></div>


### PR DESCRIPTION
This PR adds utlities for the [`scrollbar-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width) CSS property.

Supported in Firefox for a while.

Chrome is supported behind a flag as of 115.

I'm midway through implementing support in WebKit.

Chrome (in-progress) bug: https://crbug.com/891944

Safari bug: https://webkit.org/b/231588

The `scrollbar-none` class also works with older Chrome and Safari with the fallback to the `::-webkit-scrollbar` pseudo element.
