### PR TITLE
Add print variant

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -150,6 +150,10 @@ export let variantPlugins = {
     }
   },
 
+  printVariant: ({ addVariant }) => {
+    addVariant('print', '@media print')
+  },
+
   screenVariants: ({ theme, addVariant }) => {
     for (let screen in theme('screens')) {
       let size = theme('screens')[screen]

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -573,6 +573,7 @@ function resolvePlugins(context, root) {
     variantPlugins['directionVariants'],
     variantPlugins['reducedMotionVariants'],
     variantPlugins['darkVariants'],
+    variantPlugins['printVariant'],
     variantPlugins['screenVariants'],
   ]
 

--- a/tests/variants.test.css
+++ b/tests/variants.test.css
@@ -709,6 +709,12 @@
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
     var(--tw-shadow);
 }
+@media print {
+  .print\:bg-yellow-300 {
+    --tw-bg-opacity: 1;
+      background-color: rgb(253 224 71 / var(--tw-bg-opacity));
+  }
+}
 @media (min-width: 640px) {
   .sm\:shadow-md {
     --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -1px rgb(0 0 0 / 0.06);

--- a/tests/variants.test.html
+++ b/tests/variants.test.html
@@ -122,6 +122,9 @@
     <!-- Dark mode variants -->
     <div class="dark:shadow-md"></div>
 
+    <!-- Print variant -->
+    <div class="print:bg-yellow-300"></div>
+
     <!-- Screen variants -->
     <div class="sm:shadow-md"></div>
     <div class="md:shadow-md"></div>


### PR DESCRIPTION
This PR adds a new `print` variant, which allows to add styles specifically targeted for print media. For example:

```html
<nav class="print:hidden">
  <!-- Hide menu when printing -->
</nav>

<h1 class="text-blue-700 print:text-black">
  <!-- Make text black when printing -->
</h1>
```

This will generate the following CSS:

```css
@media print {
  .print\:hidden {
    display: none;
  }
}

@media print {
  .print\:text-black {
    color: black;
  }
}
```