### PR TITLE
Fix use of falsy values in theme config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Allow use of falsy values in theme config ([#6917](https://github.com/tailwindlabs/tailwindcss/pull/6917))
+
 
 ## [3.0.11] - 2022-01-05
 

--- a/src/util/pluginUtils.js
+++ b/src/util/pluginUtils.js
@@ -185,7 +185,7 @@ export function coerceValue(types, modifier, options, tailwindConfig) {
   // Find first matching type
   for (let type of [].concat(types)) {
     let result = typeMap[type](modifier, options, { tailwindConfig })
-    if (result) return [result, type]
+    if (result !== undefined) return [result, type]
   }
 
   return []

--- a/tests/basic-usage.test.js
+++ b/tests/basic-usage.test.js
@@ -109,3 +109,31 @@ test('per-plugin colors with the same key can differ when using a custom colors 
     `)
   })
 })
+
+it('fasly config values still work', () => {
+  let config = {
+    content: [{ raw: html`<div class="inset-0"></div>` }],
+    theme: {
+      inset: {
+        0: 0,
+      },
+    },
+    plugins: [],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .inset-0 {
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+      }
+    `)
+  })
+})


### PR DESCRIPTION
The following would not produce any CSS for `inset-0` because it's `0` and not `'0'`:
```js
module.exports = {
  theme: {
    inset: {
      0: 0,
    },
  },
  plugins: [],
}
```

This fixes that.

cc @adamwathan @RobinMalfait 