### PR TITLE
Add `default` interop to public available functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Ensure complex variants with multiple classes work [#6311](https://github.com/tailwindlabs/tailwindcss/pull/6311)
+- Ensure complex variants with multiple classes work ([#6311](https://github.com/tailwindlabs/tailwindcss/pull/6311))
+- Re-add `default` interop to public available functions ([#6348](https://github.com/tailwindlabs/tailwindcss/pull/6348))
 
 ## [3.0.0] - 2021-12-09
 

--- a/colors.js
+++ b/colors.js
@@ -1,1 +1,2 @@
-module.exports = require('./lib/public/colors').default
+let colors = require('./lib/public/colors')
+module.exports = (colors.__esModule ? colors : { default: colors }).default

--- a/defaultConfig.js
+++ b/defaultConfig.js
@@ -1,1 +1,2 @@
-module.exports = require('./lib/public/default-config').default
+let defaultConfig = require('./lib/public/default-config')
+module.exports = (defaultConfig.__esModule ? defaultConfig : { default: defaultConfig }).default

--- a/defaultTheme.js
+++ b/defaultTheme.js
@@ -1,1 +1,2 @@
-module.exports = require('./lib/public/default-theme').default
+let defaultTheme = require('./lib/public/default-theme')
+module.exports = (defaultTheme.__esModule ? defaultTheme : { default: defaultTheme }).default

--- a/plugin.js
+++ b/plugin.js
@@ -1,1 +1,2 @@
-module.exports = require('./lib/public/create-plugin').default
+let createPlugin = require('./lib/public/create-plugin')
+module.exports = (createPlugin.__esModule ? createPlugin : { default: createPlugin }).default

--- a/resolveConfig.js
+++ b/resolveConfig.js
@@ -1,1 +1,2 @@
-module.exports = require('./lib/public/resolve-config').default
+let resolveConfig = require('./lib/public/resolve-config')
+module.exports = (resolveConfig.__esModule ? resolveConfig : { default: resolveConfig }).default


### PR DESCRIPTION
This PR should improve the interoperability with ESModules.
This should also fix errors on play.tailwindcss.com when requiring plugins.
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
