### PR TITLE
Ensure `--content` is used in the CLI when passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve type checking for formal syntax ([#9349](https://github.com/tailwindlabs/tailwindcss/pull/9349), [#9448](https://github.com/tailwindlabs/tailwindcss/pull/9448))
 - Don't require `content` key in custom plugin configs ([#9502](https://github.com/tailwindlabs/tailwindcss/pull/9502), [#9545](https://github.com/tailwindlabs/tailwindcss/pull/9545))
 - Fix content path detection on Windows ([#9569](https://github.com/tailwindlabs/tailwindcss/pull/9569))
+- Ensure `--content` is used in the CLI when passed ([#9587](https://github.com/tailwindlabs/tailwindcss/pull/9587))
 
 ## [3.1.8] - 2022-08-05
 

--- a/integrations/tailwindcss-cli/tests/cli.test.js
+++ b/integrations/tailwindcss-cli/tests/cli.test.js
@@ -169,9 +169,9 @@ describe('Build command', () => {
   })
 
   test('--content', async () => {
-    await writeInputFile('index.html', html`<div class="font-bold"></div>`)
+    await writeInputFile('other.html', html`<div class="font-bold"></div>`)
 
-    await $(`${EXECUTABLE} --content ./src/index.html --output ./dist/main.css`)
+    await $(`${EXECUTABLE} --content ./src/other.html --output ./dist/main.css`)
 
     expect(await readOutputFile('main.css')).toIncludeCss(
       css`

--- a/standalone-cli/tests/test.js
+++ b/standalone-cli/tests/test.js
@@ -51,7 +51,7 @@ it('supports postcss config files', async () => {
 /**
  * @template T
  * @param {() => T} fn
- * @returns {T}
+ * @returns {Promise<T>}
  */
 async function inIsolatedContext(fn) {
   // Create a new directory entirely outside of the package for the test
@@ -79,6 +79,6 @@ async function inIsolatedContext(fn) {
     process.chdir(__dirname)
 
     // Delete the new directory
-    await fs.rmdir(dest, { recursive: true })
+    await fs.rm(dest, { recursive: true })
   }
 }


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
