### PR TITLE
Improve return value of `resolveConfig`, unwrap `ResolvableTo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `foo-[abc]/[def]` not being handled correctly ([#9866](https://github.com/tailwindlabs/tailwindcss/pull/9866))
 - Add container queries plugin to standalone CLI ([#9865](https://github.com/tailwindlabs/tailwindcss/pull/9865))
 - Support renaming of output files by `PostCSS` plugin. ([#9944](https://github.com/tailwindlabs/tailwindcss/pull/9944))
+- Improve return value of `resolveConfig`, unwrap `ResolvableTo` ([#9972](https://github.com/tailwindlabs/tailwindcss/pull/9972))
 
 ## [3.2.4] - 2022-11-11
 

--- a/resolveConfig.d.ts
+++ b/resolveConfig.d.ts
@@ -1,3 +1,12 @@
-import type { Config } from './types/config'
-declare function resolveConfig(config: Config): Config
+import type { Config, ResolvableTo } from './types/config'
+
+type UnwrapResolvables<T> = {
+  [K in keyof T]: T[K] extends ResolvableTo<infer R> ? R : T[K]
+}
+
+type ResolvedConfig<T extends Config> = Omit<T, 'theme'> & {
+  theme: UnwrapResolvables<T['theme']>
+}
+
+declare function resolveConfig<T extends Config>(config: T): ResolvedConfig<T>
 export = resolveConfig

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -11,7 +11,7 @@ type KeyValuePair<K extends keyof any = string, V = string> = Record<K, V>
 interface RecursiveKeyValuePair<K extends keyof any = string, V = string> {
   [key: string]: V | RecursiveKeyValuePair<K, V>
 }
-type ResolvableTo<T> = T | ((utils: PluginUtils) => T)
+export type ResolvableTo<T> = T | ((utils: PluginUtils) => T)
 type CSSRuleObject = RecursiveKeyValuePair<string, null | string | string[]>
 
 interface PluginUtils {


### PR DESCRIPTION
This PR improves the return type fo the `resolveConfig` a little bit.

In the config, a lot of values can be written in various forms (and most of it is optional). We also allow for dynamic "runtime" presets, so generating the perfect TypeScript types are almost impossible.

However, some of the parts in the config accept a function that resolves to type `T`, this improvement gets rid of the callback function and results in `T` directly (because calling `resolveConfig` should resolve this).

Fixes: #9929
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
