### PR TITLE
Set -webkit-tap-highlight-color to transparent in Preflight

### DIFF
--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -21,7 +21,8 @@
 1. Use a consistent sensible line-height in all browsers.
 2. Prevent adjustments of font size after orientation changes in iOS.
 3. Use a more readable tab size.
-4. Use the user's configured `sans` font-family by default.
+4. Remove the highlight over a link while it's being tapped.
+5. Use the user's configured `sans` font-family by default.
 */
 
 html {
@@ -29,7 +30,8 @@ html {
   -webkit-text-size-adjust: 100%; /* 2 */
   -moz-tab-size: 4; /* 3 */
   tab-size: 4; /* 3 */
-  font-family: theme('fontFamily.sans', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"); /* 4 */
+  -webkit-tap-highlight-color: transparent; /* 4 */
+  font-family: theme('fontFamily.sans', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"); /* 5 */
 }
 
 /*


### PR DESCRIPTION
This PR removes the highlight over a link while it's being tapped.

For many, the blue highlight over a link on mobile is unexpected and personally I disable it on every project. There's also some bigger projects I know of that set the highlight color to transparent. In my opinion it would be good to have this as a default in Preflight. I'm open to discussion though, if you think this is a bad idea.

For reference, this has been requested in several discussions here as well:

- https://github.com/tailwindlabs/tailwindcss/discussions/2984
- https://github.com/tailwindlabs/tailwindcss/discussions/3023
- https://github.com/tailwindlabs/tailwindcss/discussions/6122