### PR TITLE
Remove optional chaining usage

### DIFF
--- a/nesting/plugin.js
+++ b/nesting/plugin.js
@@ -16,7 +16,7 @@ module.exports = function nesting(opts = postcssNested) {
     let plugin = (() => {
       if (
         typeof opts === 'function' ||
-        (typeof opts === 'object' && opts?.hasOwnProperty('postcssPlugin'))
+        (typeof opts === 'object' && opts.hasOwnProperty('postcssPlugin'))
       ) {
         return opts
       }


### PR DESCRIPTION
This PR removes the use of [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining#browser_compatibility) syntax to ensure compatibility with Node.js versions 13 and below.

For reference: https://github.com/tailwindlabs/tailwindcss/commit/8293c2d33d4d059e5ed9be8963967892f838e6c9#r63911585