### PR TITLE
Make `Config` completely optional for plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ignore unset values (like `null` or `undefined`) when resolving the classList for intellisense ([#9385](https://github.com/tailwindlabs/tailwindcss/pull/9385))
 - Implement fallback plugins when arbitrary values result in css from multiple plugins ([#9376](https://github.com/tailwindlabs/tailwindcss/pull/9376))
 - Improve type checking for formal syntax ([#9349](https://github.com/tailwindlabs/tailwindcss/pull/9349), [#9448](https://github.com/tailwindlabs/tailwindcss/pull/9448))
+- Don't require `content` key in custom plugin configs ([#9502](https://github.com/tailwindlabs/tailwindcss/pull/9502))
 
 ## [3.1.8] - 2022-08-05
 

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -2,9 +2,9 @@ import type { Config, PluginCreator } from './types/config'
 type Plugin = {
   withOptions<T>(
     plugin: (options: T) => PluginCreator,
-    config?: (options: T) => Config
-  ): { (options: T): { handler: PluginCreator; config?: Config }; __isOptionsFunction: true }
-  (plugin: PluginCreator, config?: Config): { handler: PluginCreator; config?: Config }
+    config?: (options: T) => Partial<Config>
+  ): { (options: T): { handler: PluginCreator; config?: Partial<Config> }; __isOptionsFunction: true }
+  (plugin: PluginCreator, config?: Partial<Config>): { handler: PluginCreator; config?: Partial<Config> }
 }
 
 declare const plugin: Plugin


### PR DESCRIPTION
Right now the `Config` type requires a `content` key. However, for plugins, this should be completely optional. There’s little reason for a plugin to override content. All other keys are already optional by virtue of using `Partial<…>` so we’ll do the same for the `Config` type used by plugins.

Fixes #9499