### PR TITLE
Add full color palette for fill/stroke

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -279,7 +279,7 @@ module.exports = {
       '2xl': '0 25px 25px rgb(0 0 0 / 0.15)',
       none: '0 0 #0000',
     },
-    fill: { current: 'currentColor' },
+    fill: ({ theme }) => theme('colors'),
     grayscale: {
       0: '0',
       DEFAULT: '100%',
@@ -788,9 +788,7 @@ module.exports = {
     space: ({ theme }) => ({
       ...theme('spacing'),
     }),
-    stroke: {
-      current: 'currentColor',
-    },
+    stroke: ({ theme }) => theme('colors'),
     strokeWidth: {
       0: '0',
       1: '1',


### PR DESCRIPTION
Historically we've only included `fill-current` and `stroke-current` due to file size considerations, and recommended combining them with text color utilities like this:

```html
<svg class="fill-current text-blue-500">
```

With the JIT engine, there's no real reason for this anymore, so this PR enables all colors by default, allowing you to write this out of the box instead:

```html
<svg class="fill-blue-500">
```

Giddy up.