### PR TITLE
[oxide] Expose experimental Rust parser setup

### DIFF
--- a/oxide/crates/core/src/lib.rs
+++ b/oxide/crates/core/src/lib.rs
@@ -1,4 +1,5 @@
 use crate::parser::Extractor;
+use fxhash::FxHashSet;
 use rayon::prelude::*;
 use std::path::PathBuf;
 use tracing::event;
@@ -11,14 +12,7 @@ pub mod parser;
 pub mod utility;
 pub mod variant;
 
-#[derive(Debug, Clone)]
-pub struct ChangedContent {
-    pub file: Option<PathBuf>,
-    pub content: Option<String>,
-    pub extension: String,
-}
-
-pub fn parse_candidate_strings_from_files(changed_content: Vec<ChangedContent>) -> Vec<String> {
+fn init_tracing() {
     if matches!(std::env::var("DEBUG"), Ok(value) if value.eq("*") || value.eq("1") || value.eq("true") || value.contains("tailwind"))
     {
         tracing_subscriber::fmt()
@@ -27,8 +21,55 @@ pub fn parse_candidate_strings_from_files(changed_content: Vec<ChangedContent>) 
             .compact()
             .init();
     }
+}
 
+#[derive(Debug, Clone)]
+pub struct ChangedContent {
+    pub file: Option<PathBuf>,
+    pub content: Option<String>,
+    pub extension: String,
+}
+
+pub fn parse_candidate_strings_from_files(changed_content: Vec<ChangedContent>) -> Vec<String> {
+    init_tracing();
     parse_all_blobs(read_all_files(changed_content))
+}
+
+#[derive(Debug, Clone)]
+pub struct Options {
+    pub input: Vec<ChangedContent>,
+    pub strategy: Strategy,
+}
+
+#[derive(Debug, Clone)]
+pub struct Strategy {
+    pub io: IOStrategy,
+    pub parsing: ParsingStrategy,
+}
+
+#[derive(Debug, Clone)]
+pub enum IOStrategy {
+    Sequential,
+    Parallel,
+}
+
+#[derive(Debug, Clone)]
+pub enum ParsingStrategy {
+    Sequential,
+    Parallel,
+}
+
+pub fn parse_candidate_strings(options: Options) -> Vec<String> {
+    init_tracing();
+    let blobs = match options.strategy.io {
+        IOStrategy::Sequential => read_all_files_sync(options.input),
+        IOStrategy::Parallel => read_all_files(options.input),
+    };
+
+    match options.strategy.parsing {
+        ParsingStrategy::Sequential => parse_all_blobs_sync(blobs),
+        ParsingStrategy::Parallel => parse_all_blobs(blobs),
+    }
 }
 
 #[tracing::instrument(skip(changed_content))]
@@ -49,6 +90,24 @@ fn read_all_files(changed_content: Vec<ChangedContent>) -> Vec<Vec<u8>> {
         .collect()
 }
 
+#[tracing::instrument(skip(changed_content))]
+fn read_all_files_sync(changed_content: Vec<ChangedContent>) -> Vec<Vec<u8>> {
+    event!(
+        tracing::Level::INFO,
+        "Reading {:?} file(s)",
+        changed_content.len()
+    );
+
+    changed_content
+        .into_iter()
+        .map(|c| match (c.file, c.content) {
+            (Some(file), None) => std::fs::read(file).unwrap(),
+            (None, Some(content)) => content.into_bytes(),
+            _ => Default::default(),
+        })
+        .collect()
+}
+
 #[tracing::instrument(skip(blobs))]
 fn parse_all_blobs(blobs: Vec<Vec<u8>>) -> Vec<String> {
     let input: Vec<_> = blobs.iter().map(|blob| &blob[..]).collect();
@@ -58,6 +117,30 @@ fn parse_all_blobs(blobs: Vec<Vec<u8>>) -> Vec<String> {
         .par_iter()
         .map(|input| Extractor::unique(input, Default::default()))
         .reduce(Default::default, |mut a, b| {
+            a.extend(b);
+            a
+        })
+        .into_iter()
+        .map(|s| {
+            // SAFETY: When we parsed the candidates, we already guaranteed that the byte slices
+            // are valid, therefore we don't have to re-check here when we want to convert it back
+            // to a string.
+            unsafe { String::from_utf8_unchecked(s.to_vec()) }
+        })
+        .collect();
+    result.sort();
+    result
+}
+
+#[tracing::instrument(skip(blobs))]
+fn parse_all_blobs_sync(blobs: Vec<Vec<u8>>) -> Vec<String> {
+    let input: Vec<_> = blobs.iter().map(|blob| &blob[..]).collect();
+    let input = &input[..];
+
+    let mut result: Vec<String> = input
+        .iter()
+        .map(|input| Extractor::unique(input, Default::default()))
+        .fold(FxHashSet::default(), |mut a, b| {
             a.extend(b);
             a
         })

--- a/oxide/crates/node/src/lib.rs
+++ b/oxide/crates/node/src/lib.rs
@@ -29,71 +29,21 @@ pub fn parse_candidate_strings_from_files(changed_content: Vec<ChangedContent>) 
   )
 }
 
-#[derive(Debug, Clone)]
-#[napi(object)]
-pub struct Options {
-  pub input: Vec<ChangedContent>,
-  pub strategy: Strategy,
-}
-
-impl From<Options> for tailwindcss_core::Options {
-  fn from(options: Options) -> Self {
-    tailwindcss_core::Options {
-      input: options.input.into_iter().map(Into::into).collect(),
-      strategy: options.strategy.into(),
-    }
-  }
-}
-
-#[derive(Debug, Clone)]
-#[napi(object)]
-pub struct Strategy {
-  pub io: IOStrategy,
-  pub parsing: ParsingStrategy,
-}
-
-impl From<Strategy> for tailwindcss_core::Strategy {
-  fn from(strategy: Strategy) -> Self {
-    tailwindcss_core::Strategy {
-      io: strategy.io.into(),
-      parsing: strategy.parsing.into(),
-    }
-  }
+#[derive(Debug)]
+#[napi]
+pub enum IO {
+  Sequential = 0b0001,
+  Parallel = 0b0010,
 }
 
 #[derive(Debug)]
 #[napi]
-pub enum IOStrategy {
-  Sequential,
-  Parallel,
-}
-
-impl From<IOStrategy> for tailwindcss_core::IOStrategy {
-  fn from(io_strategy: IOStrategy) -> Self {
-    match io_strategy {
-      IOStrategy::Sequential => tailwindcss_core::IOStrategy::Sequential,
-      IOStrategy::Parallel => tailwindcss_core::IOStrategy::Parallel,
-    }
-  }
-}
-
-#[derive(Debug)]
-#[napi]
-pub enum ParsingStrategy {
-  Sequential,
-  Parallel,
-}
-
-impl From<ParsingStrategy> for tailwindcss_core::ParsingStrategy {
-  fn from(parsing_strategy: ParsingStrategy) -> Self {
-    match parsing_strategy {
-      ParsingStrategy::Sequential => tailwindcss_core::ParsingStrategy::Sequential,
-      ParsingStrategy::Parallel => tailwindcss_core::ParsingStrategy::Parallel,
-    }
-  }
+pub enum Parsing {
+  Sequential = 0b0100,
+  Parallel = 0b1000,
 }
 
 #[napi]
-pub fn parse_candidate_strings(options: Options) -> Vec<String> {
-  tailwindcss_core::parse_candidate_strings(options.into())
+pub fn parse_candidate_strings(input: Vec<ChangedContent>, strategy: u8) -> Vec<String> {
+  tailwindcss_core::parse_candidate_strings(input.into_iter().map(Into::into).collect(), strategy)
 }

--- a/oxide/crates/node/src/lib.rs
+++ b/oxide/crates/node/src/lib.rs
@@ -1,3 +1,4 @@
+use napi::bindgen_prelude::ToNapiValue;
 use std::path::PathBuf;
 
 #[macro_use]
@@ -11,16 +12,88 @@ pub struct ChangedContent {
   pub extension: String,
 }
 
+impl From<ChangedContent> for tailwindcss_core::ChangedContent {
+  fn from(changed_content: ChangedContent) -> Self {
+    tailwindcss_core::ChangedContent {
+      file: changed_content.file.map(PathBuf::from),
+      content: changed_content.content,
+      extension: changed_content.extension,
+    }
+  }
+}
+
 #[napi]
 pub fn parse_candidate_strings_from_files(changed_content: Vec<ChangedContent>) -> Vec<String> {
   tailwindcss_core::parse_candidate_strings_from_files(
-    changed_content
-      .into_iter()
-      .map(|changed_content| tailwindcss_core::ChangedContent {
-        file: changed_content.file.map(PathBuf::from),
-        content: changed_content.content,
-        extension: changed_content.extension,
-      })
-      .collect(),
+    changed_content.into_iter().map(Into::into).collect(),
   )
+}
+
+#[derive(Debug, Clone)]
+#[napi(object)]
+pub struct Options {
+  pub input: Vec<ChangedContent>,
+  pub strategy: Strategy,
+}
+
+impl From<Options> for tailwindcss_core::Options {
+  fn from(options: Options) -> Self {
+    tailwindcss_core::Options {
+      input: options.input.into_iter().map(Into::into).collect(),
+      strategy: options.strategy.into(),
+    }
+  }
+}
+
+#[derive(Debug, Clone)]
+#[napi(object)]
+pub struct Strategy {
+  pub io: IOStrategy,
+  pub parsing: ParsingStrategy,
+}
+
+impl From<Strategy> for tailwindcss_core::Strategy {
+  fn from(strategy: Strategy) -> Self {
+    tailwindcss_core::Strategy {
+      io: strategy.io.into(),
+      parsing: strategy.parsing.into(),
+    }
+  }
+}
+
+#[derive(Debug)]
+#[napi]
+pub enum IOStrategy {
+  Sequential,
+  Parallel,
+}
+
+impl From<IOStrategy> for tailwindcss_core::IOStrategy {
+  fn from(io_strategy: IOStrategy) -> Self {
+    match io_strategy {
+      IOStrategy::Sequential => tailwindcss_core::IOStrategy::Sequential,
+      IOStrategy::Parallel => tailwindcss_core::IOStrategy::Parallel,
+    }
+  }
+}
+
+#[derive(Debug)]
+#[napi]
+pub enum ParsingStrategy {
+  Sequential,
+  Parallel,
+}
+
+impl From<ParsingStrategy> for tailwindcss_core::ParsingStrategy {
+  fn from(parsing_strategy: ParsingStrategy) -> Self {
+    match parsing_strategy {
+      ParsingStrategy::Sequential => tailwindcss_core::ParsingStrategy::Sequential,
+      ParsingStrategy::Parallel => tailwindcss_core::ParsingStrategy::Parallel,
+    }
+  }
+}
+
+#[napi]
+pub fn parse_candidate_strings(options: Options) -> Vec<String> {
+  tailwindcss_core::parse_candidate_strings(options.into())
 }


### PR DESCRIPTION
This PR introduces a new internal API that is only used for testing and benchmarking purposes. This
is not a public API and will be removed in the future.

---

Usage example:

```js
import { parseCandidateStrings, IO, Parsing } from '@tailwindcss/oxide'

parseCandidateStrings(input, IO.Sequential | Parsing.Sequential)
parseCandidateStrings(input, IO.Sequential | Parsing.Parallel)
parseCandidateStrings(input, IO.Parallel | Parsing.Sequential)
parseCandidateStrings(input, IO.Parallel | Parsing.Parallel)
```

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
