### PR TITLE
Gracefully handle missing config when Tailwind doesn't need to run

### DIFF
--- a/src/lib/evaluateTailwindFunctions.js
+++ b/src/lib/evaluateTailwindFunctions.js
@@ -267,3 +267,26 @@ export default function (context) {
     })
   }
 }
+
+/**
+ *
+ * @param {import('postcss').Node} node
+ * @returns {boolean}
+ */
+export function hasTailwindFunctions(node) {
+  let property = nodeTypePropertyMap[node.type]
+  if (property === undefined) {
+    return false
+  }
+
+  let hasFunction = false
+
+  parseValue(node[property]).walk((vnode) => {
+    if (vnode.type === 'function' && (vnode.value === 'theme' || vnode.value === 'screen')) {
+      hasFunction = true
+      return false
+    }
+  })
+
+  return hasFunction
+}

--- a/src/lib/setupTrackingContext.js
+++ b/src/lib/setupTrackingContext.js
@@ -62,6 +62,13 @@ function getTailwindConfig(configOrPath) {
     return [newConfig, userConfigPath, newHash, newDeps]
   }
 
+  // In this situation we may not have a config
+  // And the `@config` directive is not present
+  // This means we should use the default config
+  if (configOrPath === undefined) {
+    configOrPath = {}
+  }
+
   // It's a plain object, not a path
   let newConfig = resolveConfig(
     configOrPath.config === undefined ? configOrPath : configOrPath.config

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -2,6 +2,7 @@ import setupTrackingContext from './lib/setupTrackingContext'
 import processTailwindFeatures from './processTailwindFeatures'
 import { env } from './lib/sharedState'
 import { findAtConfigPath } from './lib/findAtConfigPath'
+import { shouldRun } from './shouldRun'
 
 module.exports = function tailwindcss(configOrPath) {
   return {
@@ -14,6 +15,10 @@ module.exports = function tailwindcss(configOrPath) {
           return root
         },
       function (root, result) {
+        if (!shouldRun(root)) {
+          return
+        }
+
         // Use the path for the `@config` directive if it exists, otherwise use the
         // path for the file being processed
         configOrPath = findAtConfigPath(root, result) ?? configOrPath

--- a/src/shouldRun.js
+++ b/src/shouldRun.js
@@ -1,0 +1,61 @@
+import { hasTailwindFunctions } from './lib/evaluateTailwindFunctions'
+
+/**
+ * Determine if Tailwind should run for a given file
+ *
+ * @param {import('postcss').Root} root
+ */
+export function shouldRun(root) {
+  let shouldRun = false
+
+  root.walk((node) => {
+    if (node.type === 'atrule' && isRelevantAtRule(node)) {
+      shouldRun = true
+      return false
+    }
+
+    if (hasTailwindFunctions(node)) {
+      shouldRun = true
+      return false
+    }
+  })
+
+  return shouldRun
+}
+
+/**
+ * @param {import('postcss').AtRule} atRule
+ * @returns {boolean}
+ */
+function isRelevantAtRule(atRule) {
+  let layers = ['base', 'components', 'utilities']
+  let directives = ['base', 'components', 'utilities', 'variants']
+  let imports = [
+    `"tailwindcss/base"`,
+    `'tailwindcss/base'`,
+    `"tailwindcss/components"`,
+    `'tailwindcss/components'`,
+    `"tailwindcss/utilities"`,
+    `'tailwindcss/utilities'`,
+    `"tailwindcss/variants"`,
+    `'tailwindcss/variants'`,
+  ]
+
+  if (atRule.name === 'apply') {
+    return true
+  } else if (atRule.name === 'variants') {
+    return true
+  } else if (atRule.name === 'responsive') {
+    return true
+  } else if (atRule.name === 'defaults') {
+    return true // TODO: Should be here?
+  } else if (atRule.name === 'tailwind') {
+    return directives.includes(atRule.params)
+  } else if (atRule.name === 'layer') {
+    return layers.includes(atRule.params)
+  } else if (atRule.name === 'import') {
+    return imports.includes(atRule.params)
+  }
+
+  return false
+}

--- a/tests/customConfig.test.js
+++ b/tests/customConfig.test.js
@@ -385,4 +385,53 @@ crosscheck(() => {
       `)
     })
   })
+
+  // If the user is using an @config directive in their main CSS file
+  // And, for example, also has Vue SFCs with <style> blocks
+  // And that <style> block doesn't have an @config directive
+  // Then we'll end up looking for the default config which
+  // may not exist if the user is using a custom config file
+  // and we want to be sure to handle this situation gracefully
+  test('a missing default config doesnt break the build', async () => {
+    // This is intentionally `undefined`
+    let config = undefined
+
+    // This is like a <style> block in a Vue SFC which doesn't contain an @config directive
+    let input = css`
+      @tailwind utilities;
+      .example {
+        @apply text-red-500/50;
+      }
+    `
+
+    let result = await run(input, config)
+
+    // In this case Tailwind CSS should not be run because there is no config to run it with
+    expect(result.css).toMatchFormattedCss(css`
+      .example {
+        color: #ef444480;
+      }
+    `)
+  })
+
+  test('a missing default config doesnt break the build (object version)', async () => {
+    let config = { config: undefined }
+
+    // This is like a <style> block in a Vue SFC which doesn't contain an @config directive
+    let input = css`
+      @tailwind utilities;
+      .example {
+        @apply text-red-500/50;
+      }
+    `
+
+    let result = await run(input, config)
+
+    // In this case Tailwind CSS should not be run because there is no config to run it with
+    expect(result.css).toMatchFormattedCss(css`
+      .example {
+        color: #ef444480;
+      }
+    `)
+  })
 })

--- a/tests/customConfig.test.js
+++ b/tests/customConfig.test.js
@@ -386,31 +386,33 @@ crosscheck(() => {
     })
   })
 
-  test.only('a missing config file throws an error (config: default)', async () => {
+  test('a missing config file throws an error (config: default)', async () => {
     let config = undefined
     let result = run(`@tailwind utilities;`, config)
 
-    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(``)
-  })
-
-  test('a missing config file throws an error (config: object -> default)', async () => {
-    let config = { config: undefined }
-    let result = run(`@tailwind utilities;`, config)
-
-    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(``)
+    await expect(result).rejects.toThrow(
+      `You must specify a Tailwind config file path or an object.`
+    )
   })
 
   test('a missing config file throws an error (config: named)', async () => {
     let config = './i.do.not.exist.js'
     let result = run(`@tailwind utilities;`, config)
 
-    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(``)
+    await expect(result).rejects.toThrow(/The config file \[[^[]+\] could not be found/)
   })
 
   test('a missing config file throws an error (config: object -> named)', async () => {
     let config = { config: './i.do.not.exist.js' }
     let result = run(`@tailwind utilities;`, config)
 
-    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(``)
+    await expect(result).rejects.toThrow(/The config file \[[^[]+\] could not be found/)
+  })
+
+  test('a missing config file does not throw an error if Tailwind does not need to run', async () => {
+    let config = undefined
+    let result = await run(`.example { color: red; }`, config)
+
+    expect(result.css).toMatchFormattedCss(`.example { color: red; }`)
   })
 })

--- a/tests/customConfig.test.js
+++ b/tests/customConfig.test.js
@@ -386,55 +386,6 @@ crosscheck(() => {
     })
   })
 
-  // If the user is using an @config directive in their main CSS file
-  // And, for example, also has Vue SFCs with <style> blocks
-  // And that <style> block doesn't have an @config directive
-  // Then we'll end up looking for the default config which
-  // may not exist if the user is using a custom config file
-  // and we want to be sure to handle this situation gracefully
-  test('a missing default config doesnt break the build', async () => {
-    // This is intentionally `undefined`
-    let config = undefined
-
-    // This is like a <style> block in a Vue SFC which doesn't contain an @config directive
-    let input = css`
-      @tailwind utilities;
-      .example {
-        @apply text-red-500/50;
-      }
-    `
-
-    let result = await run(input, config)
-
-    // In this case Tailwind CSS should not be run because there is no config to run it with
-    expect(result.css).toMatchFormattedCss(css`
-      .example {
-        color: #ef444480;
-      }
-    `)
-  })
-
-  test('a missing default config doesnt break the build (object version)', async () => {
-    let config = { config: undefined }
-
-    // This is like a <style> block in a Vue SFC which doesn't contain an @config directive
-    let input = css`
-      @tailwind utilities;
-      .example {
-        @apply text-red-500/50;
-      }
-    `
-
-    let result = await run(input, config)
-
-    // In this case Tailwind CSS should not be run because there is no config to run it with
-    expect(result.css).toMatchFormattedCss(css`
-      .example {
-        color: #ef444480;
-      }
-    `)
-  })
-
   test.only('a missing config file throws an error (config: default)', async () => {
     let config = undefined
     let result = run(`@tailwind utilities;`, config)

--- a/tests/customConfig.test.js
+++ b/tests/customConfig.test.js
@@ -434,4 +434,32 @@ crosscheck(() => {
       }
     `)
   })
+
+  test.only('a missing config file throws an error (config: default)', async () => {
+    let config = undefined
+    let result = run(`@tailwind utilities;`, config)
+
+    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(``)
+  })
+
+  test('a missing config file throws an error (config: object -> default)', async () => {
+    let config = { config: undefined }
+    let result = run(`@tailwind utilities;`, config)
+
+    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(``)
+  })
+
+  test('a missing config file throws an error (config: named)', async () => {
+    let config = './i.do.not.exist.js'
+    let result = run(`@tailwind utilities;`, config)
+
+    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(``)
+  })
+
+  test('a missing config file throws an error (config: object -> named)', async () => {
+    let config = { config: './i.do.not.exist.js' }
+    let result = run(`@tailwind utilities;`, config)
+
+    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(``)
+  })
 })


### PR DESCRIPTION
Right now we fail not-so-gracefully if we expect a config file and don't find one. This can become more apparent when using `@config` with a custom config file path _and_ Vue SFCs as style blocks are processed independently.

This proof-of-concept does two things:

1. Adds usable error messages when config files are missing.
2. Bails as early as possible if Tailwind doesn't need to run. We base this on the presence of `tailwind`, `layer`, `import`, and some other at-rules as well as uses of the `theme` and `screen` functions. However, we no longer deduplicate adjacent rules for all inputs where we did previously — even if Tailwind itself didn't otherwise produce the resulting CSS. It's possible we'll want to still do that no matter what.

Fixes #10654 