### PR TITLE
Add word-break: break-word with break-word

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1480,6 +1480,7 @@ export let corePlugins = {
     addUtilities({
       '.break-normal': { 'overflow-wrap': 'normal', 'word-break': 'normal' },
       '.break-words': { 'overflow-wrap': 'break-word' },
+      '.break-word': { 'word-break': 'break-word' },
       '.break-all': { 'word-break': 'break-all' },
       '.break-keep': { 'word-break': 'keep-all' },
     })


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->

Add new CSS style, because `break-words` isn't working properly (not break words to new line as I need)

<img width="1392" alt="Screenshot 2023-02-03 at 13 51 50" src="https://user-images.githubusercontent.com/49816584/216596903-99afff29-8f25-4c83-95fb-bf65d699059b.png">
Should be "приватних" together, like next:
<img width="1311" alt="Screenshot 2023-02-03 at 13 55 56" src="https://user-images.githubusercontent.com/49816584/216597694-9d9c3813-2c67-4cd0-b4dd-22d56253b73b.png">
