### PR TITLE
Don't use pointer cursor on disabled buttons by default

### DIFF
--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -318,6 +318,13 @@ button,
 }
 
 /*
+Make sure disabled buttons don't get the pointer cursor.
+*/
+:disabled {
+  cursor: default;
+}
+
+/*
 1. Make replaced elements `display: block` by default. (https://github.com/mozdevs/cssremedy/issues/14)
 2. Add `vertical-align: middle` to align replaced elements more sensibly by default. (https://github.com/jensimmons/cssremedy/issues/14#issuecomment-634934210)
    This can trigger a poorly considered lint error in some tools but is included by design.


### PR DESCRIPTION
Resolves #5768.

This PR adds the following CSS to Preflight:

```css
:disabled {
  cursor: default;
}
```

This ensures that even though we reset buttons to use the `pointer` cursor, _disabled_ buttons use the browser default which does less to communicate the button being interactive and makes more sense when the element can't actually be clicked.