### PR TITLE
Add utilities for `scrollbar-gutter`

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1278,6 +1278,29 @@ export let corePlugins = {
     })
   },
 
+  scrollbarGutter: ({ addUtilities, addBase }) => {
+    addBase({
+      '@defaults scrollbar-gutter': {
+        '--tw-scrollbar-gutter-modifier': '',
+      },
+    })
+
+    addUtilities([
+      {
+        '.scrollbar-gutter-auto': {
+          'scrollbar-gutter': 'auto',
+        },
+        '.scrollbar-stable': {
+          '@defaults scrollbar-gutter': {},
+          'scrollbar-gutter': 'stable var(--tw-scrollbar-gutter-modifier)',
+        },
+        '.scrollbar-both-edges': {
+          '--tw-scrollbar-gutter-modifier': 'both-edges',
+        },
+      },
+    ])
+  },
+
   textOverflow: ({ addUtilities }) => {
     addUtilities({
       '.truncate': { overflow: 'hidden', 'text-overflow': 'ellipsis', 'white-space': 'nowrap' },


### PR DESCRIPTION
This PR adds utilities for the [`scrollbar-gutter`](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter) CSS property.

Currently only supported in Chromium >= 94.

Firefox bug: https://bugzil.la/1715112 (Looks to be [aiming to ship](https://groups.google.com/a/mozilla.org/g/dev-platform/c/pAh2tDhBFOU/m/wQBctGKCCwAJ) in version 97)

WebKit bug: https://webkit.org/b/167335

This is a useful property for avoiding horizontal layout shift.

Went with `scrollbar-gutter-auto` to avoid ambiguity with [`scrollbar-width: auto`](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width) or [`scrollbar-color: auto`](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color)