### PR TITLE
Move `important` selector to the front when `@apply`-ing selector-modifying variants in custom utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove default `[hidden]` style in preflight ([#8248](https://github.com/tailwindlabs/tailwindcss/pull/8248))
 - Only check selectors containing base apply candidates for circular dependencies ([#8222](https://github.com/tailwindlabs/tailwindcss/pull/8222))
 - Rewrite default class extractor ([#8204](https://github.com/tailwindlabs/tailwindcss/pull/8204))
+- Move `important` selector to the front when `@apply`-ing selector-modifying variants in custom utilities ([#8313](https://github.com/tailwindlabs/tailwindcss/pull/8313))
 
 ### Changed
 

--- a/tests/apply.test.js
+++ b/tests/apply.test.js
@@ -1467,3 +1467,84 @@ it('should apply using the updated user CSS when the source has changed', async 
     }
   `)
 })
+
+it('apply + layer utilities + selector variants (like group) + important selector', async () => {
+  let config = {
+    important: '#myselector',
+    content: [{ raw: html`<div class="custom-utility"></div>` }],
+    plugins: [],
+  }
+
+  let input = css`
+    @tailwind utilities;
+    @layer utilities {
+      .custom-utility {
+        @apply font-normal group-hover:underline;
+      }
+    }
+  `
+
+  let result = await run(input, config)
+
+  expect(result.css).toMatchFormattedCss(css`
+    #myselector .custom-utility {
+      font-weight: 400;
+    }
+
+    #myselector .group:hover .custom-utility {
+      text-decoration-line: underline;
+    }
+  `)
+})
+
+it('apply + user CSS + selector variants (like group) + important selector (1)', async () => {
+  let config = {
+    important: '#myselector',
+    content: [{ raw: html`<div class="custom-utility"></div>` }],
+    plugins: [],
+  }
+
+  let input = css`
+    .custom-utility {
+      @apply font-normal group-hover:underline;
+    }
+  `
+
+  let result = await run(input, config)
+
+  expect(result.css).toMatchFormattedCss(css`
+    .custom-utility {
+      font-weight: 400;
+    }
+
+    .group:hover .custom-utility {
+      text-decoration-line: underline;
+    }
+  `)
+})
+
+it('apply + user CSS + selector variants (like group) + important selector (2)', async () => {
+  let config = {
+    important: '#myselector',
+    content: [{ raw: html`<div class="custom-utility"></div>` }],
+    plugins: [],
+  }
+
+  let input = css`
+    #myselector .custom-utility {
+      @apply font-normal group-hover:underline;
+    }
+  `
+
+  let result = await run(input, config)
+
+  expect(result.css).toMatchFormattedCss(css`
+    #myselector .custom-utility {
+      font-weight: 400;
+    }
+
+    .group:hover #myselector .custom-utility {
+      text-decoration-line: underline;
+    }
+  `)
+})


### PR DESCRIPTION
Previously when given using an important selector (ex: `#myselector`), adding custom utilities to the utilities layer, using `@apply`, and a class with a selector-modifying variant was applied we would put the selector in the wrong place — before the important selector. It's important to note that this behavior is **correct** for non-utility/user-defined CSS but is not correct for generated utilities.

Now, when using `@layer utilities` or `@layer components` and applying a class that modifies the selector — like `group-hover:underline` — we now place the selector *after* the important selector when there is one.

tl;dr:

Before:
```css
/* input.css */
@tailwind utilities;
@layer utilities {
  .custom-utility {
    @apply font-normal group-hover:underline;
  }
}

/* output.css */
#myselector .custom-utility {
  font-weight: 400;
}

.group:hover #myselector .custom-utility {
  text-decoration-line: underline;
}
```

After:
```css
/* input.css */
@tailwind utilities;
@layer utilities {
  .custom-utility {
    @apply font-normal group-hover:underline;
  }
}

/* output.css */
#myselector .custom-utility {
  font-weight: 400;
}

/** This is the the part that has been changed */
#myselector .group:hover .custom-utility {
  text-decoration-line: underline;
}
```

Fixes #8305