### PR TITLE
fix safelist variant key required by typings

### DIFF
--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -49,7 +49,7 @@ type SafelistConfig =
   | string[]
   | {
       pattern: RegExp
-      variants: string[]
+      variants?: string[]
     }[]
 
 // Presets related config


### PR DESCRIPTION
The typescript typings were requiring a `variant` key on the `safelist` object in the config. This pr fixes that.

Screen shot of false positive:
<img width="530" alt="image" src="https://user-images.githubusercontent.com/43254861/187042217-a502964f-9a29-4f95-b608-81285e0ef9dc.png">
<img width="656" alt="image" src="https://user-images.githubusercontent.com/43254861/187042228-59a15d6a-4560-407c-87b6-f1348e74adce.png">

Docs that show `variant` key should not be required:
https://tailwindcss.com/docs/content-configuration#using-regular-expressions
<img width="448" alt="image" src="https://user-images.githubusercontent.com/43254861/187042245-2698df10-1dfb-4245-9689-7742e822d0cb.png">

