### PR TITLE
Add `content-normal` and `content-stretch` utilities

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1196,6 +1196,7 @@ export let corePlugins = {
 
   alignContent: ({ addUtilities }) => {
     addUtilities({
+      '.content-normal': { 'align-content': 'normal' },
       '.content-center': { 'align-content': 'center' },
       '.content-start': { 'align-content': 'flex-start' },
       '.content-end': { 'align-content': 'flex-end' },

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1203,6 +1203,7 @@ export let corePlugins = {
       '.content-around': { 'align-content': 'space-around' },
       '.content-evenly': { 'align-content': 'space-evenly' },
       '.content-baseline': { 'align-content': 'baseline' },
+      '.content-stretch': { 'align-content': 'stretch' },
     })
   },
 


### PR DESCRIPTION
I'd like to add a utility for the CSS `align-content: stretch`.

This is the default align-content value for flexbox and grid layouts if none other is specified. The reason to include this in Tailwind is that it is necessary to be able to reset the `align-content` value to its default on a breakpoint, e.g. `content-center lg:content-stretch`. Also it isn't possible to use arbitrary values for `align-content` since `content-[stretch]` would instead create the CSS `content: stretch`. So the only option to use that CSS currently is with arbitrary properties: `content-center lg:[align-content:stretch]`.

Let me know what you think. 😊