### PR TITLE
Update README to use `picture`/`source` syntax to avoid deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 <p align="center">
-  <a href="https://tailwindcss.com/#gh-light-mode-only" target="_blank">
-    <img src="./.github/logo-light.svg" alt="Tailwind CSS" width="350" height="70">
-  </a>
-  <a href="https://tailwindcss.com/#gh-dark-mode-only" target="_blank">
-    <img src="./.github/logo-dark.svg" alt="Tailwind CSS" width="350" height="70">
+  <a href="https://tailwindcss.com" target="_blank">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="./.github/logo-dark.svg">
+      <source media="(prefers-color-scheme: light)" srcset="./.github/logo-light.svg">
+      <img alt="Tailwind CSS" src="./.github/logo-light.svg" width="350" height="70" style="max-width: 100%;">
+    </picture>
   </a>
 </p>
 


### PR DESCRIPTION
I noticed a deprecation and removal warning from GitHub regarding the old `#gh-light-mode-only` and `#gh-dark-mode-only` way of showing different logos for light/dark mode.

The notice can be found here: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to

This PR updates the logo in the README to replace the deprecated syntax with the newly recommended `picture` and `srcset` syntax.