### PR TITLE
Improve data type analysis for arbitrary values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't mutate shared config objects ([#9294](https://github.com/tailwindlabs/tailwindcss/pull/9294))
 - Fix ordering of parallel variants ([#9282](https://github.com/tailwindlabs/tailwindcss/pull/9282))
 - Handle variants in utility selectors using `:where()` and `:has()` ([#9309](https://github.com/tailwindlabs/tailwindcss/pull/9309))
+- Improve data type analyses for arbitrary values ([#9320](https://github.com/tailwindlabs/tailwindcss/pull/9320))
 
 ## [3.1.8] - 2022-08-05
 

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -461,7 +461,7 @@ function splitWithSeparator(input, separator) {
     return [sharedState.NOT_ON_DEMAND]
   }
 
-  return Array.from(splitAtTopLevelOnly(input, separator))
+  return splitAtTopLevelOnly(input, separator)
 }
 
 function* recordCandidates(matches, classCandidate) {

--- a/src/util/dataTypes.js
+++ b/src/util/dataTypes.js
@@ -6,10 +6,6 @@ let cssFunctions = ['min', 'max', 'clamp', 'calc']
 
 // Ref: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Types
 
-function splitBy(value, delimiter) {
-  return Array.from(splitAtTopLevelOnly(value, delimiter))
-}
-
 // This is not a data type, but rather a function that can normalize the
 // correct values.
 export function normalize(value, isRoot = true) {
@@ -63,7 +59,7 @@ export function number(value) {
 }
 
 export function percentage(value) {
-  return splitBy(value, '_').every((part) => {
+  return splitAtTopLevelOnly(value, '_').every((part) => {
     return /%$/g.test(part) || cssFunctions.some((fn) => new RegExp(`^${fn}\\(.+?%`).test(part))
   })
 }
@@ -88,7 +84,7 @@ let lengthUnits = [
 ]
 let lengthUnitsPattern = `(?:${lengthUnits.join('|')})`
 export function length(value) {
-  return splitBy(value, '_').every((part) => {
+  return splitAtTopLevelOnly(value, '_').every((part) => {
     return (
       part === '0' ||
       new RegExp(`${lengthUnitsPattern}$`).test(part) ||
@@ -117,7 +113,7 @@ export function shadow(value) {
 export function color(value) {
   let colors = 0
 
-  let result = splitBy(value, '_').every((part) => {
+  let result = splitAtTopLevelOnly(value, '_').every((part) => {
     part = normalize(part)
 
     if (part.startsWith('var(')) return true
@@ -132,7 +128,7 @@ export function color(value) {
 
 export function image(value) {
   let images = 0
-  let result = splitBy(value, ',').every((part) => {
+  let result = splitAtTopLevelOnly(value, ',').every((part) => {
     part = normalize(part)
 
     if (part.startsWith('var(')) return true
@@ -173,7 +169,7 @@ export function gradient(value) {
 let validPositions = new Set(['center', 'top', 'right', 'bottom', 'left'])
 export function position(value) {
   let positions = 0
-  let result = splitBy(value, '_').every((part) => {
+  let result = splitAtTopLevelOnly(value, '_').every((part) => {
     part = normalize(part)
 
     if (part.startsWith('var(')) return true
@@ -191,7 +187,7 @@ export function position(value) {
 
 export function familyName(value) {
   let fonts = 0
-  let result = splitBy(value, ',').every((part) => {
+  let result = splitAtTopLevelOnly(value, ',').every((part) => {
     part = normalize(part)
 
     if (part.startsWith('var(')) return true

--- a/src/util/dataTypes.js
+++ b/src/util/dataTypes.js
@@ -1,33 +1,13 @@
 import { parseColor } from './color'
 import { parseBoxShadowValue } from './parseBoxShadowValue'
+import { splitAtTopLevelOnly } from './splitAtTopLevelOnly'
 
 let cssFunctions = ['min', 'max', 'clamp', 'calc']
 
 // Ref: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Types
 
-function splitBy(value, delimiter, exceptIn = [['(', ')']]) {
-  let except = new Map(exceptIn)
-
-  let stack = []
-  let parts = []
-  let lastPos = 0
-
-  for (let [idx, char] of value.split('').entries()) {
-    if (char === delimiter && stack.length <= 0) {
-      parts.push(value.slice(lastPos, idx))
-      lastPos = idx + 1 /* Skip delimiter itself */
-    }
-
-    if (except.has(char)) {
-      stack.push(except.get(char))
-    } else if (stack[stack.length - 1] === char) {
-      stack.pop()
-    }
-  }
-
-  parts.push(value.slice(lastPos))
-
-  return parts
+function splitBy(value, delimiter) {
+  return Array.from(splitAtTopLevelOnly(value, delimiter))
 }
 
 // This is not a data type, but rather a function that can normalize the

--- a/src/util/parseBoxShadowValue.js
+++ b/src/util/parseBoxShadowValue.js
@@ -5,7 +5,7 @@ let SPACE = /\ +(?![^(]*\))/g // Similar to the one above, but with spaces inste
 let LENGTH = /^-?(\d+|\.\d+)(.*?)$/g
 
 export function parseBoxShadowValue(input) {
-  let shadows = Array.from(splitAtTopLevelOnly(input, ','))
+  let shadows = splitAtTopLevelOnly(input, ',')
   return shadows.map((shadow) => {
     let value = shadow.trim()
     let result = { raw: value }

--- a/tests/arbitrary-values.test.css
+++ b/tests/arbitrary-values.test.css
@@ -661,6 +661,9 @@
 .bg-opacity-\[var\(--value\)\] {
   --tw-bg-opacity: var(--value);
 }
+.bg-\[linear-gradient\(to_left\2c rgb\(var\(--green\)\)\2c blue\)\] {
+  background-image: linear-gradient(to left, rgb(var(--green)), blue);
+}
 .bg-\[url\(\'\/path-to-image\.png\'\)\] {
   background-image: url('/path-to-image.png');
 }

--- a/tests/arbitrary-values.test.html
+++ b/tests/arbitrary-values.test.html
@@ -220,6 +220,7 @@
     <div class="bg-[#0f0_var(--value)]"></div>
     <div class="bg-[var(--value1)_var(--value2)]"></div>
     <div class="bg-[color:var(--value1)_var(--value2)]"></div>
+    <div class="bg-[linear-gradient(to_left,rgb(var(--green)),blue)]"></div>
 
     <div class="bg-[url('/path-to-image.png')] bg-[url:var(--url)]"></div>
     <div class="bg-[linear-gradient(#eee,#fff)]"></div>


### PR DESCRIPTION
This PR fixes an issue with incorrect splitting of arbitrary values and therefore improving the data type detection so that we require fewer type hints.

The original RegEx did mostly what we want, the idea is that we wanted to split by a `,` but one that was not within `()`. This is useful when you define multiple background colors for example:
```html
<div class="bg-[rgb(0,0,0),rgb(255,255,255)]"></div>
```

In this case splitting by the regex would result in the proper result:
```js
let result = [
  'rgb(0,0,0)',
  'rgb(255,255,255)'
]
```

Visually, you can think of it like:
```
    ┌─[./example.html]
    │
∙ 1 │   <div class="bg-[rgb(0,0,0),rgb(255,255,255)]"></div>
    ·                       ──┬── ┬    ─────┬─────
    ·                         │   │         ╰─────── Guarded by parens
    ·                         │   ╰───────────────── We will split here
    ·                         ╰───────────────────── Guarded by parens
    │
    └─
```

We properly split by `,` not inside a `()`. However, this RegEx fails the moment you have deeply nested `,` values or an `(` is seen at the right of the current position. If you have the following example:

```html
<div class="bg-[rgba(0,0,0,var(--alpha))]"></div>
```

Visually, this is what's happening:
```
    ┌─[./example.html]
    │
∙ 1 │   <div class="bg-[rgba(0,0,0,var(--alpha))]"></div>
    ·                         ┬ ┬ ┬
    ·                         ╰─┴─┴── We accidentally split here
    │
    └─
```

This is because on the right of the `,`, the first paren is an opening paren `(` instead of a closing one `)`.

I'm not 100% sure how we can improve the RegEx to handle that case as well, instead I wrote a small `splitBy` function that allows you to split the string by a character (just like you could do before) but ignores the ones inside the given exceptions. This keeps track of a stack to know whether we are within parens or not.

Visually, the fix looks like this:
```
    ┌─[./example.html]
    │
∙ 1 │   <div class="bg-[rgba(0,0,0,var(--alpha)),rgb(255,255,255,var(--alpha))]"></div>
    ·                         ┬ ┬ ┬             ┬       ┬   ┬   ┬
    ·                         │ │ │             │       ╰───┴───┴── Guarded by parens
    ·                         │ │ │             ╰────────────────── We will split here
    ·                         ╰─┴─┴──────────────────────────────── Guarded by parens
    │
    └─
```

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
