### PR TITLE
Support using variables as arbitrary values without var()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support using variables as arbitrary values without `var(...)` ([#9880](https://github.com/tailwindlabs/tailwindcss/pull/9880))
+
 ### Fixed
 
 - Cleanup unused `variantOrder` ([#9829](https://github.com/tailwindlabs/tailwindcss/pull/9829))

--- a/src/util/dataTypes.js
+++ b/src/util/dataTypes.js
@@ -13,6 +13,10 @@ function isCSSFunction(value) {
 // This is not a data type, but rather a function that can normalize the
 // correct values.
 export function normalize(value, isRoot = true) {
+  if (value.startsWith('--')) {
+    return `var(${value})`
+  }
+
   // Keep raw strings if it starts with `url(`
   if (value.includes('url(')) {
     return value

--- a/tests/arbitrary-values.test.js
+++ b/tests/arbitrary-values.test.js
@@ -541,7 +541,11 @@ it('can explicitly specify type for percentage and length', () => {
 it('can use CSS variables as arbitrary values without `var()`', () => {
   let config = {
     content: [
-      { raw: html`<div class="w-[--width-var] bg-[--color-var] text-[length:--size-var]"></div>` },
+      {
+        raw: html`<div
+          class="w-[--width-var] bg-[--color-var] bg-[--color-var,#000] bg-[length:--size-var] text-[length:--size-var,12px]"
+        ></div>`,
+      },
     ],
     corePlugins: { preflight: false },
     plugins: [],
@@ -559,8 +563,14 @@ it('can use CSS variables as arbitrary values without `var()`', () => {
       .bg-\[--color-var\] {
         background-color: var(--color-var);
       }
-      .text-\[length\:--size-var\] {
-        font-size: var(--size-var);
+      .bg-\[--color-var\2c \#000\] {
+        background-color: var(--color-var, #000);
+      }
+      .bg-\[length\:--size-var\] {
+        background-size: var(--size-var);
+      }
+      .text-\[length\:--size-var\2c 12px\] {
+        font-size: var(--size-var, 12px);
       }
     `)
   })

--- a/tests/arbitrary-values.test.js
+++ b/tests/arbitrary-values.test.js
@@ -537,3 +537,31 @@ it('can explicitly specify type for percentage and length', () => {
     `)
   })
 })
+
+it('can use CSS variables as arbitrary values without `var()`', () => {
+  let config = {
+    content: [
+      { raw: html`<div class="w-[--width-var] bg-[--color-var] text-[length:--size-var]"></div>` },
+    ],
+    corePlugins: { preflight: false },
+    plugins: [],
+  }
+
+  let input = css`
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .w-\[--width-var\] {
+        width: var(--width-var);
+      }
+      .bg-\[--color-var\] {
+        background-color: var(--color-var);
+      }
+      .text-\[length\:--size-var\] {
+        font-size: var(--size-var);
+      }
+    `)
+  })
+})


### PR DESCRIPTION
This PR makes it possible to use CSS variables as arbitrary values without having to wrap them in `var(...)` for terser code. Since any arbitrary value starting with `--` is unambiguously a CSS variable, we can know with certainty that the user isn't trying to do anything else so I can't find any reason that this isn't safe to do.

```html
<!-- Before -->
<div class="w-[var(--width-var)] bg-[var(--color-var)] text-[length:var(--size-var)]">

<!-- After -->
<div class="w-[--width-var] bg-[--color-var] text-[length:--size-var]">
```

As you can see in the example above, this works with type-hints as well for when you need to tell Tailwind which utility you are trying to invoke explicitly.

Need to prepare documentation before merging.