### PR TITLE
Support alpha values for `theme()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `matchVariant` API ([#8310](https://github.com/tailwindlabs/tailwindcss/pull/8310))
 - Add `prefers-contrast` media query variants ([#8410](https://github.com/tailwindlabs/tailwindcss/pull/8410))
 - Experimental support for variant grouping ([#8405](https://github.com/tailwindlabs/tailwindcss/pull/8405))
+- Add opacity support when referencing colors with `theme` function ([#8416](https://github.com/tailwindlabs/tailwindcss/pull/8416))
 
 ## [3.0.24] - 2022-04-12
 

--- a/src/lib/evaluateTailwindFunctions.js
+++ b/src/lib/evaluateTailwindFunctions.js
@@ -5,6 +5,7 @@ import parseValue from 'postcss-value-parser'
 import { normalizeScreens } from '../util/normalizeScreens'
 import buildMediaQuery from '../util/buildMediaQuery'
 import { toPath } from '../util/toPath'
+import { withAlphaValue } from '../util/withAlphaVariable'
 
 function isObject(input) {
   return typeof input === 'object' && input !== null
@@ -37,7 +38,7 @@ function listKeys(obj) {
   return list(Object.keys(obj))
 }
 
-function validatePath(config, path, defaultValue) {
+function validatePath(config, path, defaultValue, themeOpts = {}) {
   const pathString = Array.isArray(path)
     ? pathToString(path)
     : path.replace(/^['"]+/g, '').replace(/['"]+$/g, '')
@@ -114,7 +115,7 @@ function validatePath(config, path, defaultValue) {
 
   return {
     isValid: true,
-    value: transformThemeValue(themeSection)(value),
+    value: transformThemeValue(themeSection)(value, themeOpts),
   }
 }
 
@@ -160,14 +161,27 @@ let nodeTypePropertyMap = {
 export default function ({ tailwindConfig: config }) {
   let functions = {
     theme: (node, path, ...defaultValue) => {
-      const { isValid, value, error } = validatePath(
+      let matches = path.match(/^([^\/\s]+)(?:\s*\/\s*([^\/\s]+))$/)
+      let alpha = undefined
+
+      if (matches) {
+        path = matches[1]
+        alpha = matches[2]
+      }
+
+      let { isValid, value, error } = validatePath(
         config,
         path,
-        defaultValue.length ? defaultValue : undefined
+        defaultValue.length ? defaultValue : undefined,
+        { opacityValue: alpha }
       )
 
       if (!isValid) {
         throw node.error(error)
+      }
+
+      if (alpha !== undefined) {
+        value = withAlphaValue(value, alpha, value)
       }
 
       return value

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -221,16 +221,25 @@ function buildPluginApi(tailwindConfig, context, { variantList, variantMap, offs
     return context.tailwindConfig.prefix + identifier
   }
 
+  function resolveThemeValue(path, defaultValue, opts = {}) {
+    const [pathRoot, ...subPaths] = toPath(path)
+    const value = getConfigValue(['theme', pathRoot, ...subPaths], defaultValue)
+    return transformThemeValue(pathRoot)(value, opts)
+  }
+
+  const theme = Object.assign(
+    (path, defaultValue = undefined) => resolveThemeValue(path, defaultValue),
+    {
+      withAlpha: (path, opacityValue) => resolveThemeValue(path, undefined, { opacityValue }),
+    }
+  )
+
   let api = {
     postcss,
     prefix: applyConfiguredPrefix,
     e: escapeClassName,
     config: getConfigValue,
-    theme(path, defaultValue) {
-      const [pathRoot, ...subPaths] = toPath(path)
-      const value = getConfigValue(['theme', pathRoot, ...subPaths], defaultValue)
-      return transformThemeValue(pathRoot)(value)
-    },
+    theme,
     corePlugins: (path) => {
       if (Array.isArray(tailwindConfig.corePlugins)) {
         return tailwindConfig.corePlugins.includes(path)

--- a/src/util/resolveConfig.js
+++ b/src/util/resolveConfig.js
@@ -8,6 +8,7 @@ import { toPath } from './toPath'
 import { normalizeConfig } from './normalizeConfig'
 import isPlainObject from './isPlainObject'
 import { cloneDeep } from './cloneDeep'
+import { withAlphaValue } from './withAlphaVariable'
 
 function isFunction(input) {
   return typeof input === 'function'
@@ -187,11 +188,22 @@ function resolveFunctionKeys(object) {
     return val
   }
 
-  resolvePath.theme = resolvePath
+  Object.assign(resolvePath, {
+    theme: resolvePath,
+    ...configUtils,
+    withAlpha(key, opacityValue) {
+      // TODO: This is kinda iffy but it works
+      const path = toPath(key)
+      const lastSegment = path.pop()
+      let value = resolvePath(path)[lastSegment]
 
-  for (let key in configUtils) {
-    resolvePath[key] = configUtils[key]
-  }
+      if (value === undefined) {
+        return value
+      }
+
+      return withAlphaValue(value, opacityValue)
+    },
+  })
 
   return Object.keys(object).reduce((resolved, key) => {
     return {

--- a/src/util/resolveConfig.js
+++ b/src/util/resolveConfig.js
@@ -206,10 +206,9 @@ function resolveFunctionKeys(object) {
   })
 
   return Object.keys(object).reduce((resolved, key) => {
-    return {
-      ...resolved,
-      [key]: isFunction(object[key]) ? object[key](resolvePath, configUtils) : object[key],
-    }
+    resolved[key] = isFunction(object[key]) ? object[key](resolvePath, configUtils) : object[key]
+
+    return resolved
   }, {})
 }
 

--- a/src/util/toPath.js
+++ b/src/util/toPath.js
@@ -4,7 +4,7 @@
  * Square bracket notation `a[b]` may be used to "escape" dots that would otherwise be interpreted as path separators.
  *
  * Example:
- * a -> ['a]
+ * a -> ['a']
  * a.b.c -> ['a', 'b', 'c']
  * a[b].c -> ['a', 'b', 'c']
  * a[b.c].e.f -> ['a', 'b.c', 'e', 'f']

--- a/src/util/transformThemeValue.js
+++ b/src/util/transformThemeValue.js
@@ -44,8 +44,10 @@ export default function transformThemeValue(themeSection) {
     }
   }
 
-  return (value) => {
-    if (typeof value === 'function') value = value({})
+  return (value, opts = {}) => {
+    if (typeof value === 'function') {
+      value = value(opts)
+    }
 
     return value
   }

--- a/tests/opacity.test.js
+++ b/tests/opacity.test.js
@@ -427,3 +427,203 @@ it('the hsl helper throws when not passing custom properties', () => {
     'The hsl() helper requires a custom property name to be passed as the first argument.'
   )
 })
+
+test('Theme function in JS can apply alpha values to colors (1)', () => {
+  let input = css`
+    @tailwind utilities;
+  `
+
+  let output = css`
+    .text-foo {
+      color: rgb(59 130 246 / 50%);
+    }
+  `
+
+  return run(input, {
+    content: [{ raw: html`text-foo` }],
+    corePlugins: { textOpacity: false },
+    theme: {
+      colors: { blue: { 500: '#3b82f6' } },
+      extend: {
+        textColor: ({ theme }) => ({
+          foo: theme.withAlpha('colors.blue.500', '50%'),
+        }),
+      },
+    },
+  }).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('TTheme function in JS can apply alpha values to colors (2)', () => {
+  let input = css`
+    @tailwind utilities;
+  `
+
+  let output = css`
+    .text-foo {
+      color: rgb(59 130 246 / 0.5);
+    }
+  `
+
+  return run(input, {
+    content: [{ raw: html`text-foo` }],
+    corePlugins: { textOpacity: false },
+    theme: {
+      colors: { blue: { 500: '#3b82f6' } },
+      extend: {
+        textColor: ({ theme }) => ({
+          foo: theme.withAlpha('colors.blue.500', '0.5'),
+        }),
+      },
+    },
+  }).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('TTheme function in JS can apply alpha values to colors (3)', () => {
+  let input = css`
+    @tailwind utilities;
+  `
+
+  let output = css`
+    .text-foo {
+      color: rgb(59 130 246 / var(--my-alpha));
+    }
+  `
+
+  return run(input, {
+    content: [{ raw: html`text-foo` }],
+    corePlugins: { textOpacity: false },
+    theme: {
+      colors: { blue: { 500: '#3b82f6' } },
+      extend: {
+        textColor: ({ theme }) => ({
+          foo: theme.withAlpha('colors.blue.500', 'var(--my-alpha)'),
+        }),
+      },
+    },
+  }).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('TTheme function in JS can apply alpha values to colors (4)', () => {
+  let input = css`
+    @tailwind utilities;
+  `
+
+  let output = css`
+    .text-foo {
+      color: hsl(217 91% 60% / 50%);
+    }
+  `
+
+  return run(input, {
+    content: [{ raw: html`text-foo` }],
+    corePlugins: { textOpacity: false },
+    theme: {
+      colors: { blue: { 500: 'hsl(217, 91%, 60%)' } },
+      extend: {
+        textColor: ({ theme }) => ({
+          foo: theme.withAlpha('colors.blue.500', '50%'),
+        }),
+      },
+    },
+  }).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('TTheme function in JS can apply alpha values to colors (5)', () => {
+  let input = css`
+    @tailwind utilities;
+  `
+
+  let output = css`
+    .text-foo {
+      color: hsl(217 91% 60% / 0.5);
+    }
+  `
+
+  return run(input, {
+    content: [{ raw: html`text-foo` }],
+    corePlugins: { textOpacity: false },
+    theme: {
+      colors: { blue: { 500: 'hsl(217, 91%, 60%)' } },
+      extend: {
+        textColor: ({ theme }) => ({
+          foo: theme.withAlpha('colors.blue.500', '0.5'),
+        }),
+      },
+    },
+  }).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('TTheme function in JS can apply alpha values to colors (6)', () => {
+  let input = css`
+    @tailwind utilities;
+  `
+
+  let output = css`
+    .text-foo {
+      color: hsl(217 91% 60% / var(--my-alpha));
+    }
+  `
+
+  return run(input, {
+    content: [{ raw: html`text-foo` }],
+    corePlugins: { textOpacity: false },
+    theme: {
+      colors: { blue: { 500: 'hsl(217, 91%, 60%)' } },
+      extend: {
+        textColor: ({ theme }) => ({
+          foo: theme.withAlpha('colors.blue.500', 'var(--my-alpha)'),
+        }),
+      },
+    },
+  }).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('TTheme function in JS can apply alpha values to colors (7)', () => {
+  let input = css`
+    @tailwind utilities;
+  `
+
+  let output = css`
+    .text-foo {
+      color: rgb(var(--foo) / var(--my-alpha));
+    }
+  `
+
+  return run(input, {
+    content: [{ raw: html`text-foo` }],
+    corePlugins: { textOpacity: false },
+    theme: {
+      colors: ({ rgb }) => ({
+        blue: {
+          500: rgb('--foo'),
+        },
+      }),
+      extend: {
+        textColor: ({ theme }) => ({
+          foo: theme.withAlpha('colors.blue.500', 'var(--my-alpha)'),
+        }),
+      },
+    },
+  }).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})

--- a/tests/opacity.test.js
+++ b/tests/opacity.test.js
@@ -456,7 +456,7 @@ test('Theme function in JS can apply alpha values to colors (1)', () => {
   })
 })
 
-test('TTheme function in JS can apply alpha values to colors (2)', () => {
+test('Theme function in JS can apply alpha values to colors (2)', () => {
   let input = css`
     @tailwind utilities;
   `
@@ -484,7 +484,7 @@ test('TTheme function in JS can apply alpha values to colors (2)', () => {
   })
 })
 
-test('TTheme function in JS can apply alpha values to colors (3)', () => {
+test('Theme function in JS can apply alpha values to colors (3)', () => {
   let input = css`
     @tailwind utilities;
   `
@@ -512,7 +512,7 @@ test('TTheme function in JS can apply alpha values to colors (3)', () => {
   })
 })
 
-test('TTheme function in JS can apply alpha values to colors (4)', () => {
+test('Theme function in JS can apply alpha values to colors (4)', () => {
   let input = css`
     @tailwind utilities;
   `
@@ -540,7 +540,7 @@ test('TTheme function in JS can apply alpha values to colors (4)', () => {
   })
 })
 
-test('TTheme function in JS can apply alpha values to colors (5)', () => {
+test('Theme function in JS can apply alpha values to colors (5)', () => {
   let input = css`
     @tailwind utilities;
   `
@@ -568,7 +568,7 @@ test('TTheme function in JS can apply alpha values to colors (5)', () => {
   })
 })
 
-test('TTheme function in JS can apply alpha values to colors (6)', () => {
+test('Theme function in JS can apply alpha values to colors (6)', () => {
   let input = css`
     @tailwind utilities;
   `
@@ -596,7 +596,7 @@ test('TTheme function in JS can apply alpha values to colors (6)', () => {
   })
 })
 
-test('TTheme function in JS can apply alpha values to colors (7)', () => {
+test('Theme function in JS can apply alpha values to colors (7)', () => {
   let input = css`
     @tailwind utilities;
   `
@@ -619,6 +619,38 @@ test('TTheme function in JS can apply alpha values to colors (7)', () => {
       extend: {
         textColor: ({ theme }) => ({
           foo: theme('colors.blue.500 / var(--my-alpha)'),
+        }),
+      },
+    },
+  }).then((result) => {
+    expect(result.css).toMatchCss(output)
+    expect(result.warnings().length).toBe(0)
+  })
+})
+
+test('Theme function prefers existing values in config', () => {
+  let input = css`
+    @tailwind utilities;
+  `
+
+  let output = css`
+    .text-foo {
+      color: purple;
+    }
+  `
+
+  return run(input, {
+    content: [{ raw: html`text-foo` }],
+    corePlugins: { textOpacity: false },
+    theme: {
+      colors: {
+        blue: {
+          '500 / 50%': 'purple',
+        },
+      },
+      extend: {
+        textColor: ({ theme }) => ({
+          foo: theme('colors.blue.500 / 50%'),
         }),
       },
     },

--- a/tests/opacity.test.js
+++ b/tests/opacity.test.js
@@ -446,7 +446,7 @@ test('Theme function in JS can apply alpha values to colors (1)', () => {
       colors: { blue: { 500: '#3b82f6' } },
       extend: {
         textColor: ({ theme }) => ({
-          foo: theme.withAlpha('colors.blue.500', '50%'),
+          foo: theme('colors.blue.500 / 50%'),
         }),
       },
     },
@@ -474,7 +474,7 @@ test('TTheme function in JS can apply alpha values to colors (2)', () => {
       colors: { blue: { 500: '#3b82f6' } },
       extend: {
         textColor: ({ theme }) => ({
-          foo: theme.withAlpha('colors.blue.500', '0.5'),
+          foo: theme('colors.blue.500 / 0.5'),
         }),
       },
     },
@@ -502,7 +502,7 @@ test('TTheme function in JS can apply alpha values to colors (3)', () => {
       colors: { blue: { 500: '#3b82f6' } },
       extend: {
         textColor: ({ theme }) => ({
-          foo: theme.withAlpha('colors.blue.500', 'var(--my-alpha)'),
+          foo: theme('colors.blue.500 / var(--my-alpha)'),
         }),
       },
     },
@@ -530,7 +530,7 @@ test('TTheme function in JS can apply alpha values to colors (4)', () => {
       colors: { blue: { 500: 'hsl(217, 91%, 60%)' } },
       extend: {
         textColor: ({ theme }) => ({
-          foo: theme.withAlpha('colors.blue.500', '50%'),
+          foo: theme('colors.blue.500 / 50%'),
         }),
       },
     },
@@ -558,7 +558,7 @@ test('TTheme function in JS can apply alpha values to colors (5)', () => {
       colors: { blue: { 500: 'hsl(217, 91%, 60%)' } },
       extend: {
         textColor: ({ theme }) => ({
-          foo: theme.withAlpha('colors.blue.500', '0.5'),
+          foo: theme('colors.blue.500 / 0.5'),
         }),
       },
     },
@@ -586,7 +586,7 @@ test('TTheme function in JS can apply alpha values to colors (6)', () => {
       colors: { blue: { 500: 'hsl(217, 91%, 60%)' } },
       extend: {
         textColor: ({ theme }) => ({
-          foo: theme.withAlpha('colors.blue.500', 'var(--my-alpha)'),
+          foo: theme('colors.blue.500 / var(--my-alpha)'),
         }),
       },
     },
@@ -618,7 +618,7 @@ test('TTheme function in JS can apply alpha values to colors (7)', () => {
       }),
       extend: {
         textColor: ({ theme }) => ({
-          foo: theme.withAlpha('colors.blue.500', 'var(--my-alpha)'),
+          foo: theme('colors.blue.500 / var(--my-alpha)'),
         }),
       },
     },


### PR DESCRIPTION
This PR provides two new APIs, one in CSS and one in JS, to handle changing the alpha value of a color when possible.

In CSS we've co-opted the `/ alpha` syntax used in functions like `rgb`, `hsl`, and `color` and have applied this our `theme` function usable from CSS. The provided alpha is a _raw_ opacity value but you can use the `theme` function here to pull from your config.

The following all work now in CSS:

```css
color: theme(colors.rose.500 / 50%); /* color: rgb(244 63 94 / 50%); */
color: theme(colors.blue.500 / 0.5); /* color: rgb(59 130 246 / 50%); */
color: theme(colors.emerald.500 / var(--my-alpha-value)); /* color: rgb(16 185 129 / 50%); */
color: theme(colors.emerald.500 / theme(opacity.50)); /* color: rgb(16 185 129 / 50%); */
```

In JS-land we have `theme.withAlpha(key, opacity)` that is usable from your config:

```js
theme: {
  extend: {
    textColor: ({ theme }) => ({
      translucentBlue: theme.withAlpha('colors.blue.500', 'var(--my-alpha)'),
    }),
  },
},
```

The JS API is still subject to change.

In addition, either from CSS or JS, using the `rgb` and `hsl` helpers in your config for defining colors with customizable opacity works as well:

```js
theme: {
  extend: {
    colors: ({ rgb }) => ({
      primary: rgb('--primary'),
    }),
  },
},
```

```css
color: theme(colors.primary / 50%); /* color: rgb(var(--primary) / 50%); */
```
