### PR TITLE
Add `delay-0` and `duration-0` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support using variables as arbitrary values without `var(...)` ([#9880](https://github.com/tailwindlabs/tailwindcss/pull/9880), [#9962](https://github.com/tailwindlabs/tailwindcss/pull/9962))
 - Add `--watch=always` option to prevent exit when stdin closes ([#9966](https://github.com/tailwindlabs/tailwindcss/pull/9966))
 - Add standalone CLI build for 64-bit Windows on ARM (`node16-win-arm64`) ([#10001](https://github.com/tailwindlabs/tailwindcss/pull/10001))
+- Add `delay-0` and `duration-0` by default ([#10294](https://github.com/tailwindlabs/tailwindcss/pull/10294))
 
 ### Fixed
 

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -864,6 +864,7 @@ module.exports = {
     },
     transitionDuration: {
       DEFAULT: '150ms',
+      0: '0s',
       75: '75ms',
       100: '100ms',
       150: '150ms',

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -852,6 +852,7 @@ module.exports = {
       'top-left': 'top left',
     },
     transitionDelay: {
+      0: '0s',
       75: '75ms',
       100: '100ms',
       150: '150ms',


### PR DESCRIPTION
Adds a `0s` value to the default `transitionDelay` and `transitionDuration` configurations. Useful as a conditional reset. Using `s` rather than `ms` because it’s shorter, which means a smaller CSS file and blazing fast performance.