### PR TITLE
Improve `theme.extend` types

### DIFF
--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -76,8 +76,6 @@ type ScreensConfig = string[] | KeyValuePair<string, string | Screen | Screen[]>
 
 // Theme related config
 interface ThemeConfig {
-  extend: Partial<Omit<ThemeConfig, 'extend'>>
-
   /** Responsiveness */
   screens: ResolvableTo<ScreensConfig>
 
@@ -317,7 +315,7 @@ interface OptionalConfig {
   future: Partial<FutureConfig>
   experimental: Partial<ExperimentalConfig>
   darkMode: Partial<DarkModeConfig>
-  theme: Partial<ThemeConfig>
+  theme: Partial<ThemeConfig & { extend: Partial<ThemeConfig> }>
   corePlugins: Partial<CorePluginsConfig>
   plugins: Partial<PluginsConfig>
   /** Custom */


### PR DESCRIPTION
This PR improves the types for `theme.extend` so that completions work correctly. There seems to be a known issue with `Omit` and completions:

- https://github.com/microsoft/TypeScript/issues/32289
- https://github.com/microsoft/TypeScript/issues/31153
- https://stackoverflow.com/questions/60636985/why-i-cant-use-omit-on-asyncprops-of-react-select

**Before**

<img width="687" alt="CleanShot 2022-05-23 at 20 25 42@2x" src="https://user-images.githubusercontent.com/2615508/169891889-dc1567ea-27ab-40c2-8ce0-9f606a92637f.png">

**After**

<img width="690" alt="CleanShot 2022-05-23 at 20 25 08@2x" src="https://user-images.githubusercontent.com/2615508/169891825-708f2dc3-d578-43a6-ad2f-200a6f022af9.png">