### PR TITLE
Try using local `postcss` installation first in the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Only check selectors containing base apply candidates for circular dependencies ([#8222](https://github.com/tailwindlabs/tailwindcss/pull/8222))
 - Rewrite default class extractor ([#8204](https://github.com/tailwindlabs/tailwindcss/pull/8204))
 
+### Changed
+
+- Try using local `postcss` installation first in the CLI ([#8270](https://github.com/tailwindlabs/tailwindcss/pull/8270))
+
 ### Added
 
 - Allow default ring color to be a function ([#7587](https://github.com/tailwindlabs/tailwindcss/pull/7587))

--- a/src/cli-peer-dependencies.js
+++ b/src/cli-peer-dependencies.js
@@ -1,4 +1,6 @@
-export let postcss = require('postcss')
+export function lazyPostcss() {
+  return require('postcss')
+}
 
 export function lazyAutoprefixer() {
   return require('autoprefixer')

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { postcss, lazyCssnano, lazyAutoprefixer } from '../peers/index.js'
+import { lazyPostcss, lazyCssnano, lazyAutoprefixer } from '../peers/index.js'
 
 import chokidar from 'chokidar'
 import path from 'path'
@@ -144,6 +144,15 @@ function oneOf(...options) {
     },
     { manualParsing: true }
   )
+}
+
+function loadPostcss() {
+  // Try to load a local `postcss` version first
+  try {
+    return require('postcss')
+  } catch {}
+
+  return lazyPostcss()
 }
 
 let commands = {
@@ -576,6 +585,7 @@ async function build() {
         })(),
     ].filter(Boolean)
 
+    let postcss = loadPostcss()
     let processor = postcss(plugins)
 
     function processCSS(css) {
@@ -709,6 +719,7 @@ async function build() {
       let tailwindPluginIdx = plugins.indexOf('__TAILWIND_PLUGIN_POSITION__')
       let copy = plugins.slice()
       copy.splice(tailwindPluginIdx, 1, tailwindPlugin)
+      let postcss = loadPostcss()
       let processor = postcss(copy)
 
       function processCSS(css) {


### PR DESCRIPTION
The CLI currently uses it's built-in postcss package unconditionally. This isn't ideal if there's a bug fix or new features in PostCSS. This doesn't affect anyone using tailwindcss as a posstcss plugin — only those invoking the CLI command directly or via scripts.

Fixes #8260 (sorta) — PostCSS already fixed the underlying issue and we've already updated our internal postcss version to account for this on the insiders build but user's can't swap out the postcss version. We'll do this to allow them to. This is still only. going on the insiders build so it'll be helpful for future situations.