### PR TITLE
Only check selectors containing apply candidates for circular dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve type detection for arbitrary color values ([#8201](https://github.com/tailwindlabs/tailwindcss/pull/8201))
 - Support PostCSS config options in config file in CLI ([#8226](https://github.com/tailwindlabs/tailwindcss/pull/8226))
 - Remove default `[hidden]` style in preflight ([#8248](https://github.com/tailwindlabs/tailwindcss/pull/8248))
+- Only check selectors containing base apply candidates for circular dependencies ([#8222](https://github.com/tailwindlabs/tailwindcss/pull/8222))
 
 ### Added
 

--- a/tests/apply.test.js
+++ b/tests/apply.test.js
@@ -658,6 +658,94 @@ it('should throw when trying to apply an indirect circular dependency with a mod
   })
 })
 
+it('should not throw when the circular dependency is part of a different selector (1)', () => {
+  let config = {
+    content: [{ raw: html`<div class="c"></div>` }],
+    plugins: [],
+  }
+
+  let input = css`
+    @tailwind utilities;
+
+    @layer utilities {
+      html.dark .a,
+      .b {
+        color: red;
+      }
+    }
+
+    html.dark .c {
+      @apply b;
+    }
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      html.dark .c {
+        color: red;
+      }
+    `)
+  })
+})
+
+it('should not throw when the circular dependency is part of a different selector (2)', () => {
+  let config = {
+    content: [{ raw: html`<div class="c"></div>` }],
+    plugins: [],
+  }
+
+  let input = css`
+    @tailwind utilities;
+
+    @layer utilities {
+      html.dark .a,
+      .b {
+        color: red;
+      }
+    }
+
+    html.dark .c {
+      @apply hover:b;
+    }
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      html.dark .c:hover {
+        color: red;
+      }
+    `)
+  })
+})
+
+it('should throw when the circular dependency is part of the same selector', () => {
+  let config = {
+    content: [{ raw: html`<div class="c"></div>` }],
+    plugins: [],
+  }
+
+  let input = css`
+    @tailwind utilities;
+
+    @layer utilities {
+      html.dark .a,
+      html.dark .b {
+        color: red;
+      }
+    }
+
+    html.dark .c {
+      @apply hover:b;
+    }
+  `
+
+  return run(input, config).catch((err) => {
+    expect(err.reason).toBe(
+      'You cannot `@apply` the `hover:b` utility here because it creates a circular dependency.'
+    )
+  })
+})
+
 it('rules with vendor prefixes are still separate when optimizing defaults rules', () => {
   let config = {
     experimental: { optimizeUniversalDefaults: true },


### PR DESCRIPTION
When given a two rule like `html.dark .a, .b { … }` and `html.dark .c { @apply b }` we would see `.dark` in both the base rule and the rule being applied and consider it a circular dependency. However, the selectors `html.dark .a` and `.b` should be considered on their own and as a result not introduce a circular dependency.

This better matches the user’s mental model that the selectors are just two definitions sharing the same properties.

Fixes #7844