### PR TITLE
Show warnings for invalid content config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Added
+
+- Show warnings for invalid content config ([#7065](https://github.com/tailwindlabs/tailwindcss/pull/7065))
 
 ## [3.0.13] - 2022-01-11
 

--- a/src/lib/expandTailwindAtRules.js
+++ b/src/lib/expandTailwindAtRules.js
@@ -231,10 +231,9 @@ export default function expandTailwindAtRules(context) {
     // If we've got a utility layer and no utilities are generated there's likely something wrong
     // TODO: Detect utility variants only
     if (layerNodes.utilities && utilityNodes.size === 0 && screenNodes.size === 0) {
-      log.warn(
-        'no-utilities-generated',
+      log.warn('no-utilities-generated', [
         'No utilities were generated there is likely a problem with the `content` key in the tailwind config.'
-      )
+      ])
     }
 
     // ---

--- a/src/lib/expandTailwindAtRules.js
+++ b/src/lib/expandTailwindAtRules.js
@@ -231,8 +231,8 @@ export default function expandTailwindAtRules(context) {
     // If we've got a utility layer and no utilities are generated there's likely something wrong
     // TODO: Detect utility variants only
     if (layerNodes.utilities && utilityNodes.size === 0 && screenNodes.size === 0) {
-      log.warn('no-utilities-generated', [
-        'No utilities were generated there is likely a problem with the `content` key in the tailwind config.'
+      log.warn('content-problems', [
+        'No utilities were generated there is likely a problem with the `content` key in the tailwind config. For more information see the documentation: https://tailwindcss.com/docs/content-configuration',
       ])
     }
 

--- a/src/lib/expandTailwindAtRules.js
+++ b/src/lib/expandTailwindAtRules.js
@@ -2,6 +2,7 @@ import LRU from 'quick-lru'
 import * as sharedState from './sharedState'
 import { generateRules } from './generateRules'
 import bigSign from '../util/bigSign'
+import log from '../util/log'
 import cloneNodes from '../util/cloneNodes'
 import { defaultExtractor } from './defaultExtractor'
 
@@ -225,6 +226,15 @@ export default function expandTailwindAtRules(context) {
       layerNodes.variants.remove()
     } else {
       root.append(cloneNodes([...screenNodes], root.source))
+    }
+
+    // If we've got a utility layer and no utilities are generated there's likely something wrong
+    // TODO: Detect utility variants only
+    if (layerNodes.utilities && utilityNodes.size === 0 && screenNodes.size === 0) {
+      log.warn(
+        'no-utilities-generated',
+        'No utilities were generated there is likely a problem with the `content` key in the tailwind config.'
+      )
     }
 
     // ---

--- a/src/lib/setupTrackingContext.js
+++ b/src/lib/setupTrackingContext.js
@@ -118,12 +118,6 @@ export default function setupTrackingContext(configOrPath) {
       let [tailwindConfig, userConfigPath, tailwindConfigHash, configDependencies] =
         getTailwindConfig(configOrPath)
 
-      if (tailwindConfig.content.files.length === 0) {
-        log.warn('no-content-found', [
-          'The `content` key is missing or empty. Please populate the content key as Tailwind generates utilities on-demand based on the files that use them.'
-        ])
-      }
-
       let contextDependencies = new Set(configDependencies)
 
       // If there are no @tailwind or @apply rules, we don't consider this CSS

--- a/src/lib/setupTrackingContext.js
+++ b/src/lib/setupTrackingContext.js
@@ -16,7 +16,6 @@ import { env } from './sharedState'
 
 import { getContext, getFileModifiedMap } from './setupContextUtils'
 import parseDependency from '../util/parseDependency'
-import log from '../util/log'
 
 let configPathCache = new LRU({ maxSize: 100 })
 

--- a/src/lib/setupTrackingContext.js
+++ b/src/lib/setupTrackingContext.js
@@ -119,10 +119,9 @@ export default function setupTrackingContext(configOrPath) {
         getTailwindConfig(configOrPath)
 
       if (tailwindConfig.content.files.length === 0) {
-        log.warn(
-          'no-content-found',
+        log.warn('no-content-found', [
           'The `content` key is missing or empty. Please populate the content key as Tailwind generates utilities on-demand based on the files that use them.'
-        )
+        ])
       }
 
       let contextDependencies = new Set(configDependencies)

--- a/src/lib/setupTrackingContext.js
+++ b/src/lib/setupTrackingContext.js
@@ -16,6 +16,7 @@ import { env } from './sharedState'
 
 import { getContext, getFileModifiedMap } from './setupContextUtils'
 import parseDependency from '../util/parseDependency'
+import log from '../util/log'
 
 let configPathCache = new LRU({ maxSize: 100 })
 
@@ -116,6 +117,13 @@ export default function setupTrackingContext(configOrPath) {
     return (root, result) => {
       let [tailwindConfig, userConfigPath, tailwindConfigHash, configDependencies] =
         getTailwindConfig(configOrPath)
+
+      if (tailwindConfig.content.files.length === 0) {
+        log.warn(
+          'no-content-found',
+          'The `content` key is missing or empty. Please populate the content key as Tailwind generates utilities on-demand based on the files that use them.'
+        )
+      }
 
       let contextDependencies = new Set(configDependencies)
 

--- a/src/util/normalizeConfig.js
+++ b/src/util/normalizeConfig.js
@@ -258,5 +258,11 @@ export function normalizeConfig(config) {
     }
   }
 
+  if (config.content.files.length === 0) {
+    log.warn('no-content-found', [
+      'The `content` key is missing or empty. Please populate the content key as Tailwind generates utilities on-demand based on the files that use them.'
+    ])
+  }
+
   return config
 }

--- a/src/util/normalizeConfig.js
+++ b/src/util/normalizeConfig.js
@@ -259,8 +259,8 @@ export function normalizeConfig(config) {
   }
 
   if (config.content.files.length === 0) {
-    log.warn('no-content-found', [
-      'The `content` key is missing or empty. Please populate the content key as Tailwind generates utilities on-demand based on the files that use them.'
+    log.warn('content-problems', [
+      'The `content` key is missing or empty. Please populate the content key as Tailwind generates utilities on-demand based on the files that use them. For more information see the documentation: https://tailwindcss.com/docs/content-configuration',
     ])
   }
 

--- a/tests/warnings.test.js
+++ b/tests/warnings.test.js
@@ -41,3 +41,34 @@ test('it warns when there is an empty content key', async () => {
   expect(warn).toHaveBeenCalledTimes(1)
   expect(warn.mock.calls.map((x) => x[0])).toEqual(['no-content-found'])
 })
+
+test('it warns when there are no utilities generated', async () => {
+  let config = {
+    content: [{ raw: html`nothing here matching a utility` }],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind utilities;
+  `
+
+  await run(input, config)
+
+  expect(warn).toHaveBeenCalledTimes(1)
+  expect(warn.mock.calls.map((x) => x[0])).toEqual(['no-utilities-generated'])
+})
+
+it('warnings are not thrown when only variant utilities are generated', async () => {
+  let config = {
+    content: [{ raw: html`<div class="sm:underline"></div>` }],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind utilities;
+  `
+
+  await run(input, config)
+
+  expect(warn).toHaveBeenCalledTimes(0)
+})

--- a/tests/warnings.test.js
+++ b/tests/warnings.test.js
@@ -1,0 +1,43 @@
+import { html, run, css } from './util/run'
+
+let warn
+
+beforeEach(() => {
+  let log = require('../src/util/log')
+  warn = jest.spyOn(log.default, 'warn')
+})
+
+afterEach(() => {
+  warn.mockClear()
+})
+
+test('it warns when there is no content key', async () => {
+  let config = {
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+  `
+
+  await run(input, config)
+
+  expect(warn).toHaveBeenCalledTimes(1)
+  expect(warn.mock.calls.map((x) => x[0])).toEqual(['no-content-found'])
+})
+
+test('it warns when there is an empty content key', async () => {
+  let config = {
+    content: [],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+  `
+
+  await run(input, config)
+
+  expect(warn).toHaveBeenCalledTimes(1)
+  expect(warn.mock.calls.map((x) => x[0])).toEqual(['no-content-found'])
+})

--- a/tests/warnings.test.js
+++ b/tests/warnings.test.js
@@ -23,7 +23,7 @@ test('it warns when there is no content key', async () => {
   await run(input, config)
 
   expect(warn).toHaveBeenCalledTimes(1)
-  expect(warn.mock.calls.map((x) => x[0])).toEqual(['no-content-found'])
+  expect(warn.mock.calls.map((x) => x[0])).toEqual(['content-problems'])
 })
 
 test('it warns when there is an empty content key', async () => {
@@ -39,7 +39,7 @@ test('it warns when there is an empty content key', async () => {
   await run(input, config)
 
   expect(warn).toHaveBeenCalledTimes(1)
-  expect(warn.mock.calls.map((x) => x[0])).toEqual(['no-content-found'])
+  expect(warn.mock.calls.map((x) => x[0])).toEqual(['content-problems'])
 })
 
 test('it warns when there are no utilities generated', async () => {
@@ -55,7 +55,7 @@ test('it warns when there are no utilities generated', async () => {
   await run(input, config)
 
   expect(warn).toHaveBeenCalledTimes(1)
-  expect(warn.mock.calls.map((x) => x[0])).toEqual(['no-utilities-generated'])
+  expect(warn.mock.calls.map((x) => x[0])).toEqual(['content-problems'])
 })
 
 it('warnings are not thrown when only variant utilities are generated', async () => {


### PR DESCRIPTION
We will now show a warning when the content key is missing or empty in the tailwind config. Additionally, we'll also show a warning when no utilities are generated if you have `@tailwind utilities;` in your config and no utilities are generated as this is likely unexpected.