### PR TITLE
Improve type checking for formal syntax

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1481,7 +1481,7 @@ export let corePlugins = {
   },
 
   backgroundSize: createUtilityPlugin('backgroundSize', [['bg', ['background-size']]], {
-    type: ['lookup', 'length', 'percentage'],
+    type: ['lookup', 'length', 'percentage', 'size'],
   }),
 
   backgroundAttachment: ({ addUtilities }) => {

--- a/src/util/dataTypes.js
+++ b/src/util/dataTypes.js
@@ -6,6 +6,10 @@ let cssFunctions = ['min', 'max', 'clamp', 'calc']
 
 // Ref: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Types
 
+function isCSSFunction(value) {
+  return cssFunctions.some((fn) => new RegExp(`^${fn}\\(.*\\)`).test(value))
+}
+
 // This is not a data type, but rather a function that can normalize the
 // correct values.
 export function normalize(value, isRoot = true) {
@@ -55,13 +59,11 @@ export function url(value) {
 }
 
 export function number(value) {
-  return !isNaN(Number(value)) || cssFunctions.some((fn) => new RegExp(`^${fn}\\(.+?`).test(value))
+  return !isNaN(Number(value)) || isCSSFunction(value)
 }
 
 export function percentage(value) {
-  return splitAtTopLevelOnly(value, '_').every((part) => {
-    return /%$/g.test(part) || cssFunctions.some((fn) => new RegExp(`^${fn}\\(.+?%`).test(part))
-  })
+  return (value.endsWith('%') && number(value.slice(0, -1))) || isCSSFunction(value)
 }
 
 let lengthUnits = [
@@ -84,13 +86,11 @@ let lengthUnits = [
 ]
 let lengthUnitsPattern = `(?:${lengthUnits.join('|')})`
 export function length(value) {
-  return splitAtTopLevelOnly(value, '_').every((part) => {
-    return (
-      part === '0' ||
-      new RegExp(`${lengthUnitsPattern}$`).test(part) ||
-      cssFunctions.some((fn) => new RegExp(`^${fn}\\(.+?${lengthUnitsPattern}`).test(part))
-    )
-  })
+  return (
+    value === '0' ||
+    new RegExp(`^[+-]?[0-9]*\.?[0-9]+(?:[eE][+-]?[0-9]+)?${lengthUnitsPattern}$`).test(value) ||
+    isCSSFunction(value)
+  )
 }
 
 let lineWidths = new Set(['thin', 'medium', 'thick'])

--- a/src/util/pluginUtils.js
+++ b/src/util/pluginUtils.js
@@ -18,6 +18,7 @@ import {
   shadow,
 } from './dataTypes'
 import negateValue from './negateValue'
+import { backgroundSize } from './validateFormalSyntax'
 
 export function updateAllClasses(selectors, updateClass) {
   let parser = selectorParser((selectors) => {
@@ -162,6 +163,7 @@ let typeMap = {
   'absolute-size': guess(absoluteSize),
   'relative-size': guess(relativeSize),
   shadow: guess(shadow),
+  size: guess(backgroundSize),
 }
 
 let supportedTypes = Object.keys(typeMap)

--- a/src/util/validateFormalSyntax.js
+++ b/src/util/validateFormalSyntax.js
@@ -1,0 +1,34 @@
+import { length, percentage } from './dataTypes'
+import { splitAtTopLevelOnly } from './splitAtTopLevelOnly'
+
+/**
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/background-size#formal_syntax
+ *
+ * background-size =
+ *  <bg-size>#
+ *
+ * <bg-size> =
+ *   [ <length-percentage [0,∞]> | auto ]{1,2}  |
+ *   cover                                      |
+ *   contain
+ *
+ * <length-percentage> =
+ *   <length>      |
+ *   <percentage>
+ *
+ * @param {string} value
+ */
+export function backgroundSize(value) {
+  const keywordValues = ['cover', 'contain']
+  // the <length-percentage> type will probably be a css function
+  // so we have to use `splitAtTopLevelOnly`
+  return splitAtTopLevelOnly(value, ',').every((part) => {
+    const sizes = splitAtTopLevelOnly(part, '_').filter(Boolean)
+    if (sizes.length === 1 && keywordValues.includes(sizes[0])) return true
+
+    if (sizes.length !== 1 && sizes.length !== 2) return false
+
+    return sizes.every((size) => length(size) || percentage(size) || size === 'auto')
+  })
+}

--- a/tests/arbitrary-values.test.js
+++ b/tests/arbitrary-values.test.js
@@ -456,7 +456,7 @@ it('should correctly validate combination of percentage and length', () => {
 it('can explicitly specify type for percentage and length', () => {
   let config = {
     content: [
-      { raw: html`<div class="bg-[size:50px_10%] bg-[50px_10px] bg-[position:50%_10%]"></div>` },
+      { raw: html`<div class="bg-[50px_10px] bg-[size:50px_10%] bg-[position:50%_10%]"></div>` },
     ],
     corePlugins: { preflight: false },
     plugins: [],

--- a/tests/arbitrary-values.test.js
+++ b/tests/arbitrary-values.test.js
@@ -416,3 +416,39 @@ it('should correctly validate each part when checking for `percentage` data type
     `)
   })
 })
+
+it('should correctly validate background size', () => {
+  let config = {
+    content: [{ raw: html`<div class="bg-[auto_auto,cover,_contain,10px,10px_10%]"></div>` }],
+    corePlugins: { preflight: false },
+    plugins: [],
+  }
+
+  let input = css`
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .bg-\[auto_auto\2c cover\2c _contain\2c 10px\2c 10px_10\%\] {
+        background-size: auto auto, cover, contain, 10px, 10px 10%;
+      }
+    `)
+  })
+})
+
+it('should correctly validate combination of percentage and length', () => {
+  let config = {
+    content: [{ raw: html`<div class="bg-[50px_10%] bg-[50%_10%] bg-[50px_10px]"></div>` }],
+    corePlugins: { preflight: false },
+    plugins: [],
+  }
+
+  let input = css`
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css.trim()).toHaveLength(0)
+  })
+})

--- a/tests/arbitrary-values.test.js
+++ b/tests/arbitrary-values.test.js
@@ -452,3 +452,28 @@ it('should correctly validate combination of percentage and length', () => {
     expect(result.css.trim()).toHaveLength(0)
   })
 })
+
+it('can explicitly specify type for percentage and length', () => {
+  let config = {
+    content: [
+      { raw: html`<div class="bg-[size:50px_10%] bg-[50px_10px] bg-[position:50%_10%]"></div>` },
+    ],
+    corePlugins: { preflight: false },
+    plugins: [],
+  }
+
+  let input = css`
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(`
+      .bg-\\[size\\:50px_10\\%\\] {
+        background-size: 50px 10%;
+      }
+      .bg-\\[position\\:50\\%_10\\%\\] {
+        background-position: 50% 10%;
+      }
+    `)
+  })
+})


### PR DESCRIPTION
There are type validators in `dataType.js` referencing [CSS Types](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Types), but splitting the basic data types([\<length\>](https://github.com/tailwindlabs/tailwindcss/blob/master/src/util/dataTypes.js#L62) and [\<percentage\>](https://github.com/tailwindlabs/tailwindcss/blob/master/src/util/dataTypes.js#L87) ) is not a good solution for further maintenance and development. We can just keep them as minimal validators for the css data type.


In my opinion, `familyName`  and `position` is something like [value definition syntax](https://developer.mozilla.org/en-US/docs/Web/CSS/Value_definition_syntax). And we should take them out as validators for formal syntax for better type checking, and `dataType.js` is only for basic css data types.


This PR created `validateFormalSyntax.js` and `size` type (or formal syntax) for better background-size checking based on [background-size MDN web docs](https://developer.mozilla.org/en-US/docs/Web/CSS/background-size#formal_syntax).
https://github.com/tailwindlabs/tailwindcss/blob/b37a44a85d803ca353f299c1989c425874da9af5/src/util/validateFormalSyntax.js#L22
 and I think it's also a better solution for https://github.com/tailwindlabs/tailwindcss/issues/7997, which can also fix https://github.com/tailwindlabs/tailwindcss/issues/9352

Also, as [MDN web doc](https://developer.mozilla.org/en-US/docs/Web/CSS/calc) says, the `calc() min() max() clamp()` function can all be used anywhere a [\<length\>](https://developer.mozilla.org/en-US/docs/Web/CSS/length), [\<frequency\>](https://developer.mozilla.org/en-US/docs/Web/CSS/frequency), [\<angle\>](https://developer.mozilla.org/en-US/docs/Web/CSS/angle), [\<time\>](https://developer.mozilla.org/en-US/docs/Web/CSS/time), [\<percentage\>](https://developer.mozilla.org/en-US/docs/Web/CSS/percentage), [\<number\>](https://developer.mozilla.org/en-US/docs/Web/CSS/number), or [\<integer\>](https://developer.mozilla.org/en-US/docs/Web/CSS/integer) is allowed. So we can basically just check the value is wrapped by css functions in `number`, `length`, and `percentage` https://github.com/tailwindlabs/tailwindcss/blob/b37a44a85d803ca353f299c1989c425874da9af5/src/util/dataTypes.js#L9

So we can now create some crazy stuff like
```css
/* bg-[rgb(11,22,33)] */
.bg-\[rgb\(11\2c 22\2c 33\)\] {
  --tw-bg-opacity: 1;
  background-color: rgb(11 22 33 / var(--tw-bg-opacity))
}

/* bg-[linear-gradient(45deg,_red_0_50%,_blue_50%_100%)] */
.bg-\[linear-gradient\(45deg\2c _red_0_50\%\2c _blue_50\%_100\%\)\] {
  background-image: linear-gradient(45deg, red 0 50%, blue 50% 100%)
}

/* bg-[auto_auto,cover,_contain,calc(10px_+_12%),max(20px,_10%)_10%] */
.bg-\[auto_auto\2c cover\2c _contain\2c calc\(10px_\+_12\%\)\2c max\(20px\2c _10\%\)_10\%\] {
  background-size: auto auto,cover, contain,calc(10px + 12%),max(20px, 10%) 10%
}
```
discussions: https://github.com/tailwindlabs/tailwindcss/discussions/9351