### PR TITLE
Add `--watch=always` option to prevent exit when stdin closes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `line-height` modifier support to `font-size` utilities ([#9875](https://github.com/tailwindlabs/tailwindcss/pull/9875))
 - Support using variables as arbitrary values without `var(...)` ([#9880](https://github.com/tailwindlabs/tailwindcss/pull/9880))
+- Add `--watch=always` option to prevent exit when stdin closes ([#9966](https://github.com/tailwindlabs/tailwindcss/pull/9966))
 
 ### Fixed
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -159,8 +159,8 @@ let args = (() => {
       let flag = result['_'][i]
       if (!flag.startsWith('-')) continue
 
-      let flagName = flag
-      let handler = flags[flag]
+      let [flagName, flagValue] = flag.split('=')
+      let handler = flags[flagName]
 
       // Resolve flagName & handler
       while (typeof handler === 'string') {
@@ -173,19 +173,27 @@ let args = (() => {
       let args = []
       let offset = i + 1
 
-      // Parse args for current flag
-      while (result['_'][offset] && !result['_'][offset].startsWith('-')) {
-        args.push(result['_'][offset++])
+      // --flag value syntax was used so we need to pull `value` from `args`
+      if (flagValue === undefined) {
+        // Parse args for current flag
+        while (result['_'][offset] && !result['_'][offset].startsWith('-')) {
+          args.push(result['_'][offset++])
+        }
+
+        // Cleanup manually parsed flags + args
+        result['_'].splice(i, 1 + args.length)
+
+        // No args were provided, use default value defined in handler
+        // One arg was provided, use that directly
+        // Multiple args were provided so pass them all in an array
+        flagValue = args.length === 0 ? undefined : args.length === 1 ? args[0] : args
+      } else {
+        // Remove the whole flag from the args array
+        result['_'].splice(i, 1)
       }
 
-      // Cleanup manually parsed flags + args
-      result['_'].splice(i, 1 + args.length)
-
       // Set the resolved value in the `result` object
-      result[flagName] = handler.type(
-        args.length === 0 ? undefined : args.length === 1 ? args[0] : args,
-        flagName
-      )
+      result[flagName] = handler.type(flagValue, flagName)
     }
 
     // Ensure that the `command` is always the first argument in the `args`.

--- a/src/cli.js
+++ b/src/cli.js
@@ -62,7 +62,10 @@ let commands = {
     args: {
       '--input': { type: String, description: 'Input file' },
       '--output': { type: String, description: 'Output file' },
-      '--watch': { type: Boolean, description: 'Watch for changes and rebuild as needed' },
+      '--watch': {
+        type: oneOf(String, Boolean),
+        description: 'Watch for changes and rebuild as needed',
+      },
       '--poll': {
         type: Boolean,
         description: 'Use polling instead of filesystem events when watching',

--- a/src/cli/build/index.js
+++ b/src/cli/build/index.js
@@ -34,8 +34,12 @@ export async function build(args, configs) {
   let processor = await createProcessor(args, configPath)
 
   if (shouldWatch) {
-    /* Abort the watcher if stdin is closed to avoid zombie processes */
-    process.stdin.on('end', () => process.exit(0))
+    // Abort the watcher if stdin is closed to avoid zombie processes
+    // You can disable this behavior with --watch=always
+    if (args['--watch'] !== 'always') {
+      process.stdin.on('end', () => process.exit(0))
+    }
+
     process.stdin.resume()
 
     await processor.watch()


### PR DESCRIPTION
Fixes #9870

We were trying our best to not need an option for this but there are too many scenarios where one behavior works for a tool and the other one does not.

In general, exiting when stdin closes is still the only reliable way to guarantee a process actually exits appropriately when orphaned because the OS / kernel itself will close the file handle associated with stdin. But, in certain scenarios, stdin isn't wired up in the first place. For instance:
- Turborepo does this (or did at one point — not sure if it has been changed yet)
- Bash does this when running commands in the background ONLY when not in an interactive shell