### PR TITLE
Fix CLI `--content` option

### DIFF
--- a/integrations/tailwindcss-cli/tests/cli.test.js
+++ b/integrations/tailwindcss-cli/tests/cli.test.js
@@ -145,6 +145,20 @@ describe('Build command', () => {
     )
   })
 
+  test('--content', async () => {
+    await writeInputFile('index.html', html`<div class="font-bold"></div>`)
+
+    await $(`${EXECUTABLE} --content ./src/index.html --output ./dist/main.css`)
+
+    expect(await readOutputFile('main.css')).toIncludeCss(
+      css`
+        .font-bold {
+          font-weight: 700;
+        }
+      `
+    )
+  })
+
   test('--postcss (postcss.config.js)', async () => {
     await writeInputFile('index.html', html`<div class="font-bold"></div>`)
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -430,7 +430,7 @@ async function build() {
     }
 
     if (args['--content']) {
-      resolvedConfig.content = args['--content'].split(/(?<!{[^}]+),/)
+      resolvedConfig.content.files = args['--content'].split(/(?<!{[^}]+),/)
     }
 
     return resolvedConfig


### PR DESCRIPTION
This PR fixes the CLI `--content` option. Following resolution the content config looks like this, so it's actually `content.files` that needs updating:

```js
{
  files: [],
  extract: {
    DEFAULT: undefined
  },
  transform: {}
}
```

~~Side note: is `extract.DEFAULT` supposed to be `undefined` here? 🤔~~ See #5778