### PR TITLE
Use `:is` to make important selector option insensitive to DOM order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `line-clamp` utilities from `@tailwindcss/line-clamp` to core ([#10768](https://github.com/tailwindlabs/tailwindcss/pull/10768))
 - Support ESM and TypeScript config files ([#10785](https://github.com/tailwindlabs/tailwindcss/pull/10785))
 - Add `list-style-image` utilities ([#10817](https://github.com/tailwindlabs/tailwindcss/pull/10817))
+- Use `:is` to make important selector option insensitive to DOM order ([#10835](https://github.com/tailwindlabs/tailwindcss/pull/10835))
 
 ### Fixed
 

--- a/src/lib/expandApplyAtRules.js
+++ b/src/lib/expandApplyAtRules.js
@@ -3,6 +3,7 @@ import parser from 'postcss-selector-parser'
 
 import { resolveMatches } from './generateRules'
 import escapeClassName from '../util/escapeClassName'
+import { applyImportantSelector } from '../util/applyImportantSelector'
 
 /** @typedef {Map<string, [any, import('postcss').Rule[]]>} ApplyCache */
 
@@ -555,7 +556,7 @@ function processApply(root, context, localCache) {
 
             // And then re-add it if it was removed
             if (importantSelector && parentSelector !== parent.selector) {
-              rule.selector = `${importantSelector} :is(${rule.selector})`
+              rule.selector = applyImportantSelector(rule.selector, importantSelector)
             }
 
             rule.walkDecls((d) => {

--- a/src/lib/expandApplyAtRules.js
+++ b/src/lib/expandApplyAtRules.js
@@ -548,14 +548,14 @@ function processApply(root, context, localCache) {
 
             let parentSelector =
               isGenerated && importantSelector && parent.selector.indexOf(importantSelector) === 0
-                ? parent.selector.slice(importantSelector.length)
+                ? parent.selector.slice(importantSelector.length + 5 /* ' is:('.length */, -1)
                 : parent.selector
 
             rule.selector = replaceSelector(parentSelector, rule.selector, applyCandidate)
 
             // And then re-add it if it was removed
             if (importantSelector && parentSelector !== parent.selector) {
-              rule.selector = `${importantSelector} ${rule.selector}`
+              rule.selector = `${importantSelector} :is(${rule.selector})`
             }
 
             rule.walkDecls((d) => {

--- a/src/lib/expandApplyAtRules.js
+++ b/src/lib/expandApplyAtRules.js
@@ -549,7 +549,7 @@ function processApply(root, context, localCache) {
 
             let parentSelector =
               isGenerated && importantSelector && parent.selector.indexOf(importantSelector) === 0
-                ? parent.selector.slice(importantSelector.length + 5 /* ' is:('.length */, -1)
+                ? parent.selector.slice(importantSelector.length)
                 : parent.selector
 
             rule.selector = replaceSelector(parentSelector, rule.selector, applyCandidate)

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -868,7 +868,7 @@ function getImportantStrategy(important) {
       }
 
       rule.selectors = rule.selectors.map((selector) => {
-        return `${important} ${selector}`
+        return `${important} :is(${selector})`
       })
     }
   }

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -17,6 +17,7 @@ import { isValidVariantFormatString, parseVariant } from './setupContextUtils'
 import isValidArbitraryValue from '../util/isSyntacticallyValidPropertyValue'
 import { splitAtTopLevelOnly } from '../util/splitAtTopLevelOnly.js'
 import { flagEnabled } from '../featureFlags'
+import { applyImportantSelector } from '../util/applyImportantSelector'
 
 let classNameParser = selectorParser((selectors) => {
   return selectors.first.filter(({ type }) => type === 'class').pop().value
@@ -868,7 +869,7 @@ function getImportantStrategy(important) {
       }
 
       rule.selectors = rule.selectors.map((selector) => {
-        return `${important} :is(${selector})`
+        return applyImportantSelector(selector, important)
       })
     }
   }

--- a/src/util/applyImportantSelector.js
+++ b/src/util/applyImportantSelector.js
@@ -1,0 +1,19 @@
+import { splitAtTopLevelOnly } from './splitAtTopLevelOnly'
+
+export function applyImportantSelector(selector, important) {
+  let matches = /^(.*?)(:before|:after|::[\w-]+)(\)*)$/g.exec(selector)
+  if (!matches) return `${important} ${wrapWithIs(selector)}`
+
+  let [, before, pseudo, brackets] = matches
+  return `${important} ${wrapWithIs(before + brackets)}${pseudo}`
+}
+
+function wrapWithIs(selector) {
+  let parts = splitAtTopLevelOnly(selector, ' ')
+
+  if (parts.length === 1 && parts[0].startsWith(':is(') && parts[0].endsWith(')')) {
+    return selector
+  }
+
+  return `:is(${selector})`
+}

--- a/tests/apply.test.js
+++ b/tests/apply.test.js
@@ -2120,10 +2120,10 @@ crosscheck(({ stable, oxide }) => {
     let result = await run(input, config)
 
     expect(result.css).toMatchFormattedCss(css`
-      #myselector .custom-utility {
+      #myselector :is(.custom-utility) {
         font-weight: 400;
       }
-      #myselector .group:hover .custom-utility {
+      #myselector :is(.group:hover .custom-utility) {
         text-decoration-line: underline;
       }
     `)

--- a/tests/experimental.test.js
+++ b/tests/experimental.test.js
@@ -176,15 +176,15 @@ crosscheck(() => {
           --tw-shadow: 0 0 #0000;
           --tw-shadow-colored: 0 0 #0000;
         }
-        #app .resize {
+        #app :is(.resize) {
           resize: both;
         }
-        #app .divide-y > :not([hidden]) ~ :not([hidden]) {
+        #app :is(.divide-y > :not([hidden]) ~ :not([hidden])) {
           --tw-divide-y-reverse: 0;
           border-top-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
           border-bottom-width: calc(1px * var(--tw-divide-y-reverse));
         }
-        #app .shadow {
+        #app :is(.shadow) {
           --tw-shadow: 0 1px 3px 0 #0000001a, 0 1px 2px -1px #0000001a;
           --tw-shadow-colored: 0 1px 3px 0 var(--tw-shadow-color),
             0 1px 2px -1px var(--tw-shadow-color);

--- a/tests/format-variant-selector.test.js
+++ b/tests/format-variant-selector.test.js
@@ -348,6 +348,8 @@ crosscheck(() => {
       ${'.parent::before &:hover'}                             | ${'.parent &:hover::before'}
       ${':where(&::before) :is(h1, h2, h3, h4)'}               | ${':where(&) :is(h1, h2, h3, h4)::before'}
       ${':where(&::file-selector-button) :is(h1, h2, h3, h4)'} | ${':where(&::file-selector-button) :is(h1, h2, h3, h4)'}
+      ${'#app :is(.dark &::before)'}                           | ${'#app :is(.dark &)::before'}
+      ${'#app :is(:is(.dark &)::before)'}                      | ${'#app :is(:is(.dark &))::before'}
     `('should translate "$before" into "$after"', ({ before, after }) => {
       let result = finalizeSelector('.a', [{ format: before, isArbitraryVariant: false }], {
         candidate: 'a',

--- a/tests/important-selector.test.js
+++ b/tests/important-selector.test.js
@@ -20,7 +20,7 @@ crosscheck(({ stable, oxide }) => {
             <div class="dark:focus:text-left"></div>
             <div class="group-hover:focus-within:text-left"></div>
             <div class="rtl:active:text-center"></div>
-            <div class="dark:before:bg-black"></div>
+            <div class="dark:before:underline"></div>
           `,
         },
       ],
@@ -143,6 +143,10 @@ crosscheck(({ stable, oxide }) => {
             text-align: center;
           }
         }
+        #app :is(.dark .dark\:before\:underline):before {
+          content: var(--tw-content);
+          text-decoration-line: underline;
+        }
         #app :is(:is(.dark .dark\:focus\:text-left:focus)) {
           text-align: left;
         }
@@ -174,7 +178,6 @@ crosscheck(({ stable, oxide }) => {
     `
 
     return run(input, config).then((result) => {
-      console.log(result.css)
       stable.expect(result.css).toMatchFormattedCss(css`
         ${defaults}
         #app :is(.dark .dark\:before\:bg-black)::before {

--- a/tests/important-selector.test.js
+++ b/tests/important-selector.test.js
@@ -122,31 +122,31 @@ crosscheck(() => {
             transform: rotate(360deg);
           }
         }
-        #app .animate-spin {
+        #app :is(.animate-spin) {
           animation: 1s linear infinite spin;
         }
-        #app .font-bold {
+        #app :is(.font-bold) {
           font-weight: 700;
         }
         .custom-util {
           button: no;
         }
-        #app .group:hover .group-hover\:focus-within\:text-left:focus-within {
+        #app :is(.group:hover .group-hover\:focus-within\:text-left:focus-within) {
           text-align: left;
         }
-        #app :is([dir='rtl'] .rtl\:active\:text-center:active) {
+        #app :is(:is([dir='rtl'] .rtl\:active\:text-center:active)) {
           text-align: center;
         }
         @media (prefers-reduced-motion: no-preference) {
-          #app .motion-safe\:hover\:text-center:hover {
+          #app :is(.motion-safe\:hover\:text-center:hover) {
             text-align: center;
           }
         }
-        #app :is(.dark .dark\:focus\:text-left:focus) {
+        #app :is(:is(.dark .dark\:focus\:text-left:focus)) {
           text-align: left;
         }
         @media (min-width: 768px) {
-          #app .md\:hover\:text-right:hover {
+          #app :is(.md\:hover\:text-right:hover) {
             text-align: right;
           }
         }

--- a/tests/important-selector.test.js
+++ b/tests/important-selector.test.js
@@ -1,6 +1,6 @@
 import { crosscheck, run, html, css, defaults } from './util/run'
 
-crosscheck(() => {
+crosscheck(({ stable, oxide }) => {
   test('important selector', () => {
     let config = {
       important: '#app',
@@ -20,6 +20,7 @@ crosscheck(() => {
             <div class="dark:focus:text-left"></div>
             <div class="group-hover:focus-within:text-left"></div>
             <div class="rtl:active:text-center"></div>
+            <div class="dark:before:bg-black"></div>
           `,
         },
       ],
@@ -149,6 +150,44 @@ crosscheck(() => {
           #app :is(.md\:hover\:text-right:hover) {
             text-align: right;
           }
+        }
+      `)
+    })
+  })
+
+  test('pseudo-elements are appended after the `:is()`', () => {
+    let config = {
+      important: '#app',
+      darkMode: 'class',
+      content: [
+        {
+          raw: html` <div class="dark:before:bg-black"></div> `,
+        },
+      ],
+      corePlugins: { preflight: false },
+    }
+
+    let input = css`
+      @tailwind base;
+      @tailwind components;
+      @tailwind utilities;
+    `
+
+    return run(input, config).then((result) => {
+      console.log(result.css)
+      stable.expect(result.css).toMatchFormattedCss(css`
+        ${defaults}
+        #app :is(.dark .dark\:before\:bg-black)::before {
+          content: var(--tw-content);
+          --tw-bg-opacity: 1;
+          background-color: rgb(0 0 0 / var(--tw-bg-opacity));
+        }
+      `)
+      oxide.expect(result.css).toMatchFormattedCss(css`
+        ${defaults}
+        #app :is(.dark .dark\:before\:bg-black)::before {
+          content: var(--tw-content);
+          background-color: #000;
         }
       `)
     })

--- a/tests/util/apply-important-selector.test.js
+++ b/tests/util/apply-important-selector.test.js
@@ -1,0 +1,24 @@
+import { crosscheck } from '../util/run'
+import { applyImportantSelector } from '../../src/util/applyImportantSelector'
+
+crosscheck(() => {
+  it.each`
+    before                                        | after
+    ${'.foo'}                                     | ${'#app :is(.foo)'}
+    ${'.foo .bar'}                                | ${'#app :is(.foo .bar)'}
+    ${'.foo:hover'}                               | ${'#app :is(.foo:hover)'}
+    ${'.foo .bar:hover'}                          | ${'#app :is(.foo .bar:hover)'}
+    ${'.foo::before'}                             | ${'#app :is(.foo)::before'}
+    ${'.foo::before'}                             | ${'#app :is(.foo)::before'}
+    ${'.foo::file-selector-button'}               | ${'#app :is(.foo)::file-selector-button'}
+    ${'.foo::-webkit-progress-bar'}               | ${'#app :is(.foo)::-webkit-progress-bar'}
+    ${'.foo:hover::before'}                       | ${'#app :is(.foo:hover)::before'}
+    ${':is(.dark :is([dir="rtl"] .foo::before))'} | ${'#app :is(.dark :is([dir="rtl"] .foo))::before'}
+    ${':is(.dark .foo) .bar'}                     | ${'#app :is(:is(.dark .foo) .bar)'}
+    ${':is(.foo) :is(.bar)'}                      | ${'#app :is(:is(.foo) :is(.bar))'}
+    ${':is(.foo)::before'}                        | ${'#app :is(.foo)::before'}
+    ${'.foo:before'}                              | ${'#app :is(.foo):before'}
+  `('should generate "$after" from "$before"', ({ before, after }) => {
+    expect(applyImportantSelector(before, '#app')).toEqual(after)
+  })
+})


### PR DESCRIPTION
This PR changes the implementation of the [important option's selector strategy](https://tailwindcss.com/docs/configuration#selector-strategy) to wrap the underlying selector with `:is(...)` to make it insensitive to DOM order. This is especially useful when using the "class" dark mode strategy, or using the `rtl` and `ltr` modifiers because it allows you to add the `.dark` class or `dir="rtl"` attributes to the `<html>` element instead of to some descendant of the element where you've added your important selector.

For example, given this configuration:

```js
module.exports = {
  // ...
  important: '#app',
  darkMode: 'class',
}
```

...Tailwind would historically generate classes like this:

```css
#app .dark .dark\:bg-black {
  background-color: #000;
}
```

That means that this DOM structure wouldn't work:

```html
<html class="dark">
<!-- ... -->
<body>
  <div id="app">
    <div class="dark:bg-black">
      <!-- ... -->
    </div>
  </div>
</body>
</html>
```

With the changes in this PR, Tailwind will generate this CSS instead:

```css
#app :is(.dark .dark\:bg-black) {
  background-color: #000;
}
```

...which means the above DOM structure _will_ work, which is more intuitive behavior.

The `:is(...)` pseudo-class has good browser support, with the most recent adopter being Safari in v14, which is almost three years old and two major versions in the past.