### PR TITLE
Ensure module dependencies for value `null`, is an empty `Set`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Disallow multiple selectors in arbitrary variants ([#10655](https://github.com/tailwindlabs/tailwindcss/pull/10655))
 - Sort class lists deterministically for Prettier plugin ([#10672](https://github.com/tailwindlabs/tailwindcss/pull/10672))
 - Ensure CLI builds have a non-zero exit code on failure ([#10703](https://github.com/tailwindlabs/tailwindcss/pull/10703))
+- Ensure module dependencies for value `null`, is an empty `Set` ([#10877](https://github.com/tailwindlabs/tailwindcss/pull/10877))
 
 ### Changed
 

--- a/src/lib/getModuleDependencies.js
+++ b/src/lib/getModuleDependencies.js
@@ -72,6 +72,7 @@ function* _getModuleDependencies(filename, base, seen, ext = path.extname(filena
 }
 
 export default function getModuleDependencies(absoluteFilePath) {
+  if (absoluteFilePath === null) return new Set()
   return new Set(
     _getModuleDependencies(absoluteFilePath, path.dirname(absoluteFilePath), new Set())
   )


### PR DESCRIPTION
This PR fixes an issue where resolving the module dependencies of a path crashes if the path is `null`.

This happens in the CLI where we don't have a guaranteed `path` for the config file. This can happen in practice if you use:

```console
npx tailwindcss --content ./index.html --output ./output.css
```

... and if you don't have a `tailwind.config.{js,ts,cjs,...}` in the current directory.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
