### PR TITLE
Fix nested types

### DIFF
--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -304,19 +304,20 @@ interface RequiredConfig {
 }
 
 interface OptionalConfig {
-  important: ImportantConfig
-  prefix: PrefixConfig
-  separator: SeparatorConfig
-  safelist: SafelistConfig
-  presets: PresetsConfig
-  future: FutureConfig
-  experimental: ExperimentalConfig
-  darkMode: DarkModeConfig
-  theme: ThemeConfig
-  corePlugins: CorePluginsConfig
-  plugins: PluginsConfig
+  important: Partial<ImportantConfig>
+  prefix: Partial<PrefixConfig>
+  separator: Partial<SeparatorConfig>
+  safelist: Partial<SafelistConfig>
+  presets: Partial<PresetsConfig>
+  future: Partial<FutureConfig>
+  experimental: Partial<ExperimentalConfig>
+  darkMode: Partial<DarkModeConfig>
+  theme: Partial<ThemeConfig>
+  corePlugins: Partial<CorePluginsConfig>
+  plugins: Partial<PluginsConfig>
   /** Custom */
   [key: string]: any
 }
 
 export type Config = RequiredConfig & Partial<OptionalConfig>
+


### PR DESCRIPTION
This PR fixes a nesting issue in the types provided for the `tailwind.config.js` file.

`Partial` is only 1 level deep. We don't want it to be recursively deep, that's for the plugin itself to decide. But the parts under `theme` should all be optional.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
