### PR TITLE
Remove `autoprefixer` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make font settings propagate into buttons, inputs, etc. ([#10940](https://github.com/tailwindlabs/tailwindcss/pull/10940))
 - Fix parsing of `theme()` inside `calc()` when there are no spaces around operators ([#11157](https://github.com/tailwindlabs/tailwindcss/pull/11157))
 - Ensure `repeating-conic-gradient` is detected as an image ([#11180](https://github.com/tailwindlabs/tailwindcss/pull/11180))
+- Remove `autoprefixer` dependency ([#11315](https://github.com/tailwindlabs/tailwindcss/pull/11315))
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
         "@swc/core": "^1.3.56",
         "@swc/jest": "^0.2.26",
         "@swc/register": "^0.1.10",
-        "autoprefixer": "^10.4.14",
         "concurrently": "^8.0.1",
         "eslint": "^8.39.0",
         "eslint-config-prettier": "^8.8.0",
@@ -92,7 +91,7 @@
       "name": "@tailwindcss/integrations-rollup",
       "version": "0.0.0",
       "devDependencies": {
-        "rollup": "3.23.0",
+        "rollup": "^3.23.0",
         "rollup-plugin-postcss": "^4.0.2"
       }
     },
@@ -100,7 +99,7 @@
       "name": "@tailwindcss/integrations-rollup-sass",
       "version": "0.0.0",
       "devDependencies": {
-        "rollup": "3.23.0",
+        "rollup": "^3.23.0",
         "rollup-plugin-postcss": "^4.0.2",
         "sass": "^1.62.1"
       }
@@ -5070,39 +5069,6 @@
         "node": ">= 4.5.0"
       }
     },
-    "node_modules/autoprefixer": {
-      "version": "10.4.14",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
-      "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-        }
-      ],
-      "dependencies": {
-        "browserslist": "^4.21.5",
-        "caniuse-lite": "^1.0.30001464",
-        "fraction.js": "^4.2.0",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.0",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.5.0.tgz",
@@ -8291,18 +8257,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/fraction.js": {
-      "version": "4.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "type": "patreon",
-        "url": "https://www.patreon.com/infusion"
-      }
-    },
     "node_modules/fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -11352,14 +11306,6 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/normalize-range": {
-      "version": "0.1.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -19009,14 +18955,14 @@
     "@tailwindcss/integrations-rollup": {
       "version": "file:integrations/rollup",
       "requires": {
-        "rollup": "3.23.0",
+        "rollup": "^3.23.0",
         "rollup-plugin-postcss": "^4.0.2"
       }
     },
     "@tailwindcss/integrations-rollup-sass": {
       "version": "file:integrations/rollup-sass",
       "requires": {
-        "rollup": "3.23.0",
+        "rollup": "^3.23.0",
         "rollup-plugin-postcss": "^4.0.2",
         "sass": "^1.62.1"
       }
@@ -20085,20 +20031,6 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
-    },
-    "autoprefixer": {
-      "version": "10.4.14",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
-      "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
-      "dev": true,
-      "requires": {
-        "browserslist": "^4.21.5",
-        "caniuse-lite": "^1.0.30001464",
-        "fraction.js": "^4.2.0",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.0.0",
-        "postcss-value-parser": "^4.2.0"
-      }
     },
     "babel-jest": {
       "version": "29.5.0",
@@ -22476,10 +22408,6 @@
         }
       }
     },
-    "fraction.js": {
-      "version": "4.2.0",
-      "dev": true
-    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -24755,10 +24683,6 @@
     },
     "normalize-path": {
       "version": "3.0.0"
-    },
-    "normalize-range": {
-      "version": "0.1.2",
-      "dev": true
     },
     "normalize-url": {
       "version": "6.1.0",
@@ -27283,7 +27207,6 @@
         "@tailwindcss/integrations-webpack-5": "file:integrations/webpack-5",
         "@tailwindcss/oxide": "file:oxide/crates/node",
         "arg": "^5.0.2",
-        "autoprefixer": "^10.4.14",
         "browserslist": "^4.21.5",
         "chokidar": "^3.5.3",
         "concurrently": "^8.0.1",
@@ -29755,14 +29678,14 @@
         "@tailwindcss/integrations-rollup": {
           "version": "file:integrations/rollup",
           "requires": {
-            "rollup": "3.23.0",
+            "rollup": "^3.23.0",
             "rollup-plugin-postcss": "^4.0.2"
           }
         },
         "@tailwindcss/integrations-rollup-sass": {
           "version": "file:integrations/rollup-sass",
           "requires": {
-            "rollup": "3.23.0",
+            "rollup": "^3.23.0",
             "rollup-plugin-postcss": "^4.0.2",
             "sass": "^1.62.1"
           }
@@ -30831,20 +30754,6 @@
           "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
           "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
           "dev": true
-        },
-        "autoprefixer": {
-          "version": "10.4.14",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
-          "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
-          "dev": true,
-          "requires": {
-            "browserslist": "^4.21.5",
-            "caniuse-lite": "^1.0.30001464",
-            "fraction.js": "^4.2.0",
-            "normalize-range": "^0.1.2",
-            "picocolors": "^1.0.0",
-            "postcss-value-parser": "^4.2.0"
-          }
         },
         "babel-jest": {
           "version": "29.5.0",
@@ -33222,10 +33131,6 @@
             }
           }
         },
-        "fraction.js": {
-          "version": "4.2.0",
-          "dev": true
-        },
         "fragment-cache": {
           "version": "0.2.1",
           "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -35501,10 +35406,6 @@
         },
         "normalize-path": {
           "version": "3.0.0"
-        },
-        "normalize-range": {
-          "version": "0.1.2",
-          "dev": true
         },
         "normalize-url": {
           "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@swc/core": "^1.3.56",
     "@swc/jest": "^0.2.26",
     "@swc/register": "^0.1.10",
-    "autoprefixer": "^10.4.14",
     "concurrently": "^8.0.1",
     "eslint": "^8.39.0",
     "eslint-config-prettier": "^8.8.0",


### PR DESCRIPTION
This PR removes an unused dependency called `autoprefixer`.

This was only used in the CLI and we are not using it anymore. The functionality of `autoprefixer` is baked into `lightningcss`.

We forgot to remove this as part of #11275

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
