### PR TITLE
Ensure the `percentage` data type is validated correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow for custom properties in `rgb`, `rgba`, `hsl` and `hsla` colors ([#7933](https://github.com/tailwindlabs/tailwindcss/pull/7933))
 - Remove autoprefixer as explicit peer-dependency to avoid invalid warnings in situations where it isn't actually needed ([#7949](https://github.com/tailwindlabs/tailwindcss/pull/7949))
 - Types: allow for arbitrary theme values (for 3rd party plugins) ([#7926](https://github.com/tailwindlabs/tailwindcss/pull/7926))
+- Ensure the `percentage` data type is validated correctly ([#8015](https://github.com/tailwindlabs/tailwindcss/pull/8015))
 
 ### Changed
 

--- a/src/util/dataTypes.js
+++ b/src/util/dataTypes.js
@@ -57,7 +57,9 @@ export function number(value) {
 }
 
 export function percentage(value) {
-  return /%$/g.test(value) || cssFunctions.some((fn) => new RegExp(`^${fn}\\(.+?%`).test(value))
+  return value.split(UNDERSCORE).every((part) => {
+    return /%$/g.test(part) || cssFunctions.some((fn) => new RegExp(`^${fn}\\(.+?%`).test(part))
+  })
 }
 
 let lengthUnits = [

--- a/tests/arbitrary-values.test.js
+++ b/tests/arbitrary-values.test.js
@@ -384,3 +384,25 @@ it('should not output unparsable arbitrary CSS values', () => {
     return expect(result.css).toMatchFormattedCss(``)
   })
 })
+
+// Issue: https://github.com/tailwindlabs/tailwindcss/issues/7997
+// `top_right_50%` was a valid percentage before introducing this change
+it('should correctly validate each part when checking for `percentage` data types', () => {
+  let config = {
+    content: [{ raw: html`<div class="bg-[top_right_50%]"></div>` }],
+    corePlugins: { preflight: false },
+    plugins: [],
+  }
+
+  let input = css`
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .bg-\[top_right_50\%\] {
+        background-position: top right 50%;
+      }
+    `)
+  })
+})


### PR DESCRIPTION
When checking for our data types, we have to make sure that each part is correct, this wasn't happening for the `percentage` data type, which meant that `top_right_50%` was a valid percentage value because it ended in `%` which is not correct.

Because of this, the generated code was non-existent because we got a
warning:

```
The class `bg-[top_right_50%]` is ambiguous and matches multiple utilities.
  Use `bg-[length:top_right_50%]` for `background-size: top right 50%`
  Use `bg-[position:top_right_50%]` for `background-position: top right 50%`
If this is content and not a class, replace it with `bg-&lsqb;top_right_50%&rsqb;` to silence this warning.
```

But this is not correct because this can never be a valid background size due to the `top right` section.

This fixes it by validating each part individually, and now we get generated css.

Fixes: #7997

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
