### PR TITLE
feat: add `plus-lighter` support for `mix-blend-mode`

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1867,6 +1867,7 @@ export let corePlugins = {
       '.mix-blend-saturation': { 'mix-blend-mode': 'saturation' },
       '.mix-blend-color': { 'mix-blend-mode': 'color' },
       '.mix-blend-luminosity': { 'mix-blend-mode': 'luminosity' },
+      '.mix-blend-plus-lighter': { 'mix-blend-mode': 'plus-lighter' },
     })
   },
 


### PR DESCRIPTION
This PR adds support for `plus-lighter` to `mix-blend-mode`, which allows for real DOM cross-fading.

This new blend mode is relatively new, but is supported in Safari, [Chrome 100](https://groups.google.com/a/chromium.org/g/blink-dev/c/KXAJlJsbBak/m/JisA_CS2AAAJ), and [Firefox 99](https://bugzilla.mozilla.org/show_bug.cgi?id=1746248). 

For more information:

- https://jakearchibald.com/2021/dom-cross-fade/
- https://github.com/w3c/fxtf-drafts/pull/444

This is a follow-up to #7758 now that this feature is more supported across browsers.