### PR TITLE
Drop `@tailwindcss/line-clamp` warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Try resolving `config.default` before `config` to ensure the config file is resolved correctly ([#10898](https://github.com/tailwindlabs/tailwindcss/pull/10898))
 - Pull pseudo elements outside of `:is` and `:has` when using `@apply` ([#10903](https://github.com/tailwindlabs/tailwindcss/pull/10903))
 - Update the types for the `safelist` config ([#10901](https://github.com/tailwindlabs/tailwindcss/pull/10901))
+- Drop `@tailwindcss/line-clamp` warning ([#10915](https://github.com/tailwindlabs/tailwindcss/pull/10915))
 
 ## [3.3.0] - 2023-03-27
 

--- a/src/util/normalizeConfig.js
+++ b/src/util/normalizeConfig.js
@@ -297,22 +297,5 @@ export function normalizeConfig(config) {
     }
   }
 
-  // Warn if the line-clamp plugin is installed
-  if (config.plugins.length > 0) {
-    let plugin
-    try {
-      plugin = require('@tailwindcss/line-clamp')
-    } catch {}
-
-    if (plugin && config.plugins.includes(plugin)) {
-      log.warn('line-clamp-in-core', [
-        'As of Tailwind CSS v3.3, the `@tailwindcss/line-clamp` plugin is now included by default.',
-        'Remove it from the `plugins` array in your configuration to eliminate this warning.',
-      ])
-
-      config.plugins = config.plugins.filter((p) => p !== plugin)
-    }
-  }
-
   return config
 }


### PR DESCRIPTION
This PR fixes an issue where applications could break when using the new Tailwind CSS v3.3.0 version.

This happens because we're trying to detect whether or not the `@tailwindcss/line-clamp` plugin is being used by conditionally requiring it. This is done because the line-clamp plugin is now part of Tailwind CSS itself, and so the plugin is no longer required.

Unfortunately some build tools hoist conditional `require` calls as static imports, even if they are inside of a `try/catch` block, causing build failures when the `@tailwindcss/line-clamp` package is not installed.

To solve this we removed this warning from Tailwind CSS and are instead including it in the latest patch version of the `@tailwindcss/line-clamp` plugin (https://github.com/tailwindlabs/tailwindcss-line-clamp/pull/26).

Unfortunately this means that, unless the user updates to the latest version of the `@tailwindcss/line-clamp` plugin, we can no longer automatically disable the line-clamp plugin — which could result in having duplicated CSS entries for the line-clamp utilities. The good news is that this doesn't actually break your UI, it just results in a bit of extra CSS in the final output.

Fixes: #10894