### PR TITLE
remove address italics in preflight

### DIFF
--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -136,6 +136,14 @@ sup {
 }
 
 /*
+Remove the default italics for addresses.
+*/
+
+address {
+  font-style: normal;
+}
+
+/*
 1. Remove text indentation from table contents in Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=999088, https://bugs.webkit.org/show_bug.cgi?id=201297)
 2. Correct table border color inheritance in all Chrome and Safari. (https://bugs.chromium.org/p/chromium/issues/detail?id=935729, https://bugs.webkit.org/show_bug.cgi?id=195016)
 3. Remove gaps between table borders by default.


### PR DESCRIPTION
I realize this is very easy to do in your own config, but it seems like a reasonable default to not have addresses italicized.