### PR TITLE
Refactor `parseCandidateStringsFromFiles` to `parseCandidateStrings`

### DIFF
--- a/oxide/crates/core/Cargo.toml
+++ b/oxide/crates/core/Cargo.toml
@@ -24,5 +24,5 @@ name = "parse_candidates"
 harness = false
 
 [[bench]]
-name = "parse_candidate_strings_from_files"
+name = "parse_candidate_strings"
 harness = false

--- a/oxide/crates/core/benches/parse_candidate_strings.rs
+++ b/oxide/crates/core/benches/parse_candidate_strings.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::path::PathBuf;
-use tailwindcss_core::{parse_candidate_strings_from_files, ChangedContent};
+use tailwindcss_core::{parse_candidate_strings, ChangedContent, Parsing, IO};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     // current_dir will be set to ./crates/core
@@ -51,8 +51,13 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         })
         .collect();
 
-    c.bench_function("parse_candidate_strings_from_files", |b| {
-        b.iter(|| parse_candidate_strings_from_files(changed_content.clone()))
+    c.bench_function("parse_candidate_strings", |b| {
+        b.iter(|| {
+            parse_candidate_strings(
+                changed_content.clone(),
+                Parsing::Parallel as u8 | IO::Parallel as u8,
+            )
+        })
     });
 }
 

--- a/oxide/crates/core/src/lib.rs
+++ b/oxide/crates/core/src/lib.rs
@@ -335,11 +335,6 @@ impl From<u8> for Parsing {
     }
 }
 
-pub fn parse_candidate_strings_from_files(changed_content: Vec<ChangedContent>) -> Vec<String> {
-    init_tracing();
-    parse_all_blobs(read_all_files(changed_content))
-}
-
 pub fn parse_candidate_strings(input: Vec<ChangedContent>, options: u8) -> Vec<String> {
     init_tracing();
 

--- a/oxide/crates/node/src/lib.rs
+++ b/oxide/crates/node/src/lib.rs
@@ -22,13 +22,6 @@ impl From<ChangedContent> for tailwindcss_core::ChangedContent {
   }
 }
 
-#[napi]
-pub fn parse_candidate_strings_from_files(changed_content: Vec<ChangedContent>) -> Vec<String> {
-  tailwindcss_core::parse_candidate_strings_from_files(
-    changed_content.into_iter().map(Into::into).collect(),
-  )
-}
-
 #[derive(Debug, Clone)]
 #[napi(object)]
 pub struct ContentPathInfo {

--- a/src/lib/expandTailwindAtRules.js
+++ b/src/lib/expandTailwindAtRules.js
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import LRU from '@alloc/quick-lru'
-import { parseCandidateStringsFromFiles } from '@tailwindcss/oxide'
+import { parseCandidateStrings, IO, Parsing } from '@tailwindcss/oxide'
 import * as sharedState from './sharedState'
 import { generateRules } from './generateRules'
 import log from '../util/log'
@@ -134,8 +134,9 @@ export default function expandTailwindAtRules(context) {
 
     if (flagEnabled(context.tailwindConfig, 'oxideParser')) {
       // TODO: Pass through or implement `extractor`
-      for (let candidate of parseCandidateStringsFromFiles(
-        context.changedContent
+      for (let candidate of parseCandidateStrings(
+        context.changedContent,
+        IO.Parallel | Parsing.Parallel
         // Object.assign({}, builtInTransformers, context.tailwindConfig.content.transform)
       )) {
         candidates.add(candidate)


### PR DESCRIPTION
We currently have both `parseCandidateStringsFromFiles` and `parseCandidateStrings`. The `parseCandidateStrings` can take some options to make sure that you are running IO or the Parsing step in a sequential or parallel way.

Both functions accept `ChangedContent` which is an `extension` and either the raw content or a file path. We make use of the `raw` content in our tests, but this is also used when using the `safelist` option in your config.

But, now that both functions exists and one can be implementation in function of the other, it is a bit nicer to remove the duplication and just support a single function.

This code doesn't exist in "production" builds right now and the code is purely internal API so there should be no breaking chnages when deleting the `parseCandidateStringsFromFiles` function.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
