### PR TITLE
Ensure `\` is a valid arbitrary variant token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Ensure `\` is a valid arbitrary variant token ([#8576](https://github.com/tailwindlabs/tailwindcss/pull/8576))
 
 ## [3.1.1] - 2022-06-09
 

--- a/src/lib/defaultExtractor.js
+++ b/src/lib/defaultExtractor.js
@@ -69,7 +69,7 @@ function* buildRegExps(context) {
     '((?=((',
     regex.any(
       [
-        regex.pattern([/([^\s"'`\[\\]+-)?\[[^\s"'`\\]+\]/, separator]),
+        regex.pattern([/([^\s"'`\[\\]+-)?\[[^\s"'`]+\]/, separator]),
         regex.pattern([/[^\s"'`\[\\]+/, separator]),
       ],
       true

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -405,3 +405,91 @@ test('with @apply', () => {
     `)
   })
 })
+
+test('keeps escaped underscores', () => {
+  let config = {
+    content: [
+      {
+        raw: '<div class="[&_.foo\\_\\_bar]:underline"></div>',
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = `
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      ${defaults}
+
+      .\[\&_\.foo\\_\\_bar\]\:underline .foo__bar {
+        text-decoration-line: underline;
+      }
+    `)
+  })
+})
+
+test('keeps escaped underscores with multiple arbitrary variants', () => {
+  let config = {
+    content: [
+      {
+        raw: '<div class="[&_.foo\\_\\_bar]:[&_.bar\\_\\_baz]:underline"></div>',
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = `
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      ${defaults}
+
+      .\[\&_\.foo\\_\\_bar\]\:\[\&_\.bar\\_\\_baz\]\:underline .bar__baz .foo__bar {
+        text-decoration-line: underline;
+      }
+    `)
+  })
+})
+
+test('keeps escaped underscores in arbitrary variants mixed with normal variants', () => {
+  let config = {
+    content: [
+      {
+        raw: `
+          <div class="[&_.foo\\_\\_bar]:hover:underline"></div>
+          <div class="hover:[&_.foo\\_\\_bar]:underline"></div>
+        `,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = `
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      ${defaults}
+
+      .\[\&_\.foo\\_\\_bar\]\:hover\:underline:hover .foo__bar {
+        text-decoration-line: underline;
+      }
+
+      .hover\:\[\&_\.foo\\_\\_bar\]\:underline .foo__bar:hover {
+        text-decoration-line: underline;
+      }
+    `)
+  })
+})


### PR DESCRIPTION
We use `\` for escaping `.` or `_` so they should be part of the
arbitrary variant regex.

Fixes: #8573
Fixes: #8575

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
