### PR TITLE
feat: add hyphens

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1409,6 +1409,14 @@ export let corePlugins = {
     })
   },
 
+  hyphens: ({ addUtilities }) => {
+    addUtilities({
+      '.hyphens-none': { hyphens: 'none' },
+      '.hyphens-manual': { hyphens: 'manual' },
+      '.hyphens-auto': { hyphens: 'auto' },
+    })
+  },
+
   whitespace: ({ addUtilities }) => {
     addUtilities({
       '.whitespace-normal': { 'white-space': 'normal' },


### PR DESCRIPTION
In german language we have many long words. We concat cohesive words without whitespaces. It's pretty easy to have words with 15+ characters. The german language also has strict rules how to hyphenate based on syllables, so the https://tailwindcss.com/docs/word-break does not help at all for normal language.

So the hyphens rule comes in pretty handy: https://developer.mozilla.org/en-US/docs/Web/CSS/hyphens

It's pretty straight forward addition, that's requested by a few people:
- https://github.com/tailwindlabs/tailwindcss/discussions/7286
- https://github.com/tailwindlabs/tailwindcss/discussions/2243
- https://github.com/tailwindlabs/tailwindcss/discussions/8508
- https://github.com/tailwindlabs/tailwindcss/discussions/1846
- https://github.com/tailwindlabs/tailwindcss/discussions/3985