### PR TITLE
Drop Node.js 12 from workflows because of EOL

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [14, 16]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12]
+        node-version: [14]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
IDK if this question was already discussed, but since [Node.js 12 entered EOL since 30 April 2022](https://nodejs.org/es/blog/release/v12.22.12/), does the project have a reason to still use it on workflows?