### PR TITLE
Ensure integration tests are using `@swc/jest` transforms

### DIFF
--- a/integrations/content-resolution/package.json
+++ b/integrations/content-resolution/package.json
@@ -11,7 +11,11 @@
     "displayName": "Content Resolution",
     "setupFilesAfterEnv": [
       "<rootDir>/../../jest/customMatchers.js"
-    ]
+    ],
+    "transform": {
+      "\\.js$": "@swc/jest",
+      "\\.ts$": "@swc/jest"
+    }
   },
   "devDependencies": {
     "postcss": "^8.4.21",

--- a/integrations/parcel/package.json
+++ b/integrations/parcel/package.json
@@ -12,7 +12,11 @@
     "displayName": "parcel",
     "setupFilesAfterEnv": [
       "<rootDir>/../../jest/customMatchers.js"
-    ]
+    ],
+    "transform": {
+      "\\.js$": "@swc/jest",
+      "\\.ts$": "@swc/jest"
+    }
   },
   "devDependencies": {
     "parcel": "^2.8.3"

--- a/integrations/postcss-cli/package.json
+++ b/integrations/postcss-cli/package.json
@@ -11,7 +11,11 @@
     "displayName": "PostCSS CLI",
     "setupFilesAfterEnv": [
       "<rootDir>/../../jest/customMatchers.js"
-    ]
+    ],
+    "transform": {
+      "\\.js$": "@swc/jest",
+      "\\.ts$": "@swc/jest"
+    }
   },
   "devDependencies": {
     "postcss": "^8.4.21",

--- a/integrations/rollup-sass/package.json
+++ b/integrations/rollup-sass/package.json
@@ -11,7 +11,11 @@
     "displayName": "rollup.js",
     "setupFilesAfterEnv": [
       "<rootDir>/../../jest/customMatchers.js"
-    ]
+    ],
+    "transform": {
+      "\\.js$": "@swc/jest",
+      "\\.ts$": "@swc/jest"
+    }
   },
   "devDependencies": {
     "rollup": "^3.15.0",

--- a/integrations/rollup/package.json
+++ b/integrations/rollup/package.json
@@ -11,7 +11,11 @@
     "displayName": "rollup.js",
     "setupFilesAfterEnv": [
       "<rootDir>/../../jest/customMatchers.js"
-    ]
+    ],
+    "transform": {
+      "\\.js$": "@swc/jest",
+      "\\.ts$": "@swc/jest"
+    }
   },
   "devDependencies": {
     "rollup": "^3.15.0",

--- a/integrations/tailwindcss-cli/package.json
+++ b/integrations/tailwindcss-cli/package.json
@@ -14,6 +14,10 @@
     "displayName": "Tailwind CSS CLI",
     "setupFilesAfterEnv": [
       "<rootDir>/../../jest/customMatchers.js"
-    ]
+    ],
+    "transform": {
+      "\\.js$": "@swc/jest",
+      "\\.ts$": "@swc/jest"
+    }
   }
 }

--- a/integrations/vite/package.json
+++ b/integrations/vite/package.json
@@ -13,7 +13,11 @@
     "displayName": "vite",
     "setupFilesAfterEnv": [
       "<rootDir>/../../jest/customMatchers.js"
-    ]
+    ],
+    "transform": {
+      "\\.js$": "@swc/jest",
+      "\\.ts$": "@swc/jest"
+    }
   },
   "devDependencies": {
     "isomorphic-fetch": "^3.0.0",

--- a/integrations/webpack-4/package.json
+++ b/integrations/webpack-4/package.json
@@ -14,7 +14,11 @@
     "displayName": "webpack 4",
     "setupFilesAfterEnv": [
       "<rootDir>/../../jest/customMatchers.js"
-    ]
+    ],
+    "transform": {
+      "\\.js$": "@swc/jest",
+      "\\.ts$": "@swc/jest"
+    }
   },
   "devDependencies": {
     "css-loader": "^5.2.7",

--- a/integrations/webpack-5/package.json
+++ b/integrations/webpack-5/package.json
@@ -14,7 +14,11 @@
     "displayName": "webpack 5",
     "setupFilesAfterEnv": [
       "<rootDir>/../../jest/customMatchers.js"
-    ]
+    ],
+    "transform": {
+      "\\.js$": "@swc/jest",
+      "\\.ts$": "@swc/jest"
+    }
   },
   "devDependencies": {
     "css-loader": "^6.7.1",


### PR DESCRIPTION
This PR fixes a bug on `master`, where the integration tests are not running anymore.

In the `customMatchers` we are now always spying on the `log.warn` function. But we also use these
same `customMatchers` in the integration tests. We use a `require` for this, but the actual `log`
file uses `imports`.

This PR ensures that we also use `@swc/jest` transforms in the integration tests.
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
