### PR TITLE
Remove opacity variables from `:visited` pseudo class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Remove opacity variables from `:visited` pseudo class ([#7458](https://github.com/tailwindlabs/tailwindcss/pull/7458))
 
 ## [3.0.22] - 2022-02-11
 

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -73,6 +73,22 @@ export let variantPlugins = {
       [
         'visited',
         ({ container }) => {
+          let toRemove = ['--tw-text-opacity', '--tw-border-opacity', '--tw-bg-opacity']
+
+          container.walkDecls((decl) => {
+            if (toRemove.includes(decl.prop)) {
+              decl.remove()
+
+              return
+            }
+
+            for (const varName of toRemove) {
+              if (decl.value.includes(`/ var(${varName})`)) {
+                decl.value = decl.value.replace(`/ var(${varName})`, '')
+              }
+            }
+          })
+
           return ':visited'
         },
       ],

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -70,7 +70,12 @@ export let variantPlugins = {
       'only-of-type',
 
       // State
-      'visited',
+      [
+        'visited',
+        ({ container }) => {
+          return ':visited'
+        },
+      ],
       'target',
       ['open', '[open]'],
 
@@ -100,15 +105,27 @@ export let variantPlugins = {
     ].map((variant) => (Array.isArray(variant) ? variant : [variant, `:${variant}`]))
 
     for (let [variantName, state] of pseudoVariants) {
-      addVariant(variantName, `&${state}`)
+      addVariant(variantName, (ctx) => {
+        let result = typeof state === 'function' ? state(ctx) : state
+
+        return `&${result}`
+      })
     }
 
     for (let [variantName, state] of pseudoVariants) {
-      addVariant(`group-${variantName}`, `:merge(.group)${state} &`)
+      addVariant(`group-${variantName}`, (ctx) => {
+        let result = typeof state === 'function' ? state(ctx) : state
+
+        return `:merge(.group)${result} &`
+      })
     }
 
     for (let [variantName, state] of pseudoVariants) {
-      addVariant(`peer-${variantName}`, `:merge(.peer)${state} ~ &`)
+      addVariant(`peer-${variantName}`, (ctx) => {
+        let result = typeof state === 'function' ? state(ctx) : state
+
+        return `:merge(.peer)${result} ~ &`
+      })
     }
   },
 

--- a/tests/variants.test.js
+++ b/tests/variants.test.js
@@ -539,3 +539,32 @@ it('variants for utilities should not be produced in a file without a utilities 
     `)
   })
 })
+
+test('The visited variant removes opacity support', () => {
+  let config = {
+    content: [
+      {
+        raw: html`
+          <a class="visited:border-red-500 visited:bg-red-500 visited:text-red-500"
+            >Look, it's a link!</a
+          >
+        `,
+      },
+    ],
+    plugins: [],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    return expect(result.css).toMatchFormattedCss(css`
+      .visited\:border-red-500:visited {
+        border-color: rgb(239 68 68);
+      }
+      .visited\:bg-red-500:visited {
+        background-color: rgb(239 68 68);
+      }
+      .visited\:text-red-500:visited {
+        color: rgb(239 68 68);
+      }
+    `)
+  })
+})


### PR DESCRIPTION
The `:visited` pseudo-class has significant restrictions on what can be done with it for privacy reasons. You can read more about the limitations on the MDN article [Privacy and the `:visited` selector](https://developer.mozilla.org/en-US/docs/Web/CSS/Privacy_and_the_:visited_selector).

Some examples:
1. Any declarations that use `var()` are discarded (discovered this one via testing)
2. Opacity changes to color/background color/etc are not applied — it preserves the opacity from the non-`:visited` version of the element/class.
3. You can only apply a `:visited` color *if* a color has already been set on the base property.
4. There are significant limitations on what properties can actually be applied to a `:visited` link.

Tailwind CSS, by default, generates text opacity, border opacity, and background opacity variables that are used when applying the `text-{color}`, `border-{color}`, and `bg-{color}` utilities. This causes the utility to not work at all because the relevant color declaration is being treated as if it wasn't there at all.

You can disable those plugins (which aren't necessary given that the color modifier syntax now exists) to work around the issue however it makes more sene for Tailwind CSS to handle this itself if/when it is feasible.

Fixes #7441