### PR TITLE
CLI: Only listen for stdin close on TTYs

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -875,8 +875,10 @@ async function build() {
 
   if (shouldWatch) {
     /* Abort the watcher if stdin is closed to avoid zombie processes */
-    process.stdin.on('end', () => process.exit(0))
-    process.stdin.resume()
+    if (process.stdin.isTTY) {
+      process.stdin.on('end', () => process.exit(0))
+      process.stdin.resume()
+    }
     startWatcher()
   } else {
     buildOnce()


### PR DESCRIPTION
We have an incompatibility with turborepo because it doesn't pipe stdin to child processes. We currently always listen for stdin close (by closing the file descriptor, or in a TTY by pressing Ctrl + D) as a way to kill the process. If an app starts the Tailwind CLI with stdin closed it won't watch any files because as soon as we call resume we get an end event and exit.

To work around this we'll only wire up these listeners if the process is run in a terminal (a TTY) rather than as a general child process. I've verified this fix by running it in zsh but closed the file descriptor first: `0<&- ./lib/cli.js --watch input.css`. If an input file is not provided we still try to read from stdin which exits as expected because we can't read from stdin since there is no pipe.

Fixes #8517