### PR TITLE
Fix styling resets for Edge and Safari

### DIFF
--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -241,6 +241,16 @@ Remove the inner padding in Chrome and Safari on macOS.
 }
 
 /*
+Remove X form decoration in Edge and Chrome.
+*/
+
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-results-button,
+input[type="search"]::-webkit-search-results-decoration {
+    -webkit-appearance: none;
+}
+
+/*
 1. Correct the inability to style clickable types in iOS and Safari.
 2. Change font properties to `inherit` in Safari.
 */
@@ -301,6 +311,13 @@ Prevent resizing textareas horizontally by default.
 
 textarea {
   resize: vertical;
+}
+
+/*
+Remove default black outline in Edge and Chrome
+*/
+textarea, input {
+    outline: none;
 }
 
 /*


### PR DESCRIPTION
## Current TailwindCSS preflight styles
![image](https://user-images.githubusercontent.com/83793501/158950550-fb918a94-71ed-4701-ba28-67c57ea354f1.png)

## After additional styling to reset default css
![image](https://user-images.githubusercontent.com/83793501/158950951-7bdbe094-4a1d-4bdd-a854-e09cabe0258c.png)

**The issue is that in Chrome and Edge, a blue _x_ decorator will appear as a cancel button. I also removed the border that appears in Safari, Edge and Chrome.**


