### PR TITLE
Arbitrary variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `backdrop` variant ([#7924](https://github.com/tailwindlabs/tailwindcss/pull/7924))
 - Add `grid-flow-dense` utility ([#8193](https://github.com/tailwindlabs/tailwindcss/pull/8193))
 - Add `mix-blend-plus-lighter` utility ([#8288](https://github.com/tailwindlabs/tailwindcss/pull/8288))
+- Add arbitrary variants ([#8299](https://github.com/tailwindlabs/tailwindcss/pull/8299))
 
 ## [3.0.24] - 2022-04-12
 

--- a/src/lib/defaultExtractor.js
+++ b/src/lib/defaultExtractor.js
@@ -19,7 +19,7 @@ export function defaultExtractor(content) {
 function* buildRegExps() {
   yield regex.pattern([
     // Variants
-    /((?=([^\s"'\\]+:))\2)?/,
+    /((?=((\[[^\s"'\[\]\\]+\]:|[^\s"'\[\\]+:)+))\2)?/,
 
     // Important (optional)
     /!?/,

--- a/src/lib/defaultExtractor.js
+++ b/src/lib/defaultExtractor.js
@@ -1,25 +1,34 @@
 import * as regex from './regex'
 
-let patterns = Array.from(buildRegExps())
+export function defaultExtractor(context) {
+  let patterns = Array.from(buildRegExps(context))
 
-/**
- * @param {string} content
- */
-export function defaultExtractor(content) {
-  /** @type {(string|string)[]} */
-  let results = []
+  /**
+   * @param {string} content
+   */
+  return (content) => {
+    /** @type {(string|string)[]} */
+    let results = []
 
-  for (let pattern of patterns) {
-    results.push(...(content.match(pattern) ?? []))
+    for (let pattern of patterns) {
+      results.push(...(content.match(pattern) ?? []))
+    }
+
+    return results.filter((v) => v !== undefined).map(clipAtBalancedParens)
   }
-
-  return results.filter((v) => v !== undefined).map(clipAtBalancedParens)
 }
 
-function* buildRegExps() {
+function* buildRegExps(context) {
+  let separator = context.tailwindConfig.separator
+
   yield regex.pattern([
     // Variants
-    /((?=((\[[^\s"'\\]+\]:|[^\s"'\[\\]+:)+))\2)?/,
+    '((?=((',
+    regex.any(
+      [regex.pattern([/\[[^\s"'\\]+\]/, separator]), regex.pattern([/[^\s"'\[\\]+/, separator])],
+      true
+    ),
+    ')+))\\2)?',
 
     // Important (optional)
     /!?/,

--- a/src/lib/defaultExtractor.js
+++ b/src/lib/defaultExtractor.js
@@ -19,7 +19,7 @@ export function defaultExtractor(content) {
 function* buildRegExps() {
   yield regex.pattern([
     // Variants
-    /((?=((\[[^\s"'\[\]\\]+\]:|[^\s"'\[\\]+:)+))\2)?/,
+    /((?=((\[[^\s"'\\]+\]:|[^\s"'\[\\]+:)+))\2)?/,
 
     // Important (optional)
     /!?/,

--- a/src/lib/defaultExtractor.js
+++ b/src/lib/defaultExtractor.js
@@ -19,7 +19,7 @@ export function defaultExtractor(content) {
 function* buildRegExps() {
   yield regex.pattern([
     // Variants
-    /((?=([^\s"'\\\[]+:))\2)?/,
+    /((?=([^\s"'\\]+:))\2)?/,
 
     // Important (optional)
     /!?/,

--- a/src/lib/expandTailwindAtRules.js
+++ b/src/lib/expandTailwindAtRules.js
@@ -24,7 +24,7 @@ function getExtractor(context, fileExtension) {
     extractors[fileExtension] ||
     extractors.DEFAULT ||
     builtInExtractors[fileExtension] ||
-    builtInExtractors.DEFAULT
+    builtInExtractors.DEFAULT(context)
   )
 }
 

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -9,6 +9,7 @@ import * as sharedState from './sharedState'
 import { formatVariantSelector, finalizeSelector } from '../util/formatVariantSelector'
 import { asClass } from '../util/nameClass'
 import { normalize } from '../util/dataTypes'
+import { parseVariant } from './setupContextUtils'
 import isValidArbitraryValue from '../util/isValidArbitraryValue'
 
 let classNameParser = selectorParser((selectors) => {
@@ -128,8 +129,12 @@ function applyVariant(variant, matches, context) {
   // Register arbitrary variants
   if (isArbitraryValue(variant) && !context.variantMap.has(variant)) {
     let selector = normalize(variant.slice(1, -1))
+
+    // TODO: Error recovery for @supports(what:ever) -- note the absence of a space
+    let fn = parseVariant(selector)
+
     let sort = Array.from(context.variantOrder.values()).pop() << 1n
-    context.variantMap.set(variant, [[sort, () => selector]])
+    context.variantMap.set(variant, [[sort, fn]])
     context.variantOrder.set(variant, sort)
   }
 

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -131,7 +131,6 @@ function applyVariant(variant, matches, context) {
   if (isArbitraryValue(variant) && !context.variantMap.has(variant)) {
     let selector = normalize(variant.slice(1, -1))
 
-    // TODO: Error recovery for @supports(what:ever) -- note the absence of a space
     let fn = parseVariant(selector)
 
     let sort = Array.from(context.variantOrder.values()).pop() << 1n

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -125,6 +125,14 @@ function applyVariant(variant, matches, context) {
     return matches
   }
 
+  // Register arbitrary variants
+  if (isArbitraryValue(variant) && !context.variantMap.has(variant)) {
+    let selector = normalize(variant.slice(1, -1))
+    let sort = Array.from(context.variantOrder.values()).pop() << 1n
+    context.variantMap.set(variant, [[sort, () => selector]])
+    context.variantOrder.set(variant, sort)
+  }
+
   if (context.variantMap.has(variant)) {
     let variantFunctionTuples = context.variantMap.get(variant)
     let result = []

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -11,6 +11,7 @@ import { asClass } from '../util/nameClass'
 import { normalize } from '../util/dataTypes'
 import { parseVariant } from './setupContextUtils'
 import isValidArbitraryValue from '../util/isValidArbitraryValue'
+import { splitAtTopLevelOnly } from '../util/splitAtTopLevelOnly.js'
 
 let classNameParser = selectorParser((selectors) => {
   return selectors.first.filter(({ type }) => type === 'class').pop().value
@@ -420,7 +421,7 @@ function splitWithSeparator(input, separator) {
     return [sharedState.NOT_ON_DEMAND]
   }
 
-  return input.split(new RegExp(`\\${separator}(?![^[]*\\])`, 'g'))
+  return Array.from(splitAtTopLevelOnly(input, separator))
 }
 
 function* recordCandidates(matches, classCandidate) {

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -170,6 +170,30 @@ function withIdentifiers(styles) {
   })
 }
 
+export function parseVariant(variant) {
+  variant = variant
+    .replace(/\n+/g, '')
+    .replace(/\s{1,}/g, ' ')
+    .trim()
+
+  let fns = parseVariantFormatString(variant)
+    .map((str) => {
+      if (!str.startsWith('@')) {
+        return ({ format }) => format(str)
+      }
+
+      let [, name, params] = /@(.*?) (.*)/g.exec(str)
+      return ({ wrap }) => wrap(postcss.atRule({ name, params }))
+    })
+    .reverse()
+
+  return (api) => {
+    for (let fn of fns) {
+      fn(api)
+    }
+  }
+}
+
 function buildPluginApi(tailwindConfig, context, { variantList, variantMap, offsets, classList }) {
   function getConfigValue(path, defaultValue) {
     return path ? dlv(tailwindConfig, path, defaultValue) : tailwindConfig
@@ -201,27 +225,7 @@ function buildPluginApi(tailwindConfig, context, { variantList, variantMap, offs
           }
         }
 
-        variantFunction = variantFunction
-          .replace(/\n+/g, '')
-          .replace(/\s{1,}/g, ' ')
-          .trim()
-
-        let fns = parseVariantFormatString(variantFunction)
-          .map((str) => {
-            if (!str.startsWith('@')) {
-              return ({ format }) => format(str)
-            }
-
-            let [, name, params] = /@(.*?) (.*)/g.exec(str)
-            return ({ wrap }) => wrap(postcss.atRule({ name, params }))
-          })
-          .reverse()
-
-        return (api) => {
-          for (let fn of fns) {
-            fn(api)
-          }
-        }
+        return parseVariant(variantFunction)
       })
 
       insertInto(variantList, variantName, options)

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -182,8 +182,8 @@ export function parseVariant(variant) {
         return ({ format }) => format(str)
       }
 
-      let [, name, params] = /@(.*?) (.*)/g.exec(str)
-      return ({ wrap }) => wrap(postcss.atRule({ name, params }))
+      let [, name, params] = /@(.*?)( .+|[({].*)/g.exec(str)
+      return ({ wrap }) => wrap(postcss.atRule({ name, params: params.trim() }))
     })
     .reverse()
 

--- a/src/util/parseBoxShadowValue.js
+++ b/src/util/parseBoxShadowValue.js
@@ -1,58 +1,11 @@
+import { splitAtTopLevelOnly } from './splitAtTopLevelOnly'
+
 let KEYWORDS = new Set(['inset', 'inherit', 'initial', 'revert', 'unset'])
 let SPACE = /\ +(?![^(]*\))/g // Similar to the one above, but with spaces instead.
 let LENGTH = /^-?(\d+|\.\d+)(.*?)$/g
 
-let SPECIALS = /[(),]/g
-
-/**
- * This splits a string on top-level commas.
- *
- * Regex doesn't support recursion (at least not the JS-flavored version).
- * So we have to use a tiny state machine to keep track of paren vs comma
- * placement. Before we'd only exclude commas from the inner-most nested
- * set of parens rather than any commas that were not contained in parens
- * at all which is the intended behavior here.
- *
- * Expected behavior:
- * var(--a, 0 0 1px rgb(0, 0, 0)), 0 0 1px rgb(0, 0, 0)
- *       ─┬─             ┬  ┬    ┬
- *        x              x  x    ╰──────── Split because top-level
- *        ╰──────────────┴──┴───────────── Ignored b/c inside >= 1 levels of parens
- *
- * @param {string} input
- */
-function* splitByTopLevelCommas(input) {
-  SPECIALS.lastIndex = -1
-
-  let depth = 0
-  let lastIndex = 0
-  let found = false
-
-  // Find all parens & commas
-  // And only split on commas if they're top-level
-  for (let match of input.matchAll(SPECIALS)) {
-    if (match[0] === '(') depth++
-    if (match[0] === ')') depth--
-    if (match[0] === ',' && depth === 0) {
-      found = true
-
-      yield input.substring(lastIndex, match.index)
-      lastIndex = match.index + match[0].length
-    }
-  }
-
-  // Provide the last segment of the string if available
-  // Otherwise the whole string since no commas were found
-  // This mirrors the behavior of string.split()
-  if (found) {
-    yield input.substring(lastIndex)
-  } else {
-    yield input
-  }
-}
-
 export function parseBoxShadowValue(input) {
-  let shadows = Array.from(splitByTopLevelCommas(input))
+  let shadows = Array.from(splitAtTopLevelOnly(input, ','))
   return shadows.map((shadow) => {
     let value = shadow.trim()
     let result = { raw: value }

--- a/src/util/splitAtTopLevelOnly.js
+++ b/src/util/splitAtTopLevelOnly.js
@@ -1,0 +1,50 @@
+import * as regex from '../lib/regex'
+
+/**
+ * This splits a string on a top-level character.
+ *
+ * Regex doesn't support recursion (at least not the JS-flavored version).
+ * So we have to use a tiny state machine to keep track of paren placement.
+ *
+ * Expected behavior using commas:
+ * var(--a, 0 0 1px rgb(0, 0, 0)), 0 0 1px rgb(0, 0, 0)
+ *       ─┬─             ┬  ┬    ┬
+ *        x              x  x    ╰──────── Split because top-level
+ *        ╰──────────────┴──┴───────────── Ignored b/c inside >= 1 levels of parens
+ *
+ * @param {string} input
+ * @param {string} char
+ */
+export function* splitAtTopLevelOnly(input, char) {
+  let SPECIALS = new RegExp(`[(){}\\[\\]${regex.escape(char)}]`, 'g')
+
+  let depth = 0
+  let lastIndex = 0
+  let found = false
+
+  // Find all paren-like things & character
+  // And only split on commas if they're top-level
+  for (let match of input.matchAll(SPECIALS)) {
+    if (match[0] === '(') depth++
+    if (match[0] === ')') depth--
+    if (match[0] === '[') depth++
+    if (match[0] === ']') depth--
+    if (match[0] === '{') depth++
+    if (match[0] === '}') depth--
+    if (match[0] === char && depth === 0) {
+      found = true
+
+      yield input.substring(lastIndex, match.index)
+      lastIndex = match.index + match[0].length
+    }
+  }
+
+  // Provide the last segment of the string if available
+  // Otherwise the whole string since no `char`s were found
+  // This mirrors the behavior of string.split()
+  if (found) {
+    yield input.substring(lastIndex)
+  } else {
+    yield input
+  }
+}

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -157,3 +157,26 @@ test('at-rules', () => {
     `)
   })
 })
+
+test('attribute selectors', () => {
+  let config = {
+    content: [{ raw: html`<div class="[&:[data-open]]:underline"></div>` }],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      ${defaults}
+
+      .\[\&\:data-open\]\:underline > * {
+        text-decoration-line: underline;
+      }
+    `)
+  })
+})

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -135,7 +135,7 @@ test('using the important modifier', () => {
 
 test('at-rules', () => {
   let config = {
-    content: [{ raw: html`<div class="[@supports_(what:ever){&:hover}]:underline"></div>` }],
+    content: [{ raw: html`<div class="[@supports_(what:ever)]:underline"></div>` }],
     corePlugins: { preflight: false },
   }
 
@@ -150,7 +150,32 @@ test('at-rules', () => {
       ${defaults}
 
       @supports (what: ever) {
-        .\[\@supports_\(what\:ever\)\{\&\:hover\}\]\:underline:hover {
+        .\[\@supports_\(what\:ever\)\]\:underline {
+          text-decoration-line: underline;
+        }
+      }
+    `)
+  })
+})
+
+test('at-rules with selector modifications', () => {
+  let config = {
+    content: [{ raw: html`<div class="[@media_(hover:hover){&:hover}]:underline"></div>` }],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      ${defaults}
+
+      @media (hover: hover) {
+        .\[\@media_\(hover\:hover\)\{\&\:hover\}\]\:underline:hover {
           text-decoration-line: underline;
         }
       }

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -132,3 +132,28 @@ test('using the important modifier', () => {
     `)
   })
 })
+
+test('at-rules', () => {
+  let config = {
+    content: [{ raw: html`<div class="[@supports_(what:ever){&:hover}]:underline"></div>` }],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      ${defaults}
+
+      @supports (what: ever) {
+        .\[\@supports_\(what\:ever\)\{\&\:hover\}\]\:underline:hover {
+          text-decoration-line: underline;
+        }
+      }
+    `)
+  })
+})

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -1,0 +1,134 @@
+import { run, html, css, defaults } from './util/run'
+
+test('basic arbitrary variants', () => {
+  let config = {
+    content: [{ raw: html`<div class="[&>*]:underline"></div>` }],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      ${defaults}
+
+      .\[\&\>\*\]\:underline > * {
+        text-decoration-line: underline;
+      }
+    `)
+  })
+})
+
+test('spaces in selector (using _)', () => {
+  let config = {
+    content: [
+      {
+        raw: html`<div class="[.a.b_&]:underline"></div>`,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      ${defaults}
+
+      .a.b .\[\.a\.b_\&\]\:underline {
+        text-decoration-line: underline;
+      }
+    `)
+  })
+})
+
+test('arbitrary variants with modifiers', () => {
+  let config = {
+    content: [{ raw: html`<div class="dark:lg:hover:[&>*]:underline"></div>` }],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      ${defaults}
+
+      @media (prefers-color-scheme: dark) {
+        @media (min-width: 1024px) {
+          .dark\:lg\:hover\:\[\&\>\*\]\:underline > *:hover {
+            text-decoration-line: underline;
+          }
+        }
+      }
+    `)
+  })
+})
+
+test('arbitrary variants are sorted after other variants', () => {
+  let config = {
+    content: [{ raw: html`<div class="[&>*]:underline underline lg:underline"></div>` }],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      ${defaults}
+
+      .underline {
+        text-decoration-line: underline;
+      }
+
+      @media (min-width: 1024px) {
+        .lg\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      .\[\&\>\*\]\:underline > * {
+        text-decoration-line: underline;
+      }
+    `)
+  })
+})
+
+test('using the important modifier', () => {
+  let config = {
+    content: [{ raw: html`<div class="[&>*]:!underline"></div>` }],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      ${defaults}
+
+      .\[\&\>\*\]\:\!underline > * {
+        text-decoration-line: underline !important;
+      }
+    `)
+  })
+})

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -160,7 +160,7 @@ test('at-rules', () => {
 
 test('attribute selectors', () => {
   let config = {
-    content: [{ raw: html`<div class="[&:[data-open]]:underline"></div>` }],
+    content: [{ raw: html`<div class="[&[data-open]]:underline"></div>` }],
     corePlugins: { preflight: false },
   }
 
@@ -174,7 +174,7 @@ test('attribute selectors', () => {
     expect(result.css).toMatchFormattedCss(css`
       ${defaults}
 
-      .\[\&\:data-open\]\:underline > * {
+      .\[\&\[data-open\]\]\:underline[data-open] {
         text-decoration-line: underline;
       }
     `)

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -135,7 +135,7 @@ test('using the important modifier', () => {
 
 test('at-rules', () => {
   let config = {
-    content: [{ raw: html`<div class="[@supports_(what:ever)]:underline"></div>` }],
+    content: [{ raw: html`<div class="[@supports(what:ever)]:underline"></div>` }],
     corePlugins: { preflight: false },
   }
 
@@ -150,7 +150,7 @@ test('at-rules', () => {
       ${defaults}
 
       @supports (what: ever) {
-        .\[\@supports_\(what\:ever\)\]\:underline {
+        .\[\@supports\(what\:ever\)\]\:underline {
           text-decoration-line: underline;
         }
       }
@@ -162,7 +162,7 @@ test('nested at-rules', () => {
   let config = {
     content: [
       {
-        raw: html`<div class="[@media_screen{@media_(hover:hover)}]:underline"></div>`,
+        raw: html`<div class="[@media_screen{@media(hover:hover)}]:underline"></div>`,
       },
     ],
     corePlugins: { preflight: false },
@@ -180,7 +180,7 @@ test('nested at-rules', () => {
 
       @media screen {
         @media (hover: hover) {
-          .\[\@media_screen\{\@media_\(hover\:hover\)\}\]\:underline {
+          .\[\@media_screen\{\@media\(hover\:hover\)\}\]\:underline {
             text-decoration-line: underline;
           }
         }
@@ -191,7 +191,7 @@ test('nested at-rules', () => {
 
 test('at-rules with selector modifications', () => {
   let config = {
-    content: [{ raw: html`<div class="[@media_(hover:hover){&:hover}]:underline"></div>` }],
+    content: [{ raw: html`<div class="[@media(hover:hover){&:hover}]:underline"></div>` }],
     corePlugins: { preflight: false },
   }
 
@@ -206,7 +206,7 @@ test('at-rules with selector modifications', () => {
       ${defaults}
 
       @media (hover: hover) {
-        .\[\@media_\(hover\:hover\)\{\&\:hover\}\]\:underline:hover {
+        .\[\@media\(hover\:hover\)\{\&\:hover\}\]\:underline:hover {
           text-decoration-line: underline;
         }
       }
@@ -218,7 +218,7 @@ test('nested at-rules with selector modifications', () => {
   let config = {
     content: [
       {
-        raw: html`<div class="[@media_screen{@media_(hover:hover){&:hover}}]:underline"></div>`,
+        raw: html`<div class="[@media_screen{@media(hover:hover){&:hover}}]:underline"></div>`,
       },
     ],
     corePlugins: { preflight: false },
@@ -236,7 +236,7 @@ test('nested at-rules with selector modifications', () => {
 
       @media screen {
         @media (hover: hover) {
-          .\[\@media_screen\{\@media_\(hover\:hover\)\{\&\:hover\}\}\]\:underline:hover {
+          .\[\@media_screen\{\@media\(hover\:hover\)\{\&\:hover\}\}\]\:underline:hover {
             text-decoration-line: underline;
           }
         }

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -158,6 +158,37 @@ test('at-rules', () => {
   })
 })
 
+test('nested at-rules', () => {
+  let config = {
+    content: [
+      {
+        raw: html`<div class="[@media_screen{@media_(hover:hover)}]:underline"></div>`,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      ${defaults}
+
+      @media screen {
+        @media (hover: hover) {
+          .\[\@media_screen\{\@media_\(hover\:hover\)\}\]\:underline {
+            text-decoration-line: underline;
+          }
+        }
+      }
+    `)
+  })
+})
+
 test('at-rules with selector modifications', () => {
   let config = {
     content: [{ raw: html`<div class="[@media_(hover:hover){&:hover}]:underline"></div>` }],
@@ -177,6 +208,37 @@ test('at-rules with selector modifications', () => {
       @media (hover: hover) {
         .\[\@media_\(hover\:hover\)\{\&\:hover\}\]\:underline:hover {
           text-decoration-line: underline;
+        }
+      }
+    `)
+  })
+})
+
+test('nested at-rules with selector modifications', () => {
+  let config = {
+    content: [
+      {
+        raw: html`<div class="[@media_screen{@media_(hover:hover){&:hover}}]:underline"></div>`,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      ${defaults}
+
+      @media screen {
+        @media (hover: hover) {
+          .\[\@media_screen\{\@media_\(hover\:hover\)\{\&\:hover\}\}\]\:underline:hover {
+            text-decoration-line: underline;
+          }
         }
       }
     `)

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -342,3 +342,38 @@ test('multiple attribute selectors with custom separator (2)', () => {
     `)
   })
 })
+
+test('with @apply', () => {
+  let config = {
+    content: [
+      {
+        raw: html`<div class="foo"></div>`,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = `
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+
+    .foo {
+      @apply [@media_screen{@media(hover:hover){&:hover}}]:underline;
+    }
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      ${defaults}
+
+      @media screen {
+        @media (hover: hover) {
+          .foo:hover {
+            text-decoration-line: underline;
+          }
+        }
+      }
+    `)
+  })
+})

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -180,3 +180,26 @@ test('attribute selectors', () => {
     `)
   })
 })
+
+test('multiple attribute selectors', () => {
+  let config = {
+    content: [{ raw: html`<div class="[&[data-foo][data-bar]:not([data-baz])]:underline"></div>` }],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      ${defaults}
+
+      .\[\&\[data-foo\]\[data-bar\]\:not\(\[data-baz\]\)\]\:underline[data-foo][data-bar]:not([data-baz]) {
+        text-decoration-line: underline;
+      }
+    `)
+  })
+})

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -204,7 +204,7 @@ test('multiple attribute selectors', () => {
   })
 })
 
-test('multiple attribute selectors with custom separator', () => {
+test('multiple attribute selectors with custom separator (1)', () => {
   let config = {
     separator: '__',
     content: [
@@ -224,6 +224,32 @@ test('multiple attribute selectors with custom separator', () => {
       ${defaults}
 
       .\[\&\[data-foo\]\[data-bar\]\:not\(\[data-baz\]\)\]__underline[data-foo][data-bar]:not([data-baz]) {
+        text-decoration-line: underline;
+      }
+    `)
+  })
+})
+
+test('multiple attribute selectors with custom separator (2)', () => {
+  let config = {
+    separator: '_@',
+    content: [
+      { raw: html`<div class="[&[data-foo][data-bar]:not([data-baz])]_@underline"></div>` },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      ${defaults}
+
+      .\[\&\[data-foo\]\[data-bar\]\:not\(\[data-baz\]\)\]_\@underline[data-foo][data-bar]:not([data-baz]) {
         text-decoration-line: underline;
       }
     `)

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -203,3 +203,29 @@ test('multiple attribute selectors', () => {
     `)
   })
 })
+
+test('multiple attribute selectors with custom separator', () => {
+  let config = {
+    separator: '__',
+    content: [
+      { raw: html`<div class="[&[data-foo][data-bar]:not([data-baz])]__underline"></div>` },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      ${defaults}
+
+      .\[\&\[data-foo\]\[data-bar\]\:not\(\[data-baz\]\)\]__underline[data-foo][data-bar]:not([data-baz]) {
+        text-decoration-line: underline;
+      }
+    `)
+  })
+})

--- a/tests/default-extractor.test.js
+++ b/tests/default-extractor.test.js
@@ -1,5 +1,5 @@
 import { html } from './util/run'
-import { defaultExtractor } from '../src/lib/defaultExtractor'
+import { defaultExtractor as createDefaultExtractor } from '../src/lib/defaultExtractor'
 
 const jsExamples = `
   document.body.classList.add(["pl-1.5"].join(" "));
@@ -162,6 +162,13 @@ const excludes = [
   `<div class='hover:test'>`,
   `test`,
 ]
+
+let defaultExtractor
+
+beforeEach(() => {
+  let context = { tailwindConfig: { separator: ':' } }
+  defaultExtractor = createDefaultExtractor(context)
+})
 
 test('The default extractor works as expected', async () => {
   const extractions = defaultExtractor([jsExamples, jsxExamples, htmlExamples].join('\n').trim())


### PR DESCRIPTION
With the new `addVariant` API, we have a beautiful way of creating new variants.

You can use it as:
```js
addVariant('children', '& > *')
```

Now you can use the `children:` variant. The API uses a `&` as a reference for the candidate, which means that:
```html
children:pl-4
```

Will result in:
```css
.children\:pl-4 > * { .. }
```

Notice that the `&` was replaced by `.children\:pl-4`.

We can leverage this API to implement arbitrary variants, this means that you can write those `&>*` (Notice that we don't have spaces) inside a variant directly. An example of this can be:
```html
<ul class="[&>*]:underline">
  <li>A</li>
  <li>B</li>
  <li>C</li>
</ul>
```

Which generates the following css:
```css
.\[\&\>\*\]\:underline > * {
  text-decoration-line: underline;
}
```

Now all the children of the `ul` will have an `underline`. The selector itself is a bit crazy since it contains the candidate which is the selector itself, it is just escaped.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
