### PR TITLE
Add `text-emphasis-*` utilities

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1646,6 +1646,38 @@ export let corePlugins = {
     )
   },
 
+  textEmphasis: ({ addUtilities }) => {
+    addUtilities({
+      '.emphasis-filled': { 'text-emphasis': 'filled' },
+      '.emphasis-open': { 'text-emphasis': 'open' },
+      '.emphasis-dot': { 'text-emphasis': 'dot' },
+      '.emphasis-circle': { 'text-emphasis': 'circle' },
+      '.emphasis-double-circle': { 'text-emphasis': 'double-circle' },
+      '.emphasis-triangle': { 'text-emphasis': 'triangle' },
+      '.emphasis-sesame': { 'text-emphasis': 'sesame' },
+    })
+  },
+
+  textEmphasisColor: ({ matchUtilities, theme }) => {
+    matchUtilities(
+      {
+        emphasis: (value) => {
+          return { 'text-emphasis-color': toColorValue(value) }
+        },
+      },
+      { values: flattenColorPalette(theme('textEmphasisColor')), type: ['color', 'any'] }
+    )
+  },
+
+  textEmphasisPosition: ({ addUtilities }) => {
+    addUtilities({
+      '.emphasis-over': { 'text-emphasis-position': 'over' },
+      '.emphasis-under': { 'text-emphasis-position': 'under' },
+      '.emphasis-right': { 'text-emphasis-position': 'right' },
+      '.emphasis-left': { 'text-emphasis-position': 'left' },
+    })
+  },
+
   fontSmoothing: ({ addUtilities }) => {
     addUtilities({
       '.antialiased': {

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -797,6 +797,7 @@ module.exports = {
     },
     textColor: ({ theme }) => theme('colors'),
     textDecorationColor: ({ theme }) => theme('colors'),
+    textEmphasisColor: ({ theme }) => theme('colors'),
     textIndent: ({ theme }) => ({
       ...theme('spacing'),
     }),

--- a/tests/arbitrary-values.test.css
+++ b/tests/arbitrary-values.test.css
@@ -825,6 +825,24 @@
 .decoration-\[var\(--color\)\] {
   text-decoration-color: var(--color);
 }
+.emphasis-\[black\] {
+  text-emphasis-color: black;
+}
+.emphasis-\[rgb\(123\2c 123\2c 123\)\] {
+  text-emphasis-color: rgb(123, 123, 123);
+}
+.emphasis-\[rgb\(123\2c _123\2c _123\)\] {
+  text-emphasis-color: rgb(123, 123, 123);
+}
+.emphasis-\[rgb\(123_123_123\)\] {
+  text-emphasis-color: rgb(123 123 123);
+}
+.emphasis-\[color\:var\(--color\)\] {
+  text-emphasis-color: var(--color);
+}
+.emphasis-\[var\(--color\)\] {
+  text-emphasis-color: var(--color);
+}
 .placeholder-\[var\(--placeholder\)\]::placeholder {
   color: var(--placeholder);
 }

--- a/tests/arbitrary-values.test.html
+++ b/tests/arbitrary-values.test.html
@@ -305,6 +305,13 @@
     <div class="decoration-[color:var(--color)]"></div>
     <div class="decoration-[var(--color)]"></div>
 
+    <div class="emphasis-[black]"></div>
+    <div class="emphasis-[rgb(123,123,123)]"></div>
+    <div class="emphasis-[rgb(123,_123,_123)]"></div>
+    <div class="emphasis-[rgb(123_123_123)]"></div>
+    <div class="emphasis-[color:var(--color)]"></div>
+    <div class="emphasis-[var(--color)]"></div>
+
     <div class="placeholder-[var(--placeholder)]"></div>
 
     <div class="placeholder-opacity-[var(--placeholder-opacity)]"></div>

--- a/tests/basic-usage.test.css
+++ b/tests/basic-usage.test.css
@@ -776,6 +776,15 @@
 .decoration-red-600 {
   text-decoration-color: #dc2626;
 }
+.emphasis-filled {
+  text-emphasis: filled;
+}
+.emphasis-red-600 {
+  text-emphasis-color: #dc2626;
+}
+.emphasis-over {
+  text-emphasis-position: over;
+}
 .antialiased {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/tests/basic-usage.test.html
+++ b/tests/basic-usage.test.html
@@ -161,6 +161,9 @@
     <div class="text-opacity-10"></div>
     <div class="underline"></div>
     <div class="decoration-red-600"></div>
+    <div class="emphasis-filled"></div>
+    <div class="emphasis-red-600"></div>
+    <div class="emphasis-over"></div>
     <div class="overflow-ellipsis truncate"></div>
     <div class="uppercase"></div>
     <div class="transform transform-gpu transform-none"></div>


### PR DESCRIPTION
Adds utilities for:

- [`text-emphasis-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-style)
- [`text-emphasis-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-color)
- [`text-emphasis-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-position)

The property for `text-emphasis-style` is `text-emphasis` to be consistent with [`text-decoration`](https://tailwindcss.com/docs/text-decoration).