### PR TITLE
Types: allow for arbitrary theme values (for 3rd party plugins)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix generation of `div:not(.foo)` if `.foo` is never defined ([#7815](https://github.com/tailwindlabs/tailwindcss/pull/7815))
 - Allow for custom properties in `rgb`, `rgba`, `hsl` and `hsla` colors ([#7933](https://github.com/tailwindlabs/tailwindcss/pull/7933))
 - Remove autoprefixer as explicit peer-dependency to avoid invalid warnings in situations where it isn't actually needed ([#7949](https://github.com/tailwindlabs/tailwindcss/pull/7949))
+- Types: allow for arbitrary theme values (for 3rd party plugins) ([#7926](https://github.com/tailwindlabs/tailwindcss/pull/7926))
 
 ### Changed
 

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -218,6 +218,9 @@ interface ThemeConfig {
   transitionDuration: ResolvableTo<KeyValuePair>
   willChange: ResolvableTo<KeyValuePair>
   content: ResolvableTo<KeyValuePair>
+
+  /** Custom */
+  [key: string]: any
 }
 
 // Core plugins related config

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -13,9 +13,53 @@ interface RecursiveKeyValuePair<K extends keyof any = string, V = string> {
 }
 type ResolvableTo<T> = T | ((utils: PluginUtils) => T)
 
+type DotNotation<T, K extends keyof T = keyof T> = K extends string
+  ? T[K] extends Record<string, any>
+    ? T[K] extends any[]
+      ? K | `${K}.${DotNotation<T[K], Exclude<keyof T[K], keyof any[]>>}`
+      : K | `${K}.${DotNotation<T[K], keyof T[K]>}`
+    : K
+  : never
+type Path<T> = DotNotation<T> | keyof T
+type PathValue<T, P extends Path<T>> = P extends `${infer K}.${infer Rest}`
+  ? K extends keyof T
+    ? Rest extends Path<T[K]>
+      ? PathValue<T[K], Rest>
+      : never
+    : never
+  : P extends keyof T
+  ? T[P]
+  : never
+
+// Removes arbitrary values like: { [key: string]: any }
+type WithoutStringKey<T> = { [K in keyof T as string extends K ? never : K]: T[K] }
+
+type Unpack<T> = T extends ResolvableTo<infer R>
+  ? { [K in keyof R]: Unpack<R[K]> }
+  : T extends object
+  ? { [K in keyof T]: Unpack<T[K]> }
+  : T
+
+// This will remove all the callbacks and simplify it to the actual object
+// it uses or the object it returns. It will also remove the `extend`
+// section because at runtime that's gone anyway.
+type UnpackedTheme = Omit<WithoutStringKey<Unpack<Config['theme']>>, 'extend'>
+
+// This will add additional information purely for code completion. E.g.:
+type AugmentedTheme = Expand<Omit<UnpackedTheme, 'colors'> & { colors: DefaultColors }>
+
 interface PluginUtils {
   colors: DefaultColors
-  theme(path: string, defaultValue: unknown): keyof ThemeConfig
+
+  // Dynamic based on (default) theme config
+  theme<P extends Path<AugmentedTheme>, TDefaultValue>(
+    path: P,
+    defaultValue?: TDefaultValue
+  ): PathValue<AugmentedTheme, P>
+  // Path is just a string, useful for third party plugins where we don't
+  // know the resulting type without generics.
+  theme<TDefaultValue = any>(path: string, defaultValue?: TDefaultValue): TDefaultValue
+
   breakpoints<I = Record<string, unknown>, O = I>(arg: I): O
   rgb(arg: string): (arg: Partial<{ opacityVariable: string; opacityValue: number }>) => string
   hsl(arg: string): (arg: Partial<{ opacityVariable: string; opacityValue: number }>) => string


### PR DESCRIPTION
This PR provides more improvements to the types config.

- Allows for arbitrary objects in the `theme` section for third party plugins.
- ~~Provides code completion for the `theme()` helper function~~

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
