### PR TITLE
Avoid writing to output files when no changes

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -560,6 +560,7 @@ async function build() {
     let changedContent = []
     let configDependencies = []
     let contextDependencies = new Set()
+    let lastBuiltCSS = ''
     let watcher = null
 
     function refreshConfig() {
@@ -664,12 +665,20 @@ async function build() {
               return process.stdout.write(result.css)
             }
 
+            if (result.css === lastBuiltCSS) {
+              // there is no change on the built CSS
+              // no need to rewrite the output file
+              return
+            }
+
             await Promise.all(
               [
                 fs.promises.writeFile(output, result.css, () => true),
                 result.map && fs.writeFile(output + '.map', result.map.toString(), () => true),
               ].filter(Boolean)
             )
+
+            lastBuiltCSS = result.css
           })
           .then(() => {
             let end = process.hrtime.bigint()

--- a/src/cli.js
+++ b/src/cli.js
@@ -41,6 +41,33 @@ function formatNodes(root) {
   }
 }
 
+let outputStates = new Map()
+async function outputFile(file, contents) {
+  if (outputStates.has(file)) {
+    let { contents: oldContents, stats: oldStats } = outputStates.get(file)
+
+    let stats = await fs.promises.stat(file, { bigint: true })
+
+    // If the modified timestamp changed then we need to write the file. It
+    // could be that we end up with the exact same contents, but we already did
+    // the work internally so just writing it will be faster than comparing
+    // full output files.
+    // If the contents changed, then we also have to write the file.
+    if (stats.mtimeMs === oldStats.mtimeMs && contents === oldContents) {
+      return // Skip writing the file
+    }
+  }
+
+  // Write the file
+  await fs.promises.writeFile(file, contents, 'utf8')
+
+  // Store latest information in the cache
+  outputStates.set(file, {
+    contents,
+    stats: await fs.promises.stat(file, { bigint: true }),
+  })
+}
+
 function help({ message, usage, commands, options }) {
   let indent = 2
 
@@ -534,6 +561,7 @@ async function build() {
           if (!output) {
             return process.stdout.write(result.css)
           }
+
           return Promise.all(
             [
               fs.promises.writeFile(output, result.css, () => true),
@@ -560,7 +588,6 @@ async function build() {
     let changedContent = []
     let configDependencies = []
     let contextDependencies = new Set()
-    let lastBuiltCSS = ''
     let watcher = null
 
     function refreshConfig() {
@@ -665,20 +692,12 @@ async function build() {
               return process.stdout.write(result.css)
             }
 
-            if (result.css === lastBuiltCSS) {
-              // there is no change on the built CSS
-              // no need to rewrite the output file
-              return
-            }
-
-            await Promise.all(
+            return Promise.all(
               [
-                fs.promises.writeFile(output, result.css, () => true),
-                result.map && fs.writeFile(output + '.map', result.map.toString(), () => true),
+                outputFile(output, result.css),
+                result.map && outputFile(output + '.map', result.map.toString()),
               ].filter(Boolean)
             )
-
-            lastBuiltCSS = result.css
           })
           .then(() => {
             let end = process.hrtime.bigint()

--- a/src/cli.js
+++ b/src/cli.js
@@ -41,31 +41,13 @@ function formatNodes(root) {
   }
 }
 
-let outputStates = new Map()
 async function outputFile(file, contents) {
-  if (outputStates.has(file)) {
-    let { contents: oldContents, stats: oldStats } = outputStates.get(file)
-
-    let stats = await fs.promises.stat(file, { bigint: true })
-
-    // If the modified timestamp changed then we need to write the file. It
-    // could be that we end up with the exact same contents, but we already did
-    // the work internally so just writing it will be faster than comparing
-    // full output files.
-    // If the contents changed, then we also have to write the file.
-    if (stats.mtimeMs === oldStats.mtimeMs && contents === oldContents) {
-      return // Skip writing the file
-    }
+  if (fs.existsSync(file) && (await fs.promises.readFile(file, 'utf8')) === contents) {
+    return // Skip writing the file
   }
 
   // Write the file
   await fs.promises.writeFile(file, contents, 'utf8')
-
-  // Store latest information in the cache
-  outputStates.set(file, {
-    contents,
-    stats: await fs.promises.stat(file, { bigint: true }),
-  })
 }
 
 function help({ message, usage, commands, options }) {


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
Hello, 

First of all thank you for creating Tailwind. I am a big fan of this project 😄 
I am also a fan of the [Remix](https://github.com/remix-run/run) project.

I wanted to use Remix in addition of Tailwind, but I encountered an issue. 
Indeed the Tailwind CLI writes the result of the CSS processing to the configured output file even if the file already contains this same output (if we change TSX for example). This cause a double rebuild Remix side (one useless for the unmodified CSS file and one for the TSX change).
I simply did a comparison before writing to the output file and this fix the issue. 

However I think I can still improve this PR, as the Tailwind CLI still output "Rebuilding ..." even if it is not really writing any output. 
What do you think ? 😅 

If you want to try this easily I created a reproduction repository [here](https://github.com/g3offrey/reproduction-tailwind-duplication). Simply modify "Change me" in `app/routes/index.tsx` and you'll see that Tailwind rewrite the css file.

Thank you per advance.