### PR TITLE
Correctly parse shadow lengths without a leading zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix preflight border color fallback ([#7288](https://github.com/tailwindlabs/tailwindcss/pull/7288))
+- Correctly parse shadow lengths without a leading zero ([#7289](https://github.com/tailwindlabs/tailwindcss/pull/7289))
 
 ## [3.0.18] - 2022-01-28
 

--- a/src/util/parseBoxShadowValue.js
+++ b/src/util/parseBoxShadowValue.js
@@ -1,7 +1,7 @@
 let KEYWORDS = new Set(['inset', 'inherit', 'initial', 'revert', 'unset'])
 let COMMA = /\,(?![^(]*\))/g // Comma separator that is not located between brackets. E.g.: `cubiz-bezier(a, b, c)` these don't count.
 let SPACE = /\ +(?![^(]*\))/g // Similar to the one above, but with spaces instead.
-let LENGTH = /^-?(\d+)(.*?)$/g
+let LENGTH = /^-?(\d+|\.\d+)(.*?)$/g
 
 export function parseBoxShadowValue(input) {
   let shadows = input.split(COMMA)

--- a/tests/basic-usage.test.js
+++ b/tests/basic-usage.test.js
@@ -137,3 +137,36 @@ it('fasly config values still work', () => {
     `)
   })
 })
+
+it('shadows support values without a leading zero', () => {
+  let config = {
+    content: [{ raw: html`<div class="shadow-one shadow-two"></div>` }],
+    theme: {
+      boxShadow: {
+        one: '0.5rem 0.5rem 0.5rem #0005',
+        two: '.5rem .5rem .5rem #0005',
+      },
+    },
+    plugins: [],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .shadow-one {
+        --tw-shadow: 0.5rem 0.5rem 0.5rem #0005;
+        --tw-shadow-colored: 0.5rem 0.5rem 0.5rem var(--tw-shadow-color);
+        box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+      }
+      .shadow-two {
+        --tw-shadow: 0.5rem 0.5rem 0.5rem #0005;
+        --tw-shadow-colored: 0.5rem 0.5rem 0.5rem var(--tw-shadow-color);
+        box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+      }
+    `)
+  })
+})

--- a/tests/basic-usage.test.js
+++ b/tests/basic-usage.test.js
@@ -160,12 +160,14 @@ it('shadows support values without a leading zero', () => {
       .shadow-one {
         --tw-shadow: 0.5rem 0.5rem 0.5rem #0005;
         --tw-shadow-colored: 0.5rem 0.5rem 0.5rem var(--tw-shadow-color);
-        box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+        box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
+          var(--tw-shadow);
       }
       .shadow-two {
         --tw-shadow: 0.5rem 0.5rem 0.5rem #0005;
         --tw-shadow-colored: 0.5rem 0.5rem 0.5rem var(--tw-shadow-color);
-        box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+        box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
+          var(--tw-shadow);
       }
     `)
   })


### PR DESCRIPTION
We were not parsing shadow lengths without a leading zero. This caused custom box shadow colors to not work for these custom shadows.

Fixes #7178 