### PR TITLE
Fix generation of `div:not(.foo)` if `.foo` is never defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correctly parse and prefix animation names with dots ([#7163](https://github.com/tailwindlabs/tailwindcss/pull/7163))
 - Fix extraction from template literal/function with array ([#7481](https://github.com/tailwindlabs/tailwindcss/pull/7481))
 - Don't output unparsable arbitrary values ([#7789](https://github.com/tailwindlabs/tailwindcss/pull/7789))
+- Fix generation of `div:not(.foo)` if `.foo` is never defined ([#7815](https://github.com/tailwindlabs/tailwindcss/pull/7815))
 
 ### Changed
 

--- a/tests/basic-usage.test.js
+++ b/tests/basic-usage.test.js
@@ -376,3 +376,28 @@ it('can parse box shadows with variables', () => {
     `)
   })
 })
+
+it('should generate styles using :not(.unknown-class) even if `.unknown-class` does not exist', () => {
+  let config = {
+    content: [{ raw: html`<div></div>` }],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind components;
+
+    @layer components {
+      div:not(.unknown-class) {
+        color: red;
+      }
+    }
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      div:not(.unknown-class) {
+        color: red;
+      }
+    `)
+  })
+})

--- a/tests/basic-usage.test.js
+++ b/tests/basic-usage.test.js
@@ -349,7 +349,7 @@ it('does not produce duplicate output when seeing variants preceding a wildcard 
   })
 })
 
-it('it can parse box shadows with variables', () => {
+it('can parse box shadows with variables', () => {
   let config = {
     content: [{ raw: html`<div class="shadow-lg"></div>` }],
     theme: {


### PR DESCRIPTION
This PR will fix an issue where some code never got generated.

E.g.:

```css
@layer base {
  div:not(.foo) {
    background-color: pink;
  }
}
```

```html
<div>I am a div</div>
```

You would expect that this `div` has a background color of `pink`, but that's not the case because we never generated the above css. This is because it contains a class that doesn't exist and therefore we never generated it.
It could happen that you forget about this code, and all of a sudden you use `.foo` in an unrelated spot. This means that all of a sudden this code **doess** get generated and now your div is pink.

This PR will fix that by making sure that this gets generated. We already generate non "on-demandable" code (always). For example `div {}` will always be generated.
To fix this, we ignore everything inside the `:not` when extracting classes, this results in `div {}` and doesn't contain any classes thus we generate it. Note, removal of `:not()` only happens when extract classes, the final result still contains the `:not`.

Fixes: #7750

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
