### PR TITLE
Fix CLI not watching atomically renamed files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sort tags before classes when `@applying` a selector with joined classes ([#9107](https://github.com/tailwindlabs/tailwindcss/pull/9107))
 - Remove invalid `outline-hidden` utility ([#9147](https://github.com/tailwindlabs/tailwindcss/pull/9147))
 - Honor the `hidden` attribute on elements in preflight ([#9174](https://github.com/tailwindlabs/tailwindcss/pull/9174))
+- Don't stop watching atomically renamed files ([#9173](https://github.com/tailwindlabs/tailwindcss/pull/9173))
 
 ## [3.1.8] - 2022-08-05
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -843,6 +843,11 @@ async function build() {
     }
 
     watcher = chokidar.watch([...contextDependencies, ...extractFileGlobs(config)], {
+      // Force checking for atomic writes in all situations
+      // This causes chokidar to wait up to 100ms for a file to re-added after it's been unlinked
+      // This only works when watching directories though
+      atomic: true,
+
       usePolling: shouldPoll,
       interval: shouldPoll ? pollInterval : undefined,
       ignoreInitial: true,


### PR DESCRIPTION
Chokidar should take care of this itself but sometimes it doesn’t do so OR is otherwise very sensitive to timing problems.

Fixes #7759
Fixes #9072