### PR TITLE
Add color opacity for safelist with regex

### DIFF
--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -703,7 +703,7 @@ function registerPlugins(plugins, context) {
           : [util]
 
         for (let util of utils) {
-          for (let { pattern, variants = [] } of checks) {
+          for (let { pattern, variants = [], opacities = [] } of checks) {
             // RegExp with the /g flag are stateful, so let's reset the last
             // index pointer to reset the state.
             pattern.lastIndex = 0
@@ -720,6 +720,18 @@ function registerPlugins(plugins, context) {
             for (let variant of variants) {
               context.changedContent.push({
                 content: variant + context.tailwindConfig.separator + util,
+                extension: 'html',
+              })
+              for (let opacity of opacities) {
+                context.changedContent.push({
+                  content: variant + context.tailwindConfig.separator + util + '/' + opacity,
+                  extension: 'html',
+                })
+              }
+            }
+            for (let opacity of opacities) {
+              context.changedContent.push({
+                content: util + '/' + opacity,
                 extension: 'html',
               })
             }

--- a/tests/safelist.test.js
+++ b/tests/safelist.test.js
@@ -53,6 +53,7 @@ it('should safelist based on a pattern regex', () => {
       {
         pattern: /bg-(red)-(100|200)/,
         variants: ['hover'],
+        opacities: ['50'],
       },
     ],
   }
@@ -64,9 +65,17 @@ it('should safelist based on a pattern regex', () => {
         background-color: rgb(254 226 226 / var(--tw-bg-opacity));
       }
 
+      .bg-red-100\/50 {
+        background-color: rgb(254 226 226 / 0.5);
+      }
+
       .bg-red-200 {
         --tw-bg-opacity: 1;
         background-color: rgb(254 202 202 / var(--tw-bg-opacity));
+      }
+
+      .bg-red-200\/50 {
+        background-color: rgb(254 202 202 / 0.5);
       }
 
       .uppercase {
@@ -78,9 +87,17 @@ it('should safelist based on a pattern regex', () => {
         background-color: rgb(254 226 226 / var(--tw-bg-opacity));
       }
 
+      .hover\:bg-red-100\/50:hover {
+        background-color: rgb(254 226 226 / 0.5);
+      }
+
       .hover\:bg-red-200:hover {
         --tw-bg-opacity: 1;
         background-color: rgb(254 202 202 / var(--tw-bg-opacity));
+      }
+
+      .hover\:bg-red-200\/50:hover {
+        background-color: rgb(254 202 202 / 0.5);
       }
     `)
   })


### PR DESCRIPTION
The pattern-based safelisting currently doesn't support colors with opacity (https://github.com/tailwindlabs/tailwindcss/discussions/6770).

This pull request is trying to solve that by adding opacities option in addition to variants.