### PR TITLE
Fix `fontFamily` config types

### DIFF
--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -153,7 +153,14 @@ interface ThemeConfig {
   objectPosition: ResolvableTo<KeyValuePair>
   padding: ThemeConfig['spacing']
   textIndent: ThemeConfig['spacing']
-  fontFamily: ResolvableTo<KeyValuePair<string, string[]>>
+  fontFamily: ResolvableTo<
+    KeyValuePair<
+      string,
+      | string
+      | string[]
+      | [fontFamily: string | string[], configuration: Partial<{ fontFeatureSettings: string }>]
+    >
+  >
   fontSize: ResolvableTo<
     KeyValuePair<
       string,


### PR DESCRIPTION
Previously only the following format was permitted:

```js
module.exports = {
  theme: {
    fontFamily: {
      sans: ['Inter', 'sans-serif'],
    },
  },
}
```

Now all of these formats are permitted:

```js
module.exports = {
  theme: {
    fontFamily: {
      sans: ['Inter', 'sans-serif'],
      sans2: [['Inter', 'sans-serif'], { fontFeatureSettings: '"cv11"' }],
      serif: 'Times, serif',
      serif2: ['Times, serif', { fontFeatureSettings: '"cv11"' }].
    },
  },
}
```

### References

- [`fontFamily` tests](https://github.com/tailwindlabs/tailwindcss/blob/master/tests/plugins/fontFamily.test.js)
- https://github.com/tailwindlabs/tailwindcss/pull/9039