### PR TITLE
Add missing `.grid-flow-dense` utility

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -884,6 +884,7 @@ export let corePlugins = {
     addUtilities({
       '.grid-flow-row': { gridAutoFlow: 'row' },
       '.grid-flow-col': { gridAutoFlow: 'column' },
+      '.grid-flow-dense': { gridAutoFlow: 'dense' },
       '.grid-flow-row-dense': { gridAutoFlow: 'row dense' },
       '.grid-flow-col-dense': { gridAutoFlow: 'column dense' },
     })


### PR DESCRIPTION
This PR adds a missing utility for the `gridAutoFlow` plugin. `.grid-flow-dense` allows users to fill the gaps on a grid container without overwriting the current grid definition and forcing it to have only one row or column.

https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-flow#dense