### PR TITLE
Add standalone-cli node16-linux-arm64 build (make docker on Apple Silicon M1 workflow possible)

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -47,11 +47,13 @@ jobs:
           draft: true
           tag_name: ${{ steps.vars.outputs.tag_name }}
           body: |
+            * [Linux (arm64)](https://github.com/tailwindlabs/tailwindcss/releases/download/${{ steps.vars.outputs.tag_name }}/tailwindcss-linux-arm64)
             * [Linux (x64)](https://github.com/tailwindlabs/tailwindcss/releases/download/${{ steps.vars.outputs.tag_name }}/tailwindcss-linux-x64)
             * [macOS (arm64)](https://github.com/tailwindlabs/tailwindcss/releases/download/${{ steps.vars.outputs.tag_name }}/tailwindcss-macos-arm64)
             * [macOS (x64)](https://github.com/tailwindlabs/tailwindcss/releases/download/${{ steps.vars.outputs.tag_name }}/tailwindcss-macos-x64)
             * [Windows (x64)](https://github.com/tailwindlabs/tailwindcss/releases/download/${{ steps.vars.outputs.tag_name }}/tailwindcss-windows-x64.exe)
           files: |
+            standalone-cli/dist/tailwindcss-linux-arm64
             standalone-cli/dist/tailwindcss-linux-x64
             standalone-cli/dist/tailwindcss-macos-arm64
             standalone-cli/dist/tailwindcss-macos-x64

--- a/standalone-cli/package.json
+++ b/standalone-cli/package.json
@@ -2,9 +2,9 @@
   "name": "tailwindcss-standalone",
   "version": "0.0.0",
   "scripts": {
-    "build": "pkg standalone.js --out-path dist --targets node16-macos-x64,node16-macos-arm64,node16-win-x64,node16-linux-x64 --compress Brotli --no-bytecode --public-packages \"*\" --public",
+    "build": "pkg standalone.js --out-path dist --targets node16-macos-x64,node16-macos-arm64,node16-win-x64,node16-linux-x64,node16-linux-arm64 --compress Brotli --no-bytecode --public-packages \"*\" --public",
     "prebuild": "rimraf dist",
-    "postbuild": "move-file dist/standalone-macos-x64 dist/tailwindcss-macos-x64 && move-file dist/standalone-macos-arm64 dist/tailwindcss-macos-arm64 && move-file dist/standalone-win-x64.exe dist/tailwindcss-windows-x64.exe && move-file dist/standalone-linux-x64 dist/tailwindcss-linux-x64",
+    "postbuild": "move-file dist/standalone-macos-x64 dist/tailwindcss-macos-x64 && move-file dist/standalone-macos-arm64 dist/tailwindcss-macos-arm64 && move-file dist/standalone-win-x64.exe dist/tailwindcss-windows-x64.exe && move-file dist/standalone-linux-x64 dist/tailwindcss-linux-x64 && move-file dist/standalone-linux-arm64 dist/tailwindcss-linux-arm64",
     "test": "jest"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull request is pretty simple and just adds another standalone-cli platform: Linux arm64

Why is this needed:

I am using a workflow were I run a Rails 7 application during development in Docker on an M1 Apple Silicon device.

Docker on M1 macOS starts a Linux arm64 virtual machine for which currently no binary is available. As tailwindcss-rails depends on a binary download from this repository, I would like to add the Linux arm64 build.