### PR TITLE
Normalize arbitrary modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Honor default `to` position of gradient when using implicit transparent colors ([#11002](https://github.com/tailwindlabs/tailwindcss/pull/11002))
 - Ensure `@tailwindcss/oxide` doesn't leak in the stable engine ([#10988](https://github.com/tailwindlabs/tailwindcss/pull/10988))
 - Ensure multiple `theme(spacing[5])` calls with bracket notation in arbitrary properties work ([#11039](https://github.com/tailwindlabs/tailwindcss/pull/11039))
+- Normalize arbitrary modifiers ([#11057](https://github.com/tailwindlabs/tailwindcss/pull/11057))
 
 ## [3.3.1] - 2023-03-30
 

--- a/src/util/pluginUtils.js
+++ b/src/util/pluginUtils.js
@@ -115,11 +115,7 @@ export function parseColorFormat(value) {
 }
 
 function unwrapArbitraryModifier(modifier) {
-  modifier = modifier.slice(1, -1)
-  if (modifier.startsWith('--')) {
-    modifier = `var(${modifier})`
-  }
-  return modifier
+  return normalize(modifier.slice(1, -1))
 }
 
 export function asColor(modifier, options = {}, { tailwindConfig = {} } = {}) {

--- a/tests/arbitrary-values.test.js
+++ b/tests/arbitrary-values.test.js
@@ -637,4 +637,19 @@ crosscheck(({ stable, oxide }) => {
       `)
     })
   })
+
+  it('should support underscores in arbitrary modifiers', () => {
+    let config = {
+      content: [{ raw: html`<div class="text-lg/[calc(50px_*_2)]"></div>` }],
+    }
+
+    return run('@tailwind utilities', config).then((result) => {
+      return expect(result.css).toMatchFormattedCss(css`
+        .text-lg\/\[calc\(50px_\*_2\)\] {
+          font-size: 1.125rem;
+          line-height: calc(50px * 2);
+        }
+      `)
+    })
+  })
 })


### PR DESCRIPTION
This PR fixes an issue where arbitrary modifiers are not treated the same as arbitrary values.

Currently it is not possible to use underscores (`_`) in arbitrary modifiers because they stay there as-is instead of getting replaced by spaces.

This PR makes sure that the arbitrary modifiers are normalized, it will use the same rules as arbitrary values. This means that you should be able to use `_` instead of a space. If you do want to keep the `_` then you have to escape it using `\_`.

Fixes: #11045

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
