### PR TITLE
Add `placeholder` variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Nothing yet!
 
 - Enforce the order of some variants (like `before` and `after`) ([#6018](https://github.com/tailwindlabs/tailwindcss/pull/6018))
 
+### Added
+
+- Add `placeholder` variant ([#6106](https://github.com/tailwindlabs/tailwindcss/pull/6106))
+
 ## [3.0.0-alpha.2] - 2021-11-08
 
 ### Changed

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -23,6 +23,8 @@ export let variantPlugins = {
 
     addVariant('file', '&::file-selector-button')
 
+    addVariant('placeholder', '&::placeholder')
+
     addVariant('before', ({ container }) => {
       container.walkRules((rule) => {
         let foundContent = false

--- a/tests/variants.test.css
+++ b/tests/variants.test.css
@@ -165,6 +165,13 @@
   --tw-text-opacity: 1;
   color: rgb(255 255 255 / var(--tw-text-opacity));
 }
+.placeholder\:font-bold::placeholder {
+  font-weight: 700;
+}
+.placeholder\:text-red-500::placeholder {
+  --tw-text-opacity: 1;
+  color: rgb(239 68 68 / var(--tw-text-opacity));
+}
 .before\:block::before {
   content: var(--tw-content);
   display: block;

--- a/tests/variants.test.html
+++ b/tests/variants.test.html
@@ -49,6 +49,7 @@
     <div class="file:bg-blue-500 file:text-white"></div>
     <div class="before:block before:bg-red-500"></div>
     <div class="after:flex after:uppercase"></div>
+    <div class="placeholder:font-bold placeholder:text-red-500"></div>
 
     <!-- Group variants -->
     <div class="group-open:bg-red-200"></div>


### PR DESCRIPTION
This PR adds `placeholder` as a variant.

This could replace the `placeholder-red-500` (color) and opacity plugins.
But for now, this also allows us to apply more styles directly to the `::placeholder` pseudo element.
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
