### PR TITLE
Ensure that we test every value for the `length` datatype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add CSS functions to data types ([#6258](https://github.com/tailwindlabs/tailwindcss/pull/6258))
 - Add CSS functions to data types ([#6258](https://github.com/tailwindlabs/tailwindcss/pull/6258))
 - Support negative values for `scale-*` utilities ([c48e629](https://github.com/tailwindlabs/tailwindcss/commit/c48e629955585ad18dadba9f470fda59cc448ab7))
+- Improve `length` data type, by validating each value individually ([#6283](https://github.com/tailwindlabs/tailwindcss/pull/6283))
 
 ### Changed
 

--- a/src/util/dataTypes.js
+++ b/src/util/dataTypes.js
@@ -80,11 +80,13 @@ let lengthUnits = [
 ]
 let lengthUnitsPattern = `(?:${lengthUnits.join('|')})`
 export function length(value) {
-  return (
-    value === '0' ||
-    new RegExp(`${lengthUnitsPattern}$`).test(value) ||
-    cssFunctions.some((fn) => new RegExp(`^${fn}\\(.+?${lengthUnitsPattern}`).test(value))
-  )
+  return value.split(UNDERSCORE).every((part) => {
+    return (
+      part === '0' ||
+      new RegExp(`${lengthUnitsPattern}$`).test(part) ||
+      cssFunctions.some((fn) => new RegExp(`^${fn}\\(.+?${lengthUnitsPattern}`).test(part))
+    )
+  })
 }
 
 let lineWidths = new Set(['thin', 'medium', 'thick'])

--- a/tests/arbitrary-values.test.css
+++ b/tests/arbitrary-values.test.css
@@ -666,6 +666,9 @@
 .bg-\[length\:var\(--value\)\] {
   background-size: var(--value);
 }
+.bg-\[center_top_1rem\] {
+  background-position: center top 1rem;
+}
 .bg-\[position\:200px_100px\] {
   background-position: 200px 100px;
 }

--- a/tests/arbitrary-values.test.html
+++ b/tests/arbitrary-values.test.html
@@ -236,6 +236,7 @@
     <div class="bg-[length:200px_100px]"></div>
     <div class="bg-[length:var(--value)]"></div>
 
+    <div class="bg-[center_top_1rem]"></div>
     <div class="bg-[position:200px_100px]"></div>
     <div class="bg-[position:var(--value)]"></div>
 


### PR DESCRIPTION
This PR will improve the matching of the `length` data type.

The issue is that we are basically validating if `center_top_1rem` is a valid data type. According to our definition, this is the case. The regex tests against `(?:cm|mm|Q|in|pc|pt|px|em|ex|ch|rem|lh|vw|vh|vmin|vmax)$` and it happens to be that we end in `1rem` which is valid.
However, this is not enough so we could potentially check that it also start with a number. But this will break examples where we have `1rem_2rem`.


Instead, we will split by underscores (except if they are inside brackets `[` and `]`) and validate each part of it.
This should result in the fact that `1rem_2rem_3rem` is valid, but `center_1rem` is not.
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
