### PR TITLE
Temporarily move postcss to dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Temporarily move postcss to dependencies ([#7424](https://github.com/tailwindlabs/tailwindcss/pull/7424))
 
 ## [3.0.21] - 2022-02-10
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^27.4.7",
     "jest-diff": "^27.4.6",
-    "postcss": "^8.4.6",
     "prettier": "^2.5.1",
     "prettier-plugin-tailwindcss": "^0.1.7",
     "rimraf": "^3.0.0"
@@ -73,6 +72,7 @@
     "is-glob": "^4.0.3",
     "normalize-path": "^3.0.0",
     "object-hash": "^2.2.0",
+    "postcss": "^8.4.6",
     "postcss-js": "^4.0.0",
     "postcss-load-config": "^3.1.0",
     "postcss-nested": "5.0.6",


### PR DESCRIPTION
This is unfortunate but upgrading postcss-js caused postcss to not be installed at all. This is *fine* except in this case of NPM <= 6 when running npx tailwindcss init, or yarn v1, or npm 7/8 with legacy peer deps behavior and doing a similar thing. Deduping will still allow the user to install postcss and upgrade it and Tailwind CSS will pick it up. A more permanent solution may involve hijacking require or something similar.
