### PR TITLE
Fix merging of arrays during config resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Escape special characters in resolved content base paths ([#9650](https://github.com/tailwindlabs/tailwindcss/pull/9650))
 - Don't reuse container for array returning variant functions ([#9644](https://github.com/tailwindlabs/tailwindcss/pull/9644))
 - Exclude non-relevant selectors when generating rules with the important modifier ([#9677](https://github.com/tailwindlabs/tailwindcss/issues/9677))
+- Fix merging of arrays during config resolution ([#9706](https://github.com/tailwindlabs/tailwindcss/issues/9706))
 
 ## [3.2.1] - 2022-10-21
 

--- a/src/util/resolveConfig.js
+++ b/src/util/resolveConfig.js
@@ -16,10 +16,6 @@ function isFunction(input) {
   return typeof input === 'function'
 }
 
-function isObject(input) {
-  return typeof input === 'object' && input !== null
-}
-
 function mergeWith(target, ...sources) {
   let customizer = sources.pop()
 
@@ -28,7 +24,7 @@ function mergeWith(target, ...sources) {
       let merged = customizer(target[k], source[k])
 
       if (merged === undefined) {
-        if (isObject(target[k]) && isObject(source[k])) {
+        if (isPlainObject(target[k]) && isPlainObject(source[k])) {
           target[k] = mergeWith({}, target[k], source[k], customizer)
         } else {
           target[k] = source[k]
@@ -103,12 +99,12 @@ function mergeThemes(themes) {
 
 function mergeExtensionCustomizer(merged, value) {
   // When we have an array of objects, we do want to merge it
-  if (Array.isArray(merged) && isObject(merged[0])) {
+  if (Array.isArray(merged) && isPlainObject(merged[0])) {
     return merged.concat(value)
   }
 
   // When the incoming value is an array, and the existing config is an object, prepend the existing object
-  if (Array.isArray(value) && isObject(value[0]) && isObject(merged)) {
+  if (Array.isArray(value) && isPlainObject(value[0]) && isPlainObject(merged)) {
     return [merged, ...value]
   }
 

--- a/tests/resolveConfig.test.js
+++ b/tests/resolveConfig.test.js
@@ -591,6 +591,8 @@ test('theme values in the extend section are not deeply merged when they are sim
       extend: {
         fonts: {
           sans: ['Comic Sans'],
+          serif: ['Papyrus', { fontFeatureSettings: '"cv11"' }],
+          mono: [['Lobster', 'Papyrus'], { fontFeatureSettings: '"cv11"' }],
         },
       },
     },
@@ -619,8 +621,8 @@ test('theme values in the extend section are not deeply merged when they are sim
     theme: {
       fonts: {
         sans: ['Comic Sans'],
-        serif: ['Constantia', 'Georgia', 'serif'],
-        mono: ['Menlo', 'Courier New', 'monospace'],
+        serif: ['Papyrus', { fontFeatureSettings: '"cv11"' }],
+        mono: [['Lobster', 'Papyrus'], { fontFeatureSettings: '"cv11"' }],
       },
     },
   })


### PR DESCRIPTION
Fixes #9666

The result of the `theme values in the extend section are not deeply merged when they are simple arrays` test prior to this fix (the new array is appended onto the existing array instead of overriding it):

```js
{
  fonts: {
    sans: ['Comic Sans'],
    serif: ['Papyrus', { fontFeatureSettings: '"cv11"' }],
    mono: [
      ['Menlo', 'Courier New', 'monospace'],
      ['Lobster', 'Papyrus'],
      { fontFeatureSettings: '"cv11"' },
    ],
  },
}
```

This fix assumes that the original intent was to use `isPlainObject` instead of the `isObject` function that returns `true` for arrays.