### PR TITLE
add text-initial class

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1576,6 +1576,7 @@ export let corePlugins = {
 
   textAlign: ({ addUtilities }) => {
     addUtilities({
+      '.text-initial': { 'text-align': 'initial' },
       '.text-left': { 'text-align': 'left' },
       '.text-center': { 'text-align': 'center' },
       '.text-right': { 'text-align': 'right' },

--- a/tests/parallel-variants.test.js
+++ b/tests/parallel-variants.test.js
@@ -67,11 +67,11 @@ test('parallel variants can be generated using a function that returns parallel 
       .test\:font-bold *::test {
         font-weight: 700;
       }
-      .test\:font-medium *::test {
-        font-weight: 500;
-      }
       .test\:font-bold::test {
         font-weight: 700;
+      }
+      .test\:font-medium *::test {
+        font-weight: 500;
       }
       .test\:font-medium::test {
         font-weight: 500;
@@ -116,11 +116,11 @@ test('a function that returns parallel variants can modify the container', async
       .test\:font-bold *::test {
         font-weight: calc(0 + 700);
       }
-      .test\:font-medium *::test {
-        font-weight: calc(0 + 500);
-      }
       .test\:font-bold::test {
         font-weight: calc(0 + 700);
+      }
+      .test\:font-medium *::test {
+        font-weight: calc(0 + 500);
       }
       .test\:font-medium::test {
         font-weight: calc(0 + 500);


### PR DESCRIPTION
here is a basic example, i know i can just wrap the content which i need to be centered

<img src="https://user-images.githubusercontent.com/29691074/174411773-47bb8c78-443b-492d-ab2e-2ac368de8a5a.png" width="640" />

but the most common case is using modal inside a full page with a centered text, we need to add [text-align: initial] to modal to work as normal, so i though adding the class may be useful.

