### PR TITLE
Fix intellisense for plugins with multiple `@apply` rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Require matching prefix when detecting negatives ([#8121](https://github.com/tailwindlabs/tailwindcss/pull/8121))
 - Handle duplicate At Rules without children ([#8122](https://github.com/tailwindlabs/tailwindcss/pull/8122))
 - Allow arbitrary values with commas in `@apply` ([#8125](https://github.com/tailwindlabs/tailwindcss/pull/8125))
+- Fix intellisense for plugins with multiple `@apply` rules ([#8213](https://github.com/tailwindlabs/tailwindcss/pull/8213))
 
 ### Added
 

--- a/src/lib/expandApplyAtRules.js
+++ b/src/lib/expandApplyAtRules.js
@@ -309,7 +309,7 @@ function processApply(root, context, localCache) {
 
   // Collect all apply candidates and their rules
   for (let apply of applies) {
-    let candidates = []
+    let [candidates] = perParentApplies.get(apply.parent) || [[], apply.source]
 
     perParentApplies.set(apply.parent, [candidates, apply.source])
 


### PR DESCRIPTION
Intellisense uses `expandApplyAtRules` directly and doesn’t partition them. When a plugin registers components using something like `”@apply flex”: {}` more than once in the same component intellisense will break. This isn’t a problem for Tailwind CSS proper because we do rule partitioning. Given that Intellisense is using it directly though we shouldn’t outright break in the face of this situation even if the result isn’t 100% accurate (the source maps won’t be correct for all but the first `@apply` found but that should not cause issues for Intellisense).

Fixes #8203