### PR TITLE
Fix shadowed variable when using raw content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Fixed use of `raw` content in the CLI ([#9773](https://github.com/tailwindlabs/tailwindcss/pull/9773))
 
 ## [3.2.2] - 2022-11-04
 

--- a/integrations/tailwindcss-cli/tests/integration.test.js
+++ b/integrations/tailwindcss-cli/tests/integration.test.js
@@ -191,6 +191,40 @@ describe('static build', () => {
       `
     )
   })
+
+  it('should work with raw content', async () => {
+    await writeInputFile(
+      '../tailwind.config.js',
+      javascript`
+        module.exports = {
+          content: {
+            files: [{ raw: 'bg-red-500'}],
+          },
+          theme: {
+            extend: {
+            },
+          },
+          corePlugins: {
+            preflight: false,
+          },
+          plugins: [],
+        }
+      `
+    )
+
+    await $('node ../../lib/cli.js -i ./src/index.css -o ./dist/main.css', {
+      env: { NODE_ENV: 'production' },
+    })
+
+    expect(await readOutputFile('main.css')).toIncludeCss(
+      css`
+        .bg-red-500 {
+          --tw-bg-opacity: 1;
+          background-color: rgb(239 68 68 / var(--tw-bg-opacity));
+        }
+      `
+    )
+  })
 })
 
 describe('watcher', () => {

--- a/src/cli/build/plugin.js
+++ b/src/cli/build/plugin.js
@@ -195,8 +195,8 @@ let state = {
       return file !== null && typeof file === 'object'
     })
 
-    for (let { raw: content, extension = 'html' } of rawContent) {
-      content.push({ content, extension })
+    for (let { raw: htmlContent, extension = 'html' } of rawContent) {
+      content.push({ content: htmlContent, extension })
     }
 
     return content


### PR DESCRIPTION
Using `{raw: ...}` in the content config no longer works. It looks like the reason why is the `content` variable was being shadowed. I just renamed the variable so `content` remains accessible inside the loop.