### PR TITLE
Recursively collapse adjacent rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Prevent nesting plugin from breaking other plugins ([#7563](https://github.com/tailwindlabs/tailwindcss/pull/7563))
+- Recursively collapse adjacent rules ([#7565](https://github.com/tailwindlabs/tailwindcss/pull/7565))
 
 ## [3.0.23] - 2022-02-16
 

--- a/src/lib/collapseAdjacentRules.js
+++ b/src/lib/collapseAdjacentRules.js
@@ -5,7 +5,7 @@ let comparisonMap = {
 let types = new Set(Object.keys(comparisonMap))
 
 export default function collapseAdjacentRules() {
-  return (root) => {
+  function collapseRulesIn(root) {
     let currentRule = null
     root.each((node) => {
       if (!types.has(node.type)) {
@@ -35,5 +35,20 @@ export default function collapseAdjacentRules() {
         currentRule = node
       }
     })
+
+    // After we've collapsed adjacent rules & at-rules, we need to collapse
+    // adjacent rules & at-rules that are children of at-rules.
+    // We do not care about nesting rules because Tailwind CSS
+    // explicitly does not handle rule nesting on its own as
+    // the user is expected to use a nesting plugin
+    root.each((node) => {
+      if (node.type === 'atrule') {
+        collapseRulesIn(node)
+      }
+    })
+  }
+
+  return (root) => {
+    collapseRulesIn(root)
   }
 }

--- a/tests/apply.test.js
+++ b/tests/apply.test.js
@@ -1289,9 +1289,6 @@ it('apply partitioning works with media queries', async () => {
       body {
         --tw-text-opacity: 1;
         color: rgb(220 38 38 / var(--tw-text-opacity));
-      }
-      html,
-      body {
         font-size: 2rem;
       }
     }

--- a/tests/collapse-adjacent-rules.test.css
+++ b/tests/collapse-adjacent-rules.test.css
@@ -72,6 +72,29 @@
   color: black;
   font-weight: 700;
 }
+@supports (foo: bar) {
+  .some-apply-thing {
+    font-weight: 700;
+    --tw-text-opacity: 1;
+    color: rgb(0 0 0 / var(--tw-text-opacity));
+  }
+}
+@media (min-width: 768px) {
+  .some-apply-thing {
+    font-weight: 700;
+    --tw-text-opacity: 1;
+    color: rgb(0 0 0 / var(--tw-text-opacity));
+  }
+}
+@supports (foo: bar) {
+  @media (min-width: 768px) {
+    .some-apply-thing {
+      font-weight: 700;
+      --tw-text-opacity: 1;
+      color: rgb(0 0 0 / var(--tw-text-opacity));
+    }
+  }
+}
 @media (min-width: 640px) {
   .sm\:text-center {
     text-align: center;

--- a/tests/collapse-adjacent-rules.test.html
+++ b/tests/collapse-adjacent-rules.test.html
@@ -19,5 +19,6 @@
     <div class="md:text-center"></div>
     <div class="lg:font-bold"></div>
     <div class="lg:text-center"></div>
+    <div class="some-apply-thing"></div>
   </body>
 </html>

--- a/tests/collapse-adjacent-rules.test.js
+++ b/tests/collapse-adjacent-rules.test.js
@@ -8,7 +8,11 @@ test('collapse adjacent rules', () => {
     content: [path.resolve(__dirname, './collapse-adjacent-rules.test.html')],
     corePlugins: { preflight: false },
     theme: {},
-    plugins: [],
+    plugins: [
+      function ({ addVariant }) {
+        addVariant('foo-bar', '@supports (foo: bar)')
+      },
+    ],
   }
 
   let input = css`
@@ -44,6 +48,9 @@ test('collapse adjacent rules', () => {
     .foo,
     .bar {
       font-weight: 700;
+    }
+    .some-apply-thing {
+      @apply foo-bar:md:text-black foo-bar:md:font-bold foo-bar:text-black foo-bar:font-bold md:font-bold md:text-black;
     }
   `
 

--- a/tests/kitchen-sink.test.css
+++ b/tests/kitchen-sink.test.css
@@ -498,8 +498,6 @@ div {
       transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
       transition-duration: 150ms;
     }
-  }
-  @media (prefers-reduced-motion: no-preference) {
     .dark .md\:dark\:motion-safe\:foo\:active\:custom-util:active {
       background: #abcdef !important;
     }


### PR DESCRIPTION
We collapse adjacent rules and media queries automatically. This is because of the way `@apply` works by generating a Rule/AtRule for every class in an apply. However, when given something like `@apply md:text-black md:bg-white` we would not collapse the rules inside the media query. This isn't strictly necessary but it would result in a bit of a win with smaller generated CSS if you're using `@apply`.

I refactored a bit to collapse adjacent rules at the top level and then find all at rules and collapse their children recursively until there's nothing left to collapse.

Fixes #4896