### PR TITLE
Remove class prefix in arbitrary variant that is used multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Don’t prefix classes within reused arbitrary variants ([#8992](https://github.com/tailwindlabs/tailwindcss/pull/8992))
 
 ## [3.1.7] - 2022-07-29
 

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -129,7 +129,6 @@ function applyVariant(variant, matches, context) {
   }
 
   let args
-  let isArbitraryVariant = false
 
   // Find partial arbitrary variants
   if (variant.endsWith(']') && !variant.startsWith('[')) {
@@ -144,8 +143,6 @@ function applyVariant(variant, matches, context) {
     if (!isValidVariantFormatString(selector)) {
       return []
     }
-
-    isArbitraryVariant = true
 
     let fn = parseVariant(selector)
 
@@ -303,7 +300,7 @@ function applyVariant(variant, matches, context) {
             ...meta,
             sort: variantSort | meta.sort,
             collectedFormats: (meta.collectedFormats ?? []).concat(collectedFormats),
-            isArbitraryVariant,
+            isArbitraryVariant: isArbitraryValue(variant),
           },
           clone.nodes[0],
         ]

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -566,3 +566,52 @@ test('classes in arbitrary variants should not be prefixed', () => {
     `)
   })
 })
+
+test('classes in the same arbitrary variant should not be prefixed', () => {
+  let config = {
+    prefix: 'tw-',
+    content: [
+      {
+        raw: `
+          <div class="[.foo_&]:tw-text-red-400 [.foo_&]:tw-bg-white">should not be red</div>
+          <div class="foo">
+            <div class="[.foo_&]:tw-text-red-400 [.foo_&]:tw-bg-white">should be red</div>
+          </div>
+          <div class="[&_.foo]:tw-text-red-400 [&_.foo]:tw-bg-white">
+            <div>should not be red</div>
+            <div class="foo">should be red</div>
+          </div>
+        `,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = `
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .foo .\[\.foo_\&\]\:tw-bg-white {
+        --tw-bg-opacity: 1;
+        background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+      }
+
+      .foo .\[\.foo_\&\]\:tw-text-red-400 {
+        --tw-text-opacity: 1;
+        color: rgb(248 113 113 / var(--tw-text-opacity));
+      }
+
+      .\[\&_\.foo\]\:tw-bg-white .foo {
+        --tw-bg-opacity: 1;
+        background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+      }
+
+      .\[\&_\.foo\]\:tw-text-red-400 .foo {
+        --tw-text-opacity: 1;
+        color: rgb(248 113 113 / var(--tw-text-opacity));
+      }
+    `)
+  })
+})


### PR DESCRIPTION
### Discussed in #8932

Fixes the issue when a class prefix is configured and an arbitrary variant with a class name is used within the variant, the class within the variant would have the class prefix when the same arbitrary variant is used more than once.

Extension of PR #8773.
