### PR TITLE
Switch to alternate variant label / modifier syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `fill-none` and `stroke-none` utilities by default ([#9403](https://github.com/tailwindlabs/tailwindcss/pull/9403))
 - Support `sort` function in `matchVariant` ([#9423](https://github.com/tailwindlabs/tailwindcss/pull/9423))
 - Implement the `supports` variant ([#9453](https://github.com/tailwindlabs/tailwindcss/pull/9453))
-- Add experimental `label`s for variants ([#9456](https://github.com/tailwindlabs/tailwindcss/pull/9456))
+- Add experimental `label`s for variants ([#9456](https://github.com/tailwindlabs/tailwindcss/pull/9456), [#9520](https://github.com/tailwindlabs/tailwindcss/pull/9520))
 - Added 'place-content-baseline' utility ([#9498](https://github.com/tailwindlabs/tailwindcss/pull/9498))
 - Added 'place-items-baseline' utility ([#9507](https://github.com/tailwindlabs/tailwindcss/pull/9507))
 - Added 'content-baseline' utility ([#9507](https://github.com/tailwindlabs/tailwindcss/pull/9507))

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -144,20 +144,20 @@ export let variantPlugins = {
     }
 
     let variants = {
-      group: ({ label }) =>
-        label ? [`:merge(.group\\/${label})`, ' &'] : [`:merge(.group)`, ' &'],
-      peer: ({ label }) =>
-        label ? [`:merge(.peer\\/${label})`, ' ~ &'] : [`:merge(.peer)`, ' ~ &'],
+      group: ({ modifier }) =>
+        modifier ? [`:merge(.group\\/${modifier})`, ' &'] : [`:merge(.group)`, ' &'],
+      peer: ({ modifier }) =>
+        modifier ? [`:merge(.peer\\/${modifier})`, ' ~ &'] : [`:merge(.peer)`, ' ~ &'],
     }
 
     for (let [name, fn] of Object.entries(variants)) {
       matchVariant(
         name,
         (ctx = {}) => {
-          let { label, value = '' } = ctx
-          if (label) {
-            log.warn(`labelled-${name}-experimental`, [
-              `The labelled ${name} feature in Tailwind CSS is currently in preview.`,
+          let { modifier, value = '' } = ctx
+          if (modifier) {
+            log.warn(`modifier-${name}-experimental`, [
+              `The ${name} variant modifier feature in Tailwind CSS is currently in preview.`,
               'Preview features are not covered by semver, and may be improved in breaking ways at any time.',
             ])
           }
@@ -165,7 +165,7 @@ export let variantPlugins = {
           let result = normalize(typeof value === 'function' ? value(ctx) : value)
           if (!result.includes('&')) result = '&' + result
 
-          let [a, b] = fn({ label })
+          let [a, b] = fn({ modifier })
           return result.replace(/&(\S+)?/g, (_, pseudo = '') => a + pseudo + b)
         },
         { values: Object.fromEntries(pseudoVariants) }

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -145,9 +145,9 @@ export let variantPlugins = {
 
     let variants = {
       group: ({ label }) =>
-        label ? [`:merge(.group\\<${label}\\>)`, ' &'] : [`:merge(.group)`, ' &'],
+        label ? [`:merge(.group\\/${label})`, ' &'] : [`:merge(.group)`, ' &'],
       peer: ({ label }) =>
-        label ? [`:merge(.peer\\<${label}\\>)`, ' ~ &'] : [`:merge(.peer)`, ' ~ &'],
+        label ? [`:merge(.peer\\/${label})`, ' ~ &'] : [`:merge(.peer)`, ' ~ &'],
     }
 
     for (let [name, fn] of Object.entries(variants)) {

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -132,10 +132,10 @@ function applyVariant(variant, matches, context) {
 
   // Retrieve "label"
   {
-    let match = /^[\w-]+\<(.*)\>-/g.exec(variant)
+    let match = /(.*)\/(.*)$/g.exec(variant)
     if (match) {
-      variant = variant.replace(`<${match[1]}>`, '')
-      args.label = match[1]
+      variant = match[1]
+      args.label = match[2]
     }
   }
 

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -130,12 +130,12 @@ function applyVariant(variant, matches, context) {
 
   let args = {}
 
-  // Retrieve "label"
+  // Retrieve "modifier"
   {
     let match = /(.*)\/(.*)$/g.exec(variant)
     if (match) {
       variant = match[1]
-      args.label = match[2]
+      args.modifier = match[2]
     }
   }
 

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -707,7 +707,7 @@ it('should support supports', () => {
   })
 })
 
-it('should be possible to use labels and arbitrary groups', () => {
+it('should be possible to use modifiers and arbitrary groups', () => {
   let config = {
     content: [
       {
@@ -736,7 +736,7 @@ it('should be possible to use labels and arbitrary groups', () => {
               <div class="group-[.in-foo]:underline"></div>
             </div>
 
-            <!-- The same as above, but with labels -->
+            <!-- The same as above, but with modifiers -->
             <div class="group/foo">
             <div class="group/foo">
             <div class="group/foo">
@@ -824,7 +824,7 @@ it('should be possible to use labels and arbitrary groups', () => {
   })
 })
 
-it('should be possible to use labels and arbitrary peers', () => {
+it('should be possible to use modifiers and arbitrary peers', () => {
   let config = {
     content: [
       {
@@ -853,7 +853,7 @@ it('should be possible to use labels and arbitrary peers', () => {
               <div class="peer-[.in-foo]:underline"></div>
             </div>
 
-            <!-- The same as above, but with labels -->
+            <!-- The same as above, but with modifiers -->
             <div class="peer/foo">
             <div class="peer/foo">
             <div class="peer/foo">

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -737,17 +737,33 @@ it('should be possible to use labels and arbitrary groups', () => {
             </div>
 
             <!-- The same as above, but with labels -->
-            <div class="group<foo>">
-              <div class="group<foo>-hover:underline"></div>
+            <div class="group/foo">
+            <div class="group/foo">
+            <div class="group/foo">
+              <div class="group-hover/foo:underline"></div>
+              <div class="group-hover/foo:underline"></div>
+              <div class="group-hover/foo:underline"></div>
 
-              <div class="group<foo>-[&:focus]:underline"></div>
-              <div class="group<foo>-[:hover]:underline"></div>
+              <div class="group-[&:focus]/foo:underline"></div>
+              <div class="group-[&:focus]/foo:underline"></div>
+              <div class="group-[&:focus]/foo:underline"></div>
+              <div class="group-[:hover]/foo:underline"></div>
+              <div class="group-[:hover]/foo:underline"></div>
+              <div class="group-[:hover]/foo:underline"></div>
 
-              <div class="group<foo>-[&[data-open]]:underline"></div>
-              <div class="group<foo>-[[data-open]]:underline"></div>
+              <div class="group-[&[data-open]]/foo:underline"></div>
+              <div class="group-[&[data-open]]/foo:underline"></div>
+              <div class="group-[&[data-open]]/foo:underline"></div>
+              <div class="group-[[data-open]]/foo:underline"></div>
+              <div class="group-[[data-open]]/foo:underline"></div>
+              <div class="group-[[data-open]]/foo:underline"></div>
 
-              <div class="group<foo>-[.in-foo_&]:underline"></div>
-              <div class="group<foo>-[.in-foo]:underline"></div>
+              <div class="group-[.in-foo_&]/foo:underline"></div>
+              <div class="group-[.in-foo_&]/foo:underline"></div>
+              <div class="group-[.in-foo_&]/foo:underline"></div>
+              <div class="group-[.in-foo]/foo:underline"></div>
+              <div class="group-[.in-foo]/foo:underline"></div>
+              <div class="group-[.in-foo]/foo:underline"></div>
             </div>
           </div>
         `,
@@ -765,7 +781,7 @@ it('should be possible to use labels and arbitrary groups', () => {
       .group:hover .group-hover\:underline {
         text-decoration-line: underline;
       }
-      .group\<foo\>:hover .group\<foo\>-hover\:underline {
+      .group\/foo:hover .group-hover\/foo\:underline {
         text-decoration-line: underline;
       }
       .group:focus .group-\[\&\:focus\]\:underline {
@@ -786,22 +802,22 @@ it('should be possible to use labels and arbitrary groups', () => {
       .group.in-foo .group-\[\.in-foo\]\:underline {
         text-decoration-line: underline;
       }
-      .group\<foo\>:focus .group\<foo\>-\[\&\:focus\]\:underline {
+      .group\/foo:focus .group-\[\&\:focus\]\/foo\:underline {
         text-decoration-line: underline;
       }
-      .group\<foo\>:hover .group\<foo\>-\[\:hover\]\:underline {
+      .group\/foo:hover .group-\[\:hover\]\/foo\:underline {
         text-decoration-line: underline;
       }
-      .group\<foo\>[data-open] .group\<foo\>-\[\&\[data-open\]\]\:underline {
+      .group\/foo[data-open] .group-\[\&\[data-open\]\]\/foo\:underline {
         text-decoration-line: underline;
       }
-      .group\<foo\>[data-open] .group\<foo\>-\[\[data-open\]\]\:underline {
+      .group\/foo[data-open] .group-\[\[data-open\]\]\/foo\:underline {
         text-decoration-line: underline;
       }
-      .in-foo .group\<foo\> .group\<foo\>-\[\.in-foo_\&\]\:underline {
+      .in-foo .group\/foo .group-\[\.in-foo_\&\]\/foo\:underline {
         text-decoration-line: underline;
       }
-      .group\<foo\>.in-foo .group\<foo\>-\[\.in-foo\]\:underline {
+      .group\/foo.in-foo .group-\[\.in-foo\]\/foo\:underline {
         text-decoration-line: underline;
       }
     `)
@@ -838,17 +854,33 @@ it('should be possible to use labels and arbitrary peers', () => {
             </div>
 
             <!-- The same as above, but with labels -->
-            <div class="peer<foo>">
-              <div class="peer<foo>-hover:underline"></div>
+            <div class="peer/foo">
+            <div class="peer/foo">
+            <div class="peer/foo">
+              <div class="peer-hover/foo:underline"></div>
+              <div class="peer-hover/foo:underline"></div>
+              <div class="peer-hover/foo:underline"></div>
 
-              <div class="peer<foo>-[&:focus]:underline"></div>
-              <div class="peer<foo>-[:hover]:underline"></div>
+              <div class="peer-[&:focus]/foo:underline"></div>
+              <div class="peer-[&:focus]/foo:underline"></div>
+              <div class="peer-[&:focus]/foo:underline"></div>
+              <div class="peer-[:hover]/foo:underline"></div>
+              <div class="peer-[:hover]/foo:underline"></div>
+              <div class="peer-[:hover]/foo:underline"></div>
 
-              <div class="peer<foo>-[&[data-open]]:underline"></div>
-              <div class="peer<foo>-[[data-open]]:underline"></div>
+              <div class="peer-[&[data-open]]/foo:underline"></div>
+              <div class="peer-[&[data-open]]/foo:underline"></div>
+              <div class="peer-[&[data-open]]/foo:underline"></div>
+              <div class="peer-[[data-open]]/foo:underline"></div>
+              <div class="peer-[[data-open]]/foo:underline"></div>
+              <div class="peer-[[data-open]]/foo:underline"></div>
 
-              <div class="peer<foo>-[.in-foo_&]:underline"></div>
-              <div class="peer<foo>-[.in-foo]:underline"></div>
+              <div class="peer-[.in-foo_&]/foo:underline"></div>
+              <div class="peer-[.in-foo_&]/foo:underline"></div>
+              <div class="peer-[.in-foo_&]/foo:underline"></div>
+              <div class="peer-[.in-foo]/foo:underline"></div>
+              <div class="peer-[.in-foo]/foo:underline"></div>
+              <div class="peer-[.in-foo]/foo:underline"></div>
             </div>
           </div>
         `,
@@ -866,7 +898,7 @@ it('should be possible to use labels and arbitrary peers', () => {
       .peer:hover ~ .peer-hover\:underline {
         text-decoration-line: underline;
       }
-      .peer\<foo\>:hover ~ .peer\<foo\>-hover\:underline {
+      .peer\/foo:hover ~ .peer-hover\/foo\:underline {
         text-decoration-line: underline;
       }
       .peer:focus ~ .peer-\[\&\:focus\]\:underline {
@@ -887,22 +919,22 @@ it('should be possible to use labels and arbitrary peers', () => {
       .peer.in-foo ~ .peer-\[\.in-foo\]\:underline {
         text-decoration-line: underline;
       }
-      .peer\<foo\>:focus ~ .peer\<foo\>-\[\&\:focus\]\:underline {
+      .peer\/foo:focus ~ .peer-\[\&\:focus\]\/foo\:underline {
         text-decoration-line: underline;
       }
-      .peer\<foo\>:hover ~ .peer\<foo\>-\[\:hover\]\:underline {
+      .peer\/foo:hover ~ .peer-\[\:hover\]\/foo\:underline {
         text-decoration-line: underline;
       }
-      .peer\<foo\>[data-open] ~ .peer\<foo\>-\[\&\[data-open\]\]\:underline {
+      .peer\/foo[data-open] ~ .peer-\[\&\[data-open\]\]\/foo\:underline {
         text-decoration-line: underline;
       }
-      .peer\<foo\>[data-open] ~ .peer\<foo\>-\[\[data-open\]\]\:underline {
+      .peer\/foo[data-open] ~ .peer-\[\[data-open\]\]\/foo\:underline {
         text-decoration-line: underline;
       }
-      .in-foo .peer\<foo\> ~ .peer\<foo\>-\[\.in-foo_\&\]\:underline {
+      .in-foo .peer\/foo ~ .peer-\[\.in-foo_\&\]\/foo\:underline {
         text-decoration-line: underline;
       }
-      .peer\<foo\>.in-foo ~ .peer\<foo\>-\[\.in-foo\]\:underline {
+      .peer\/foo.in-foo ~ .peer-\[\.in-foo\]\/foo\:underline {
         text-decoration-line: underline;
       }
     `)

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -738,31 +738,15 @@ it('should be possible to use modifiers and arbitrary groups', () => {
 
             <!-- The same as above, but with modifiers -->
             <div class="group/foo">
-            <div class="group/foo">
-            <div class="group/foo">
-              <div class="group-hover/foo:underline"></div>
-              <div class="group-hover/foo:underline"></div>
               <div class="group-hover/foo:underline"></div>
 
               <div class="group-[&:focus]/foo:underline"></div>
-              <div class="group-[&:focus]/foo:underline"></div>
-              <div class="group-[&:focus]/foo:underline"></div>
-              <div class="group-[:hover]/foo:underline"></div>
-              <div class="group-[:hover]/foo:underline"></div>
               <div class="group-[:hover]/foo:underline"></div>
 
               <div class="group-[&[data-open]]/foo:underline"></div>
-              <div class="group-[&[data-open]]/foo:underline"></div>
-              <div class="group-[&[data-open]]/foo:underline"></div>
-              <div class="group-[[data-open]]/foo:underline"></div>
-              <div class="group-[[data-open]]/foo:underline"></div>
               <div class="group-[[data-open]]/foo:underline"></div>
 
               <div class="group-[.in-foo_&]/foo:underline"></div>
-              <div class="group-[.in-foo_&]/foo:underline"></div>
-              <div class="group-[.in-foo_&]/foo:underline"></div>
-              <div class="group-[.in-foo]/foo:underline"></div>
-              <div class="group-[.in-foo]/foo:underline"></div>
               <div class="group-[.in-foo]/foo:underline"></div>
             </div>
           </div>
@@ -830,58 +814,42 @@ it('should be possible to use modifiers and arbitrary peers', () => {
       {
         raw: html`
           <div>
-            <div class="peer">
-              <!-- Default peer usage -->
-              <div class="peer-hover:underline"></div>
+            <div class="peer"></div>
 
-              <!-- Arbitrary variants with pseudo class for peer -->
-              <!-- With & -->
-              <div class="peer-[&:focus]:underline"></div>
-              <!-- Without & -->
-              <div class="peer-[:hover]:underline"></div>
+            <!-- Default peer usage -->
+            <div class="peer-hover:underline"></div>
 
-              <!-- Arbitrary variants with attributes selectors for peer -->
-              <!-- With & -->
-              <div class="peer-[&[data-open]]:underline"></div>
-              <!-- Without & -->
-              <div class="peer-[[data-open]]:underline"></div>
+            <!-- Arbitrary variants with pseudo class for peer -->
+            <!-- With & -->
+            <div class="peer-[&:focus]:underline"></div>
+            <!-- Without & -->
+            <div class="peer-[:hover]:underline"></div>
 
-              <!-- Arbitrary variants with other selectors -->
-              <!-- With & -->
-              <div class="peer-[.in-foo_&]:underline"></div>
-              <!-- Without & -->
-              <div class="peer-[.in-foo]:underline"></div>
-            </div>
+            <!-- Arbitrary variants with attributes selectors for peer -->
+            <!-- With & -->
+            <div class="peer-[&[data-open]]:underline"></div>
+            <!-- Without & -->
+            <div class="peer-[[data-open]]:underline"></div>
+
+            <!-- Arbitrary variants with other selectors -->
+            <!-- With & -->
+            <div class="peer-[.in-foo_&]:underline"></div>
+            <!-- Without & -->
+            <div class="peer-[.in-foo]:underline"></div>
 
             <!-- The same as above, but with modifiers -->
-            <div class="peer/foo">
-            <div class="peer/foo">
-            <div class="peer/foo">
-              <div class="peer-hover/foo:underline"></div>
-              <div class="peer-hover/foo:underline"></div>
-              <div class="peer-hover/foo:underline"></div>
+            <div class="peer/foo"></div>
 
-              <div class="peer-[&:focus]/foo:underline"></div>
-              <div class="peer-[&:focus]/foo:underline"></div>
-              <div class="peer-[&:focus]/foo:underline"></div>
-              <div class="peer-[:hover]/foo:underline"></div>
-              <div class="peer-[:hover]/foo:underline"></div>
-              <div class="peer-[:hover]/foo:underline"></div>
+            <div class="peer-hover/foo:underline"></div>
 
-              <div class="peer-[&[data-open]]/foo:underline"></div>
-              <div class="peer-[&[data-open]]/foo:underline"></div>
-              <div class="peer-[&[data-open]]/foo:underline"></div>
-              <div class="peer-[[data-open]]/foo:underline"></div>
-              <div class="peer-[[data-open]]/foo:underline"></div>
-              <div class="peer-[[data-open]]/foo:underline"></div>
+            <div class="peer-[&:focus]/foo:underline"></div>
+            <div class="peer-[:hover]/foo:underline"></div>
 
-              <div class="peer-[.in-foo_&]/foo:underline"></div>
-              <div class="peer-[.in-foo_&]/foo:underline"></div>
-              <div class="peer-[.in-foo_&]/foo:underline"></div>
-              <div class="peer-[.in-foo]/foo:underline"></div>
-              <div class="peer-[.in-foo]/foo:underline"></div>
-              <div class="peer-[.in-foo]/foo:underline"></div>
-            </div>
+            <div class="peer-[&[data-open]]/foo:underline"></div>
+            <div class="peer-[[data-open]]/foo:underline"></div>
+
+            <div class="peer-[.in-foo_&]/foo:underline"></div>
+            <div class="peer-[.in-foo]/foo:underline"></div>
           </div>
         `,
       },


### PR DESCRIPTION
This is a continuation of the feature introduced in #9456. We're switching to an alternate syntax for variant modifiers (previously known as labels). The new syntax has changed to move the label to the end like `/foo` instead of `<foo>` after the name of the variant.

This pretty closely matches the opacity modifier syntax we have for utilities (e.g. `text-red-500/30`) except that the modifier at the end is not looked up in a config. Though, this could be done by a variant if they see a need for it.

Here's a short table of the changes noted from the example in the original PR above:

| Old Syntax | New Syntax |
| -- | -- |
| `group<foo>` | `group/foo` |
| `group<foo>-hover:underline` | `group-hover/foo:underline` |
| `group<foo>-[&:focus]:underline` | `group-[&:focus]/foo:underline` |
| `group<foo>-[:hover]:underline` | `group-[:hover]/foo:underline` |
| `group<foo>-[&[data-open]]:underline` | `group-[&[data-open]]/foo:underline` |
| `group<foo>-[[data-open]]:underline` | `group-[[data-open]]/foo:underline` |
| `group<foo>-[.in-foo_&]:underline` | `group-[.in-foo_&]/foo:underline` |
| `group<foo>-[.in-foo]:underline` | `group-[.in-foo]/foo:underline` |
