### PR TITLE
Add support for PostCSS `Document` nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow default ring color to be a function ([#7587](https://github.com/tailwindlabs/tailwindcss/pull/7587))
 - Add `rgb` and `hsl` color helpers for CSS variables ([#7665](https://github.com/tailwindlabs/tailwindcss/pull/7665))
+- Support PostCSS `Document` nodes ([#7291](https://github.com/tailwindlabs/tailwindcss/pull/7291))
 
 ## [3.0.23] - 2022-02-16
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,21 @@ module.exports = function tailwindcss(configOrPath) {
           return root
         },
       function (root, result) {
-        processTailwindFeatures(setupTrackingContext(configOrPath))(root, result)
+        let context = setupTrackingContext(configOrPath)
+
+        if (root.type === 'document') {
+          let roots = root.nodes.filter((node) => node.type === 'root')
+
+          for (const root of roots) {
+            if (root.type === 'root') {
+              processTailwindFeatures(context)(root, result)
+            }
+          }
+
+          return
+        }
+
+        processTailwindFeatures(context)(root, result)
       },
       env.DEBUG &&
         function (root) {


### PR DESCRIPTION
This is *very* experimental fix but I think maybe in the right direction. It still needs a good bit of thought.

The short summary is that PostCSS now has an optional `Document` node that represents a file with multiple disjoint sections to be processed by PostCSS. Previously PostCSS only ever assumed a single root node as did Tailwind. Now, when presented with a document node, we'll run the entire Tailwind plugin over each root node contained in the document.

Fixes #7207