### PR TITLE
Add support for `white-space: break-spaces`

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1492,6 +1492,7 @@ export let corePlugins = {
       '.whitespace-pre': { 'white-space': 'pre' },
       '.whitespace-pre-line': { 'white-space': 'pre-line' },
       '.whitespace-pre-wrap': { 'white-space': 'pre-wrap' },
+      '.whitespace-break-spaces': { 'white-space': 'break-spaces' },
     })
   },
 


### PR DESCRIPTION
Simply added a line to add support for `white-space: break-spaces` as it now has nearly universal modern browser support.

[MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space#values) | [caniuse](https://caniuse.com/mdn-css_properties_white-space_break-spaces)