### PR TITLE
[Oxide] Ensure generated `tailwind.config.js` file is formatted properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `aria-busy` utility ([#10966](https://github.com/tailwindlabs/tailwindcss/pull/10966))
 - [Oxide] Use `lightningcss` for nesting and vendor prefixes in PostCSS plugin ([#10399](https://github.com/tailwindlabs/tailwindcss/pull/10399))
 - Support `@import "tailwindcss"` using top-level `index.css` file ([#11205](https://github.com/tailwindlabs/tailwindcss/pull/11205))
-- [Oxide] Automatically detect content paths when no `content` configuration is provided ([#11173](https://github.com/tailwindlabs/tailwindcss/pull/11173))
+- [Oxide] Automatically detect content paths when no `content` configuration is provided ([#11173](https://github.com/tailwindlabs/tailwindcss/pull/11173), [#11221](https://github.com/tailwindlabs/tailwindcss/pull/11221))
 
 ### Changed
 

--- a/src/cli/init/index.js
+++ b/src/cli/init/index.js
@@ -40,7 +40,7 @@ export function init(args) {
 
     // Drop `content` in the oxide engine to promote auto content
     if (__OXIDE__) {
-      stubContentsFile = stubContentsFile.replace(/\s*content: \[\],\n/, '')
+      stubContentsFile = stubContentsFile.replace(/ *content: \[\],\n/, '')
     }
 
     // Change colors import

--- a/src/oxide/cli/init/index.ts
+++ b/src/oxide/cli/init/index.ts
@@ -38,7 +38,7 @@ export function init(args) {
 
     // Drop `content` in the oxide engine to promote auto content
     if (__OXIDE__) {
-      stubContentsFile = stubContentsFile.replace(/\s*content: \[\],\n/, '')
+      stubContentsFile = stubContentsFile.replace(/ *content: \[\],\n/, '')
     }
 
     // Change colors import


### PR DESCRIPTION
This PR fixes a small formatting issue when generating the `tailwind.config.js` file when using the `npx tailwindcss init` command using the oxide engine.

We dropped the `content: []` by default such that the auto content detection can be used as a default. However we used a regex to replace the `content: []` which included a `\s` in the regex.
This is problematic because `\s` includes `\n` so therefore the previous `\n` was removed as well.

Everything still worked, but the formatting of the generated file was off.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
