### PR TITLE
Always sort candidates

### DIFF
--- a/oxide/crates/core/src/lib.rs
+++ b/oxide/crates/core/src/lib.rs
@@ -54,7 +54,7 @@ fn parse_all_blobs(blobs: Vec<Vec<u8>>) -> Vec<String> {
     let input: Vec<_> = blobs.iter().map(|blob| &blob[..]).collect();
     let input = &input[..];
 
-    input
+    let mut result: Vec<String> = input
         .par_iter()
         .map(|input| Extractor::unique(input, Default::default()))
         .reduce(Default::default, |mut a, b| {
@@ -68,5 +68,7 @@ fn parse_all_blobs(blobs: Vec<Vec<u8>>) -> Vec<String> {
             // to a string.
             unsafe { String::from_utf8_unchecked(s.to_vec()) }
         })
-        .collect()
+        .collect();
+    result.sort();
+    result
 }

--- a/src/lib/expandTailwindAtRules.js
+++ b/src/lib/expandTailwindAtRules.js
@@ -163,15 +163,16 @@ export default function expandTailwindAtRules(context) {
     let classCacheCount = context.classCache.size
 
     env.DEBUG && console.time('Generate rules')
-    // TODO: This has a small cost but is needed to make builds deterministic. Move this to Rust eventually.
     env.DEBUG && console.time('Sorting candidates')
-    let sortedCandidates = new Set(
-      [...candidates].sort((a, z) => {
-        if (a === z) return 0
-        if (a < z) return -1
-        return 1
-      })
-    )
+    let sortedCandidates = env.OXIDE
+      ? candidates
+      : new Set(
+          [...candidates].sort((a, z) => {
+            if (a === z) return 0
+            if (a < z) return -1
+            return 1
+          })
+        )
     env.DEBUG && console.timeEnd('Sorting candidates')
     generateRules(sortedCandidates, context)
     env.DEBUG && console.timeEnd('Generate rules')

--- a/src/lib/expandTailwindAtRules.js
+++ b/src/lib/expandTailwindAtRules.js
@@ -163,19 +163,15 @@ export default function expandTailwindAtRules(context) {
     let classCacheCount = context.classCache.size
 
     env.DEBUG && console.time('Generate rules')
-    // TODO: Sorting is _probably_ slow, but right now it can guarantee the same order. Eventually
-    // we will be able to get rid of this.
+    // TODO: This has a small cost but is needed to make builds deterministic. Move this to Rust eventually.
     env.DEBUG && console.time('Sorting candidates')
-    let sortedCandidates =
-      typeof process !== 'undefined' && process.env.JEST_WORKER_ID
-        ? new Set(
-            [...candidates].sort((a, z) => {
-              if (a === z) return 0
-              if (a < z) return -1
-              return 1
-            })
-          )
-        : candidates
+    let sortedCandidates = new Set(
+      [...candidates].sort((a, z) => {
+        if (a === z) return 0
+        if (a < z) return -1
+        return 1
+      })
+    )
     env.DEBUG && console.timeEnd('Sorting candidates')
     generateRules(sortedCandidates, context)
     env.DEBUG && console.timeEnd('Generate rules')


### PR DESCRIPTION
The generated CSS order in Tailwind is not deterministic and depends on the order that Tailwind scans your template files, so if one machine happens to look at `User.jsx` first and another looks at `Navbar.jsx` first, some things in the CSS file might be in a slightly different order even if nothing in the project has actually changed.

Prior to this PR we would sort class candidates when running in a test environment to ensure identical output between our stable engine and new Rust engine for testing purposes. We didn't do this for real builds because sorting the class names detected in templates introduces a small performance penalty and doesn't impact the behavior of the final CSS, because we already sort the CSS to the degree it's actually necessary, for example ensuring all `px-*` utilities come before `pl-*`.

With this PR, we _always_ sort the candidates, which ensures deterministic output across different systems.

Resolves #10378.