### PR TITLE
Update detectNesting.js

### DIFF
--- a/src/lib/detectNesting.js
+++ b/src/lib/detectNesting.js
@@ -4,8 +4,12 @@ export default function (_context) {
 
     root.walkAtRules('tailwind', (node) => {
       if (found) return false
+      
+      const parentIsRoot = node.parent && node.parent.type === 'root';
+      const parentIsGlobal = node.parent && node.parent.selector === ':global';
+      const grandparentIsRoot = node.parent && node.parent.parent && node.parent.parent.type === 'root';
 
-      if (node.parent && node.parent.type !== 'root') {
+      if (!parentIsRoot && !parentIsGlobal && !grandparentIsRoot) {
         found = true
         node.warn(
           result,

--- a/src/lib/detectNesting.js
+++ b/src/lib/detectNesting.js
@@ -4,12 +4,13 @@ export default function (_context) {
 
     root.walkAtRules('tailwind', (node) => {
       if (found) return false
-      
-      const parentIsRoot = node.parent && node.parent.type === 'root';
-      const parentIsGlobal = node.parent && node.parent.selector === ':global';
-      const grandparentIsRoot = node.parent && node.parent.parent && node.parent.parent.type === 'root';
 
-      if (!parentIsRoot && !parentIsGlobal && !grandparentIsRoot) {
+      const parentIsRoot = node.parent && node.parent.type === 'root'
+      const parentIsGlobal = node.parent && node.parent.selector === ':global'
+      const grandparentIsRoot =
+        node.parent && node.parent.parent && node.parent.parent.type === 'root'
+
+      if (!parentIsRoot && !(parentIsGlobal && grandparentIsRoot)) {
         found = true
         node.warn(
           result,

--- a/tests/detect-nesting.test.js
+++ b/tests/detect-nesting.test.js
@@ -55,6 +55,23 @@ it('should warn when we detect namespaced @tailwind at rules', () => {
   })
 })
 
+it('should not warn when namespaced @tailwind at rules are within a :global pseudo-class', () => {
+  let config = {
+    content: [{ raw: html`<div class="text-center"></div>` }],
+  }
+
+  let input = css`
+    :global {
+      @tailwind utilities;
+    }
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.messages).toHaveLength(0)
+    expect(result.messages).toEqual([])
+  })
+})
+
 it('should not warn when nesting a single rule inside a media query', () => {
   let config = {
     content: [{ raw: html`<div class="nested"></div>` }],


### PR DESCRIPTION
Update `detectNesting()` to permit `:global` pseudo-class as valid parent, as long as it's at the root. See discussion https://github.com/tailwindlabs/tailwindcss/discussions/8412 for more information.