### PR TITLE
Move some config error checking out of resolveConfig

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -17,6 +17,7 @@ import getModuleDependencies from './lib/getModuleDependencies'
 import log from './util/log'
 import packageJson from '../package.json'
 import normalizePath from 'normalize-path'
+import { validateConfig } from './util/validateConfig.js'
 
 let env = {
   DEBUG: process.env.DEBUG !== undefined && process.env.DEBUG !== '0',
@@ -490,10 +491,13 @@ async function build() {
       let files = args['--content'].split(/(?<!{[^}]+),/)
       let resolvedConfig = resolveConfigInternal(config, { content: { files } })
       resolvedConfig.content.files = files
+      resolvedConfig = validateConfig(resolvedConfig)
       return resolvedConfig
     }
 
-    return resolveConfigInternal(config)
+    let resolvedConfig = resolveConfigInternal(config)
+    resolvedConfig = validateConfig(resolvedConfig)
+    return resolvedConfig
   }
 
   function extractFileGlobs(config) {

--- a/src/lib/setupTrackingContext.js
+++ b/src/lib/setupTrackingContext.js
@@ -16,6 +16,7 @@ import { env } from './sharedState'
 
 import { getContext, getFileModifiedMap } from './setupContextUtils'
 import parseDependency from '../util/parseDependency'
+import { validateConfig } from '../util/validateConfig.js'
 
 let configPathCache = new LRU({ maxSize: 100 })
 
@@ -63,6 +64,7 @@ function getTailwindConfig(configOrPath) {
       delete require.cache[file]
     }
     let newConfig = resolveConfig(require(userConfigPath))
+    newConfig = validateConfig(newConfig)
     let newHash = hash(newConfig)
     configPathCache.set(userConfigPath, [newConfig, newHash, newDeps, newModified])
     return [newConfig, userConfigPath, newHash, newDeps]
@@ -72,6 +74,8 @@ function getTailwindConfig(configOrPath) {
   let newConfig = resolveConfig(
     configOrPath.config === undefined ? configOrPath : configOrPath.config
   )
+
+  newConfig = validateConfig(newConfig)
 
   return [newConfig, null, hash(newConfig), []]
 }

--- a/src/util/normalizeConfig.js
+++ b/src/util/normalizeConfig.js
@@ -258,13 +258,5 @@ export function normalizeConfig(config) {
     }
   }
 
-  if (config.content.files.length === 0) {
-    log.warn('content-problems', [
-      'The `content` option in your Tailwind CSS configuration is missing or empty.',
-      'Configure your content sources or your generated CSS will be missing styles.',
-      'https://tailwindcss.com/docs/content-configuration',
-    ])
-  }
-
   return config
 }

--- a/src/util/validateConfig.js
+++ b/src/util/validateConfig.js
@@ -1,0 +1,13 @@
+import log from './log'
+
+export function validateConfig(config) {
+  if (config.content.files.length === 0) {
+    log.warn('content-problems', [
+      'The `content` option in your Tailwind CSS configuration is missing or empty.',
+      'Configure your content sources or your generated CSS will be missing styles.',
+      'https://tailwindcss.com/docs/content-configuration',
+    ])
+  }
+
+  return config
+}


### PR DESCRIPTION
Since `resolveConfig` is a public API it is usable by other plugins. We currently issue empty `content` key warnings in `resolveConfig`. When plugins use it to get "resolved" default values it causes confusion because it outputs a message to the console telling the user that their content key is empty when it is not. In this situation it's a false negative warning. Tailwind CSS still generates classes properly because of it honoring your own config.

Fixes #8346