### PR TITLE
Add `0` as an arbitrary value for utilities (jit)

### DIFF
--- a/src/util/dataTypes.js
+++ b/src/util/dataTypes.js
@@ -80,7 +80,8 @@ let lengthUnitsPattern = `(?:${lengthUnits.join('|')})`
 export function length(value) {
   return (
     new RegExp(`${lengthUnitsPattern}$`).test(value) ||
-    new RegExp(`^calc\\(.+?${lengthUnitsPattern}`).test(value)
+    new RegExp(`^calc\\(.+?${lengthUnitsPattern}`).test(value) ||
+    value === 0
   )
 }
 


### PR DESCRIPTION
Tried adding`0` as an arbitrary value for utilities.

I just added `value === 0` to the `length` function as I think it might not require a regular expression for just `0`.

I am not sure if this will solve the issue, because I am not sure how to test it for jit, can someone help me to test it out.

For issue: #6227 