### PR TITLE
Remove process dependency from log functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Try using local `postcss` installation first in the CLI ([#8270](https://github.com/tailwindlabs/tailwindcss/pull/8270))
 - Allow default ring color to be a function ([#7587](https://github.com/tailwindlabs/tailwindcss/pull/7587))
 - Don't inherit `to` value from parent gradients ([#8489](https://github.com/tailwindlabs/tailwindcss/pull/8489))
+- Remove process dependency from log functions ([#8530](https://github.com/tailwindlabs/tailwindcss/pull/8530))
 
 ### Changed
 

--- a/src/util/log.js
+++ b/src/util/log.js
@@ -3,7 +3,7 @@ import colors from 'picocolors'
 let alreadyShown = new Set()
 
 function log(type, messages, key) {
-  if (process.env.JEST_WORKER_ID !== undefined) return
+  if (typeof process.env.JEST_WORKER_ID !== 'undefined') return
 
   if (key && alreadyShown.has(key)) return
   if (key) alreadyShown.add(key)

--- a/src/util/log.js
+++ b/src/util/log.js
@@ -3,7 +3,7 @@ import colors from 'picocolors'
 let alreadyShown = new Set()
 
 function log(type, messages, key) {
-  if (typeof process.env.JEST_WORKER_ID !== 'undefined') return
+  if (typeof process !== 'undefined' && process.env.JEST_WORKER_ID) return
 
   if (key && alreadyShown.has(key)) return
   if (key) alreadyShown.add(key)


### PR DESCRIPTION
Currently if you do `import colors from 'tailwindcss/colors';` on the browser side it will crash due to [the process.env.JEST_WORKER_ID check in log.js](https://github.com/tailwindlabs/tailwindcss/blob/4f400767a8e86128858fb8eda3123d6d6e885102/src/util/log.js#L6).

This is a small tweak that keeps the check, but doesn't crash the browser.