### PR TITLE
Revert "Only listen for stdin close on TTYs (#8523)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handle variants in utility selectors using `:where()` and `:has()` ([#9309](https://github.com/tailwindlabs/tailwindcss/pull/9309))
 - Improve data type analyses for arbitrary values ([#9320](https://github.com/tailwindlabs/tailwindcss/pull/9320))
 - Don't emit generated utilities with invalid uses of theme functions ([#9319](https://github.com/tailwindlabs/tailwindcss/pull/9319))
+- Revert change that only listened for stdin close on TTYs ([#9331](https://github.com/tailwindlabs/tailwindcss/pull/9331))
 
 ## [3.1.8] - 2022-08-05
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -1016,10 +1016,8 @@ async function build() {
 
   if (shouldWatch) {
     /* Abort the watcher if stdin is closed to avoid zombie processes */
-    if (process.stdin.isTTY) {
-      process.stdin.on('end', () => process.exit(0))
-      process.stdin.resume()
-    }
+    process.stdin.on('end', () => process.exit(0))
+    process.stdin.resume()
     startWatcher()
   } else {
     buildOnce()


### PR DESCRIPTION
This reverts commit 14f6574318b66f7df4d8767c2c70ecb73c4ee26d.

This was originally done to fix issues with Turborepo but it had some unforeseen side effects that would leave dangling processes. For things that use Erlang (for example Phoenix) this is a problem because Erlang does not have the necessary APIs to send signals to processes — instead relying only on stdin closing behavior or wrapper scripts to work around this.

As a bonus it seems that Turborepo has updated their official tailwind example to use `concurrently` which sidesteps this problem entirely because it acts as the wrapper in this case and handles stdin for child processes appropriately.

Fixes #9264