### PR TITLE
Improve nesting detection

### DIFF
--- a/src/lib/detectNesting.js
+++ b/src/lib/detectNesting.js
@@ -2,6 +2,23 @@ export default function (_context) {
   return (root, result) => {
     let found = false
 
+    root.walkAtRules('tailwind', (node) => {
+      if (found) return false
+
+      if (node.parent && node.parent.type !== 'root') {
+        found = true
+        node.warn(
+          result,
+          [
+            'Nested @tailwind rules were detected, but are not supported.',
+            "Consider using a prefix to scope Tailwind's classes: https://tailwindcss.com/docs/configuration#prefix",
+            'Alternatively, use the important selector strategy: https://tailwindcss.com/docs/configuration#selector-strategy',
+          ].join('\n')
+        )
+        return false
+      }
+    })
+
     root.walkRules((rule) => {
       if (found) return false
 
@@ -9,10 +26,12 @@ export default function (_context) {
         found = true
         nestedRule.warn(
           result,
-          // TODO: Improve this warning message
-          'Nested CSS detected, checkout the docs on how to support nesting: https://tailwindcss.com/docs/using-with-preprocessors#nesting'
+          [
+            'Nested CSS was detected, but CSS nesting has not been configured correctly.',
+            'Please enable a CSS nesting plugin *before* Tailwind in your configuration.',
+            'See how here: https://tailwindcss.com/docs/using-with-preprocessors#nesting',
+          ].join('\n')
         )
-
         return false
       })
     })

--- a/tests/detect-nesting.test.js
+++ b/tests/detect-nesting.test.js
@@ -19,7 +19,37 @@ it('should warn when we detect nested css', () => {
     expect(result.messages).toMatchObject([
       {
         type: 'warning',
-        text: 'Nested CSS detected, checkout the docs on how to support nesting: https://tailwindcss.com/docs/using-with-preprocessors#nesting',
+        text: [
+          'Nested CSS was detected, but CSS nesting has not been configured correctly.',
+          'Please enable a CSS nesting plugin *before* Tailwind in your configuration.',
+          'See how here: https://tailwindcss.com/docs/using-with-preprocessors#nesting',
+        ].join('\n'),
+      },
+    ])
+  })
+})
+
+it('should warn when we detect namespaced @tailwind at rules', () => {
+  let config = {
+    content: [{ raw: html`<div class="text-center"></div>` }],
+  }
+
+  let input = css`
+    .namespace {
+      @tailwind utilities;
+    }
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.messages).toHaveLength(1)
+    expect(result.messages).toMatchObject([
+      {
+        type: 'warning',
+        text: [
+          'Nested @tailwind rules were detected, but are not supported.',
+          "Consider using a prefix to scope Tailwind's classes: https://tailwindcss.com/docs/configuration#prefix",
+          'Alternatively, use the important selector strategy: https://tailwindcss.com/docs/configuration#selector-strategy',
+        ].join('\n'),
       },
     ])
   })


### PR DESCRIPTION
This PR improves the nesting detection.

Currently we only detected rules inside of rules, and if we did then we would trigger a PostCSS warning.

However, some people try to do something like this:
```css
.namespace {
  @tailwind base;
  @tailwind components;
  @tailwind utilities;
}
```

While in theory this could work~ish, this is not something we support. The biggest reason is that `base` styles (and thus also the preflight/reset) would end up looking like this: `.namespace html {}` for example which doesn't make much sense.

This PR also detects `@tailwind` at rules, with a parent that is not of type `root` and shows a similar message:
> Nested @tailwind rules detected, instead try to use a prefix: https://tailwindcss.com/docs/configuration#prefix or scope it using the important selector strategy https://tailwindcss.com/docs/configuration#selector-strategy

(@reinink can you double check the wording used in the message? Or do we keep it as is and improve all warning messages before v3 launch?)