### PR TITLE
Fix preflight border color fallback

### DIFF
--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -9,7 +9,7 @@
   box-sizing: border-box; /* 1 */
   border-width: 0; /* 2 */
   border-style: solid; /* 2 */
-  border-color: theme('borderColor.DEFAULT', 'currentColor'); /* 2 */
+  border-color: theme('borderColor.DEFAULT', currentColor); /* 2 */
 }
 
 ::before,

--- a/tests/preflight.test.js
+++ b/tests/preflight.test.js
@@ -1,0 +1,21 @@
+import { run, html, css } from './util/run'
+
+it('preflight has a correct border color fallback', () => {
+  let config = {
+    content: [{ raw: html`<div class="border-black"></div>` }],
+    theme: {
+      borderColor: ({ theme }) => theme('colors'),
+    },
+    plugins: [],
+    corePlugins: { preflight: true },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toContain(`border-color: currentColor;`)
+  })
+})


### PR DESCRIPTION
The fallback color in preflight for borders was being emitted as `"currentColor"` instead of `currentColor`. This fixes that.

Fixes #7186