### PR TITLE
Ignore content files that don't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Preserve case of css variables added by plugins ([#6888](https://github.com/tailwindlabs/tailwindcss/pull/6888))
+- Ignore content files that don't exist ([#6901](https://github.com/tailwindlabs/tailwindcss/pull/6901))
 
 ## [3.0.10] - 2022-01-04
 


### PR DESCRIPTION
This PR will ignore content files that are passed in but that don't really exist.

E.g.: PostCSS CLI will give you a fake file path that ends in /stdin if you are reading from stdin.

Fixes: #6894

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
