### PR TITLE
Implement `getClassOrder` instead of `sortClassList`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove opacity variables from `:visited` pseudo class ([#7458](https://github.com/tailwindlabs/tailwindcss/pull/7458))
 - Support arbitrary values + calc + theme with quotes ([#7462](https://github.com/tailwindlabs/tailwindcss/pull/7462))
 - Don't duplicate layer output when scanning content with variants + wildcards ([#7478](https://github.com/tailwindlabs/tailwindcss/pull/7478))
+- Implement `getClassOrder` instead of `sortClassList` ([#7459](https://github.com/tailwindlabs/tailwindcss/pull/7459))
 
 ## [3.0.22] - 2022-02-11
 

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -744,33 +744,25 @@ function registerPlugins(plugins, context) {
   // sorting could be weird since you still require them in order to make the
   // host utitlies work properly. (Thanks Biology)
   let parasiteUtilities = new Set([prefix(context, 'group'), prefix(context, 'peer')])
-  context.sortClassList = function sortClassList(classes) {
+  context.getSortOrder = function getSortOrder(classes) {
     let sortedClassNames = new Map()
     for (let [sort, rule] of generateRules(new Set(classes), context)) {
       if (sortedClassNames.has(rule.raws.tailwind.candidate)) continue
       sortedClassNames.set(rule.raws.tailwind.candidate, sort)
     }
 
-    return classes
-      .map((className) => {
-        let order = sortedClassNames.get(className) ?? null
+    return classes.map((className) => {
+      let order = sortedClassNames.get(className) ?? null
 
-        if (order === null && parasiteUtilities.has(className)) {
-          // This will make sure that it is at the very beginning of the
-          // `components` layer which technically means 'before any
-          // components'.
-          order = context.layerOrder.components
-        }
+      if (order === null && parasiteUtilities.has(className)) {
+        // This will make sure that it is at the very beginning of the
+        // `components` layer which technically means 'before any
+        // components'.
+        order = context.layerOrder.components
+      }
 
-        return [className, order]
-      })
-      .sort(([, a], [, z]) => {
-        if (a === z) return 0
-        if (a === null) return -1
-        if (z === null) return 1
-        return bigSign(a - z)
-      })
-      .map(([className]) => className)
+      return [className, order]
+    })
   }
 
   // Generate a list of strings for autocompletion purposes, e.g.

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -744,7 +744,7 @@ function registerPlugins(plugins, context) {
   // sorting could be weird since you still require them in order to make the
   // host utitlies work properly. (Thanks Biology)
   let parasiteUtilities = new Set([prefix(context, 'group'), prefix(context, 'peer')])
-  context.getSortOrder = function getSortOrder(classes) {
+  context.getClassOrder = function getClassOrder(classes) {
     let sortedClassNames = new Map()
     for (let [sort, rule] of generateRules(new Set(classes), context)) {
       if (sortedClassNames.has(rule.raws.tailwind.candidate)) continue

--- a/tests/getSortOrder.test.js
+++ b/tests/getSortOrder.test.js
@@ -4,7 +4,7 @@ import bigSign from '../src/util/bigSign'
 
 /**
  * This is a function that the prettier-plugin-tailwindcss would use. It would
- * do the actual sorting based on the classes and order we return from `getSortOrder`.
+ * do the actual sorting based on the classes and order we return from `getClassOrder`.
  *
  * This way the actual sorting logic is done in the plugin which allows you to
  * put unknown classes at the end for example.
@@ -28,7 +28,7 @@ it('should return a list of tuples with the sort order', () => {
   let input = 'font-bold underline hover:font-medium unknown'
   let config = {}
   let context = createContext(resolveConfig(config))
-  expect(context.getSortOrder(input.split(' '))).toEqual([
+  expect(context.getClassOrder(input.split(' '))).toEqual([
     ['font-bold', expect.any(BigInt)],
     ['underline', expect.any(BigInt)],
     ['hover:font-medium', expect.any(BigInt)],
@@ -70,7 +70,7 @@ it.each([
 ])('should sort "%s" based on the order we generate them in to "%s"', (input, output) => {
   let config = {}
   let context = createContext(resolveConfig(config))
-  expect(defaultSort(context.getSortOrder(input.split(' ')))).toEqual(output)
+  expect(defaultSort(context.getClassOrder(input.split(' ')))).toEqual(output)
 })
 
 it.each([
@@ -110,6 +110,6 @@ it.each([
   (input, output) => {
     let config = { prefix: 'tw-' }
     let context = createContext(resolveConfig(config))
-    expect(defaultSort(context.getSortOrder(input.split(' ')))).toEqual(output)
+    expect(defaultSort(context.getClassOrder(input.split(' ')))).toEqual(output)
   }
 )


### PR DESCRIPTION
This PR implements a `getClassOrder` instead of `sortClassList`.

Had a conversation with @bradlc and while sorting in Tailwind itself works, it can happen that instead of placing unknown classes in the front that you want to put it in the back. This is an option that we can expose in the `prettier-plugin-tailwindcss` if we event want to do that. But if we want those options in Tailwind itself then we have to keep an options object into account or even more unknown complex scenarios.
So instead we will expose a `getSortOrder` that will return a list of tuples with the className and the order it appears in the final css when we generate it. 
- Note: the order value is a bigint and the first value in the css will be the lowest number, the last value in the css will be the highest number. Those numbers are not per se consecutive. 

Now the `prettier-plugin-tailwindcss` can sort the classes based on configuration settings in the plugin and using the information we expose via the `getClassOrder `.

When a class is passed to the function that doesn't exist, then the sort value will be set to `null`.

If we in the future want to change the sort algorithm internally, then we can expose the same list but maybe with different numbers as long as they stay in order.

Remaining questions:
- ~~Is the name `getSortOrder` good, or do we prefer something like `getClassOrder` (similar to the already existing `getClassList`)?~~ Renamed it to `getClassOrder`

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
