### PR TITLE
Don't emit utilities containing invalid theme fn keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ isolate*.log
 
 # Generated files
 /src/corePluginList.js
+
+# Generated files during tests
+/tests/evaluate-tailwind-functions.test.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix ordering of parallel variants ([#9282](https://github.com/tailwindlabs/tailwindcss/pull/9282))
 - Handle variants in utility selectors using `:where()` and `:has()` ([#9309](https://github.com/tailwindlabs/tailwindcss/pull/9309))
 - Improve data type analyses for arbitrary values ([#9320](https://github.com/tailwindlabs/tailwindcss/pull/9320))
+- Don't emit generated utilities with invalid uses of theme functions ([#9319](https://github.com/tailwindlabs/tailwindcss/pull/9319))
 
 ## [3.1.8] - 2022-08-05
 


### PR DESCRIPTION
Fixes #9318

This fix isn't ideal — need to iterate on it some before merging. We shouldn't even generate the utility in the first place. The problem here is the utility and the evaluation of the `theme()` function are at two separate stages. This causes the utility to be stored in the map when it is otherwise technically invalid. As a perf optimization we don't clear out the utility list when "watching" — it's effectively append-only causing this to throw as soon as you accidentally introduce a utility w/ a theme key that doesn't exist.