### PR TITLE
Update `screens` types

### DIFF
--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -71,12 +71,15 @@ type DarkModeConfig =
   /** Use the `class` stategy with a custom class instead of `.dark`. */
   | ['class', string]
 
+type Screen = { raw: string } | { min: string } | { max: string } | { min: string; max: string }
+type ScreensConfig = string[] | KeyValuePair<string, string | Screen | Screen[]>
+
 // Theme related config
 interface ThemeConfig {
   extend: Partial<Omit<ThemeConfig, 'extend'>>
 
   /** Responsiveness */
-  screens: ResolvableTo<KeyValuePair>
+  screens: ResolvableTo<ScreensConfig>
 
   /** Reusable base configs */
   colors: ResolvableTo<RecursiveKeyValuePair>
@@ -85,12 +88,7 @@ interface ThemeConfig {
   /** Components */
   container: ResolvableTo<
     Partial<{
-      screens:
-        | string[] /** List of breakpoints. E.g.: '400px', '500px' */
-        /** Named breakpoints. E.g.: { sm: '400px' } */
-        | Record<string | number, string>
-        /** Name breakpoints with explicit min and max values. E.g.: { sm: { min: '300px', max: '400px' } } */
-        | Record<string, { min: string; max: string }>
+      screens: ScreensConfig
       center: boolean
       padding: string | Record<string, string>
     }>


### PR DESCRIPTION
This PR updates the `theme.screens` and `theme.container.screens` types, ensuring that it supports the following formats for individual screens:


```js
string
{ raw: string }
{ min: string }
{ max: string }
{ min: string, max: string }
Array<{raw: string} | { min: string } | { max: string } | { min: string, max: string }>
```

It also handles an array of strings at the top level, e.g.

```js
module.exports = {
  theme: {
    screens: ['100px', '200px'],
  },
}
```

**Before:**

<img width="441" alt="CleanShot 2022-04-04 at 12 49 56@2x" src="https://user-images.githubusercontent.com/2615508/161537807-08a7e1db-29ab-4788-acc4-61f7342b637b.png">

**After:**

<img width="439" alt="CleanShot 2022-04-04 at 12 50 19@2x" src="https://user-images.githubusercontent.com/2615508/161537857-f78c40ab-d4a5-49eb-a59a-83e077c3e9f3.png">
