### PR TITLE
Fix "Maximum call stack size exceeded" bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ignore PostCSS nodes returned by `addVariant` ([#8608](https://github.com/tailwindlabs/tailwindcss/pull/8608))
 - Fix missing spaces around arithmetic operators ([#8615](https://github.com/tailwindlabs/tailwindcss/pull/8615))
 - Detect alpha value in CSS `theme()` function when using quotes ([#8625](https://github.com/tailwindlabs/tailwindcss/pull/8625))
+- Fix "Maximum call stack size exceeded" bug ([#8636](https://github.com/tailwindlabs/tailwindcss/pull/8636))
 
 ## [3.1.2] - 2022-06-10
 

--- a/src/lib/defaultExtractor.js
+++ b/src/lib/defaultExtractor.js
@@ -12,7 +12,7 @@ export function defaultExtractor(context) {
     let results = []
 
     for (let pattern of patterns) {
-      results.push(...(content.match(pattern) ?? []))
+      results = [...results, ...(content.match(pattern) ?? []))
     }
 
     return results.filter((v) => v !== undefined).map(clipAtBalancedParens)

--- a/src/lib/defaultExtractor.js
+++ b/src/lib/defaultExtractor.js
@@ -12,7 +12,7 @@ export function defaultExtractor(context) {
     let results = []
 
     for (let pattern of patterns) {
-      results = [...results, ...(content.match(pattern) ?? []))
+      results = [...results, ...(content.match(pattern) ?? [])]
     }
 
     return results.filter((v) => v !== undefined).map(clipAtBalancedParens)

--- a/tests/default-extractor.test.js
+++ b/tests/default-extractor.test.js
@@ -476,3 +476,9 @@ test('multi-word + arbitrary values + quotes', async () => {
 
   expect(extractions).toContain(`grid-cols-['repeat(2)']`)
 })
+
+test('a lot of data', () => {
+  let extractions = defaultExtractor('underline '.repeat(2 ** 17))
+
+  expect(extractions).toContain(`underline`)
+})


### PR DESCRIPTION
For performance reasons we already read the content line by line, this allows us to cache individual lines if we already saw them. This also allows us to do the necessary work on relatively "small" content chunks because not a lot of developers use very long lines in the source files.

However...

Some people either misconfigure the `content` paths to include everything (even node_modules) or in a more realistic scenario link to a 3rd party dependency that uses Tailwind inside the node_modules folder. Those files are typically minified, all on one line. The stack size issue occurs when we try to push a lot of matches into an array. We used `result.push(...x)` which is limited by the length of `x` because functions have a maximum amount of parameters they can receive.

Thanks to @nam-tran-tego for the wonderful reproduction and fix for this!

Fixes: #8582