### PR TITLE
Don't add default config multiple times when presets are used

### DIFF
--- a/src/util/getAllConfigs.js
+++ b/src/util/getAllConfigs.js
@@ -1,11 +1,12 @@
 import defaultConfig from '../../stubs/defaultConfig.stub.js'
 import { flagEnabled } from '../featureFlags'
 
-export default function getAllConfigs(config) {
-  const configs = (config?.presets ?? [defaultConfig])
+export default function getAllConfigs(config, depth = 0) {
+  const presets = config?.presets ?? (depth > 0 ? [] : [defaultConfig])
+  const configs = presets
     .slice()
     .reverse()
-    .flatMap((preset) => getAllConfigs(preset instanceof Function ? preset() : preset))
+    .flatMap((preset) => getAllConfigs(preset instanceof Function ? preset() : preset, depth + 1))
 
   const features = {
     // Add experimental configs here...

--- a/tests/customConfig.test.js
+++ b/tests/customConfig.test.js
@@ -384,3 +384,41 @@ test('function presets can be mixed with object presets', () => {
     `)
   })
 })
+
+test('Using presets without an empty presets array doesnt overwrite plugins', () => {
+  let plugin = require('../plugin')
+
+  let config = {
+    presets: [
+      require('../stubs/defaultConfig.stub.js'),
+      {
+        theme: {},
+        plugins: [
+          plugin(
+            function ({ matchUtilities, theme }) {
+              matchUtilities(
+                { 'aspect-w': (value) => [{ color: value }] },
+                { values: theme('aspectRatio') }
+              )
+            },
+            {
+              theme: { aspectRatio: { foo: 'red' } },
+            }
+          ),
+        ],
+      },
+      {
+        theme: { colors: {} },
+      },
+    ],
+    content: [{ raw: `<div class="aspect-w-foo"></div>` }],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .aspect-w-foo {
+        color: red;
+      }
+    `)
+  })
+})


### PR DESCRIPTION
Fixes https://github.com/tailwindlabs/tailwindcss-aspect-ratio/issues/30

When using presets if you included a config that did not specify `presets: []` it would add the default config for each of those presets. We only want to do this once at the top level so we track depth when getting all configs so we only ever add the default config once at the beginning if we need to.