### PR TITLE
Separate two different button resets to avoid too much specificity

### DIFF
--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -177,14 +177,29 @@ select {
 }
 
 /*
-Correct the inability to style clickable types in iOS and Safari.
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Remove default button styles.
+
+Note: Keep separate from [type] to avoid too much specificity.
 */
 
-button,
+button {
+  -webkit-appearance: button; /* 1 */
+  background-color: transparent; /* 2 */
+  background-image: none; /* 2 */
+}
+
+/*
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Remove default button styles.
+*/
+
 [type='button'],
 [type='reset'],
 [type='submit'] {
-  -webkit-appearance: button;
+  -webkit-appearance: button; /* 1 */
+  background-color: transparent; /* 2 */
+  background-image: none; /* 2 */
 }
 
 /*

--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -177,17 +177,23 @@ select {
 }
 
 /*
-1. Correct the inability to style clickable types in iOS and Safari.
-2. Remove default button styles.
+Correct the inability to style clickable types in iOS and Safari.
 */
 
 button,
 [type='button'],
 [type='reset'],
 [type='submit'] {
-  -webkit-appearance: button; /* 1 */
-  background-color: transparent; /* 2 */
-  background-image: none; /* 2 */
+  -webkit-appearance: button;
+}
+
+/*
+Remove default button styles.
+*/
+
+button {
+  background-color: transparent;
+  background-image: none;
 }
 
 /*

--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -203,15 +203,6 @@ input[type='submit'] {
 }
 
 /*
-Remove default button styles.
-*/
-
-button {
-  background-color: transparent;
-  background-image: none;
-}
-
-/*
 Use the modern Firefox focus style for all focusable elements.
 */
 

--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -194,9 +194,9 @@ button {
 2. Remove default button styles.
 */
 
-[type='button'],
-[type='reset'],
-[type='submit'] {
+input[type='button'],
+input[type='reset'],
+input[type='submit'] {
   -webkit-appearance: button; /* 1 */
   background-color: transparent; /* 2 */
   background-image: none; /* 2 */


### PR DESCRIPTION
 - Taking a look at https://github.com/sindresorhus/modern-normalize/blob/main/modern-normalize.css#L188, I think we should separate the style reset from the iOS Safari reset.  I don't think we need to target the style reset of background-image and background-color to [type=] as well as button.
 - This will make it so using tailwind with other libraries is a bit simpler than before, since the specificity of [type=X] is fairly high compared to other selectors.


I wanted to start a discussion around possibly separating these two resets / normalize actions.

Based on what I see in the original modern-normalize, I'm thinking we only need to target button for the removal of default button styles.  

**NOTE:  The snapshot test is failing on this branch, so if we want this change I'd need some help on how to update it.**
