### PR TITLE
Add `aria-*` variants

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -257,6 +257,13 @@ export let variantPlugins = {
     )
   },
 
+  ariaVariants: ({ matchVariant, theme }) => {
+    let options = { values: theme('aria') ?? {} }
+    matchVariant('aria', (value) => `&[aria-${value}]`, options)
+    matchVariant('group-aria', (value) => `:merge(.group)[aria-${value}] &`, options)
+    matchVariant('peer-aria', (value) => `:merge(.peer)[aria-${value}] ~ &`, options)
+  },
+
   orientationVariants: ({ addVariant }) => {
     addVariant('portrait', '@media (orientation: portrait)')
     addVariant('landscape', '@media (orientation: landscape)')

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -258,10 +258,23 @@ export let variantPlugins = {
   },
 
   ariaVariants: ({ matchVariant, theme }) => {
-    let options = { values: theme('aria') ?? {} }
-    matchVariant('aria', (value) => `&[aria-${value}]`, options)
-    matchVariant('group-aria', (value) => `:merge(.group)[aria-${value}] &`, options)
-    matchVariant('peer-aria', (value) => `:merge(.peer)[aria-${value}] ~ &`, options)
+    matchVariant('aria', (value) => `&[aria-${value}]`, { values: theme('aria') ?? {} })
+    matchVariant(
+      'group-aria',
+      (value, { modifier }) =>
+        modifier
+          ? `:merge(.group\\/${modifier})[aria-${value}] &`
+          : `:merge(.group)[aria-${value}] &`,
+      { values: theme('aria') ?? {} }
+    )
+    matchVariant(
+      'peer-aria',
+      (value, { modifier }) =>
+        modifier
+          ? `:merge(.peer\\/${modifier})[aria-${value}] ~ &`
+          : `:merge(.peer)[aria-${value}] ~ &`,
+      { values: theme('aria') ?? {} }
+    )
   },
 
   orientationVariants: ({ addVariant }) => {

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -715,6 +715,7 @@ function resolvePlugins(context, root) {
   let beforeVariants = [
     variantPlugins['pseudoElementVariants'],
     variantPlugins['pseudoClassVariants'],
+    variantPlugins['ariaVariants'],
   ]
   let afterVariants = [
     variantPlugins['supportsVariants'],

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -112,6 +112,16 @@ module.exports = {
       pulse: 'pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite',
       bounce: 'bounce 1s infinite',
     },
+    aria: {
+      checked: 'checked="true"',
+      disabled: 'disabled="true"',
+      expanded: 'expanded="true"',
+      hidden: 'hidden="true"',
+      pressed: 'pressed="true"',
+      readonly: 'readonly="true"',
+      required: 'required="true"',
+      selected: 'selected="true"',
+    },
     aspectRatio: {
       auto: 'auto',
       square: '1 / 1',

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -626,6 +626,12 @@ it('should support aria variants', () => {
             <div class="aria-[sort=ascending]:underline"></div>
             <div class="group-aria-checked:underline"></div>
             <div class="peer-aria-checked:underline"></div>
+            <div class="group-aria-checked/foo:underline"></div>
+            <div class="peer-aria-checked/foo:underline"></div>
+            <div class="group-aria-[sort=ascending]:underline"></div>
+            <div class="peer-aria-[sort=ascending]:underline"></div>
+            <div class="group-aria-[sort=ascending]/foo:underline"></div>
+            <div class="peer-aria-[sort=ascending]/foo:underline"></div>
           </div>
         `,
       },
@@ -648,7 +654,25 @@ it('should support aria variants', () => {
       .group[aria-checked='true'] .group-aria-checked\:underline {
         text-decoration-line: underline;
       }
+      .group\/foo[aria-checked='true'] .group-aria-checked\/foo\:underline {
+        text-decoration-line: underline;
+      }
+      .group[aria-sort='ascending'] .group-aria-\[sort\=ascending\]\:underline {
+        text-decoration-line: underline;
+      }
+      .group\/foo[aria-sort='ascending'] .group-aria-\[sort\=ascending\]\/foo\:underline {
+        text-decoration-line: underline;
+      }
       .peer[aria-checked='true'] ~ .peer-aria-checked\:underline {
+        text-decoration-line: underline;
+      }
+      .peer\/foo[aria-checked='true'] ~ .peer-aria-checked\/foo\:underline {
+        text-decoration-line: underline;
+      }
+      .peer[aria-sort='ascending'] ~ .peer-aria-\[sort\=ascending\]\:underline {
+        text-decoration-line: underline;
+      }
+      .peer\/foo[aria-sort='ascending'] ~ .peer-aria-\[sort\=ascending\]\/foo\:underline {
         text-decoration-line: underline;
       }
     `)

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -624,6 +624,8 @@ it('should support aria variants', () => {
           <div>
             <div class="aria-checked:underline"></div>
             <div class="aria-[sort=ascending]:underline"></div>
+            <div class="group-aria-checked:underline"></div>
+            <div class="peer-aria-checked:underline"></div>
           </div>
         `,
       },
@@ -641,6 +643,12 @@ it('should support aria variants', () => {
         text-decoration-line: underline;
       }
       .aria-\[sort\=ascending\]\:underline[aria-sort='ascending'] {
+        text-decoration-line: underline;
+      }
+      .group[aria-checked='true'] .group-aria-checked\:underline {
+        text-decoration-line: underline;
+      }
+      .peer[aria-checked='true'] ~ .peer-aria-checked\:underline {
         text-decoration-line: underline;
       }
     `)

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -616,6 +616,37 @@ test('classes in the same arbitrary variant should not be prefixed', () => {
   })
 })
 
+it('should support aria variants', () => {
+  let config = {
+    content: [
+      {
+        raw: html`
+          <div>
+            <div class="aria-checked:underline"></div>
+            <div class="aria-[sort=ascending]:underline"></div>
+          </div>
+        `,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .aria-checked\:underline[aria-checked='true'] {
+        text-decoration-line: underline;
+      }
+      .aria-\[sort\=ascending\]\:underline[aria-sort='ascending'] {
+        text-decoration-line: underline;
+      }
+    `)
+  })
+})
+
 it('should support supports', () => {
   let config = {
     theme: {


### PR DESCRIPTION
This PR adds a new `aria-{state}` variant which makes it easier to style elements based on the states of ARIA attributes.

For example, you can update the background color of an element based on whether the `aria-checked` state is `true`:

```html
<div aria-checked="true" class="bg-gray-600 aria-checked:bg-blue-600">
  <!-- ... -->
</div>
```

## Included variants

By default Tailwind provides the variants for the most common boolean ARIA attributes:

| Variant  | CSS  |
|---|---|
| `aria-checked:`  | `[aria-checked="true"]` |
| `aria-disabled:`  | `[aria-disabled="true"]` |
| `aria-expanded:`  | `[aria-expanded="true"]` |
| `aria-hidden:`  | `[aria-hidden="true"]` |
| `aria-pressed:`  | `[aria-pressed="true"]` |
| `aria-readonly:`  | `[aria-readonly="true"]` |
| `aria-required:`  | `[aria-required="true"]` |
| `aria-selected:`  | `[aria-selected="true"]` |

## Using custom values

You can customize which ARIA variants are available by editing `theme.aria` or `theme.extend.aria` in your `tailwind.config.js` file:

```js
module.exports = {
  theme: {
    extend: {
      aria: {
        'asc': 'sort="ascending"',
        'desc': 'sort="descending"',
      }
    }
  }
}
```

Then you can use any custom ARIA variants you've configured in your project:

```html
<th
  aria-sort="ascending"
  class="
    aria-asc:bg-[url('/img/up-arrow.svg')]
    aria-desc:bg-[url('/img/down-arrow.svg')]
  "
>
  <!-- ... -->
</th>
```

## Arbitrary values

For more complex ARIA attributes that take specific values (like `aria-activedescendant`), or for situations where it just doesn't feel worth it to add an alias to your theme, you can use the arbitrary value/square bracket notation to create custom ARIA variants on the fly:

```html
<th
  aria-sort="ascending"
  class="
    aria-[sort=ascending]:bg-[url('/img/up-arrow.svg')]
    aria-[sort=descending]:bg-[url('/img/down-arrow.svg')]
  "
>
  <!-- ... -->
</th>
```

## Group and peer variants

The ARIA variants are also available as `group` and `peer` modifiers.

```html
<div>Message:</div>
<div role="textbox" contenteditable aria-required="true" class="peer"></div>
<div class="hidden peer-aria-required:block">*A message is required</div>
```