### PR TITLE
Display: Support `initial` and `inherit`

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -468,6 +468,8 @@ export let corePlugins = {
 
   display: ({ addUtilities }) => {
     addUtilities({
+      '.inherit': { display: 'inherit' },
+      '.initial': { display: 'initial' },
       '.block': { display: 'block' },
       '.inline-block': { display: 'inline-block' },
       '.inline': { display: 'inline' },


### PR DESCRIPTION
As outlined in [tailwindlabs/tailwindcss#4623][], it can be useful to
rely on an element's initial display value.

For example, consider rendering HTML in a Rails partial that accepts its
tagName as a parameter:

```erb
<%# app/views/application/_my_partial.html.erb %>

<%= content_tag local_assigns.fetch(:tag_name, :div),
                "I'm block when a peer is `:checked`",
                class: "hidden peer-checked:block" %>

<%= render "my_partial" %>
<%# => <div class="hidden peer-checked:block">I'm block when a peer is `:checked`</div> %>

<%= render "my_partial", tag_name: :span %>
<%# => <span class="hidden peer-checked:block">I'm block when a peer is `:checked`</span> %>
```

Assuming that the visible display is `display: block` might be true when
the partial renders a `<div>`, but if called with `tag_name: :span`, the
`peer-checked:` variant would _override_ the display from `inline` to
`block`.

With support for `initial`, that won't be the case:

```erb
<%# app/views/application/_my_partial.html.erb %>

<%= content_tag local_assigns.fetch(:tag_name, :div)
                "I'm block or inline when a peer is `:checked`",
                class: "hidden peer-checked:initial" %>

<%= render "my_partial" %>
<%# => <div class="hidden peer-checked:initial">I'm block or inline when a peer is `:checked`</div> %>

<%= render "my_partial", tag_name: :span %>
<%# => <span class="hidden peer-checked:initial">I'm block or inline when a peer is `:checked`</span> %>
```

Adding support for `inherit` has a similar motivating intention with slightly different reseting semantics.

[tailwindlabs/tailwindcss#4623]: https://github.com/tailwindlabs/tailwindcss/discussions/4623