### PR TITLE
Sort classes width then height

### DIFF
--- a/tests/any-type.test.js
+++ b/tests/any-type.test.js
@@ -44,12 +44,12 @@ crosscheck(({ stable, oxide }) => {
             <div class="mb-[var(--any-value)]"></div>
             <div class="ml-[var(--any-value)]"></div>
             <div class="aspect-[var(--any-value)]"></div>
-            <div class="h-[var(--any-value)]"></div>
-            <div class="max-h-[var(--any-value)]"></div>
-            <div class="min-h-[var(--any-value)]"></div>
             <div class="w-[var(--any-value)]"></div>
             <div class="max-w-[var(--any-value)]"></div>
             <div class="min-w-[var(--any-value)]"></div>
+            <div class="h-[var(--any-value)]"></div>
+            <div class="max-h-[var(--any-value)]"></div>
+            <div class="min-h-[var(--any-value)]"></div>
             <div class="flex-[var(--any-value)]"></div>
             <div class="flex-shrink-[var(--any-value)]"></div>
             <div class="shrink-[var(--any-value)]"></div>
@@ -259,15 +259,6 @@ crosscheck(({ stable, oxide }) => {
         .aspect-\[var\(--any-value\)\] {
           aspect-ratio: var(--any-value);
         }
-        .h-\[var\(--any-value\)\] {
-          height: var(--any-value);
-        }
-        .max-h-\[var\(--any-value\)\] {
-          max-height: var(--any-value);
-        }
-        .min-h-\[var\(--any-value\)\] {
-          min-height: var(--any-value);
-        }
         .w-\[var\(--any-value\)\] {
           width: var(--any-value);
         }
@@ -276,6 +267,15 @@ crosscheck(({ stable, oxide }) => {
         }
         .max-w-\[var\(--any-value\)\] {
           max-width: var(--any-value);
+        }
+        .h-\[var\(--any-value\)\] {
+          height: var(--any-value);
+        }
+        .max-h-\[var\(--any-value\)\] {
+          max-height: var(--any-value);
+        }
+        .min-h-\[var\(--any-value\)\] {
+          min-height: var(--any-value);
         }
         .flex-\[var\(--any-value\)\] {
           flex: var(--any-value);
@@ -808,15 +808,6 @@ crosscheck(({ stable, oxide }) => {
         .aspect-\[var\(--any-value\)\] {
           aspect-ratio: var(--any-value);
         }
-        .h-\[var\(--any-value\)\] {
-          height: var(--any-value);
-        }
-        .max-h-\[var\(--any-value\)\] {
-          max-height: var(--any-value);
-        }
-        .min-h-\[var\(--any-value\)\] {
-          min-height: var(--any-value);
-        }
         .w-\[var\(--any-value\)\] {
           width: var(--any-value);
         }
@@ -825,6 +816,15 @@ crosscheck(({ stable, oxide }) => {
         }
         .max-w-\[var\(--any-value\)\] {
           max-width: var(--any-value);
+        }
+        .h-\[var\(--any-value\)\] {
+          height: var(--any-value);
+        }
+        .max-h-\[var\(--any-value\)\] {
+          max-height: var(--any-value);
+        }
+        .min-h-\[var\(--any-value\)\] {
+          min-height: var(--any-value);
         }
         .flex-\[var\(--any-value\)\] {
           flex: var(--any-value);

--- a/tests/arbitrary-values.oxide.test.css
+++ b/tests/arbitrary-values.oxide.test.css
@@ -106,33 +106,6 @@
 .aspect-\[var\(--aspect\)\] {
   aspect-ratio: var(--aspect);
 }
-.h-\[3\.23rem\] {
-  height: 3.23rem;
-}
-.h-\[calc\(100\%\+1rem\)\] {
-  height: calc(100% + 1rem);
-}
-.h-\[var\(--height\)\] {
-  height: var(--height);
-}
-.max-h-\[3\.23rem\] {
-  max-height: 3.23rem;
-}
-.max-h-\[calc\(100\%\+1rem\)\] {
-  max-height: calc(100% + 1rem);
-}
-.max-h-\[var\(--height\)\] {
-  max-height: var(--height);
-}
-.min-h-\[3\.23rem\] {
-  min-height: 3.23rem;
-}
-.min-h-\[calc\(100\%\+1rem\)\] {
-  min-height: calc(100% + 1rem);
-}
-.min-h-\[var\(--height\)\] {
-  min-height: var(--height);
-}
 .w-\[\'\)\(\)\'\] {
   width: ')()';
 }
@@ -207,6 +180,33 @@
 }
 .max-w-\[var\(--width\)\] {
   max-width: var(--width);
+}
+.h-\[3\.23rem\] {
+  height: 3.23rem;
+}
+.h-\[calc\(100\%\+1rem\)\] {
+  height: calc(100% + 1rem);
+}
+.h-\[var\(--height\)\] {
+  height: var(--height);
+}
+.max-h-\[3\.23rem\] {
+  max-height: 3.23rem;
+}
+.max-h-\[calc\(100\%\+1rem\)\] {
+  max-height: calc(100% + 1rem);
+}
+.max-h-\[var\(--height\)\] {
+  max-height: var(--height);
+}
+.min-h-\[3\.23rem\] {
+  min-height: 3.23rem;
+}
+.min-h-\[calc\(100\%\+1rem\)\] {
+  min-height: calc(100% + 1rem);
+}
+.min-h-\[var\(--height\)\] {
+  min-height: var(--height);
 }
 .flex-\[var\(--flex\)\] {
   flex: var(--flex);

--- a/tests/arbitrary-values.test.css
+++ b/tests/arbitrary-values.test.css
@@ -106,33 +106,6 @@
 .aspect-\[var\(--aspect\)\] {
   aspect-ratio: var(--aspect);
 }
-.h-\[3\.23rem\] {
-  height: 3.23rem;
-}
-.h-\[calc\(100\%\+1rem\)\] {
-  height: calc(100% + 1rem);
-}
-.h-\[var\(--height\)\] {
-  height: var(--height);
-}
-.max-h-\[3\.23rem\] {
-  max-height: 3.23rem;
-}
-.max-h-\[calc\(100\%\+1rem\)\] {
-  max-height: calc(100% + 1rem);
-}
-.max-h-\[var\(--height\)\] {
-  max-height: var(--height);
-}
-.min-h-\[3\.23rem\] {
-  min-height: 3.23rem;
-}
-.min-h-\[calc\(100\%\+1rem\)\] {
-  min-height: calc(100% + 1rem);
-}
-.min-h-\[var\(--height\)\] {
-  min-height: var(--height);
-}
 .w-\[\'\)\(\)\'\] {
   width: ')()';
 }
@@ -207,6 +180,33 @@
 }
 .max-w-\[var\(--width\)\] {
   max-width: var(--width);
+}
+.h-\[3\.23rem\] {
+  height: 3.23rem;
+}
+.h-\[calc\(100\%\+1rem\)\] {
+  height: calc(100% + 1rem);
+}
+.h-\[var\(--height\)\] {
+  height: var(--height);
+}
+.max-h-\[3\.23rem\] {
+  max-height: 3.23rem;
+}
+.max-h-\[calc\(100\%\+1rem\)\] {
+  max-height: calc(100% + 1rem);
+}
+.max-h-\[var\(--height\)\] {
+  max-height: var(--height);
+}
+.min-h-\[3\.23rem\] {
+  min-height: 3.23rem;
+}
+.min-h-\[calc\(100\%\+1rem\)\] {
+  min-height: calc(100% + 1rem);
+}
+.min-h-\[var\(--height\)\] {
+  min-height: var(--height);
 }
 .flex-\[var\(--flex\)\] {
   flex: var(--flex);

--- a/tests/basic-usage.oxide.test.css
+++ b/tests/basic-usage.oxide.test.css
@@ -201,15 +201,6 @@
 .aspect-video {
   aspect-ratio: 16 / 9;
 }
-.h-16 {
-  height: 4rem;
-}
-.max-h-screen {
-  max-height: 100vh;
-}
-.min-h-0 {
-  min-height: 0;
-}
 .w-12 {
   width: 3rem;
 }
@@ -218,6 +209,15 @@
 }
 .max-w-full {
   max-width: 100%;
+}
+.h-16 {
+  height: 4rem;
+}
+.max-h-screen {
+  max-height: 100vh;
+}
+.min-h-0 {
+  min-height: 0;
 }
 .flex-1 {
   flex: 1;

--- a/tests/basic-usage.test.css
+++ b/tests/basic-usage.test.css
@@ -201,15 +201,6 @@
 .aspect-video {
   aspect-ratio: 16 / 9;
 }
-.h-16 {
-  height: 4rem;
-}
-.max-h-screen {
-  max-height: 100vh;
-}
-.min-h-0 {
-  min-height: 0;
-}
 .w-12 {
   width: 3rem;
 }
@@ -218,6 +209,15 @@
 }
 .max-w-full {
   max-width: 100%;
+}
+.h-16 {
+  height: 4rem;
+}
+.max-h-screen {
+  max-height: 100vh;
+}
+.min-h-0 {
+  min-height: 0;
 }
 .flex-1 {
   flex: 1;

--- a/tests/raw-content.oxide.test.css
+++ b/tests/raw-content.oxide.test.css
@@ -143,15 +143,6 @@
 .hidden {
   display: none;
 }
-.h-16 {
-  height: 4rem;
-}
-.max-h-screen {
-  max-height: 100vh;
-}
-.min-h-0 {
-  min-height: 0;
-}
 .w-12 {
   width: 3rem;
 }
@@ -160,6 +151,15 @@
 }
 .max-w-full {
   max-width: 100%;
+}
+.h-16 {
+  height: 4rem;
+}
+.max-h-screen {
+  max-height: 100vh;
+}
+.min-h-0 {
+  min-height: 0;
 }
 .flex-1 {
   flex: 1;

--- a/tests/raw-content.test.css
+++ b/tests/raw-content.test.css
@@ -143,15 +143,6 @@
 .hidden {
   display: none;
 }
-.h-16 {
-  height: 4rem;
-}
-.max-h-screen {
-  max-height: 100vh;
-}
-.min-h-0 {
-  min-height: 0;
-}
 .w-12 {
   width: 3rem;
 }
@@ -160,6 +151,15 @@
 }
 .max-w-full {
   max-width: 100%;
+}
+.h-16 {
+  height: 4rem;
+}
+.max-h-screen {
+  max-height: 100vh;
+}
+.min-h-0 {
+  min-height: 0;
 }
 .flex-1 {
   flex: 1;


### PR DESCRIPTION
Dimensions are pretty much universally documented as `{width} x {height}` but due to the current ordering here the prettier plugin sorts these classes as `{height} x {width}`.

This PR swaps those orderings to align with the universal size descriptions 📏