### PR TITLE
Fix candidate extractor regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Fix candidate extractor regression ([#8558](https://github.com/tailwindlabs/tailwindcss/pull/8558))
 
 ## [3.1.0] - 2022-06-08
 

--- a/src/lib/defaultExtractor.js
+++ b/src/lib/defaultExtractor.js
@@ -43,7 +43,7 @@ function* buildRegExps(context) {
             /(?![{([]])/,
 
             // optionally followed by an opacity modifier
-            /(?:\/[^\s'"\\$]*)?/,
+            /(?:\/[^\s'"\\><$]*)?/,
           ]),
 
           regex.pattern([
@@ -58,7 +58,7 @@ function* buildRegExps(context) {
           ]),
 
           // Normal values w/o quotes — may include an opacity modifier
-          /[-\/][^\s'"\\$={]*/,
+          /[-\/][^\s'"\\$={><]*/,
         ])
       ),
     ]),

--- a/tests/default-extractor.test.js
+++ b/tests/default-extractor.test.js
@@ -438,3 +438,14 @@ test('with double quotes array within function', async () => {
   expect(extractions).toContain('pl-1.5')
   expect(extractions).not.toContain('pl-1')
 })
+
+test('with angle brackets', async () => {
+  const extractions = defaultExtractor(
+    `<div class="bg-blue-200 <% if (useShadow) { %>shadow-xl<% } %>">test</div>`
+  )
+
+  expect(extractions).toContain('bg-blue-200')
+  expect(extractions).toContain('shadow-xl')
+  expect(extractions).not.toContain('>shadow-xl')
+  expect(extractions).not.toContain('shadow-xl<')
+})


### PR DESCRIPTION
This is a regression where `%>utility<%` didn't properly extract `utility`

Fixes: #8553

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
