### PR TITLE
Fix consecutive builds with at apply producing different CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Fix consecutive builds with at apply producing different CSS ([#6999](https://github.com/tailwindlabs/tailwindcss/pull/6999))
 
 ## [3.0.12] - 2022-01-07
 

--- a/src/lib/partitionApplyAtRules.js
+++ b/src/lib/partitionApplyAtRules.js
@@ -1,0 +1,57 @@
+function partitionRules(root) {
+  if (!root.walkAtRules) return [root]
+
+  let applyParents = new Set()
+  let rules = []
+
+  root.walkAtRules('apply', (rule) => {
+    applyParents.add(rule.parent)
+  })
+
+  if (applyParents.size === 0) {
+    rules.push(root)
+  }
+
+  for (let rule of applyParents) {
+    let nodeGroups = []
+    let lastGroup = []
+
+    for (let node of rule.nodes) {
+      if (node.type === 'atrule' && node.name === 'apply') {
+        if (lastGroup.length > 0) {
+          nodeGroups.push(lastGroup)
+          lastGroup = []
+        }
+        nodeGroups.push([node])
+      } else {
+        lastGroup.push(node)
+      }
+    }
+
+    if (lastGroup.length > 0) {
+      nodeGroups.push(lastGroup)
+    }
+
+    if (nodeGroups.length === 1) {
+      rules.push(rule)
+      continue
+    }
+
+    for (let group of [...nodeGroups].reverse()) {
+      let clone = rule.clone({ nodes: [] })
+      clone.append(group)
+      rules.unshift(clone)
+      rule.after(clone)
+    }
+
+    rule.remove()
+  }
+
+  return rules
+}
+
+export default function expandApplyAtRules() {
+  return (root) => {
+    partitionRules(root)
+  }
+}

--- a/src/lib/partitionApplyAtRules.js
+++ b/src/lib/partitionApplyAtRules.js
@@ -1,15 +1,14 @@
 function partitionRules(root) {
-  if (!root.walkAtRules) return [root]
+  if (!root.walkAtRules) return
 
   let applyParents = new Set()
-  let rules = []
 
   root.walkAtRules('apply', (rule) => {
     applyParents.add(rule.parent)
   })
 
   if (applyParents.size === 0) {
-    rules.push(root)
+    return
   }
 
   for (let rule of applyParents) {
@@ -33,21 +32,17 @@ function partitionRules(root) {
     }
 
     if (nodeGroups.length === 1) {
-      rules.push(rule)
       continue
     }
 
     for (let group of [...nodeGroups].reverse()) {
       let clone = rule.clone({ nodes: [] })
       clone.append(group)
-      rules.unshift(clone)
       rule.after(clone)
     }
 
     rule.remove()
   }
-
-  return rules
 }
 
 export default function expandApplyAtRules() {

--- a/src/processTailwindFeatures.js
+++ b/src/processTailwindFeatures.js
@@ -6,6 +6,7 @@ import substituteScreenAtRules from './lib/substituteScreenAtRules'
 import resolveDefaultsAtRules from './lib/resolveDefaultsAtRules'
 import collapseAdjacentRules from './lib/collapseAdjacentRules'
 import collapseDuplicateDeclarations from './lib/collapseDuplicateDeclarations'
+import partitionApplyAtRules from './lib/partitionApplyAtRules'
 import detectNesting from './lib/detectNesting'
 import { createContext } from './lib/setupContextUtils'
 import { issueFlagNotices } from './featureFlags'
@@ -15,6 +16,7 @@ export default function processTailwindFeatures(setupContext) {
     let { tailwindDirectives, applyDirectives } = normalizeTailwindDirectives(root)
 
     detectNesting()(root, result)
+    partitionApplyAtRules()(root, result)
 
     let context = setupContext({
       tailwindDirectives,

--- a/tests/apply.test.js
+++ b/tests/apply.test.js
@@ -1139,3 +1139,66 @@ it('apply does not emit defaults in isolated environments without optimizeUniver
     `)
   })
 })
+
+it('should work outside of layer', async () => {
+  let config = {
+    content: [{ raw: html`<div class="input-text"></div>` }],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    .input-text {
+      @apply bg-white;
+      background-color: red;
+    }
+  `
+
+  let result
+  result = await run(input, config)
+
+  expect(result.css).toMatchFormattedCss(css`
+    .input-text {
+      --tw-bg-opacity: 1;
+      background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+      background-color: red;
+    }
+  `)
+
+  result = await run(input, config)
+
+  expect(result.css).toMatchFormattedCss(css`
+    .input-text {
+      --tw-bg-opacity: 1;
+      background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+      background-color: red;
+    }
+  `)
+})
+
+it('should work in layer', async () => {
+  let config = {
+    content: [{ raw: html`<div class="input-text"></div>` }],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind components;
+    @layer components {
+      .input-text {
+        @apply bg-white;
+        background-color: red;
+      }
+    }
+  `
+
+  await run(input, config)
+  const result = await run(input, config)
+
+  expect(result.css).toMatchFormattedCss(css`
+    .input-text {
+      --tw-bg-opacity: 1;
+      background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+      background-color: red;
+    }
+  `)
+})


### PR DESCRIPTION
Previously we were partitioning at rules in CSS when the context was created. However, if the CSS or config didn't change then this wouldn't happen because the context cache wasn't invalidated. This manifested as different CSS being produced in the first build versus subsequent builds. Instead we _always_ partition the rules up front before processing any other tailwind features to ensure we always produce the same CSS.