### PR TITLE
Prevent nesting plugin from breaking other plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+- Prevent nesting plugin from breaking other plugins ([#7563](https://github.com/tailwindlabs/tailwindcss/pull/7563))
 
 ## [3.0.23] - 2022-02-16
 

--- a/src/postcss-plugins/nesting/plugin.js
+++ b/src/postcss-plugins/nesting/plugin.js
@@ -39,6 +39,42 @@ export function nesting(opts = postcssNested) {
       decl.remove()
     })
 
+    /**
+     * Use a private PostCSS API to remove the "clean" flag from the entire AST.
+     * This is done because running process() on the AST will set the "clean"
+     * flag on all nodes, which we don't want.
+     *
+     * This causes downstream plugins using the visitor API to be skipped.
+     *
+     * This is guarded because the PostCSS API is not public
+     * and may change in future versions of PostCSS.
+     *
+     * See https://github.com/postcss/postcss/issues/1712 for more details
+     *
+     * @param {import('postcss').Node} node
+     */
+    function markDirty(node) {
+      if (!('markDirty' in node)) {
+        return
+      }
+
+      // Traverse the tree down to the leaf nodes
+      if (node.nodes) {
+        node.nodes.forEach((n) => markDirty(n))
+      }
+
+      // If it's a leaf node mark it as dirty
+      // We do this here because marking a node as dirty
+      // will walk up the tree and mark all parents as dirty
+      // resulting in a lot of unnecessary work if we did this
+      // for every single node
+      if (!node.nodes) {
+        node.markDirty()
+      }
+    }
+
+    markDirty(root)
+
     return root
   }
 }

--- a/tests/postcss-plugins/nesting/plugins.js
+++ b/tests/postcss-plugins/nesting/plugins.js
@@ -1,0 +1,42 @@
+export function visitorSpyPlugin() {
+  let Once = jest.fn()
+  let OnceExit = jest.fn()
+  let Root = jest.fn()
+  let AtRule = jest.fn()
+  let Rule = jest.fn()
+  let Comment = jest.fn()
+  let Declaration = jest.fn()
+
+  let plugin = Object.assign(
+    function () {
+      return {
+        postcssPlugin: 'visitor-test',
+
+        // These work fine
+        Once,
+        OnceExit,
+
+        // These break
+        Root,
+        Rule,
+        AtRule,
+        Declaration,
+        Comment,
+      }
+    },
+    { postcss: true }
+  )
+
+  return {
+    plugin,
+    spies: {
+      Once,
+      OnceExit,
+      Root,
+      AtRule,
+      Rule,
+      Comment,
+      Declaration,
+    },
+  }
+}


### PR DESCRIPTION
This uses a private API but it’s the only solution we have right now. It’s guarded to hopefully be less breaking if the API disappears.

See https://github.com/postcss/postcss/issues/1712 for more details

Fixes #7234
