### PR TITLE
Handle theme keys with slashes when using `theme()` in CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix usage on Node 12.x ([b4e637e](https://github.com/tailwindlabs/tailwindcss/commit/b4e637e2e096a9d6f2210efba9541f6fd4f28e56))
+- Handle theme keys with slashes when using `theme()` in CSS ([#8831](https://github.com/tailwindlabs/tailwindcss/pull/8831))
 
 ## [3.1.5] - 2022-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Fix usage on Node 12.x ([b4e637e](https://github.com/tailwindlabs/tailwindcss/commit/b4e637e2e096a9d6f2210efba9541f6fd4f28e56))
 
 ## [3.1.5] - 2022-07-07
 
@@ -15,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support configuring a default `font-weight` for each font size utility ([#8763](https://github.com/tailwindlabs/tailwindcss/pull/8763))
 - Add support for alpha values in safe list ([#8774](https://github.com/tailwindlabs/tailwindcss/pull/8774))
- 
+
 ### Fixed
 
 - Improve types to support fallback values in the CSS-in-JS syntax used in plugin APIs ([#8762](https://github.com/tailwindlabs/tailwindcss/pull/8762))

--- a/tests/evaluateTailwindFunctions.test.js
+++ b/tests/evaluateTailwindFunctions.test.js
@@ -1135,3 +1135,51 @@ test('Theme functions with alpha with quotes value around color only', () => {
     expect(result.warnings().length).toBe(0)
   })
 })
+
+it('can find values with slashes in the theme key while still allowing for alpha values ', () => {
+  let input = css`
+    .foo00 {
+      color: theme(colors.foo-5);
+    }
+    .foo01 {
+      color: theme(colors.foo-5/10);
+    }
+    .foo02 {
+      color: theme(colors.foo-5/10/25);
+    }
+    .foo03 {
+      color: theme(colors.foo-5 / 10);
+    }
+    .foo04 {
+      color: theme(colors.foo-5/10 / 25);
+    }
+  `
+
+  return runFull(input, {
+    theme: {
+      colors: {
+        'foo-5': '#050000',
+        'foo-5/10': '#051000',
+        'foo-5/10/25': '#051025',
+      },
+    },
+  }).then((result) => {
+    expect(result.css).toMatchCss(css`
+      .foo00 {
+        color: #050000;
+      }
+      .foo01 {
+        color: #051000;
+      }
+      .foo02 {
+        color: #051025;
+      }
+      .foo03 {
+        color: rgb(5 0 0 / 10);
+      }
+      .foo04 {
+        color: rgb(5 16 0 / 25);
+      }
+    `)
+  })
+})


### PR DESCRIPTION
Fixes #8824