### PR TITLE
Make sure errors are always displayed when watching for changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix watching of files on Linux when renames are involved ([#9796](https://github.com/tailwindlabs/tailwindcss/pull/9796))
+- Make sure errors are always displayed when watching for changes ([#9810](https://github.com/tailwindlabs/tailwindcss/pull/9810))
 
 ## [3.2.3] - 2022-11-09
 

--- a/src/cli/build/plugin.js
+++ b/src/cli/build/plugin.js
@@ -364,6 +364,23 @@ export async function createProcessor(args, cliConfigPath) {
         console.error()
         console.error('Done in', (end - start) / BigInt(1e6) + 'ms.')
       })
+      .then(
+        () => {},
+        (err) => {
+          // TODO: If an initial build fails we can't easily pick up any PostCSS dependencies
+          // that were collected before the error occurred
+          // The result is not stored on the error so we have to store it externally
+          // and pull the messages off of it here somehow
+
+          // This results in a less than ideal DX because the watcher will not pick up
+          // changes to imported CSS if one of them caused an error during the initial build
+          // If you fix it and then save the main CSS file so there's no error
+          // The watcher will start watching the imported CSS files and will be
+          // resilient to future errors.
+
+          console.error(err)
+        }
+      )
   }
 
   /**


### PR DESCRIPTION
Fixes #9798

My testing also revealed an unfortunate DX problem due to the way PostCSS works:

1. Runners are promise based if _any_ plugin is async
2. If any runners error then the promise rejects with an error
3. The error does NOT have access to the _partial_ result that would've been built up
4. Therefore we can't get even a partial list of dependencies to watch for more changes from an initial build

As a result of this, if there is an error produced in a file that is `@import`-ed we won't pick it up as something that can be watched for changes until the build succeeds at least once. The workaround is to fix the error and re-save the input CSS file.  I've added a TODO to find a way to work around this.