### PR TITLE
Polish `matchVariant` API

### DIFF
--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -501,13 +501,13 @@ function buildPluginApi(tailwindConfig, context, { variantList, variantMap, offs
 
   if (flagEnabled(tailwindConfig, 'matchVariant')) {
     api.matchVariant = function (variant, variantFn, options) {
-      for (let [k, v] of Object.entries(options?.values ?? {})) {
-        api.addVariant(`${variant}-${k}`, variantFn(v))
+      for (let [key, value] of Object.entries(options?.values ?? {})) {
+        api.addVariant(`${variant}-${key}`, variantFn({ value }))
       }
 
       api.addVariant(
         variant,
-        Object.assign(({ args }) => variantFn(args), { [MATCH_VARIANT]: true }),
+        Object.assign(({ args }) => variantFn({ value: args }), { [MATCH_VARIANT]: true }),
         options
       )
     }

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -500,18 +500,16 @@ function buildPluginApi(tailwindConfig, context, { variantList, variantMap, offs
   }
 
   if (flagEnabled(tailwindConfig, 'matchVariant')) {
-    api.matchVariant = function (variants, options) {
-      for (let variant in variants) {
-        for (let [k, v] of Object.entries(options?.values ?? {})) {
-          api.addVariant(`${variant}-${k}`, variants[variant](v))
-        }
-
-        api.addVariant(
-          variant,
-          Object.assign(({ args }) => variants[variant](args), { [MATCH_VARIANT]: true }),
-          options
-        )
+    api.matchVariant = function (variant, variantFn, options) {
+      for (let [k, v] of Object.entries(options?.values ?? {})) {
+        api.addVariant(`${variant}-${k}`, variantFn(v))
       }
+
+      api.addVariant(
+        variant,
+        Object.assign(({ args }) => variantFn(args), { [MATCH_VARIANT]: true }),
+        options
+      )
     }
   }
 

--- a/tests/match-variants.test.js
+++ b/tests/match-variants.test.js
@@ -11,9 +11,7 @@ test('partial arbitrary variants', () => {
     corePlugins: { preflight: false },
     plugins: [
       ({ matchVariant }) => {
-        matchVariant({
-          potato: (flavor) => `.potato-${flavor} &`,
-        })
+        matchVariant('potato', (flavor) => `.potato-${flavor} &`)
       },
     ],
   }
@@ -47,9 +45,7 @@ test('partial arbitrary variants with at-rules', () => {
     corePlugins: { preflight: false },
     plugins: [
       ({ matchVariant }) => {
-        matchVariant({
-          potato: (flavor) => `@media (potato: ${flavor})`,
-        })
+        matchVariant('potato', (flavor) => `@media (potato: ${flavor})`)
       },
     ],
   }
@@ -86,9 +82,7 @@ test('partial arbitrary variants with at-rules and placeholder', () => {
     corePlugins: { preflight: false },
     plugins: [
       ({ matchVariant }) => {
-        matchVariant({
-          potato: (flavor) => `@media (potato: ${flavor}) { &:potato }`,
-        })
+        matchVariant('potato', (flavor) => `@media (potato: ${flavor}) { &:potato }`)
       },
     ],
   }
@@ -125,17 +119,12 @@ test('partial arbitrary variants with default values', () => {
     corePlugins: { preflight: false },
     plugins: [
       ({ matchVariant }) => {
-        matchVariant(
-          {
-            tooltip: (side) => `&${side}`,
+        matchVariant('tooltip', (side) => `&${side}`, {
+          values: {
+            bottom: '[data-location="bottom"]',
+            top: '[data-location="top"]',
           },
-          {
-            values: {
-              bottom: '[data-location="bottom"]',
-              top: '[data-location="top"]',
-            },
-          }
-        )
+        })
       },
     ],
   }
@@ -170,19 +159,14 @@ test('matched variant values maintain the sort order they are registered in', ()
     corePlugins: { preflight: false },
     plugins: [
       ({ matchVariant }) => {
-        matchVariant(
-          {
-            alphabet: (side) => `&${side}`,
+        matchVariant('alphabet', (side) => `&${side}`, {
+          values: {
+            a: '[data-value="a"]',
+            b: '[data-value="b"]',
+            c: '[data-value="c"]',
+            d: '[data-value="d"]',
           },
-          {
-            values: {
-              a: '[data-value="a"]',
-              b: '[data-value="b"]',
-              c: '[data-value="c"]',
-              d: '[data-value="d"]',
-            },
-          }
-        )
+        })
       },
     ],
   }
@@ -223,9 +207,9 @@ test('matchVariant can return an array of format strings from the function', () 
     corePlugins: { preflight: false },
     plugins: [
       ({ matchVariant }) => {
-        matchVariant({
-          test: (selector) => selector.split(',').map((selector) => `&.${selector} > *`),
-        })
+        matchVariant('test', (selector) =>
+          selector.split(',').map((selector) => `&.${selector} > *`)
+        )
       },
     ],
   }

--- a/tests/match-variants.test.js
+++ b/tests/match-variants.test.js
@@ -11,7 +11,7 @@ test('partial arbitrary variants', () => {
     corePlugins: { preflight: false },
     plugins: [
       ({ matchVariant }) => {
-        matchVariant('potato', (flavor) => `.potato-${flavor} &`)
+        matchVariant('potato', ({ value: flavor }) => `.potato-${flavor} &`)
       },
     ],
   }
@@ -45,7 +45,7 @@ test('partial arbitrary variants with at-rules', () => {
     corePlugins: { preflight: false },
     plugins: [
       ({ matchVariant }) => {
-        matchVariant('potato', (flavor) => `@media (potato: ${flavor})`)
+        matchVariant('potato', ({ value: flavor }) => `@media (potato: ${flavor})`)
       },
     ],
   }
@@ -82,7 +82,7 @@ test('partial arbitrary variants with at-rules and placeholder', () => {
     corePlugins: { preflight: false },
     plugins: [
       ({ matchVariant }) => {
-        matchVariant('potato', (flavor) => `@media (potato: ${flavor}) { &:potato }`)
+        matchVariant('potato', ({ value: flavor }) => `@media (potato: ${flavor}) { &:potato }`)
       },
     ],
   }
@@ -119,7 +119,7 @@ test('partial arbitrary variants with default values', () => {
     corePlugins: { preflight: false },
     plugins: [
       ({ matchVariant }) => {
-        matchVariant('tooltip', (side) => `&${side}`, {
+        matchVariant('tooltip', ({ value: side }) => `&${side}`, {
           values: {
             bottom: '[data-location="bottom"]',
             top: '[data-location="top"]',
@@ -159,7 +159,7 @@ test('matched variant values maintain the sort order they are registered in', ()
     corePlugins: { preflight: false },
     plugins: [
       ({ matchVariant }) => {
-        matchVariant('alphabet', (side) => `&${side}`, {
+        matchVariant('alphabet', ({ value: side }) => `&${side}`, {
           values: {
             a: '[data-value="a"]',
             b: '[data-value="b"]',
@@ -207,7 +207,7 @@ test('matchVariant can return an array of format strings from the function', () 
     corePlugins: { preflight: false },
     plugins: [
       ({ matchVariant }) => {
-        matchVariant('test', (selector) =>
+        matchVariant('test', ({ value: selector }) =>
           selector.split(',').map((selector) => `&.${selector} > *`)
         )
       },

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -291,6 +291,7 @@ export interface PluginAPI {
   addBase(base: CSSRuleObject | CSSRuleObject[]): void
   // for registering custom variants
   addVariant(name: string, definition: string | string[] | (() => string) | (() => string)[]): void
+  matchVariant(name: string, cb: (options: { value: string }) => string | string[]): void
   // for looking up values in the user’s theme configuration
   theme: <TDefaultValue = Config['theme']>(
     path?: string,


### PR DESCRIPTION
This PR will polish the currently unreleased `matchVariant` API. This API will allow you to create
dynamic variants. E.g.: `supports-[display:grid]:grid`.

The API looks very similar to the `addVariant` API, but with a callback instead.

An example for demonstrating the API:
```js
matchVariant('supports', ({ value }) => `@supports(${value})`, {
  values: {
    grid: 'display: grid', // Allows us to use just `supports-grid`
  },
})
```

Input:
```html
<div class="supports-grid:grid supports-[color:red]:text-red-500"></div> 
```

Output:
```css
@supports (display: grid) {
  .supports-grid\:grid {
    display: grid;
  }
}

@supports (color: red) {
  .supports-\[color\:red\]\:text-red-500 {
    --tw-text-opacity: 1;
    color: rgb(239 68 68 / var(--tw-text-opacity));
  }
}
```

> **Note**: the API is still subject to change, this is currently a placeholder.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
