### PR TITLE
Escape special characters in resolved content base path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Escape special characters in resolved content base paths ([#9650](https://github.com/tailwindlabs/tailwindcss/pull/9650))
 
 ## [3.2.1] - 2022-10-21
 

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -94,17 +94,14 @@ function parseFilePath(filePath, ignore) {
  * @returns {ContentPath}
  */
 function resolveGlobPattern(contentPath) {
-  contentPath.pattern = contentPath.glob
-    ? `${contentPath.base}/${contentPath.glob}`
-    : contentPath.base
-
-  contentPath.pattern = contentPath.ignore ? `!${contentPath.pattern}` : contentPath.pattern
-
   // This is required for Windows support to properly pick up Glob paths.
   // Afaik, this technically shouldn't be needed but there's probably
   // some internal, direct path matching with a normalized path in
   // a package which can't handle mixed directory separators
-  contentPath.pattern = normalizePath(contentPath.pattern)
+  let base = normalizePath(contentPath.base)
+
+  contentPath.pattern = contentPath.glob ? `${base}/${contentPath.glob}` : base
+  contentPath.pattern = contentPath.ignore ? `!${contentPath.pattern}` : contentPath.pattern
 
   return contentPath
 }

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -100,6 +100,10 @@ function resolveGlobPattern(contentPath) {
   // a package which can't handle mixed directory separators
   let base = normalizePath(contentPath.base)
 
+  // If the user's file path contains any special characters (like parens) for instance fast-glob
+  // is like "OOOH SHINY" and treats them as such. So we have to escape the base path to fix this
+  base = fastGlob.escapePath(base)
+
   contentPath.pattern = contentPath.glob ? `${base}/${contentPath.glob}` : base
   contentPath.pattern = contentPath.ignore ? `!${contentPath.pattern}` : contentPath.pattern
 


### PR DESCRIPTION
We use `fast-glob` internally and it treats a handful of characters as special. Since we're resolving the base path ourselves (instead of just not at all in some previous cases) we have to escape them.

Fixes #9649

