### PR TITLE
Log error for default config file not found.

### DIFF
--- a/src/util/resolveConfigPath.js
+++ b/src/util/resolveConfigPath.js
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import log from './log'
 
 const defaultConfigFiles = [
   './tailwind.config.js',
@@ -59,7 +60,12 @@ export function resolveDefaultConfigPath() {
       const configPath = path.resolve(configFile)
       fs.accessSync(configPath)
       return configPath
-    } catch (err) {}
+    } catch (err) {
+      log.warn(
+        'default-config-not-found',
+        `Default config file not found. Path resolved to: ${err.path}. If you need to specify a custom config path use --config <path>`
+      )
+    }
   }
 
   return null


### PR DESCRIPTION
So here's the story:
After spending probably about 2 hours stuck on a bug where Tailwind would only log:
```
warn - No utility classes were detected in your source files. If this is unexpected, double-check the `content` option in your Tailwind CSS configuration.
warn - https://tailwindcss.com/docs/content-configuration
```
I finally realized that it was because I was using `npx tailwindcss` in an npm script (thus executing from package.json) while my tailwind config was actually nested in a lower directory (a test server).
When I went to the code that resolved the default path, I noticed that it wasn't logging anything, so I thought it'd be really helpful to log what happened so that it, hopefully, will save someone else some time in the future!