### PR TITLE
Add `prefers-contrast` media query variants

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -170,6 +170,11 @@ export let variantPlugins = {
     addVariant('portrait', '@media (orientation: portrait)')
     addVariant('landscape', '@media (orientation: landscape)')
   },
+
+  prefersContrastVariants: ({ addVariant }) => {
+    addVariant('contrast-more', '@media (prefers-contrast: more)')
+    addVariant('contrast-less', '@media (prefers-contrast: less)')
+  },
 }
 
 export let corePlugins = {

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -519,6 +519,7 @@ function resolvePlugins(context, root) {
     variantPlugins['printVariant'],
     variantPlugins['screenVariants'],
     variantPlugins['orientationVariants'],
+    variantPlugins['prefersContrastVariants'],
   ]
 
   return [...corePluginList, ...beforeVariants, ...userPlugins, ...afterVariants, ...layerPlugins]

--- a/tests/variants.test.css
+++ b/tests/variants.test.css
@@ -918,3 +918,15 @@
     background-color: rgb(253 224 71 / var(--tw-bg-opacity));
   }
 }
+@media (prefers-contrast: more) {
+  .contrast-more\:bg-yellow-300 {
+    --tw-bg-opacity: 1;
+    background-color: rgb(253 224 71 / var(--tw-bg-opacity));
+  }
+}
+@media (prefers-contrast: less) {
+  .contrast-less\:bg-yellow-300 {
+    --tw-bg-opacity: 1;
+    background-color: rgb(253 224 71 / var(--tw-bg-opacity));
+  }
+}

--- a/tests/variants.test.html
+++ b/tests/variants.test.html
@@ -139,6 +139,10 @@
     <div class="portrait:bg-yellow-300"></div>
     <div class="landscape:bg-yellow-300"></div>
 
+    <!-- Prefers contrast variants -->
+    <div class="contrast-more:bg-yellow-300"></div>
+    <div class="contrast-less:bg-yellow-300"></div>
+
     <!-- Stacked variants -->
     <div class="open:hover:bg-red-200"></div>
     <div class="file:hover:bg-blue-600"></div>


### PR DESCRIPTION
Add variants for the [`prefers-contrast`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-contrast) media query.

Adds `contrast-more:` and `contrast-less:` variants.
