### PR TITLE
Handle color transformations properly with `theme(...)` for all relevant plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cleanup duplicate properties ([#5830](https://github.com/tailwindlabs/tailwindcss/pull/5830))
 - Allow `_` inside `url()` when using arbitrary values ([#5853](https://github.com/tailwindlabs/tailwindcss/pull/5853))
 - Prevent crashes when using comments in `@layer` AtRules ([#5854](https://github.com/tailwindlabs/tailwindcss/pull/5854))
+- Handle color transformations properly with `theme(...)` for all relevant plugins ([#4533](https://github.com/tailwindlabs/tailwindcss/pull/4533), [#5871](https://github.com/tailwindlabs/tailwindcss/pull/5871))
 
 ## [3.0.0-alpha.1] - 2021-10-01
 

--- a/src/util/transformThemeValue.js
+++ b/src/util/transformThemeValue.js
@@ -3,13 +3,8 @@ import postcss from 'postcss'
 export default function transformThemeValue(themeSection) {
   if (['fontSize', 'outline'].includes(themeSection)) {
     return (value) => {
-      if (typeof value === 'function') {
-        value = value({})
-      }
-
-      if (Array.isArray(value)) {
-        value = value[0]
-      }
+      if (typeof value === 'function') value = value({})
+      if (Array.isArray(value)) value = value[0]
 
       return value
     }
@@ -31,13 +26,8 @@ export default function transformThemeValue(themeSection) {
     ].includes(themeSection)
   ) {
     return (value) => {
-      if (typeof value === 'function') {
-        value = value({})
-      }
-
-      if (Array.isArray(value)) {
-        value = value.join(', ')
-      }
+      if (typeof value === 'function') value = value({})
+      if (Array.isArray(value)) value = value.join(', ')
 
       return value
     }
@@ -47,22 +37,15 @@ export default function transformThemeValue(themeSection) {
   // instead of commas for arbitrary values.
   if (['gridTemplateColumns', 'gridTemplateRows', 'objectPosition'].includes(themeSection)) {
     return (value) => {
-      if (typeof value === 'function') {
-        value = value({})
-      }
-
-      if (typeof value === 'string') {
-        value = postcss.list.comma(value).join(' ')
-      }
+      if (typeof value === 'function') value = value({})
+      if (typeof value === 'string') value = postcss.list.comma(value).join(' ')
 
       return value
     }
   }
 
   return (value) => {
-    if (typeof value === 'function') {
-      value = value({})
-    }
+    if (typeof value === 'function') value = value({})
 
     return value
   }

--- a/src/util/transformThemeValue.js
+++ b/src/util/transformThemeValue.js
@@ -59,29 +59,11 @@ export default function transformThemeValue(themeSection) {
     }
   }
 
-  if (
-    [
-      'borderColor',
-      'caretColor',
-      'colors',
-      'divideColor',
-      'fill',
-      'gradientColorStops',
-      'placeholderColor',
-      'ringColor',
-      'ringOffsetColor',
-      'stroke',
-      'textColor',
-    ].includes(themeSection)
-  ) {
-    return (value) => {
-      if (typeof value === 'function') {
-        value = value({})
-      }
-
-      return value
+  return (value) => {
+    if (typeof value === 'function') {
+      value = value({})
     }
-  }
 
-  return (value) => value
+    return value
+  }
 }

--- a/src/util/transformThemeValue.js
+++ b/src/util/transformThemeValue.js
@@ -28,7 +28,22 @@ export default function transformThemeValue(themeSection) {
     return (value) => (typeof value === 'string' ? postcss.list.comma(value).join(' ') : value)
   }
 
-  if (['colors', 'textColor', 'backgroundColor', 'borderColor'].includes(themeSection)) {
+  if (
+    [
+      'backgroundColor',
+      'borderColor',
+      'caretColor',
+      'colors',
+      'divideColor',
+      'fill',
+      'gradientColorStops',
+      'placeholderColor',
+      'ringColor',
+      'ringOffsetColor',
+      'stroke',
+      'textColor',
+    ].includes(themeSection)
+  ) {
     return (value) => (typeof value === 'function' ? value({}) : value)
   }
 

--- a/src/util/transformThemeValue.js
+++ b/src/util/transformThemeValue.js
@@ -15,7 +15,6 @@ export default function transformThemeValue(themeSection) {
       'transitionTimingFunction',
       'backgroundImage',
       'backgroundSize',
-      'backgroundColor',
       'cursor',
       'animation',
     ].includes(themeSection)
@@ -29,7 +28,7 @@ export default function transformThemeValue(themeSection) {
     return (value) => (typeof value === 'string' ? postcss.list.comma(value).join(' ') : value)
   }
 
-  if (themeSection === 'colors') {
+  if (['colors', 'textColor', 'backgroundColor', 'borderColor'].includes(themeSection)) {
     return (value) => (typeof value === 'function' ? value({}) : value)
   }
 

--- a/src/util/transformThemeValue.js
+++ b/src/util/transformThemeValue.js
@@ -2,7 +2,17 @@ import postcss from 'postcss'
 
 export default function transformThemeValue(themeSection) {
   if (['fontSize', 'outline'].includes(themeSection)) {
-    return (value) => (Array.isArray(value) ? value[0] : value)
+    return (value) => {
+      if (typeof value === 'function') {
+        value = value({})
+      }
+
+      if (Array.isArray(value)) {
+        value = value[0]
+      }
+
+      return value
+    }
   }
 
   if (
@@ -15,22 +25,42 @@ export default function transformThemeValue(themeSection) {
       'transitionTimingFunction',
       'backgroundImage',
       'backgroundSize',
+      'backgroundColor',
       'cursor',
       'animation',
     ].includes(themeSection)
   ) {
-    return (value) => (Array.isArray(value) ? value.join(', ') : value)
+    return (value) => {
+      if (typeof value === 'function') {
+        value = value({})
+      }
+
+      if (Array.isArray(value)) {
+        value = value.join(', ')
+      }
+
+      return value
+    }
   }
 
   // For backwards compatibility reasons, before we switched to underscores
   // instead of commas for arbitrary values.
   if (['gridTemplateColumns', 'gridTemplateRows', 'objectPosition'].includes(themeSection)) {
-    return (value) => (typeof value === 'string' ? postcss.list.comma(value).join(' ') : value)
+    return (value) => {
+      if (typeof value === 'function') {
+        value = value({})
+      }
+
+      if (typeof value === 'string') {
+        value = postcss.list.comma(value).join(' ')
+      }
+
+      return value
+    }
   }
 
   if (
     [
-      'backgroundColor',
       'borderColor',
       'caretColor',
       'colors',
@@ -44,7 +74,13 @@ export default function transformThemeValue(themeSection) {
       'textColor',
     ].includes(themeSection)
   ) {
-    return (value) => (typeof value === 'function' ? value({}) : value)
+    return (value) => {
+      if (typeof value === 'function') {
+        value = value({})
+      }
+
+      return value
+    }
   }
 
   return (value) => value

--- a/tests/evaluateTailwindFunctions.test.js
+++ b/tests/evaluateTailwindFunctions.test.js
@@ -26,6 +26,42 @@ test('it looks up values in the theme using dot notation', () => {
   })
 })
 
+test('color can be a function', () => {
+  const input = `
+    .colors { color: theme('colors.fn'); }
+    .textColor { color: theme('textColor.fn'); }
+    .backgroundColor { color: theme('backgroundColor.fn'); }
+    .borderColor { color: theme('borderColor.fn'); }
+  `
+
+  const output = `
+    .colors { color: #f00; }
+    .textColor { color: #f00; }
+    .backgroundColor { color: #f00; }
+    .borderColor { color: #f00; }
+  `
+
+  return run(input, {
+    theme: {
+      colors: {
+        fn: () => `#f00`,
+      },
+      textColor: {
+        fn: () => '#f00',
+      },
+      backgroundColor: {
+        fn: () => '#f00',
+      },
+      borderColor: {
+        fn: () => '#f00',
+      },
+    },
+  }).then((result) => {
+    expect(result.css).toEqual(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
 test('quotes are optional around the lookup path', () => {
   const input = `
     .banana { color: theme(colors.yellow); }

--- a/tests/evaluateTailwindFunctions.test.js
+++ b/tests/evaluateTailwindFunctions.test.js
@@ -28,33 +28,51 @@ test('it looks up values in the theme using dot notation', () => {
 
 test('color can be a function', () => {
   const input = `
-    .colors { color: theme('colors.fn'); }
-    .textColor { color: theme('textColor.fn'); }
-    .backgroundColor { color: theme('backgroundColor.fn'); }
-    .borderColor { color: theme('borderColor.fn'); }
+    .backgroundColor { color: theme('backgroundColor.fn') }
+    .borderColor { color: theme('borderColor.fn') }
+    .caretColor { color: theme('caretColor.fn') }
+    .colors { color: theme('colors.fn') }
+    .divideColor { color: theme('divideColor.fn') }
+    .fill { color: theme('fill.fn') }
+    .gradientColorStops { color: theme('gradientColorStops.fn') }
+    .placeholderColor { color: theme('placeholderColor.fn') }
+    .ringColor { color: theme('ringColor.fn') }
+    .ringOffsetColor { color: theme('ringOffsetColor.fn') }
+    .stroke { color: theme('stroke.fn') }
+    .textColor { color: theme('textColor.fn') }
   `
 
   const output = `
-    .colors { color: #f00; }
-    .textColor { color: #f00; }
-    .backgroundColor { color: #f00; }
-    .borderColor { color: #f00; }
+    .backgroundColor { color: #f00 }
+    .borderColor { color: #f00 }
+    .caretColor { color: #f00 }
+    .colors { color: #f00 }
+    .divideColor { color: #f00 }
+    .fill { color: #f00 }
+    .gradientColorStops { color: #f00 }
+    .placeholderColor { color: #f00 }
+    .ringColor { color: #f00 }
+    .ringOffsetColor { color: #f00 }
+    .stroke { color: #f00 }
+    .textColor { color: #f00 }
   `
+
+  const fn = () => `#f00`
 
   return run(input, {
     theme: {
-      colors: {
-        fn: () => `#f00`,
-      },
-      textColor: {
-        fn: () => '#f00',
-      },
-      backgroundColor: {
-        fn: () => '#f00',
-      },
-      borderColor: {
-        fn: () => '#f00',
-      },
+      backgroundColor: { fn },
+      borderColor: { fn },
+      caretColor: { fn },
+      colors: { fn },
+      divideColor: { fn },
+      fill: { fn },
+      gradientColorStops: { fn },
+      placeholderColor: { fn },
+      ringColor: { fn },
+      ringOffsetColor: { fn },
+      stroke: { fn },
+      textColor: { fn },
     },
   }).then((result) => {
     expect(result.css).toEqual(output)


### PR DESCRIPTION
This PR is based on #4533, with a few more improvements. In general, the PR was good, but instead of hardcoding a list, all resolved values can handle a function. Therefore, we don't need to hardcode a list of plugins.

`Background color` still had to be in the first list, because a background color _can_ have multiple values for each `background`. E.g.: `background-color: #f00 #0f0 #00f`

Closes: #4533