### PR TITLE
Redirect to the up-to-date plugin url

### DIFF
--- a/src/postcss-plugins/nesting/README.md
+++ b/src/postcss-plugins/nesting/README.md
@@ -1,6 +1,6 @@
 # tailwindcss/nesting
 
-This is a PostCSS plugin that wraps [postcss-nested](https://github.com/postcss/postcss-nested) or [postcss-nesting](https://github.com/jonathantneal/postcss-nesting) and acts as a compatibility layer to make sure your nesting plugin of choice properly understands Tailwind's custom syntax like `@apply` and `@screen`.
+This is a PostCSS plugin that wraps [postcss-nested](https://github.com/postcss/postcss-nested) or [postcss-nesting](https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-nesting) and acts as a compatibility layer to make sure your nesting plugin of choice properly understands Tailwind's custom syntax like `@apply` and `@screen`.
 
 Add it to your PostCSS configuration, somewhere before Tailwind itself:
 
@@ -18,7 +18,7 @@ module.exports = {
 
 By default, it uses the [postcss-nested](https://github.com/postcss/postcss-nested) plugin under the hood, which uses a Sass-like syntax and is the plugin that powers nesting support in the [Tailwind CSS plugin API](https://tailwindcss.com/docs/plugins#css-in-js-syntax).
 
-If you'd rather use [postcss-nesting](https://github.com/jonathantneal/postcss-nesting) (which is based on the work-in-progress [CSS Nesting](https://drafts.csswg.org/css-nesting-1/) specification), first install the plugin alongside:
+If you'd rather use [postcss-nesting](https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-nesting) (which is based on the work-in-progress [CSS Nesting](https://drafts.csswg.org/css-nesting-1/) specification), first install the plugin alongside:
 
 ```shell
 npm install postcss-nesting


### PR DESCRIPTION
The link for [postcss-nesting](https://github.com/jonathantneal/postcss-nesting) is outdated/archived.
This is a small fix to correct the link, and direct it to where the archived repo itself points to.

https://github.com/csstools/postcss-plugins/discussions/75