### PR TITLE
Add variants for `orientation` media feature

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -165,8 +165,8 @@ export let variantPlugins = {
   },
 
   orientationVariants: ({ addVariant }) => {
-    addVariant('orientation-portrait', '@media (orientation: portrait)')
-    addVariant('orientation-landscape', '@media (orientation: landscape)')
+    addVariant('portrait', '@media (orientation: portrait)')
+    addVariant('landscape', '@media (orientation: landscape)')
   },
 }
 

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -163,6 +163,11 @@ export let variantPlugins = {
       addVariant(screen, `@media ${query}`)
     }
   },
+
+  orientationVariants: ({ addVariant }) => {
+    addVariant('orientation-portrait', '@media (orientation: portrait)')
+    addVariant('orientation-landscape', '@media (orientation: landscape)')
+  },
 }
 
 export let corePlugins = {

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -575,6 +575,7 @@ function resolvePlugins(context, root) {
     variantPlugins['darkVariants'],
     variantPlugins['printVariant'],
     variantPlugins['screenVariants'],
+    variantPlugins['orientationVariants'],
   ]
 
   return [...corePluginList, ...beforeVariants, ...userPlugins, ...afterVariants, ...layerPlugins]

--- a/tests/kitchen-sink.test.css
+++ b/tests/kitchen-sink.test.css
@@ -509,11 +509,6 @@ div {
     }
   }
 }
-@media (orientation: portrait) {
-  .portrait\:text-center {
-    text-align: center;
-  }
-}
 @media (min-width: 1280px) and (max-width: 1535px) {
   .range\:text-right {
     text-align: right;

--- a/tests/kitchen-sink.test.html
+++ b/tests/kitchen-sink.test.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="./tailwind.css" />
   </head>
   <body>
-    <div class="portrait:text-center range:text-right multi:text-left"></div>
+    <div class="range:text-right multi:text-left"></div>
     <div
       class="container hover:container sm:container md:container text-center sm:text-center md:text-center"
     ></div>

--- a/tests/kitchen-sink.test.js
+++ b/tests/kitchen-sink.test.js
@@ -11,7 +11,6 @@ test('it works', () => {
     theme: {
       extend: {
         screens: {
-          portrait: { raw: '(orientation: portrait)' },
           range: { min: '1280px', max: '1535px' },
           multi: [{ min: '640px', max: '767px' }, { max: '868px' }],
         },

--- a/tests/variants.test.css
+++ b/tests/variants.test.css
@@ -899,3 +899,15 @@
     }
   }
 }
+@media (orientation: portrait) {
+  .orientation-portrait\:bg-yellow-300 {
+    --tw-bg-opacity: 1;
+    background-color: rgb(253 224 71 / var(--tw-bg-opacity));
+  }
+}
+@media (orientation: landscape) {
+  .orientation-landscape\:bg-yellow-300 {
+    --tw-bg-opacity: 1;
+    background-color: rgb(253 224 71 / var(--tw-bg-opacity));
+  }
+}

--- a/tests/variants.test.css
+++ b/tests/variants.test.css
@@ -900,13 +900,13 @@
   }
 }
 @media (orientation: portrait) {
-  .orientation-portrait\:bg-yellow-300 {
+  .portrait\:bg-yellow-300 {
     --tw-bg-opacity: 1;
     background-color: rgb(253 224 71 / var(--tw-bg-opacity));
   }
 }
 @media (orientation: landscape) {
-  .orientation-landscape\:bg-yellow-300 {
+  .landscape\:bg-yellow-300 {
     --tw-bg-opacity: 1;
     background-color: rgb(253 224 71 / var(--tw-bg-opacity));
   }

--- a/tests/variants.test.html
+++ b/tests/variants.test.html
@@ -135,8 +135,8 @@
     <div class="hover:animate-spin"></div>
 
     <!-- Orientation variants -->
-    <div class="orientation-portrait:bg-yellow-300"></div>
-    <div class="orientation-landscape:bg-yellow-300"></div>
+    <div class="portrait:bg-yellow-300"></div>
+    <div class="landscape:bg-yellow-300"></div>
 
     <!-- Stacked variants -->
     <div class="open:hover:bg-red-200"></div>

--- a/tests/variants.test.html
+++ b/tests/variants.test.html
@@ -134,6 +134,10 @@
     <div class="lg:animate-spin"></div>
     <div class="hover:animate-spin"></div>
 
+    <!-- Orientation variants -->
+    <div class="orientation-portrait:bg-yellow-300"></div>
+    <div class="orientation-landscape:bg-yellow-300"></div>
+
     <!-- Stacked variants -->
     <div class="open:hover:bg-red-200"></div>
     <div class="file:hover:bg-blue-600"></div>


### PR DESCRIPTION
This PR adds variants for the [orientation media feature](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/orientation)

`orientation-portrait:` for targeting portrait orientation.

`orientation-landscape:` for targeting landscape orientation.