### PR TITLE
add fontSize 2xs and 3xs.

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -372,6 +372,8 @@ module.exports = {
       ],
     },
     fontSize: {
+      '3xs': ['0.5rem', { lineHeight: '0.5rem' }],
+      '2xs': ['0.625rem', { lineHeight: '0.75rem' }],
       xs: ['0.75rem', { lineHeight: '1rem' }],
       sm: ['0.875rem', { lineHeight: '1.25rem' }],
       base: ['1rem', { lineHeight: '1.5rem' }],


### PR DESCRIPTION
add Front size for
- 2xs
- 3xs

It is often used mainly in the following situations.
- UI of the administration screen.
- Comments and annotation characters.

The image applied for trial with Tailwind Play is as follows. (Red letters, red frame part.)
![スクリーンショット 2022-01-31 10 06 56](https://user-images.githubusercontent.com/24556516/151726781-b1b0c533-ee9b-4ba8-bb74-ea41e09cb947.png)