### PR TITLE
[Oxide] Add built-in `@import` processing support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Oxide] Use `lightningcss` for nesting and vendor prefixes in PostCSS plugin ([#10399](https://github.com/tailwindlabs/tailwindcss/pull/10399))
 - Support `@import "tailwindcss"` using top-level `index.css` file ([#11205](https://github.com/tailwindlabs/tailwindcss/pull/11205))
 - [Oxide] Automatically detect content paths when no `content` configuration is provided ([#11173](https://github.com/tailwindlabs/tailwindcss/pull/11173), [#11221](https://github.com/tailwindlabs/tailwindcss/pull/11221))
+- Add built-in `@import` processing support ([#11239](https://github.com/tailwindlabs/tailwindcss/pull/11239))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `aria-busy` utility ([#10966](https://github.com/tailwindlabs/tailwindcss/pull/10966))
-- [Oxide] Use `lightningcss` for nesting and vendor prefixes in PostCSS plugin ([#10399](https://github.com/tailwindlabs/tailwindcss/pull/10399))
 - Support `@import "tailwindcss"` using top-level `index.css` file ([#11205](https://github.com/tailwindlabs/tailwindcss/pull/11205))
+- [Oxide] Use `lightningcss` for nesting and vendor prefixes in PostCSS plugin ([#10399](https://github.com/tailwindlabs/tailwindcss/pull/10399))
 - [Oxide] Automatically detect content paths when no `content` configuration is provided ([#11173](https://github.com/tailwindlabs/tailwindcss/pull/11173), [#11221](https://github.com/tailwindlabs/tailwindcss/pull/11221))
-- Add built-in `@import` processing support ([#11239](https://github.com/tailwindlabs/tailwindcss/pull/11239))
+- [Oxide] Process and inline `@import` at-rules natively ([#11239](https://github.com/tailwindlabs/tailwindcss/pull/11239))
 
 ### Changed
 

--- a/src/lib/handleImportAtRules.js
+++ b/src/lib/handleImportAtRules.js
@@ -1,0 +1,33 @@
+import postcss from 'postcss'
+
+const TAILWIND = Symbol()
+
+export function handleImportAtRules(postcssImport = require('postcss-import')) {
+  let RESTORE_ATRULE_COMMENT = '__TAILWIND_RESTORE__'
+  let atRulesToRestore = ['tailwind', 'config']
+
+  return [
+    (root) => {
+      root.walkAtRules((rule) => {
+        if (!atRulesToRestore.includes(rule.name)) return rule
+
+        rule.after(
+          postcss.comment({
+            text: RESTORE_ATRULE_COMMENT,
+            raws: { [TAILWIND]: { rule } },
+          })
+        )
+        rule.remove()
+      })
+    },
+    postcssImport(),
+    (root) => {
+      root.walkComments((rule) => {
+        if (rule.text.startsWith(RESTORE_ATRULE_COMMENT)) {
+          rule.after(rule.raws[TAILWIND].rule)
+          rule.remove()
+        }
+      })
+    },
+  ]
+}

--- a/src/lib/handleImportAtRules.js
+++ b/src/lib/handleImportAtRules.js
@@ -23,7 +23,7 @@ export function handleImportAtRules(postcssImport = require('postcss-import')) {
     postcssImport(),
     (root) => {
       root.walkComments((rule) => {
-        if (rule.text.startsWith(RESTORE_ATRULE_COMMENT)) {
+        if (rule.text === RESTORE_ATRULE_COMMENT) {
           rule.after(rule.raws[TAILWIND].rule)
           rule.remove()
         }

--- a/src/lib/normalizeTailwindDirectives.js
+++ b/src/lib/normalizeTailwindDirectives.js
@@ -10,30 +10,32 @@ export default function normalizeTailwindDirectives(root) {
       applyDirectives.add(atRule)
     }
 
-    if (atRule.name === 'import') {
-      if (atRule.params === '"tailwindcss/base"' || atRule.params === "'tailwindcss/base'") {
-        atRule.name = 'tailwind'
-        atRule.params = 'base'
-      } else if (
-        atRule.params === '"tailwindcss/components"' ||
-        atRule.params === "'tailwindcss/components'"
-      ) {
-        atRule.name = 'tailwind'
-        atRule.params = 'components'
-      } else if (
-        atRule.params === '"tailwindcss/utilities"' ||
-        atRule.params === "'tailwindcss/utilities'"
-      ) {
-        atRule.name = 'tailwind'
-        atRule.params = 'utilities'
-      } else if (
-        atRule.params === '"tailwindcss/screens"' ||
-        atRule.params === "'tailwindcss/screens'" ||
-        atRule.params === '"tailwindcss/variants"' ||
-        atRule.params === "'tailwindcss/variants'"
-      ) {
-        atRule.name = 'tailwind'
-        atRule.params = 'variants'
+    if (!__OXIDE__) {
+      if (atRule.name === 'import') {
+        if (atRule.params === '"tailwindcss/base"' || atRule.params === "'tailwindcss/base'") {
+          atRule.name = 'tailwind'
+          atRule.params = 'base'
+        } else if (
+          atRule.params === '"tailwindcss/components"' ||
+          atRule.params === "'tailwindcss/components'"
+        ) {
+          atRule.name = 'tailwind'
+          atRule.params = 'components'
+        } else if (
+          atRule.params === '"tailwindcss/utilities"' ||
+          atRule.params === "'tailwindcss/utilities'"
+        ) {
+          atRule.name = 'tailwind'
+          atRule.params = 'utilities'
+        } else if (
+          atRule.params === '"tailwindcss/screens"' ||
+          atRule.params === "'tailwindcss/screens'" ||
+          atRule.params === '"tailwindcss/variants"' ||
+          atRule.params === "'tailwindcss/variants'"
+        ) {
+          atRule.name = 'tailwind'
+          atRule.params = 'variants'
+        }
       }
     }
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,7 +1,41 @@
+import postcss from 'postcss'
+import postcssImport from 'postcss-import'
 import setupTrackingContext from './lib/setupTrackingContext'
 import processTailwindFeatures from './processTailwindFeatures'
 import { env } from './lib/sharedState'
 import { findAtConfigPath } from './lib/findAtConfigPath'
+
+const TAILWIND = Symbol()
+
+function handleImportAtRules() {
+  let RESTORE_ATRULE_COMMENT = '__TAILWIND_RESTORE__'
+  let atRulesToRestore = ['tailwind', 'config']
+
+  return [
+    (root) => {
+      root.walkAtRules((rule) => {
+        if (!atRulesToRestore.includes(rule.name)) return rule
+
+        rule.after(
+          postcss.comment({
+            text: RESTORE_ATRULE_COMMENT,
+            raws: { [TAILWIND]: { rule } },
+          })
+        )
+        rule.remove()
+      })
+    },
+    postcssImport(),
+    (root) => {
+      root.walkComments((rule) => {
+        if (rule.text.startsWith(RESTORE_ATRULE_COMMENT)) {
+          rule.after(rule.raws[TAILWIND].rule)
+          rule.remove()
+        }
+      })
+    },
+  ]
+}
 
 module.exports = function tailwindcss(configOrPath) {
   return {
@@ -13,6 +47,7 @@ module.exports = function tailwindcss(configOrPath) {
           console.time('JIT TOTAL')
           return root
         },
+      ...(__OXIDE__ ? handleImportAtRules() : []),
       function (root, result) {
         // Use the path for the `@config` directive if it exists, otherwise use the
         // path for the file being processed

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,41 +1,8 @@
-import postcss from 'postcss'
-import postcssImport from 'postcss-import'
 import setupTrackingContext from './lib/setupTrackingContext'
 import processTailwindFeatures from './processTailwindFeatures'
 import { env } from './lib/sharedState'
 import { findAtConfigPath } from './lib/findAtConfigPath'
-
-const TAILWIND = Symbol()
-
-function handleImportAtRules() {
-  let RESTORE_ATRULE_COMMENT = '__TAILWIND_RESTORE__'
-  let atRulesToRestore = ['tailwind', 'config']
-
-  return [
-    (root) => {
-      root.walkAtRules((rule) => {
-        if (!atRulesToRestore.includes(rule.name)) return rule
-
-        rule.after(
-          postcss.comment({
-            text: RESTORE_ATRULE_COMMENT,
-            raws: { [TAILWIND]: { rule } },
-          })
-        )
-        rule.remove()
-      })
-    },
-    postcssImport(),
-    (root) => {
-      root.walkComments((rule) => {
-        if (rule.text.startsWith(RESTORE_ATRULE_COMMENT)) {
-          rule.after(rule.raws[TAILWIND].rule)
-          rule.remove()
-        }
-      })
-    },
-  ]
-}
+import { handleImportAtRules } from './lib/handleImportAtRules'
 
 module.exports = function tailwindcss(configOrPath) {
   return {

--- a/tests/import-processing-a.css
+++ b/tests/import-processing-a.css
@@ -1,0 +1,1 @@
+@tailwind utilities;

--- a/tests/import-processing-b.css
+++ b/tests/import-processing-b.css
@@ -1,0 +1,5 @@
+@layer utilities {
+  .foo {
+    color: red;
+  }
+}

--- a/tests/import-processing-c.css
+++ b/tests/import-processing-c.css
@@ -1,0 +1,5 @@
+@tailwind utilities;
+
+.foo {
+  color: red;
+}

--- a/tests/import-processing-c.js
+++ b/tests/import-processing-c.js
@@ -1,0 +1,9 @@
+module.exports = {
+  darkMode: 'class',
+  content: [
+    {
+      raw: `<div class="foo underline" />`,
+    },
+  ],
+  corePlugins: { preflight: false },
+}

--- a/tests/import-processing.test.js
+++ b/tests/import-processing.test.js
@@ -1,0 +1,74 @@
+import { html, css, run } from './util/run'
+
+it('should be possible to import another css file', async () => {
+  let config = {
+    darkMode: 'class',
+    content: [
+      {
+        raw: html`<div class="underline" />`,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @import './import-processing-a.css';
+  `
+
+  let result = await run(input, config)
+
+  expect(result.css).toMatchFormattedCss(css`
+    .underline {
+      text-decoration-line: underline;
+    }
+  `)
+})
+
+it('should be possible to import another css file after @tailwind directive', async () => {
+  let config = {
+    darkMode: 'class',
+    content: [
+      {
+        raw: html`<div class="foo underline" />`,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind utilities;
+
+    @import './import-processing-b.css';
+  `
+
+  let result = await run(input, config)
+
+  expect(result.css).toMatchFormattedCss(css`
+    .underline {
+      text-decoration-line: underline;
+    }
+
+    .foo {
+      color: red;
+    }
+  `)
+})
+
+it('should be possible to add @config before @import statements', async () => {
+  let input = css`
+    @config "./import-processing-c.js";
+    @import './import-processing-c.css';
+  `
+
+  let result = await run(input)
+
+  expect(result.css).toMatchFormattedCss(css`
+    .underline {
+      text-decoration-line: underline;
+    }
+
+    .foo {
+      color: red;
+    }
+  `)
+})

--- a/tests/import-processing.test.js
+++ b/tests/import-processing.test.js
@@ -1,74 +1,79 @@
-import { html, css, run } from './util/run'
+import { html, css, run, crosscheck } from './util/run'
 
-it('should be possible to import another css file', async () => {
-  let config = {
-    darkMode: 'class',
-    content: [
-      {
-        raw: html`<div class="underline" />`,
-      },
-    ],
-    corePlugins: { preflight: false },
-  }
+crosscheck(({ oxide, stable }) => {
+  stable.test.todo('Import processing is an oxide engine feature')
+  oxide.describe('import processing', () => {
+    it('should be possible to import another css file', async () => {
+      let config = {
+        darkMode: 'class',
+        content: [
+          {
+            raw: html`<div class="underline" />`,
+          },
+        ],
+        corePlugins: { preflight: false },
+      }
 
-  let input = css`
-    @import './import-processing-a.css';
-  `
+      let input = css`
+        @import './import-processing-a.css';
+      `
 
-  let result = await run(input, config)
+      let result = await run(input, config)
 
-  expect(result.css).toMatchFormattedCss(css`
-    .underline {
-      text-decoration-line: underline;
-    }
-  `)
-})
+      expect(result.css).toMatchFormattedCss(css`
+        .underline {
+          text-decoration-line: underline;
+        }
+      `)
+    })
 
-it('should be possible to import another css file after @tailwind directive', async () => {
-  let config = {
-    darkMode: 'class',
-    content: [
-      {
-        raw: html`<div class="foo underline" />`,
-      },
-    ],
-    corePlugins: { preflight: false },
-  }
+    it('should be possible to import another css file after @tailwind directive', async () => {
+      let config = {
+        darkMode: 'class',
+        content: [
+          {
+            raw: html`<div class="foo underline" />`,
+          },
+        ],
+        corePlugins: { preflight: false },
+      }
 
-  let input = css`
-    @tailwind utilities;
+      let input = css`
+        @tailwind utilities;
 
-    @import './import-processing-b.css';
-  `
+        @import './import-processing-b.css';
+      `
 
-  let result = await run(input, config)
+      let result = await run(input, config)
 
-  expect(result.css).toMatchFormattedCss(css`
-    .underline {
-      text-decoration-line: underline;
-    }
+      expect(result.css).toMatchFormattedCss(css`
+        .underline {
+          text-decoration-line: underline;
+        }
 
-    .foo {
-      color: red;
-    }
-  `)
-})
+        .foo {
+          color: red;
+        }
+      `)
+    })
 
-it('should be possible to add @config before @import statements', async () => {
-  let input = css`
-    @config "./import-processing-c.js";
-    @import './import-processing-c.css';
-  `
+    it('should be possible to add @config before @import statements', async () => {
+      let input = css`
+        @config "./import-processing-c.js";
+        @import './import-processing-c.css';
+      `
 
-  let result = await run(input)
+      let result = await run(input)
 
-  expect(result.css).toMatchFormattedCss(css`
-    .underline {
-      text-decoration-line: underline;
-    }
+      expect(result.css).toMatchFormattedCss(css`
+        .underline {
+          text-decoration-line: underline;
+        }
 
-    .foo {
-      color: red;
-    }
-  `)
+        .foo {
+          color: red;
+        }
+      `)
+    })
+  })
 })

--- a/tests/util/run.js
+++ b/tests/util/run.js
@@ -17,18 +17,18 @@ export let map = JSON.stringify({
 globalThis.__OXIDE__ = env.ENGINE === 'oxide'
 
 export function run(input, config, plugin = tailwind) {
-  let { currentTestName } = expect.getState()
+  let { currentTestName, testPath } = expect.getState()
 
   return postcss(plugin(config)).process(input, {
-    from: `${path.resolve(__filename)}?test=${currentTestName}`,
+    from: `${path.resolve(testPath)}?test=${currentTestName}`,
   })
 }
 
 export function runWithSourceMaps(input, config, plugin = tailwind) {
-  let { currentTestName } = expect.getState()
+  let { currentTestName, testPath } = expect.getState()
 
   return postcss(plugin(config)).process(input, {
-    from: `${path.resolve(__filename)}?test=${currentTestName}`,
+    from: `${path.resolve(testPath)}?test=${currentTestName}`,
     map: {
       prev: map,
     },


### PR DESCRIPTION
This PR adds built-in support for processing and inlining `@import` at-rules, in a way that is compatible with Tailwind's `@config` and `@tailwind` directives.

This removes the need for installing and configuring `postcss-import`, but won't cause any issues in projects that already have it set up.

The advantage to using the built-in support provided by this PR is that it will let you place your `@config` and `@tailwind` directives anywhere in your CSS file you like, whereas using `postcss-import` directly forces you to put all of your `@import` statements before your `@config` and `@tailwind` directives.

```css
@config "./admin/tailwind.config.js";

@tailwind base;
@import "./my-base.css";

@tailwind utilities;
@import "./my-utilities.css";

@tailwind components;
@import "./my-components.css";

@import "third-party/library.css";
```

Under the hood we are still using `postcss-import` to handle the actual inlining of the `@import` at-rules, but our intention is for this to be an implementation detail and we may migrate to another tool or something custom in the future.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
