### PR TITLE
Fix `@tailwindcss/line-clamp` warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pull pseudo elements outside of `:is` and `:has` when using `@apply` ([#10903](https://github.com/tailwindlabs/tailwindcss/pull/10903))
 - Update the types for the `safelist` config ([#10901](https://github.com/tailwindlabs/tailwindcss/pull/10901))
 - Fix `@tailwindcss/line-clamp` warning ([#10915](https://github.com/tailwindlabs/tailwindcss/pull/10915), [#10919](https://github.com/tailwindlabs/tailwindcss/pull/10919))
+- Fix `process` is not defined error ([#10919](https://github.com/tailwindlabs/tailwindcss/pull/10919))
 
 ## [3.3.0] - 2023-03-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Try resolving `config.default` before `config` to ensure the config file is resolved correctly ([#10898](https://github.com/tailwindlabs/tailwindcss/pull/10898))
 - Pull pseudo elements outside of `:is` and `:has` when using `@apply` ([#10903](https://github.com/tailwindlabs/tailwindcss/pull/10903))
 - Update the types for the `safelist` config ([#10901](https://github.com/tailwindlabs/tailwindcss/pull/10901))
-- Drop `@tailwindcss/line-clamp` warning ([#10915](https://github.com/tailwindlabs/tailwindcss/pull/10915))
+- Fix `@tailwindcss/line-clamp` warning ([#10915](https://github.com/tailwindlabs/tailwindcss/pull/10915), [#10919](https://github.com/tailwindlabs/tailwindcss/pull/10919))
 
 ## [3.3.0] - 2023-03-27
 

--- a/src/lib/sharedState.js
+++ b/src/lib/sharedState.js
@@ -1,12 +1,18 @@
 import pkg from '../../package.json'
 let OXIDE_DEFAULT_ENABLED = pkg.tailwindcss.engine === 'oxide'
 
-export const env = {
+export const env = typeof process !== 'undefined' ? {
   NODE_ENV: process.env.NODE_ENV,
   DEBUG: resolveDebug(process.env.DEBUG),
   ENGINE: pkg.tailwindcss.engine,
   OXIDE: resolveBoolean(process.env.OXIDE, OXIDE_DEFAULT_ENABLED),
+} : {
+  NODE_ENV: 'production',
+  DEBUG: false,
+  ENGINE: pkg.tailwindcss.engine,
+  OXIDE: OXIDE_DEFAULT_ENABLED,
 }
+
 export const contextMap = new Map()
 export const configContextMap = new Map()
 export const contextSourcesMap = new Map()

--- a/src/lib/sharedState.js
+++ b/src/lib/sharedState.js
@@ -1,17 +1,20 @@
 import pkg from '../../package.json'
 let OXIDE_DEFAULT_ENABLED = pkg.tailwindcss.engine === 'oxide'
 
-export const env = typeof process !== 'undefined' ? {
-  NODE_ENV: process.env.NODE_ENV,
-  DEBUG: resolveDebug(process.env.DEBUG),
-  ENGINE: pkg.tailwindcss.engine,
-  OXIDE: resolveBoolean(process.env.OXIDE, OXIDE_DEFAULT_ENABLED),
-} : {
-  NODE_ENV: 'production',
-  DEBUG: false,
-  ENGINE: pkg.tailwindcss.engine,
-  OXIDE: OXIDE_DEFAULT_ENABLED,
-}
+export const env =
+  typeof process !== 'undefined'
+    ? {
+        NODE_ENV: process.env.NODE_ENV,
+        DEBUG: resolveDebug(process.env.DEBUG),
+        ENGINE: pkg.tailwindcss.engine,
+        OXIDE: resolveBoolean(process.env.OXIDE, OXIDE_DEFAULT_ENABLED),
+      }
+    : {
+        NODE_ENV: 'production',
+        DEBUG: false,
+        ENGINE: pkg.tailwindcss.engine,
+        OXIDE: OXIDE_DEFAULT_ENABLED,
+      }
 
 export const contextMap = new Map()
 export const configContextMap = new Map()

--- a/src/util/normalizeConfig.js
+++ b/src/util/normalizeConfig.js
@@ -297,5 +297,23 @@ export function normalizeConfig(config) {
     }
   }
 
+  // Warn if the line-clamp plugin is installed
+  try {
+    let pkg = require(require('path').resolve(process.cwd(), 'package.json'))
+    if (
+      ('tailwindcss' in pkg.dependencies ||
+        'tailwindcss' in pkg.devDependencies ||
+        'tailwindcss' in pkg.peerDependencies) &&
+      ('@tailwindcss/line-clamp' in pkg.dependencies ||
+        '@tailwindcss/line-clamp' in pkg.devDependencies ||
+        '@tailwindcss/line-clamp' in pkg.peerDependencies)
+    ) {
+      log.warn('line-clamp-in-core', [
+        'As of Tailwind CSS v3.3, the `@tailwindcss/line-clamp` plugin is now included by default.',
+        'Remove it from the `plugins` array in your configuration to eliminate this warning.',
+      ])
+    }
+  } catch {}
+
   return config
 }

--- a/src/util/normalizeConfig.js
+++ b/src/util/normalizeConfig.js
@@ -297,23 +297,5 @@ export function normalizeConfig(config) {
     }
   }
 
-  // Warn if the line-clamp plugin is installed
-  try {
-    let pkg = require(require('path').resolve(process.cwd(), 'package.json'))
-    if (
-      ('tailwindcss' in pkg.dependencies ||
-        'tailwindcss' in pkg.devDependencies ||
-        'tailwindcss' in pkg.peerDependencies) &&
-      ('@tailwindcss/line-clamp' in pkg.dependencies ||
-        '@tailwindcss/line-clamp' in pkg.devDependencies ||
-        '@tailwindcss/line-clamp' in pkg.peerDependencies)
-    ) {
-      log.warn('line-clamp-in-core', [
-        'As of Tailwind CSS v3.3, the `@tailwindcss/line-clamp` plugin is now included by default.',
-        'Remove it from the `plugins` array in your configuration to eliminate this warning.',
-      ])
-    }
-  } catch {}
-
   return config
 }

--- a/src/util/validateConfig.js
+++ b/src/util/validateConfig.js
@@ -9,5 +9,23 @@ export function validateConfig(config) {
     ])
   }
 
+  // Warn if the line-clamp plugin is installed
+  try {
+    let pkg = require(require('path').resolve(process.cwd(), 'package.json'))
+    if (
+      ('tailwindcss' in pkg.dependencies ||
+        'tailwindcss' in pkg.devDependencies ||
+        'tailwindcss' in pkg.peerDependencies) &&
+      ('@tailwindcss/line-clamp' in pkg.dependencies ||
+        '@tailwindcss/line-clamp' in pkg.devDependencies ||
+        '@tailwindcss/line-clamp' in pkg.peerDependencies)
+    ) {
+      log.warn('line-clamp-in-core', [
+        'As of Tailwind CSS v3.3, the `@tailwindcss/line-clamp` plugin is now included by default.',
+        'Remove it from the `plugins` array in your configuration to eliminate this warning.',
+      ])
+    }
+  } catch {}
+
   return config
 }

--- a/src/util/validateConfig.js
+++ b/src/util/validateConfig.js
@@ -11,19 +11,14 @@ export function validateConfig(config) {
 
   // Warn if the line-clamp plugin is installed
   try {
-    let pkg = require(require('path').resolve(process.cwd(), 'package.json'))
-    if (
-      ('tailwindcss' in pkg.dependencies ||
-        'tailwindcss' in pkg.devDependencies ||
-        'tailwindcss' in pkg.peerDependencies) &&
-      ('@tailwindcss/line-clamp' in pkg.dependencies ||
-        '@tailwindcss/line-clamp' in pkg.devDependencies ||
-        '@tailwindcss/line-clamp' in pkg.peerDependencies)
-    ) {
+    let plugin = require("@tailwindcss/line-clamp")
+    if (config.plugins.includes(plugin)) {
       log.warn('line-clamp-in-core', [
         'As of Tailwind CSS v3.3, the `@tailwindcss/line-clamp` plugin is now included by default.',
         'Remove it from the `plugins` array in your configuration to eliminate this warning.',
       ])
+
+      config.plugins = config.plugins.filter((p) => p !== plugin)
     }
   } catch {}
 

--- a/src/util/validateConfig.js
+++ b/src/util/validateConfig.js
@@ -11,7 +11,7 @@ export function validateConfig(config) {
 
   // Warn if the line-clamp plugin is installed
   try {
-    let plugin = require("@tailwindcss/line-clamp")
+    let plugin = require('@tailwindcss/line-clamp')
     if (config.plugins.includes(plugin)) {
       log.warn('line-clamp-in-core', [
         'As of Tailwind CSS v3.3, the `@tailwindcss/line-clamp` plugin is now included by default.',


### PR DESCRIPTION
Previously the check was in the `resolveConfig` path which is importable externally by users because it's public API. However, due to build tools statically hoisting conditional imports (*cough* Rollup) we had to back that out.

Moving this to `validateConfig` gives us the same flexibility we had previously but now happens at build-time only. It is not public API and therefore can use dynamic requires.

While working on this we also encountered an issue with the `process` variable being accessed in the browser when using `resolveConfig` and have fixed this as well.

Fixes #10894
Fixes #10918