### PR TITLE
Add CSS `contain` utilities

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -2367,6 +2367,22 @@ export let corePlugins = {
     })
   },
 
+  contain: ({ addUtilities, matchUtilities }) => {
+    addUtilities([
+      {
+        '.contain-none': { contain: 'none' },
+        '.contain-strict': { contain: 'strict' },
+        '.contain-content': { contain: 'content' },
+        '.contain-size': { contain: 'size' },
+        '.contain-layout': { contain: 'layout' },
+        '.contain-style': { contain: 'style' },
+        '.contain-paint': { contain: 'paint' },
+      },
+    ])
+
+    matchUtilities({ contain: (value) => ({ contain: value }) })
+  },
+
   transitionProperty: ({ matchUtilities, theme }) => {
     let defaultTimingFunction = theme('transitionTimingFunction.DEFAULT')
     let defaultDuration = theme('transitionDuration.DEFAULT')

--- a/tests/arbitrary-values.test.css
+++ b/tests/arbitrary-values.test.css
@@ -1009,6 +1009,9 @@
   --tw-backdrop-sepia: sepia(0.38);
   backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
 }
+.contain-\[style_layout_paint\] {
+  contain: style layout paint;
+}
 .transition-\[opacity\2c width\] {
   transition-property: opacity, width;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);

--- a/tests/arbitrary-values.test.html
+++ b/tests/arbitrary-values.test.html
@@ -365,6 +365,8 @@
     <div class="backdrop-saturate-[144%]"></div>
     <div class="backdrop-sepia-[0.38]"></div>
 
+    <div class="contain-[style_layout_paint]"></div>
+
     <div class="transition-[opacity,width]"></div>
 
     <div class="delay-[var(--delay)]"></div>

--- a/tests/raw-content.test.css
+++ b/tests/raw-content.test.css
@@ -700,6 +700,12 @@
 .backdrop-filter-none {
   backdrop-filter: none;
 }
+.contain-content {
+  contain: content;
+}
+.contain-size {
+  contain: size;
+}
 .transition {
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke,
     opacity, box-shadow, transform, filter, backdrop-filter;

--- a/tests/raw-content.test.html
+++ b/tests/raw-content.test.html
@@ -143,5 +143,7 @@
     <div class="w-12"></div>
     <div class="break-words"></div>
     <div class="z-30"></div>
+    <div class="contain-size"></div>
+    <div class="contain-content"></div>
   </body>
 </html>


### PR DESCRIPTION
This PR adds tailwind utilities for the CSS [`contain`](https://developer.mozilla.org/en-US/docs/Web/CSS/contain) property.

This property does in fact allow multiple keywords, however I cannot find an example of a tailwind class that supports this. `text-decoration-line` is an example where the Tailwind util doesn't support it, but the property does.

https://github.com/tailwindlabs/tailwindcss/pull/7955 - in combination with content visibility I think it's common to have this multiple keyword styling. Any tips on how best to implement this would be great, alternatively potentially arbitrary value support is good enough.
