### PR TITLE
Configurable Dark Mode ClassName

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -319,7 +319,7 @@ export let variantPlugins = {
           if (variantSelector === selector) {
             return null
           }
-          let darkModeClassName = config('darkModeClassName', '.dark');
+          let darkModeClassName = config('darkModeClassName', '.dark')
           let darkSelector = prefixSelector(config('prefix'), darkModeClassName)
 
           return `${darkSelector} ${variantSelector}`

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -319,8 +319,8 @@ export let variantPlugins = {
           if (variantSelector === selector) {
             return null
           }
-
-          let darkSelector = prefixSelector(config('prefix'), `.dark`)
+          let darkModeClassName = config('darkModeClassName', '.dark');
+          let darkSelector = prefixSelector(config('prefix'), darkModeClassName)
 
           return `${darkSelector} ${variantSelector}`
         })

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -134,7 +134,8 @@ export let variantPlugins = {
   },
 
   darkVariants: ({ config, addVariant }) => {
-    let mode = config('darkMode', 'media')
+    let [mode, className = '.dark'] = [].concat(config('darkMode', 'media'))
+    
     if (mode === false) {
       mode = 'media'
       log.warn('darkmode-false', [
@@ -144,8 +145,7 @@ export let variantPlugins = {
     }
 
     if (mode === 'class') {
-      let darkModeClassName = config('darkModeClassName', '.dark')
-      addVariant('dark', `${darkModeClassName} &`)
+      addVariant('dark', `${className} &`)
     } else if (mode === 'media') {
       addVariant('dark', '@media (prefers-color-scheme: dark)')
     }

--- a/tests/dark-mode.test.js
+++ b/tests/dark-mode.test.js
@@ -22,6 +22,29 @@ it('should be possible to use the darkMode "class" mode', () => {
   })
 })
 
+it('should be possible to change default class with darkMode "class" mode', () => {
+  let config = {
+    darkMode: 'class',
+    darkModeClassName: '.test-dark',
+    content: [{ raw: html`<div class="dark:font-bold"></div>` }],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .test-dark .dark\\:font-bold {
+        font-weight: 700;
+      }
+    `)
+  })
+})
+
 it('should be possible to use the darkMode "media" mode', () => {
   let config = {
     darkMode: 'media',

--- a/tests/dark-mode.test.js
+++ b/tests/dark-mode.test.js
@@ -22,10 +22,9 @@ it('should be possible to use the darkMode "class" mode', () => {
   })
 })
 
-it('should be possible to change default class with darkMode "class" mode', () => {
+it('should be possible to change the class name', () => {
   let config = {
-    darkMode: 'class',
-    darkModeClassName: '.test-dark',
+    darkMode: ['class', '.test-dark'],
     content: [{ raw: html`<div class="dark:font-bold"></div>` }],
     corePlugins: { preflight: false },
   }


### PR DESCRIPTION
Small PR to make the default `.dark` className configurable. 

Reason for this is that utilising Tailwind with mobile frameworks , particularly Nativescript, there could be a different className utilised. 
In the case of Nativescript, the default className utilised is `.ns-dark` for when the phone is set to darkMode.  
see https://docs.nativescript.org/ui-and-styling.html#css-overview