### PR TITLE
Enable optimize universal defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Optimize universal selectors by default ([#6906](https://github.com/tailwindlabs/tailwindcss/pull/6906))
 
 ## [3.0.11] - 2022-01-05
 

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -2,11 +2,7 @@ import chalk from 'chalk'
 import log from './util/log'
 
 let defaults = {
-  // TODO: Drop this once we can safely rely on optimizeUniversalDefaults being
-  // the default.
-  optimizeUniversalDefaults: process.env.NODE_ENV === 'test' ? true : false,
-
-  // optimizeUniversalDefaults: true
+  optimizeUniversalDefaults: true,
 }
 
 let featureFlags = {

--- a/src/lib/expandTailwindAtRules.js
+++ b/src/lib/expandTailwindAtRules.js
@@ -157,7 +157,10 @@ export default function expandTailwindAtRules(context) {
       // We also want to check for @apply because the user can
       // apply classes in an isolated environment like CSS
       // modules and we still need to inject defaults
-      if (rule.name === 'apply' && flagEnabled(context.tailwindConfig, 'optimizeUniversalDefaults')) {
+      if (
+        rule.name === 'apply' &&
+        flagEnabled(context.tailwindConfig, 'optimizeUniversalDefaults')
+      ) {
         hasApply = true
       }
     })

--- a/src/lib/expandTailwindAtRules.js
+++ b/src/lib/expandTailwindAtRules.js
@@ -140,7 +140,7 @@ export default function expandTailwindAtRules(context) {
       variants: null,
     }
 
-    // let hasApply = false
+    let hasApply = false
 
     root.walkAtRules((rule) => {
       // Make sure this file contains Tailwind directives. If not, we can save
@@ -156,12 +156,12 @@ export default function expandTailwindAtRules(context) {
       // We also want to check for @apply because the user can
       // apply classes in an isolated environment like CSS
       // modules and we still need to inject defaults
-      // if (rule.name === 'apply') {
-      //   hasApply = true
-      // }
+      if (rule.name === 'apply') {
+        hasApply = true
+      }
     })
 
-    if (Object.values(layerNodes).every((n) => n === null)) {
+    if (Object.values(layerNodes).every((n) => n === null) && !hasApply) {
       return root
     }
 

--- a/src/lib/expandTailwindAtRules.js
+++ b/src/lib/expandTailwindAtRules.js
@@ -4,6 +4,7 @@ import { generateRules } from './generateRules'
 import bigSign from '../util/bigSign'
 import cloneNodes from '../util/cloneNodes'
 import { defaultExtractor } from './defaultExtractor'
+import { flagEnabled } from '../featureFlags'
 
 let env = sharedState.env
 
@@ -156,7 +157,7 @@ export default function expandTailwindAtRules(context) {
       // We also want to check for @apply because the user can
       // apply classes in an isolated environment like CSS
       // modules and we still need to inject defaults
-      if (rule.name === 'apply') {
+      if (rule.name === 'apply' && flagEnabled(context.tailwindConfig, 'optimizeUniversalDefaults')) {
         hasApply = true
       }
     })

--- a/tests/apply.test.js
+++ b/tests/apply.test.js
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-// import { DEFAULTS_LAYER } from '../src/lib/expandTailwindAtRules.js'
+import { DEFAULTS_LAYER } from '../src/lib/expandTailwindAtRules.js'
 
 import { run, html, css } from './util/run'
 
@@ -812,7 +812,6 @@ it('should be possible to apply user css without tailwind directives', () => {
   })
 })
 
-/*
 it('apply can emit defaults in isolated environments without @tailwind directives', () => {
   let config = {
     [DEFAULTS_LAYER]: true,
@@ -848,4 +847,3 @@ it('apply can emit defaults in isolated environments without @tailwind directive
     `)
   })
 })
-*/

--- a/tests/apply.test.js
+++ b/tests/apply.test.js
@@ -866,7 +866,9 @@ it('apply does not emit defaults in isolated environments without optimizeUniver
 
   return run(input, config).then((result) => {
     return expect(result.css).toMatchFormattedCss(css`
-      *,::before,::after {
+      *,
+      ::before,
+      ::after {
         --tw-translate-x: 0;
         --tw-translate-y: 0;
         --tw-rotate: 0;

--- a/tests/apply.test.js
+++ b/tests/apply.test.js
@@ -847,3 +847,41 @@ it('apply can emit defaults in isolated environments without @tailwind directive
     `)
   })
 })
+
+it('apply does not emit defaults in isolated environments without optimizeUniversalDefaults', () => {
+  let config = {
+    [DEFAULTS_LAYER]: true,
+    experimental: { optimizeUniversalDefaults: false },
+    content: [{ raw: html`<div class="foo"></div>` }],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+
+    .foo {
+      @apply focus:rotate-90;
+    }
+  `
+
+  return run(input, config).then((result) => {
+    return expect(result.css).toMatchFormattedCss(css`
+      *,::before,::after {
+        --tw-translate-x: 0;
+        --tw-translate-y: 0;
+        --tw-rotate: 0;
+        --tw-skew-x: 0;
+        --tw-skew-y: 0;
+        --tw-scale-x: 1;
+        --tw-scale-y: 1;
+        --tw-transform: translateX(var(--tw-translate-x)) translateY(var(--tw-translate-y))
+          rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
+          scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+      }
+      .foo:focus {
+        --tw-rotate: 90deg;
+        transform: var(--tw-transform);
+      }
+    `)
+  })
+})


### PR DESCRIPTION
1. Re-enable `optimizeUniversalDefaults` by default
2. Re-enable apply handling for isolated CSS modules
3. Guard apply isolation to only when `optimizeUniversalDefaults` is enabled