### PR TITLE
Don't output unparsable values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Warn about invalid globs in `content` ([#6449](https://github.com/tailwindlabs/tailwindcss/pull/6449))
 
+### Fixed
+
+- Don't output unparsable values ([#6469](https://github.com/tailwindlabs/tailwindcss/pull/6469))
+
 ## [3.0.2] - 2021-12-13
 
 ### Fixed

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -255,11 +255,11 @@ function extractArbitraryProperty(classCandidate, context) {
     return null
   }
 
-  let normalized = normalize(value)
-
-  if (!isValidArbitraryValue(normalized)) {
+  if (!isValidArbitraryValue(value)) {
     return null
   }
+
+  let normalized = normalize(value)
 
   return [
     [

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -248,10 +248,29 @@ function parseRules(rule, cache, options = {}) {
   return [cache.get(rule), options]
 }
 
+const IS_VALID_PROPERTY_NAME = /^[a-z_-]/
+
+function isValidPropName(name) {
+  return IS_VALID_PROPERTY_NAME.test(name)
+}
+
+function isParsableCssValue(property, value) {
+  try {
+    postcss.parse(`a{${property}:${value}}`).toResult()
+    return true
+  } catch (err) {
+    return false
+  }
+}
+
 function extractArbitraryProperty(classCandidate, context) {
   let [, property, value] = classCandidate.match(/^\[([a-zA-Z0-9-_]+):(\S+)\]$/) ?? []
 
   if (value === undefined) {
+    return null
+  }
+
+  if (!isValidPropName(property)) {
     return null
   }
 
@@ -260,6 +279,10 @@ function extractArbitraryProperty(classCandidate, context) {
   }
 
   let normalized = normalize(value)
+
+  if (!isParsableCssValue(property, normalized)) {
+    return null
+  }
 
   return [
     [

--- a/tests/arbitrary-properties.test.js
+++ b/tests/arbitrary-properties.test.js
@@ -231,3 +231,45 @@ test('invalid class', () => {
     expect(result.css).toMatchFormattedCss(css``)
   })
 })
+
+test('invalid arbitrary property', () => {
+  let config = {
+    content: [
+      {
+        raw: html`<div class="[autoplay:\${autoplay}]"></div>`,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css``)
+  })
+})
+
+test('invalid arbitrary property 2', () => {
+  let config = {
+    content: [
+      {
+        raw: html`[0:02]`,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css``)
+  })
+})


### PR DESCRIPTION
We do two things here:
1. Validate that arbitrary properties result in actual parsable css declarations
2. Ignore malformed css properties (for example beginning with a number)

This prevents generation of classes for things like `[0:02]` or `[autoplay:${autoplay}]` which result in invalid css. This does not fix *all* cases but should help significantly.

Fixes #6395