### PR TITLE
Ensure nesting plugins can receive options

### DIFF
--- a/nesting/plugin.js
+++ b/nesting/plugin.js
@@ -14,7 +14,10 @@ module.exports = function nesting(opts = postcssNested) {
     })
 
     let plugin = (() => {
-      if (typeof opts === 'function' || typeof opts === 'object') {
+      if (
+        typeof opts === 'function' ||
+        (typeof opts === 'object' && opts?.hasOwnProperty('postcssPlugin'))
+      ) {
         return opts
       }
 

--- a/nesting/plugin.js
+++ b/nesting/plugin.js
@@ -14,7 +14,7 @@ module.exports = function nesting(opts = postcssNested) {
     })
 
     let plugin = (() => {
-      if (typeof opts === 'function') {
+      if (typeof opts === 'function' || typeof opts === 'object') {
         return opts
       }
 

--- a/tests/postcss-plugins/nesting/index.test.js
+++ b/tests/postcss-plugins/nesting/index.test.js
@@ -74,7 +74,7 @@ it('should default to the bundled postcss-nested plugin (no options)', async () 
   `)
 })
 
-it('should default to the bundled postcss-nested plugin (empty ooptions)', async () => {
+it('should default to the bundled postcss-nested plugin (empty options)', async () => {
   let input = css`
     .foo {
       color: black;
@@ -85,6 +85,29 @@ it('should default to the bundled postcss-nested plugin (empty ooptions)', async
   `
 
   expect(await run(input, {})).toMatchCss(css`
+    .foo {
+      color: black;
+    }
+
+    @media screen(md) {
+      .foo {
+        color: blue;
+      }
+    }
+  `)
+})
+
+it('should be possible to use postcss-nested plugin with options', async () => {
+  let input = css`
+    .foo {
+      color: black;
+      @screen md {
+        color: blue;
+      }
+    }
+  `
+
+  expect(await run(input, postcssNested({ noIsPseudoSelector: true }))).toMatchCss(css`
     .foo {
       color: black;
     }


### PR DESCRIPTION
PostCSS nesting added some options that can be configured eg.
https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-nesting#noispseudoselector

Current implementation of Tailwind Nesting doesn't pass the options, becuase the `typeof` of the plugin is object with options, not function. This fixes it.

Example PostCSS Vite configuration

```js
import postcssImport from 'postcss-import';
import postcssNesting from 'postcss-nesting';
import tailwindcss from 'tailwindcss'
import tailwindcssNesting from 'tailwindcss/nesting'
import autoprefixer from 'autoprefixer'

export default {
  css: {
    postcss: {
      plugins: [postcssImport, tailwindcssNesting(postcssNesting({
        noIsPseudoSelector: true
      })), tailwindcss, autoprefixer]
    }
}
```