### PR TITLE
Refactor the term `whitelist` to `allowlist`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Changed
+- Refactored "whitelist" to "allowlist"
 
 ## [3.1.6] - 2022-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1645,7 +1645,7 @@ No release notes
 
 - Make it possible to disable all core plugins using `corePlugins: false`
 - Make it possible to configure a single list of variants that applies to all utility plugins
-- Make it possible to whitelist which core plugins should be enabled
+- Make it possible to allowlist which core plugins should be enabled
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+
 - Refactored "whitelist" to "allowlist"
 
 ## [3.1.6] - 2022-07-11

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -107,7 +107,7 @@ test('variants without & or an at-rule are ignored', () => {
 
 test('arbitrary variants are sorted after other variants', () => {
   let config = {
-    content: [{ raw: html`<div class="[&>*]:underline underline lg:underline"></div>` }],
+    content: [{ raw: html`<div class="underline lg:underline [&>*]:underline"></div>` }],
     corePlugins: { preflight: false },
   }
 

--- a/tests/configurePlugins.test.js
+++ b/tests/configurePlugins.test.js
@@ -16,7 +16,7 @@ test('passing only false removes all plugins', () => {
   expect(configuredPlugins).toEqual([])
 })
 
-test('passing an array whitelists plugins', () => {
+test('passing an array allowlists plugins', () => {
   const plugins = ['fontSize', 'display', 'backgroundPosition']
 
   const configuredPlugins = configurePlugins(['display'], plugins)

--- a/tests/prefers-contrast.test.js
+++ b/tests/prefers-contrast.test.js
@@ -3,7 +3,7 @@ import { run, html, css, defaults } from './util/run'
 it('should be possible to use contrast-more and contrast-less variants', () => {
   let config = {
     content: [
-      { raw: html`<div class="contrast-more:bg-pink-500 contrast-less:bg-black bg-white"></div>` },
+      { raw: html`<div class="bg-white contrast-more:bg-pink-500 contrast-less:bg-black"></div>` },
     ],
     corePlugins: { preflight: false },
   }


### PR DESCRIPTION
## Issue

I think it would be a good idea to start deprecating centuries old terminology that have a negative connotation associated with them.

The only term I could see in this project is "whitelist". A better term for this would be "allowlist", as it has better semantic meaning rather than relying on old metaphors.

## Suggestion

It would also be great if we could refactor the `master` branch into the now de facto `main` branch.

## Remarks

Thanks again for being one of the best frontend communities! ❤️ 
