### PR TITLE
Make the bounce animation more usable

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -13,7 +13,7 @@ module.exports = {
       spin: 'spin 1s linear infinite',
       ping: 'ping 1s cubic-bezier(0, 0, 0.2, 1) infinite',
       pulse: 'pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite',
-      bounce: 'bounce 1s infinite',
+      bounce: 'bounce 2s infinite',
     },
     aria: {
       checked: 'checked="true"',
@@ -539,14 +539,18 @@ module.exports = {
         },
       },
       bounce: {
-        '0%, 100%': {
-          transform: 'translateY(-25%)',
-          animationTimingFunction: 'cubic-bezier(0.8,0,1,1)',
+        '0%, 50%, 100%': {
+          transform: 'translateY(0)',
+          animationTimingFunction: 'cubic-bezier(0, 0, 0.2, 1)',
         },
-        '50%': {
-          transform: 'none',
-          animationTimingFunction: 'cubic-bezier(0,0,0.2,1)',
+        '25%': {
+          transform: 'translateY(-15%)',
+          animationTimingFunction: 'cubic-bezier(0.8, 0, 1, 1)',
         },
+        '75%': {
+          transform: 'translateY(-5%)',
+          animationTimingFunction: 'cubic-bezier(0, 0, 0.2, 1)',
+        }
       },
     },
     letterSpacing: {

--- a/tests/animations.test.js
+++ b/tests/animations.test.js
@@ -36,17 +36,22 @@ crosscheck(() => {
         }
         @keyframes bounce {
           0%,
+          50%,
           100% {
-            animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
-            transform: translateY(-25%);
-          }
-          50% {
+            transform: translateY(0);
             animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
-            transform: none;
+          }
+          25% {
+            transform: translateY(-15%);
+            animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+          }
+          75% {
+            transform: translateY(-5%);
+            animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
           }
         }
         .group:hover .group-hover\:animate-bounce {
-          animation: 1s infinite bounce;
+          animation: 2s infinite bounce;
         }
       `)
     })
@@ -127,13 +132,18 @@ crosscheck(() => {
       expect(result.css).toMatchFormattedCss(css`
         @keyframes bounce {
           0%,
+          50%,
           100% {
-            animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
-            transform: translateY(-25%);
-          }
-          50% {
+            transform: translateY(0);
             animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
-            transform: none;
+          }
+          25% {
+            transform: translateY(-15%);
+            animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+          }
+          75% {
+            transform: translateY(-5%);
+            animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
           }
         }
         @keyframes pulse {

--- a/tests/parseAnimationValue.test.js
+++ b/tests/parseAnimationValue.test.js
@@ -25,11 +25,11 @@ crosscheck(() => {
         },
       ],
       [
-        'bounce 1s infinite',
+        'bounce 2s infinite',
         {
-          value: 'bounce 1s infinite',
+          value: 'bounce 2s infinite',
           name: 'bounce',
-          duration: '1s',
+          duration: '2s',
           iterationCount: 'infinite',
         },
       ],

--- a/tests/variants.test.js
+++ b/tests/variants.test.js
@@ -291,23 +291,28 @@ crosscheck(({ stable, oxide }) => {
       }
       @keyframes bounce {
         0%,
+        50%,
         100% {
-          animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
-          transform: translateY(-25%);
-        }
-        50% {
+          transform: translateY(0);
           animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
-          transform: none;
+        }
+        25% {
+          transform: translateY(-15%);
+          animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+        }
+        75% {
+          transform: translateY(-5%);
+          animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
         }
       }
       .hover\:animate-bounce:hover {
-        animation: 1s infinite bounce;
+        animation: 2s infinite bounce;
       }
       .hover\:animate-spin:hover {
         animation: 1s linear infinite spin;
       }
       .focus\:animate-bounce:focus {
-        animation: 1s infinite bounce;
+        animation: 2s infinite bounce;
       }
       .focus\:animate-spin:focus {
         animation: 1s linear infinite spin;


### PR DESCRIPTION
Currently the bounce animation is difficult to use due to the fact that the animation starts with the translation being applied at 0% and 100%.

This new version starts without an instantaneous  jump in the position while also spending more time at with less translation which makes it better on buttons and other things with which the user wants to interact.

The following is the new keyframes used
```
@keyframes bounce {
  0%,
  50%,
  100%{
    transform: translateY(0);
    animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
  }
  25% {
    transform: translateY(-15%);
    animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
  }
  75% {
    transform: translateY(-5%);
    animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
  }
}
```

Additionally the duration was changed from 1 second to 2 seconds since the bounce effectively occurs twice in the keyframes now.
