### PR TITLE
Some minor fixes to the variants tests

### DIFF
--- a/tests/variants.oxide.test.css
+++ b/tests/variants.oxide.test.css
@@ -653,6 +653,10 @@
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
     var(--tw-shadow);
 }
+.peer[open] ~ .peer-open\:bg-red-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 202 202 / var(--tw-bg-opacity));
+}
 .peer:default ~ .peer-default\:shadow-md {
   --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
@@ -916,6 +920,13 @@
 @media (min-width: 1280px) {
   .xl\:shadow-md {
     --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+    --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color),
+      0 2px 4px -2px var(--tw-shadow-color);
+    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
+      var(--tw-shadow);
+  }
+  .dark .xl\:dark\:disabled\:shadow-md:disabled {
+    --tw-shadow: 0 4px 6px -1px #0000001a, 0 2px 4px -2px #0000001a;
     --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color),
       0 2px 4px -2px var(--tw-shadow-color);
     box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),

--- a/tests/variants.test.css
+++ b/tests/variants.test.css
@@ -653,6 +653,10 @@
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
     var(--tw-shadow);
 }
+.peer[open] ~ .peer-open\:bg-red-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 202 202 / var(--tw-bg-opacity));
+}
 .peer:default ~ .peer-default\:shadow-md {
   --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
@@ -916,6 +920,13 @@
 @media (min-width: 1280px) {
   .xl\:shadow-md {
     --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+    --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color),
+      0 2px 4px -2px var(--tw-shadow-color);
+    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
+      var(--tw-shadow);
+  }
+  .dark .xl\:dark\:disabled\:shadow-md:disabled {
+    --tw-shadow: 0 4px 6px -1px #0000001a, 0 2px 4px -2px #0000001a;
     --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color),
       0 2px 4px -2px var(--tw-shadow-color);
     box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),

--- a/tests/variants.test.html
+++ b/tests/variants.test.html
@@ -30,7 +30,6 @@
 <div class="out-of-range:shadow-md"></div>
 <div class="read-only:shadow-md"></div>
 <div class="empty:shadow-md"></div>
-<dialog class="backdrop:shadow-md"></dialog>
 
 <!-- Pseudo-element variants -->
 <div class="first-letter:text-2xl first-letter:text-red-500"></div>
@@ -43,6 +42,7 @@
 <div class="before:block before:bg-red-500"></div>
 <div class="after:flex after:uppercase"></div>
 <div class="placeholder:font-bold placeholder:text-red-500"></div>
+<dialog class="backdrop:shadow-md"></dialog>
 
 <!-- Group variants -->
 <div class="group-open:bg-red-200"></div>
@@ -78,6 +78,7 @@
 <div class="group-empty:shadow-md"></div>
 
 <!-- Peer variants -->
+<div class="peer-open:bg-red-200"></div>
 <div class="peer-first:shadow-md"></div>
 <div class="peer-last:shadow-md"></div>
 <div class="peer-only:shadow-md"></div>
@@ -147,7 +148,7 @@
 <div class="sm:active:shadow-md"></div>
 <div class="md:group-focus:shadow-md"></div>
 <div class="lg:dark:shadow-md"></div>
-<div class="xl:dark:disabledshadow-md"></div>
+<div class="xl:dark:disabled:shadow-md"></div>
 <div class="2xl:dark:motion-safe:focus-within:shadow-md"></div>
 
 <!-- Stacked group variants -->


### PR DESCRIPTION
Just a few small fixes to the variants tests:

- Add a test for `peer-open:` (there was already one for `group-open:`).
- Correct typo in `xl:dark:disabledshadow-md` test (missing semicolon) and create corresponding CSS.
- Move the `backdrop:` test from the pseudo-classes area to the pseudo-elements area.