### PR TITLE
Add support for paint-order CSS property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [Oxide] Use `lightningcss` for nesting and vendor prefixes in PostCSS plugin ([#10399](https://github.com/tailwindlabs/tailwindcss/pull/10399))
+
 ### Fixed
 
 - Try resolving `config.default` before `config` to ensure the config file is resolved correctly ([#10898](https://github.com/tailwindlabs/tailwindcss/pull/10898))
 - Pull pseudo elements outside of `:is` and `:has` when using `@apply` ([#10903](https://github.com/tailwindlabs/tailwindcss/pull/10903))
 - Update the types for the `safelist` config ([#10901](https://github.com/tailwindlabs/tailwindcss/pull/10901))
+
+### Changed
+
+- [Oxide] Disable color opacity plugins by default in the `oxide` engine ([#10618](https://github.com/tailwindlabs/tailwindcss/pull/10618))
+- [Oxide] Enable relative content paths for the `oxide` engine ([#10621](https://github.com/tailwindlabs/tailwindcss/pull/10621))
 
 ## [3.3.0] - 2023-03-27
 

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -7,6 +7,7 @@ import buildMediaQuery from './util/buildMediaQuery'
 import escapeClassName from './util/escapeClassName'
 import parseAnimationValue from './util/parseAnimationValue'
 import flattenColorPalette from './util/flattenColorPalette'
+import getAllCombinations from './util/getAllCombinations'
 import withAlphaVariable, { withAlphaValue } from './util/withAlphaVariable'
 import toColorValue from './util/toColorValue'
 import isPlainObject from './util/isPlainObject'
@@ -1923,6 +1924,18 @@ export let corePlugins = {
   strokeWidth: createUtilityPlugin('strokeWidth', [['stroke', ['stroke-width']]], {
     type: ['length', 'number', 'percentage'],
   }),
+
+  paintOrder: ({ addUtilities }) => {
+    const defaultPaintOrder = ['fill', 'stroke', 'markers']
+    const allPaintOrders = [['normal'], ...getAllCombinations(defaultPaintOrder)]
+    for (const paintOrder of allPaintOrders) {
+      addUtilities({
+        [`.paint-order-${paintOrder.join('-')}`]: {
+          'paint-order': paintOrder.join(' '),
+        },
+      })
+    }
+  },
 
   objectFit: ({ addUtilities }) => {
     addUtilities({

--- a/src/util/getAllCombinations.js
+++ b/src/util/getAllCombinations.js
@@ -1,7 +1,7 @@
-export function getAllCombinations(arr) {
+const getAllCombinations = (arr) => {
   const result = []
 
-  function permutations(input, prefix = []) {
+  const permutations = (input, prefix = []) => {
     if (input.length === 0) {
       result.push(prefix)
     } else {
@@ -30,3 +30,5 @@ export function getAllCombinations(arr) {
 
   return result
 }
+
+export default getAllCombinations

--- a/src/util/getAllCombinations.js
+++ b/src/util/getAllCombinations.js
@@ -1,0 +1,32 @@
+export function getAllCombinations(arr) {
+  const result = []
+
+  function permutations(input, prefix = []) {
+    if (input.length === 0) {
+      result.push(prefix)
+    } else {
+      for (let i = 0; i < input.length; i++) {
+        const newInput = input.slice(0, i).concat(input.slice(i + 1))
+        const newPrefix = prefix.concat(input[i])
+        permutations(newInput, newPrefix)
+      }
+    }
+  }
+
+  function loop(start, depth, prefix) {
+    for (let i = start; i < arr.length; i++) {
+      const next = prefix.concat(arr[i])
+      if (depth > 0) {
+        loop(i + 1, depth - 1, next)
+      } else {
+        permutations(next)
+      }
+    }
+  }
+
+  for (let i = 0; i < arr.length; i++) {
+    loop(0, i, [])
+  }
+
+  return result
+}


### PR DESCRIPTION
## Summary

This PR aims to add support for the `paint-order` CSS property in Tailwind CSS. The `paint-order` property is used to control the order in which an SVG element's stroke, fill, and markers are painted. By providing a utility for this property, Tailwind CSS users can easily control the painting order of their SVG elements directly within their markup, offering greater flexibility and efficiency.

## Background

The `paint-order` property is essential when working with SVG elements, as it allows designers and developers to control the order in which the various parts of an SVG element are rendered. This can be especially useful when creating complex illustrations, icons, or charts, where the painting order of strokes, fills, and markers can have a significant impact on the visual appearance.

The property accepts three keywords: `fill`, `stroke`, and `markers`. The default order is `fill`, `stroke`, `markers`, but by specifying a different order, users can achieve different visual effects. For example, reversing the order to `markers`, `stroke`, `fill` will cause the fill to be painted on top of the stroke and markers.

## Examples

The below example can also be seen live in Tailwind Play here: https://play.tailwindcss.com/JcWQ4jlPKh

With the new `paint-order` utility, users can easily change the painting order of their SVG elements:

```html
<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200">
  <text x="10" y="75">stroke in front</text>
  <text x="10" y="150" class="paint-order-stroke-fill">stroke behind</text>
</svg>
```

<img width="399" alt="example of paint-order CSS property" src="https://user-images.githubusercontent.com/5913254/229029723-6fde4e2e-8b1c-4cff-8b43-fdb8c007c32c.png">

[_This example is originally sourced from MDN_](https://developer.mozilla.org/en-US/docs/Web/CSS/paint-order#examples)

## Resources & support

[`paint-order` documentation (MDN)](https://developer.mozilla.org/en-US/docs/Web/CSS/paint-order)

<details><summary>supporting tweets (each linked to source tweet) — (expand / collapse)</summary><br />

<a href="https://twitter.com/hamiltonulmer/status/1641498438083944449"><img width="595" alt="image" src="https://user-images.githubusercontent.com/5913254/229030483-be3fead7-ff8a-4f24-a367-200a5d91d7d6.png"></a>

<a href="https://twitter.com/hamiltonulmer/status/1641575986654502912"><img width="595" alt="image" src="https://user-images.githubusercontent.com/5913254/229030498-deb82d00-aee4-450a-9d85-2052724b317b.png"></a>

<a href="https://twitter.com/stefanjudis/status/1179038205686865925"><img width="595" alt="image" src="https://user-images.githubusercontent.com/5913254/229030507-f2c3229f-efc9-46eb-b4aa-ddd12d0ef08e.png"></a>

<a href="https://twitter.com/stefanjudis/status/1449839589095579650"><img width="596" alt="image" src="https://user-images.githubusercontent.com/5913254/229030520-0f8515d0-37b6-4aed-bfcf-fad946c95ce9.png"></a>

</details>