### PR TITLE
Simplify rotate core plugin to a single transform

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -848,7 +848,7 @@ export let corePlugins = {
   ),
   rotate: createUtilityPlugin(
     'rotate',
-    [['rotate', [['@defaults transform', {}], '--tw-rotate', ['transform', cssTransformValue]]]],
+    [['rotate', ['--tw-rotate', ['transform', 'rotate(var(--tw-rotate))']]]],
     { supportsNegativeValues: true }
   ),
   skew: createUtilityPlugin(

--- a/tests/any-type.test.js
+++ b/tests/any-type.test.js
@@ -321,9 +321,7 @@ crosscheck(({ stable, oxide }) => {
         }
         .rotate-\[var\(--any-value\)\] {
           --tw-rotate: var(--any-value);
-          transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-            rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-            scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+          transform: rotate(var(--tw-rotate));
         }
         .scale-\[var\(--any-value\)\] {
           --tw-scale-x: var(--any-value);
@@ -875,9 +873,7 @@ crosscheck(({ stable, oxide }) => {
         }
         .rotate-\[var\(--any-value\)\] {
           --tw-rotate: var(--any-value);
-          transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-            rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-            scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+          transform: rotate(var(--tw-rotate));
         }
         .scale-\[var\(--any-value\)\] {
           --tw-scale-x: var(--any-value);

--- a/tests/apply.test.js
+++ b/tests/apply.test.js
@@ -1848,9 +1848,7 @@ crosscheck(({ stable, oxide }) => {
       return expect(result.css).toMatchFormattedCss(css`
         .foo:focus {
           --tw-rotate: 90deg;
-          transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-            rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-            scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+          transform: rotate(var(--tw-rotate));
         }
       `)
     })
@@ -1876,9 +1874,7 @@ crosscheck(({ stable, oxide }) => {
         ${defaults}
         .foo:focus {
           --tw-rotate: 90deg;
-          transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-            rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-            scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+          transform: rotate(var(--tw-rotate));
         }
       `)
     })

--- a/tests/arbitrary-values.oxide.test.css
+++ b/tests/arbitrary-values.oxide.test.css
@@ -251,27 +251,19 @@
 }
 .rotate-\[1\.5turn\] {
   --tw-rotate: 1.5turn;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate))
-    skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x))
-    scaleY(var(--tw-scale-y));
+  transform: rotate(var(--tw-rotate));
 }
 .rotate-\[2\.3rad\] {
   --tw-rotate: 131.78deg;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate))
-    skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x))
-    scaleY(var(--tw-scale-y));
+  transform: rotate(var(--tw-rotate));
 }
 .rotate-\[23deg\] {
   --tw-rotate: 23deg;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate))
-    skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x))
-    scaleY(var(--tw-scale-y));
+  transform: rotate(var(--tw-rotate));
 }
 .rotate-\[401grad\] {
   --tw-rotate: 401grad;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate))
-    skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x))
-    scaleY(var(--tw-scale-y));
+  transform: rotate(var(--tw-rotate));
 }
 .skew-x-\[3px\] {
   --tw-skew-x: 3px;

--- a/tests/arbitrary-values.test.css
+++ b/tests/arbitrary-values.test.css
@@ -251,27 +251,19 @@
 }
 .rotate-\[1\.5turn\] {
   --tw-rotate: 1.5turn;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate))
-    skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x))
-    scaleY(var(--tw-scale-y));
+  transform: rotate(var(--tw-rotate));
 }
 .rotate-\[2\.3rad\] {
   --tw-rotate: 131.78deg;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate))
-    skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x))
-    scaleY(var(--tw-scale-y));
+  transform: rotate(var(--tw-rotate));
 }
 .rotate-\[23deg\] {
   --tw-rotate: 23deg;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate))
-    skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x))
-    scaleY(var(--tw-scale-y));
+  transform: rotate(var(--tw-rotate));
 }
 .rotate-\[401grad\] {
   --tw-rotate: 401grad;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate))
-    skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x))
-    scaleY(var(--tw-scale-y));
+  transform: rotate(var(--tw-rotate));
 }
 .skew-x-\[3px\] {
   --tw-skew-x: 3px;

--- a/tests/basic-usage.oxide.test.css
+++ b/tests/basic-usage.oxide.test.css
@@ -303,9 +303,7 @@
 }
 .rotate-3 {
   --tw-rotate: 3deg;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate))
-    skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x))
-    scaleY(var(--tw-scale-y));
+  transform: rotate(var(--tw-rotate));
 }
 .skew-x-12 {
   --tw-skew-x: 12deg;

--- a/tests/basic-usage.test.css
+++ b/tests/basic-usage.test.css
@@ -303,9 +303,7 @@
 }
 .rotate-3 {
   --tw-rotate: 3deg;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate))
-    skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x))
-    scaleY(var(--tw-scale-y));
+  transform: rotate(var(--tw-rotate));
 }
 .skew-x-12 {
   --tw-skew-x: 12deg;

--- a/tests/raw-content.oxide.test.css
+++ b/tests/raw-content.oxide.test.css
@@ -217,9 +217,7 @@
 }
 .rotate-3 {
   --tw-rotate: 3deg;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate))
-    skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x))
-    scaleY(var(--tw-scale-y));
+  transform: rotate(var(--tw-rotate));
 }
 .skew-x-12 {
   --tw-skew-x: 12deg;

--- a/tests/raw-content.test.css
+++ b/tests/raw-content.test.css
@@ -217,9 +217,7 @@
 }
 .rotate-3 {
   --tw-rotate: 3deg;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate))
-    skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x))
-    scaleY(var(--tw-scale-y));
+  transform: rotate(var(--tw-rotate));
 }
 .skew-x-12 {
   --tw-skew-x: 12deg;

--- a/tests/resolve-defaults-at-rules.test.js
+++ b/tests/resolve-defaults-at-rules.test.js
@@ -29,9 +29,7 @@ crosscheck(() => {
         }
         .rotate-3 {
           --tw-rotate: 3deg;
-          transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-            rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-            scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+          transform: rotate(var(--tw-rotate));
         }
         .skew-y-6 {
           --tw-skew-y: 6deg;
@@ -85,9 +83,7 @@ crosscheck(() => {
         }
         .focus\:rotate-3:focus {
           --tw-rotate: 3deg;
-          transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-            rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-            scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+          transform: rotate(var(--tw-rotate));
         }
         .hover\:focus\:skew-y-6:focus:hover {
           --tw-skew-y: 6deg;
@@ -135,9 +131,7 @@ crosscheck(() => {
         .after\:rotate-3:after {
           content: var(--tw-content);
           --tw-rotate: 3deg;
-          transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-            rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-            scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+          transform: rotate(var(--tw-rotate));
         }
       `)
     })
@@ -177,9 +171,7 @@ crosscheck(() => {
         }
         .peer:focus ~ .peer-focus\:rotate-3 {
           --tw-rotate: 3deg;
-          transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-            rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-            scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+          transform: rotate(var(--tw-rotate));
         }
       `)
     })
@@ -223,9 +215,7 @@ crosscheck(() => {
         .peer:focus ~ .peer-focus\:after\:rotate-3:after {
           content: var(--tw-content);
           --tw-rotate: 3deg;
-          transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-            rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-            scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+          transform: rotate(var(--tw-rotate));
         }
       `)
     })
@@ -273,9 +263,7 @@ crosscheck(() => {
         .peer:focus ~ .peer-focus\:focus\:after\:rotate-3:focus:after {
           content: var(--tw-content);
           --tw-rotate: 3deg;
-          transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-            rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-            scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+          transform: rotate(var(--tw-rotate));
         }
       `)
     })
@@ -351,9 +339,7 @@ crosscheck(() => {
         }
         .foo {
           --tw-rotate: 3deg;
-          transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-            rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-            scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+          transform: rotate(var(--tw-rotate));
         }
         .bar:before {
           content: var(--tw-content);
@@ -365,9 +351,7 @@ crosscheck(() => {
         }
         .baz:before {
           --tw-rotate: 45deg;
-          transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-            rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-            scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+          transform: rotate(var(--tw-rotate));
         }
         .whats ~ .next > span:hover {
           --tw-skew-x: 6deg;
@@ -378,9 +362,7 @@ crosscheck(() => {
         @media (min-width: 768px) {
           .media-queries {
             --tw-rotate: 45deg;
-            transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-              rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-              scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+            transform: rotate(var(--tw-rotate));
           }
         }
         .a,
@@ -394,22 +376,16 @@ crosscheck(() => {
         .a,
         .b {
           --tw-rotate: 45deg;
-          transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-            rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-            scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+          transform: rotate(var(--tw-rotate));
         }
         .a:before,
         .b:after {
           --tw-rotate: 90deg;
-          transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-            rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-            scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+          transform: rotate(var(--tw-rotate));
         }
         .recursive {
           --tw-rotate: 3deg;
-          transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-            rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-            scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+          transform: rotate(var(--tw-rotate));
         }
       `)
     })
@@ -423,7 +399,7 @@ crosscheck(() => {
     }
 
     let input = css`
-      @tailwind base;
+      /* --- */
       /* --- */
       @tailwind utilities;
 
@@ -446,41 +422,21 @@ crosscheck(() => {
 
     return run(input, config).then((result) => {
       expect(result.css).toMatchFormattedCss(css`
-        .a:before,
-        .b:after,
-        .c:first-line,
-        .d:first-letter {
-          --tw-translate-x: 0;
-          --tw-translate-y: 0;
-          --tw-rotate: 0;
-          --tw-skew-x: 0;
-          --tw-skew-y: 0;
-          --tw-scale-x: 1;
-          --tw-scale-y: 1;
-        }
         .a:before {
           --tw-rotate: 45deg;
-          transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-            rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-            scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+          transform: rotate(var(--tw-rotate));
         }
         .b:after {
           --tw-rotate: 3deg;
-          transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-            rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-            scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+          transform: rotate(var(--tw-rotate));
         }
         .c:first-line {
           --tw-rotate: 1deg;
-          transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-            rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-            scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+          transform: rotate(var(--tw-rotate));
         }
         .d:first-letter {
           --tw-rotate: 6deg;
-          transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-            rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-            scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+          transform: rotate(var(--tw-rotate));
         }
       `)
     })
@@ -620,9 +576,7 @@ crosscheck(() => {
       expect(result.css).toMatchFormattedCss(css`
         .rotate-3 {
           --tw-rotate: 3deg;
-          transform: translate(var(--tw-translate-x), var(--tw-translate-y))
-            rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
-            scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+          transform: rotate(var(--tw-rotate));
         }
       `)
     })


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->

The [docs on rotate](https://github.com/tailwindlabs/tailwindcss.com/blob/6f58d2ed6c7f2e0a220c94a2c6597f6374e8d665/src/pages/docs/rotate.mdx?plain=1#L17) show that the only property used in the declaration is `rotate()`:

![Screenshot of the tailwind docs for rotate. In the table with "Class" and "Properties" columns you can see that for the `rotate-0` class, the only property is `transform: rotate(0deg);`](https://user-images.githubusercontent.com/2008881/229958399-e4dd3386-dcef-400c-9c00-fa9743ece527.png)

However, the property that was actually declared was a combination of `translate`, `rotate`, `skew`, and `scale`, all of which used CSS variables. Because of this a tailwind user would have to include `@tailwind base` just to get those variables defined, but that inclusion would add a lot of extra baggage that wasn't necessary for utility classes.

With this PR a user can only have the `utilities` layer, leading to less output, and the `rotate` utility can only be concerned with rotation.

---

This didn't feel like a significant feature so I didn't open an issue for it, but let me know if more discussion is desired.