### PR TITLE
Add a `from` when postcss parsing preflight

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -209,7 +209,10 @@ let cssBackdropFilterValue = [
 export let corePlugins = {
   preflight: ({ addBase }) => {
     let preflightStyles = postcss.parse(
-      fs.readFileSync(path.join(__dirname, './css/preflight.css'), 'utf8')
+      fs.readFileSync(path.join(__dirname, './css/preflight.css'), 'utf8'),
+      {
+        from: 'Tailwind Preflight',
+      }
     )
 
     addBase([


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
Hi, I was tracking down today why builds for some of our apps were not deterministic. I believe it's because no `from` is provided to `postcss.parse`, so it generates a random ID every compilation. I am out of my depth with frontend tooling, so I wasn't sure how this `from` value is used and if what I've done is appropriate. Regardless, I believe it should be something stable and non-null.

See https://github.com/postcss/postcss/issues/1512 and https://github.com/tailwindlabs/tailwindcss/pull/3356 for a related issue and discussion.

Fixes #7583 