### PR TITLE
Revert including `outline-color` in `transition` and `transition-colors` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix use of `:where(.btn)` when matching `!btn` ([#10601](https://github.com/tailwindlabs/tailwindcss/pull/10601))
+- Revert including `outline-color` in `transition` and `transition-colors` by default ([#10604](https://github.com/tailwindlabs/tailwindcss/pull/10604))
 
 ## [3.2.6] - 2023-02-08
 

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -879,8 +879,8 @@ module.exports = {
       none: 'none',
       all: 'all',
       DEFAULT:
-        'color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter',
-      colors: 'color, background-color, border-color, outline-color, text-decoration-color, fill, stroke',
+        'color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter',
+      colors: 'color, background-color, border-color, text-decoration-color, fill, stroke',
       opacity: 'opacity',
       shadow: 'box-shadow',
       transform: 'transform',

--- a/tests/basic-usage.oxide.test.css
+++ b/tests/basic-usage.oxide.test.css
@@ -1020,8 +1020,8 @@
   backdrop-filter: none;
 }
 .transition {
-  transition-property: color, background-color, border-color, outline-color, text-decoration-color,
-    fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke,
+    opacity, box-shadow, transform, filter, backdrop-filter;
   transition-duration: 0.15s;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }

--- a/tests/basic-usage.test.css
+++ b/tests/basic-usage.test.css
@@ -1020,8 +1020,8 @@
   backdrop-filter: none;
 }
 .transition {
-  transition-property: color, background-color, border-color, outline-color, text-decoration-color,
-    fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke,
+    opacity, box-shadow, transform, filter, backdrop-filter;
   transition-duration: 0.15s;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }

--- a/tests/kitchen-sink.test.js
+++ b/tests/kitchen-sink.test.js
@@ -698,9 +698,8 @@ crosscheck(() => {
         }
         @media (prefers-reduced-motion: no-preference) {
           .motion-safe\:transition {
-            transition-property: color, background-color, border-color, outline-color,
-              text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter,
-              backdrop-filter;
+            transition-property: color, background-color, border-color, text-decoration-color, fill,
+              stroke, opacity, box-shadow, transform, filter, backdrop-filter;
             transition-duration: 0.15s;
             transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
           }
@@ -710,9 +709,8 @@ crosscheck(() => {
         }
         @media (prefers-reduced-motion: reduce) {
           .motion-reduce\:transition {
-            transition-property: color, background-color, border-color, outline-color,
-              text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter,
-              backdrop-filter;
+            transition-property: color, background-color, border-color, text-decoration-color, fill,
+              stroke, opacity, box-shadow, transform, filter, backdrop-filter;
             transition-duration: 0.15s;
             transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
           }
@@ -759,9 +757,8 @@ crosscheck(() => {
           }
           @media (prefers-reduced-motion: no-preference) {
             .md\:motion-safe\:hover\:transition:hover {
-              transition-property: color, background-color, border-color, outline-color,
-                text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter,
-                backdrop-filter;
+              transition-property: color, background-color, border-color, text-decoration-color,
+                fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
               transition-duration: 0.15s;
               transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
             }

--- a/tests/raw-content.oxide.test.css
+++ b/tests/raw-content.oxide.test.css
@@ -761,8 +761,8 @@
   backdrop-filter: none;
 }
 .transition {
-  transition-property: color, background-color, border-color, outline-color, text-decoration-color,
-    fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke,
+    opacity, box-shadow, transform, filter, backdrop-filter;
   transition-duration: 0.15s;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }

--- a/tests/raw-content.test.css
+++ b/tests/raw-content.test.css
@@ -761,8 +761,8 @@
   backdrop-filter: none;
 }
 .transition {
-  transition-property: color, background-color, border-color, outline-color, text-decoration-color,
-    fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke,
+    opacity, box-shadow, transform, filter, backdrop-filter;
   transition-duration: 0.15s;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }


### PR DESCRIPTION
Resolves #10591

This PR reverts a change made in #10385 where we added `outline-color` to the `transition` and `transition-colors` utilities by default. Unfortunately this created a breaking change for people using `focus:outline-none` because our implementation of `outline-none` actually sets the `outline-color` to `transparent` instead of the `outline-style` to `none` for accessibility reasons related to Windows High Contrast Mode. This caused a black outline to momentarily appear on focus if you were using a `transition` or `transition-colors` utility on an element that also had `focus:outline-none`.

For anyone who does need `outline-color` to transition, you can extend your `transitionProperty` configuration to include `outline-color` in the `DEFAULT` and `colors` properties:

```js
let defaultTheme = require('tailwindcss/defaultTheme')

/** @type {import('tailwindcss').Config} */
module.exports = {
  content: [...],
  theme: {
    extend: {
      transitionProperty: {
        DEFAULT: `${defaultTheme.transitionProperty.DEFAULT}, outline-color`,
        colors: `${defaultTheme.transitionProperty.colors}, outline-color`,
      }
    },
  },
  plugins: [],
}
```

There is a good chance we add this back for Tailwind CSS v4.0 along with this change to `outline-none` that only sets the `outline-color` to `transparent` when `forced-colors` is `active`:

https://play.tailwindcss.com/fFQOGafBjR

```css
.focus\:outline-none:focus {
  outline-style: none;
}

@media screen and (forced-colors: active) {
  .focus\:outline-none:focus {
    outline: 2px solid transparent;
    outline-offset: 2px;
  }
}
```

We've opted not to make this change to `outline-none` right away so that we have more time to test it, while still correcting this breaking change right away.