### PR TITLE
Consider earlier variants before sorting functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix perf regression when checking for changed content ([#10234](https://github.com/tailwindlabs/tailwindcss/pull/10234))
 - Fix missing `blocklist` member in the `Config` type ([#10239](https://github.com/tailwindlabs/tailwindcss/pull/10239))
 - Escape group names in selectors ([#10276](https://github.com/tailwindlabs/tailwindcss/pull/10276))
+- Consider earlier variants before sorting functions ([#10288](https://github.com/tailwindlabs/tailwindcss/pull/10288))
 
 ### Changed
 


### PR DESCRIPTION
We were sorting based on functions unconditionally before. This would result in problems with utilities using stacked variants where some of them used sorting functions. The output would end up entirely based on the result of the sorting functions instead of the order of the variants as a whole. We now effectively sort on a per-variant basis while still considering sort functions for variants that use them.

Fixes #10267