### PR TITLE
Add `list-style-image` utilities

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -725,6 +725,10 @@ export let corePlugins = {
     ],
   ]),
 
+  listStyleImage: createUtilityPlugin('listStyleImage', [['list-image', ['list-style-image']]], {
+    type: ['image', 'url'],
+  }),
+
   listStylePosition: ({ addUtilities }) => {
     addUtilities({
       '.list-inside': { 'list-style-position': 'inside' },

--- a/tests/arbitrary-values.test.css
+++ b/tests/arbitrary-values.test.css
@@ -368,6 +368,9 @@
 .scroll-pt-\[var\(--scroll-padding\)\] {
   scroll-padding-top: var(--scroll-padding);
 }
+.list-image-\[url\(\'\/path-to-image\.png\'\)\] {
+  list-style-image: url('/path-to-image.png');
+}
 .list-\[\'\\1f44d\'\] {
   list-style-type: '\1F44D';
 }

--- a/tests/arbitrary-values.test.html
+++ b/tests/arbitrary-values.test.html
@@ -132,6 +132,8 @@
     <div class="list-['\1F44D']"></div>
     <div class="list-[var(--value)]"></div>
 
+    <div class="list-image-[url('/path-to-image.png')]"></div>
+
     <div class="columns-[20] columns-[var(--columns)]"></div>
 
     <div class="auto-cols-[minmax(10px,auto)]"></div>


### PR DESCRIPTION
This PR will add `list-image` utilities.

I couldn't get it to work under the keyword `list-` e.g. `list-[url('/path-to-image.png')]`.

If someone knows how to make it work:
`.list-['👉']` should generate `list-style-type: '👉'`
`.list-[url(...)]` should generate `list-style-image: url(...)`
please let me know or create new PR and close this one.