### PR TITLE
Fix missing `blocklist` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow direct nesting in `root` or `@layer` nodes ([#10229](https://github.com/tailwindlabs/tailwindcss/pull/10229))
 - Don't prefix classes in arbitrary variants ([#10214](https://github.com/tailwindlabs/tailwindcss/pull/10214))
 - Fix perf regression when checking for changed content ([#10234](https://github.com/tailwindlabs/tailwindcss/pull/10234))
+- Fix missing `blocklist` member in the `Config` type ([#10239](https://github.com/tailwindlabs/tailwindcss/pull/10239))
 
 ### Changed
 

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -53,6 +53,9 @@ type SafelistConfig =
       variants?: string[]
     }[]
 
+// Blocklist related config
+type BlocklistConfig = string[]
+
 // Presets related config
 type PresetsConfig = Config[]
 
@@ -349,6 +352,7 @@ interface OptionalConfig {
   prefix: Partial<PrefixConfig>
   separator: Partial<SeparatorConfig>
   safelist: Partial<SafelistConfig>
+  blocklist: Partial<BlocklistConfig>
   presets: Partial<PresetsConfig>
   future: Partial<FutureConfig>
   experimental: Partial<ExperimentalConfig>


### PR DESCRIPTION
Adds the [`blocklist` configuration option](https://tailwindcss.com/docs/content-configuration#discarding-classes) to the `Config` Typescript type.