### PR TITLE
add test to prove `@supports` is kept in `@layer` rule

### DIFF
--- a/tests/layer-at-rules.test.js
+++ b/tests/layer-at-rules.test.js
@@ -299,3 +299,40 @@ test('layers are grouped and inserted at the matching @tailwind rule', () => {
     `)
   })
 })
+
+it('should keep `@supports` rules inside `@layer`s', () => {
+  let config = {
+    content: [{ raw: html`<div class="test"></div>` }],
+    plugins: [],
+  }
+
+  let input = css`
+    @tailwind utilities;
+
+    @layer utilities {
+      .test {
+        --tw-test: 1;
+      }
+
+      @supports (backdrop-filter: blur(1px)) {
+        .test {
+          --tw-test: 0.9;
+        }
+      }
+    }
+  `
+
+  return run(input, config).then((result) => {
+    return expect(result.css).toMatchFormattedCss(css`
+      .test {
+        --tw-test: 1;
+      }
+
+      @supports (backdrop-filter: blur(1px)) {
+        .test {
+          --tw-test: 0.9;
+        }
+      }
+    `)
+  })
+})


### PR DESCRIPTION
This PR adds a test to prove that #5938 works or fails. Turns out that it works, but I think it's still useful to have a test for this to prevent regressions in future version.

Keeping this open a bit longer until the issue creator responds to the issue.

This PR has no impact on v3 alpha releases.


Closes: #5938