### PR TITLE
Fix format assumption when resolving module dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sort class lists deterministically for Prettier plugin ([#10672](https://github.com/tailwindlabs/tailwindcss/pull/10672))
 - Ensure CLI builds have a non-zero exit code on failure ([#10703](https://github.com/tailwindlabs/tailwindcss/pull/10703))
 - Ensure module dependencies for value `null`, is an empty `Set` ([#10877](https://github.com/tailwindlabs/tailwindcss/pull/10877))
+- Fix format assumption when resolving module dependencies ([#10878](https://github.com/tailwindlabs/tailwindcss/pull/10878))
 
 ### Changed
 

--- a/src/lib/getModuleDependencies.js
+++ b/src/lib/getModuleDependencies.js
@@ -62,7 +62,7 @@ function* _getModuleDependencies(filename, base, seen, ext = path.extname(filena
   for (let match of [
     ...contents.matchAll(/import[\s\S]*?['"](.{3,}?)['"]/gi),
     ...contents.matchAll(/import[\s\S]*from[\s\S]*?['"](.{3,}?)['"]/gi),
-    ...contents.matchAll(/require\(['"`](.{3,})['"`]\)/gi),
+    ...contents.matchAll(/require\(['"`](.+)['"`]\)/gi),
   ]) {
     // Bail out if it's not a relative file
     if (!match[1].startsWith('.')) continue


### PR DESCRIPTION
This PR fixes an assumption when resolving the module dependencies given a path.

When resolving dependencies given a path, we are only interested relative files from the current file. We are not interested in the dependencies that are listed in your `package.json` and thus in your `node_modules` folder.

We made the assumption that your imports have at least 3 characters. This sort of makes sense because there will be a `.`, then the OS separator like `/` and than a file name. E.g.: `./a` is the minimal amount of characters.

This makes sense for `import` statements, but in the case of `require`, it is totally valid to write `require('.')`. This will require the current `index.{js,ts,mjs,cjs,...}` in the current directory.

Before this change, having a `require('.')` wouldn't crash, but the dependency would not be marked as a module dependencies and therefore we won't listen for file changes for that dependency.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
