### PR TITLE
Fix debug mode being active although explicitly disabled

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -18,7 +18,7 @@ import packageJson from '../package.json'
 import normalizePath from 'normalize-path'
 
 let env = {
-  DEBUG: process.env.DEBUG !== undefined,
+  DEBUG: process.env.DEBUG !== undefined && process.env.DEBUG !== '0',
 }
 
 // ---

--- a/src/lib/sharedState.js
+++ b/src/lib/sharedState.js
@@ -1,7 +1,7 @@
 export const env = {
   TAILWIND_MODE: process.env.TAILWIND_MODE,
   NODE_ENV: process.env.NODE_ENV,
-  DEBUG: process.env.DEBUG !== undefined,
+  DEBUG: process.env.DEBUG !== undefined && process.env.DEBUG !== '0',
   TAILWIND_DISABLE_TOUCH: process.env.TAILWIND_DISABLE_TOUCH !== undefined,
   TAILWIND_TOUCH_DIR: process.env.TAILWIND_TOUCH_DIR,
 }


### PR DESCRIPTION
I wanted to migrate to Tailwind v3.0.0-alpha.1 but got blocked by a `ReferenceError: contentMatchCache is not defined` error which [got fixed already](https://github.com/tailwindlabs/tailwindcss/commit/899a46088dae337c0fcf720b72043dcf8c0c7818#diff-2f0997968f6094158825cb36c24f8b489c2d3f5aa72279d721077e5901280a30) in an unreleased commit.

After some investigating I found out that [Chromatic](https://www.chromatic.com) which I use for building and deploying Storybook on CI sets the environment variable `DEBUG=0` during the build.

Because the condition `process.env.DEBUG === '0'` still sets the debug mode to true within Tailwind, there is no way for me to disable the debug mode in Tailwind if it was set by another library. I think it makes sense to disable the debug mode if it's specifically `'0'`.

Let me know what you think. 😊