### PR TITLE
Fix missing `string[]` in the `dropShadow` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `data` key to theme types ([#10023](https://github.com/tailwindlabs/tailwindcss/pull/10023))
 - Prevent invalid arbitrary variant selectors from failing the build ([#10059](https://github.com/tailwindlabs/tailwindcss/pull/10059))
 - Properly handle subtraction followed by a variable ([#10074](https://github.com/tailwindlabs/tailwindcss/pull/10074))
+- Fix missing `string[]` in the `theme.dropShadow` types ([#10072](https://github.com/tailwindlabs/tailwindcss/pull/10072))
 
 ### Changed
 

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -209,7 +209,7 @@ interface ThemeConfig {
   blur: ResolvableTo<KeyValuePair>
   brightness: ResolvableTo<KeyValuePair>
   contrast: ResolvableTo<KeyValuePair>
-  dropShadow: ResolvableTo<KeyValuePair>
+  dropShadow: ResolvableTo<KeyValuePair<string, string | string[]>>
   grayscale: ResolvableTo<KeyValuePair>
   hueRotate: ResolvableTo<KeyValuePair>
   invert: ResolvableTo<KeyValuePair>


### PR DESCRIPTION
This PR updates the `dropShadow` type to accurately reflect the existing support for both strings and arrays of strings.