### PR TITLE
Added `block` & `inline` properties for `scroll-snap-type`

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -809,6 +809,8 @@ export let corePlugins = {
 
     addUtilities({
       '.snap-none': { 'scroll-snap-type': 'none' },
+      '.snap-block': { 'scroll-snap-type': 'block' },
+      '.snap-inline': { 'scroll-snap-type': 'inline' },
       '.snap-x': {
         '@defaults scroll-snap-type': {},
         'scroll-snap-type': 'x var(--tw-scroll-snap-strictness)',


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->

Reference: https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-snap-type

`block`: The scroll container snaps to snap positions in its block axis only.

`inline`: The scroll container snaps to snap positions in its inline axis only.