### PR TITLE
Add back fill-current and stroke-current

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -280,7 +280,10 @@ module.exports = {
       '2xl': '0 25px 25px rgb(0 0 0 / 0.15)',
       none: '0 0 #0000',
     },
-    fill: ({ theme }) => theme('colors'),
+    fill: ({ theme }) => ({
+      current: 'currentColor',
+      ...theme('colors')
+    }),
     grayscale: {
       0: '0',
       DEFAULT: '100%',
@@ -789,7 +792,10 @@ module.exports = {
     space: ({ theme }) => ({
       ...theme('spacing'),
     }),
-    stroke: ({ theme }) => theme('colors'),
+    stroke: ({ theme }) => ({
+      current: 'currentColor',
+      ...theme('colors')
+    }),
     strokeWidth: {
       0: '0',
       1: '1',


### PR DESCRIPTION
I created a PR instead of an issue due to the small change. Feel free to close if undesired or to keep it as a space for discussion if unsure. 😊

---

I noticed that the `fill-current` and `stroke-current` utilities were removed in https://github.com/tailwindlabs/tailwindcss/pull/5933. 

Despite the full color palette being available for the fill and stroke properties, I think it's important to keep the `-current` versions because every single design system I worked on uses those values for icons meant to be placed within buttons, etc. The icons should change their color if the text color is changed. This is especially important in component-based UI frameworks where a className can be passed into a component.

It's also possible to put these into the project-specific Tailwind config but maybe it makes sense to keep those in the default config since they were present before and don't cause a penalty on the runtime if they aren't used.