### PR TITLE
Support renaming of output files by `PostCSS` plugin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cleanup unused `variantOrder` ([#9829](https://github.com/tailwindlabs/tailwindcss/pull/9829))
 - Fix `foo-[abc]/[def]` not being handled correctly ([#9866](https://github.com/tailwindlabs/tailwindcss/pull/9866))
 - Add container queries plugin to standalone CLI ([#9865](https://github.com/tailwindlabs/tailwindcss/pull/9865))
+- Support renaming of output files by `PostCSS` plugin. ([#9944](https://github.com/tailwindlabs/tailwindcss/pull/9944))
 
 ## [3.2.4] - 2022-11-11
 

--- a/src/cli/build/plugin.js
+++ b/src/cli/build/plugin.js
@@ -355,8 +355,8 @@ export async function createProcessor(args, cliConfigPath) {
         }
 
         return Promise.all([
-          outputFile(output, result.css),
-          result.map && outputFile(output + '.map', result.map.toString()),
+          outputFile(result.opts.to, result.css),
+          result.map && outputFile(result.opts.to + '.map', result.map.toString()),
         ])
       })
       .then(() => {


### PR DESCRIPTION
If you use tailwindcss as a cli and set the postcss option, the output file will ignore changes to result.opts by the postcss plugin and respect the output option passed to the cli.

However, some postcss plugins, such as the cache buster plugins, work by rewriting [result.opts](https://postcss.org/api/#resultoptions).
Like this one, for example.
https://github.com/keithamus/postcss-hash/blob/v2.0.0/index.js#L55-L57

This change is to honor the end product, `result.opts.to`, as the output file during postcss adaptation.

Example of reproducing the current problem.
```
// commands.
tailwindcss -i /path/to/input.css -o /path/to/output.css --postcss postcss.config.js


// postcss.config.js
module.exports = {
  plugins: [
    require('postcss-hash')({manifest: './manifest.json'})
  ]
}

// expected: outputfile: /path/to/output.a1b2c3d4e5.css
// actual: outputfile: /path/to/output.css
```