### PR TITLE
Deprecate `--no-autoprefixer` flag in the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reset padding for `<dialog>` elements in preflight ([#11069](https://github.com/tailwindlabs/tailwindcss/pull/11069))
 - [Oxide] Disable color opacity plugins by default in the `oxide` engine ([#10618](https://github.com/tailwindlabs/tailwindcss/pull/10618))
 - [Oxide] Enable relative content paths for the `oxide` engine ([#10621](https://github.com/tailwindlabs/tailwindcss/pull/10621))
+- Deprecate `--no-autoprefixer` flag in the CLI ([#11280](https://github.com/tailwindlabs/tailwindcss/pull/11280))
 
 ## [3.3.2] - 2023-04-25
 

--- a/integrations/execute.js
+++ b/integrations/execute.js
@@ -64,7 +64,7 @@ module.exports = function $(command, options = {}) {
         messages.splice(0, idx + 1)
         let actorIdx = actors.indexOf(next)
         actors.splice(actorIdx, 1)
-        next.resolve()
+        next.resolve(message)
         break
       }
     }

--- a/integrations/tailwindcss-cli/tests/cli.test.js
+++ b/integrations/tailwindcss-cli/tests/cli.test.js
@@ -96,75 +96,35 @@ describe('Build command', () => {
     expect(withoutMinify.length).toBeGreaterThan(withMinify.length)
   })
 
-  test('--no-autoprefixer', async () => {
-    await writeInputFile('index.html', html`<div class="select-none"></div>`)
-
-    await $(`${EXECUTABLE} --output ./dist/main.css`)
-    let withAutoprefixer = await readOutputFile('main.css')
-
-    expect(withAutoprefixer).toIncludeCss(css`
-      .select-none {
-        -webkit-user-select: none;
-        user-select: none;
-      }
-    `)
-
-    await $(`${EXECUTABLE} --output ./dist/main.css --no-autoprefixer`)
-    let withoutAutoprefixer = await readOutputFile('main.css')
-
-    expect(withoutAutoprefixer).toIncludeCss(css`
-      .select-none {
-        user-select: none;
-      }
-    `)
-  })
-
-  test('--no-autoprefixer (with nesting handling)', async () => {
-    // This test mainly checks that we configured Lightning CSS correctly such that we can _still_
-    // use nesting.
+  // Deprecated
+  test('--no-autoprefixer (should produce a warning)', async () => {
     await writeInputFile('index.html', html`<div class="select-none"></div>`)
     await writeInputFile(
       'index.css',
       css`
         @tailwind utilities;
-
-        .foo {
-          & .bar {
-            display: flex;
-          }
-        }
       `
     )
 
-    await $(`${EXECUTABLE} --input ./src/index.css --output ./dist/main.css`)
-    let withAutoprefixer = await readOutputFile('main.css')
+    let runningProcess = $(
+      `${EXECUTABLE} --input ./src/index.css --output ./dist/main.css --no-autoprefixer`
+    )
+    let warning = runningProcess.onStderr((message) => message.includes('--no-autoprefixer'))
+    await runningProcess
+    expect(await warning).toMatchInlineSnapshot(`
+      "[deprecation] The --no-autoprefixer flag is deprecated and has no effect.
+      "
+    `)
+    let withoutAutoprefixer = await readOutputFile('main.css')
 
-    expect(withAutoprefixer).toIncludeCss(css`
-      .select-none {
+    // This contains --webkit-user-select which may be strange, but it is expected because we are
+    // not handling the `--no-autoprefixer` flag anymore at all.
+    expect(withoutAutoprefixer).toMatchInlineSnapshot(`
+      ".select-none {
         -webkit-user-select: none;
         user-select: none;
       }
-    `)
-
-    expect(withAutoprefixer).toIncludeCss(css`
-      .foo .bar {
-        display: flex;
-      }
-    `)
-
-    await $(`${EXECUTABLE} --input ./src/index.css --output ./dist/main.css --no-autoprefixer`)
-    let withoutAutoprefixer = await readOutputFile('main.css')
-
-    expect(withoutAutoprefixer).toIncludeCss(css`
-      .select-none {
-        user-select: none;
-      }
-    `)
-
-    expect(withoutAutoprefixer).toIncludeCss(css`
-      .foo .bar {
-        display: flex;
-      }
+      "
     `)
   })
 
@@ -540,7 +500,6 @@ describe('Build command', () => {
                  --postcss            Load custom PostCSS configuration
              -m, --minify             Minify the output
              -c, --config             Path to a custom config file
-                 --no-autoprefixer    Disable autoprefixer
              -h, --help               Display usage information
         `)
     )

--- a/integrations/tailwindcss-cli/tests/cli.test.js
+++ b/integrations/tailwindcss-cli/tests/cli.test.js
@@ -96,8 +96,7 @@ describe('Build command', () => {
     expect(withoutMinify.length).toBeGreaterThan(withMinify.length)
   })
 
-  // TODO: Handle --no-autoprefixer
-  test.skip('--no-autoprefixer', async () => {
+  test('--no-autoprefixer', async () => {
     await writeInputFile('index.html', html`<div class="select-none"></div>`)
 
     await $(`${EXECUTABLE} --output ./dist/main.css`)

--- a/src/cli/build/index.js
+++ b/src/cli/build/index.js
@@ -25,6 +25,10 @@ export async function build(args) {
     process.exit(9)
   }
 
+  if (args['--no-autoprefixer']) {
+    console.error('[deprecation] The --no-autoprefixer flag is deprecated and has no effect.')
+  }
+
   // TODO: Reference the @config path here if exists
   let configPath = args['--config'] ? args['--config'] : resolveDefaultConfigPath()
 

--- a/src/cli/build/plugin.js
+++ b/src/cli/build/plugin.js
@@ -36,7 +36,7 @@ async function lightningcss(result, { map = true, minify = true, autoprefixer = 
       inputSourceMap: result.map ? result.map.toString() : undefined,
       targets: autoprefixer
         ? lightning.browserslistToTargets(browserslist(pkg.browserslist))
-        : undefined,
+        : { chrome: 111 << 16 },
       drafts: {
         nesting: true,
       },

--- a/src/cli/build/plugin.js
+++ b/src/cli/build/plugin.js
@@ -47,7 +47,7 @@ async function lightningcss(result, { map = true, minify = true, autoprefixer = 
       map: result.map
         ? Object.assign(result.map, {
             toString() {
-              return transformed.map.toString()
+              return transformed.map?.toString()
             },
           })
         : result.map,

--- a/src/cli/build/plugin.js
+++ b/src/cli/build/plugin.js
@@ -26,7 +26,7 @@ import { validateConfig } from '../../util/validateConfig'
 import { handleImportAtRules } from '../../lib/handleImportAtRules'
 import { flagEnabled } from '../../featureFlags'
 
-async function lightningcss(result, { map = true, minify = true, autoprefixer = true } = {}) {
+async function lightningcss(result, { map = true, minify = true } = {}) {
   try {
     let transformed = lightning.transform({
       filename: result.opts.from || 'input.css',
@@ -34,9 +34,7 @@ async function lightningcss(result, { map = true, minify = true, autoprefixer = 
       minify,
       sourceMap: result.map === undefined ? map : !!result.map,
       inputSourceMap: result.map ? result.map.toString() : undefined,
-      targets: autoprefixer
-        ? lightning.browserslistToTargets(browserslist(pkg.browserslist))
-        : { chrome: 111 << 16 },
+      targets: lightning.browserslistToTargets(browserslist(pkg.browserslist)),
       drafts: {
         nesting: true,
       },
@@ -347,7 +345,6 @@ export async function createProcessor(args, cliConfigPath) {
         lightningcss(result, {
           ...options,
           minify: !!args['--minify'],
-          autoprefixer: !args['--no-autoprefixer'],
         })
       )
       .then((result) => {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -70,6 +70,7 @@ let commands = {
         description: 'Path to a custom config file',
       },
       '--no-autoprefixer': {
+        deprecated: true,
         type: Boolean,
         description: 'Disable autoprefixer',
       },

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -49,7 +49,7 @@ module.exports = function tailwindcss(configOrPath) {
             inputSourceMap: result.map ? result.map.toString() : undefined,
             targets:
               typeof process !== 'undefined' && process.env.JEST_WORKER_ID
-                ? { chrome: 110 << 16 }
+                ? { chrome: 111 << 16 }
                 : lightningcss.browserslistToTargets(
                     browserslist(require('../package.json').browserslist)
                   ),

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -49,7 +49,7 @@ module.exports = function tailwindcss(configOrPath) {
             inputSourceMap: result.map ? result.map.toString() : undefined,
             targets:
               typeof process !== 'undefined' && process.env.JEST_WORKER_ID
-                ? { chrome: 106 << 16 }
+                ? { chrome: 110 << 16 }
                 : lightningcss.browserslistToTargets(
                     browserslist(require('../package.json').browserslist)
                   ),


### PR DESCRIPTION
This PR handles the `--no-autoprefixer` option in the CLI now that we are using Lighting CSS.

It works by setting the `targets` to `undefined` which takes care of it all.
This PR also includes a test with `--no-autoprefixer` in combination with nesting such that we can guarantee that nesting still works as expected even if we ignore the targets.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
