### PR TITLE
Border Radius Full

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -93,7 +93,7 @@ module.exports = {
       xl: '0.75rem',
       '2xl': '1rem',
       '3xl': '1.5rem',
-      full: '9999px',
+      full: '50%',
     },
     borderSpacing: ({ theme }) => ({
       ...theme('spacing'),


### PR DESCRIPTION
Border Radius Full with problem
using rounded-l-full rounded-r-lg in tailwind, Border Radius has issues with 9999px At 9999px it can't create a smaller rounded for the other corner, if you just want to insert full on one side or in a corner. The correct one should be 50% in this case. so each corner takes 50% (full)

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
