### PR TITLE
Improve `boxShadow` TypeScript types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Try resolving `config.default` before `config` to ensure the config file is resolved correctly ([#10898](https://github.com/tailwindlabs/tailwindcss/pull/10898))
 - Pull pseudo elements outside of `:is` and `:has` when using `@apply` ([#10903](https://github.com/tailwindlabs/tailwindcss/pull/10903))
 - Update the types for the `safelist` config ([#10901](https://github.com/tailwindlabs/tailwindcss/pull/10901))
+- Improve `boxShadow` TypeScript types ([#10911](https://github.com/tailwindlabs/tailwindcss/pull/10911))
 
 ## [3.3.0] - 2023-03-27
 

--- a/tests/plugins/boxShadow.test.js
+++ b/tests/plugins/boxShadow.test.js
@@ -1,0 +1,50 @@
+import { crosscheck, run, html, css } from '../util/run'
+
+crosscheck(() => {
+  it('should be possible to define boxShadow as a string', () => {
+    let config = {
+      content: [{ raw: html`<div class="shadow-foo"></div>` }],
+      theme: {
+        boxShadow: {
+          foo: '0 0 0 1px #000',
+        },
+      },
+      corePlugins: { preflight: false },
+    }
+
+    return run('@tailwind utilities;', config).then((result) => {
+      expect(result.css).toMatchCss(css`
+        .shadow-foo {
+          --tw-shadow: 0 0 0 1px #000;
+          --tw-shadow-colored: 0 0 0 1px var(--tw-shadow-color);
+          box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
+            var(--tw-shadow);
+        }
+      `)
+    })
+  })
+
+  it('should be possible to define boxShadow as an array of strings', () => {
+    let config = {
+      content: [{ raw: html`<div class="shadow-foo"></div>` }],
+      theme: {
+        boxShadow: {
+          foo: ['0 0 0 1px #000', '1px 0 0 1px #000', '0 1px 0 1px #000', '1px 1px 0 1px #000'],
+        },
+      },
+      corePlugins: { preflight: false },
+    }
+
+    return run('@tailwind utilities;', config).then((result) => {
+      expect(result.css).toMatchCss(css`
+        .shadow-foo {
+          --tw-shadow: 0 0 0 1px #000, 1px 0 0 1px #000, 0 1px 0 1px #000, 1px 1px 0 1px #000;
+          --tw-shadow-colored: 0 0 0 1px var(--tw-shadow-color), 1px 0 0 1px var(--tw-shadow-color),
+            0 1px 0 1px var(--tw-shadow-color), 1px 1px 0 1px var(--tw-shadow-color);
+          box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000),
+            var(--tw-shadow);
+        }
+      `)
+    })
+  })
+})

--- a/tests/plugins/dropShadow.test.js
+++ b/tests/plugins/dropShadow.test.js
@@ -1,0 +1,55 @@
+import { crosscheck, run, html, css } from '../util/run'
+
+crosscheck(() => {
+  it('should be possible to define dropShadow as a string', () => {
+    let config = {
+      content: [{ raw: html`<div class="drop-shadow-foo"></div>` }],
+      theme: {
+        dropShadow: {
+          foo: '10px 10px 10px #000',
+        },
+      },
+      corePlugins: { preflight: false },
+    }
+
+    return run('@tailwind utilities;', config).then((result) => {
+      expect(result.css).toMatchCss(css`
+        .drop-shadow-foo {
+          --tw-drop-shadow: drop-shadow(10px 10px 10px #000);
+          filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale)
+            var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia)
+            var(--tw-drop-shadow);
+        }
+      `)
+    })
+  })
+
+  it('should be possible to define dropShadow as an array of strings', () => {
+    let config = {
+      content: [{ raw: html`<div class="drop-shadow-foo"></div>` }],
+      theme: {
+        dropShadow: {
+          foo: [
+            '0px 10px 10px #000',
+            '10px 0px 10px #000',
+            '10px 10xp 10px #000',
+            '10px 10px 0px #000',
+          ],
+        },
+      },
+      corePlugins: { preflight: false },
+    }
+
+    return run('@tailwind utilities;', config).then((result) => {
+      expect(result.css).toMatchCss(css`
+        .drop-shadow-foo {
+          --tw-drop-shadow: drop-shadow(0px 10px 10px #000) drop-shadow(10px 0px 10px #000)
+            drop-shadow(10px 10xp 10px #000) drop-shadow(10px 10px 0px #000);
+          filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale)
+            var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia)
+            var(--tw-drop-shadow);
+        }
+      `)
+    })
+  })
+})

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -200,7 +200,7 @@ interface ThemeConfig {
   caretColor: ThemeConfig['colors']
   accentColor: ThemeConfig['colors']
   opacity: ResolvableTo<KeyValuePair>
-  boxShadow: ResolvableTo<KeyValuePair>
+  boxShadow: ResolvableTo<KeyValuePair<string, string | string[]>>
   boxShadowColor: ThemeConfig['colors']
   outlineWidth: ResolvableTo<KeyValuePair>
   outlineOffset: ResolvableTo<KeyValuePair>


### PR DESCRIPTION
This PR improves the `boxShadow` types and makes it consistent with the `dropShadow` type.

This will also allow you to type the `boxShadow` as a string or as an array of strings.

Implementation wise this already worked, it's just that the types were out of sync.

Fixes: #10910

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
