### PR TITLE
Add utility `aria-current`

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -114,6 +114,7 @@ module.exports = {
     },
     aria: {
       checked: 'checked="true"',
+      current: 'current="true"',
       disabled: 'disabled="true"',
       expanded: 'expanded="true"',
       hidden: 'hidden="true"',


### PR DESCRIPTION
This PR adds a new utility for the ARIA attributes : [aria-current](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current).