### PR TITLE
Ensure all plugins are executed for a given candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Support square bracket notation in paths ([#6519](https://github.com/tailwindlabs/tailwindcss/pull/6519))
+- Ensure all plugins are executed for a given candidate ([#6540](https://github.com/tailwindlabs/tailwindcss/pull/6540))
 
 ## [3.0.5] - 2021-12-15
 
@@ -35,7 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix text decoration utilities from overriding the new text decoration color/style/thickness utilities when used with a modifier ([#6378](https://github.com/tailwindlabs/tailwindcss/pull/6378))
 - Move defaults to their own always-on layer ([#6500](https://github.com/tailwindlabs/tailwindcss/pull/6500))
 - Support negative values in safelist patterns ([#6480](https://github.com/tailwindlabs/tailwindcss/pull/6480))
-- Support square bracket notation in paths ([#6519](https://github.com/tailwindlabs/tailwindcss/pull/6519))
 
 ## [3.0.2] - 2021-12-13
 

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -325,7 +325,6 @@ function* resolveMatchedPlugins(classCandidate, context) {
   for (let [prefix, modifier] of candidatePermutations(candidatePrefix)) {
     if (context.candidateRuleMap.has(prefix)) {
       yield [context.candidateRuleMap.get(prefix), negative ? `-${modifier}` : modifier]
-      return
     }
   }
 }

--- a/tests/basic-usage.test.js
+++ b/tests/basic-usage.test.js
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 
-import { run, css } from './util/run'
+import { html, run, css } from './util/run'
 
 test('basic usage', () => {
   let config = {
@@ -20,5 +20,40 @@ test('basic usage', () => {
     let expected = fs.readFileSync(expectedPath, 'utf8')
 
     expect(result.css).toMatchFormattedCss(expected)
+  })
+})
+
+test('all plugins are executed that match a candidate', () => {
+  let config = {
+    content: [{ raw: html`<div class="bg-green-light bg-green"></div>` }],
+    theme: {
+      colors: {
+        green: {
+          light: 'green',
+        },
+      },
+    },
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind utilities;
+
+    .bg-green {
+      /* Empty on purpose */
+    }
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .bg-green-light {
+        --tw-bg-opacity: 1;
+        background-color: rgb(0 128 0 / var(--tw-bg-opacity));
+      }
+
+      .bg-green {
+        /* Empty on purpose */
+      }
+    `)
   })
 })


### PR DESCRIPTION
We had an early return so that once a plugin was matched, that we could
stop running the code through the other plugins. However, in this case
we have an issue that user defined css is technically also a plugin.

This means that:
  - `bg-green-light`
Would check for:
  - `bg-green-light` (no hit, continue)
  - `bg-green` (Hit! Don't execute next plugins)
  - `bg` (This is the one that would have generated `bg-green-light`)

We tested this change and it doesn't seem to have an impact functionally
and also not really performance wise.

Fixes: #6478 

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
