### PR TITLE
Ensure we can apply classes that are grouped with non-class selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Allow use of falsy values in theme config ([#6917](https://github.com/tailwindlabs/tailwindcss/pull/6917))
+- Ensure we can apply classes defined with non-"on-demandable" selectors ([#6922](https://github.com/tailwindlabs/tailwindcss/pull/6922))
 
 
 ## [3.0.11] - 2022-01-05

--- a/tests/apply.test.js
+++ b/tests/apply.test.js
@@ -812,6 +812,104 @@ it('should be possible to apply user css without tailwind directives', () => {
   })
 })
 
+it('should be possible to apply a class from another rule with multiple selectors (2 classes)', () => {
+  let config = {
+    content: [{ raw: html`<div class="c"></div>` }],
+    plugins: [],
+  }
+
+  let input = css`
+    @tailwind utilities;
+    @layer utilities {
+      .a,
+      .b {
+        @apply underline;
+      }
+
+      .c {
+        @apply b;
+      }
+    }
+  `
+
+  return run(input, config).then((result) => {
+    return expect(result.css).toMatchFormattedCss(css`
+      .c {
+        text-decoration-line: underline;
+      }
+    `)
+  })
+})
+
+it('should be possible to apply a class from another rule with multiple selectors (1 class, 1 tag)', () => {
+  let config = {
+    content: [{ raw: html`<div class="c"></div>` }],
+    plugins: [],
+  }
+
+  let input = css`
+    @tailwind utilities;
+
+    @layer utilities {
+      span,
+      .b {
+        @apply underline;
+      }
+
+      .c {
+        @apply b;
+      }
+    }
+  `
+
+  return run(input, config).then((result) => {
+    return expect(result.css).toMatchFormattedCss(css`
+      span,
+      .b {
+        text-decoration-line: underline;
+      }
+
+      .c {
+        text-decoration-line: underline;
+      }
+    `)
+  })
+})
+
+it('should be possible to apply a class from another rule with multiple selectors (1 class, 1 id)', () => {
+  let config = {
+    content: [{ raw: html`<div class="c"></div>` }],
+    plugins: [],
+  }
+
+  let input = css`
+    @tailwind utilities;
+    @layer utilities {
+      #a,
+      .b {
+        @apply underline;
+      }
+
+      .c {
+        @apply b;
+      }
+    }
+  `
+
+  return run(input, config).then((result) => {
+    return expect(result.css).toMatchFormattedCss(css`
+      #a,
+      .b {
+        text-decoration-line: underline;
+      }
+
+      .c {
+        text-decoration-line: underline;
+      }
+    `)
+  })
+})
+
 /*
 it('apply can emit defaults in isolated environments without @tailwind directives', () => {
   let config = {


### PR DESCRIPTION
This PR fixes a bug where you can't apply `.foo` if you defined it as `span, .foo {}` in your css. This used to work in older AOT mode, but didn't work in JIT mode yet.

When we have a css rule that is defined as `.foo, .bar {}`, then we will crawl each selector and link it to the same node. This is useful because now our Map looks something like this:

```js
Map(2) { 'foo' => Node {}, 'bar' => Node {} }
```

This allows us to later on `@apply foo` or `@apply bar` and we can do a direct lookup for this "candidate".

When we have css defined as `span {}`, then we consider this "non-ondemandable". This means that we will _always_ inject these rules into the `*` section and call it a day.

However, it could happen that you have something like this: `span, .foo {}` up until now this was totally fine. It contains a non-ondemandable selector (`span`) and therefore we injected this into that `*` section.

However, the issue occurs if you now try to `@apply foo`. Since we had an early return for this use case it didn't endup in our Map from above and now you get an error like: 

```
The `foo` class does not exist. If `foo` is a custom class, make sure it is defined within a `@layer` directive.
```

So instead what we will do is keep track whether or not a css rule contains any on-demandable classes. If this is the case then we still generate it always by putting it in that `*` section. However, we will still register all on-demandable classes in our Map (in this case `.foo`).

This allows us to `@apply foo` again!

Fixes: #6882

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
