### PR TITLE
Update `theme.fontSize` types

### DIFF
--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -158,18 +158,18 @@ interface ThemeConfig {
   textIndent: ThemeConfig['spacing']
   fontFamily: ResolvableTo<KeyValuePair<string, string[]>>
   fontSize: ResolvableTo<
-    | KeyValuePair<string, string>
-    | KeyValuePair<string, [fontSize: string, lineHeight: string]>
-    | KeyValuePair<
-        string,
-        [
+    KeyValuePair<
+      string,
+      | string
+      | [fontSize: string, lineHeight: string]
+      | [
           fontSize: string,
           configuration: Partial<{
             lineHeight: string
             letterSpacing: string
           }>
         ]
-      >
+    >
   >
   fontWeight: ResolvableTo<KeyValuePair>
   lineHeight: ResolvableTo<KeyValuePair>


### PR DESCRIPTION
This PR updates the `theme.fontSize` types so so you can mix the different formats. Currently all of the values need to have the same format, e.g.

```js
// ✅
module.exports = {
  theme: {
    fontSize: {
      foo: '4rem',
      bar: '5rem',
    },
  },
}

// ✅
module.exports = {
  theme: {
    fontSize: {
      foo: ['4rem', '6rem'],
      bar: ['5rem', '7rem'],
    },
  },
}

// ❌
module.exports = {
  theme: {
    fontSize: {
      foo: '4rem',
      bar: ['5rem', '7rem'],
    },
  },
}
```