### PR TITLE
Trigger Tailwind Play update after publishing insiders build

### DIFF
--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -56,3 +56,18 @@ jobs:
         env:
           CI: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Trigger Tailwind Play update
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.TAILWIND_PLAY_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'tailwindlabs',
+              repo: 'play.tailwindcss.com',
+              ref: 'master',
+              workflow_id: 'upgrade-tailwindcss.yml',
+              inputs: {
+                insidersVersion: '0.0.0-insiders.${{ steps.vars.outputs.sha_short }}'
+              }
+            })


### PR DESCRIPTION
This PR updates the `release-insiders` workflow so that it triggers Tailwind Play's [`upgrade-tailwindcss`](https://github.com/tailwindlabs/play.tailwindcss.com/blob/master/.github/workflows/upgrade-tailwindcss.yml) workflow, passing the new insiders version number as an input.