### PR TITLE
Add direction utilities

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -2355,6 +2355,17 @@ export let corePlugins = {
     )
   },
 
+  direction: ({ addUtilities }) => {
+    addUtilities({
+      '.direction-ltr': {
+        direction: 'ltr',
+      },
+      '.direction-rtl': {
+        direction: 'rtl',
+      },
+    })
+  },
+
   transitionDelay: createUtilityPlugin('transitionDelay', [['delay', ['transitionDelay']]]),
   transitionDuration: createUtilityPlugin(
     'transitionDuration',

--- a/tests/raw-content.test.css
+++ b/tests/raw-content.test.css
@@ -722,6 +722,9 @@
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
+.direction-rtl {
+  direction: rtl;
+}
 .delay-300 {
   transition-delay: 300ms;
 }

--- a/tests/raw-content.test.html
+++ b/tests/raw-content.test.html
@@ -143,5 +143,6 @@
     <div class="w-12"></div>
     <div class="break-words"></div>
     <div class="z-30"></div>
+    <div class="direction-rtl"></div>
   </body>
 </html>


### PR DESCRIPTION
This PR adds `direction-ltr` and `direction-rtl` [utilities](https://developer.mozilla.org/en-US/docs/Web/CSS/direction).

Have added a basic test for the utilities.

Note: This property does not affect the LTR and RTL variants. This is because there's currently no way in CSS to detect the properties value. Even the currently experimental [`:dir()`](https://developer.mozilla.org/en-US/docs/Web/CSS/:dir) selector doesn't detect it, [as per the spec](https://drafts.csswg.org/selectors/#:~:text=The%20%3Adir()%20pseudo%2Dclass%20does%20not%20select%20based%20on%20stylistic%20states%E2%80%94for%20example%2C%20the%20CSS%20direction%20property%20does%20not%20affect%20whether%20it%20matches.).

Based on this I understand if you choose not to accept the property due to possible confusion it may cause. Made the PR based on https://github.com/tailwindlabs/tailwindcss/discussions/6064 which does seem to suggest it has value.