### PR TITLE
Fix usage of special-character prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allows fallback values in plugin API helpers ([#8762](https://github.com/tailwindlabs/tailwindcss/pull/8762))
 - Fix usage of postcss.config.js in standalone CLI ([#8769](https://github.com/tailwindlabs/tailwindcss/pull/8769))
+- Fix usage of special-character prefixes ([#8772](https://github.com/tailwindlabs/tailwindcss/pull/8772))
 
 ## [3.1.4] - 2022-06-21
 

--- a/src/lib/defaultExtractor.js
+++ b/src/lib/defaultExtractor.js
@@ -22,6 +22,10 @@ export function defaultExtractor(context) {
 function* buildRegExps(context) {
   let separator = context.tailwindConfig.separator
   let variantGroupingEnabled = flagEnabled(context.tailwindConfig, 'variantGrouping')
+  let prefix =
+    context.tailwindConfig.prefix !== ''
+      ? regex.optional(regex.pattern([/-?/, regex.escape(context.tailwindConfig.prefix)]))
+      : ''
 
   let utility = regex.any([
     // Arbitrary properties
@@ -87,6 +91,8 @@ function* buildRegExps(context) {
 
       // Important (optional)
       /!?/,
+
+      prefix,
 
       variantGroupingEnabled
         ? regex.any([

--- a/src/lib/defaultExtractor.js
+++ b/src/lib/defaultExtractor.js
@@ -1,4 +1,4 @@
-import { flagEnabled } from '../featureFlags.js'
+import { flagEnabled } from '../featureFlags'
 import * as regex from './regex'
 
 export function defaultExtractor(context) {

--- a/tests/prefix.test.js
+++ b/tests/prefix.test.js
@@ -400,3 +400,111 @@ it('supports prefixed utilities using arbitrary values', async () => {
     }
   `)
 })
+
+it('supports non-word prefixes (1)', async () => {
+  let config = {
+    prefix: '@',
+    content: [
+      {
+        raw: html`
+          <div class="@underline"></div>
+          <div class="@bg-black"></div>
+          <div class="@[color:red]"></div>
+          <div class="my-utility"></div>
+          <div class="foo"></div>
+
+          <!-- these won't be detected -->
+          <div class="overline"></div>
+        `,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind utilities;
+    @layer utilities {
+      .my-utility {
+        color: orange;
+      }
+    }
+    .foo {
+      @apply @text-white;
+      @apply [background-color:red];
+    }
+  `
+
+  const result = await run(input, config)
+
+  expect(result.css).toMatchFormattedCss(css`
+    .\@bg-black {
+      --tw-bg-opacity: 1;
+      background-color: rgb(0 0 0 / var(--tw-bg-opacity));
+    }
+    .\@underline {
+      text-decoration-line: underline;
+    }
+    .my-utility {
+      color: orange;
+    }
+    .foo {
+      --tw-text-opacity: 1;
+      color: rgb(255 255 255 / var(--tw-text-opacity));
+      background-color: red;
+    }
+  `)
+})
+
+it('supports non-word prefixes (2)', async () => {
+  let config = {
+    prefix: '@]$',
+    content: [
+      {
+        raw: html`
+          <div class="@]$underline"></div>
+          <div class="@]$bg-black"></div>
+          <div class="@]$[color:red]"></div>
+          <div class="my-utility"></div>
+          <div class="foo"></div>
+
+          <!-- these won't be detected -->
+          <div class="overline"></div>
+        `,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind utilities;
+    @layer utilities {
+      .my-utility {
+        color: orange;
+      }
+    }
+    .foo {
+      @apply @]$text-white;
+      @apply [background-color:red];
+    }
+  `
+
+  const result = await run(input, config)
+
+  expect(result.css).toMatchFormattedCss(css`
+    .\@\]\$bg-black {
+      --tw-bg-opacity: 1;
+      background-color: rgb(0 0 0 / var(--tw-bg-opacity));
+    }
+    .\@\]\$underline {
+      text-decoration-line: underline;
+    }
+    .my-utility {
+      color: orange;
+    }
+    .foo {
+      --tw-text-opacity: 1;
+      color: rgb(255 255 255 / var(--tw-text-opacity));
+      background-color: red;
+    }
+  `)
+})

--- a/tests/prefix.test.js
+++ b/tests/prefix.test.js
@@ -410,6 +410,7 @@ it('supports non-word prefixes (1)', async () => {
           <div class="@underline"></div>
           <div class="@bg-black"></div>
           <div class="@[color:red]"></div>
+          <div class="hover:before:@content-['Hovering']"></div>
           <div class="my-utility"></div>
           <div class="foo"></div>
 
@@ -452,6 +453,10 @@ it('supports non-word prefixes (1)', async () => {
       color: rgb(255 255 255 / var(--tw-text-opacity));
       background-color: red;
     }
+    .hover\:before\:\@content-\[\'Hovering\'\]:hover::before {
+      --tw-content: 'Hovering';
+      content: var(--tw-content);
+    }
   `)
 })
 
@@ -464,6 +469,7 @@ it('supports non-word prefixes (2)', async () => {
           <div class="@]$underline"></div>
           <div class="@]$bg-black"></div>
           <div class="@]$[color:red]"></div>
+          <div class="hover:before:@]$content-['Hovering']"></div>
           <div class="my-utility"></div>
           <div class="foo"></div>
 
@@ -489,6 +495,9 @@ it('supports non-word prefixes (2)', async () => {
   `
 
   const result = await run(input, config)
+
+  // TODO: The class `.hover\:before\:\@\]\$content-\[\'Hovering\'\]:hover::before` is not generated
+  // This happens because of the parenthesis/brace/bracket clipping performed on candidates
 
   expect(result.css).toMatchFormattedCss(css`
     .\@\]\$bg-black {


### PR DESCRIPTION
This was a regression in v3.1 with the rewritten candidate extractor. Now we explicitly add the prefix to the regex to be matched so it could _theoretically_ be anything. In practice there are some characters that won't work for internal reasons.

We still have to pick up candidates for non-prefixed things because the user can write their own class names in an `@layer` so the prefix is optional but it will now pick it up when necessary.

Fixes #8702