### PR TITLE
fix:change preflight button selector

### DIFF
--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -179,10 +179,11 @@ select {
 /*
 1. Correct the inability to style clickable types in iOS and Safari.
 2. Remove default button styles.
+3. Exclude attribute selector higher than class when `<button type="button" />`
 */
 
 button,
-[type='button'],
+:not(button)[type='button'], /* 3 */
 [type='reset'],
 [type='submit'] {
   -webkit-appearance: button; /* 1 */


### PR DESCRIPTION
- pr change `preflight.css`
- Exclude attribute selector higher than class when `<button type="button" />`

fix: https://github.com/unocss/unocss/issues/1315
[type=button] style preset in prelight.css is not very friendly in some components  libraries
due to attribute selector higher than class, reset style overrides the class style
```html
<button type="button" class="btn">
```