### PR TITLE
Improve type detection for arbitrary color values

### DIFF
--- a/src/util/dataTypes.js
+++ b/src/util/dataTypes.js
@@ -121,7 +121,7 @@ export function color(value) {
     part = normalize(part)
 
     if (part.startsWith('var(')) return true
-    if (parseColor(part) !== null) return colors++, true
+    if (parseColor(part, { loose: true }) !== null) return colors++, true
 
     return false
   })

--- a/tests/arbitrary-values.test.js
+++ b/tests/arbitrary-values.test.js
@@ -68,6 +68,8 @@ it('should support arbitrary values for various background utilities', () => {
           <!-- By implicit type -->
           <div class="bg-[url('/image-1-0.png')]"></div>
           <div class="bg-[#ff0000]"></div>
+          <div class="bg-[rgb(var(--bg-color))]"></div>
+          <div class="bg-[hsl(var(--bg-color))]"></div>
 
           <!-- By explicit type -->
           <div class="bg-[url:var(--image-url)]"></div>
@@ -87,6 +89,14 @@ it('should support arbitrary values for various background utilities', () => {
       .bg-\[\#ff0000\] {
         --tw-bg-opacity: 1;
         background-color: rgb(255 0 0 / var(--tw-bg-opacity));
+      }
+
+      .bg-\[rgb\(var\(--bg-color\)\)\] {
+        background-color: rgb(var(--bg-color));
+      }
+
+      .bg-\[hsl\(var\(--bg-color\)\)\] {
+        background-color: hsl(var(--bg-color));
       }
 
       .bg-\[color\:var\(--bg-color\)\] {


### PR DESCRIPTION
Fixes #8171 

This PR improves type detection for arbitrary color values. Previously the following classes would not be generated because the type of the values could not be determined:

```
bg-[rgb(var(--bg-color))]
bg-[rgb(var(--red-green),40)]
bg-[rgb(12,var(--green-blue))]
```

Instead you would have to provide a type hint:

```
bg-[color:rgb(var(--bg-color))]
bg-[color:rgb(var(--red-green),40)]
bg-[color:rgb(12,var(--green-blue))]
```

The hint should not be necessary here because we can tell the values are colors based on the use of `rgb()`.

This PR adds a `loose` mode to the `parseColor` function that allows colors with fewer than 3 parts (like the above examples) as long as at least one of the parts is variable. We then use this parsing mode when looking for colors in arbitrary values.