### PR TITLE
Expose `context.getVariants` for intellisense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add aria variants ([#9557](https://github.com/tailwindlabs/tailwindcss/pull/9557))
 - Add `data-*` variants ([#9559](https://github.com/tailwindlabs/tailwindcss/pull/9559))
 - Upgrade to `postcss-nested` v6.0 ([#9546](https://github.com/tailwindlabs/tailwindcss/pull/9546))
+- Expose `context.getVariants` for intellisense ([#9505](https://github.com/tailwindlabs/tailwindcss/pull/9505))
 
 ### Fixed
 

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -375,7 +375,7 @@ export let variantPlugins = {
           check = `(${check})`
         }
 
-        return `@supports ${check} `
+        return `@supports ${check}`
       },
       { values: theme('supports') ?? {} }
     )

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -18,7 +18,7 @@ let classNameParser = selectorParser((selectors) => {
   return selectors.first.filter(({ type }) => type === 'class').pop().value
 })
 
-function getClassNameFromSelector(selector) {
+export function getClassNameFromSelector(selector) {
   return classNameParser.transformSync(selector)
 }
 

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -963,7 +963,7 @@ function registerPlugins(plugins, context) {
   context.getVariants = function getVariants() {
     let result = []
     for (let [name, options] of context.variantOptions.entries()) {
-      if (options.variantInfo === 1) continue
+      if (options.variantInfo === VARIANT_INFO.Base) continue
 
       result.push({
         name,

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -969,7 +969,7 @@ function registerPlugins(plugins, context) {
         name,
         isArbitrary: options.type === Symbol.for('MATCH_VARIANT'),
         values: Object.keys(options.values ?? {}),
-        selectors({ label, value } = {}) {
+        selectors({ modifier, value } = {}) {
           let candidate = '__TAILWIND_PLACEHOLDER__'
 
           let fns = (context.variantMap.get(name) ?? []).flatMap(([_, fn]) => fn)
@@ -979,7 +979,7 @@ function registerPlugins(plugins, context) {
             let localFormatStrings = []
 
             let api = {
-              args: { label, value: options.values?.[value] ?? value },
+              args: { modifier, value: options.values?.[value] ?? value },
               separator: context.tailwindConfig.separator,
               modifySelectors() {},
               format(str) {

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -975,6 +975,8 @@ function registerPlugins(plugins, context) {
           let rule = postcss.rule({ selector: `.${candidate}` })
           let container = postcss.root({ nodes: [rule.clone()] })
 
+          let before = container.toString()
+
           let fns = (context.variantMap.get(name) ?? []).flatMap(([_, fn]) => fn)
           let formatStrings = []
           for (let fn of fns) {
@@ -1027,39 +1029,42 @@ function registerPlugins(plugins, context) {
 
           // Reverse engineer the result of the `container`
           let manualFormatStrings = []
+          let after = container.toString()
 
-          // Figure out all selectors
-          container.walkRules((rule) => {
-            let modified = rule.selector
+          if (before !== after) {
+            // Figure out all selectors
+            container.walkRules((rule) => {
+              let modified = rule.selector
 
-            // Rebuild the base selector, this is what plugin authors would do
-            // as well. E.g.: `${variant}${separator}${className}`.
-            // However, plugin authors probably also prepend or append certain
-            // classes, pseudos, ids, ...
-            let rebuiltBase = selectorParser((selectors) => {
-              selectors.walkClasses((classNode) => {
-                classNode.value = `${name}${context.tailwindConfig.separator}${classNode.value}`
-              })
-            }).processSync(modified)
+              // Rebuild the base selector, this is what plugin authors would do
+              // as well. E.g.: `${variant}${separator}${className}`.
+              // However, plugin authors probably also prepend or append certain
+              // classes, pseudos, ids, ...
+              let rebuiltBase = selectorParser((selectors) => {
+                selectors.walkClasses((classNode) => {
+                  classNode.value = `${name}${context.tailwindConfig.separator}${classNode.value}`
+                })
+              }).processSync(modified)
 
-            // Now that we know the original selector, the new selector, and
-            // the rebuild part in between, we can replace the part that plugin
-            // authors need to rebuild with `&`, and eventually store it in the
-            // collectedFormats. Similar to what `format('...')` would do.
-            //
-            // E.g.:
-            //                   variant: foo
-            //                  selector: .markdown > p
-            //      modified (by plugin): .foo .foo\\:markdown > p
-            //    rebuiltBase (internal): .foo\\:markdown > p
-            //                    format: .foo &
-            manualFormatStrings.push(modified.replace(rebuiltBase, '&').replace(candidate, '&'))
-          })
+              // Now that we know the original selector, the new selector, and
+              // the rebuild part in between, we can replace the part that plugin
+              // authors need to rebuild with `&`, and eventually store it in the
+              // collectedFormats. Similar to what `format('...')` would do.
+              //
+              // E.g.:
+              //                   variant: foo
+              //                  selector: .markdown > p
+              //      modified (by plugin): .foo .foo\\:markdown > p
+              //    rebuiltBase (internal): .foo\\:markdown > p
+              //                    format: .foo &
+              manualFormatStrings.push(modified.replace(rebuiltBase, '&').replace(candidate, '&'))
+            })
 
-          // Figure out all atrules
-          container.walkAtRules((atrule) => {
-            manualFormatStrings.push(`@${atrule.name} (${atrule.params}) { & }`)
-          })
+            // Figure out all atrules
+            container.walkAtRules((atrule) => {
+              manualFormatStrings.push(`@${atrule.name} (${atrule.params}) { & }`)
+            })
+          }
 
           let result = formatStrings.map((formatString) =>
             finalizeSelector(formatVariantSelector('&', ...formatString), {
@@ -1074,8 +1079,7 @@ function registerPlugins(plugins, context) {
           )
 
           if (manualFormatStrings.length > 0) {
-            let combinedSelectorString = formatVariantSelector('&', ...manualFormatStrings)
-            if (combinedSelectorString !== '.&') result.push(combinedSelectorString)
+            result.push(formatVariantSelector('&', ...manualFormatStrings))
           }
 
           return result

--- a/tests/getVariants.test.js
+++ b/tests/getVariants.test.js
@@ -1,0 +1,105 @@
+import resolveConfig from '../src/public/resolve-config'
+import { createContext } from '../src/lib/setupContextUtils'
+
+it('should return a list of variants with meta information about the variant', () => {
+  let config = {}
+  let context = createContext(resolveConfig(config))
+
+  let variants = context.getVariants()
+
+  expect(variants).toContainEqual({
+    name: 'hover',
+    isArbitrary: false,
+    values: [],
+    selectors: expect.any(Function),
+  })
+
+  expect(variants).toContainEqual({
+    name: 'group',
+    isArbitrary: true,
+    values: expect.any(Array),
+    selectors: expect.any(Function),
+  })
+
+  // `group-hover` now belongs to the `group` variant. The information exposed for the `group`
+  // variant is all you need.
+  expect(variants.find((v) => v.name === 'group-hover')).toBeUndefined()
+})
+
+it('should provide selectors for simple variants', () => {
+  let config = {}
+  let context = createContext(resolveConfig(config))
+
+  let variants = context.getVariants()
+
+  let variant = variants.find((v) => v.name === 'hover')
+  expect(variant.selectors()).toEqual(['&:hover'])
+})
+
+it('should provide selectors for parallel variants', () => {
+  let config = {}
+  let context = createContext(resolveConfig(config))
+
+  let variants = context.getVariants()
+
+  let variant = variants.find((v) => v.name === 'marker')
+  expect(variant.selectors()).toEqual(['& *::marker', '&::marker'])
+})
+
+it('should provide selectors for complex matchVariant variants like `group`', () => {
+  let config = {}
+  let context = createContext(resolveConfig(config))
+
+  let variants = context.getVariants()
+
+  let variant = variants.find((v) => v.name === 'group')
+  expect(variant.selectors()).toEqual(['.group &'])
+  expect(variant.selectors({})).toEqual(['.group &'])
+  expect(variant.selectors({ value: 'hover' })).toEqual(['.group:hover &'])
+  expect(variant.selectors({ value: '.foo_&' })).toEqual(['.foo .group &'])
+  expect(variant.selectors({ label: 'foo', value: 'hover' })).toEqual(['.group\\<foo\\>:hover &'])
+  expect(variant.selectors({ label: 'foo', value: '.foo_&' })).toEqual(['.foo .group\\<foo\\> &'])
+})
+
+it('should provide selectors for variants with atrules', () => {
+  let config = {}
+  let context = createContext(resolveConfig(config))
+
+  let variants = context.getVariants()
+
+  let variant = variants.find((v) => v.name === 'supports')
+  expect(variant.selectors({ value: 'display:grid' })).toEqual(['@supports (display:grid)'])
+  expect(variant.selectors({ value: 'aspect-ratio' })).toEqual([
+    '@supports (aspect-ratio: var(--tw))',
+  ])
+})
+
+it('should provide selectors for custom plugins that do a combination of parallel variants with labels with arbitrary values and with atrules', () => {
+  let config = {
+    plugins: [
+      function ({ matchVariant }) {
+        matchVariant('foo', ({ label, value }) => {
+          return [
+            `
+              @supports (foo: ${label}) {
+                @media (width <= 400px) {
+                   &:hover
+                }
+              }
+            `,
+            `.${label}\\/${value} &:focus`,
+          ]
+        })
+      },
+    ],
+  }
+  let context = createContext(resolveConfig(config))
+
+  let variants = context.getVariants()
+
+  let variant = variants.find((v) => v.name === 'foo')
+  expect(variant.selectors({ label: 'bar', value: 'baz' })).toEqual([
+    '@supports (foo: bar) { @media (width <= 400px) { &:hover } }',
+    '.bar\\/baz &:focus',
+  ])
+})

--- a/tests/getVariants.test.js
+++ b/tests/getVariants.test.js
@@ -57,8 +57,8 @@ it('should provide selectors for complex matchVariant variants like `group`', ()
   expect(variant.selectors({})).toEqual(['.group &'])
   expect(variant.selectors({ value: 'hover' })).toEqual(['.group:hover &'])
   expect(variant.selectors({ value: '.foo_&' })).toEqual(['.foo .group &'])
-  expect(variant.selectors({ label: 'foo', value: 'hover' })).toEqual(['.group\\<foo\\>:hover &'])
-  expect(variant.selectors({ label: 'foo', value: '.foo_&' })).toEqual(['.foo .group\\<foo\\> &'])
+  expect(variant.selectors({ modifier: 'foo', value: 'hover' })).toEqual(['.group\\/foo:hover &'])
+  expect(variant.selectors({ modifier: 'foo', value: '.foo_&' })).toEqual(['.foo .group\\/foo &'])
 })
 
 it('should provide selectors for variants with atrules', () => {
@@ -74,20 +74,20 @@ it('should provide selectors for variants with atrules', () => {
   ])
 })
 
-it('should provide selectors for custom plugins that do a combination of parallel variants with labels with arbitrary values and with atrules', () => {
+it('should provide selectors for custom plugins that do a combination of parallel variants with modifiers with arbitrary values and with atrules', () => {
   let config = {
     plugins: [
       function ({ matchVariant }) {
-        matchVariant('foo', ({ label, value }) => {
+        matchVariant('foo', ({ modifier, value }) => {
           return [
             `
-              @supports (foo: ${label}) {
+              @supports (foo: ${modifier}) {
                 @media (width <= 400px) {
                    &:hover
                 }
               }
             `,
-            `.${label}\\/${value} &:focus`,
+            `.${modifier}\\/${value} &:focus`,
           ]
         })
       },
@@ -98,7 +98,7 @@ it('should provide selectors for custom plugins that do a combination of paralle
   let variants = context.getVariants()
 
   let variant = variants.find((v) => v.name === 'foo')
-  expect(variant.selectors({ label: 'bar', value: 'baz' })).toEqual([
+  expect(variant.selectors({ modifier: 'bar', value: 'baz' })).toEqual([
     '@supports (foo: bar) { @media (width <= 400px) { &:hover } }',
     '.bar\\/baz &:focus',
   ])

--- a/tests/getVariants.test.js
+++ b/tests/getVariants.test.js
@@ -80,7 +80,7 @@ it('should provide selectors for custom plugins that do a combination of paralle
   let config = {
     plugins: [
       function ({ matchVariant }) {
-        matchVariant('foo', ({ modifier, value }) => {
+        matchVariant('foo', (value, { modifier }) => {
           return [
             `
               @supports (foo: ${modifier}) {


### PR DESCRIPTION
This PR exposes a new `context.getVariants` API which is mainly used in the intellisense PR.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
