### PR TITLE
Warn when `@tailwindcss/line-clamp` plugin is being used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mark `rtl` and `ltr` variants as stable and remove warnings ([#10764](https://github.com/tailwindlabs/tailwindcss/pull/10764))
 - Use `inset` instead of `top`, `right`, `bottom`, and `left` properties ([#10765](https://github.com/tailwindlabs/tailwindcss/pull/10765))
 - Make `dark` and `rtl`/`ltr` variants insensitive to DOM order ([#10766](https://github.com/tailwindlabs/tailwindcss/pull/10766))
+- Warn when `@tailwindcss/line-clamp` plugin is being used ([#10862](https://github.com/tailwindlabs/tailwindcss/pull/10862))
 
 ## [3.2.7] - 2023-02-16
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,7 @@
       "devDependencies": {
         "rollup": "^3.20.0",
         "rollup-plugin-postcss": "^4.0.2",
-        "sass": "1.59.3"
+        "sass": "^1.59.3"
       }
     },
     "integrations/tailwindcss-cli": {
@@ -17980,7 +17980,7 @@
       "requires": {
         "rollup": "^3.20.0",
         "rollup-plugin-postcss": "^4.0.2",
-        "sass": "1.59.3"
+        "sass": "^1.59.3"
       }
     },
     "@tailwindcss/integrations-tailwindcss-cli": {
@@ -27846,7 +27846,7 @@
           "requires": {
             "rollup": "^3.20.0",
             "rollup-plugin-postcss": "^4.0.2",
-            "sass": "1.59.3"
+            "sass": "^1.59.3"
           }
         },
         "@tailwindcss/integrations-tailwindcss-cli": {

--- a/src/util/normalizeConfig.js
+++ b/src/util/normalizeConfig.js
@@ -297,5 +297,20 @@ export function normalizeConfig(config) {
     }
   }
 
+  // Warn if the line-clamp plugin is installed
+  if (config.plugins.length > 0) {
+    let plugin
+    try {
+      plugin = require('@tailwindcss/line-clamp')
+    } catch {}
+
+    if (plugin && config.plugins.includes(plugin)) {
+      log.warn('line-clamp-in-core', [
+        `The @tailwindcs/line-clamp plugin is now part of Tailwind CSS v3.3`,
+        `Remove it from your config to silence this warning`,
+      ])
+    }
+  }
+
   return config
 }

--- a/src/util/normalizeConfig.js
+++ b/src/util/normalizeConfig.js
@@ -309,6 +309,8 @@ export function normalizeConfig(config) {
         `The @tailwindcs/line-clamp plugin is now part of Tailwind CSS v3.3`,
         `Remove it from your config to silence this warning`,
       ])
+
+      config.plugins = config.plugins.filter((p) => p !== plugin)
     }
   }
 

--- a/standalone-cli/package-lock.json
+++ b/standalone-cli/package-lock.json
@@ -14,7 +14,6 @@
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/container-queries": "^0.1.0",
         "@tailwindcss/forms": "^0.5.2",
-        "@tailwindcss/line-clamp": "^0.4.0",
         "@tailwindcss/typography": "^0.5.4",
         "fs-extra": "^10.1.0",
         "jest": "^27.2.5",
@@ -25,57 +24,67 @@
       }
     },
     "..": {
-      "version": "3.2.4",
+      "version": "3.2.7",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "integrations/*",
+        "oxide/crates/node"
+      ],
       "dependencies": {
+        "@tailwindcss/oxide": "file:oxide/crates/node",
         "arg": "^5.0.2",
+        "browserslist": "^4.21.5",
         "chokidar": "^3.5.3",
         "color-name": "^1.1.4",
-        "detective": "^5.2.1",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
         "fast-glob": "^3.2.12",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "lilconfig": "^2.0.6",
+        "jiti": "^1.17.2",
+        "lightningcss": "^1.18.0",
+        "lilconfig": "^2.1.0",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.18",
+        "postcss": "^8.4.21",
         "postcss-import": "^14.1.0",
-        "postcss-js": "^4.0.0",
+        "postcss-js": "^4.0.1",
         "postcss-load-config": "^3.1.4",
-        "postcss-nested": "6.0.0",
-        "postcss-selector-parser": "^6.0.10",
+        "postcss-nested": "6.0.1",
+        "postcss-selector-parser": "^6.0.11",
         "postcss-value-parser": "^4.2.0",
         "quick-lru": "^5.1.1",
-        "resolve": "^1.22.1"
+        "resolve": "^1.22.1",
+        "sucrase": "^3.29.0"
       },
       "bin": {
         "tailwind": "lib/cli.js",
         "tailwindcss": "lib/cli.js"
       },
       "devDependencies": {
-        "@swc/cli": "^0.1.57",
-        "@swc/core": "^1.3.11",
-        "@swc/jest": "^0.2.23",
-        "@swc/register": "^0.1.10",
-        "autoprefixer": "^10.4.13",
-        "cssnano": "^5.1.14",
-        "esbuild": "^0.15.12",
-        "eslint": "^8.26.0",
-        "eslint-config-prettier": "^8.5.0",
+        "@swc/cli": "0.1.62",
+        "@swc/core": "1.3.41",
+        "@swc/jest": "0.2.24",
+        "@swc/register": "0.1.10",
+        "autoprefixer": "^10.4.14",
+        "concurrently": "^7.5.0",
+        "cssnano": "^5.1.15",
+        "esbuild": "^0.17.10",
+        "eslint": "^8.35.0",
+        "eslint-config-prettier": "^8.7.0",
         "eslint-plugin-prettier": "^4.2.1",
-        "jest": "^28.1.3",
-        "jest-diff": "^28.1.3",
-        "prettier": "^2.7.1",
-        "rimraf": "^3.0.0",
-        "source-map-js": "^1.0.2"
+        "jest": "^29.5.0",
+        "jest-diff": "^29.5.0",
+        "prettier": "^2.8.4",
+        "rimraf": "^4.4.0",
+        "source-map-js": "^1.0.2",
+        "turbo": "^1.8.3"
       },
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "postcss": "^8.0.9"
@@ -1027,15 +1036,6 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1"
-      }
-    },
-    "node_modules/@tailwindcss/line-clamp": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.0.tgz",
-      "integrity": "sha512-HQZo6gfx1D0+DU3nWlNLD5iA6Ef4JAXh0LeD8lOGrJwEDBwwJNKQza6WoXhhY1uQrxOuU8ROxV7CqiQV4CoiLw==",
-      "dev": true,
-      "peerDependencies": {
-        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
     "node_modules/@tailwindcss/typography": {
@@ -6617,13 +6617,6 @@
         "mini-svg-data-uri": "^1.2.3"
       }
     },
-    "@tailwindcss/line-clamp": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.0.tgz",
-      "integrity": "sha512-HQZo6gfx1D0+DU3nWlNLD5iA6Ef4JAXh0LeD8lOGrJwEDBwwJNKQza6WoXhhY1uQrxOuU8ROxV7CqiQV4CoiLw==",
-      "dev": true,
-      "requires": {}
-    },
     "@tailwindcss/typography": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.4.tgz",
@@ -9856,44 +9849,50 @@
     "tailwindcss": {
       "version": "file:..",
       "requires": {
-        "@swc/cli": "^0.1.57",
-        "@swc/core": "^1.3.11",
-        "@swc/jest": "^0.2.23",
-        "@swc/register": "^0.1.10",
+        "@swc/cli": "0.1.62",
+        "@swc/core": "1.3.41",
+        "@swc/jest": "0.2.24",
+        "@swc/register": "0.1.10",
+        "@tailwindcss/oxide": "file:oxide/crates/node",
         "arg": "^5.0.2",
-        "autoprefixer": "^10.4.13",
+        "autoprefixer": "^10.4.14",
+        "browserslist": "^4.21.5",
         "chokidar": "^3.5.3",
         "color-name": "^1.1.4",
-        "cssnano": "^5.1.14",
-        "detective": "^5.2.1",
+        "concurrently": "^7.5.0",
+        "cssnano": "^5.1.15",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
-        "esbuild": "^0.15.12",
-        "eslint": "^8.26.0",
-        "eslint-config-prettier": "^8.5.0",
+        "esbuild": "^0.17.10",
+        "eslint": "^8.35.0",
+        "eslint-config-prettier": "^8.7.0",
         "eslint-plugin-prettier": "^4.2.1",
         "fast-glob": "^3.2.12",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "jest": "^28.1.3",
-        "jest-diff": "^28.1.3",
-        "lilconfig": "^2.0.6",
+        "jest": "^29.5.0",
+        "jest-diff": "^29.5.0",
+        "jiti": "^1.17.2",
+        "lightningcss": "^1.18.0",
+        "lilconfig": "^2.1.0",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.18",
+        "postcss": "^8.4.21",
         "postcss-import": "^14.1.0",
-        "postcss-js": "^4.0.0",
+        "postcss-js": "^4.0.1",
         "postcss-load-config": "^3.1.4",
-        "postcss-nested": "6.0.0",
-        "postcss-selector-parser": "^6.0.10",
+        "postcss-nested": "6.0.1",
+        "postcss-selector-parser": "^6.0.11",
         "postcss-value-parser": "^4.2.0",
-        "prettier": "^2.7.1",
+        "prettier": "^2.8.4",
         "quick-lru": "^5.1.1",
         "resolve": "^1.22.1",
-        "rimraf": "^3.0.0",
-        "source-map-js": "^1.0.2"
+        "rimraf": "^4.4.0",
+        "source-map-js": "^1.0.2",
+        "sucrase": "^3.29.0",
+        "turbo": "^1.8.3"
       }
     },
     "tar-fs": {

--- a/standalone-cli/package.json
+++ b/standalone-cli/package.json
@@ -12,7 +12,6 @@
     "@tailwindcss/aspect-ratio": "^0.4.0",
     "@tailwindcss/container-queries": "^0.1.0",
     "@tailwindcss/forms": "^0.5.2",
-    "@tailwindcss/line-clamp": "^0.4.0",
     "@tailwindcss/typography": "^0.5.4",
     "fs-extra": "^10.1.0",
     "jest": "^27.2.5",

--- a/standalone-cli/standalone.js
+++ b/standalone-cli/standalone.js
@@ -1,5 +1,6 @@
 let Module = require('module')
 let origRequire = Module.prototype.require
+let log = require('tailwindcss/lib/util/log')
 
 let localModules = {
   'tailwindcss/colors': require('tailwindcss/colors'),
@@ -11,7 +12,12 @@ let localModules = {
   '@tailwindcss/aspect-ratio': require('@tailwindcss/aspect-ratio'),
   '@tailwindcss/container-queries': require('@tailwindcss/container-queries'),
   '@tailwindcss/forms': require('@tailwindcss/forms'),
-  '@tailwindcss/line-clamp': require('@tailwindcss/line-clamp'),
+  '@tailwindcss/line-clamp': () => {
+    log.warn('line-clamp-in-core', [
+      `The @tailwindcs/line-clamp plugin is now part of Tailwind CSS v3.3`,
+      `Remove it from your config to silence this warning`,
+    ])
+  },
   '@tailwindcss/typography': require('@tailwindcss/typography'),
 
   // These are present to allow them to be specified in the PostCSS config file

--- a/standalone-cli/standalone.js
+++ b/standalone-cli/standalone.js
@@ -1,6 +1,6 @@
 let Module = require('module')
 let origRequire = Module.prototype.require
-let log = require('tailwindcss/lib/util/log')
+let log = require('tailwindcss/lib/util/log').default
 
 let localModules = {
   'tailwindcss/colors': require('tailwindcss/colors'),


### PR DESCRIPTION
It's now part of core in v3.3 and no longer necessary. We will remove the plugin from the loaded plugins when this happens as well.