### PR TITLE
Handle variants on complex selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Re-use existing entries in the rule cache ([#9208](https://github.com/tailwindlabs/tailwindcss/pull/9208))
 - Don't output duplicate utilities ([#9208](https://github.com/tailwindlabs/tailwindcss/pull/9208))
 - Fix `fontFamily` config TypeScript types ([#9214](https://github.com/tailwindlabs/tailwindcss/pull/9214))
+- Handle variants on complex selector utilities ([#9262](https://github.com/tailwindlabs/tailwindcss/pull/9262))
 
 ## [3.1.8] - 2022-08-05
 

--- a/tests/variants.test.js
+++ b/tests/variants.test.js
@@ -855,3 +855,92 @@ test('hoverOnlyWhenSupported adds hover and pointer media features by default', 
     `)
   })
 })
+
+test('multi-class utilities handle selector-mutating variants correctly', () => {
+  let config = {
+    content: [
+      {
+        raw: html`<div
+          class="hover:foo hover:bar hover:baz group-hover:foo group-hover:bar group-hover:baz peer-checked:foo peer-checked:bar peer-checked:baz"
+        ></div>`,
+      },
+      {
+        raw: html`<div
+          class="hover:foo1 hover:bar1 hover:baz1 group-hover:foo1 group-hover:bar1 group-hover:baz1 peer-checked:foo1 peer-checked:bar1 peer-checked:baz1"
+        ></div>`,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind utilities;
+    @layer utilities {
+      .foo.bar.baz {
+        color: red;
+      }
+      .foo1 .bar1 .baz1 {
+        color: red;
+      }
+    }
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .hover\:foo.bar.baz:hover {
+        color: red;
+      }
+      .hover\:bar.foo.baz:hover {
+        color: red;
+      }
+      .hover\:baz.foo.bar:hover {
+        color: red;
+      }
+      .hover\:foo1:hover .bar1 .baz1 {
+        color: red;
+      }
+      .foo1 .hover\:bar1:hover .baz1 {
+        color: red;
+      }
+      .foo1 .bar1 .hover\:baz1:hover {
+        color: red;
+      }
+      .group:hover .group-hover\:foo.bar.baz {
+        color: red;
+      }
+      .group:hover .group-hover\:bar.foo.baz {
+        color: red;
+      }
+      .group:hover .group-hover\:baz.foo.bar {
+        color: red;
+      }
+      .group:hover .group-hover\:foo1 .bar1 .baz1 {
+        color: red;
+      }
+      .foo1 .group:hover .group-hover\:bar1 .baz1 {
+        color: red;
+      }
+      .foo1 .bar1 .group:hover .group-hover\:baz1 {
+        color: red;
+      }
+      .peer:checked ~ .peer-checked\:foo.bar.baz {
+        color: red;
+      }
+      .peer:checked ~ .peer-checked\:bar.foo.baz {
+        color: red;
+      }
+      .peer:checked ~ .peer-checked\:baz.foo.bar {
+        color: red;
+      }
+      .peer:checked ~ .peer-checked\:foo1 .bar1 .baz1 {
+        color: red;
+      }
+      .foo1 .peer:checked ~ .peer-checked\:bar1 .baz1 {
+        color: red;
+      }
+      .foo1 .bar1 .peer:checked ~ .peer-checked\:baz1 {
+        color: red;
+      }
+    `)
+  })
+})


### PR DESCRIPTION
For a utility .foo.bar we would replace the candidate class in-place. This resulted in a problem where we'd produce something like the following for `peer-checked:bar`:
```css
.foo.peer:checked ~ .peer-checked\:bar {
    /* ... */
}
```

This is obviously a mistake as it completely mangles the original meaning of the selector. This PR fixes this.

Fixes #9056

---

This, however, opens an interesting question:

When given a utility like `.foo .bar` the replacement is fairly simple for either `hover:foo` or `hover:bar`. But what about `group-hover:foo`, `peer-checked:foo`, `group-hover:bar`, and `peer-checked:bar`?

With this there are obvious interpretations for `foo` but not necessarily so for `bar`:

```css
/* Given the utility */
.foo .bar { color: red; }

/* obvious interpretations for `foo` */
.group:hover .group-hover\:foo .bar { color: green; }
.peer:checked ~ .peer-checked\:foo .bar { color: green; }

/* ambiguous interpretations for `bar` */
.group:hover .foo .group-hover\:bar { color: green; }
.foo .group:hover .group-hover\:bar { color: green; }

.peer:checked ~ .foo .peer-checked\:bar { color: green; }
.foo .peer:checked ~ .peer-checked\:bar { color: green; }
```

We've decided that, while it may not suit all use cases, the best way to approach this is to slot in the entire variant selector in the spot where the class candidate is. As such the variants for foo and bar above will produce the following:
```css
.group:hover .group-hover\:foo .bar { color: green; }
.peer:checked ~ .peer-checked\:foo .bar { color: green; }
.foo .group:hover .group-hover\:bar { color: green; }
.foo .peer:checked ~ .peer-checked\:bar { color: green; }
```