### PR TITLE
Add support for TypeScript configuration files

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,23 @@
+type TailwindConfig = any
+
+/**
+ * Defines the Tailwind CSS configuration.
+ * 
+ * @example
+ * ```ts
+ * import { defineConfig } from 'tailwindcss'
+ * 
+ * export default defineConfig({
+ *   content: ['src/*.vue'],
+ *   theme: {
+ *     // ...
+ *   }
+ * })
+ * ```
+ */
+export function defineConfig(options?: TailwindConfig): TailwindConfig
+
+/**
+ * Tailwind CSS as a PostCSS plugin.
+ */
+export const tailwindcss: Plugin

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
         "postcss-selector-parser": "^6.0.9",
         "postcss-value-parser": "^4.2.0",
         "quick-lru": "^5.1.1",
-        "resolve": "^1.22.0"
+        "resolve": "^1.22.0",
+        "unconfig": "^0.2.2"
       },
       "bin": {
         "tailwind": "lib/cli.js",
@@ -57,6 +58,17 @@
       "peerDependencies": {
         "autoprefixer": "^10.0.2",
         "postcss": "^8.0.9"
+      }
+    },
+    "node_modules/@antfu/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-UU8TLr/EoXdg7OjMp0h9oDoIAVr+Z/oW9cpOxQQyrsz6Qzd2ms/1CdWx8fl2OQdFpxGmq5Vc4TwfLHId6nAZjA==",
+      "dependencies": {
+        "@types/throttle-debounce": "^2.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1447,6 +1459,11 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
+    "node_modules/@types/throttle-debounce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/throttle-debounce/-/throttle-debounce-2.1.0.tgz",
+      "integrity": "sha512-5eQEtSCoESnh2FsiLTxE121IiE60hnMqcb435fShf4bpLRjEu1Eoekht23y6zXS9Ts3l+Szu3TARnTsA0GkOkQ=="
+    },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
@@ -2350,6 +2367,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+    },
+    "node_modules/defu": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-5.0.1.tgz",
+      "integrity": "sha512-EPS1carKg+dkEVy3qNTqIdp2qV7mUP08nIsupfwQpz++slCVRw7qbQyWvSTig+kFPwz2XXp5/kIIkH+CwrJKkQ=="
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -4418,6 +4440,14 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jiti": {
+      "version": "1.12.15",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.12.15.tgz",
+      "integrity": "sha512-/+K89y6KJA2nISbWrlc/773XdpDgSQq/LdQ+ZZyw2jRxUNyquPtbsDCCCMRzzNORUgroUGc4nAXxJEnQvpViCA==",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6282,6 +6312,19 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/unconfig": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/unconfig/-/unconfig-0.2.2.tgz",
+      "integrity": "sha512-JN1MeYJ/POnjBj7NgOJJxPp6+NcD6Nd0hEuK0D89kjm9GvQQUq8HeE2Eb7PZgtu+64mWkDiqeJn1IZoLH7htPg==",
+      "dependencies": {
+        "@antfu/utils": "^0.3.0",
+        "defu": "^5.0.0",
+        "jiti": "^1.12.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -6554,6 +6597,14 @@
     }
   },
   "dependencies": {
+    "@antfu/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-UU8TLr/EoXdg7OjMp0h9oDoIAVr+Z/oW9cpOxQQyrsz6Qzd2ms/1CdWx8fl2OQdFpxGmq5Vc4TwfLHId6nAZjA==",
+      "requires": {
+        "@types/throttle-debounce": "^2.1.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
@@ -7565,6 +7616,11 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
+    "@types/throttle-debounce": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/throttle-debounce/-/throttle-debounce-2.1.0.tgz",
+      "integrity": "sha512-5eQEtSCoESnh2FsiLTxE121IiE60hnMqcb435fShf4bpLRjEu1Eoekht23y6zXS9Ts3l+Szu3TARnTsA0GkOkQ=="
+    },
     "@types/yargs": {
       "version": "16.0.4",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
@@ -8250,6 +8306,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+    },
+    "defu": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-5.0.1.tgz",
+      "integrity": "sha512-EPS1carKg+dkEVy3qNTqIdp2qV7mUP08nIsupfwQpz++slCVRw7qbQyWvSTig+kFPwz2XXp5/kIIkH+CwrJKkQ=="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -9756,6 +9817,11 @@
         }
       }
     },
+    "jiti": {
+      "version": "1.12.15",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.12.15.tgz",
+      "integrity": "sha512-/+K89y6KJA2nISbWrlc/773XdpDgSQq/LdQ+ZZyw2jRxUNyquPtbsDCCCMRzzNORUgroUGc4nAXxJEnQvpViCA=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11049,6 +11115,16 @@
       "dev": true,
       "requires": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "unconfig": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/unconfig/-/unconfig-0.2.2.tgz",
+      "integrity": "sha512-JN1MeYJ/POnjBj7NgOJJxPp6+NcD6Nd0hEuK0D89kjm9GvQQUq8HeE2Eb7PZgtu+64mWkDiqeJn1IZoLH7htPg==",
+      "requires": {
+        "@antfu/utils": "^0.3.0",
+        "defu": "^5.0.0",
+        "jiti": "^1.12.9"
       }
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "postcss-selector-parser": "^6.0.9",
     "postcss-value-parser": "^4.2.0",
     "quick-lru": "^5.1.1",
-    "resolve": "^1.22.0"
+    "resolve": "^1.22.0",
+    "unconfig": "^0.2.2"
   },
   "browserslist": [
     "> 1%",

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import setupTrackingContext from './lib/setupTrackingContext'
 import processTailwindFeatures from './processTailwindFeatures'
 import { env } from './lib/sharedState'
 
-module.exports = function tailwindcss(configOrPath) {
+const plugin = function tailwindcss(configOrPath) {
   return {
     postcssPlugin: 'tailwindcss',
     plugins: [
@@ -12,8 +12,8 @@ module.exports = function tailwindcss(configOrPath) {
           console.time('JIT TOTAL')
           return root
         },
-      function (root, result) {
-        processTailwindFeatures(setupTrackingContext(configOrPath))(root, result)
+      async function (root, result) {
+        await processTailwindFeatures(setupTrackingContext(configOrPath))(root, result)
       },
       env.DEBUG &&
         function (root) {
@@ -25,4 +25,7 @@ module.exports = function tailwindcss(configOrPath) {
   }
 }
 
+module.exports = plugin
 module.exports.postcss = true
+module.exports.tailwindcss = plugin
+module.exports.defineConfig = (config) => config

--- a/src/processTailwindFeatures.js
+++ b/src/processTailwindFeatures.js
@@ -12,7 +12,7 @@ import { createContext } from './lib/setupContextUtils'
 import { issueFlagNotices } from './featureFlags'
 
 export default function processTailwindFeatures(setupContext) {
-  return function (root, result) {
+  return async function (root, result) {
     let { tailwindDirectives, applyDirectives } = normalizeTailwindDirectives(root)
 
     detectNesting()(root, result)
@@ -21,7 +21,7 @@ export default function processTailwindFeatures(setupContext) {
     // itself.
     partitionApplyAtRules()(root, result)
 
-    let context = setupContext({
+    let context = await setupContext({
       tailwindDirectives,
       applyDirectives,
       registerDependency(dependency) {

--- a/tests/customConfig.test.js
+++ b/tests/customConfig.test.js
@@ -4,9 +4,24 @@ import { cjsConfigFile, defaultConfigFile } from '../src/constants'
 import inTempDirectory from '../jest/runInTempDirectory'
 
 import { run, html, css, javascript } from './util/run'
+import { getTailwindConfig } from '../src/lib/setupTrackingContext'
 
 test('it uses the values from the custom config file', () => {
   let config = require(path.resolve(`${__dirname}/fixtures/custom-config.js`))
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      @media (min-width: 400px) {
+        .mobile\:font-bold {
+          font-weight: 700;
+        }
+      }
+    `)
+  })
+})
+
+test('it resolves a typescript config file', async () => {
+  let [config] = await getTailwindConfig(path.resolve(`${__dirname}/fixtures/ts-config.ts`))
 
   return run('@tailwind utilities', config).then((result) => {
     expect(result.css).toMatchFormattedCss(css`

--- a/tests/fixtures/ts-config.ts
+++ b/tests/fixtures/ts-config.ts
@@ -1,0 +1,11 @@
+// @ts-ignore
+import { defineConfig } from '../../src'
+
+export default defineConfig({
+  content: [{ raw: '<div class="mobile:font-bold"></div>' }],
+  theme: {
+    screens: {
+      mobile: '400px',
+    },
+  },
+})


### PR DESCRIPTION
This PR adds support for loading TypeScript configuration files. 

```ts
// tailwind.config.ts
import { defineConfig } from 'tailwindcss'

export default defineConfig({
	content: [
		'./resources/views/entries/**/*.blade.php',
		'./resources/views/scripts/**/*.ts',
		'./resources/views/**/*.vue',
	],

	plugins: [
		require('@tailwindcss/forms'),
	],
})
```

## Why?

Personally, it's basically my only pet peeve with Tailwind CSS: to be forced to use a `.js` config file and not to have auto-completion on the config object.

In the front-end ecosystem, especially on the Vite side, it's common to have `xxx.config.ts` files. They all provide types, so IDEs can provide auto-completion and we don't have to go back and forth to the documentation. It's also usual to have a `defineConfig` wrapper function to provide these types.

Examples of this are Vite, Vitest, Vue, Nuxt, Unbuild, Tsup, Windi...

## Implementation notes

I went safe with the implementation by relying on a tool specifically made for this; [unconfig](https://github.com/antfu/unconfig). It itself relies on [`jiti`](https://github.com/unjs/jiti) (which I recommend checking out). 

I would understand if you don't want to have a dependency here, but that was the easiest and most reliable option for me to implement this because I'm not familiar with the codebase. 

A side-effect of using `unconfig` is that it handles multiple configuration files, so `ts`, `mts`, `cts`, and `json` are supported too. 

That being said [detective](https://github.com/browserify/detective) is not used for them and the config won't be invalidated when its dependencies are updated. 

This is most likely fixable by I wanted to keep the PR understandable.

## Advantages

- Consistent configuration files in modern projects (`*.config.ts`)
- Blessed with types and autocompletion
- [`unconfig`](https://github.com/antfu/unconfig/) is made with interoperability in mind, so the VSC extension can use it too

--- 

This PR is a draft because, while it's working, it can be improved:
- To invalidate the config when it changes (should be implementable easily)
- To invalidate the config on dependency updates (need to get the transpiled TS config for that)
- ~~To add types, I didn't add them yet since I was not sure if you were going to consider the PR and it was a bit of work~~ https://github.com/tailwindlabs/tailwindcss/pull/7891
- Ensure everything works with the promises I had to introduce (lightly)

Whether this specific PR is going to be merged or not, please consider supporting TypeScript configs. I'm sure you are aware how it improves DX. 🙏 

Related:
- https://github.com/tailwindlabs/tailwindcss/discussions/7151
- https://github.com/tailwindlabs/tailwindcss/discussions/5311
- https://github.com/tailwindlabs/tailwindcss/discussions/5545
- https://github.com/tailwindlabs/tailwindcss/discussions/3335