### PR TITLE
Add `::file-selector-button` reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `placeholder` variant ([#6106](https://github.com/tailwindlabs/tailwindcss/pull/6106))
 - Add tuple syntax for configuring screens while guaranteeing order ([#5956](https://github.com/tailwindlabs/tailwindcss/pull/5956))
 - Add combinable `touch-action` support ([#6115](https://github.com/tailwindlabs/tailwindcss/pull/6115))
+- Add `::file-selector-button` reset ([#6125](https://github.com/tailwindlabs/tailwindcss/pull/6125))
 
 ## [3.0.0-alpha.2] - 2021-11-08
 

--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -17,6 +17,10 @@
   --tw-content: '';
 }
 
+::file-selector-button {
+  border-style: solid; /* 2 */
+}
+
 /*
 1. Use a consistent sensible line-height in all browsers.
 2. Prevent adjustments of font size after orientation changes in iOS.


### PR DESCRIPTION
Otherwise you have to apply `file:border-solid` which you don't have to
do for other elements with borders.

See: https://play.tailwindcss.com/EvtdftCPt6

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
