### PR TITLE
Add type annotations to the `tailwind.config.js` file

### DIFF
--- a/integrations/tailwindcss-cli/tests/cli.test.js
+++ b/integrations/tailwindcss-cli/tests/cli.test.js
@@ -441,46 +441,6 @@ describe('Init command', () => {
     // multiple keys in `theme` exists. However it loads `tailwindcss/colors`
     // which doesn't exists in this context.
     expect((await readOutputFile('../full.config.js')).split('\n').length).toBeGreaterThan(50)
-
-    expect(await readOutputFile('../full.config.js')).not.toContain(
-      `/** @type {import('tailwindcss/types').Config} */`
-    )
-  })
-
-  test('--types', async () => {
-    cleanupFile('simple.config.js')
-
-    let { combined } = await $(`${EXECUTABLE} init simple.config.js --types`)
-
-    expect(combined).toMatchInlineSnapshot(`
-      "
-      Created Tailwind CSS config file: simple.config.js
-      "
-    `)
-
-    expect(await readOutputFile('../simple.config.js')).toContain(
-      `/** @type {import('tailwindcss/types').Config} */`
-    )
-  })
-
-  test('--full --types', async () => {
-    cleanupFile('full.config.js')
-
-    let { combined } = await $(`${EXECUTABLE} init full.config.js --full --types`)
-
-    expect(combined).toMatchInlineSnapshot(`
-      "
-      Created Tailwind CSS config file: full.config.js
-      "
-    `)
-
-    // Not a clean way to test this. We could require the file and verify that
-    // multiple keys in `theme` exists. However it loads `tailwindcss/colors`
-    // which doesn't exists in this context.
-    expect((await readOutputFile('../full.config.js')).split('\n').length).toBeGreaterThan(50)
-    expect(await readOutputFile('../full.config.js')).toContain(
-      `/** @type {import('tailwindcss/types').Config} */`
-    )
   })
 
   test('--postcss', async () => {
@@ -513,7 +473,6 @@ describe('Init command', () => {
         Options:
            -f, --full               Initialize a full \`tailwind.config.js\` file
            -p, --postcss            Initialize a \`postcss.config.js\` file
-               --types              Add TypeScript types for the \`tailwind.config.js\` file
            -h, --help               Display usage information
       `)
     )
@@ -542,7 +501,6 @@ describe('Init command', () => {
         Options:
            -f, --full               Initialize a full \`tailwind.config.cjs\` file
            -p, --postcss            Initialize a \`postcss.config.cjs\` file
-               --types              Add TypeScript types for the \`tailwind.config.cjs\` file
            -h, --help               Display usage information
       `)
     )
@@ -575,10 +533,6 @@ describe('Init command', () => {
 
     // Not a clean way to test this.
     expect(await readOutputFile('../tailwind.config.cjs')).toContain('module.exports =')
-
-    expect(await readOutputFile('../tailwind.config.cjs')).not.toContain(
-      `/** @type {import('tailwindcss/types').Config} */`
-    )
 
     await writeInputFile('../package.json', pkg)
   })

--- a/src/cli.js
+++ b/src/cli.js
@@ -183,10 +183,6 @@ let commands = {
     args: {
       '--full': { type: Boolean, description: `Initialize a full \`${configs.tailwind}\` file` },
       '--postcss': { type: Boolean, description: `Initialize a \`${configs.postcss}\` file` },
-      '--types': {
-        type: Boolean,
-        description: `Add TypeScript types for the \`${configs.tailwind}\` file`,
-      },
       '-f': '--full',
       '-p': '--postcss',
     },
@@ -245,7 +241,7 @@ if (
   help({
     usage: [
       'tailwindcss [--input input.css] [--output output.css] [--watch] [options...]',
-      'tailwindcss init [--full] [--postcss] [--types] [options...]',
+      'tailwindcss init [--full] [--postcss] [options...]',
     ],
     commands: Object.keys(commands)
       .filter((command) => command !== 'build')
@@ -371,13 +367,6 @@ function init() {
         : path.resolve(__dirname, '../stubs/simpleConfig.stub.js'),
       'utf8'
     )
-
-    if (args['--types']) {
-      let typesHeading = "/** @type {import('tailwindcss/types').Config} */"
-      stubFile =
-        stubFile.replace(`module.exports = `, `${typesHeading}\nconst config = `) +
-        '\nmodule.exports = config'
-    }
 
     // Change colors import
     stubFile = stubFile.replace('../colors', 'tailwindcss/colors')

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss/types').Config} */
 module.exports = {
   content: [],
   presets: [],

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -1,4 +1,4 @@
-/** @type {import('tailwindcss/types').Config} */
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [],
   presets: [],

--- a/stubs/simpleConfig.stub.js
+++ b/stubs/simpleConfig.stub.js
@@ -1,3 +1,4 @@
+/** @type {import('tailwindcss/types').Config} */
 module.exports = {
   content: [],
   theme: {

--- a/stubs/simpleConfig.stub.js
+++ b/stubs/simpleConfig.stub.js
@@ -1,4 +1,4 @@
-/** @type {import('tailwindcss/types').Config} */
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [],
   theme: {

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,1 +1,0 @@
-export type { Config } from './types/config'

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,1 +1,1 @@
-declare namespace tailwindcss {}
+export type { Config } from './config.d'


### PR DESCRIPTION
This PR adds the `@type` annotation to the `tailwind.config.js` file by default.
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
