### PR TITLE
Handle group/peer variants with quoted strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Consider earlier variants before sorting functions ([#10288](https://github.com/tailwindlabs/tailwindcss/pull/10288))
 - Allow variants with slashes ([#10336](https://github.com/tailwindlabs/tailwindcss/pull/10336))
 - Ensure generated CSS is always sorted in the same order for a given set of templates ([#10382](https://github.com/tailwindlabs/tailwindcss/pull/10382))
+- Handle variants when the same class appears multiple times in a selector ([#10397](https://github.com/tailwindlabs/tailwindcss/pull/10397))
+- Handle group/peer variants with quoted strings ([#10400](https://github.com/tailwindlabs/tailwindcss/pull/10400))
 
 ### Changed
 

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -168,7 +168,32 @@ export let variantPlugins = {
           if (!result.includes('&')) result = '&' + result
 
           let [a, b] = fn('', extra)
-          return result.replace(/&(\S+)?/g, (_, pseudo = '') => a + pseudo + b)
+
+          let start = null;
+          let end = null;
+          let quotes = 0;
+
+          for (let i = 0; i < result.length; ++i) {
+            let c = result[i]
+            if (c === '&') {
+              start = i;
+            } else if (c === '\'' || c === '"') {
+              quotes += 1;
+            } else if (start !== null && c === ' ' && !quotes) {
+              end = i;
+            }
+          }
+
+          if (start !== null && end === null) {
+            end = result.length
+          }
+
+          // Basically this but can handle quotes:
+          // result.replace(/&(\S+)?/g, (_, pseudo = '') => a + pseudo + b)
+
+          result = result.slice(0, start) + a + result.slice(start+1, end) + b + result.slice(end)
+
+          return result
         },
         { values: Object.fromEntries(pseudoVariants) }
       )

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -169,18 +169,18 @@ export let variantPlugins = {
 
           let [a, b] = fn('', extra)
 
-          let start = null;
-          let end = null;
-          let quotes = 0;
+          let start = null
+          let end = null
+          let quotes = 0
 
           for (let i = 0; i < result.length; ++i) {
             let c = result[i]
             if (c === '&') {
-              start = i;
-            } else if (c === '\'' || c === '"') {
-              quotes += 1;
+              start = i
+            } else if (c === "'" || c === '"') {
+              quotes += 1
             } else if (start !== null && c === ' ' && !quotes) {
-              end = i;
+              end = i
             }
           }
 
@@ -191,7 +191,7 @@ export let variantPlugins = {
           // Basically this but can handle quotes:
           // result.replace(/&(\S+)?/g, (_, pseudo = '') => a + pseudo + b)
 
-          result = result.slice(0, start) + a + result.slice(start+1, end) + b + result.slice(end)
+          result = result.slice(0, start) + a + result.slice(start + 1, end) + b + result.slice(end)
 
           return result
         },

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -191,9 +191,7 @@ export let variantPlugins = {
           // Basically this but can handle quotes:
           // result.replace(/&(\S+)?/g, (_, pseudo = '') => a + pseudo + b)
 
-          result = result.slice(0, start) + a + result.slice(start + 1, end) + b + result.slice(end)
-
-          return result
+          return result.slice(0, start) + a + result.slice(start + 1, end) + b + result.slice(end)
         },
         { values: Object.fromEntries(pseudoVariants) }
       )

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -152,30 +152,26 @@ function applyVariant(variant, matches, context) {
 
   // Retrieve "modifier"
   {
-    let start = null;
-    let parens = 0;
-    let brackets = 0;
+    let start = null
+    let parens = 0
+    let brackets = 0
 
     for (let i = 0; i < variant.length; i++) {
       let c = variant[i]
       if (c === '[') {
-        brackets++;
+        brackets++
       } else if (c === ']') {
-        brackets--;
+        brackets--
       } else if (c === '(') {
-        parens++;
+        parens++
       } else if (c === ')') {
-        parens--;
+        parens--
       } else if (parens === 0 && brackets === 0 && c === '/') {
-        start = i;
+        start = i
       }
     }
 
-    let match = start === null ? null : [
-      variant,
-      variant.slice(0, start),
-      variant.slice(start + 1),
-    ]
+    let match = start === null ? null : [variant, variant.slice(0, start), variant.slice(start + 1)]
 
     if (match && !context.variantMap.has(variant)) {
       variant = match[1]

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -152,7 +152,31 @@ function applyVariant(variant, matches, context) {
 
   // Retrieve "modifier"
   {
-    let match = /(.*)\/(.*)$/g.exec(variant)
+    let start = null;
+    let parens = 0;
+    let brackets = 0;
+
+    for (let i = 0; i < variant.length; i++) {
+      let c = variant[i]
+      if (c === '[') {
+        brackets++;
+      } else if (c === ']') {
+        brackets--;
+      } else if (c === '(') {
+        parens++;
+      } else if (c === ')') {
+        parens--;
+      } else if (parens === 0 && brackets === 0 && c === '/') {
+        start = i;
+      }
+    }
+
+    let match = start === null ? null : [
+      variant,
+      variant.slice(0, start),
+      variant.slice(start + 1),
+    ]
+
     if (match && !context.variantMap.has(variant)) {
       variant = match[1]
       args.modifier = match[2]

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -152,7 +152,7 @@ function applyVariant(variant, matches, context) {
 
   // Retrieve "modifier"
   {
-    let [baseVariant, ...modifiers] = splitAtTopLevelOnly(variant, '/', 2)
+    let [baseVariant, ...modifiers] = splitAtTopLevelOnly(variant, '/')
 
     // This is a hack to support variants with `/` in them, like `ar-1/10/20:text-red-500`
     // In this case 1/10 is a value but /20 is a modifier

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -152,30 +152,18 @@ function applyVariant(variant, matches, context) {
 
   // Retrieve "modifier"
   {
-    let start = null
-    let parens = 0
-    let brackets = 0
+    let [baseVariant, ...modifiers] = splitAtTopLevelOnly(variant, '/', 2)
 
-    for (let i = 0; i < variant.length; i++) {
-      let c = variant[i]
-      if (c === '[') {
-        brackets++
-      } else if (c === ']') {
-        brackets--
-      } else if (c === '(') {
-        parens++
-      } else if (c === ')') {
-        parens--
-      } else if (parens === 0 && brackets === 0 && c === '/') {
-        start = i
-      }
+    // This is a hack to support variants with `/` in them, like `ar-1/10/20:text-red-500`
+    // In this case 1/10 is a value but /20 is a modifier
+    if (modifiers.length > 1) {
+      baseVariant = baseVariant + '/' + modifiers.slice(0, -1).join('/')
+      modifiers = modifiers.slice(-1)
     }
 
-    let match = start === null ? null : [variant, variant.slice(0, start), variant.slice(start + 1)]
-
-    if (match && !context.variantMap.has(variant)) {
-      variant = match[1]
-      args.modifier = match[2]
+    if (modifiers.length && !context.variantMap.has(variant)) {
+      variant = baseVariant
+      args.modifier = modifiers[0]
 
       if (!flagEnabled(context.tailwindConfig, 'generalizedModifiers')) {
         return []

--- a/tests/basic-usage.test.js
+++ b/tests/basic-usage.test.js
@@ -966,7 +966,7 @@ crosscheck(({ stable, oxide }) => {
     let result = await run(input, config)
 
     oxide.expect(result.css).toMatchFormattedCss(css`
-      .group[href^="/"] .group-\[\[href\^\=\'\/\'\]\]\:hidden {
+      .group[href^='/'] .group-\[\[href\^\=\'\/\'\]\]\:hidden {
         display: none;
       }
     `)
@@ -975,7 +975,7 @@ crosscheck(({ stable, oxide }) => {
       .hidden {
         display: none;
       }
-      .group[href^="/"] .group-\[\[href\^\=\'\/\'\]\]\:hidden {
+      .group[href^='/'] .group-\[\[href\^\=\'\/\'\]\]\:hidden {
         display: none;
       }
     `)
@@ -997,7 +997,7 @@ crosscheck(({ stable, oxide }) => {
     let result = await run(input, config)
 
     oxide.expect(result.css).toMatchFormattedCss(css`
-      .group[href^=" bar"] .group-\[\[href\^\=\'_bar\'\]\]\:hidden {
+      .group[href^=' bar'] .group-\[\[href\^\=\'_bar\'\]\]\:hidden {
         display: none;
       }
     `)
@@ -1006,7 +1006,7 @@ crosscheck(({ stable, oxide }) => {
       .hidden {
         display: none;
       }
-      .group[href^=" bar"] .group-\[\[href\^\=\'_bar\'\]\]\:hidden {
+      .group[href^=' bar'] .group-\[\[href\^\=\'_bar\'\]\]\:hidden {
         display: none;
       }
     `)

--- a/tests/basic-usage.test.js
+++ b/tests/basic-usage.test.js
@@ -949,4 +949,66 @@ crosscheck(({ stable, oxide }) => {
       `)
     })
   })
+
+  test('detects quoted arbitrary values containing a slash', async () => {
+    let config = {
+      content: [
+        {
+          raw: html`<div class="group-[[href^='/']]:hidden"></div>`,
+        },
+      ],
+    }
+
+    let input = css`
+      @tailwind utilities;
+    `
+
+    let result = await run(input, config)
+
+    oxide.expect(result.css).toMatchFormattedCss(css`
+      .group[href^="/"] .group-\[\[href\^\=\'\/\'\]\]\:hidden {
+        display: none;
+      }
+    `)
+
+    stable.expect(result.css).toMatchFormattedCss(css`
+      .hidden {
+        display: none;
+      }
+      .group[href^="/"] .group-\[\[href\^\=\'\/\'\]\]\:hidden {
+        display: none;
+      }
+    `)
+  })
+
+  test('handled quoted arbitrary values containing escaped spaces', async () => {
+    let config = {
+      content: [
+        {
+          raw: html`<div class="group-[[href^='_bar']]:hidden"></div>`,
+        },
+      ],
+    }
+
+    let input = css`
+      @tailwind utilities;
+    `
+
+    let result = await run(input, config)
+
+    oxide.expect(result.css).toMatchFormattedCss(css`
+      .group[href^=" bar"] .group-\[\[href\^\=\'_bar\'\]\]\:hidden {
+        display: none;
+      }
+    `)
+
+    stable.expect(result.css).toMatchFormattedCss(css`
+      .hidden {
+        display: none;
+      }
+      .group[href^=" bar"] .group-\[\[href\^\=\'_bar\'\]\]\:hidden {
+        display: none;
+      }
+    `)
+  })
 })

--- a/tests/util/run.js
+++ b/tests/util/run.js
@@ -70,7 +70,7 @@ let nullProxy = new Proxy(
  */
 
 /**
- * @param {(data: CrossCheck) => unknown} fn
+ * @param {(data: CrossCheck) => void} fn
  */
 export function crosscheck(fn) {
   let engines =

--- a/tests/util/run.js
+++ b/tests/util/run.js
@@ -60,6 +60,18 @@ let nullProxy = new Proxy(
   }
 )
 
+/**
+ * @typedef {object} CrossCheck
+ * @property {typeof import('@jest/globals')} oxide
+ * @property {typeof import('@jest/globals')} stable
+ * @property {object} engine
+ * @property {boolean} engine.oxide
+ * @property {boolean} engine.stable
+ */
+
+/**
+ * @param {(data: CrossCheck) => unknown} fn
+ */
 export function crosscheck(fn) {
   let engines =
     env.ENGINE === 'oxide' ? [{ engine: 'Stable' }, { engine: 'Oxide' }] : [{ engine: 'Stable' }]


### PR DESCRIPTION
Fixes #10353

This fixes two issues:
1. We were splitting on `/` in a quoted string in group/peer variants
2. We were splitting not-a-space but should've consumed spaces inside quoted string in group/peer variants.