### PR TITLE
Switch to using linuxstatic build target for the CLI

### DIFF
--- a/standalone-cli/package.json
+++ b/standalone-cli/package.json
@@ -2,9 +2,9 @@
   "name": "tailwindcss-standalone",
   "version": "0.0.0",
   "scripts": {
-    "build": "pkg standalone.js --out-path dist --targets node16-macos-x64,node16-macos-arm64,node16-win-x64,node16-linux-x64,node16-linux-arm64 --compress Brotli --no-bytecode --public-packages \"*\" --public",
+    "build": "pkg standalone.js --out-path dist --targets node16-macos-x64,node16-macos-arm64,node16-win-x64,node16-linuxstatic-x64,node16-linuxstatic-arm64 --compress Brotli --no-bytecode --public-packages \"*\" --public",
     "prebuild": "rimraf dist",
-    "postbuild": "move-file dist/standalone-macos-x64 dist/tailwindcss-macos-x64 && move-file dist/standalone-macos-arm64 dist/tailwindcss-macos-arm64 && move-file dist/standalone-win-x64.exe dist/tailwindcss-windows-x64.exe && move-file dist/standalone-linux-x64 dist/tailwindcss-linux-x64 && move-file dist/standalone-linux-arm64 dist/tailwindcss-linux-arm64",
+    "postbuild": "move-file dist/standalone-macos-x64 dist/tailwindcss-macos-x64 && move-file dist/standalone-macos-arm64 dist/tailwindcss-macos-arm64 && move-file dist/standalone-win-x64.exe dist/tailwindcss-windows-x64.exe && move-file dist/standalone-linuxstatic-x64 dist/tailwindcss-linux-x64 && move-file dist/standalone-linuxstatic-arm64 dist/tailwindcss-linux-arm64",
     "test": "jest"
   },
   "devDependencies": {


### PR DESCRIPTION
👋 Hi this is a pull request to go with the discussion https://github.com/tailwindlabs/tailwindcss/discussions/6785

The current linux build is dynamically linked, so it requires libraries to be present on the system when running. This means it does not work on minimal Alpine containers (https://github.com/tailwindlabs/tailwindcss/issues/6690) unless the user knows to install two library packages. It also appears to not be compatible with NixOS (https://github.com/tailwindlabs/tailwindcss/discussions/6785#discussioncomment-1913331)

Packaging the linux binary statically will fix these issues and make it platform independent. It also will not take up any more space, based on my test builds below.

| Arch   | Dynamic | Static |
| -- | ------------- | ------------- |
| x64 | 41mb | 39mb |  
| arm64 | 43mb | 36mb |