### PR TITLE
Remove invalid `.outline-hidden` utility

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1980,7 +1980,6 @@ export let corePlugins = {
       '.outline-dashed': { 'outline-style': 'dashed' },
       '.outline-dotted': { 'outline-style': 'dotted' },
       '.outline-double': { 'outline-style': 'double' },
-      '.outline-hidden': { 'outline-style': 'hidden' },
     })
   },
 


### PR DESCRIPTION
This invalid CSS value was added in https://github.com/tailwindlabs/tailwindcss/pull/5887
Cannot find any references to it in the [CSS spec](https://developer.mozilla.org/en-US/docs/Web/CSS/outline-style)