### PR TITLE
Improve circular dependency detection when using `@apply`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Don't mutate custom color palette when overriding per-plugin colors ([#6546](https://github.com/tailwindlabs/tailwindcss/pull/6546))
+- Improve circular dependency detection when using `@apply` ([#6588](https://github.com/tailwindlabs/tailwindcss/pull/6588))
 
 ## [3.0.6] - 2021-12-16
 

--- a/tests/apply.test.js
+++ b/tests/apply.test.js
@@ -484,7 +484,9 @@ it('should throw when trying to apply a direct circular dependency', () => {
   `
 
   return run(input, config).catch((err) => {
-    expect(err.reason).toBe('Circular dependency detected when using: `@apply text-red-500`')
+    expect(err.reason).toBe(
+      'You cannot `@apply` the `text-red-500` utility here because it creates a circular dependency.'
+    )
   })
 })
 
@@ -514,7 +516,39 @@ it('should throw when trying to apply an indirect circular dependency', () => {
   `
 
   return run(input, config).catch((err) => {
-    expect(err.reason).toBe('Circular dependency detected when using: `@apply a`')
+    expect(err.reason).toBe(
+      'You cannot `@apply` the `a` utility here because it creates a circular dependency.'
+    )
+  })
+})
+
+it('should not throw when the selector is different (but contains the base partially)', () => {
+  let config = {
+    content: [{ raw: html`<div class="bg-gray-500"></div>` }],
+    plugins: [],
+  }
+
+  let input = css`
+    @tailwind components;
+    @tailwind utilities;
+
+    .focus\:bg-gray-500 {
+      @apply bg-gray-500;
+    }
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .bg-gray-500 {
+        --tw-bg-opacity: 1;
+        background-color: rgb(107 114 128 / var(--tw-bg-opacity));
+      }
+
+      .focus\:bg-gray-500 {
+        --tw-bg-opacity: 1;
+        background-color: rgb(107 114 128 / var(--tw-bg-opacity));
+      }
+    `)
   })
 })
 
@@ -544,7 +578,9 @@ it('should throw when trying to apply an indirect circular dependency with a mod
   `
 
   return run(input, config).catch((err) => {
-    expect(err.reason).toBe('Circular dependency detected when using: `@apply hover:a`')
+    expect(err.reason).toBe(
+      'You cannot `@apply` the `hover:a` utility here because it creates a circular dependency.'
+    )
   })
 })
 
@@ -574,7 +610,9 @@ it('should throw when trying to apply an indirect circular dependency with a mod
   `
 
   return run(input, config).catch((err) => {
-    expect(err.reason).toBe('Circular dependency detected when using: `@apply a`')
+    expect(err.reason).toBe(
+      'You cannot `@apply` the `a` utility here because it creates a circular dependency.'
+    )
   })
 })
 


### PR DESCRIPTION
This PR will improve the detection of circular dependencies.
We incorrectly had a false positive in this case:

HTML:
```html
<div class="bg-gray-500"></div>
```

CSS:
```css
.focus\:bg-gray-500 {
  @apply bg-gray-500;
}
```

While you should not do this, this resulted in an incorrect circular dependency error.
Now it will result in the correct css:

```css
.bg-gray-500 {
  --tw-bg-opacity: 1;
  background-color: rgb(107 114 128 / var(--tw-bg-opacity));
}

.focus\:bg-gray-500 {
  --tw-bg-opacity: 1;
  background-color: rgb(107 114 128 / var(--tw-bg-opacity));
}
```

I also changed the circular dependency message to the same message we used in v2.
Before:
```
Circular dependency detected when using: `@apply text-red-500`
```

After:
```
You cannot `@apply` the `text-red-500` utility here because it creates a circular dependency.
```

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
