### PR TITLE
Add support for functions in flattenColorPalette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [Oxide] Use `lightningcss` for nesting and vendor prefixes in PostCSS plugin ([#10399](https://github.com/tailwindlabs/tailwindcss/pull/10399))
+
 ### Fixed
 
 - Don’t move unknown pseudo-elements to the end of selectors ([#10943](https://github.com/tailwindlabs/tailwindcss/pull/10943), [#10962](https://github.com/tailwindlabs/tailwindcss/pull/10962))
+
+### Changed
+
+- [Oxide] Disable color opacity plugins by default in the `oxide` engine ([#10618](https://github.com/tailwindlabs/tailwindcss/pull/10618))
+- [Oxide] Enable relative content paths for the `oxide` engine ([#10621](https://github.com/tailwindlabs/tailwindcss/pull/10621))
 
 ## [3.3.1] - 2023-03-30
 

--- a/src/util/flattenColorPalette.js
+++ b/src/util/flattenColorPalette.js
@@ -1,4 +1,4 @@
-const flattenColorPalette = (colors) =>
+const flattenColorPalette = (colors, includeFunctions, ...functionParameters) =>
   Object.assign(
     {},
     ...Object.entries(colors ?? {}).flatMap(([color, values]) =>
@@ -6,6 +6,10 @@ const flattenColorPalette = (colors) =>
         ? Object.entries(flattenColorPalette(values)).map(([number, hex]) => ({
             [color + (number === 'DEFAULT' ? '' : `-${number}`)]: hex,
           }))
+        : typeof values == 'function'
+        ? includeFunctions
+          ? [{ [`${color}`]: values(...functionParameters) }]
+          : []
         : [{ [`${color}`]: values }]
     )
   )

--- a/tests/flattenColorPalette.test.js
+++ b/tests/flattenColorPalette.test.js
@@ -78,6 +78,44 @@ crosscheck(() => {
     })
   })
 
+  test('it flattens deeply nested color objects with functions', () => {
+    expect(
+      flattenColorPalette(
+        {
+          primary: function dark(color) {
+            return `dark${color}`
+          },
+          secondary: {
+            DEFAULT: 'blue',
+            hover: 'cyan',
+            focus: 'red',
+          },
+          button: {
+            primary: {
+              DEFAULT: 'magenta',
+              hover: 'green',
+              focus: {
+                DEFAULT: 'yellow',
+                variant: 'orange',
+              },
+            },
+          },
+        },
+        true,
+        'cyan'
+      )
+    ).toEqual({
+      primary: 'darkcyan',
+      secondary: 'blue',
+      'secondary-hover': 'cyan',
+      'secondary-focus': 'red',
+      'button-primary': 'magenta',
+      'button-primary-hover': 'green',
+      'button-primary-focus': 'yellow',
+      'button-primary-focus-variant': 'orange',
+    })
+  })
+
   test('it handles empty objects', () => {
     expect(flattenColorPalette({})).toEqual({})
   })


### PR DESCRIPTION
Currently flattenColorPalette does not handle values that are functions. This change allows for functions to be be flattened optionally, so it should not break existing setups. This could potentially be further enhanced by then also checking if the function's returned value is an object and flattening that as a well. I also added a simple test for this new functionality.
