### PR TITLE
Add line-height modifier for font-size utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `line-height` modifier support to `font-size` utilities ([#9875](https://github.com/tailwindlabs/tailwindcss/pull/9875))
+
 ### Fixed
 
 - Cleanup unused `variantOrder` ([#9829](https://github.com/tailwindlabs/tailwindcss/pull/9829))

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1834,8 +1834,16 @@ export let corePlugins = {
   fontSize: ({ matchUtilities, theme }) => {
     matchUtilities(
       {
-        text: (value) => {
+        text: (value, { modifier }) => {
           let [fontSize, options] = Array.isArray(value) ? value : [value]
+
+          if (modifier) {
+            return {
+              'font-size': fontSize,
+              'line-height': modifier,
+            }
+          }
+
           let { lineHeight, letterSpacing, fontWeight } = isPlainObject(options)
             ? options
             : { lineHeight: options }
@@ -1850,6 +1858,7 @@ export let corePlugins = {
       },
       {
         values: theme('fontSize'),
+        modifiers: theme('lineHeight'),
         type: ['absolute-size', 'relative-size', 'length', 'percentage'],
       }
     )

--- a/src/util/pluginUtils.js
+++ b/src/util/pluginUtils.js
@@ -290,13 +290,6 @@ export function* getMatchingTypes(types, rawModifier, options, tailwindConfig) {
         utilityModifier = utilityModifier.slice(1, -1)
       }
     }
-
-    // TODO: What is this chunk for, since it doesn't use `utilityModifier`?
-    let result = asValue(rawModifier, options)
-
-    if (result !== undefined) {
-      yield [result, 'any', null]
-    }
   }
 
   for (let { type } of types ?? []) {

--- a/src/util/pluginUtils.js
+++ b/src/util/pluginUtils.js
@@ -291,6 +291,7 @@ export function* getMatchingTypes(types, rawModifier, options, tailwindConfig) {
       }
     }
 
+    // TODO: What is this chunk for, since it doesn't use `utilityModifier`?
     let result = asValue(rawModifier, options)
 
     if (result !== undefined) {

--- a/src/util/pluginUtils.js
+++ b/src/util/pluginUtils.js
@@ -290,6 +290,12 @@ export function* getMatchingTypes(types, rawModifier, options, tailwindConfig) {
         utilityModifier = utilityModifier.slice(1, -1)
       }
     }
+
+    let result = asValue(rawModifier, options)
+
+    if (result !== undefined) {
+      yield [result, 'any', null]
+    }
   }
 
   for (let { type } of types ?? []) {

--- a/tests/match-utilities.test.js
+++ b/tests/match-utilities.test.js
@@ -4,7 +4,9 @@ test('match utilities with modifiers', async () => {
   let config = {
     content: [
       {
-        raw: html`<div class="test test/foo test-1/foo test-2/foo test/[foo] test-1/[foo]"></div> `,
+        raw: html`<div
+          class="test test/foo test-1/foo test-2/foo test/[foo] test-1/[foo] test-[8]/[9]"
+        ></div> `,
       },
     ],
     corePlugins: { preflight: false },
@@ -24,6 +26,7 @@ test('match utilities with modifiers', async () => {
               '1': 'one',
               '2': 'two',
               '1/foo': 'onefoo',
+              '[8]/[9]': 'eightnine',
             },
             modifiers: 'any',
           }

--- a/tests/match-utilities.test.js
+++ b/tests/match-utilities.test.js
@@ -60,6 +60,9 @@ test('match utilities with modifiers', async () => {
     .test-1\/\[foo\] {
       color: one_[foo];
     }
+    .test-\[8\]\/\[9\] {
+      color: eightnine_null;
+    }
   `)
 })
 

--- a/tests/plugins/fontSize.test.js
+++ b/tests/plugins/fontSize.test.js
@@ -119,3 +119,48 @@ test('font-size utilities can include a font-weight', () => {
     `)
   })
 })
+
+test('font-size utilities can include a line-height modifier', () => {
+  let config = {
+    content: [
+      {
+        raw: html`<div class="text-sm md:text-base">
+          <div class="text-sm/6 md:text-base/7"></div>
+        </div>`,
+      },
+    ],
+    theme: {
+      fontSize: {
+        sm: ['12px', '20px'],
+        base: ['16px', '24px'],
+      },
+      lineHeight: {
+        6: '24px',
+        7: '28px',
+      },
+    },
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchCss(css`
+      .text-sm {
+        font-size: 12px;
+        line-height: 20px;
+      }
+      .text-sm\/6 {
+        font-size: 12px;
+        line-height: 24px;
+      }
+      @media (min-width: 768px) {
+        .md\:text-base {
+          font-size: 16px;
+          line-height: 24px;
+        }
+        .md\:text-base\/7 {
+          font-size: 16px;
+          line-height: 28px;
+        }
+      }
+    `)
+  })
+})

--- a/tests/plugins/fontSize.test.js
+++ b/tests/plugins/fontSize.test.js
@@ -127,6 +127,7 @@ test('font-size utilities can include a line-height modifier', () => {
         raw: html`<div class="text-sm md:text-base">
           <div class="text-sm/6 md:text-base/7"></div>
           <div class="text-sm/[21px] md:text-base/[33px]"></div>
+          <div class="text-sm/999 md:text-base/000"></div>
         </div>`,
       },
     ],

--- a/tests/plugins/fontSize.test.js
+++ b/tests/plugins/fontSize.test.js
@@ -127,6 +127,8 @@ test('font-size utilities can include a line-height modifier', () => {
         raw: html`<div class="text-sm md:text-base">
           <div class="text-sm/6 md:text-base/7"></div>
           <div class="text-sm/[21px] md:text-base/[33px]"></div>
+          <div class="text-[13px]/6 md:text-[19px]/8"></div>
+          <div class="text-[17px]/[23px] md:text-[21px]/[29px]"></div>
           <div class="text-sm/999 md:text-base/000"></div>
         </div>`,
       },
@@ -139,6 +141,7 @@ test('font-size utilities can include a line-height modifier', () => {
       lineHeight: {
         6: '24px',
         7: '28px',
+        8: '32px',
       },
     },
   }
@@ -157,6 +160,14 @@ test('font-size utilities can include a line-height modifier', () => {
         font-size: 12px;
         line-height: 21px;
       }
+      .text-\[13px\]\/6 {
+        font-size: 13px;
+        line-height: 24px;
+      }
+      .text-\[17px\]\/\[23px\] {
+        font-size: 17px;
+        line-height: 23px;
+      }
       @media (min-width: 768px) {
         .md\:text-base {
           font-size: 16px;
@@ -169,6 +180,14 @@ test('font-size utilities can include a line-height modifier', () => {
         .md\:text-base\/\[33px\] {
           font-size: 16px;
           line-height: 33px;
+        }
+        .md\:text-\[19px\]\/8 {
+          font-size: 19px;
+          line-height: 32px;
+        }
+        .md\:text-\[21\]\/\[29px\] {
+          font-size: 21px;
+          line-height: 29px;
         }
       }
     `)

--- a/tests/plugins/fontSize.test.js
+++ b/tests/plugins/fontSize.test.js
@@ -126,6 +126,7 @@ test('font-size utilities can include a line-height modifier', () => {
       {
         raw: html`<div class="text-sm md:text-base">
           <div class="text-sm/6 md:text-base/7"></div>
+          <div class="text-sm/[21px] md:text-base/[33px]"></div>
         </div>`,
       },
     ],
@@ -151,6 +152,10 @@ test('font-size utilities can include a line-height modifier', () => {
         font-size: 12px;
         line-height: 24px;
       }
+      .text-sm\/\[21px\] {
+        font-size: 12px;
+        line-height: 21px;
+      }
       @media (min-width: 768px) {
         .md\:text-base {
           font-size: 16px;
@@ -159,6 +164,10 @@ test('font-size utilities can include a line-height modifier', () => {
         .md\:text-base\/7 {
           font-size: 16px;
           line-height: 28px;
+        }
+        .md\:text-base\/\[33px\] {
+          font-size: 16px;
+          line-height: 33px;
         }
       }
     `)

--- a/tests/plugins/fontSize.test.js
+++ b/tests/plugins/fontSize.test.js
@@ -185,7 +185,7 @@ test('font-size utilities can include a line-height modifier', () => {
           font-size: 19px;
           line-height: 32px;
         }
-        .md\:text-\[21\]\/\[29px\] {
+        .md\:text-\[21px\]\/\[29px\] {
           font-size: 21px;
           line-height: 29px;
         }


### PR DESCRIPTION
This PR makes use of generalized modifier support added in v3.2 to add a new line-height modifier to the existing font-size utilities.

This makes it possible to define your font-size and line-height together in a single class for terser code, like you can when using the opacity modifier with color utilities.

```html
<!-- Before -->
<div class="text-lg leading-8">

<!-- Now -->
<div class="text-lg/8">
````

The potential modifier values are pulled from your `lineHeight` configuration. You can also use arbitrary values like this:

```html
<!-- Arbitrary line-height modifier -->
<div class="text-xl/[30px]">

<!-- Arbitrary font-size with configured line-height modifier -->
<div class="text-[19px]/7">

<!-- Arbitrary font-size with arbitrary line-height modifier -->
<div class="text-[19px]/[27px]">
```

The `leading-*` classes of course aren't going anywhere and are still both useful and supported.

Need to prepare documentation before merging.