### PR TITLE
✨ Add `word-break: keep-all` with `break-keep`

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1222,7 +1222,7 @@ export let corePlugins = {
       '.break-normal': { 'overflow-wrap': 'normal', 'word-break': 'normal' },
       '.break-words': { 'overflow-wrap': 'break-word' },
       '.break-all': { 'word-break': 'break-all' },
-      '.keep-all': { 'word-break': 'keep-all' },
+      '.break-keep': { 'word-break': 'keep-all' },
     })
   },
 

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1222,6 +1222,7 @@ export let corePlugins = {
       '.break-normal': { 'overflow-wrap': 'normal', 'word-break': 'normal' },
       '.break-words': { 'overflow-wrap': 'break-word' },
       '.break-all': { 'word-break': 'break-all' },
+      '.keep-all': { 'word-break': 'keep-all' },
     })
   },
 


### PR DESCRIPTION
ref. https://developer.mozilla.org/en-US/docs/Web/CSS/word-break

`whitespace-nowrap` and `word-break: keep-all` behave differently in different browsers.

Demo: https://jsfiddle.net/h1aj6nvy/

There is a difference between Firefox and Google chrome.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
