### PR TITLE
Remove the file extension period in getTransformer and getExtractor (closes #6266)

### DIFF
--- a/src/lib/expandTailwindAtRules.js
+++ b/src/lib/expandTailwindAtRules.js
@@ -39,6 +39,7 @@ const builtInTransformers = {
 
 function getExtractor(tailwindConfig, fileExtension) {
   let extractors = tailwindConfig.content.extract
+  fileExtension = fileExtension.replace(/\./g, '')
 
   return (
     extractors[fileExtension] ||
@@ -50,6 +51,7 @@ function getExtractor(tailwindConfig, fileExtension) {
 
 function getTransformer(tailwindConfig, fileExtension) {
   let transformers = tailwindConfig.content.transform
+  fileExtension = fileExtension.replace(/\./g, '')
 
   return (
     transformers[fileExtension] ||


### PR DESCRIPTION
Please refer to the #6266 issue for more details.

If this correction is merged, it would probably make sense to backport to the v2 branch:

https://github.com/tailwindlabs/tailwindcss/blob/v2/src/jit/lib/expandTailwindAtRules.js#L59-L75