### PR TITLE
fix normalizing subtraction followed by a variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deterministic sorting of arbitrary variants ([#10016](https://github.com/tailwindlabs/tailwindcss/pull/10016))
 - Add `data` key to theme types ([#10023](https://github.com/tailwindlabs/tailwindcss/pull/10023))
 - Prevent invalid arbitrary variant selectors from failing the build ([#10059](https://github.com/tailwindlabs/tailwindcss/pull/10059))
+- Properly handle subtraction followed by a variable ([#10074](https://github.com/tailwindlabs/tailwindcss/pull/10074))
 
 ### Changed
 

--- a/tests/arbitrary-values.test.css
+++ b/tests/arbitrary-values.test.css
@@ -197,6 +197,9 @@
 .min-w-\[calc\(1-\(var\(--something\)\*0\.5\)\)\] {
   min-width: calc(1 - (var(--something) * 0.5));
 }
+.min-w-\[calc\(1-\(\(12-3\)\*0\.5\)\)\] {
+  min-width: calc(1 - ((12 - 3) * 0.5));
+}
 .min-w-\[3\.23rem\] {
   min-width: 3.23rem;
 }

--- a/tests/arbitrary-values.test.css
+++ b/tests/arbitrary-values.test.css
@@ -191,6 +191,12 @@
 .w-\[\'\}\{\}\'\] {
   width: '}{}';
 }
+.min-w-\[calc\(1-var\(--something\)\*0\.5\)\] {
+  min-width: calc(1 - var(--something) * 0.5);
+}
+.min-w-\[calc\(1-\(var\(--something\)\*0\.5\)\)\] {
+  min-width: calc(1 - (var(--something) * 0.5));
+}
 .min-w-\[3\.23rem\] {
   min-width: 3.23rem;
 }

--- a/tests/arbitrary-values.test.html
+++ b/tests/arbitrary-values.test.html
@@ -69,6 +69,7 @@
     <div class="w-[calc(100%/3-1rem*2)]"></div>
     <div class="min-w-[calc(1-var(--something)*0.5)]"></div>
     <div class="min-w-[calc(1-(var(--something)*0.5))]"></div>
+    <div class="min-w-[calc(1-((12-3)*0.5))]"></div>
 
     <div class="min-w-[3.23rem]"></div>
     <div class="min-w-[calc(100%+1rem)]"></div>

--- a/tests/arbitrary-values.test.html
+++ b/tests/arbitrary-values.test.html
@@ -67,6 +67,8 @@
     <div class="w-[var(--width)]"></div>
     <div class="w-[var(--width,calc(100%+1rem))]"></div>
     <div class="w-[calc(100%/3-1rem*2)]"></div>
+    <div class="min-w-[calc(1-var(--something)*0.5)]"></div>
+    <div class="min-w-[calc(1-(var(--something)*0.5))]"></div>
 
     <div class="min-w-[3.23rem]"></div>
     <div class="min-w-[calc(100%+1rem)]"></div>


### PR DESCRIPTION
Fixes #9832

```diff
-/(-?\d*\.?\d(?!\b-.+[,)](?![^+\-/*])\D)(?:%|[a-z]+)?|\))([+\-/*])/g
+/(-?\d*\.?\d(?!\b-\d.+[,)](?![^+\-/*])\D)(?:%|[a-z]+)?|\))([+\-/*])/g
                   ^ added `\d` to regex
```

This is fixed the issue but caused some false positives on classes like `calc(var(--headings-h1-size)*100)`:
```diff
// normalize-data-types.test.js
-calc(var(--headings-h1-size)*100)
+calc(var(--headings-h1 - size) * 100)
```
I couldn't figure out how to fix that with regex. To solve this problem, I extracted the variable names and replaced them with safe ones before processing.