### PR TITLE
Disallow using multiple selectors in arbitrary variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `caption-side` utilities ([#10470](https://github.com/tailwindlabs/tailwindcss/pull/10470))
 - Add `justify-normal` and `justify-stretch` utilities ([#10560](https://github.com/tailwindlabs/tailwindcss/pull/10560))
 
+### Fixed
+
+- Disallow multiple selectors in arbitrary variants ([#10655](https://github.com/tailwindlabs/tailwindcss/pull/10655))
+
 ### Changed
 
 - [Oxide] Disable color opacity plugins by default in the `oxide` engine ([#10618](https://github.com/tailwindlabs/tailwindcss/pull/10618))

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -205,17 +205,21 @@ function applyVariant(variant, matches, context) {
 
   // Register arbitrary variants
   if (isArbitraryValue(variant) && !context.variantMap.has(variant)) {
-    let selector = normalize(variant.slice(1, -1))
+    let sort = context.offsets.recordVariant(variant)
 
-    if (!isValidVariantFormatString(selector)) {
+    let selector = normalize(variant.slice(1, -1))
+    let selectors = splitAtTopLevelOnly(selector, ',')
+
+    if (!selectors.every(isValidVariantFormatString)) {
       return []
     }
 
-    let fn = parseVariant(selector)
+    let records = selectors.map((sel, idx) => [
+      context.offsets.applyParallelOffset(sort, idx),
+      parseVariant(sel.trim()),
+    ])
 
-    let sort = context.offsets.recordVariant(variant)
-
-    context.variantMap.set(variant, [[sort, fn]])
+    context.variantMap.set(variant, records)
   }
 
   if (context.variantMap.has(variant)) {

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -210,6 +210,11 @@ function applyVariant(variant, matches, context) {
     let selector = normalize(variant.slice(1, -1))
     let selectors = splitAtTopLevelOnly(selector, ',')
 
+    // We do not support multiple selectors for arbitrary variants
+    if (selectors.length > 1) {
+      return []
+    }
+
     if (!selectors.every(isValidVariantFormatString)) {
       return []
     }

--- a/src/util/splitAtTopLevelOnly.js
+++ b/src/util/splitAtTopLevelOnly.js
@@ -17,15 +17,22 @@ export function splitAtTopLevelOnly(input, separator) {
   let stack = []
   let parts = []
   let lastPos = 0
+  let isEscaped = false
 
   for (let idx = 0; idx < input.length; idx++) {
     let char = input[idx]
 
-    if (stack.length === 0 && char === separator[0]) {
+    if (stack.length === 0 && char === separator[0] && !isEscaped) {
       if (separator.length === 1 || input.slice(idx, idx + separator.length) === separator) {
         parts.push(input.slice(lastPos, idx))
         lastPos = idx + separator.length
       }
+    }
+
+    if (isEscaped) {
+      isEscaped = false
+    } else if (char === '\\') {
+      isEscaped = true
     }
 
     if (char === '(' || char === '[' || char === '{') {

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -1134,11 +1134,13 @@ crosscheck(({ stable, oxide }) => {
             <div class="hover:[div_&,span]:p-1"></div>
             <div class="hover:[div,span_&]:p-1"></div>
             <div class="hover:[div_&,span_&]:p-1"></div>
-
-            <!-- escaped commas are a-ok -->
-            <div class="hover:[.span\,div_&]:p-1"></div>
             <div class="hover:[:is(span,div)_&]:p-1"></div>
           `,
+        },
+        {
+          // escaped commas are a-ok
+          // This is separate because prettier complains about `\,` in the template string
+          raw: '<div class="hover:[.span\\,div_&]:p-1"></div>'
         },
       ],
       corePlugins: { preflight: false },

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -1137,6 +1137,7 @@ crosscheck(({ stable, oxide }) => {
 
             <!-- escaped commas are a-ok -->
             <div class="hover:[.span\,div_&]:p-1"></div>
+            <div class="hover:[:is(span,div)_&]:p-1"></div>
           `,
         },
       ],
@@ -1151,6 +1152,7 @@ crosscheck(({ stable, oxide }) => {
       expect(result.css).toMatchFormattedCss(css`
         .p-1,
         .span\,div .hover\:\[\.span\\\,div_\&\]\:p-1:hover,
+        :is(span, div) .hover\:\[\:is\(span\,div\)_\&\]\:p-1:hover,
         div .\[div_\&\]\:p-1,
         div .hover\:\[div_\&\]\:p-1:hover {
           padding: 0.25rem;

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -1140,7 +1140,7 @@ crosscheck(({ stable, oxide }) => {
         {
           // escaped commas are a-ok
           // This is separate because prettier complains about `\,` in the template string
-          raw: '<div class="hover:[.span\\,div_&]:p-1"></div>'
+          raw: '<div class="hover:[.span\\,div_&]:p-1"></div>',
         },
       ],
       corePlugins: { preflight: false },


### PR DESCRIPTION
When given a utility like `[div,span_&]:p-1` we would previously generate just a rule for `div` effectively chopping off the variant at the `,` even though that portion of the selector doesn't include a "nesting" marker to tell us where the candidate goes in the selector. This is also a problem because it would match every div no matter what.

Arbitrary variants were not intended to support multiple selectors _at all_ and the fact that this produces any rules is a bug. Furthermore, if you put `[span_&,div_&]:p-1` into Tailwind CSS today it doesn't generate anything (as intended) making the idea that this could be relied on and/or useful even less likely.

This PR fixes this by splitting on commas at the top-level and discarding candidates that have multiple selectors. Note that you can still use commas in a class name when it is escaped. For example: `[.span\,div_&]:p-1`.

Fixes #10576