### PR TITLE
Replaced borderRadius.full to '100vmax'

### DIFF
--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -93,7 +93,7 @@ module.exports = {
       xl: '0.75rem',
       '2xl': '1rem',
       '3xl': '1.5rem',
-      full: '9999px',
+      full: '100vmax',
     },
     borderSpacing: ({ theme }) => ({
       ...theme('spacing'),


### PR DESCRIPTION
## Larger value is required for `rounded-full` class

Suppose there is an element larger than `9999px` (in width or height), there is required a larger value. 

By using `100vmax` this can be achieved. It has no behavior (eg. elliptical borders for non-square elements) like percentage units (eg. `50%`, `100%` etc). It does this job perfectly.

### Changes 
- Replaced `9999px` to `100vmax`