### PR TITLE
Add `leading-0` utility

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -558,6 +558,7 @@ module.exports = {
       widest: '0.1em',
     },
     lineHeight: {
+      0: '0',
       none: '1',
       tight: '1.25',
       snug: '1.375',


### PR DESCRIPTION
Adds a `leading-0` utility for `line-height: 0`.

There's already a `leading-none` utility for `line-height: 1`, but sometimes you really _do_ want zero line-height (and I do mean [you](https://github.com/tailwindlabs/tailwindcss/blob/master/src/css/preflight.css#L124-L130)!).