### PR TITLE
Only apply hover styles when supported (future)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Try using local `postcss` installation first in the CLI ([#8270](https://github.com/tailwindlabs/tailwindcss/pull/8270))
+- Only apply hover styles when supported (future) ([#8394](https://github.com/tailwindlabs/tailwindcss/pull/8394))
 
 ### Added
 

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -6,7 +6,7 @@ let defaults = {
 }
 
 let featureFlags = {
-  future: [],
+  future: ['hoverOnlyWhenSupported'],
   experimental: ['optimizeUniversalDefaults'],
 }
 

--- a/tests/variants.test.js
+++ b/tests/variants.test.js
@@ -769,3 +769,39 @@ it('variants only picks the used selectors in a group (apply)', () => {
     `)
   })
 })
+
+test('hoverOnlyWhenSupported adds hover and pointer media features by default', () => {
+  let config = {
+    future: {
+      hoverOnlyWhenSupported: true,
+    },
+    content: [
+      { raw: html`<div class="hover:underline group-hover:underline peer-hover:underline"></div>` },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      ${defaults}
+
+      @media (hover: hover) and (pointer: fine) {
+        .hover\:underline:hover {
+          text-decoration-line: underline;
+        }
+        .group:hover .group-hover\:underline {
+          text-decoration-line: underline;
+        }
+        .peer:hover ~ .peer-hover\:underline {
+          text-decoration-line: underline;
+        }
+      }
+    `)
+  })
+})


### PR DESCRIPTION
_Alternate solution to #7939._

This PR changes how the `hover` variant works, so that hover styles are only applied on devices that properly support hover.

```css
/* Old CSS */
.hover\:underline:hover {
  text-decoration-line: underline;
}

/* New CSS */
@media (hover: hover) and (pointer: fine) {
  .hover\:underline:hover {
    text-decoration-line: underline;
  }
}
```

This solves the ["sticky hover" problem](https://css-tricks.com/solving-sticky-hover-states-with-media-hover-hover/) where tapping something that includes a hover style on mobile will persist that hover style until tapping elsewhere.

This is technically a breaking change because there are likely lots of people building things where they actually _depend_ on hover styles taking effect on mobile on tap, like menus that open on hover.

Because of this, we are putting this change behind a `future` flag until v4. So by default, nothing will change and you will still get the old hover strategy, but you can opt-in to what will become the default in v4 using the `hoverOnlyWhenSupported` future flag:

```js
// tailwind.config.js
module.exports = {
  future: {
    hoverOnlyWhenSupported: true,
  },
  // ...
}
```

If you ever need to use the old hover strategy in a one-off situation while relying on the new strategy more generally, you can still do this using the new arbitrary variants feature that will be shipping in the next release:

```html
<!-- Uses @media (hover: hover) -->
<div class="hover:underline">...</div>

<!-- Uses only the :hover pseudo -->
<div class="[&:hover]:underline">...</div>
```

Again this will be a breaking change in v4, but only for evil people who were writing code like `hidden group-hover:block`. Until then, everything will work the same, and you can opt-in to this if you want to start using it now.