### PR TITLE
Improve DEBUG parsing: only take care of `tailwindcss` and not `tailwind`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Improve `DEBUG` flag ([#6797](https://github.com/tailwindlabs/tailwindcss/pull/6797))
+- Improve `DEBUG` flag ([#6797](https://github.com/tailwindlabs/tailwindcss/pull/6797), [#6804](https://github.com/tailwindlabs/tailwindcss/pull/6804))
 
 ## [3.0.8] - 2021-12-28
 

--- a/src/lib/sharedState.js
+++ b/src/lib/sharedState.js
@@ -35,13 +35,13 @@ export function resolveDebug(debug) {
 
   let debuggers = debug.split(',').map((d) => d.split(':')[0])
 
-  // Ignoring tailwind / tailwindcss
-  if (debuggers.includes('-tailwindcss') || debuggers.includes('-tailwind')) {
+  // Ignoring tailwindcss
+  if (debuggers.includes('-tailwindcss')) {
     return false
   }
 
-  // Definitely including tailwind / tailwindcss
-  if (debuggers.includes('tailwindcss') || debuggers.includes('tailwind')) {
+  // Including tailwindcss
+  if (debuggers.includes('tailwindcss')) {
     return true
   }
 

--- a/tests/shared-state.test.js
+++ b/tests/shared-state.test.js
@@ -7,20 +7,12 @@ it.each`
   ${'false'}                | ${false}
   ${'0'}                    | ${false}
   ${'*'}                    | ${true}
-  ${'tailwind'}             | ${true}
-  ${'tailwind:*'}           | ${true}
   ${'tailwindcss'}          | ${true}
   ${'tailwindcss:*'}        | ${true}
-  ${'other,tailwind'}       | ${true}
-  ${'other,tailwind:*'}     | ${true}
   ${'other,tailwindcss'}    | ${true}
   ${'other,tailwindcss:*'}  | ${true}
-  ${'other,-tailwind'}      | ${false}
-  ${'other,-tailwind:*'}    | ${false}
   ${'other,-tailwindcss'}   | ${false}
   ${'other,-tailwindcss:*'} | ${false}
-  ${'-tailwind'}            | ${false}
-  ${'-tailwind:*'}          | ${false}
   ${'-tailwindcss'}         | ${false}
   ${'-tailwindcss:*'}       | ${false}
 `('should resolve the debug ($value) flag correctly ($expected)', ({ value, expected }) => {


### PR DESCRIPTION
This PR only looks for `tailwindcss` instead of also for `tailwind` when parsing the `DEBUG` environment variable.

This is an addition to: #6797