### PR TITLE
Add desktop first media queries

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -9,6 +9,11 @@ module.exports = {
       lg: '1024px',
       xl: '1280px',
       '2xl': '1536px',
+      '-2xl': { max: '1535px' },
+      '-xl': { max: '1279px' },
+      '-lg': { max: '1023px' },
+      '-md': { max: '767px' },
+      '-sm': { max: '639px' },
     },
     colors: ({ colors }) => ({
       inherit: colors.inherit,


### PR DESCRIPTION
This is a simple change we can discuss it in the PR maybe?

I think it's super useful when someone wants to add inverse media queries (desktop first).

I'm not sure the order of media queries is right, which one should have precedence (mobile first or desktop first), for sure the desktop first media queries must be in inverse order.