### PR TITLE
Remove `menu` element styles

### DIFF
--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -258,16 +258,6 @@ summary {
   display: list-item;
 }
 
-/* 
-Removes the default spacing and list style for `main` element.
-*/
-
-main {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-}
-
 /*
 Removes the default spacing and border for appropriate elements.
 */
@@ -298,7 +288,8 @@ legend {
 }
 
 ol,
-ul {
+ul,
+menu {
   list-style: none;
   margin: 0;
   padding: 0;

--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -258,6 +258,16 @@ summary {
   display: list-item;
 }
 
+/* 
+Removes the default spacing and list style for `main` element.
+*/
+
+main {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
 /*
 Removes the default spacing and border for appropriate elements.
 */


### PR DESCRIPTION
Removed the default spacing and set `list-style-type` to `none` for the `menu` element.

To fix issue: #6191 

P.S. - This is my first pull request so please forgive any mistakes.