### PR TITLE
Upgrade rimraf: 3.0.2 → 4.1.2 (major)

### DIFF
--- a/jest/runInTempDirectory.js
+++ b/jest/runInTempDirectory.js
@@ -17,7 +17,9 @@ export default function (callback) {
 
     callback().then(() => {
       process.chdir(currentPath)
-      rimraf(tmpPath, resolve)
+
+      rimraf.sync(tmpPath)
+      resolve()
     })
   })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "picocolors": "^1.0.0",
         "postcss": "^8.4.21",
         "postcss-import": "^14.1.0",
-        "postcss-js": "^4.0.0",
+        "postcss-js": "^4.0.1",
         "postcss-load-config": "^3.1.4",
         "postcss-nested": "6.0.0",
         "postcss-selector-parser": "^6.0.11",
@@ -59,7 +59,7 @@
         "jest": "^29.4.1",
         "jest-diff": "^29.4.1",
         "prettier": "^2.8.4",
-        "rimraf": "^3.0.0",
+        "rimraf": "^4.1.2",
         "source-map-js": "^1.0.2",
         "turbo": "^1.7.4"
       },
@@ -7828,6 +7828,21 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/flat-cache/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/flatted": {
       "version": "3.1.1",
       "dev": true,
@@ -11565,8 +11580,9 @@
       }
     },
     "node_modules/postcss-js": {
-      "version": "4.0.0",
-      "license": "MIT",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
+      "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
       "dependencies": {
         "camelcase-css": "^2.0.1"
       },
@@ -11578,7 +11594,7 @@
         "url": "https://opencollective.com/postcss/"
       },
       "peerDependencies": {
-        "postcss": "^8.3.3"
+        "postcss": "^8.4.21"
       }
     },
     "node_modules/postcss-load-config": {
@@ -12625,14 +12641,15 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "3.0.2",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.1.2.tgz",
+      "integrity": "sha512-BlIbgFryTbw3Dz6hyoWFhKk+unCcHMSkZGrTFVAx2WmttdBSonsdtRlwiuTbDqTKr+UlXIUqJVS4QT5tUzGENQ==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
       "bin": {
-        "rimraf": "bin.js"
+        "rimraf": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -21032,6 +21049,17 @@
       "requires": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flatted": {
@@ -23740,7 +23768,9 @@
       }
     },
     "postcss-js": {
-      "version": "4.0.0",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
+      "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
       "requires": {
         "camelcase-css": "^2.0.1"
       }
@@ -24410,11 +24440,10 @@
       "version": "1.0.4"
     },
     "rimraf": {
-      "version": "3.0.2",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.3"
-      }
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.1.2.tgz",
+      "integrity": "sha512-BlIbgFryTbw3Dz6hyoWFhKk+unCcHMSkZGrTFVAx2WmttdBSonsdtRlwiuTbDqTKr+UlXIUqJVS4QT5tUzGENQ==",
+      "dev": true
     },
     "ripemd160": {
       "version": "2.0.2",
@@ -25207,7 +25236,7 @@
         "picocolors": "^1.0.0",
         "postcss": "^8.4.21",
         "postcss-import": "^14.1.0",
-        "postcss-js": "^4.0.0",
+        "postcss-js": "^4.0.1",
         "postcss-load-config": "^3.1.4",
         "postcss-nested": "6.0.0",
         "postcss-selector-parser": "^6.0.11",
@@ -25215,7 +25244,7 @@
         "prettier": "^2.8.4",
         "quick-lru": "^5.1.1",
         "resolve": "^1.22.1",
-        "rimraf": "^3.0.0",
+        "rimraf": "^4.1.2",
         "source-map-js": "^1.0.2",
         "turbo": "^1.7.4"
       },
@@ -30732,6 +30761,17 @@
           "requires": {
             "flatted": "^3.1.0",
             "rimraf": "^3.0.2"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+              "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+              "dev": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            }
           }
         },
         "flatted": {
@@ -33440,7 +33480,9 @@
           }
         },
         "postcss-js": {
-          "version": "4.0.0",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
+          "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
           "requires": {
             "camelcase-css": "^2.0.1"
           }
@@ -34110,11 +34152,10 @@
           "version": "1.0.4"
         },
         "rimraf": {
-          "version": "3.0.2",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.1.2.tgz",
+          "integrity": "sha512-BlIbgFryTbw3Dz6hyoWFhKk+unCcHMSkZGrTFVAx2WmttdBSonsdtRlwiuTbDqTKr+UlXIUqJVS4QT5tUzGENQ==",
+          "dev": true
         },
         "ripemd160": {
           "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "jest": "^29.4.1",
     "jest-diff": "^29.4.1",
     "prettier": "^2.8.4",
-    "rimraf": "^3.0.0",
+    "rimraf": "^4.1.2",
     "source-map-js": "^1.0.2",
     "turbo": "^1.7.4"
   },


### PR DESCRIPTION
Continuation of: #10579

This PR is a different approach compared to what I originally tried when fixing the broken build in #10579. 

Bumping `rimraf` requires a small API change, this is used in our tests which is currently shared for both the `oxide` and `stable` engine. This in turn requires us to bump it in the `stable` engine as well. 

The problem is that our `stable` engine is using Node.js v12 and the latest `rimraf` version requires Node.js v14.

To solve this, we can keep using `rimraf` v3 in the `stable` engine and use the newer `rimraf` v4 in the `oxide` engine. The only requirement is that we conditionally use the correct API for the current version.

Closes: #10579
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
