### PR TITLE
Fix watching of files on Linux when renames are involved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Fix watching of files on Linux when renames are involved ([#9796](https://github.com/tailwindlabs/tailwindcss/pull/9796))
 
 ## [3.2.3] - 2022-11-09
 


### PR DESCRIPTION
Fixes #7759

It was still broken because of the order things were firing in but this should work around the problem. The solution here still isn't ideal but without changes to chokidar or a slightly different abstraction I think this is probably as good as we're gonna get.