### PR TITLE
Fix custom theme, all color properties of boxShadow are reset to `var(--tw-shadow-color)`.

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -2328,7 +2328,7 @@ export let corePlugins = {
                 continue
               }
 
-              shadow.color = 'var(--tw-shadow-color)'
+              shadow.color = shadow.color ?? 'var(--tw-shadow-color)'
             }
 
             return {


### PR DESCRIPTION
I was configuring `boxShadow` in my `tailwind.config.js` file and found that all my color values were replaced with the `-tw-shadow-color` variable.
I think this should be a bug.

```
const tailwindcssConfig = {
  theme: {
    extend: {
      boxShadow: {
        'jz-black': 'inset 0 0 0 2px, 2px 2px 0 0 rgb(255,255,255), 4px 4px 0 0',
      },
    },
  },
};
```
> The current effect

![image](https://user-images.githubusercontent.com/114130827/233915132-79f95c2a-bfd3-499d-9d04-3e2a5df3da0a.png)

> The values are replaced with `-tw-shadow-color`

![2023-04-24 14 24 34](https://user-images.githubusercontent.com/114130827/233915775-3a54409e-9a7b-4770-9997-8c739c9ba9d9.png)

> The effect after the fix

![image](https://user-images.githubusercontent.com/114130827/233917209-0b47ac1b-00ba-4215-9fb1-52647a75e18d.png)
