### PR TITLE
Reduce specificity of abbr rule in preflight

### DIFF
--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -58,7 +58,7 @@ hr {
 Add the correct text decoration in Chrome, Edge, and Safari.
 */
 
-abbr[title] {
+abbr:where([title]) {
   text-decoration: underline dotted;
 }
 


### PR DESCRIPTION
Resolves #6623

This PR updates the `abbr[title]` rule in Preflight to use a lower specificity so that you can override the styles using Tailwind's utility classes.