### PR TITLE
Escape group names in selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't prefix classes in arbitrary variants ([#10214](https://github.com/tailwindlabs/tailwindcss/pull/10214))
 - Fix perf regression when checking for changed content ([#10234](https://github.com/tailwindlabs/tailwindcss/pull/10234))
 - Fix missing `blocklist` member in the `Config` type ([#10239](https://github.com/tailwindlabs/tailwindcss/pull/10239))
+- Escape group names in selectors ([#10276](https://github.com/tailwindlabs/tailwindcss/pull/10276))
 
 ### Changed
 

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -150,9 +150,13 @@ export let variantPlugins = {
 
     let variants = {
       group: (_, { modifier }) =>
-        modifier ? [`:merge(.group\\/${modifier})`, ' &'] : [`:merge(.group)`, ' &'],
+        modifier
+          ? [`:merge(.group\\/${escapeClassName(modifier)})`, ' &']
+          : [`:merge(.group)`, ' &'],
       peer: (_, { modifier }) =>
-        modifier ? [`:merge(.peer\\/${modifier})`, ' ~ &'] : [`:merge(.peer)`, ' ~ &'],
+        modifier
+          ? [`:merge(.peer\\/${escapeClassName(modifier)})`, ' ~ &']
+          : [`:merge(.peer)`, ' ~ &'],
     }
 
     for (let [name, fn] of Object.entries(variants)) {

--- a/tests/basic-usage.test.js
+++ b/tests/basic-usage.test.js
@@ -689,3 +689,27 @@ it('Ring color utilities are generated when using respectDefaultRingColorOpacity
     `)
   })
 })
+
+it('should not crash when group names contain special characters', () => {
+  let config = {
+    future: { respectDefaultRingColorOpacity: true },
+    content: [
+      {
+        raw: '<div class="group/${id}"><div class="group-hover/${id}:visible"></div></div>',
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .group\/\$\{id\}:hover .group-hover\/\$\{id\}\:visible {
+        visibility: visible;
+      }
+    `)
+  })
+})


### PR DESCRIPTION
In v3.2.4 we would hard crash on the group variant `group/${id}`. This is because the name `${id}`:
1. Had `{` and `}` in it
2. These were unescaped
3. Even if manually escaped, we weren't handling this properly.

Here we fix this by doing two things:
1. Escaping the group / peer names so they can appear in a selector un-modified.
2. Handling escaped characters properly in a variant format string

Fixes #10266