### PR TITLE
Add `pair-*` variants

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -145,22 +145,11 @@ export let variantPlugins = {
     }
 
     for (let [variantName, state] of pseudoVariants) {
-      Object.keys(theme("pair") ?? {}).forEach(key => {
-        addVariant(
-          `pair-${key}-${variantName}`,
-          ({ modifySelectors, separator }) => {
-            modifySelectors(({ className }) => {
-              return (
-                `.pair-${key}:${variantName} ~ .${e(
-                  `pair-${key}-${variantName}${separator}${className}`
-                )},\n` +
-                `.pair-${key}:${variantName} ~ * .${e(
-                  `pair-${key}-${variantName}${separator}${className}`
-                )}`
-              );
-            });
-          }
-        );
+      Object.keys(theme("pair") ?? {}).forEach((key) => {
+        addVariant(`pair-${key}-${variantName}`, [
+          `:merge(.pair-${key})${state} ~ &`,
+          `:merge(.pair-${key})${state} ~ * &`,
+        ]);
       });
     }
   },
@@ -2376,14 +2365,13 @@ export let corePlugins = {
   content: createUtilityPlugin('content', [
     ['content', ['--tw-content', ['content', 'var(--tw-content)']]],
   ]),
-  pair: ({ addUtilities, theme, e,}) => {
+
+  pair: ({ addUtilities, theme }) => {
     const pairUtilities = Object.keys(theme("pair") ?? {});
     addUtilities(
       pairUtilities.map(key => {
-        return {
-          [`.${e(`pair-${key}`)}`]: {},
-        };
+        return {[`.pair-${key}`]: {}}
       })
     );
-  },
+  }
 }

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -145,12 +145,12 @@ export let variantPlugins = {
     }
 
     for (let [variantName, state] of pseudoVariants) {
-      Object.keys(theme("pair") ?? {}).forEach((key) => {
+      Object.keys(theme('pair') ?? {}).forEach((key) => {
         addVariant(`pair-${key}-${variantName}`, [
           `:merge(.pair-${key})${state} ~ &`,
           `:merge(.pair-${key})${state} ~ * &`,
-        ]);
-      });
+        ])
+      })
     }
   },
 
@@ -2367,11 +2367,11 @@ export let corePlugins = {
   ]),
 
   pair: ({ addUtilities, theme }) => {
-    const pairUtilities = Object.keys(theme("pair") ?? {});
+    const pairUtilities = Object.keys(theme('pair') ?? {})
     addUtilities(
-      pairUtilities.map(key => {
-        return {[`.pair-${key}`]: {}}
+      pairUtilities.map((key) => {
+        return { [`.pair-${key}`]: {} }
       })
-    );
-  }
+    )
+  },
 }

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -143,6 +143,26 @@ export let variantPlugins = {
         return `:merge(.peer)${result} ~ &`
       })
     }
+
+    for (let [variantName, state] of pseudoVariants) {
+      Object.keys(theme("pair") ?? {}).forEach(key => {
+        addVariant(
+          `pair-${key}-${variantName}`,
+          ({ modifySelectors, separator }) => {
+            modifySelectors(({ className }) => {
+              return (
+                `.pair-${key}:${variantName} ~ .${e(
+                  `pair-${key}-${variantName}${separator}${className}`
+                )},\n` +
+                `.pair-${key}:${variantName} ~ * .${e(
+                  `pair-${key}-${variantName}${separator}${className}`
+                )}`
+              );
+            });
+          }
+        );
+      });
+    }
   },
 
   directionVariants: ({ addVariant }) => {
@@ -2356,4 +2376,14 @@ export let corePlugins = {
   content: createUtilityPlugin('content', [
     ['content', ['--tw-content', ['content', 'var(--tw-content)']]],
   ]),
+  pair: ({ addUtilities, theme, e,}) => {
+    const pairUtilities = Object.keys(theme("pair") ?? {});
+    addUtilities(
+      pairUtilities.map(key => {
+        return {
+          [`.${e(`pair-${key}`)}`]: {},
+        };
+      })
+    );
+  },
 }

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -145,11 +145,15 @@ export let variantPlugins = {
     }
 
     for (let [variantName, state] of pseudoVariants) {
-      Object.keys(theme('pair') ?? {}).forEach((key) => {
-        addVariant(`pair-${key}-${variantName}`, [
-          `:merge(.pair-${key})${state} ~ &`,
-          `:merge(.pair-${key})${state} ~ * &`,
-        ])
+      Object.keys(theme('pair', {})).forEach((key) => {
+        addVariant(`pair-${key}-${variantName}`, ({ modifySelectors, separator }) => {
+          modifySelectors(({ className }) => {
+            return (
+              `.pair-${key}${state} ~ .pair-${key}-${variantName}\\${separator}${className},\n` +
+              `.pair-${key}${state} ~ * .pair-${key}-${variantName}\\${separator}${className}`
+            )
+          })
+        })
       })
     }
   },
@@ -2367,11 +2371,11 @@ export let corePlugins = {
   ]),
 
   pair: ({ addUtilities, theme }) => {
-    const pairUtilities = Object.keys(theme('pair') ?? {})
-    addUtilities(
-      pairUtilities.map((key) => {
-        return { [`.pair-${key}`]: {} }
+    const pairUtilities = Object.keys(theme('pair', {}))
+    pairUtilities.forEach((key) => {
+      addUtilities({
+        [`.pair-${key}`]: {},
       })
-    )
+    })
   },
 }

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -57,7 +57,7 @@ export let variantPlugins = {
     })
   },
 
-  pseudoClassVariants: ({ addVariant }) => {
+  pseudoClassVariants: ({ addVariant, theme }) => {
     let pseudoVariants = [
       // Positional
       ['first', ':first-child'],

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -927,6 +927,11 @@ module.exports = {
       40: '40',
       50: '50',
     },
+    pair: {
+      "1": "",
+      "2": "",
+      "3": "",
+    }
   },
   variantOrder: [
     'first',


### PR DESCRIPTION
`pair` is a utility and variant like `peer`.

Most different of they is `pair` have channel, and it can affect to the elements which **not only is brother but also can be brother's childs**.

for example, this is `peer`:
```js
<input type="checkbox" class="peer" />
<span class="peer-checked:text-green-500 block">I'm affected</span>
<div>
  <span class="peer-checked:text-green-500">I'm unaffected</span>
</div>
```

but `pair` can do this:
```js
<input type="checkbox" class="pair-1" />Pair1
<br />
<input type="checkbox" class="pair-2" />Pair2
<span class="pair-1-checked:text-green-500 block">I'm affected</span>
<div>
  <span class="pair-1-checked:text-green-500">I'm affected</span>
  <span class="pair-2-checked:text-yellow-500">I'm affected</span>
</div>
```

see effects in playground:
https://play.tailwindcss.com/HEw7nG0zMO

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
