### PR TITLE
Support `@import "tailwindcss"` using top-level `index.css` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [Oxide] Use `lightningcss` for nesting and vendor prefixes in PostCSS plugin ([#10399](https://github.com/tailwindlabs/tailwindcss/pull/10399))
+- Support `@import "tailwindcss"` using top-level `index.css` file ([#11205](https://github.com/tailwindlabs/tailwindcss/pull/11205))
 
 ### Changed
 

--- a/index.css
+++ b/index.css
@@ -1,0 +1,5 @@
+@tailwind base;
+
+@tailwind components;
+
+@tailwind utilities;


### PR DESCRIPTION
This PR adds an `index.css` file to the root of the package that contains the `@tailwind` directives for each of Tailwind's layers.

```css
/* node_modules/tailwindcss/index.css */
@tailwind base;
@tailwind components;
@tailwind utilities;
```

If you have `postcss-import` configured in your project, this makes it possible to add Tailwind to your CSS using a simple `@import` instead of writing out the `@tailwind` directives yourself:

```css
@import "tailwindcss";
```

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
