### PR TITLE
Add `justify-normal` and `justify-stretch` classes

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1224,6 +1224,7 @@ export let corePlugins = {
       '.justify-between': { 'justify-content': 'space-between' },
       '.justify-around': { 'justify-content': 'space-around' },
       '.justify-evenly': { 'justify-content': 'space-evenly' },
+      '.justify-normal': { 'justify-content': 'normal' },
     })
   },
 

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1218,6 +1218,7 @@ export let corePlugins = {
 
   justifyContent: ({ addUtilities }) => {
     addUtilities({
+      '.justify-normal': { 'justify-content': 'normal' },
       '.justify-start': { 'justify-content': 'flex-start' },
       '.justify-end': { 'justify-content': 'flex-end' },
       '.justify-center': { 'justify-content': 'center' },

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1224,7 +1224,7 @@ export let corePlugins = {
       '.justify-between': { 'justify-content': 'space-between' },
       '.justify-around': { 'justify-content': 'space-around' },
       '.justify-evenly': { 'justify-content': 'space-evenly' },
-      '.justify-normal': { 'justify-content': 'normal' },
+      '.justify-stretch': { 'justify-content': 'stretch' },
     })
   },
 


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->

### Discussed in https://github.com/tailwindlabs/tailwindcss/discussions/10558

<div type='discussions-op-text'>

<sup>Originally posted by **DavydeVries** February 12, 2023</sup>
Hi,

Currently, I'm using for viewport `sm` the class `sm:justify-center`. But I like to make the element full width on viewport `md`. The default value of `justify-content` is normally `justify-content: normal` (maybe differs on other browsers?). But there is no way to "reset" back to `normal` value.

Do you have suggestions to solve my issue, or is this value missing from the core?

Example:
Element not full width: https://play.tailwindcss.com/pj23KKG5cV
What I like to achieve/Expected behaviour: https://play.tailwindcss.com/oQ38fSUAsn

Kind regards,
Davy

_PS. I already tried to add `normal` to my config as an "extend" but didn't get it to work._</div>

See https://github.com/tailwindlabs/tailwindcss/issues/10559
