### PR TITLE
Don’t reorder webkit scrollbar pseudo elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support renaming of output files by `PostCSS` plugin. ([#9944](https://github.com/tailwindlabs/tailwindcss/pull/9944))
 - Improve return value of `resolveConfig`, unwrap `ResolvableTo` ([#9972](https://github.com/tailwindlabs/tailwindcss/pull/9972))
 - Clip unbalanced brackets in arbitrary values ([#9973](https://github.com/tailwindlabs/tailwindcss/pull/9973))
+- Don’t reorder webkit scrollbar pseudo elements ([#9991](https://github.com/tailwindlabs/tailwindcss/pull/9991))
 
 ### Changed
 

--- a/src/util/formatVariantSelector.js
+++ b/src/util/formatVariantSelector.js
@@ -250,7 +250,18 @@ export function finalizeSelector(
 let pseudoElementsBC = [':before', ':after', ':first-line', ':first-letter']
 
 // These pseudo-elements _can_ be combined with other pseudo selectors AND the order does matter.
-let pseudoElementExceptions = ['::file-selector-button']
+let pseudoElementExceptions = [
+  '::file-selector-button',
+
+  // Webkit scroll bar pseudo elements can be combined with user-action pseudo classes
+  '::-webkit-scrollbar',
+  '::-webkit-scrollbar-button',
+  '::-webkit-scrollbar-thumb',
+  '::-webkit-scrollbar-track',
+  '::-webkit-scrollbar-track-piece',
+  '::-webkit-scrollbar-corner',
+  '::-webkit-resizer',
+]
 
 // This will make sure to move pseudo's to the correct spot (the end for
 // pseudo elements) because otherwise the selector will never work

--- a/tests/variants.test.js
+++ b/tests/variants.test.js
@@ -1096,3 +1096,52 @@ test('variant functions returning arrays should output correct results when nest
     }
   `)
 })
+
+test.only('arbitrary variant selectors should not re-order scrollbar pseudo classes', async () => {
+  let config = {
+    content: [
+      {
+        raw: html`
+          <div class="[&::-webkit-scrollbar:hover]:underline" />
+          <div class="[&::-webkit-scrollbar-button:hover]:underline" />
+          <div class="[&::-webkit-scrollbar-thumb:hover]:underline" />
+          <div class="[&::-webkit-scrollbar-track:hover]:underline" />
+          <div class="[&::-webkit-scrollbar-track-piece:hover]:underline" />
+          <div class="[&::-webkit-scrollbar-corner:hover]:underline" />
+          <div class="[&::-webkit-resizer:hover]:underline" />
+        `,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind utilities;
+  `
+
+  let result = await run(input, config)
+
+  expect(result.css).toMatchFormattedCss(css`
+    .\[\&\:\:-webkit-scrollbar\:hover\]\:underline::-webkit-scrollbar:hover {
+      text-decoration-line: underline;
+    }
+    .\[\&\:\:-webkit-scrollbar-button\:hover\]\:underline::-webkit-scrollbar-button:hover {
+      text-decoration-line: underline;
+    }
+    .\[\&\:\:-webkit-scrollbar-thumb\:hover\]\:underline::-webkit-scrollbar-thumb:hover {
+      text-decoration-line: underline;
+    }
+    .\[\&\:\:-webkit-scrollbar-track\:hover\]\:underline::-webkit-scrollbar-track:hover {
+      text-decoration-line: underline;
+    }
+    .\[\&\:\:-webkit-scrollbar-track-piece\:hover\]\:underline::-webkit-scrollbar-track-piece:hover {
+      text-decoration-line: underline;
+    }
+    .\[\&\:\:-webkit-scrollbar-corner\:hover\]\:underline::-webkit-scrollbar-corner:hover {
+      text-decoration-line: underline;
+    }
+    .\[\&\:\:-webkit-resizer\:hover\]\:underline::-webkit-resizer:hover {
+      text-decoration-line: underline;
+    }
+  `)
+})


### PR DESCRIPTION
In reality, we need to stop reordering pseudo elements completely as `::before:hover` and `::after:hover` are 100% valid and should work per the CSS selector spec even though no browser currently supports it but that would be a pretty big breaking change.

So we'll just add some more exceptions to the reordering mechanics instead.

Fixes #9977