### PR TITLE
Ensure `@apply` of a rule inside an AtRule works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Only generate variants for non-`user` layers ([#6589](https://github.com/tailwindlabs/tailwindcss/pull/6589))
 - Properly extract classes with arbitrary values in arrays and classes followed by escaped quotes ([#6590](https://github.com/tailwindlabs/tailwindcss/pull/6590))
 - Improve jsx interpolation candidate matching ([#6593](https://github.com/tailwindlabs/tailwindcss/pull/6593))
+- Ensure `@apply` of a rule inside an AtRule works ([#6594](https://github.com/tailwindlabs/tailwindcss/pull/6594))
 
 ## [3.0.6] - 2021-12-16
 

--- a/tests/apply.test.js
+++ b/tests/apply.test.js
@@ -712,3 +712,65 @@ it('should not be possible to apply user css with variants', () => {
     )
   })
 })
+
+it('should not apply unrelated siblings when applying something from within atrules', () => {
+  let config = {
+    content: [{ raw: html`<div class="foo bar something-unrelated"></div>` }],
+    plugins: [],
+  }
+
+  let input = css`
+    @tailwind components;
+    @tailwind utilities;
+
+    @layer components {
+      .foo {
+        font-weight: bold;
+        @apply bar;
+      }
+
+      .bar {
+        color: green;
+      }
+
+      @supports (a: b) {
+        .bar {
+          color: blue;
+        }
+
+        .something-unrelated {
+          color: red;
+        }
+      }
+    }
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .foo {
+        font-weight: bold;
+        color: green;
+      }
+
+      @supports (a: b) {
+        .foo {
+          color: blue;
+        }
+      }
+
+      .bar {
+        color: green;
+      }
+
+      @supports (a: b) {
+        .bar {
+          color: blue;
+        }
+
+        .something-unrelated {
+          color: red;
+        }
+      }
+    `)
+  })
+})


### PR DESCRIPTION
This PR will ensure that if you are using `@apply something` and that `something` happens to be in an AtRule and that AtRule contains an unrelated node that we only apply the related node... 🥵

Let's imagine you have the following structure:

```css
.foo {
  @apply bar;
}

@supports (a: b) {
  .bar {
    color: blue
  }

  .something-unrelated {}
}
```

In this case we want to apply `.bar` but it happens to be in an AtRule node. We clone that node instead of the nested one because we still want that `@supports` rule to be there once we applied everything.

However it happens to be that the `.something-unrelated` is also in that same shared `@supports` atrule. This is not good, and this should not be there. The good part is that this is a clone already and it can be safely removed. The question is how do we know we can remove it. Basically what we can do is match it against the applyCandidate that you want to apply. If it doesn't match the we can safely delete it.

If we didn't do this, then the `replaceSelector` function would have replaced this with something that didn't exist and therefore it removed the selector altogether. In this specific case it would result in `{}` instead of `.something-unrelated {}`

Fixes: #6246

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
