### PR TITLE
Add an explicit `--poll` option to the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support PostCSS `Document` nodes ([#7291](https://github.com/tailwindlabs/tailwindcss/pull/7291))
 - Add `text-start` and `text-end` utilities ([#6656](https://github.com/tailwindlabs/tailwindcss/pull/6656))
 - Support customizing class name when using `darkMode: 'class'` ([#5800](https://github.com/tailwindlabs/tailwindcss/pull/5800))
+- Add `--poll` option to the CLI ([#7725](https://github.com/tailwindlabs/tailwindcss/pull/7725))
 
 ## [3.0.23] - 2022-02-16
 

--- a/integrations/tailwindcss-cli/tests/cli.test.js
+++ b/integrations/tailwindcss-cli/tests/cli.test.js
@@ -291,6 +291,7 @@ describe('Build command', () => {
            -i, --input              Input file
            -o, --output             Output file
            -w, --watch              Watch for changes and rebuild as needed
+           -p, --poll               Use polling instead of filesystem events when watching
                --content            Content paths to use for removing unused classes
                --postcss            Load custom PostCSS configuration
            -m, --minify             Minify the output

--- a/src/cli.js
+++ b/src/cli.js
@@ -161,6 +161,10 @@ let commands = {
       '--input': { type: String, description: 'Input file' },
       '--output': { type: String, description: 'Output file' },
       '--watch': { type: Boolean, description: 'Watch for changes and rebuild as needed' },
+      '--poll': {
+        type: Boolean,
+        description: 'Use polling instead of filesystem events when watching',
+      },
       '--content': {
         type: String,
         description: 'Content paths to use for removing unused classes',
@@ -187,6 +191,7 @@ let commands = {
       '-o': '--output',
       '-m': '--minify',
       '-w': '--watch',
+      '-p': '--poll',
     },
   },
 }
@@ -367,11 +372,12 @@ async function build() {
   let input = args['--input']
   let output = args['--output']
   let shouldWatch = args['--watch']
-  let shouldCoalesceWriteEvents = process.platform === 'win32'
+  let shouldPoll = args['--poll']
+  let shouldCoalesceWriteEvents = shouldPoll || process.platform === 'win32'
   let includePostCss = args['--postcss']
 
   // Polling interval in milliseconds
-  // Used only when coalescing add/change events on Windows
+  // Used only when polling or coalescing add/change events on Windows
   let pollInterval = 10
 
   // TODO: Deprecate this in future versions
@@ -751,6 +757,8 @@ async function build() {
     }
 
     watcher = chokidar.watch([...contextDependencies, ...extractFileGlobs(config)], {
+      usePolling: shouldPoll,
+      interval: shouldPoll ? pollInterval : undefined,
       ignoreInitial: true,
       awaitWriteFinish: shouldCoalesceWriteEvents
         ? {


### PR DESCRIPTION
We currently enable `awaitWriteFinish` on Windows because a file may be created, an event delivered for that, and then written to and these events are not necessarily coalesced. This may also be necessary to do over network connections — for example when using SSH. Additionally, `watchFile`-based polling in chokidar is recommended when watching files over a network connection. If polling is not used rebuilds may happen too early or even not at all when working over a network.

I've added an explicit flag (`--poll`) that lets user's enable polling behavior in case they're operating over a network or otherwise have latency issues on when a file is created / written to / done writing.

Fixes #7467