### PR TITLE
Eliminate recursion from candidatePermutations

### DIFF
--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -25,33 +25,33 @@ function getClassNameFromSelector(selector) {
 // Example with dynamic classes:
 // ['grid-cols', '[[linename],1fr,auto]']
 // ['grid', 'cols-[[linename],1fr,auto]']
-function* candidatePermutations(candidate, lastIndex = Infinity) {
-  if (lastIndex < 0) {
-    return
+function* candidatePermutations(candidate) {
+  let lastIndex = Infinity
+
+  while (lastIndex >= 0) {
+    let dashIdx
+
+    if (lastIndex === Infinity && candidate.endsWith(']')) {
+      let bracketIdx = candidate.indexOf('[')
+
+      // If character before `[` isn't a dash or a slash, this isn't a dynamic class
+      // eg. string[]
+      dashIdx = ['-', '/'].includes(candidate[bracketIdx - 1]) ? bracketIdx - 1 : -1
+    } else {
+      dashIdx = candidate.lastIndexOf('-', lastIndex)
+    }
+
+    if (dashIdx < 0) {
+      break
+    }
+
+    let prefix = candidate.slice(0, dashIdx)
+    let modifier = candidate.slice(dashIdx + 1)
+
+    yield [prefix, modifier]
+
+    lastIndex = dashIdx - 1
   }
-
-  let dashIdx
-
-  if (lastIndex === Infinity && candidate.endsWith(']')) {
-    let bracketIdx = candidate.indexOf('[')
-
-    // If character before `[` isn't a dash or a slash, this isn't a dynamic class
-    // eg. string[]
-    dashIdx = ['-', '/'].includes(candidate[bracketIdx - 1]) ? bracketIdx - 1 : -1
-  } else {
-    dashIdx = candidate.lastIndexOf('-', lastIndex)
-  }
-
-  if (dashIdx < 0) {
-    return
-  }
-
-  let prefix = candidate.slice(0, dashIdx)
-  let modifier = candidate.slice(dashIdx + 1)
-
-  yield [prefix, modifier]
-
-  yield* candidatePermutations(candidate, dashIdx - 1)
 }
 
 function applyPrefix(matches, context) {

--- a/tests/basic-usage.test.js
+++ b/tests/basic-usage.test.js
@@ -172,3 +172,19 @@ it('shadows support values without a leading zero', () => {
     `)
   })
 })
+
+it('can scan extremely long classes without crashing', () => {
+  let val = 'cols-' + '-a'.repeat(65536)
+  let config = {
+    content: [{ raw: html`<div class="${val}"></div>` }],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css``)
+  })
+})


### PR DESCRIPTION
V8 (and therefore Node) does not support Proper Tail Calls. Passing very long dash separated strings to `candidatePermutations` will cause Node to hit a max stack size. I replaced the recursion with a while loop which should eliminate this possibility. This should theoretically reduce memory usage as well since it doesn't have to save/restore stack space for the recursive function calls.

This is a possible fix for: https://github.com/tailwindlabs/tailwindcss/discussions/7330