### PR TITLE
Remove `aspect-attrs` utility

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -115,7 +115,6 @@ module.exports = {
       auto: 'auto',
       square: '1 / 1',
       video: '16 / 9',
-      attrs: 'attr(width) / attr(height)'
     },
     backdropBlur: ({ theme }) => theme('blur'),
     backdropBrightness: ({ theme }) => theme('brightness'),


### PR DESCRIPTION
This PR removes the `aspect-attrs` utility added in #6178, as it unfortunately does not work due to lack of browser support.