### PR TITLE
Reset all properties when using `line-clamp-none`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `caption-side` utilities ([#10470](https://github.com/tailwindlabs/tailwindcss/pull/10470))
 - Add `justify-normal` and `justify-stretch` utilities ([#10560](https://github.com/tailwindlabs/tailwindcss/pull/10560))
 - Add `content-normal` and `content-stretch` utilities ([#10645](https://github.com/tailwindlabs/tailwindcss/pull/10645))
-- Add `line-clamp` utilities from `@tailwindcss/line-clamp` to core ([#10768](https://github.com/tailwindlabs/tailwindcss/pull/10768))
+- Add `line-clamp` utilities from `@tailwindcss/line-clamp` to core ([#10768](https://github.com/tailwindlabs/tailwindcss/pull/10768), [#10876](https://github.com/tailwindlabs/tailwindcss/pull/10876))
 - Support ESM and TypeScript config files ([#10785](https://github.com/tailwindlabs/tailwindcss/pull/10785))
 - Add `list-style-image` utilities ([#10817](https://github.com/tailwindlabs/tailwindcss/pull/10817))
 - Use `:is` to make important selector option insensitive to DOM order ([#10835](https://github.com/tailwindlabs/tailwindcss/pull/10835))

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -717,7 +717,12 @@ export let corePlugins = {
     )
 
     addUtilities({
-      '.line-clamp-none': { '-webkit-line-clamp': 'unset' },
+      '.line-clamp-none': {
+        overflow: 'visible',
+        display: 'block',
+        '-webkit-box-orient': 'horizontal',
+        '-webkit-line-clamp': 'none',
+      },
     })
   },
 

--- a/tests/kitchen-sink.test.js
+++ b/tests/kitchen-sink.test.js
@@ -454,7 +454,10 @@ crosscheck(({ stable, oxide }) => {
           overflow: hidden;
         }
         .line-clamp-none {
-          -webkit-line-clamp: unset;
+          -webkit-line-clamp: none;
+          -webkit-box-orient: horizontal;
+          display: block;
+          overflow: visible;
         }
         .scale-50 {
           --tw-scale-x: 0.5;
@@ -1019,7 +1022,10 @@ crosscheck(({ stable, oxide }) => {
           overflow: hidden;
         }
         .line-clamp-none {
-          -webkit-line-clamp: unset;
+          -webkit-line-clamp: none;
+          -webkit-box-orient: horizontal;
+          display: block;
+          overflow: visible;
         }
         .scale-50 {
           --tw-scale-x: 0.5;


### PR DESCRIPTION
This PR resets all the properties in `line-clamp-none`. We can safely do this because the plugin is now defined before the `overflow` and `display` utilities, which means that those will take precedence when used in combination with responsive variants.
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
