### PR TITLE
[v2] Configure `awaitWriteFinish` for chokidar

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -734,6 +734,10 @@ async function build() {
 
     watcher = chokidar.watch([...contextDependencies, ...extractFileGlobs(config)], {
       ignoreInitial: true,
+      awaitWriteFinish: {
+        stabilityThreshold: 50,
+        pollInterval: 10,
+      },
     })
 
     let chain = Promise.resolve()

--- a/src/cli.js
+++ b/src/cli.js
@@ -734,10 +734,13 @@ async function build() {
 
     watcher = chokidar.watch([...contextDependencies, ...extractFileGlobs(config)], {
       ignoreInitial: true,
-      awaitWriteFinish: {
-        stabilityThreshold: 50,
-        pollInterval: 10,
-      },
+      awaitWriteFinish:
+        process.platform === 'win32'
+          ? {
+              stabilityThreshold: 50,
+              pollInterval: 10,
+            }
+          : false,
     })
 
     let chain = Promise.resolve()

--- a/src/jit/lib/setupWatchingContext.js
+++ b/src/jit/lib/setupWatchingContext.js
@@ -84,6 +84,10 @@ function rebootWatcher(context, configPath, configDependencies, candidateFiles) 
 
     watcher = chokidar.watch([...candidateFiles, ...configDependencies], {
       ignoreInitial: true,
+      awaitWriteFinish: {
+        stabilityThreshold: 50,
+        pollInterval: 10,
+      },
     })
 
     setWatcher(context, watcher)

--- a/src/jit/lib/setupWatchingContext.js
+++ b/src/jit/lib/setupWatchingContext.js
@@ -84,10 +84,13 @@ function rebootWatcher(context, configPath, configDependencies, candidateFiles) 
 
     watcher = chokidar.watch([...candidateFiles, ...configDependencies], {
       ignoreInitial: true,
-      awaitWriteFinish: {
-        stabilityThreshold: 50,
-        pollInterval: 10,
-      },
+      awaitWriteFinish:
+        process.platform === 'win32'
+          ? {
+              stabilityThreshold: 50,
+              pollInterval: 10,
+            }
+          : false,
     })
 
     setWatcher(context, watcher)


### PR DESCRIPTION
This PR configures the `awaitWriteFinish` setting for `chokidar.watch`. From the [`chokidar` documentation](https://github.com/paulmillr/chokidar#performance):

> [...] in some cases some change events will be emitted while the file is being written. In some cases, especially when watching for large files there will be a need to wait for the write operation to finish before responding to a file creation or modification.

The exact settings (`stabilityThreshold: 50, pollInterval: 10`) are based on those used by `postcss-cli`: https://github.com/postcss/postcss-cli/blob/master/index.js#L125-L128

When looking into #5753 I observed that occasionally a [file read](https://github.com/tailwindlabs/tailwindcss/blob/v2/src/cli.js#L761) will return an empty string on Windows, even when the file has contents. This can cause new classes to be missed. Configuring `awaitWriteFinish` helps to avoid this by delaying the `change` event until the file size has not change for 50ms. I was not able to reproduce the empty string issue with `awaitWriteFinish` configured as per this PR.