### PR TITLE
fix: add prefix to PluginApi type

### DIFF
--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -294,6 +294,8 @@ export interface PluginAPI {
   corePlugins(path: string): boolean
   // for manually escaping strings meant to be used in class names
   e: (className: string) => string
+  // for manually prefixing selectors
+  prefix: (selector: string) => string
 }
 export type PluginCreator = (api: PluginAPI) => void
 export type PluginsConfig = (


### PR DESCRIPTION
After migrating to Tailwind 3.x on my project, Typescript was yelling at me about `prefix` not being available in one of my plugins, but it is!

https://github.com/tailwindlabs/tailwindcss/blob/445970dcb798b32b6d3b3f76c51e456d6f553d93/src/lib/setupContextUtils.js#L240

This PR is about adding the existence of the `prefix` helper to the official types
