### PR TITLE
Allow the use of `@media print` without parens

### DIFF
--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -230,7 +230,7 @@ function buildPluginApi(tailwindConfig, context, { variantList, variantMap, offs
               return ({ format }) => format(str)
             }
 
-            let [, name, params] = /@(.*?) (\(.*\))/g.exec(str)
+            let [, name, params] = /@(.*?) (.*)/g.exec(str)
             return ({ wrap }) => wrap(postcss.atRule({ name, params }))
           })
           .reverse()

--- a/tests/variants.test.js
+++ b/tests/variants.test.js
@@ -239,6 +239,31 @@ it('should properly handle keyframes with multiple variants', async () => {
   `)
 })
 
+test('custom addVariant with more complex media query params', () => {
+  let config = {
+    content: [
+      {
+        raw: html` <div class="magic:text-center"></div> `,
+      },
+    ],
+    plugins: [
+      function ({ addVariant }) {
+        addVariant('magic', '@media screen and (max-wdith: 600px)')
+      },
+    ],
+  }
+
+  return run('@tailwind components;@tailwind utilities', config).then((result) => {
+    return expect(result.css).toMatchFormattedCss(css`
+      @media screen and (max-wdith: 600px) {
+        .magic\:text-center {
+          text-align: center;
+        }
+      }
+    `)
+  })
+})
+
 test('custom addVariant with nested media & format shorthand', () => {
   let config = {
     content: [
@@ -248,7 +273,7 @@ test('custom addVariant with nested media & format shorthand', () => {
     ],
     plugins: [
       function ({ addVariant }) {
-        addVariant('magic', '@supports (hover: hover) { @media (print) { &:disabled } }')
+        addVariant('magic', '@supports (hover: hover) { @media print { &:disabled } }')
       },
     ],
   }
@@ -256,7 +281,7 @@ test('custom addVariant with nested media & format shorthand', () => {
   return run('@tailwind components;@tailwind utilities', config).then((result) => {
     return expect(result.css).toMatchFormattedCss(css`
       @supports (hover: hover) {
-        @media (print) {
+        @media print {
           .magic\:text-center:disabled {
             text-align: center;
           }


### PR DESCRIPTION
This PR will allow you to write:

```js
addVariant('print', '@media print')
```
Instead of the incorrect:
```js
addVariant('print', '@media (print)')
```

Improves: #5885 