### PR TITLE
Improve `[0]` arbitrary value support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `portrait` and `landscape` variants ([#6046](https://github.com/tailwindlabs/tailwindcss/pull/6046))
 - Add `text-decoration-style`, `text-decoration-thickness`, and `text-underline-offset` utilities ([#6004](https://github.com/tailwindlabs/tailwindcss/pull/6004))
 - Add `menu` reset to preflight ([#6213](https://github.com/tailwindlabs/tailwindcss/pull/6213))
-- Allow `0` as a valid `length` value ([#6233](https://github.com/tailwindlabs/tailwindcss/pull/6233))
+- Allow `0` as a valid `length` value ([#6233](https://github.com/tailwindlabs/tailwindcss/pull/6233), [#6259](https://github.com/tailwindlabs/tailwindcss/pull/6259))
 - Add css functions to data types ([#6258](https://github.com/tailwindlabs/tailwindcss/pull/6258))
 
 ### Changed

--- a/src/util/dataTypes.js
+++ b/src/util/dataTypes.js
@@ -81,7 +81,7 @@ let lengthUnits = [
 let lengthUnitsPattern = `(?:${lengthUnits.join('|')})`
 export function length(value) {
   return (
-    value === 0 ||
+    value === '0' ||
     new RegExp(`${lengthUnitsPattern}$`).test(value) ||
     cssFunctions.some((fn) => new RegExp(`^${fn}\\(.+?${lengthUnitsPattern}`).test(value))
   )

--- a/tests/arbitrary-values.test.css
+++ b/tests/arbitrary-values.test.css
@@ -764,6 +764,9 @@
 .font-\[\'Some_Font\'\2c var\(--other-font\)\] {
   font-family: 'Some Font', var(--other-font);
 }
+.text-\[0\] {
+  font-size: 0;
+}
 .text-\[2\.23rem\] {
   font-size: 2.23rem;
 }

--- a/tests/arbitrary-values.test.html
+++ b/tests/arbitrary-values.test.html
@@ -278,6 +278,7 @@
     <div class="font-[var(--font1),var(--font2)]"></div>
     <div class="font-[invalid_font_because_spaces]"></div>
 
+    <div class="text-[0]"></div>
     <div class="text-[2.23rem]"></div>
     <div class="text-[length:var(--font-size)]"></div>
     <div class="text-[angle:var(--angle)]"></div>


### PR DESCRIPTION
This PR improves the `0` as arbitrary value. The test I wrote was using `w-[0]`, but since the width plugins doesn't have any ambiguity with other plugins, the data type is set to `any`. This means that `w-[0]` already worked.

This PR then improves upon that where we actually check `text-[0]` which does have ambiguity and therefore the data type is important.
This also fixes an issue, because the value is `'0'` instead of `0`.
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
