### PR TITLE
Add `max-h-none` utility

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -584,6 +584,7 @@ module.exports = {
     }),
     maxHeight: ({ theme }) => ({
       ...theme('spacing'),
+      none: 'none',
       full: '100%',
       screen: '100vh',
       min: 'min-content',


### PR DESCRIPTION
Adds a `max-h-none` utility.

As with the existing `max-w-none` utility, the typical use-case would be to responsively "undo" a value, like `class="max-h-20 sm:max-h-none"` (`none` being the initial value for both the `max-width` and `max-height` CSS properties).