### PR TITLE
Resolve broken relative logo sources on npmjs (relative → absolute)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
   <a href="https://tailwindcss.com" target="_blank">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="./.github/logo-dark.svg">
-      <source media="(prefers-color-scheme: light)" srcset="./.github/logo-light.svg">
-      <img alt="Tailwind CSS" src="./.github/logo-light.svg" width="350" height="70" style="max-width: 100%;">
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tailwindlabs/tailwindcss/HEAD/.github/logo-dark.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/tailwindlabs/tailwindcss/HEAD/.github/logo-light.svg">
+      <img alt="Tailwind CSS" src="https://raw.githubusercontent.com/tailwindlabs/tailwindcss/HEAD/.github/logo-light.svg" width="350" height="70" style="max-width: 100%;">
     </picture>
   </a>
 </p>


### PR DESCRIPTION
@RobinMalfait Looks like that last PR caused a slight regression on npmjs where the logo is completely broken now, because it registers the `source` URLs as relative links instead of absolute links.

You can see that bug here: https://www.npmjs.com/package/tailwindcss

Before and after this PR (assuming this works 🤷🏻‍♂️… it should)

|  | Before | After |
| - | - | - |
| Light | ![Screen Shot 2022-10-19 at 18 40 02](https://user-images.githubusercontent.com/5913254/196817953-b34ec545-4539-49ff-bbe1-d7861cce0251.png) | ![Screen Shot 2022-10-19 at 18 39 42](https://user-images.githubusercontent.com/5913254/196817978-1a44560a-6d40-4f6e-9a37-3d07d1fd2d0d.png) |
| Dark | ![Screen Shot 2022-10-19 at 18 40 02](https://user-images.githubusercontent.com/5913254/196817953-b34ec545-4539-49ff-bbe1-d7861cce0251.png) | ![Screen Shot 2022-10-19 at 18 39 21](https://user-images.githubusercontent.com/5913254/196817985-7645e220-bc9f-4237-ba49-7b2be9dd9af5.png) |

Unfortunately, npmjs doesn't yet have a dark mode of their own, so even after corrected, the logo will be mostly invisible on their site unless a stroke or some other sort of style is added to the logo to add contrast between the white text and white background.