### PR TITLE
Add 0 line-height utility

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -594,6 +594,7 @@ module.exports = {
       normal: '1.5',
       relaxed: '1.625',
       loose: '2',
+      0: '0rem',
       3: '.75rem',
       4: '1rem',
       5: '1.25rem',


### PR DESCRIPTION
Hi,

This PR adds support for a 0 line height utility. This is very useful when you want to have a very big text lying consistently behind, by using absolute positioning, like this:

<img width="972" alt="image" src="https://user-images.githubusercontent.com/1198915/159855507-92e72f72-7be7-4e7a-a8fc-3927cff17ea1.png">
