### PR TITLE
Remove autoprefixer as peer-dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't output unparsable arbitrary values ([#7789](https://github.com/tailwindlabs/tailwindcss/pull/7789))
 - Fix generation of `div:not(.foo)` if `.foo` is never defined ([#7815](https://github.com/tailwindlabs/tailwindcss/pull/7815))
 - Allow for custom properties in `rgb`, `rgba`, `hsl` and `hsla` colors ([#7933](https://github.com/tailwindlabs/tailwindcss/pull/7933))
+- Remove autoprefixer as explicit peer-dependency to avoid invalid warnings in situations where it isn't actually needed ([#7949](https://github.com/tailwindlabs/tailwindcss/pull/7949))
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,6 @@
         "node": ">=12.13.0"
       },
       "peerDependencies": {
-        "autoprefixer": "^10.0.2",
         "postcss": "^8.0.9"
       }
     },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "source-map-js": "^1.0.2"
   },
   "peerDependencies": {
-    "autoprefixer": "^10.0.2",
     "postcss": "^8.0.9"
   },
   "dependencies": {


### PR DESCRIPTION
We list autoprefixer as a peer-dependency because it's used by the CLI, but it's not actually needed by Tailwind itself. If you are using a build tool other than our CLI, you might not need it at all (for example Parcel handles vendor prefixing on its own without autoprefixer), so users aren't actually always required to install it.

This makes our handling of autoprefixer and cssnano consistent, which are both used by the CLI but autoprefixer was marked as a peer-dependency and cssnano wasn't. We compile these peer-dependencies into what we distribute via npm anyways so that there's a fallback available if people don't install them (for instance using `npx tailwindcss` without installing Tailwind locally) so everything will continue to work fine anyways.

/cc @devongovett