### PR TITLE
Add inherit spacing

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -103,6 +103,7 @@ module.exports = {
       72: '18rem',
       80: '20rem',
       96: '24rem',
+      inherit: 'inherit'
     },
     animation: {
       none: 'none',


### PR DESCRIPTION
This PR adds support for the inherit spacing value. Tailwind currently lacks a lot for the "inherit" keyword, and there are various cases where it is actually useful. For instance, imagine a common form with some gap between fields, and with two fields that you would like to be two per row but preserving the global gap. For now we are forced to repeat everything:

```
<div class="grid gap-2 sm:gap-3 lg:gap-4">
  <div class="grid gap-2 sm:gap-3 lg:gap-4 sm:tw-grid-cols-2">
    <input>
    <input>
  </div>
  <input ...>
</div>
```

With this we can simply use:

```
<div class="grid gap-2 sm:gap-3 lg:gap-4">
  <div class="grid gap-inherit sm:tw-grid-cols-2">
    <input>
    <input>
  </div>
  <input ...>
</div>
```