### PR TITLE
added dfn tag to preflight to remove italics

### DIFF
--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -58,6 +58,14 @@ abbr[title] {
 }
 
 /*
+Remove the italics.
+*/
+
+dfn {
+  font-style: normal;
+}
+
+/*
 Remove the default font size and weight for headings.
 */
 


### PR DESCRIPTION
The [`<dfn>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dfn) tag has italics by default that preflight does not reset.

This change removes the italics, making the font-style opt-in, rather than opt-out.

Fixes https://github.com/tailwindlabs/tailwindcss/issues/5805