### PR TITLE
Enable relative content paths for the `oxide` engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [Oxide] Disable color opacity plugins by default in the `oxide` engine ([#10618](https://github.com/tailwindlabs/tailwindcss/pull/10618))
+- [Oxide] Enable relative content paths for the `oxide` engine ([#10621](https://github.com/tailwindlabs/tailwindcss/pull/10621))
 
 ## [3.2.7] - 2023-02-16
 

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -8,6 +8,9 @@ let defaults = {
   get disableColorOpacityUtilitiesByDefault() {
     return env.OXIDE
   },
+  get relativeContentPathsByDefault() {
+    return env.OXIDE
+  },
 }
 
 let featureFlags = {

--- a/src/util/normalizeConfig.js
+++ b/src/util/normalizeConfig.js
@@ -1,3 +1,4 @@
+import { flagEnabled } from '../featureFlags'
 import log, { dim } from './log'
 
 export function normalizeConfig(config) {
@@ -189,7 +190,7 @@ export function normalizeConfig(config) {
         return content.relative
       }
 
-      return config.future?.relativeContentPathsByDefault ?? false
+      return flagEnabled(config, 'relativeContentPathsByDefault')
     })(),
 
     files: (() => {

--- a/tests/normalize-config.test.js
+++ b/tests/normalize-config.test.js
@@ -36,19 +36,21 @@ crosscheck(({ stable, oxide }) => {
 
   oxide.test.todo('should normalize extractors')
   stable.test.each`
-  config
-  ${{ content: [{ raw: 'text-center' }], purge: { extract: () => ['font-bold'] } }}
-  ${{ content: [{ raw: 'text-center' }], purge: { extract: { DEFAULT: () => ['font-bold'] } } }}
-  ${{
-    content: [{ raw: 'text-center' }],
-    purge: { options: { defaultExtractor: () => ['font-bold'] } },
-  }}
-  ${{
-    content: [{ raw: 'text-center' }],
-    purge: { options: { extractors: [{ extractor: () => ['font-bold'], extensions: ['html'] }] } },
-  }}
-  ${{ content: [{ raw: 'text-center' }], purge: { extract: { html: () => ['font-bold'] } } }}
-`('should normalize extractors $config', ({ config }) => {
+    config
+    ${{ content: [{ raw: 'text-center' }], purge: { extract: () => ['font-bold'] } }}
+    ${{ content: [{ raw: 'text-center' }], purge: { extract: { DEFAULT: () => ['font-bold'] } } }}
+    ${{
+      content: [{ raw: 'text-center' }],
+      purge: { options: { defaultExtractor: () => ['font-bold'] } },
+    }}
+    ${{
+      content: [{ raw: 'text-center' }],
+      purge: {
+        options: { extractors: [{ extractor: () => ['font-bold'], extensions: ['html'] }] },
+      },
+    }}
+    ${{ content: [{ raw: 'text-center' }], purge: { extract: { html: () => ['font-bold'] } } }}
+  `('should normalize extractors $config', ({ config }) => {
     return run('@tailwind utilities', config).then((result) => {
       return expect(result.css).toMatchFormattedCss(css`
         .font-bold {
@@ -111,9 +113,15 @@ crosscheck(({ stable, oxide }) => {
       content: ['./example-folder/**/*.{html,js}'],
     }
 
-    expect(normalizeConfig(resolveConfig(config)).content).toEqual({
+    stable.expect(normalizeConfig(resolveConfig(config)).content).toEqual({
       files: ['./example-folder/**/*.{html,js}'],
       relative: false,
+      extract: {},
+      transform: {},
+    })
+    oxide.expect(normalizeConfig(resolveConfig(config)).content).toEqual({
+      files: ['./example-folder/**/*.{html,js}'],
+      relative: true,
       extract: {},
       transform: {},
     })
@@ -130,14 +138,26 @@ crosscheck(({ stable, oxide }) => {
       ],
     }
 
+    let normalizedConfig = normalizeConfig(resolveConfig(config)).content
+
     // No rewrite happens
-    expect(normalizeConfig(resolveConfig(config)).content).toEqual({
+    stable.expect(normalizedConfig).toEqual({
       files: [
         './{example-folder}/**/*.{html,js}',
         './{example-folder}/**/*.{html}',
         './example-folder/**/*.{html}',
       ],
       relative: false,
+      extract: {},
+      transform: {},
+    })
+    oxide.expect(normalizedConfig).toEqual({
+      files: [
+        './{example-folder}/**/*.{html,js}',
+        './{example-folder}/**/*.{html}',
+        './example-folder/**/*.{html}',
+      ],
+      relative: true,
       extract: {},
       transform: {},
     })


### PR DESCRIPTION
This PR will resolve content paths relative to the config file by default for the `oxide` engine.
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
