### PR TITLE
Implement the `supports` variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `@config` support ([#9405](https://github.com/tailwindlabs/tailwindcss/pull/9405))
 - Add `fill-none` and `stroke-none` utilities by default ([#9403](https://github.com/tailwindlabs/tailwindcss/pull/9403))
 - Support `sort` function in `matchVariant` ([#9423](https://github.com/tailwindlabs/tailwindcss/pull/9423))
+- Implement the `supports` variant ([#9453](https://github.com/tailwindlabs/tailwindcss/pull/9453))
 
 ### Fixed
 

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -234,7 +234,7 @@ export let variantPlugins = {
         }
 
         if (!check.includes(':')) {
-          check = `${check}: var(--tw-empty)`
+          check = `${check}: var(--tw)`
         }
 
         if (!(check.startsWith('(') && check.endsWith(')'))) {

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -16,6 +16,7 @@ import { normalizeScreens } from './util/normalizeScreens'
 import { formatBoxShadowValue, parseBoxShadowValue } from './util/parseBoxShadowValue'
 import { removeAlphaVariables } from './util/removeAlphaVariables'
 import { flagEnabled } from './featureFlags'
+import { normalize } from './util/dataTypes'
 
 export let variantPlugins = {
   pseudoElementVariants: ({ addVariant }) => {
@@ -213,6 +214,37 @@ export let variantPlugins = {
 
       addVariant(screen.name, `@media ${query}`)
     }
+  },
+
+  supportsVariants: ({ matchVariant, theme, config }) => {
+    if (!flagEnabled(config(), 'matchVariant')) return
+
+    matchVariant(
+      'supports',
+      ({ value = '' }) => {
+        let check = normalize(value)
+        let isRaw = /^\w*\s*\(/.test(check)
+
+        // Chrome has a bug where `(condtion1)or(condition2)` is not valid
+        // But `(condition1) or (condition2)` is supported.
+        check = isRaw ? check.replace(/\b(and|or|not)\b/g, ' $1 ') : check
+
+        if (isRaw) {
+          return `@supports ${check}`
+        }
+
+        if (!check.includes(':')) {
+          check = `${check}: var(--tw-empty)`
+        }
+
+        if (!(check.startsWith('(') && check.endsWith(')'))) {
+          check = `(${check})`
+        }
+
+        return `@supports ${check} `
+      },
+      { values: theme('supports') ?? {} }
+    )
   },
 
   orientationVariants: ({ addVariant }) => {

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -655,6 +655,7 @@ function resolvePlugins(context, root) {
     variantPlugins['pseudoClassVariants'],
   ]
   let afterVariants = [
+    variantPlugins['supportsVariants'],
     variantPlugins['directionVariants'],
     variantPlugins['reducedMotionVariants'],
     variantPlugins['prefersContrastVariants'],

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -640,7 +640,7 @@ it('should support supports', () => {
             <div class="supports-[(foo:bar)or(bar:baz)]:underline"></div>
             <!-- 'and' check (raw) -->
             <div class="supports-[(foo:bar)and(bar:baz)]:underline"></div>
-            <!-- No value give for the property, defaulting to prop: var(--tw-empty) -->
+            <!-- No value give for the property, defaulting to prop: var(--tw) -->
             <div class="supports-[container-type]:underline"></div>
             <!-- Named supports usage -->
             <div class="supports-grid:underline"></div>
@@ -699,7 +699,7 @@ it('should support supports', () => {
         }
       }
 
-      @supports (container-type: var(--tw-empty)) {
+      @supports (container-type: var(--tw)) {
         .supports-\[container-type\]\:underline {
           text-decoration-line: underline;
         }

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -615,3 +615,95 @@ test('classes in the same arbitrary variant should not be prefixed', () => {
     `)
   })
 })
+
+it('should support supports', () => {
+  let config = {
+    experimental: { matchVariant: true },
+    theme: {
+      supports: {
+        grid: 'display: grid',
+      },
+    },
+    content: [
+      {
+        raw: html`
+          <div>
+            <!-- Property check -->
+            <div class="supports-[display:grid]:grid"></div>
+            <!-- Value with spaces, needs to be normalized -->
+            <div class="supports-[transform-origin:5%_5%]:underline"></div>
+            <!-- Selectors (raw) -->
+            <div class="supports-[selector(A>B)]:underline"></div>
+            <!-- 'not' check (raw) -->
+            <div class="supports-[not(foo:bar)]:underline"></div>
+            <!-- 'or' check (raw) -->
+            <div class="supports-[(foo:bar)or(bar:baz)]:underline"></div>
+            <!-- 'and' check (raw) -->
+            <div class="supports-[(foo:bar)and(bar:baz)]:underline"></div>
+            <!-- No value give for the property, defaulting to prop: var(--tw-empty) -->
+            <div class="supports-[container-type]:underline"></div>
+            <!-- Named supports usage -->
+            <div class="supports-grid:underline"></div>
+          </div>
+        `,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      @supports (display: grid) {
+        .supports-grid\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @supports (display: grid) {
+        .supports-\[display\:grid\]\:grid {
+          display: grid;
+        }
+      }
+
+      @supports (transform-origin: 5% 5%) {
+        .supports-\[transform-origin\:5\%_5\%\]\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @supports selector(A > B) {
+        .supports-\[selector\(A\>B\)\]\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @supports not (foo: bar) {
+        .supports-\[not\(foo\:bar\)\]\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @supports (foo: bar) or (bar: baz) {
+        .supports-\[\(foo\:bar\)or\(bar\:baz\)\]\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @supports (foo: bar) and (bar: baz) {
+        .supports-\[\(foo\:bar\)and\(bar\:baz\)\]\:underline {
+          text-decoration-line: underline;
+        }
+      }
+
+      @supports (container-type: var(--tw-empty)) {
+        .supports-\[container-type\]\:underline {
+          text-decoration-line: underline;
+        }
+      }
+    `)
+  })
+})


### PR DESCRIPTION
This PR adds a new `supports` variant.

It allows you to check if a certain css property / value is supported or not so that you can apply certain utilities or not.

This variant doesn't ship with any named variants, but you can use arbitrary variants which gives you the full flexibility of this variant plugin.

E.g.:
```html
<div class="supports-[display:grid]:grid"></div>
```

Which results in the following css:
```css
@supports (display: grid) {
  /* ... */
}
```

If you require spaces in your supports check, then you can use the `_` similar to how we handle that in arbitrary values already.

```html
<div class="supports-[transform-origin:5%_5%]:grid"></div>
```

Which results in the following css:
```css
@supports (transform-origin: 5% 5%) {
  /* ... */
}
```

If you are just interested in checking wether the propery is supported regardless of the value, then you can just provide the property name and we will fill in a value for you:

```html
<div class="supports-[container-type]:grid"></div>
```

Which results in the following css:

```css
@supports (container-type: var(--tw)) {
  /* ... */
}
```

We also read from your config file if you want named supports variants if there is a check you are repeating all over the place.

```js
module.exports = {
  theme: {
    // ...
    supports: {
      grid: 'display: grid'
    }
  }
}
```

```html
<div class="supports-grid:grid"></div>
```

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
