### PR TITLE
Add `touch` and `no-touch` variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+- Add `touch` and `no-touch` variants ([#8907](https://github.com/tailwindlabs/tailwindcss/pull/8907))
 
 ## [3.1.6] - 2022-07-11
 

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -224,6 +224,11 @@ export let variantPlugins = {
     addVariant('contrast-more', '@media (prefers-contrast: more)')
     addVariant('contrast-less', '@media (prefers-contrast: less)')
   },
+
+  touchVariants: ({ addVariant }) => {
+    addVariant('touch', '@media (hover: none)')
+    addVariant('no-touch', '@media (hover: hover)')
+  },
 }
 
 let cssTransformValue = [

--- a/tests/variants.test.css
+++ b/tests/variants.test.css
@@ -833,6 +833,18 @@
     background-color: rgb(253 224 71 / var(--tw-bg-opacity));
   }
 }
+@media (hover: none) {
+  .touch\:bg-yellow-300 {
+    --tw-bg-opacity: 1;
+    background-color: rgb(253 224 71 / var(--tw-bg-opacity));
+  }
+}
+@media (hover: hover) {
+  .no-touch\:bg-yellow-300 {
+    --tw-bg-opacity: 1;
+    background-color: rgb(253 224 71 / var(--tw-bg-opacity));
+  }
+}
 .dark .dark\:shadow-md {
   --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);

--- a/tests/variants.test.html
+++ b/tests/variants.test.html
@@ -150,6 +150,9 @@
     <div class="contrast-more:bg-yellow-300"></div>
     <div class="contrast-less:bg-yellow-300"></div>
 
+    <div class="touch:bg-yellow-300"></div>
+    <div class="no-touch:bg-yellow-300"></div>
+
     <!-- Stacked variants -->
     <div class="open:hover:bg-red-200"></div>
     <div class="file:hover:bg-blue-600"></div>


### PR DESCRIPTION
Hi
This PR adds `touch` and `no-touch` variants to detect if the device is touch-enabled. 
It uses [`(hover: hover) & (hover: none)`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/hover), but I can change the media query to use [`(pointer: fine)` & `(pointer: coarse)`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/pointer).

```html
<p class="hidden no-touch:block">Use your mouse wheel to zoom.</p>
<p class="hidden touch:block">Use pinch to zoom.</p>
```

Thanks