### PR TITLE
Explicitly list published CSS files 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `aria-busy` utility ([#10966](https://github.com/tailwindlabs/tailwindcss/pull/10966))
-- Support `@import "tailwindcss"` using top-level `index.css` file ([#11205](https://github.com/tailwindlabs/tailwindcss/pull/11205))
+- [Oxide] Support `@import "tailwindcss"` using top-level `index.css` file ([#11205](https://github.com/tailwindlabs/tailwindcss/pull/11205), ([#11260](https://github.com/tailwindlabs/tailwindcss/pull/11260)))
 - [Oxide] Use `lightningcss` for nesting and vendor prefixes in PostCSS plugin ([#10399](https://github.com/tailwindlabs/tailwindcss/pull/10399))
 - [Oxide] Automatically detect content paths when no `content` configuration is provided ([#11173](https://github.com/tailwindlabs/tailwindcss/pull/11173), [#11221](https://github.com/tailwindlabs/tailwindcss/pull/11221))
 - [Oxide] Process and inline `@import` at-rules natively ([#11239](https://github.com/tailwindlabs/tailwindcss/pull/11239))

--- a/package.stable.json
+++ b/package.stable.json
@@ -42,8 +42,13 @@
     "nesting/*",
     "types/**/*",
     "*.d.ts",
-    "*.css",
-    "*.js"
+    "*.js",
+    "base.css",
+    "components.css",
+    "screens.css",
+    "tailwind.css",
+    "utilities.css",
+    "variants.css"
   ],
   "devDependencies": {
     "@swc/cli": "^0.1.62",


### PR DESCRIPTION
This PR explicitly lists the CSS files that are published to NPM instead of relying on `*.css`.

The main reason for this change is that we will expose `index.css` for the oxide engine to make
things a bit smoother, but there is no need to include this new feature in the stable release (3.3.x).


<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
