### PR TITLE
Temporarily remove optional chaining in nesting plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Temporarily remove optional chaining in nesting plugin ([#7077](https://github.com/tailwindlabs/tailwindcss/pull/7077))
 
 ## [3.0.14] - 2022-01-14
 

--- a/nesting/plugin.js
+++ b/nesting/plugin.js
@@ -16,7 +16,7 @@ module.exports = function nesting(opts = postcssNested) {
     let plugin = (() => {
       if (
         typeof opts === 'function' ||
-        (typeof opts === 'object' && opts?.hasOwnProperty('postcssPlugin'))
+        (typeof opts === 'object' && opts.hasOwnProperty('postcssPlugin'))
       ) {
         return opts
       }


### PR DESCRIPTION
This PR is a quick fix:

The optional chaining breaks on Node versions lower than version 13. Normally
we transpile everything, but we currently don't do this for the nesting plugin
since it is not really part of the `src` folder.

Will get this fixed in a better way, but for now this is a quick fix to
get everything working again!

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
