### PR TITLE
Add standalone-cli build for Windows Arm64 platform

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -75,3 +75,4 @@ jobs:
             standalone-cli/dist/tailwindcss-macos-arm64
             standalone-cli/dist/tailwindcss-macos-x64
             standalone-cli/dist/tailwindcss-windows-x64.exe
+            standalone-cli/dist/tailwindcss-windows-arm64.exe

--- a/standalone-cli/package.json
+++ b/standalone-cli/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "pkg . --compress Brotli --no-bytecode --public-packages \"*\" --public",
     "prebuild": "rimraf dist",
-    "postbuild": "move-file dist/tailwindcss-standalone-macos-x64 dist/tailwindcss-macos-x64 && move-file dist/tailwindcss-standalone-macos-arm64 dist/tailwindcss-macos-arm64 && move-file dist/tailwindcss-standalone-win-x64.exe dist/tailwindcss-windows-x64.exe && move-file dist/tailwindcss-standalone-linuxstatic-x64 dist/tailwindcss-linux-x64 && move-file dist/tailwindcss-standalone-linuxstatic-arm64 dist/tailwindcss-linux-arm64 && move-file dist/tailwindcss-standalone-linuxstatic-armv7 dist/tailwindcss-linux-armv7",
+    "postbuild": "move-file dist/tailwindcss-standalone-macos-x64 dist/tailwindcss-macos-x64 && move-file dist/tailwindcss-standalone-macos-arm64 dist/tailwindcss-macos-arm64 && move-file dist/tailwindcss-standalone-win-x64.exe dist/tailwindcss-windows-x64.exe && move-file dist/tailwindcss-standalone-win-arm64.exe dist/tailwindcss-windows-arm64.exe && move-file dist/tailwindcss-standalone-linuxstatic-x64 dist/tailwindcss-linux-x64 && move-file dist/tailwindcss-standalone-linuxstatic-arm64 dist/tailwindcss-linux-arm64 && move-file dist/tailwindcss-standalone-linuxstatic-armv7 dist/tailwindcss-linux-armv7",
     "test": "jest"
   },
   "devDependencies": {
@@ -27,6 +27,7 @@
       "node16-macos-x64",
       "node16-macos-arm64",
       "node16-win-x64",
+      "node16-win-arm64",
       "node16-linuxstatic-x64",
       "node16-linuxstatic-arm64",
       "node16-linuxstatic-armv7"

--- a/standalone-cli/tests/test.js
+++ b/standalone-cli/tests/test.js
@@ -5,9 +5,7 @@ const fs = require('fs-extra')
 const platformMap = {
   darwin: `./dist/tailwindcss-macos-${process.arch}`,
   linux: `./dist/tailwindcss-linux-${process.arch}`,
-  win32: `.\\dist\\tailwindcss-windows-${(
-    process.env.PROCESSOR_ARCHITEW6432 || process.arch
-  ).toLowerCase()}.exe`,
+  win32: `.\\dist\\tailwindcss-windows-${process.arch}`,
 }
 
 function exec(args) {

--- a/standalone-cli/tests/test.js
+++ b/standalone-cli/tests/test.js
@@ -3,14 +3,14 @@ const os = require('os')
 const fs = require('fs-extra')
 
 const platformMap = {
-  darwin: 'macos',
-  win32: 'windows',
-  linux: 'linux',
+  darwin: `./dist/tailwindcss-macos-${process.arch}`,
+  linux: `./dist/tailwindcss-linux-${process.arch}`,
+  win32: `.\\dist\\tailwindcss-windows-${(process.env.PROCESSOR_ARCHITEW6432 || process.arch).toLowerCase()}.exe`,
 }
 
 function exec(args) {
   return execSync(
-    `./dist/tailwindcss-${platformMap[process.platform]}-${process.arch} ${args}`
+    `${platformMap[process.platform]} ${args}`
   ).toString()
 }
 

--- a/standalone-cli/tests/test.js
+++ b/standalone-cli/tests/test.js
@@ -5,13 +5,13 @@ const fs = require('fs-extra')
 const platformMap = {
   darwin: `./dist/tailwindcss-macos-${process.arch}`,
   linux: `./dist/tailwindcss-linux-${process.arch}`,
-  win32: `.\\dist\\tailwindcss-windows-${(process.env.PROCESSOR_ARCHITEW6432 || process.arch).toLowerCase()}.exe`,
+  win32: `.\\dist\\tailwindcss-windows-${(
+    process.env.PROCESSOR_ARCHITEW6432 || process.arch
+  ).toLowerCase()}.exe`,
 }
 
 function exec(args) {
-  return execSync(
-    `${platformMap[process.platform]} ${args}`
-  ).toString()
+  return execSync(`${platformMap[process.platform]} ${args}`).toString()
 }
 
 it('works', () => {


### PR DESCRIPTION
This PR adds building the standalone-cli for windows targeting Am64. Updates are made to the standalone-cli tests to ensure the proper executable is used for running tests under windows when the node binary is targeting a different architecture than the host OS.

With the release of the [Windows Dev Kit 2023](https://learn.microsoft.com/en-us/windows/arm/dev-kit/) and [Arm64 Visual Studio](https://devblogs.microsoft.com/visualstudio/arm64-visual-studio-is-officially-here/) as well as existing support for arm64 on other platforms, it seems natural to release the standalone-cli for Windows. It's especially helpful when using the standalone-cli as part of automated builds for non-javascript projects.

Built and tested with Windows 11 22H2 Arm64 on a Windows Dev Kit 2023 with Visual Studio 17.5 Preview 1 using the bundled node.js