### PR TITLE
Add `line-clamp` utilities from `@tailwindcss/line-clamp` to core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `caption-side` utilities ([#10470](https://github.com/tailwindlabs/tailwindcss/pull/10470))
 - Add `justify-normal` and `justify-stretch` utilities ([#10560](https://github.com/tailwindlabs/tailwindcss/pull/10560))
 - Add `content-normal` and `content-stretch` utilities ([#10645](https://github.com/tailwindlabs/tailwindcss/pull/10645))
+- Add `line-clamp` utilities from `@tailwindcss/line-clamp` to core ([#10768](https://github.com/tailwindlabs/tailwindcss/pull/10768))
 
 ### Fixed
 

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -703,6 +703,24 @@ export let corePlugins = {
     })
   },
 
+  lineClamp: ({ matchUtilities, addUtilities, theme }) => {
+    matchUtilities(
+      {
+        'line-clamp': (value) => ({
+          overflow: 'hidden',
+          display: '-webkit-box',
+          '-webkit-box-orient': 'vertical',
+          '-webkit-line-clamp': `${value}`,
+        }),
+      },
+      { values: theme('lineClamp') }
+    )
+
+    addUtilities({
+      '.line-clamp-none': { '-webkit-line-clamp': 'unset' },
+    })
+  },
+
   display: ({ addUtilities }) => {
     addUtilities({
       '.block': { display: 'block' },

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -582,6 +582,14 @@ module.exports = {
       auto: 'auto',
       ...theme('spacing'),
     }),
+    lineClamp: {
+      1: '1',
+      2: '2',
+      3: '3',
+      4: '4',
+      5: '5',
+      6: '6',
+    },
     maxHeight: ({ theme }) => ({
       ...theme('spacing'),
       none: 'none',

--- a/tests/kitchen-sink.test.js
+++ b/tests/kitchen-sink.test.js
@@ -7,6 +7,9 @@ crosscheck(({ stable, oxide }) => {
       content: [
         {
           raw: html`
+            <div
+              class="line-clamp-2 line-clamp-[33] line-clamp-[var(--line-clamp-variable)] line-clamp-none"
+            ></div>
             <div class="range:text-right multi:text-left"></div>
             <div
               class="container hover:container sm:container md:container text-center sm:text-center md:text-center"
@@ -431,6 +434,27 @@ crosscheck(({ stable, oxide }) => {
         }
         .mt-6 {
           margin-top: 1.5rem;
+        }
+        .line-clamp-2 {
+          -webkit-line-clamp: 2;
+          -webkit-box-orient: vertical;
+          display: -webkit-box;
+          overflow: hidden;
+        }
+        .line-clamp-\[33\] {
+          -webkit-line-clamp: 33;
+          -webkit-box-orient: vertical;
+          display: -webkit-box;
+          overflow: hidden;
+        }
+        .line-clamp-\[var\(--line-clamp-variable\)\] {
+          -webkit-line-clamp: var(--line-clamp-variable);
+          -webkit-box-orient: vertical;
+          display: -webkit-box;
+          overflow: hidden;
+        }
+        .line-clamp-none {
+          -webkit-line-clamp: unset;
         }
         .scale-50 {
           --tw-scale-x: 0.5;
@@ -975,6 +999,27 @@ crosscheck(({ stable, oxide }) => {
         }
         .mt-6 {
           margin-top: 1.5rem;
+        }
+        .line-clamp-2 {
+          -webkit-line-clamp: 2;
+          -webkit-box-orient: vertical;
+          display: -webkit-box;
+          overflow: hidden;
+        }
+        .line-clamp-\[33\] {
+          -webkit-line-clamp: 33;
+          -webkit-box-orient: vertical;
+          display: -webkit-box;
+          overflow: hidden;
+        }
+        .line-clamp-\[var\(--line-clamp-variable\)\] {
+          -webkit-line-clamp: var(--line-clamp-variable);
+          -webkit-box-orient: vertical;
+          display: -webkit-box;
+          overflow: hidden;
+        }
+        .line-clamp-none {
+          -webkit-line-clamp: unset;
         }
         .scale-50 {
           --tw-scale-x: 0.5;


### PR DESCRIPTION
This PR moves the `line-clamp` related utilities that we originally had as a separate package ([`@tailwindcss/line-clamp`](https://github.com/tailwindlabs/tailwindcss-line-clamp)) directly into core.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
