### PR TITLE
Add additional safelist regex variations

### DIFF
--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -677,29 +677,37 @@ function registerPlugins(plugins, context) {
           for (let check of checks) {
             let [pattern = /(?:)/, variants = [], opacities = []] = (() => {
               if (check instanceof RegExp) {
-                let pattern = check
-                return [pattern]
-              } else if (Array.isArray(check) || Array.isArray(check.pattern)) {
-                if (Array.isArray(check.pattern)) check = check.pattern
+                return [check]
+              }
+
+              if (Array.isArray(check)) {
                 if (check.length == 1) {
-                  let [pattern] = check
-                  return [pattern]
-                } else if (check.length == 2) {
+                  return check
+                }
+
+                if (check.length == 2) {
                   if (check[1] instanceof RegExp) {
                     let [variants, pattern] = check
                     return [pattern, variants]
-                  } else {
-                    let [pattern, opacities] = check
-                    return [pattern, [], opacities]
                   }
-                } else if (check.length == 3) {
+
+                  let [pattern, opacities] = check
+                  return [pattern, [], opacities]
+                }
+
+                if (check.length == 3) {
                   let [variants, pattern, opacities] = check
                   return [pattern, variants, opacities]
-                } else return
-              } else if (check instanceof Object) {
-                let { pattern, variants = [] } = check
-                return [pattern, variants]
-              } else return
+                }
+
+                throw new Error(
+                  `Array values in your Tailwind CSS \`safelist\` must contain 1–3 items, found invalid entry containing ${check.length}.`
+                )
+              }
+
+              // Check must be an object in the shape of { pattern: ..., variants: ... }
+              let { pattern, variants = [] } = check
+              return [pattern, variants]
             })()
 
             // RegExp with the /g flag are stateful, so let's reset the last

--- a/tests/safelist.test.js
+++ b/tests/safelist.test.js
@@ -86,6 +86,234 @@ it('should safelist based on a pattern regex', () => {
   })
 })
 
+it('should safelist based on a pattern tupple with regex', () => {
+  let config = {
+    content: [{ raw: html`<div class="uppercase"></div>` }],
+    safelist: [
+      {
+        pattern: [['hover'], /bg-(red)-(100|200)/],
+      },
+      {
+        pattern: [/bg-(green)-(100|200)/, ['50']],
+      },
+      {
+        pattern: [['hover'], /bg-(blue)-(100|200)/, ['50']],
+      },
+    ],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    return expect(result.css).toMatchCss(css`
+      .bg-red-100 {
+        --tw-bg-opacity: 1;
+        background-color: rgb(254 226 226 / var(--tw-bg-opacity));
+      }
+
+      .bg-red-200 {
+        --tw-bg-opacity: 1;
+        background-color: rgb(254 202 202 / var(--tw-bg-opacity));
+      }
+
+      .bg-green-100 {
+        --tw-bg-opacity: 1;
+        background-color: rgb(220 252 231 / var(--tw-bg-opacity));
+      }
+
+      .bg-green-100\/50 {
+        background-color: rgb(220 252 231 / 0.5);
+      }
+
+      .bg-green-200 {
+        --tw-bg-opacity: 1;
+        background-color: rgb(187 247 208 / var(--tw-bg-opacity));
+      }
+
+      .bg-green-200\/50 {
+        background-color: rgb(187 247 208 / 0.5);
+      }
+
+      .bg-blue-100 {
+        --tw-bg-opacity: 1;
+        background-color: rgb(219 234 254 / var(--tw-bg-opacity));
+      }
+
+      .bg-blue-100\/50 {
+        background-color: rgb(219 234 254 / 0.5);
+      }
+
+      .bg-blue-200 {
+        --tw-bg-opacity: 1;
+        background-color: rgb(191 219 254 / var(--tw-bg-opacity));
+      }
+
+      .bg-blue-200\/50 {
+        background-color: rgb(191 219 254 / 0.5);
+      }
+
+      .uppercase {
+        text-transform: uppercase;
+      }
+
+      .hover\:bg-red-100:hover {
+        --tw-bg-opacity: 1;
+        background-color: rgb(254 226 226 / var(--tw-bg-opacity));
+      }
+
+      .hover\:bg-red-200:hover {
+        --tw-bg-opacity: 1;
+        background-color: rgb(254 202 202 / var(--tw-bg-opacity));
+      }
+
+      .hover\:bg-blue-100:hover {
+        --tw-bg-opacity: 1;
+        background-color: rgb(219 234 254 / var(--tw-bg-opacity));
+      }
+
+      .hover\:bg-blue-100\/50:hover {
+        background-color: rgb(219 234 254 / 0.5);
+      }
+
+      .hover\:bg-blue-200:hover {
+        --tw-bg-opacity: 1;
+        background-color: rgb(191 219 254 / var(--tw-bg-opacity));
+      }
+
+      .hover\:bg-blue-200\/50:hover {
+        background-color: rgb(191 219 254 / 0.5);
+      }
+    `)
+  })
+})
+
+it('should safelist based on a regex', () => {
+  let config = {
+    content: [{ raw: html`<div class="uppercase"></div>` }],
+    safelist: [/bg-(red)-(100|200)/],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    return expect(result.css).toMatchCss(css`
+      .bg-red-100 {
+        --tw-bg-opacity: 1;
+        background-color: rgb(254 226 226 / var(--tw-bg-opacity));
+      }
+
+      .bg-red-200 {
+        --tw-bg-opacity: 1;
+        background-color: rgb(254 202 202 / var(--tw-bg-opacity));
+      }
+
+      .uppercase {
+        text-transform: uppercase;
+      }
+    `)
+  })
+})
+
+it('should safelist based on a tupple with regex', () => {
+  let config = {
+    content: [{ raw: html`<div class="uppercase"></div>` }],
+    safelist: [
+      [/bg-(red)-(100|200)/],
+      [['hover'], /bg-(blue)-(100|200)/],
+      [/bg-(green)-(100|200)/, ['50']],
+      [['hover'], /bg-(yellow)-(100|200)/, ['50']],
+    ],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    return expect(result.css).toMatchCss(css`
+      .bg-red-100 {
+        --tw-bg-opacity: 1;
+        background-color: rgb(254 226 226 / var(--tw-bg-opacity));
+      }
+
+      .bg-red-200 {
+        --tw-bg-opacity: 1;
+        background-color: rgb(254 202 202 / var(--tw-bg-opacity));
+      }
+
+      .bg-yellow-100 {
+        --tw-bg-opacity: 1;
+        background-color: rgb(254 249 195 / var(--tw-bg-opacity));
+      }
+
+      .bg-yellow-100\/50 {
+        background-color: rgb(254 249 195 / 0.5);
+      }
+
+      .bg-yellow-200 {
+        --tw-bg-opacity: 1;
+        background-color: rgb(254 240 138 / var(--tw-bg-opacity));
+      }
+
+      .bg-yellow-200\/50 {
+        background-color: rgb(254 240 138 / 0.5);
+      }
+
+      .bg-green-100 {
+        --tw-bg-opacity: 1;
+        background-color: rgb(220 252 231 / var(--tw-bg-opacity));
+      }
+
+      .bg-green-100\/50 {
+        background-color: rgb(220 252 231 / 0.5);
+      }
+
+      .bg-green-200 {
+        --tw-bg-opacity: 1;
+        background-color: rgb(187 247 208 / var(--tw-bg-opacity));
+      }
+
+      .bg-green-200\/50 {
+        background-color: rgb(187 247 208 / 0.5);
+      }
+
+      .bg-blue-100 {
+        --tw-bg-opacity: 1;
+        background-color: rgb(219 234 254 / var(--tw-bg-opacity));
+      }
+
+      .bg-blue-200 {
+        --tw-bg-opacity: 1;
+        background-color: rgb(191 219 254 / var(--tw-bg-opacity));
+      }
+
+      .uppercase {
+        text-transform: uppercase;
+      }
+
+      .hover\:bg-yellow-100:hover {
+        --tw-bg-opacity: 1;
+        background-color: rgb(254 249 195 / var(--tw-bg-opacity));
+      }
+
+      .hover\:bg-yellow-100\/50:hover {
+        background-color: rgb(254 249 195 / 0.5);
+      }
+
+      .hover\:bg-yellow-200:hover {
+        --tw-bg-opacity: 1;
+        background-color: rgb(254 240 138 / var(--tw-bg-opacity));
+      }
+
+      .hover\:bg-yellow-200\/50:hover {
+        background-color: rgb(254 240 138 / 0.5);
+      }
+
+      .hover\:bg-blue-100:hover {
+        --tw-bg-opacity: 1;
+        background-color: rgb(219 234 254 / var(--tw-bg-opacity));
+      }
+
+      .hover\:bg-blue-200:hover {
+        --tw-bg-opacity: 1;
+        background-color: rgb(191 219 254 / var(--tw-bg-opacity));
+      }
+    `)
+  })
+})
+
 it('should not generate duplicates', () => {
   let config = {
     content: [{ raw: html`<div class="uppercase"></div>` }],

--- a/tests/safelist.test.js
+++ b/tests/safelist.test.js
@@ -86,105 +86,6 @@ it('should safelist based on a pattern regex', () => {
   })
 })
 
-it('should safelist based on a pattern tupple with regex', () => {
-  let config = {
-    content: [{ raw: html`<div class="uppercase"></div>` }],
-    safelist: [
-      {
-        pattern: [['hover'], /bg-(red)-(100|200)/],
-      },
-      {
-        pattern: [/bg-(green)-(100|200)/, ['50']],
-      },
-      {
-        pattern: [['hover'], /bg-(blue)-(100|200)/, ['50']],
-      },
-    ],
-  }
-
-  return run('@tailwind utilities', config).then((result) => {
-    return expect(result.css).toMatchCss(css`
-      .bg-red-100 {
-        --tw-bg-opacity: 1;
-        background-color: rgb(254 226 226 / var(--tw-bg-opacity));
-      }
-
-      .bg-red-200 {
-        --tw-bg-opacity: 1;
-        background-color: rgb(254 202 202 / var(--tw-bg-opacity));
-      }
-
-      .bg-green-100 {
-        --tw-bg-opacity: 1;
-        background-color: rgb(220 252 231 / var(--tw-bg-opacity));
-      }
-
-      .bg-green-100\/50 {
-        background-color: rgb(220 252 231 / 0.5);
-      }
-
-      .bg-green-200 {
-        --tw-bg-opacity: 1;
-        background-color: rgb(187 247 208 / var(--tw-bg-opacity));
-      }
-
-      .bg-green-200\/50 {
-        background-color: rgb(187 247 208 / 0.5);
-      }
-
-      .bg-blue-100 {
-        --tw-bg-opacity: 1;
-        background-color: rgb(219 234 254 / var(--tw-bg-opacity));
-      }
-
-      .bg-blue-100\/50 {
-        background-color: rgb(219 234 254 / 0.5);
-      }
-
-      .bg-blue-200 {
-        --tw-bg-opacity: 1;
-        background-color: rgb(191 219 254 / var(--tw-bg-opacity));
-      }
-
-      .bg-blue-200\/50 {
-        background-color: rgb(191 219 254 / 0.5);
-      }
-
-      .uppercase {
-        text-transform: uppercase;
-      }
-
-      .hover\:bg-red-100:hover {
-        --tw-bg-opacity: 1;
-        background-color: rgb(254 226 226 / var(--tw-bg-opacity));
-      }
-
-      .hover\:bg-red-200:hover {
-        --tw-bg-opacity: 1;
-        background-color: rgb(254 202 202 / var(--tw-bg-opacity));
-      }
-
-      .hover\:bg-blue-100:hover {
-        --tw-bg-opacity: 1;
-        background-color: rgb(219 234 254 / var(--tw-bg-opacity));
-      }
-
-      .hover\:bg-blue-100\/50:hover {
-        background-color: rgb(219 234 254 / 0.5);
-      }
-
-      .hover\:bg-blue-200:hover {
-        --tw-bg-opacity: 1;
-        background-color: rgb(191 219 254 / var(--tw-bg-opacity));
-      }
-
-      .hover\:bg-blue-200\/50:hover {
-        background-color: rgb(191 219 254 / 0.5);
-      }
-    `)
-  })
-})
-
 it('should safelist based on a regex', () => {
   let config = {
     content: [{ raw: html`<div class="uppercase"></div>` }],
@@ -210,7 +111,7 @@ it('should safelist based on a regex', () => {
   })
 })
 
-it('should safelist based on a tupple with regex', () => {
+it('should safelist based on a tuple with regex', () => {
   let config = {
     content: [{ raw: html`<div class="uppercase"></div>` }],
     safelist: [


### PR DESCRIPTION
This pull request is trying to bring a new way of doing regex safelisting, and to allow for color opacities in a safelist with regex (https://github.com/tailwindlabs/tailwindcss/discussions/6770).

The current format:
```js
safelist: [
  {
    pattern: /bg-(red)-(100|200)/,
    variants: ['hover'],
  },
],
```

The new formats:
```js
safelist: [
  {
    pattern: [['hover'], /bg-(red)-(100|200)/, ['50']],
    pattern: [['hover'], /bg-(green)-(100|200)/],
    pattern: [/bg-(blue)-(100|200)/, ['50']],
    pattern: [/bg-(yellow)-(100|200)/],
  },
],
```

```js
safelist: [
  /bg-(red)-(100|200)/,
],
```

```js
safelist: [
  [['hover'], /bg-(red)-(100|200)/, ['50']],
  [['hover'], /bg-(green)-(100|200)/],
  [/bg-(blue)-(100|200)/, ['50']],
  [/bg-(yellow)-(100|200)/],
],
```

@adamwathan, is this something you had in mind (https://github.com/tailwindlabs/tailwindcss/pull/7582)?
