### PR TITLE
Add new outline style, color, width and offset utilities

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1801,6 +1801,14 @@ export let corePlugins = {
     })
   },
 
+  outlineWidth: createUtilityPlugin('outlineWidth', [['outline', ['outline-width']]], {
+    type: ['length', 'number', 'percentage'],
+  }),
+
+  outlineOffset: createUtilityPlugin('outlineOffset', [['outline-offset', ['outline-offset']]], {
+    type: ['length', 'number', 'percentage'],
+  }),
+
   outlineColor: ({ matchUtilities, theme }) => {
     matchUtilities(
       {
@@ -1811,14 +1819,6 @@ export let corePlugins = {
       { values: flattenColorPalette(theme('outlineColor')), type: ['color'] }
     )
   },
-
-  outlineWidth: createUtilityPlugin('outlineWidth', [['outline', ['outline-width']]], {
-    type: ['length', 'number', 'percentage'],
-  }),
-
-  outlineOffset: createUtilityPlugin('outlineOffset', [['outline-offset', ['outline-offset']]], {
-    type: ['length', 'number', 'percentage'],
-  }),
 
   ringWidth: ({ matchUtilities, addBase, addUtilities, theme }) => {
     let ringOpacityDefault = theme('ringOpacity.DEFAULT', '0.5')

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1792,12 +1792,15 @@ export let corePlugins = {
 
   outlineStyle: ({ addUtilities }) => {
     addUtilities({
+      '.outline-none': {
+        outline: '2px solid transparent',
+        'outline-offset': '2px',
+      },
       '.outline': { 'outline-style': 'solid' },
       '.outline-dashed': { 'outline-style': 'dashed' },
       '.outline-dotted': { 'outline-style': 'dotted' },
       '.outline-double': { 'outline-style': 'double' },
       '.outline-hidden': { 'outline-style': 'hidden' },
-      '.outline-none': { outline: '2px solid transparent' },
     })
   },
 

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1797,7 +1797,7 @@ export let corePlugins = {
       '.outline-dotted': { 'outline-style': 'dotted' },
       '.outline-double': { 'outline-style': 'double' },
       '.outline-hidden': { 'outline-style': 'hidden' },
-      '.outline-none': { 'outline': '2px solid transparent' },
+      '.outline-none': { outline: '2px solid transparent' },
     })
   },
 

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1797,7 +1797,7 @@ export let corePlugins = {
       '.outline-dotted': { 'outline-style': 'dotted' },
       '.outline-double': { 'outline-style': 'double' },
       '.outline-hidden': { 'outline-style': 'hidden' },
-      '.outline-none': { 'outline-style': 'none' },
+      '.outline-none': { 'outline': '2px solid transparent' },
     })
   },
 

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1790,19 +1790,35 @@ export let corePlugins = {
     }
   })(),
 
-  outline: ({ matchUtilities, theme }) => {
+  outlineStyle: ({ addUtilities }) => {
+    addUtilities({
+      '.outline': { 'outline-style': 'solid' },
+      '.outline-dashed': { 'outline-style': 'dashed' },
+      '.outline-dotted': { 'outline-style': 'dotted' },
+      '.outline-double': { 'outline-style': 'double' },
+      '.outline-hidden': { 'outline-style': 'hidden' },
+      '.outline-none': { 'outline-style': 'none' },
+    })
+  },
+
+  outlineColor: ({ matchUtilities, theme }) => {
     matchUtilities(
       {
         outline: (value) => {
-          value = Array.isArray(value) ? value : value.split(',')
-          let [outline, outlineOffset = '0'] = Array.isArray(value) ? value : [value]
-
-          return { outline, 'outline-offset': outlineOffset }
+          return { 'outline-color': toColorValue(value) }
         },
       },
-      { values: theme('outline') }
+      { values: flattenColorPalette(theme('outlineColor')), type: ['color'] }
     )
   },
+
+  outlineWidth: createUtilityPlugin('outlineWidth', [['outline', ['outline-width']]], {
+    type: ['length', 'number', 'percentage'],
+  }),
+
+  outlineOffset: createUtilityPlugin('outlineOffset', [['outline-offset', ['outline-offset']]], {
+    type: ['length', 'number', 'percentage'],
+  }),
 
   ringWidth: ({ matchUtilities, addBase, addUtilities, theme }) => {
     let ringOpacityDefault = theme('ringOpacity.DEFAULT', '0.5')

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -701,14 +701,14 @@ module.exports = {
     placeholderColor: ({ theme }) => theme('colors'),
     placeholderOpacity: ({ theme }) => theme('opacity'),
     outlineColor: ({ theme }) => theme('colors'),
-    outlineWidth: {
+    outlineOffset: {
       0: '0px',
       1: '1px',
       2: '2px',
       4: '4px',
       8: '8px',
     },
-    outlineOffset: {
+    outlineWidth: {
       0: '0px',
       1: '1px',
       2: '2px',

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -697,11 +697,6 @@ module.exports = {
       11: '11',
       12: '12',
     },
-    outline: {
-      none: ['2px solid transparent', '2px'],
-      white: ['2px dotted white', '2px'],
-      black: ['2px dotted black', '2px'],
-    },
     padding: ({ theme }) => theme('spacing'),
     placeholderColor: ({ theme }) => theme('colors'),
     placeholderOpacity: ({ theme }) => theme('opacity'),

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -705,6 +705,21 @@ module.exports = {
     padding: ({ theme }) => theme('spacing'),
     placeholderColor: ({ theme }) => theme('colors'),
     placeholderOpacity: ({ theme }) => theme('opacity'),
+    outlineColor: ({ theme }) => theme('colors'),
+    outlineWidth: {
+      0: '0px',
+      1: '1px',
+      2: '2px',
+      4: '4px',
+      8: '8px',
+    },
+    outlineOffset: {
+      0: '0px',
+      1: '1px',
+      2: '2px',
+      4: '4px',
+      8: '8px',
+    },
     ringColor: ({ theme }) => ({
       DEFAULT: theme('colors.blue.500', '#3b82f6'),
       ...theme('colors'),

--- a/tests/arbitrary-values.test.css
+++ b/tests/arbitrary-values.test.css
@@ -859,12 +859,6 @@
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
     var(--tw-shadow);
 }
-.outline-\[black\] {
-  outline-color: black;
-}
-.outline-\[color\:var\(--outline\)\] {
-  outline-color: var(--outline);
-}
 .outline-\[10px\] {
   outline-width: 10px;
 }
@@ -873,6 +867,12 @@
 }
 .outline-offset-\[10px\] {
   outline-offset: 10px;
+}
+.outline-\[black\] {
+  outline-color: black;
+}
+.outline-\[color\:var\(--outline\)\] {
+  outline-color: var(--outline);
 }
 .ring-\[10px\] {
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width)

--- a/tests/arbitrary-values.test.css
+++ b/tests/arbitrary-values.test.css
@@ -859,25 +859,20 @@
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
     var(--tw-shadow);
 }
-.outline-\[2px_solid_black\] {
-  outline: 2px solid black;
-  outline-offset: 0;
+.outline-\[black\] {
+  outline-color: black;
 }
-.outline-\[2px_solid_black\2c 2px\] {
-  outline: 2px solid black;
-  outline-offset: 2px;
+.outline-\[color\:var\(--outline\)\] {
+  outline-color: var(--outline);
 }
-.outline-\[var\(--outline\)\] {
-  outline: var(--outline);
-  outline-offset: 0;
+.outline-\[10px\] {
+  outline-width: 10px;
 }
-.outline-\[var\(--outline\)\2c 3px\] {
-  outline: var(--outline);
-  outline-offset: 3px;
+.outline-\[length\:var\(--outline\)\] {
+  outline-width: var(--outline);
 }
-.outline-\[2px_solid_black\2c var\(--outline-offset\)\] {
-  outline: 2px solid black;
-  outline-offset: var(--outline-offset);
+.outline-offset-\[10px\] {
+  outline-offset: 10px;
 }
 .ring-\[10px\] {
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width)

--- a/tests/arbitrary-values.test.html
+++ b/tests/arbitrary-values.test.html
@@ -321,11 +321,11 @@
     <div class="shadow-[0px_1px_2px_black]"></div>
     <div class="shadow-[var(--value)]"></div>
 
-    <div class="outline-[2px_solid_black]"></div>
-    <div class="outline-[2px_solid_black,2px]"></div>
-    <div class="outline-[var(--outline)]"></div>
-    <div class="outline-[var(--outline),3px]"></div>
-    <div class="outline-[2px_solid_black,var(--outline-offset)]"></div>
+    <div class="outline-[black]"></div>
+    <div class="outline-[10px]"></div>
+    <div class="outline-[color:var(--outline)]"></div>
+    <div class="outline-[length:var(--outline)]"></div>
+    <div class="outline-offset-[10px]"></div>
 
     <div class="ring-[#76ad65]"></div>
     <div class="ring-[color:var(--value)]"></div>

--- a/tests/basic-usage.test.css
+++ b/tests/basic-usage.test.css
@@ -830,14 +830,14 @@
 .outline-none {
   outline-style: none;
 }
-.outline-black {
-  outline-color: #000;
-}
 .outline-4 {
   outline-width: 4px;
 }
 .outline-offset-2 {
   outline-offset: 2px;
+}
+.outline-black {
+  outline-color: #000;
 }
 .ring {
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width)

--- a/tests/basic-usage.test.css
+++ b/tests/basic-usage.test.css
@@ -821,12 +821,22 @@
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
     var(--tw-shadow);
 }
+.outline {
+  outline-style: solid;
+}
+.outline-dashed {
+  outline-style: dashed;
+}
 .outline-none {
-  outline: 2px solid transparent;
-  outline-offset: 2px;
+  outline-style: none;
 }
 .outline-black {
-  outline: 2px dotted black;
+  outline-color: #000;
+}
+.outline-4 {
+  outline-width: 4px;
+}
+.outline-offset-2 {
   outline-offset: 2px;
 }
 .ring {

--- a/tests/basic-usage.test.css
+++ b/tests/basic-usage.test.css
@@ -828,7 +828,7 @@
   outline-style: dashed;
 }
 .outline-none {
-  outline-style: none;
+  outline: 2px solid transparent;
 }
 .outline-4 {
   outline-width: 4px;

--- a/tests/basic-usage.test.css
+++ b/tests/basic-usage.test.css
@@ -821,14 +821,15 @@
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
     var(--tw-shadow);
 }
+.outline-none {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
 .outline {
   outline-style: solid;
 }
 .outline-dashed {
   outline-style: dashed;
-}
-.outline-none {
-  outline: 2px solid transparent;
 }
 .outline-4 {
   outline-width: 4px;

--- a/tests/basic-usage.test.html
+++ b/tests/basic-usage.test.html
@@ -97,7 +97,7 @@
     <div class="bg-blend-darken bg-blend-difference"></div>
     <div class="mix-blend-multiply mix-blend-saturation"></div>
     <div class="order-last order-2"></div>
-    <div class="outline-none outline-black"></div>
+    <div class="outline outline-dashed outline-none outline-black outline-4 outline-offset-2"></div>
     <div class="overflow-hidden"></div>
     <div class="overscroll-contain"></div>
     <div class="p-4 py-2 px-3 pt-1 pr-2 pb-3 pl-4"></div>

--- a/tests/raw-content.test.css
+++ b/tests/raw-content.test.css
@@ -595,14 +595,6 @@
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
     var(--tw-shadow);
 }
-.outline-none {
-  outline: 2px solid transparent;
-  outline-offset: 2px;
-}
-.outline-black {
-  outline: 2px dotted black;
-  outline-offset: 2px;
-}
 .ring {
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width)
     var(--tw-ring-offset-color);

--- a/tests/raw-content.test.html
+++ b/tests/raw-content.test.html
@@ -93,7 +93,6 @@
     <div class="bg-blend-darken bg-blend-difference"></div>
     <div class="mix-blend-multiply mix-blend-saturation"></div>
     <div class="order-last order-2"></div>
-    <div class="outline-none outline-black"></div>
     <div class="overflow-hidden"></div>
     <div class="overscroll-contain"></div>
     <div class="scroll-smooth"></div>


### PR DESCRIPTION
This PR replaces the existing `outline` utilities with new `outline-style`, `outline-color`, `outline-width` and `outline-offset` utilities. This approach is more inline with how the existing ring and border utilities work.

## outline-style

The [outline-style](https://developer.mozilla.org/en-US/docs/Web/CSS/outline-style) utilities both enable (or disable) the outline styles, and also determine what type of outline should be drawn. Note that for now this only includes the same values as are available for border styles.

```html
<div class="outline">
  <!-- A black 3px outline will be added -->
</div>

<div class="outline-dotted">
  <!-- A dotted 3px outline will be added -->
</div>
```

The `outline` class here is a shorthand for `outline-solid`, since it's the most common style to use.

Note also that when you don't specify an outline width or color, you'll just get the browser defaults, which is a `black` outline that's `3px` wide.

| Class | CSS |
| --- | --- |
| `.outline` | `outline-style: solid` |
| `.outline-dashed` | `outline-style: dashed` |
| `.outline-dotted` | `outline-style: dotted` |
| `.outline-double` | `outline-style: double` |
| `.outline-hidden` | `outline-style: hidden` |
| `.outline-none` | `outline-style: none` |

## outline-color

The [outline-color](https://developer.mozilla.org/en-US/docs/Web/CSS/outline-color) utilities set the color for the outline. The color values are taken from the `outlineColor` key in the Tailwind config, which extends the default color palette by default.

The outline color utilities support both the alpha shorthand, such as `outline-red-600/50`, as well as arbitrary values, such as `outline-[#FF0000]`.

If an outline color is not set it falls back to the browser default, which is `black`.

```html
<div class="outline outline-red-600">
  <!-- A red 3px outline will be added -->
</div>
```

| Class | CSS |
| --- | --- |
| `.outline-inherit` | `outline-color: inherit` |
| `.outline-current` | `outline-color: currentColor` |
| `.outline-transparent` | `outline-color: transparent` |
| `.outline-black` | `outline-color: #000` |
| `.outline-white` | `outline-color: #fff` |
| `.outline-slate-100` | `outline-color: #f1f5f9` |
| `.outline-slate-200` | `outline-color: #e2e8f0` |
| `.outline-slate-300` | `outline-color: #cbd5e1` |


## outline-width

The [outline-width](https://developer.mozilla.org/en-US/docs/Web/CSS/outline-width) utilities set the width of the outline. The width values are taken from the `outlineWidth` key in the Tailwind config.

The outline width utilities also support arbitrary values, such as `outline-[10px]`.

If an outline width is not set it falls back to the browser default, which is `3px`.

```html
<div class="outline outline-8">
  <!-- A black 8px outline will be added -->
</div>
```

| Class | CSS |
| --- | --- |
| `.outline-0`| `outline-width: 0px` |
| `.outline-1`| `outline-width: 1px` |
| `.outline-2`| `outline-width: 2px` |
| `.outline-4`| `outline-width: 4px` |
| `.outline-8`| `outline-width: 8px` |

## outline-offset

The [outline-offset](https://developer.mozilla.org/en-US/docs/Web/CSS/outline-offset) utilities set the offset of the outline (the distance from the element). The offset values are taken from the `outlineOffset` key in the Tailwind config.

The outline offset utilities also support arbitrary values, such as `outline-offset-[10px]`.

```html
<div class="outline outline-offset-8">
  <!-- A black 3px outline that's offset 8px will be added -->
</div>
```

| Class | CSS |
| --- | --- |
| `.outline-offset-0`| `outline-offset: 0px` |
| `.outline-offset-1`| `outline-offset: 1px` |
| `.outline-offset-2`| `outline-offset: 2px` |
| `.outline-offset-4`| `outline-offset: 4px` |
| `.outline-offset-8`| `outline-offset: 8px` |

## Breaking changes

These new outline utilities replace the previous versions, which were based on the `outline` shorthand property. If you haven't customized these values or used any arbitrary values, no changes are required, as the default utilities (`outline-none`, `outline-white` and `outline-black`) all still exist in this update.

That said, please be aware that the `outline-white` and `outline-black` styles have changed slightly — they are no longer dotted (but now solid), and they are also no longer offset by `2px`.

```diff
  .outline-black {
+    outline-color: #000;
-    outline: 2px dotted black;
-    outline-offset: 2px;
  }

  .outline-white {
+    outline-color: #fff;
-    outline: 2px dotted white;
-    outline-offset: 2px;
  }
```