### PR TITLE
Bump Rust version to 1.70.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,15 +58,22 @@ jobs:
             ./oxide/crates/node/index.d.ts
           key: ${{ runner.os }}-oxide-${{ hashFiles('./oxide/crates/**/*') }}
 
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
       - name: Check versions
         run: |
           echo "Node:" `node --version`
           echo "NPM:" `npm --version`
           echo "Rust:" `rustc --version`
           echo "Cargo:" `cargo --version`
-
-      - name: Install dependencies
-        run: npm install
 
       - name: Build Tailwind CSS
         run: npx turbo run build --filter=//

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,13 @@ jobs:
             ./oxide/crates/node/index.d.ts
           key: ${{ runner.os }}-oxide-${{ hashFiles('./oxide/crates/**/*') }}
 
+      - name: Check versions
+        run: |
+          echo "Node:" `node --version`
+          echo "NPM:" `npm --version`
+          echo "Rust:" `rustc --version`
+          echo "Cargo:" `cargo --version`
+
       - name: Install dependencies
         run: npm install
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -73,6 +73,20 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Check versions
+        run: |
+          echo "Node:" `node --version`
+          echo "NPM:" `npm --version`
+          echo "Rust:" `rustc --version`
+          echo "Cargo:" `cargo --version`
+
       - name: Build Tailwind CSS
         run: npx turbo run build --filter=//
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -53,6 +53,20 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Check versions
+        run: |
+          echo "Node:" `node --version`
+          echo "NPM:" `npm --version`
+          echo "Rust:" `rustc --version`
+          echo "Cargo:" `cargo --version`
+
       - name: Build Tailwind CSS
         run: npm run build
 

--- a/oxide/crates/cli/src/main.rs
+++ b/oxide/crates/cli/src/main.rs
@@ -105,7 +105,7 @@ fn main() -> Result<(), std::io::Error> {
     let candidates = content_paths.par_bridge().flat_map(|path| {
         read_lines(path)
             .unwrap()
-            .filter_map(Result::ok)
+            .map_while(Result::ok)
             .par_bridge()
             .flat_map_iter(|line| {
                 Extractor::unique(line.as_bytes(), Default::default())

--- a/oxide/crates/core/benches/parse_candidate_strings.rs
+++ b/oxide/crates/core/benches/parse_candidate_strings.rs
@@ -11,7 +11,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     let mut all_files: Vec<(u64, PathBuf)> = std::fs::read_dir(fixtures_path)
         .unwrap()
-        .into_iter()
         .filter_map(Result::ok)
         .map(|dir_entry| dir_entry.path())
         .filter(|path| path.is_file())

--- a/oxide/crates/core/src/candidate.rs
+++ b/oxide/crates/core/src/candidate.rs
@@ -22,7 +22,6 @@ impl Candidate {
                     x == ':' && !in_arbitrary
                 }
             })
-            .into_iter()
             .collect::<Vec<_>>();
 
         let utility = match parts.pop() {

--- a/oxide/crates/core/src/glob.rs
+++ b/oxide/crates/core/src/glob.rs
@@ -12,7 +12,6 @@ pub fn fast_glob(
                 .follow_links(true)
                 .build()
                 .unwrap()
-                .into_iter()
                 .filter_map(Result::ok)
                 .map(|file| file.path().to_path_buf())
         }))

--- a/oxide/crates/core/src/lib.rs
+++ b/oxide/crates/core/src/lib.rs
@@ -43,7 +43,7 @@ pub fn resolve_content_paths(args: ContentPathInfo) -> Vec<String> {
     let root = Path::new(&args.base);
 
     let allowed_paths = FxHashSet::from_iter(
-        WalkBuilder::new(&root)
+        WalkBuilder::new(root)
             .hidden(false)
             .filter_entry(|entry| match entry.file_type() {
                 Some(file_type) if file_type.is_dir() => entry
@@ -94,7 +94,7 @@ pub fn resolve_content_paths(args: ContentPathInfo) -> Vec<String> {
 
     // Collect all valid paths from the root. This will already filter out ignored files, unknown
     // extensions and binary files.
-    let mut it = WalkDir::new(&root)
+    let mut it = WalkDir::new(root)
         // Sorting to make sure that we always see the directories before the files. Also sorting
         // alphabetically by default.
         .sort_by(

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -31,13 +31,13 @@ pub struct Extractor<'a> {
 
 impl<'a> Extractor<'a> {
     pub fn all(input: &'a [u8], opts: ExtractorOptions) -> Vec<&'a [u8]> {
-        Self::new(input, opts).into_iter().collect()
+        Self::new(input, opts).collect()
     }
 
     pub fn unique(input: &'a [u8], opts: ExtractorOptions) -> FxHashSet<&'a [u8]> {
         let mut candidates: FxHashSet<&[u8]> = Default::default();
         candidates.reserve(100);
-        candidates.extend(Self::new(input, opts).into_iter());
+        candidates.extend(Self::new(input, opts));
         candidates
     }
 


### PR DESCRIPTION
This PR bumps the Rust version to the latest version which should be: `1.70.0`

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
