### PR TITLE
Move prettier plugin to dev dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+- Move prettier plugin to dev dependencies ([#7418](https://github.com/tailwindlabs/tailwindcss/pull/7418))
 
 ## [3.0.20] - 2022-02-10
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "jest-diff": "^27.4.6",
     "postcss": "^8.4.6",
     "prettier": "^2.5.1",
+    "prettier-plugin-tailwindcss": "^0.1.7",
     "rimraf": "^3.0.0"
   },
   "peerDependencies": {
@@ -77,7 +78,6 @@
     "postcss-nested": "5.0.6",
     "postcss-selector-parser": "^6.0.9",
     "postcss-value-parser": "^4.2.0",
-    "prettier-plugin-tailwindcss": "^0.1.7",
     "quick-lru": "^5.1.1",
     "resolve": "^1.22.0"
   },


### PR DESCRIPTION
We added the prettier plugin for internal usage here and mistakenly put it in dependencies. Whoops.