### PR TITLE
Fix `foo-[abc]/[def]` not being handled correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Cleanup unused `variantOrder` ([#9829](https://github.com/tailwindlabs/tailwindcss/pull/9829))
+- Fix `foo-[abc]/[def]` not being handled correctl ([#9866](https://github.com/tailwindlabs/tailwindcss/pull/9866))
 
 ### Added
 

--- a/tests/match-utilities.test.js
+++ b/tests/match-utilities.test.js
@@ -165,3 +165,342 @@ test('match utilities can omit utilities by returning null', async () => {
     }
   `)
 })
+
+test('matching utilities with an arbitrary value and configured modifier', () => {
+  let config = {
+    content: [{ raw: html`<div class="test-[foo]/bar"></div>` }],
+    theme: {},
+    plugins: [
+      function ({ matchUtilities }) {
+        matchUtilities(
+          {
+            test: (value, { modifier }) => ({ value, modifier }),
+          },
+          {
+            modifiers: {
+              bar: 'configured_bar',
+            },
+          }
+        )
+      },
+    ],
+    corePlugins: [],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchCss(css`
+      .test-\[foo\]\/bar {
+        value: foo;
+        modifier: configured_bar;
+      }
+    `)
+  })
+})
+
+test('matching utilities with an configured value and an arbitrary modifier (raw)', () => {
+  let config = {
+    content: [{ raw: html`<div class="test-foo/[bar]"></div>` }],
+    theme: {},
+    plugins: [
+      function ({ matchUtilities }) {
+        matchUtilities(
+          {
+            test: (value, { modifier }) => ({ value, modifier }),
+          },
+          {
+            values: {
+              foo: 'configured_foo',
+            },
+            modifiers: 'any', // Raw `[value]`
+          }
+        )
+      },
+    ],
+    corePlugins: [],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchCss(css`
+      .test-foo\/\[bar\] {
+        value: configured_foo;
+        modifier: [bar];
+      }
+    `)
+  })
+})
+
+test('matching utilities with an configured value and an arbitrary modifier (non-raw)', () => {
+  let config = {
+    content: [{ raw: html`<div class="test-foo/[bar]"></div>` }],
+    theme: {},
+    plugins: [
+      function ({ matchUtilities }) {
+        matchUtilities(
+          {
+            test: (value, { modifier }) => ({ value, modifier }),
+          },
+          {
+            values: {
+              foo: 'configured_foo',
+            },
+            modifiers: {},
+          }
+        )
+      },
+    ],
+    corePlugins: [],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchCss(css`
+      .test-foo\/\[bar\] {
+        value: configured_foo;
+        modifier: bar;
+      }
+    `)
+  })
+})
+
+test('matching utilities with an configured value and a configured modifier', () => {
+  let config = {
+    content: [{ raw: html`<div class="test-foo/bar"></div>` }],
+    theme: {},
+    plugins: [
+      function ({ matchUtilities }) {
+        matchUtilities(
+          {
+            test: (value, { modifier }) => ({ value, modifier }),
+          },
+          {
+            values: {
+              foo: 'configured_foo',
+            },
+            modifiers: {
+              bar: 'configured_bar',
+            },
+          }
+        )
+      },
+    ],
+    corePlugins: [],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchCss(css`
+      .test-foo\/bar {
+        value: configured_foo;
+        modifier: configured_bar;
+      }
+    `)
+  })
+})
+
+test('matching utilities with an arbitrary value and an arbitrary modifier (raw)', () => {
+  let config = {
+    content: [{ raw: html`<div class="test-[foo]/[bar]"></div>` }],
+    theme: {},
+    plugins: [
+      function ({ matchUtilities }) {
+        matchUtilities(
+          {
+            test: (value, { modifier }) => ({ value, modifier }),
+          },
+          {
+            modifiers: 'any',
+          }
+        )
+      },
+    ],
+    corePlugins: [],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchCss(css`
+      .test-\[foo\]\/\[bar\] {
+        value: foo;
+        modifier: [bar];
+      }
+    `)
+  })
+})
+
+test('matching utilities with an arbitrary value and an arbitrary modifier (non-raw)', () => {
+  let config = {
+    content: [{ raw: html`<div class="test-[foo]/[bar]"></div>` }],
+    theme: {},
+    plugins: [
+      function ({ matchUtilities }) {
+        matchUtilities(
+          {
+            test: (value, { modifier }) => ({ value, modifier }),
+          },
+          {
+            modifiers: {},
+          }
+        )
+      },
+    ],
+    corePlugins: [],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchCss(css`
+      .test-\[foo\]\/\[bar\] {
+        value: foo;
+        modifier: bar;
+      }
+    `)
+  })
+})
+
+test('matching utilities with a lookup value that looks like an arbitrary value and modifier', () => {
+  let config = {
+    content: [{ raw: html`<div class="test-[foo]/[bar]"></div>` }],
+    theme: {},
+    plugins: [
+      function ({ matchUtilities }) {
+        matchUtilities(
+          {
+            test: (value, { modifier }) => ({ value, modifier }),
+          },
+          {
+            values: {
+              '[foo]/[bar]': 'hello',
+            },
+          }
+        )
+      },
+    ],
+    corePlugins: [],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchCss(css`
+      .test-\[foo\]\/\[bar\] {
+        value: hello;
+      }
+    `)
+  })
+})
+
+test('matching utilities with a lookup value that looks like an arbitrary value and modifier (with modifiers = any)', () => {
+  let config = {
+    content: [{ raw: html`<div class="test-[foo]/[bar]"></div>` }],
+    theme: {},
+    plugins: [
+      function ({ matchUtilities }) {
+        matchUtilities(
+          {
+            test: (value, { modifier }) => ({ value, modifier }),
+          },
+          {
+            values: {
+              '[foo]/[bar]': 'hello',
+            },
+            modifiers: 'any',
+          }
+        )
+      },
+    ],
+    corePlugins: [],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchCss(css`
+      .test-\[foo\]\/\[bar\] {
+        value: hello;
+      }
+    `)
+  })
+})
+
+test('matching utilities with a lookup value that looks like an arbitrary value and modifier (with modifiers = {})', () => {
+  let config = {
+    content: [{ raw: html`<div class="test-[foo]/[bar]"></div>` }],
+    theme: {},
+    plugins: [
+      function ({ matchUtilities }) {
+        matchUtilities(
+          {
+            test: (value, { modifier }) => ({ value, modifier }),
+          },
+          {
+            values: {
+              '[foo]/[bar]': 'hello',
+            },
+            modifiers: {},
+          }
+        )
+      },
+    ],
+    corePlugins: [],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchCss(css`
+      .test-\[foo\]\/\[bar\] {
+        value: hello;
+      }
+    `)
+  })
+})
+
+test('matching utilities with a lookup value that looks like an arbitrary value and a configured modifier', () => {
+  let config = {
+    content: [{ raw: html`<div class="test-[foo]/bar"></div>` }],
+    theme: {},
+    plugins: [
+      function ({ matchUtilities }) {
+        matchUtilities(
+          {
+            test: (value, { modifier }) => ({ value, modifier }),
+          },
+          {
+            values: {
+              '[foo]/bar': 'hello',
+            },
+          }
+        )
+      },
+    ],
+    corePlugins: [],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchCss(css`
+      .test-\[foo\]\/bar {
+        value: hello;
+      }
+    `)
+  })
+})
+
+test('matching utilities with a lookup value that looks like a configured value and an arbitrary modifier', () => {
+  let config = {
+    content: [{ raw: html`<div class="test-foo/[bar]"></div>` }],
+    theme: {},
+    plugins: [
+      function ({ matchUtilities }) {
+        matchUtilities(
+          {
+            test: (value, { modifier }) => ({ value, modifier }),
+          },
+          {
+            values: {
+              'foo/[bar]': 'hello',
+            },
+          }
+        )
+      },
+    ],
+    corePlugins: [],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchCss(css`
+      .test-foo\/\[bar\] {
+        value: hello;
+      }
+    `)
+  })
+})


### PR DESCRIPTION
This commit does a bit of cleanup, it also ensures that we lookup `[abc]/[def]` in the `values` first, and if it doesn't exist, then we start parsing all the values out.

We also ensure that `abc` and `def` are parsed out correctly for the correct type instead of dropping the rule altogether because we happen to end up with an `any` rule.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
