### PR TITLE
Prevent failing at virtual files

### DIFF
--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -470,7 +470,9 @@ function trackModified(files, fileModifiedMap) {
     let parsed = url.parse(file)
     let pathname = parsed.hash ? parsed.href.replace(parsed.hash, '') : parsed.href
     pathname = parsed.search ? pathname.replace(parsed.search, '') : pathname
-    let newModified = fs.statSync(decodeURIComponent(pathname)).mtimeMs
+    let { mtimeMs: newModified } = fs.statSync(decodeURIComponent(pathname), {
+      throwIfNoEntry: false,
+    }) || { mtimeMs: Date.now() }
 
     if (!fileModifiedMap.has(file) || newModified > fileModifiedMap.get(file)) {
       changed = true


### PR DESCRIPTION
Vite can serve virtual css files and those files are processed through postcss. If those files includes some "at rules" that Tailwind can parse Tailwind will throw error while trying to find them on filesystem.