### PR TITLE
Handle variants when the same class appears multiple times in a selector

### DIFF
--- a/src/util/formatVariantSelector.js
+++ b/src/util/formatVariantSelector.js
@@ -218,7 +218,7 @@ export function finalizeSelector(current, formats, { context, candidate, base })
     parent.insertAfter(simpleSelector[simpleSelector.length - 1], simpleEnd)
 
     for (let child of formatNodes) {
-      parent.insertBefore(simpleSelector[0], child)
+      parent.insertBefore(simpleSelector[0], child.clone())
     }
 
     node.remove()

--- a/tests/basic-usage.test.js
+++ b/tests/basic-usage.test.js
@@ -922,4 +922,31 @@ crosscheck(({ stable, oxide }) => {
       `)
     })
   })
+
+  it('should not crash when matching variants where utility classes are doubled up', () => {
+    let config = {
+      content: [
+        {
+          raw: '<div class="hover:foo"></div>',
+        },
+      ],
+    }
+
+    let input = css`
+      @tailwind utilities;
+      @layer utilities {
+        .foo.foo {
+          text-decoration-line: underline;
+        }
+      }
+    `
+
+    return run(input, config).then((result) => {
+      expect(result.css).toMatchFormattedCss(css`
+        .hover\:foo:hover.hover\:foo:hover {
+          text-decoration-line: underline;
+        }
+      `)
+    })
+  })
 })


### PR DESCRIPTION
Given the utility `.foo.foo` and the candidate `hover:foo`, we would replace both instances of `.foo` with the exact same node representing `hover:foo`. In `postcss-selector-parser` nodes effectively have identity. This meant that it would see the node at position 1 and then again at position 2 causing in an infinite loop that was allocating memory and resulted in a crash. So we clone the `formatAst` nodes before inserting them which results in the correct selector `.hover\:foo:hover.hover\:foo:hover`

Fixes #10355