### PR TITLE
Remove false positive warning in CLI when using the `--content` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Remove false positive warning in CLI when using the `--content` option ([#7220](https://github.com/tailwindlabs/tailwindcss/pull/7220))
 
 ## [3.0.16] - 2022-01-24
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -437,7 +437,6 @@ async function build() {
 
   function resolveConfig() {
     let config = configPath ? require(configPath) : {}
-    let resolvedConfig = resolveConfigInternal(config)
 
     if (args['--purge']) {
       log.warn('purge-flag-deprecated', [
@@ -450,10 +449,13 @@ async function build() {
     }
 
     if (args['--content']) {
-      resolvedConfig.content.files = args['--content'].split(/(?<!{[^}]+),/)
+      let files = args['--content'].split(/(?<!{[^}]+),/)
+      let resolvedConfig = resolveConfigInternal(config, { content: { files } })
+      resolvedConfig.content.files = files
+      return resolvedConfig
     }
 
-    return resolvedConfig
+    return resolveConfigInternal(config)
   }
 
   function extractFileGlobs(config) {


### PR DESCRIPTION
This PR will remove the false positive warning about the empty content option in your config.

When you are using the CLI, then we try to resolve the `tailwind.config.js`, but it can happen that you don't have one and that you are using the `--content` flag instead.

E.g.:
```
npx tailwindcss -i input.css -o output.css --content ./index.html
```

We do make sure that the `./index.html` file is eventually present in your config, but it isn't initially and therefore you get the (incorrect) warning.

We fixed this by making sure that your `--content` is present immediately which removes the incorrect warning.

Note: You will still receive a warning if we didn't generate any utilities at all. This is a valid warning, and an indication that you might have linked the wrong content files, or that you didn't use any Tailwind classes yet.

Fixes: #7210