### PR TITLE
Make `version` number dynamic in integration tests

### DIFF
--- a/integrations/tailwindcss-cli/tests/cli.test.js
+++ b/integrations/tailwindcss-cli/tests/cli.test.js
@@ -3,12 +3,28 @@ let $ = require('../../execute')
 let { css, html, javascript } = require('../../syntax')
 let resolveToolRoot = require('../../resolve-tool-root')
 
+let version = require('../../../package.json').version
+
 let { readOutputFile, writeInputFile, cleanupFile, fileExists, removeFile } = require('../../io')({
   output: 'dist',
   input: 'src',
 })
 
 let EXECUTABLE = 'node ../../lib/cli.js'
+
+function dedent(input) {
+  let lines = input.split('\n')
+
+  let minIndent = lines.reduce(
+    (min, line) => Math.min(min, line.trim() === '' ? Infinity : line.match(/^\s*/)[0].length),
+    Infinity
+  )
+
+  return lines
+    .map((line) => line.slice(minIndent))
+    .join('\n')
+    .trim()
+}
 
 describe('Build command', () => {
   test('--output', async () => {
@@ -264,26 +280,25 @@ describe('Build command', () => {
   test('--help', async () => {
     let { combined } = await $(`${EXECUTABLE} --help`)
 
-    expect(combined).toMatchInlineSnapshot(`
-      "
-      tailwindcss v3.0.0-alpha.1
+    expect(dedent(combined)).toEqual(
+      dedent(`
+        tailwindcss v${version}
 
-      Usage:
-         tailwindcss build [options]
+        Usage:
+           tailwindcss build [options]
 
-      Options:
-         -i, --input              Input file
-         -o, --output             Output file
-         -w, --watch              Watch for changes and rebuild as needed
-             --content            Content paths to use for removing unused classes
-             --postcss            Load custom PostCSS configuration
-         -m, --minify             Minify the output
-         -c, --config             Path to a custom config file
-             --no-autoprefixer    Disable autoprefixer
-         -h, --help               Display usage information
-
-      "
-    `)
+        Options:
+           -i, --input              Input file
+           -o, --output             Output file
+           -w, --watch              Watch for changes and rebuild as needed
+               --content            Content paths to use for removing unused classes
+               --postcss            Load custom PostCSS configuration
+           -m, --minify             Minify the output
+           -c, --config             Path to a custom config file
+               --no-autoprefixer    Disable autoprefixer
+           -h, --help               Display usage information
+      `)
+    )
   })
 })
 
@@ -325,19 +340,18 @@ describe('Init command', () => {
   test('--help', async () => {
     let { combined } = await $(`${EXECUTABLE} init --help`)
 
-    expect(combined).toMatchInlineSnapshot(`
-      "
-      tailwindcss v3.0.0-alpha.1
+    expect(dedent(combined)).toEqual(
+      dedent(`
+        tailwindcss v${version}
 
-      Usage:
-         tailwindcss init [options]
+        Usage:
+           tailwindcss init [options]
 
-      Options:
-         -f, --full               Initialize a full \`tailwind.config.js\` file
-         -p, --postcss            Initialize a \`postcss.config.js\` file
-         -h, --help               Display usage information
-
-      "
-    `)
+        Options:
+           -f, --full               Initialize a full \`tailwind.config.js\` file
+           -p, --postcss            Initialize a \`postcss.config.js\` file
+           -h, --help               Display usage information
+      `)
+    )
   })
 })


### PR DESCRIPTION
Every time we release a new version, the integration tests start failing. This
is because we have a CLI test where we look at the output of the `tailwindcss --help` output.

This output contains a version number, that will be out of date when we release a new version.

This PR fixes that by making the version dynamic based on the `package.json`
version value. This should be safe to do because the goal of the tests is
ensuring that the CLI help output is consistent, not so much the version
number. BUT it is still important that the version is in sync. This will ensure
it is always in sync.
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
