### PR TITLE
Removing blur-0 as blur-none exists and updating blur-none value

### DIFF
--- a/stubs/config.full.js
+++ b/stubs/config.full.js
@@ -68,8 +68,7 @@ module.exports = {
       contain: 'contain',
     },
     blur: {
-      0: '0',
-      none: '0',
+      none: '0px',
       sm: '4px',
       DEFAULT: '8px',
       md: '12px',

--- a/stubs/config.full.js
+++ b/stubs/config.full.js
@@ -93,9 +93,7 @@ module.exports = {
       '3xl': '1.5rem',
       full: '9999px',
     },
-    borderSpacing: ({ theme }) => ({
-      ...theme('spacing'),
-    }),
+    borderSpacing: ({ theme }) => theme('spacing'),
     borderWidth: {
       DEFAULT: '1px',
       0: '0px',
@@ -783,9 +781,7 @@ module.exports = {
       xl: '1280px',
       '2xl': '1536px',
     },
-    scrollMargin: ({ theme }) => ({
-      ...theme('spacing'),
-    }),
+    scrollMargin: ({ theme }) => theme('spacing'),
     scrollPadding: ({ theme }) => theme('spacing'),
     sepia: {
       0: '0',
@@ -799,9 +795,7 @@ module.exports = {
       6: '6deg',
       12: '12deg',
     },
-    space: ({ theme }) => ({
-      ...theme('spacing'),
-    }),
+    space: ({ theme }) => theme('spacing'),
     spacing: {
       px: '1px',
       0: '0px',
@@ -861,9 +855,7 @@ module.exports = {
       4: '4px',
       8: '8px',
     },
-    textIndent: ({ theme }) => ({
-      ...theme('spacing'),
-    }),
+    textIndent: ({ theme }) => theme('spacing'),
     textOpacity: ({ theme }) => theme('opacity'),
     textUnderlineOffset: {
       auto: 'auto',


### PR DESCRIPTION
In this pull request, blur-0 is proposed to be removed as we are now using blur-none as standard. Value of blur-none is also changed from 0 to 0px to maintain consistency with other values like rounded-none value is 0px.
File formatted to maintain consistency throughout the file.
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
