### PR TITLE
Fix defaults optimization when vendor prefixes are involved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure complex variants with multiple classes work ([#6311](https://github.com/tailwindlabs/tailwindcss/pull/6311))
 - Re-add `default` interop to public available functions ([#6348](https://github.com/tailwindlabs/tailwindcss/pull/6348))
 - Detect circular dependencies when using `@apply` ([#6365](https://github.com/tailwindlabs/tailwindcss/pull/6365))
+- Fix defaults optimization when vendor prefixes are involved ([#6369](https://github.com/tailwindlabs/tailwindcss/pull/6369))
 
 ## [3.0.0] - 2021-12-09
 

--- a/tests/apply.test.js
+++ b/tests/apply.test.js
@@ -577,3 +577,42 @@ it('should throw when trying to apply an indirect circular dependency with a mod
     expect(err.reason).toBe('Circular dependency detected when using: `@apply a`')
   })
 })
+
+it('rules with vendor prefixes are still separate when optimizing defaults rules', () => {
+  let config = {
+    experimental: { optimizeUniversalDefaults: true },
+    content: [{ raw: html`<div class="border"></div>` }],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+
+    @layer components {
+      input[type='range']::-moz-range-thumb {
+        @apply border;
+      }
+    }
+  `
+
+  return run(input, config).then((result) => {
+    return expect(result.css).toMatchFormattedCss(css`
+      [type='range']::-moz-range-thumb {
+        --tw-border-opacity: 1;
+        border-color: rgb(229 231 235 / var(--tw-border-opacity));
+      }
+      .border {
+        --tw-border-opacity: 1;
+        border-color: rgb(229 231 235 / var(--tw-border-opacity));
+      }
+      input[type='range']::-moz-range-thumb {
+        border-width: 1px;
+      }
+      .border {
+        border-width: 1px;
+      }
+    `)
+  })
+})


### PR DESCRIPTION
Fixes #6360

If selector contains a vendor prefix after a pseudo element or class, we now consider them separately because merging the declarations into a single rule will cause browsers that do not understand the vendor prefix to throw out the whole rule.