### PR TITLE
Add media hover variant

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -172,6 +172,11 @@ export let variantPlugins = {
     addVariant('motion-reduce', '@media (prefers-reduced-motion: reduce)')
   },
 
+  hoverVariants: ({ addVariant }) => {
+    addVariant('hover-none', '@media (hover: none)')
+    addVariant('hover-hover', '@media (hover: hover)')
+  },
+
   darkVariants: ({ config, addVariant }) => {
     let [mode, className = '.dark'] = [].concat(config('darkMode', 'media'))
 

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -560,6 +560,7 @@ function resolvePlugins(context, root) {
   let afterVariants = [
     variantPlugins['directionVariants'],
     variantPlugins['reducedMotionVariants'],
+    variantPlugins['hoverVariants'],
     variantPlugins['darkVariants'],
     variantPlugins['printVariant'],
     variantPlugins['screenVariants'],


### PR DESCRIPTION
This allows us to target devices that have a primary input device with hover capabilities.

- https://developer.mozilla.org/en-US/docs/Web/CSS/@media/hover
- https://caniuse.com/mdn-css_at-rules_media_hover

The naming probably needs a little discussion, and I'm not sure how to test exactly, but wanted to get the conversation started.

It might also be of value to discuss having a configuration option to set a default for **all** hover classes throughout the site.