### PR TITLE
Add support for configuring default font-feature-settings for a font-family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support fo configuring default `font-feature-settings` for a font family ([#9039](https://github.com/tailwindlabs/tailwindcss/pull/9039))
+
 ### Fixed
 
 - Use absolute paths when resolving changed files for resilience against working directory changes ([#9032](https://github.com/tailwindlabs/tailwindcss/pull/9032))

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1604,9 +1604,28 @@ export let corePlugins = {
     matchUtilities({ align: (value) => ({ 'vertical-align': value }) })
   },
 
-  fontFamily: createUtilityPlugin('fontFamily', [['font', ['fontFamily']]], {
-    type: ['lookup', 'generic-name', 'family-name'],
-  }),
+  fontFamily: ({ matchUtilities, theme }) => {
+    matchUtilities(
+      {
+        font: (value) => {
+          let [families, options = {}] =
+            Array.isArray(value) && isPlainObject(value[1]) ? value : [value]
+          let { fontFeatureSettings } = options
+
+          return {
+            'font-family': Array.isArray(families) ? families.join(', ') : families,
+            ...(fontFeatureSettings === undefined
+              ? {}
+              : { 'font-feature-settings': fontFeatureSettings }),
+          }
+        },
+      },
+      {
+        values: theme('fontFamily'),
+        type: ['lookup', 'generic-name', 'family-name'],
+      }
+    )
+  },
 
   fontSize: ({ matchUtilities, theme }) => {
     matchUtilities(

--- a/tests/plugins/fontFamily.test.js
+++ b/tests/plugins/fontFamily.test.js
@@ -1,0 +1,98 @@
+import { run, html, css } from '../util/run'
+
+test('font-family utilities can be defined as a string', () => {
+  let config = {
+    content: [{ raw: html`<div class="font-sans"></div>` }],
+    theme: {
+      fontFamily: {
+        sans: 'Helvetica, Arial, sans-serif',
+      },
+    },
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchCss(css`
+      .font-sans {
+        font-family: Helvetica, Arial, sans-serif;
+      }
+    `)
+  })
+})
+
+test('font-family utilities can be defined as an array', () => {
+  let config = {
+    content: [{ raw: html`<div class="font-sans"></div>` }],
+    theme: {
+      fontFamily: {
+        sans: ['Helvetica', 'Arial', 'sans-serif'],
+      },
+    },
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchCss(css`
+      .font-sans {
+        font-family: Helvetica, Arial, sans-serif;
+      }
+    `)
+  })
+})
+
+test('font-family values are not automatically escaped', () => {
+  let config = {
+    content: [{ raw: html`<div class="font-sans"></div>` }],
+    theme: {
+      fontFamily: {
+        sans: ["'Exo 2'", 'sans-serif'],
+      },
+    },
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchCss(css`
+      .font-sans {
+        font-family: 'Exo 2', sans-serif;
+      }
+    `)
+  })
+})
+
+test('font-feature-settings can be provided when families are defined as a string', () => {
+  let config = {
+    content: [{ raw: html`<div class="font-sans"></div>` }],
+    theme: {
+      fontFamily: {
+        sans: ['Helvetica, Arial, sans-serif', { fontFeatureSettings: '"cv11", "ss01"' }],
+      },
+    },
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchCss(`
+      .font-sans {
+        font-family: Helvetica, Arial, sans-serif;
+        font-feature-settings: "cv11", "ss01";
+      }
+    `)
+  })
+})
+
+test('font-feature-settings can be provided when families are defined as an array', () => {
+  let config = {
+    content: [{ raw: html`<div class="font-sans"></div>` }],
+    theme: {
+      fontFamily: {
+        sans: [['Helvetica', 'Arial', 'sans-serif'], { fontFeatureSettings: '"cv11", "ss01"' }],
+      },
+    },
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchCss(`
+      .font-sans {
+        font-family: Helvetica, Arial, sans-serif;
+        font-feature-settings: "cv11", "ss01";
+      }
+    `)
+  })
+})


### PR DESCRIPTION
This PR adds support for an options object when configuring custom font families where you can specify default [font-feature-settings](https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings) for that font.

Inspired by this discussion: https://github.com/tailwindlabs/tailwindcss/discussions/9034

```js
module.exports = {
  // ...
  theme: {
    fontFamily: {
      sans: [
        "Inter var, sans-serif",
        { fontFeatureSettings: '"cv11", "ss01"' },
      ],
    },
  },
}
```

```js
module.exports = {
  // ...
  theme: {
    fontFamily: {
      sans: [
        ["Inter var", "sans-serif"],
        { fontFeatureSettings: '"cv11", "ss01"' },
      ],
    },
  },
}
```