### PR TITLE
Warn about invalid globs in `content`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Added
+
+- Warn about invalid globs in `content` ([#6449](https://github.com/tailwindlabs/tailwindcss/pull/6449))
 
 ## [3.0.2] - 2021-12-13
 

--- a/src/util/log.js
+++ b/src/util/log.js
@@ -12,6 +12,10 @@ function log(chalk, messages, key) {
   messages.forEach((message) => console.warn(chalk, '-', message))
 }
 
+export function dim(input) {
+  return chalk.dim(input)
+}
+
 export default {
   info(key, messages) {
     log(chalk.bold.cyan('info'), ...(Array.isArray(key) ? [key] : [messages, key]))

--- a/src/util/normalizeConfig.js
+++ b/src/util/normalizeConfig.js
@@ -1,4 +1,4 @@
-import log from './log'
+import log, { dim } from './log'
 
 export function normalizeConfig(config) {
   // Quick structure validation
@@ -245,12 +245,18 @@ export function normalizeConfig(config) {
     })(),
   }
 
-  // Rewrite globs to prevent bogus globs.
+  // Validate globs to prevent bogus globs.
   // E.g.: `./src/*.{html}` is invalid, the `{html}` should just be `html`
-  config.content.files = config.content.files.map((file) => {
-    if (typeof file !== 'string') return file
-    return file.replace(/{([^,]*?)}/g, '$1')
-  })
+  for (let file of config.content.files) {
+    if (typeof file === 'string' && /{([^,]*?)}/g.test(file)) {
+      log.warn('invalid-glob-braces', [
+        `The glob pattern ${dim(file)} in your config is invalid.`,
+        `    Update it to ${dim(file.replace(/{([^,]*?)}/g, '$1'))} to silence this warning.`,
+        // TODO: Add https://tw.wtf/invalid-glob-braces
+      ])
+      break
+    }
+  }
 
   return config
 }

--- a/src/util/normalizeConfig.js
+++ b/src/util/normalizeConfig.js
@@ -245,5 +245,12 @@ export function normalizeConfig(config) {
     })(),
   }
 
+  // Rewrite globs to prevent bogus globs.
+  // E.g.: `./src/*.{html}` is invalid, the `{html}` should just be `html`
+  config.content.files = config.content.files.map((file) => {
+    if (typeof file !== 'string') return file
+    return file.replace(/{([^,]*?)}/g, '$1')
+  })
+
   return config
 }

--- a/tests/normalize-config.test.js
+++ b/tests/normalize-config.test.js
@@ -110,7 +110,10 @@ it('should keep content files with globs', () => {
   })
 })
 
-it('should rewrite globs with incorrect bracket expansion', () => {
+it('should warn when we detect invalid globs with incorrect brace expansion', () => {
+  let log = require('../src/util/log')
+  let spy = jest.spyOn(log.default, 'warn')
+
   let config = {
     content: [
       './{example-folder}/**/*.{html,js}',
@@ -119,13 +122,20 @@ it('should rewrite globs with incorrect bracket expansion', () => {
     ],
   }
 
+  // No rewrite happens
   expect(normalizeConfig(resolveConfig(config)).content).toEqual({
     files: [
-      './example-folder/**/*.{html,js}',
-      './example-folder/**/*.html',
-      './example-folder/**/*.html',
+      './{example-folder}/**/*.{html,js}',
+      './{example-folder}/**/*.{html}',
+      './example-folder/**/*.{html}',
     ],
     extract: {},
     transform: {},
   })
+
+  // But a warning should happen
+  expect(spy).toHaveBeenCalledTimes(2)
+  expect(spy.mock.calls.map((x) => x[0])).toEqual(['invalid-glob-braces', 'invalid-glob-braces'])
+
+  spy.mockClear()
 })

--- a/tests/normalize-config.test.js
+++ b/tests/normalize-config.test.js
@@ -1,4 +1,6 @@
+import { normalizeConfig } from '../src/util/normalizeConfig'
 import { run, css } from './util/run'
+import resolveConfig from '../src/public/resolve-config'
 
 it.each`
   config
@@ -93,5 +95,37 @@ it('should still be possible to use the "old" v2 config', () => {
         font-weight: 700;
       }
     `)
+  })
+})
+
+it('should keep content files with globs', () => {
+  let config = {
+    content: ['./example-folder/**/*.{html,js}'],
+  }
+
+  expect(normalizeConfig(resolveConfig(config)).content).toEqual({
+    files: ['./example-folder/**/*.{html,js}'],
+    extract: {},
+    transform: {},
+  })
+})
+
+it('should rewrite globs with incorrect bracket expansion', () => {
+  let config = {
+    content: [
+      './{example-folder}/**/*.{html,js}',
+      './{example-folder}/**/*.{html}',
+      './example-folder/**/*.{html}',
+    ],
+  }
+
+  expect(normalizeConfig(resolveConfig(config)).content).toEqual({
+    files: [
+      './example-folder/**/*.{html,js}',
+      './example-folder/**/*.html',
+      './example-folder/**/*.html',
+    ],
+    extract: {},
+    transform: {},
   })
 })


### PR DESCRIPTION
This PR will try and fix bogus globs

When using globs, there is this option called "brace expansion", this means that you can simplify some globs instead of repeating the same thing over and over again. For example:

```sh
./src/**/*.html
./src/**/*.js
```

Can be simplified as:
```sh
./src/**/*.{html,js}
```

This is also what we explain in our docs: https://tailwindcss.com/docs/installation

However, it seems like some people are changing that glob to better match their project which is totally fine. However, a lot of people end up with invalid globs.
```js
./src/**/*.{html}
```

This is an invalid glob, notice that there is only 1 item inside the `{` & `}`.
This is the same behaviour as brace expansion in your terminal.

Here is an example from my terminal output inside the tailwindcss repo:
```sh
$ ls -la *.{json} # Invalid
zsh: no matches found: *.{json}
```

```sh
$ ls -lah *.json # Valid
-rw-r--r--  1 robin  staff   438K Dec 12 22:18 package-lock.json
-rw-r--r--  1 robin  staff   3.1K Dec 12 22:18 package.json
```

```sh
$ ls -lah *.{json,js} # Valid
-rw-r--r--  1 robin  staff   120B Dec 12 22:18 colors.js
-rw-r--r--  1 robin  staff   156B Dec 12 22:18 defaultConfig.js
-rw-r--r--  1 robin  staff   151B Dec 12 22:18 defaultTheme.js
-rw-r--r--  1 robin  staff   438K Dec 12 22:18 package-lock.json
-rw-r--r--  1 robin  staff   3.1K Dec 12 22:18 package.json
-rw-r--r--  1 robin  staff   151B Dec 12 22:18 plugin.js
-rw-r--r--  1 robin  staff   446B Sep  1 17:36 prettier.config.js
-rw-r--r--  1 robin  staff   156B Dec 12 22:18 resolveConfig.js
```

This PR will try and detect those bogus cases and ~~rewrite~~ show a warning with a fix for the glob.

```sh
./src/**/*.{html}
```

Should become:
```sh
./src/**/*.html
```

Example warning output:
```
warn - The glob pattern ./src/**/*.{html} in your config is invalid.
warn -     Update it to ./src/**/*.html to silence this warning.
```

<img width="1038" alt="image" src="https://user-images.githubusercontent.com/1834413/145822256-355497f8-45a0-4083-9366-ee7505d89cd6.png">

Fixes: #6394

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
