### PR TITLE
Add support for alpha values in safelist

### DIFF
--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -762,6 +762,17 @@ function registerPlugins(plugins, context) {
                 ]
               }
 
+              if ([].concat(options?.type).includes('color')) {
+                classes = [
+                  ...classes,
+                  ...classes.flatMap((cls) =>
+                    Object.keys(context.tailwindConfig.theme.opacity).map(
+                      (opacity) => `${cls}/${opacity}`
+                    )
+                  ),
+                ]
+              }
+
               return classes
             })()
           : [util]

--- a/tests/getClassList.test.js
+++ b/tests/getClassList.test.js
@@ -59,3 +59,26 @@ it('should generate every possible class while handling negatives and prefixes',
 
   expect(classes).not.toContain('-tw-m-DEFAULT')
 })
+
+it('should not generate utilities with opacity by default', () => {
+  let config = {}
+  let context = createContext(resolveConfig(config))
+  let classes = context.getClassList()
+
+  expect(classes).not.toContain('bg-red-500/50')
+})
+
+it('should not generate utilities with opacity even if safe-listed', () => {
+  let config = {
+    safelist: [
+      {
+        pattern: /^bg-red-(400|500)(\/(40|50))?$/,
+      },
+    ],
+  }
+
+  let context = createContext(resolveConfig(config))
+  let classes = context.getClassList()
+
+  expect(classes).not.toContain('bg-red-500/50')
+})

--- a/tests/safelist.test.js
+++ b/tests/safelist.test.js
@@ -51,7 +51,7 @@ it('should safelist based on a pattern regex', () => {
     content: [{ raw: html`<div class="uppercase"></div>` }],
     safelist: [
       {
-        pattern: /bg-(red)-(100|200)/,
+        pattern: /^bg-(red)-(100|200)$/,
         variants: ['hover'],
       },
     ],
@@ -92,15 +92,15 @@ it('should not generate duplicates', () => {
     safelist: [
       'uppercase',
       {
-        pattern: /bg-(red)-(100|200)/,
+        pattern: /^bg-(red)-(100|200)$/,
         variants: ['hover'],
       },
       {
-        pattern: /bg-(red)-(100|200)/,
+        pattern: /^bg-(red)-(100|200)$/,
         variants: ['hover'],
       },
       {
-        pattern: /bg-(red)-(100|200)/,
+        pattern: /^bg-(red)-(100|200)$/,
         variants: ['hover'],
       },
     ],
@@ -141,7 +141,7 @@ it('should safelist when using a custom prefix', () => {
     content: [{ raw: html`<div class="tw-uppercase"></div>` }],
     safelist: [
       {
-        pattern: /tw-bg-red-(100|200)/g,
+        pattern: /^tw-bg-red-(100|200)$/g,
       },
     ],
   }
@@ -218,6 +218,88 @@ it('should safelist negatives based on a pattern regex', () => {
 
       .hover\:-top-1:hover {
         top: -0.25rem;
+      }
+    `)
+  })
+})
+
+it('should safelist negatives based on a pattern regex', () => {
+  let config = {
+    content: [{ raw: html`<div class="uppercase"></div>` }],
+    safelist: [
+      {
+        pattern: /^bg-red-(400|500)(\/(40|50))?$/,
+        variants: ['hover'],
+      },
+      {
+        pattern: /^(fill|ring|text)-red-200\/50$/,
+        variants: ['hover'],
+      },
+    ],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    return expect(result.css).toMatchCss(css`
+      .bg-red-400 {
+        --tw-bg-opacity: 1;
+        background-color: rgb(248 113 113 / var(--tw-bg-opacity));
+      }
+      .bg-red-500 {
+        --tw-bg-opacity: 1;
+        background-color: rgb(239 68 68 / var(--tw-bg-opacity));
+      }
+      .bg-red-400\/40 {
+        background-color: rgb(248 113 113 / 0.4);
+      }
+      .bg-red-400\/50 {
+        background-color: rgb(248 113 113 / 0.5);
+      }
+      .bg-red-500\/40 {
+        background-color: rgb(239 68 68 / 0.4);
+      }
+      .bg-red-500\/50 {
+        background-color: rgb(239 68 68 / 0.5);
+      }
+      .fill-red-200\/50 {
+        fill: rgb(254 202 202 / 0.5);
+      }
+      .uppercase {
+        text-transform: uppercase;
+      }
+      .text-red-200\/50 {
+        color: rgb(254 202 202 / 0.5);
+      }
+      .ring-red-200\/50 {
+        --tw-ring-color: rgb(254 202 202 / 0.5);
+      }
+      .hover\:bg-red-400:hover {
+        --tw-bg-opacity: 1;
+        background-color: rgb(248 113 113 / var(--tw-bg-opacity));
+      }
+      .hover\:bg-red-500:hover {
+        --tw-bg-opacity: 1;
+        background-color: rgb(239 68 68 / var(--tw-bg-opacity));
+      }
+      .hover\:bg-red-400\/40:hover {
+        background-color: rgb(248 113 113 / 0.4);
+      }
+      .hover\:bg-red-400\/50:hover {
+        background-color: rgb(248 113 113 / 0.5);
+      }
+      .hover\:bg-red-500\/40:hover {
+        background-color: rgb(239 68 68 / 0.4);
+      }
+      .hover\:bg-red-500\/50:hover {
+        background-color: rgb(239 68 68 / 0.5);
+      }
+      .hover\:fill-red-200\/50:hover {
+        fill: rgb(254 202 202 / 0.5);
+      }
+      .hover\:text-red-200\/50:hover {
+        color: rgb(254 202 202 / 0.5);
+      }
+      .hover\:ring-red-200\/50:hover {
+        --tw-ring-color: rgb(254 202 202 / 0.5);
       }
     `)
   })


### PR DESCRIPTION
This PR adds support for opacity values when safe listing utilities. You can specify these opacity values in the pattern used to generate the utilities like so:

```js
safelist: [
  {
    pattern: /^bg-(red)-(100|200)(\/40|50)?$/,
    variants: ['hover'],
  },
],
```

Note that the opacity modifier in the above pattern is **_optional_** which means we'll generate the bare utility along side the utility with an opacity. The pattern above will generate the following classes: `bg-red-100`, `bg-red-100/40`, `bg-red-100/50`, `bg-red-200`, `bg-red-200/40`, `bg-red-200/50` as well as all their hover variants.

With this change it becomes more important to anchor your patterns with `^` and `$` as the pattern `/bg-red-100/` will generate `bg-red-100`, `bg-red-100/5`, `bg-red-100/10`, `bg-red-100/20`, etc… which may not be what you want. Anchoring your patterns will address this issue.

Supersedes #7674