### PR TITLE
Reject invalid custom and arbitrary variants

### DIFF
--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -9,7 +9,7 @@ import * as sharedState from './sharedState'
 import { formatVariantSelector, finalizeSelector } from '../util/formatVariantSelector'
 import { asClass } from '../util/nameClass'
 import { normalize } from '../util/dataTypes'
-import { parseVariant } from './setupContextUtils'
+import { isValidVariantFormatString, parseVariant } from './setupContextUtils'
 import isValidArbitraryValue from '../util/isValidArbitraryValue'
 import { splitAtTopLevelOnly } from '../util/splitAtTopLevelOnly.js'
 
@@ -130,6 +130,10 @@ function applyVariant(variant, matches, context) {
   // Register arbitrary variants
   if (isArbitraryValue(variant) && !context.variantMap.has(variant)) {
     let selector = normalize(variant.slice(1, -1))
+
+    if (!isValidVariantFormatString(selector)) {
+      return []
+    }
 
     let fn = parseVariant(selector)
 

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -228,7 +228,9 @@ function buildPluginApi(tailwindConfig, context, { variantList, variantMap, offs
             let result = variantFunction({ modifySelectors, container, separator })
 
             if (typeof result === 'string' && !isValidVariantFormatString(result)) {
-              throw new Error("Custom variants must use a media query or provide an `&` to specify selector placement.")
+              throw new Error(
+                `Your custom variant \`${variantName}\` has an invalid format string. Make sure it's an at-rule or contains a \`&\` placeholder.`
+              )
             }
 
             return result
@@ -236,7 +238,9 @@ function buildPluginApi(tailwindConfig, context, { variantList, variantMap, offs
         }
 
         if (!isValidVariantFormatString(variantFunction)) {
-          throw new Error("Custom variants must use a media query or provide an `&` to specify selector placement.")
+          throw new Error(
+            `Your custom variant \`${variantName}\` has an invalid format string. Make sure it's an at-rule or contains a \`&\` placeholder.`
+          )
         }
 
         return parseVariant(variantFunction)

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -230,7 +230,7 @@ function buildPluginApi(tailwindConfig, context, { variantList, variantMap, offs
         }
 
         if (!isValidVariantFormatString(variantFunction)) {
-          throw new Error("you're holding it wrong")
+          throw new Error("Custom variants must use a media query or provide an `&` to specify selector placement.")
         }
 
         return parseVariant(variantFunction)

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -170,6 +170,10 @@ function withIdentifiers(styles) {
   })
 }
 
+export function isValidVariantFormatString(format) {
+  return format.startsWith('@') || format.includes('&')
+}
+
 export function parseVariant(variant) {
   variant = variant
     .replace(/\n+/g, '')
@@ -223,6 +227,10 @@ function buildPluginApi(tailwindConfig, context, { variantList, variantMap, offs
           return ({ modifySelectors, container, separator }) => {
             return variantFunction({ modifySelectors, container, separator })
           }
+        }
+
+        if (!isValidVariantFormatString(variantFunction)) {
+          throw new Error("you're holding it wrong")
         }
 
         return parseVariant(variantFunction)

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -225,7 +225,13 @@ function buildPluginApi(tailwindConfig, context, { variantList, variantMap, offs
         if (typeof variantFunction !== 'string') {
           // Safelist public API functions
           return ({ modifySelectors, container, separator }) => {
-            return variantFunction({ modifySelectors, container, separator })
+            let result = variantFunction({ modifySelectors, container, separator })
+
+            if (typeof result === 'string' && !isValidVariantFormatString(result)) {
+              throw new Error("Custom variants must use a media query or provide an `&` to specify selector placement.")
+            }
+
+            return result
           }
         }
 

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -77,6 +77,34 @@ test('arbitrary variants with modifiers', () => {
   })
 })
 
+test('variants without & or an at-rule are ignored', () => {
+  let config = {
+    content: [
+      {
+        raw: html`
+          <div class="[div]:underline"></div>
+          <div class="[:hover]:underline"></div>
+          <div class="[wtf-bbq]:underline"></div>
+          <div class="[lol]:hover:underline"></div>
+        `,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      ${defaults}
+    `)
+  })
+})
+
 test('arbitrary variants are sorted after other variants', () => {
   let config = {
     content: [{ raw: html`<div class="[&>*]:underline underline lg:underline"></div>` }],

--- a/tests/variants.test.js
+++ b/tests/variants.test.js
@@ -222,7 +222,7 @@ describe('custom advanced variants', () => {
     }
 
     await expect(run('@tailwind components;@tailwind utilities', config)).rejects.toThrowError(
-      "Custom variants must use a media query or provide an `&` to specify selector placement."
+      "Your custom variant `wtf-bbq` has an invalid format string. Make sure it's an at-rule or contains a `&` placeholder."
     )
   })
 
@@ -241,7 +241,7 @@ describe('custom advanced variants', () => {
     }
 
     await expect(run('@tailwind components;@tailwind utilities', config)).rejects.toThrowError(
-      "Custom variants must use a media query or provide an `&` to specify selector placement."
+      "Your custom variant `wtf-bbq` has an invalid format string. Make sure it's an at-rule or contains a `&` placeholder."
     )
   })
 })

--- a/tests/variants.test.js
+++ b/tests/variants.test.js
@@ -207,7 +207,7 @@ describe('custom advanced variants', () => {
     })
   })
 
-  test('variant format string must include at-rule or &', async () => {
+  test('variant format string must include at-rule or & (1)', async () => {
     let config = {
       content: [
         {
@@ -222,7 +222,7 @@ describe('custom advanced variants', () => {
     }
 
     await expect(run('@tailwind components;@tailwind utilities', config)).rejects.toThrowError(
-      "you're holding it wrong"
+      "Custom variants must use a media query or provide an `&` to specify selector placement."
     )
   })
 })

--- a/tests/variants.test.js
+++ b/tests/variants.test.js
@@ -206,6 +206,25 @@ describe('custom advanced variants', () => {
       `)
     })
   })
+
+  test('variant format string must include at-rule or &', async () => {
+    let config = {
+      content: [
+        {
+          raw: html` <div class="wtf-bbq:text-center"></div> `,
+        },
+      ],
+      plugins: [
+        function ({ addVariant }) {
+          addVariant('wtf-bbq', 'lol')
+        },
+      ],
+    }
+
+    await expect(run('@tailwind components;@tailwind utilities', config)).rejects.toThrowError(
+      "you're holding it wrong"
+    )
+  })
 })
 
 test('stacked peer variants', async () => {

--- a/tests/variants.test.js
+++ b/tests/variants.test.js
@@ -225,6 +225,25 @@ describe('custom advanced variants', () => {
       "Custom variants must use a media query or provide an `&` to specify selector placement."
     )
   })
+
+  test('variant format string must include at-rule or & (2)', async () => {
+    let config = {
+      content: [
+        {
+          raw: html` <div class="wtf-bbq:text-center"></div> `,
+        },
+      ],
+      plugins: [
+        function ({ addVariant }) {
+          addVariant('wtf-bbq', () => 'lol')
+        },
+      ],
+    }
+
+    await expect(run('@tailwind components;@tailwind utilities', config)).rejects.toThrowError(
+      "Custom variants must use a media query or provide an `&` to specify selector placement."
+    )
+  })
 })
 
 test('stacked peer variants', async () => {


### PR DESCRIPTION
Prior to this PR, you could create custom variants that generated rules with selectors we don't explicitly support.

For example:

```js
addVariant('html', 'html')
```

Using that variant, you could write some HTML like this:

```html
<div class="html:bg-black">
```

...which would generate this CSS:

```css
html {
  background-color: #000;
}
```

Notice how that CSS doesn't even contain the `html:bg-black` class at all? This doesn't make any sense, because this CSS isn't actually going to be triggered by the use of that class in the browser, and makes it possible to cause a lot of bad side-effects. For example if you had `html:bg-black`, `html:bg-white`, and `html:bg-red-500` in your project, all 3 of them would be active at all times, regardless of whether one of those classes was used on the current page or not. Just makes no sense!

So this PR explicitly disallows variant format strings that either don't contain the `&` placeholder, or aren't at-rules.

When adding a custom variant with `addVariant`, invalid variants will throw an exception:

```js
addVariant('html', 'html')
// Throws an exception at build-time
```

When using arbitrary variants, the class is just ignored but no error is thrown (we never throw errors because of things we detect in your content files):

```html
<div class="[html]:bg-black">
```

In the future we might re-purpose variants without the `&` placeholder for convenient shorthands, but we haven't decided exactly what we'd want to do there so introducing an explicit error in the meantime to effectively "reserve" it for future API.