### PR TITLE
Add `aria-busy` utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix issue where some pseudo-element variants generated the wrong selector ([#10943](https://github.com/tailwindlabs/tailwindcss/pull/10943), [#10962](https://github.com/tailwindlabs/tailwindcss/pull/10962))
 - Make font settings propagate into buttons, inputs, etc. ([#10940](https://github.com/tailwindlabs/tailwindcss/pull/10940))
 
+### Added
+
+- Add `aria-busy` utility ([#10966](https://github.com/tailwindlabs/tailwindcss/pull/10966))
+
 ## [3.3.2] - 2023-04-25
 
 ### Fixed

--- a/stubs/config.full.js
+++ b/stubs/config.full.js
@@ -15,6 +15,7 @@ module.exports = {
       bounce: 'bounce 1s infinite',
     },
     aria: {
+      busy: 'busy="true"',
       checked: 'checked="true"',
       disabled: 'disabled="true"',
       expanded: 'expanded="true"',


### PR DESCRIPTION
This is useful to show a spinner or dim a region that is updating.

Very useful in conjunction with [Turbo](https://turbo.hotwired.dev/reference/attributes#automatically-added-attributes)
