### PR TITLE
Add support for `text-wrap` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Process and inline `@import` at-rules natively ([#11239](https://github.com/tailwindlabs/tailwindcss/pull/11239))
 - Add `svh`, `lvh`, and `dvh` values to default `height`/`min-height`/`max-height` theme ([#11317](https://github.com/tailwindlabs/tailwindcss/pull/11317))
 - Add `has-*` variants for `:has(...)` pseudo-class ([#11318](https://github.com/tailwindlabs/tailwindcss/pull/11318))
+- Add `text-wrap` utilities including `text-balance` ([#11320](https://github.com/tailwindlabs/tailwindcss/pull/11320))
 
 ### Changed
 

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1523,6 +1523,14 @@ export let corePlugins = {
     })
   },
 
+  textWrap: ({ addUtilities }) => {
+    addUtilities({
+      '.text-wrap': { 'text-wrap': 'wrap' },
+      '.text-nowrap': { 'text-wrap': 'nowrap' },
+      '.text-balance': { 'text-wrap': 'balance' },
+    })
+  },
+
   wordBreak: ({ addUtilities }) => {
     addUtilities({
       '.break-normal': { 'overflow-wrap': 'normal', 'word-break': 'normal' },

--- a/tests/basic-usage.test.css
+++ b/tests/basic-usage.test.css
@@ -597,6 +597,15 @@
 .whitespace-nowrap {
   white-space: nowrap;
 }
+.text-wrap {
+  text-wrap: wrap;
+}
+.text-nowrap {
+  text-wrap: nowrap;
+}
+.text-balance {
+  text-wrap: balance;
+}
 .break-words {
   overflow-wrap: break-word;
 }

--- a/tests/basic-usage.test.js
+++ b/tests/basic-usage.test.js
@@ -192,6 +192,7 @@ test('basic usage', () => {
           <div class="invisible"></div>
           <div class="collapse"></div>
           <div class="whitespace-nowrap"></div>
+          <div class="text-wrap text-balance text-nowrap"></div>
           <div class="w-12"></div>
           <div class="break-words"></div>
           <div class="z-30"></div>


### PR DESCRIPTION
This PR adds support for the new [`text-wrap` CSS property](https://www.w3.org/TR/css-text-4/#text-wrap), with the following three utilities:

| Class | CSS |
| --- | --- |
| `text-wrap` | `text-wrap: wrap` |
| `text-nowrap` | `text-wrap: nowrap` |
| `text-balance` | `text-wrap: balance` |

The most interesting one here is `text-balance` that attempts to automatically balance text across multiple lines so that you don't have one really long line and one really short line.

<img width="797" alt="image" src="https://github.com/tailwindlabs/tailwindcss/assets/4323180/ec19ad40-14b9-4c48-8ade-d8ef0564b5e2">

With the addition of the new `text-wrap` property, the CSS `white-space` property now decomposes into `text-wrap` and the new `white-space-collapse` property, but we are opting to leave explicit support for `white-space-collapse` to a future improvement for now because none of this stuff is supported anywhere except for the very latest version of Chrome.

This still feels useful for now though because `text-balance` gracefully degrades back to regular unbalanced text which doesn't look as nice but doesn't actually break the experience for anyone, so people might want to start using it today even if browser support is still catching up.