### PR TITLE
Fix TypeError (#6393)

### DIFF
--- a/src/lib/setupTrackingContext.js
+++ b/src/lib/setupTrackingContext.js
@@ -70,7 +70,7 @@ function getTailwindConfig(configOrPath) {
 
   // It's a plain object, not a path
   let newConfig = resolveConfig(
-    configOrPath.config === undefined ? configOrPath : configOrPath.config
+    configOrPath?.config === undefined ? configOrPath : configOrPath.config
   )
 
   return [newConfig, null, hash(newConfig), []]

--- a/src/lib/setupWatchingContext.js
+++ b/src/lib/setupWatchingContext.js
@@ -185,7 +185,7 @@ function getTailwindConfig(configOrPath) {
 
   // It's a plain object, not a path
   let newConfig = resolveConfig(
-    configOrPath.config === undefined ? configOrPath : configOrPath.config
+    configOrPath?.config === undefined ? configOrPath : configOrPath.config
   )
 
   return [newConfig, null, hash(newConfig), []]


### PR DESCRIPTION
Fixes #6393

Before, if the `tailwindcss` function is passed a null/undefined value, `TypeError: Cannot read property 'config' of undefined` is thrown.

I've added the `?` 'Optional Chaining' operator to remove this error.