### PR TITLE
Dont set height to auto if an img tag has an height

### DIFF
--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -349,12 +349,16 @@ object {
 }
 
 /*
-Constrain images and videos to the parent width and preserve their intrinsic aspect ratio. (https://github.com/mozdevs/cssremedy/issues/14)
+Constrain images and videos to the parent width and preserve their intrinsic aspect ratio. (https://github.com/mozdevs/cssremedy/issues/14). Only use height auto if height hasnt been set on the img tag
 */
 
 img,
 video {
   max-width: 100%;
+}
+
+video:not([height]),
+img:not([height]){
   height: auto;
 }
 


### PR DESCRIPTION
Since there is no way to override height once it has been set (to make it behave as the same way as if no height attribute has been set at all), it would be less opinionated to only set height: auto if an height attribute on the img tag doesnt exists.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
