### PR TITLE
Improve types of the `tailwindcss/plugin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Error when registering an invalid custom variant ([#8345](https://github.com/tailwindlabs/tailwindcss/pull/8345))
 - Create tailwind.config.cjs file in ESM package when running init ([#8363](https://github.com/tailwindlabs/tailwindcss/pull/8363))
 - Fix `matchVariants` that use at-rules and placeholders ([#8392](https://github.com/tailwindlabs/tailwindcss/pull/8392))
+- Improve types of the `tailwindcss/plugin` ([#8400](https://github.com/tailwindlabs/tailwindcss/pull/8400))
 
 ### Changed
 

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -1,6 +1,11 @@
 import type { Config, PluginCreator } from './types/config'
-declare function createPlugin(
-  plugin: PluginCreator,
-  config?: Config
-): { handler: PluginCreator; config?: Config }
-export = createPlugin
+type Plugin = {
+  withOptions<T>(
+    plugin: (options: T) => PluginCreator,
+    config?: (options: T) => Config
+  ): { (options: T): { handler: PluginCreator; config?: Config }; __isOptionsFunction: true }
+  (plugin: PluginCreator, config?: Config): { handler: PluginCreator; config?: Config }
+}
+
+declare const plugin: Plugin
+export = plugin

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -297,7 +297,11 @@ export interface PluginAPI {
   e: (className: string) => string
 }
 export type PluginCreator = (api: PluginAPI) => void
-export type PluginsConfig = (PluginCreator | { handler: PluginCreator; config?: Config })[]
+export type PluginsConfig = (
+  | PluginCreator
+  | { handler: PluginCreator; config?: Config }
+  | { (options: any): { handler: PluginCreator; config?: Config }; __isOptionsFunction: true }
+)[]
 
 // Top level config related
 interface RequiredConfig {


### PR DESCRIPTION
This also exposes/types the `plugin.withOptions` as described here: https://tailwindcss.com/docs/plugins#exposing-options

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
