### PR TITLE
Cache the `oxide` targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,10 @@ jobs:
         run: npm install
 
       - name: Build Tailwind CSS
-        run: npm run build
+        run: npx turbo run build --filter=//
 
       - name: Test
-        run: npm run test
+        run: npx turbo run test --filter=//
 
       - name: Lint
-        run: npm run style
+        run: npx turbo run style --filter=//

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,19 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('./oxide/**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      # Cache the `oxide` Rust build
+      - name: Cache oxide build
+        uses: actions/cache@v3
+        with:
+          path: |
+            ./oxide/crates/target
+            ./oxide/crates/node/target
+            ./oxide/crates/node/*.node
+            ./oxide/crates/node/index.js
+            ./oxide/crates/node/index.d.ts
+          key: ${{ runner.os }}-cargo-${{ hashFiles('./oxide/crates/**/*') }}
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,12 +53,11 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ./oxide/crates/target
-            ./oxide/crates/node/target
+            ./oxide/target/
             ./oxide/crates/node/*.node
             ./oxide/crates/node/index.js
             ./oxide/crates/node/index.d.ts
-          key: ${{ runner.os }}-cargo-${{ hashFiles('./oxide/crates/**/*') }}
+          key: ${{ runner.os }}-oxide-${{ hashFiles('./oxide/crates/**/*') }}
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,10 @@ jobs:
         run: npm install
 
       - name: Build Tailwind CSS
-        run: npx turbo run build --filter=//
+        run: npm run build
 
       - name: Test
-        run: npx turbo run test --filter=//
+        run: npm run test
 
       - name: Lint
-        run: npx turbo run style --filter=//
+        run: npm run style

--- a/.github/workflows/integration-tests-oxide.yml
+++ b/.github/workflows/integration-tests-oxide.yml
@@ -58,7 +58,18 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('./oxide/**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      # Cache the `oxide` Rust build
+      - name: Cache oxide build
+        uses: actions/cache@v3
+        with:
+          path: |
+            ./oxide/target/
+            ./oxide/crates/node/*.node
+            ./oxide/crates/node/index.js
+            ./oxide/crates/node/index.d.ts
+          key: ${{ runner.os }}-oxide-${{ hashFiles('./oxide/crates/**/*') }}
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/release-insiders-oxide.yml
+++ b/.github/workflows/release-insiders-oxide.yml
@@ -45,7 +45,18 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('./oxide/**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      # Cache the `oxide` Rust build
+      - name: Cache oxide build
+        uses: actions/cache@v3
+        with:
+          path: |
+            ./oxide/target/
+            ./oxide/crates/node/*.node
+            ./oxide/crates/node/index.js
+            ./oxide/crates/node/index.d.ts
+          key: ${{ runner.os }}-oxide-${{ hashFiles('./oxide/crates/**/*') }}
 
       - name: Install Node.JS
         uses: actions/setup-node@v3
@@ -104,7 +115,18 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('./oxide/**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      # Cache the `oxide` Rust build
+      - name: Cache oxide build
+        uses: actions/cache@v3
+        with:
+          path: |
+            ./oxide/target/
+            ./oxide/crates/node/*.node
+            ./oxide/crates/node/index.js
+            ./oxide/crates/node/index.d.ts
+          key: ${{ runner.os }}-oxide-${{ hashFiles('./oxide/crates/**/*') }}
 
       - name: Install Node.JS
         uses: actions/setup-node@v3
@@ -188,7 +210,18 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('./oxide/**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      # Cache the `oxide` Rust build
+      - name: Cache oxide build
+        uses: actions/cache@v3
+        with:
+          path: |
+            ./oxide/target/
+            ./oxide/crates/node/*.node
+            ./oxide/crates/node/index.js
+            ./oxide/crates/node/index.d.ts
+          key: ${{ runner.os }}-oxide-${{ matrix.target }}-${{ hashFiles('./oxide/crates/**/*') }}
 
       - name: Install Node.JS
         uses: actions/setup-node@v3
@@ -255,7 +288,18 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('./oxide/**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      # Cache the `oxide` Rust build
+      - name: Cache oxide build
+        uses: actions/cache@v3
+        with:
+          path: |
+            ./oxide/target/
+            ./oxide/crates/node/*.node
+            ./oxide/crates/node/index.js
+            ./oxide/crates/node/index.d.ts
+          key: ${{ runner.os }}-oxide-${{ hashFiles('./oxide/crates/**/*') }}
 
       - name: Install dependencies
         run: npm install

--- a/turbo.json
+++ b/turbo.json
@@ -2,15 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "pipeline": {
     "//#build": {
-      "outputs": [
-        "lib/**",
-        "peers/**",
-        "types/generated/**",
-        "oxide/target/**",
-        "oxide/crates/node/*.node",
-        "oxide/crates/node/index.d.ts",
-        "oxide/crates/node/index.js"
-      ]
+      "outputs": ["lib/**", "peers/**", "types/generated/**"]
     },
     "test": {
       "env": ["OXIDE"],


### PR DESCRIPTION
This will cache the oxide related build files to hopefully minimize the
amount of Rust compiling.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
