### PR TITLE
Add support for arbitrary properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `placeholder` variant ([#6106](https://github.com/tailwindlabs/tailwindcss/pull/6106))
 - Add tuple syntax for configuring screens while guaranteeing order ([#5956](https://github.com/tailwindlabs/tailwindcss/pull/5956))
 - Add combinable `touch-action` support ([#6115](https://github.com/tailwindlabs/tailwindcss/pull/6115))
+- Add support for "arbitrary properties" ([#6161](https://github.com/tailwindlabs/tailwindcss/pull/6161))
 
 ## [3.0.0-alpha.2] - 2021-11-08
 

--- a/src/lib/expandTailwindAtRules.js
+++ b/src/lib/expandTailwindAtRules.js
@@ -15,6 +15,8 @@ const PATTERNS = [
   /([^<>"'`\s]*\[\w*\("[^'`\s]*"\)\])/.source, // bg-[url("..."),url("...")]
   /([^<>"'`\s]*\['[^"'`\s]*'\])/.source, // `content-['hello']` but not `content-['hello']']`
   /([^<>"'`\s]*\["[^"'`\s]*"\])/.source, // `content-["hello"]` but not `content-["hello"]"]`
+  /([^<>"'`\s]*\[[^<>"'`\s]*:'[^"'`\s]*'\])/.source, // `[content:'hello']` but not `[content:"hello"]`
+  /([^<>"'`\s]*\[[^<>"'`\s]*:"[^"'`\s]*"\])/.source, // `[content:"hello"]` but not `[content:'hello']`
   /([^<>"'`\s]*\[[^"'`\s]+\][^<>"'`\s]*)/.source, // `fill-[#bada55]`, `fill-[#bada55]/50`
   /([^<>"'`\s]*[^"'`\s:])/.source, //  `px-1.5`, `uppercase` but not `uppercase:`
 ].join('|')

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -6,7 +6,7 @@ import prefixSelector from '../util/prefixSelector'
 import { updateAllClasses } from '../util/pluginUtils'
 import log from '../util/log'
 import { formatVariantSelector, finalizeSelector } from '../util/formatVariantSelector'
-import nameClass from '../util/nameClass'
+import { asClass } from '../util/nameClass'
 import { normalize } from '../util/dataTypes'
 
 let classNameParser = selectorParser((selectors) => {
@@ -258,16 +258,13 @@ function resolveArbitraryProperty(classCandidate, context) {
 
   return [
     [
-      [
-        { sort: context.arbitraryPropertiesSort, layer: 'utilities' },
-        () => ({
-          [nameClass(classCandidate, 'DEFAULT')]: {
-            [property]: normalize(value),
-          },
-        }),
-      ],
+      { sort: context.arbitraryPropertiesSort, layer: 'utilities' },
+      () => ({
+        [asClass(classCandidate)]: {
+          [property]: normalize(value),
+        },
+      }),
     ],
-    'DEFAULT',
   ]
 }
 
@@ -277,7 +274,7 @@ function* resolveMatchedPlugins(classCandidate, context) {
   }
 
   if (isArbitraryProperty(classCandidate)) {
-    yield resolveArbitraryProperty(classCandidate, context)
+    yield [resolveArbitraryProperty(classCandidate, context), 'DEFAULT']
   }
 
   let candidatePrefix = classCandidate

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -617,6 +617,10 @@ function registerPlugins(plugins, context) {
   ])
   let reservedBits = BigInt(highestOffset.toString(2).length)
 
+  // A number one less than the top range of the highest offset area
+  // so arbitrary properties are always sorted at the end.
+  context.arbitraryPropertiesSort = ((1n << reservedBits) << 0n) - 1n
+
   context.layerOrder = {
     base: (1n << reservedBits) << 0n,
     components: (1n << reservedBits) << 1n,

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -18,6 +18,7 @@ import { env } from './sharedState'
 import { toPath } from '../util/toPath'
 import log from '../util/log'
 import negateValue from '../util/negateValue'
+import isValidArbitraryValue from '../util/isValidArbitraryValue'
 
 function parseVariantFormatString(input) {
   if (input.includes('{')) {
@@ -128,64 +129,6 @@ function withIdentifiers(styles) {
       return [c, nodeMap.get(node)]
     })
   })
-}
-
-let matchingBrackets = new Map([
-  ['{', '}'],
-  ['[', ']'],
-  ['(', ')'],
-])
-let inverseMatchingBrackets = new Map(
-  Array.from(matchingBrackets.entries()).map(([k, v]) => [v, k])
-)
-
-let quotes = new Set(['"', "'", '`'])
-
-// Arbitrary values must contain balanced brackets (), [] and {}. Escaped
-// values don't count, and brackets inside quotes also don't count.
-//
-// E.g.: w-[this-is]w-[weird-and-invalid]
-// E.g.: w-[this-is\\]w-\\[weird-but-valid]
-// E.g.: content-['this-is-also-valid]-weirdly-enough']
-function isValidArbitraryValue(value) {
-  let stack = []
-  let inQuotes = false
-
-  for (let i = 0; i < value.length; i++) {
-    let char = value[i]
-
-    // Non-escaped quotes allow us to "allow" anything in between
-    if (quotes.has(char) && value[i - 1] !== '\\') {
-      inQuotes = !inQuotes
-    }
-
-    if (inQuotes) continue
-    if (value[i - 1] === '\\') continue // Escaped
-
-    if (matchingBrackets.has(char)) {
-      stack.push(char)
-    } else if (inverseMatchingBrackets.has(char)) {
-      let inverse = inverseMatchingBrackets.get(char)
-
-      // Nothing to pop from, therefore it is unbalanced
-      if (stack.length <= 0) {
-        return false
-      }
-
-      // Popped value must match the inverse value, otherwise it is unbalanced
-      if (stack.pop() !== inverse) {
-        return false
-      }
-    }
-  }
-
-  // If there is still something on the stack, it is also unbalanced
-  if (stack.length > 0) {
-    return false
-  }
-
-  // All good, totally balanced!
-  return true
 }
 
 function buildPluginApi(tailwindConfig, context, { variantList, variantMap, offsets, classList }) {

--- a/src/util/isValidArbitraryValue.js
+++ b/src/util/isValidArbitraryValue.js
@@ -1,0 +1,61 @@
+let matchingBrackets = new Map([
+  ['{', '}'],
+  ['[', ']'],
+  ['(', ')'],
+])
+let inverseMatchingBrackets = new Map(
+  Array.from(matchingBrackets.entries()).map(([k, v]) => [v, k])
+)
+
+let quotes = new Set(['"', "'", '`'])
+
+// Arbitrary values must contain balanced brackets (), [] and {}. Escaped
+// values don't count, and brackets inside quotes also don't count.
+//
+// E.g.: w-[this-is]w-[weird-and-invalid]
+// E.g.: w-[this-is\\]w-\\[weird-but-valid]
+// E.g.: content-['this-is-also-valid]-weirdly-enough']
+export default function isValidArbitraryValue(value) {
+  let stack = []
+  let inQuotes = false
+
+  for (let i = 0; i < value.length; i++) {
+    let char = value[i]
+
+    if (char === ':' && !inQuotes && stack.length === 0) {
+      return false
+    }
+
+    // Non-escaped quotes allow us to "allow" anything in between
+    if (quotes.has(char) && value[i - 1] !== '\\') {
+      inQuotes = !inQuotes
+    }
+
+    if (inQuotes) continue
+    if (value[i - 1] === '\\') continue // Escaped
+
+    if (matchingBrackets.has(char)) {
+      stack.push(char)
+    } else if (inverseMatchingBrackets.has(char)) {
+      let inverse = inverseMatchingBrackets.get(char)
+
+      // Nothing to pop from, therefore it is unbalanced
+      if (stack.length <= 0) {
+        return false
+      }
+
+      // Popped value must match the inverse value, otherwise it is unbalanced
+      if (stack.pop() !== inverse) {
+        return false
+      }
+    }
+  }
+
+  // If there is still something on the stack, it is also unbalanced
+  if (stack.length > 0) {
+    return false
+  }
+
+  // All good, totally balanced!
+  return true
+}

--- a/src/util/nameClass.js
+++ b/src/util/nameClass.js
@@ -1,7 +1,7 @@
 import escapeClassName from './escapeClassName'
 import escapeCommas from './escapeCommas'
 
-function asClass(name) {
+export function asClass(name) {
   return escapeCommas(`.${escapeClassName(name)}`)
 }
 

--- a/tests/arbitrary-properties.test.js
+++ b/tests/arbitrary-properties.test.js
@@ -165,7 +165,7 @@ test('colons are allowed in quotes', () => {
   let config = {
     content: [
       {
-        raw: html`<div class="[a:'b:c:d']"></div>`,
+        raw: html`<div class="[content:'foo:bar']"></div>`,
       },
     ],
     corePlugins: { preflight: false },
@@ -179,8 +179,8 @@ test('colons are allowed in quotes', () => {
 
   return run(input, config).then((result) => {
     expect(result.css).toMatchFormattedCss(css`
-      .\[a\'\:b\:c\:d\'\] {
-        a: 'b:c:d';
+      .\[content\:\'foo\:bar\'\] {
+        content: 'foo:bar';
       }
     `)
   })
@@ -190,7 +190,7 @@ test('colons are allowed in braces', () => {
   let config = {
     content: [
       {
-        raw: html`<div class="[a:(b:c:d)]"></div>`,
+        raw: html`<div class="[background-image:url(http://example.com/picture.jpg)]"></div>`,
       },
     ],
     corePlugins: { preflight: false },
@@ -204,8 +204,8 @@ test('colons are allowed in braces', () => {
 
   return run(input, config).then((result) => {
     expect(result.css).toMatchFormattedCss(css`
-      .\[a\(\:b\:c\:d\)\] {
-        a: (b: c: d);
+      .\[background-image\:url\(http\:\/\/example\.com\/picture\.jpg\)\] {
+        background-image: url(http://example.com/picture.jpg);
       }
     `)
   })

--- a/tests/arbitrary-properties.test.js
+++ b/tests/arbitrary-properties.test.js
@@ -1,0 +1,233 @@
+import { run, html, css } from './util/run'
+
+test('basic arbitrary properties', () => {
+  let config = {
+    content: [
+      {
+        raw: html`<div class="[paint-order:markers]"></div>`,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .\[paint-order\:markers\] {
+        paint-order: markers;
+      }
+    `)
+  })
+})
+
+test('arbitrary properties with modifiers', () => {
+  let config = {
+    content: [
+      {
+        raw: html`<div class="dark:lg:hover:[paint-order:markers]"></div>`,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      @media (prefers-color-scheme: dark) {
+        @media (min-width: 1024px) {
+          .\[paint-order\:markers\] {
+            paint-order: markers;
+          }
+        }
+      }
+    `)
+  })
+})
+
+test('arbitrary properties are sorted after utilities', () => {
+  let config = {
+    content: [
+      {
+        raw: html`<div class="content-none [paint-order:markers] hover:pointer-events-none"></div>`,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .content-none {
+        --tw-content: none;
+        content: var(--tw-content);
+      }
+      .\[paint-order\:markers\] {
+        paint-order: markers;
+      }
+      .hover\:pointer-events-none:hover {
+        pointer-events: none;
+      }
+    `)
+  })
+})
+
+test('using CSS variables', () => {
+  let config = {
+    content: [
+      {
+        raw: html`<div class="[--my-var:auto]"></div>`,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .\[--my-var\:auto\] {
+        --my-var: auto;
+      }
+    `)
+  })
+})
+
+test('using underscores as spaces', () => {
+  let config = {
+    content: [
+      {
+        raw: html`<div class="[--my-var:2px_4px]"></div>`,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .\[--my-var\:2px_4px\] {
+        --my-var: 2px 4px;
+      }
+    `)
+  })
+})
+
+test('using the important modifier', () => {
+  let config = {
+    content: [
+      {
+        raw: html`<div class="![--my-var:2px_4px]"></div>`,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .\!\[--my-var\:2px_4px\] {
+        --my-var: 2px 4px !important;
+      }
+    `)
+  })
+})
+
+test('colons are allowed in quotes', () => {
+  let config = {
+    content: [
+      {
+        raw: html`<div class="[a:'b:c:d']"></div>`,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .\[a\'\:b\:c\:d\'\] {
+        a: 'b:c:d';
+      }
+    `)
+  })
+})
+
+test('colons are allowed in braces', () => {
+  let config = {
+    content: [
+      {
+        raw: html`<div class="[a:(b:c:d)]"></div>`,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .\[a\(\:b\:c\:d\)\] {
+        a: (b: c: d);
+      }
+    `)
+  })
+})
+
+test('invalid class', () => {
+  let config = {
+    content: [
+      {
+        raw: html`<div class="[a:b:c:d]"></div>`,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css``)
+  })
+})


### PR DESCRIPTION
This PR adds support for using classes that define completely arbitrary CSS property/value pairs:

```html
<div class="[paint-order:markers]">
```

On its own this isn't that useful, since you could also just do this with inline styles. Where this becomes more powerful is when you combine it with modifiers like our responsive modifiers, or `hover`, `focus`, etc.

```html
<div class="[paint-order:markers] md:[paint-order:normal]">
```

Inline styles don't let you use pseudo-classes or media queries, but this feature does, making it sort of like a more powerful version of inline styles.

It lets people use CSS properties Tailwind doesn't include yet with all the power you get with Tailwind's built-in utilities, which makes the user experience a lot less frustrating when you need something obscure or new that we haven't added yet.

Works with CSS variables too which is pretty cool:

```html
<div class="[--my-var:2rem] lg:[--my-var:4rem]">
```

Like other arbitrary stuff, you use `_` to represent spaces where necessary:

```html
<div class="[margin:2px_4px_5px_1px]">
```
