### PR TITLE
Add margin, padding and inset safe area utilities

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -341,6 +341,37 @@ export let corePlugins = {
     { supportsNegativeValues: true }
   ),
 
+  insetSafe: ({ addUtilities }) => {
+    addUtilities({
+      '.inset-safe': {
+        top: 'env(safe-area-inset-top)',
+        bottom: 'env(safe-area-inset-bottom)',
+        left: 'env(safe-area-inset-left)',
+        right: 'env(safe-area-inset-right)',
+      },
+      '.inset-x-safe': {
+        left: 'env(safe-area-inset-left)',
+        right: 'env(safe-area-inset-right)',
+      },
+      '.inset-y-safe': {
+        top: 'env(safe-area-inset-top)',
+        bottom: 'env(safe-area-inset-bottom)',
+      },
+      '.top-safe': {
+        top: 'env(safe-area-inset-top)',
+      },
+      '.bottom-safe': {
+        bottom: 'env(safe-area-inset-bottom)',
+      },
+      '.left-safe': {
+        left: 'env(safe-area-inset-left)',
+      },
+      '.right-safe': {
+        right: 'env(safe-area-inset-right)',
+      },
+    })
+  },
+
   isolation: ({ addUtilities }) => {
     addUtilities({
       '.isolate': { isolation: 'isolate' },
@@ -391,6 +422,35 @@ export let corePlugins = {
     ],
     { supportsNegativeValues: true }
   ),
+
+  marginSafe: ({ addUtilities }) => {
+    addUtilities({
+      '.m-safe': {
+        margin:
+          'env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left)',
+      },
+      '.mx-safe': {
+        'margin-left': 'env(safe-area-inset-left)',
+        'margin-right': 'env(safe-area-inset-right)',
+      },
+      '.my-safe': {
+        'margin-top': 'env(safe-area-inset-top)',
+        'margin-bottom': 'env(safe-area-inset-bottom)',
+      },
+      '.mt-safe': {
+        'margin-top': 'env(safe-area-inset-top)',
+      },
+      '.mb-safe': {
+        'margin-bottom': 'env(safe-area-inset-bottom)',
+      },
+      '.ml-safe': {
+        'margin-left': 'env(safe-area-inset-left)',
+      },
+      '.mr-safe': {
+        'margin-right': 'env(safe-area-inset-right)',
+      },
+    })
+  },
 
   boxSizing: ({ addUtilities }) => {
     addUtilities({
@@ -1501,6 +1561,35 @@ export let corePlugins = {
       ['pl', ['padding-left']],
     ],
   ]),
+
+  paddingSafe: ({ addUtilities }) => {
+    addUtilities({
+      '.p-safe': {
+        padding:
+          'env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left)',
+      },
+      '.px-safe': {
+        'padding-left': 'env(safe-area-inset-left)',
+        'padding-right': 'env(safe-area-inset-right)',
+      },
+      '.py-safe': {
+        'padding-top': 'env(safe-area-inset-top)',
+        'padding-bottom': 'env(safe-area-inset-bottom)',
+      },
+      '.pt-safe': {
+        'padding-top': 'env(safe-area-inset-top)',
+      },
+      '.pb-safe': {
+        'padding-bottom': 'env(safe-area-inset-bottom)',
+      },
+      '.pl-safe': {
+        'padding-left': 'env(safe-area-inset-left)',
+      },
+      '.pr-safe': {
+        'padding-right': 'env(safe-area-inset-right)',
+      },
+    })
+  },
 
   textAlign: ({ addUtilities }) => {
     addUtilities({

--- a/tests/raw-content.test.css
+++ b/tests/raw-content.test.css
@@ -72,6 +72,32 @@
 .left-16 {
   left: 4rem;
 }
+.inset-safe {
+  top: env(safe-area-inset-top);
+  bottom: env(safe-area-inset-bottom);
+  left: env(safe-area-inset-left);
+  right: env(safe-area-inset-right);
+}
+.inset-x-safe {
+  left: env(safe-area-inset-left);
+  right: env(safe-area-inset-right);
+}
+.inset-y-safe {
+  top: env(safe-area-inset-top);
+  bottom: env(safe-area-inset-bottom);
+}
+.top-safe {
+  top: env(safe-area-inset-top);
+}
+.bottom-safe {
+  bottom: env(safe-area-inset-bottom);
+}
+.left-safe {
+  left: env(safe-area-inset-left);
+}
+.right-safe {
+  right: env(safe-area-inset-right);
+}
 .isolate {
   isolation: isolate;
 }
@@ -133,6 +159,29 @@
 }
 .ml-4 {
   margin-left: 1rem;
+}
+.m-safe {
+  margin: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+}
+.mx-safe {
+  margin-left: env(safe-area-inset-left);
+  margin-right: env(safe-area-inset-right);
+}
+.my-safe {
+  margin-top: env(safe-area-inset-top);
+  margin-bottom: env(safe-area-inset-bottom);
+}
+.mt-safe {
+  margin-top: env(safe-area-inset-top);
+}
+.mb-safe {
+  margin-bottom: env(safe-area-inset-bottom);
+}
+.ml-safe {
+  margin-left: env(safe-area-inset-left);
+}
+.mr-safe {
+  margin-right: env(safe-area-inset-right);
 }
 .box-border {
   box-sizing: border-box;
@@ -487,6 +536,29 @@
 }
 .pl-4 {
   padding-left: 1rem;
+}
+.p-safe {
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+}
+.px-safe {
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+}
+.py-safe {
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+}
+.pt-safe {
+  padding-top: env(safe-area-inset-top);
+}
+.pb-safe {
+  padding-bottom: env(safe-area-inset-bottom);
+}
+.pl-safe {
+  padding-left: env(safe-area-inset-left);
+}
+.pr-safe {
+  padding-right: env(safe-area-inset-right);
 }
 .text-center {
   text-align: center;

--- a/tests/raw-content.test.html
+++ b/tests/raw-content.test.html
@@ -143,5 +143,14 @@
     <div class="w-12"></div>
     <div class="break-words"></div>
     <div class="z-30"></div>
+    <div class="m-safe"></div>
+    <div class="mx-safe my-safe"></div>
+    <div class="ml-safe mr-safe mt-safe mb-safe"></div>
+    <div class="p-safe"></div>
+    <div class="px-safe py-safe"></div>
+    <div class="pl-safe pr-safe pt-safe pb-safe"></div>
+    <div class="inset-safe"></div>
+    <div class="inset-x-safe inset-y-safe"></div>
+    <div class="left-safe right-safe top-safe bottom-safe"></div>
   </body>
 </html>


### PR DESCRIPTION
This MR adds [safe area inset](https://developer.mozilla.org/en-US/docs/Web/CSS/env()) utilities for margin, padding and inset. This is particularly useful when [designing for notched iPhones](https://webkit.org/blog/7929/designing-websites-for-iphone-x/).
