### PR TITLE
Do not set / 1 opacity for rgb/hsl helpers

### DIFF
--- a/src/util/resolveConfig.js
+++ b/src/util/resolveConfig.js
@@ -75,7 +75,7 @@ const configUtils = {
 
     return ({ opacityValue }) => {
       if (opacityValue === undefined || opacityValue === 1) {
-        return `rgb(var(${property}) / 1.0)`
+        return `rgb(var(${property}))`
       }
 
       return `rgb(var(${property}) / ${opacityValue})`
@@ -90,7 +90,7 @@ const configUtils = {
 
     return ({ opacityValue }) => {
       if (opacityValue === undefined || opacityValue === 1) {
-        return `hsl(var(${property}) / 1)`
+        return `hsl(var(${property}))`
       }
 
       return `hsl(var(${property}) / ${opacityValue})`

--- a/tests/opacity.test.js
+++ b/tests/opacity.test.js
@@ -209,37 +209,37 @@ it('can use rgb helper when defining custom properties for colors (opacity plugi
   return run('@tailwind utilities', config).then((result) => {
     expect(result.css).toMatchFormattedCss(css`
       .divide-primary > :not([hidden]) ~ :not([hidden]) {
-        border-color: rgb(var(--color-primary) / 1);
+        border-color: rgb(var(--color-primary));
       }
       .divide-primary\/50 > :not([hidden]) ~ :not([hidden]) {
         border-color: rgb(var(--color-primary) / 0.5);
       }
       .border-primary {
-        border-color: rgb(var(--color-primary) / 1);
+        border-color: rgb(var(--color-primary));
       }
       .border-primary\/50 {
         border-color: rgb(var(--color-primary) / 0.5);
       }
       .bg-primary {
-        background-color: rgb(var(--color-primary) / 1);
+        background-color: rgb(var(--color-primary));
       }
       .bg-primary\/50 {
         background-color: rgb(var(--color-primary) / 0.5);
       }
       .text-primary {
-        color: rgb(var(--color-primary) / 1);
+        color: rgb(var(--color-primary));
       }
       .text-primary\/50 {
         color: rgb(var(--color-primary) / 0.5);
       }
       .placeholder-primary::placeholder {
-        color: rgb(var(--color-primary) / 1);
+        color: rgb(var(--color-primary));
       }
       .placeholder-primary\/50::placeholder {
         color: rgb(var(--color-primary) / 0.5);
       }
       .ring-primary {
-        --tw-ring-color: rgb(var(--color-primary) / 1);
+        --tw-ring-color: rgb(var(--color-primary));
       }
       .ring-primary\/50 {
         --tw-ring-color: rgb(var(--color-primary) / 0.5);
@@ -361,37 +361,37 @@ it('can use hsl helper when defining custom properties for colors (opacity plugi
   return run('@tailwind utilities', config).then((result) => {
     expect(result.css).toMatchCss(css`
       .divide-primary > :not([hidden]) ~ :not([hidden]) {
-        border-color: hsl(var(--color-primary) / 1);
+        border-color: hsl(var(--color-primary));
       }
       .divide-primary\/50 > :not([hidden]) ~ :not([hidden]) {
         border-color: hsl(var(--color-primary) / 0.5);
       }
       .border-primary {
-        border-color: hsl(var(--color-primary) / 1);
+        border-color: hsl(var(--color-primary));
       }
       .border-primary\/50 {
         border-color: hsl(var(--color-primary) / 0.5);
       }
       .bg-primary {
-        background-color: hsl(var(--color-primary) / 1);
+        background-color: hsl(var(--color-primary));
       }
       .bg-primary\/50 {
         background-color: hsl(var(--color-primary) / 0.5);
       }
       .text-primary {
-        color: hsl(var(--color-primary) / 1);
+        color: hsl(var(--color-primary));
       }
       .text-primary\/50 {
         color: hsl(var(--color-primary) / 0.5);
       }
       .placeholder-primary::placeholder {
-        color: hsl(var(--color-primary) / 1);
+        color: hsl(var(--color-primary));
       }
       .placeholder-primary\/50::placeholder {
         color: hsl(var(--color-primary) / 0.5);
       }
       .ring-primary {
-        --tw-ring-color: hsl(var(--color-primary) / 1);
+        --tw-ring-color: hsl(var(--color-primary));
       }
       .ring-primary\/50 {
         --tw-ring-color: hsl(var(--color-primary) / 0.5);


### PR DESCRIPTION
Hi,

This PR makes sure that the / 1 is not outputted when there is no opacity defined.

The reason for this change is to allow Tailwind to better play with CSS variables.

For instance, in our use case I have in our config a "current" background defined to a CSS variable:

```
backgroundColor: ({ theme, rgb }) => ({
  'current': '--background'
})
```

This --background variable is dynamically set on some div, with optional opacity:

```
<div class="bg-[rgb(--background)]" style="--background: 255 0 0 / 0.5">
  <span class="text-accent bg-current">0</span>
</div>
```

The issue is that currently, on the inner span, Tailwind will try to generate this:

```
.bg-current {
  background-color: rgb(var(--background) / 1);
}
```

However, due to the fact that --background already contains a component with an alpha, this resolves as rgb(255 0 0 / 0.5 / 1).

This PR allows to add this extra use case :).