### PR TITLE
Ensure the oxide parser has feature parity with the stable RegEx parser

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,11 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.rs]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/oxide/crates/core/benches/parse_candidates.rs
+++ b/oxide/crates/core/benches/parse_candidates.rs
@@ -31,6 +31,20 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("parse_candidate_strings (real world)", |b| {
         b.iter(|| parse(include_bytes!("./fixtures/template-499.html")))
     });
+
+    let mut group = c.benchmark_group("sample-size-example");
+    group.sample_size(10);
+
+    group.bench_function("parse_candidate_strings (fast space skipping)", |b| {
+        let count = 10_000;
+        let crazy1 = format!("{}underline", " ".repeat(count));
+        let crazy2 = crazy1.repeat(count);
+        let crazy3 = crazy2.as_bytes();
+
+        b.iter(|| {
+            parse(black_box(crazy3))
+        })
+    });
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/oxide/crates/core/benches/parse_candidates.rs
+++ b/oxide/crates/core/benches/parse_candidates.rs
@@ -41,9 +41,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         let crazy2 = crazy1.repeat(count);
         let crazy3 = crazy2.as_bytes();
 
-        b.iter(|| {
-            parse(black_box(crazy3))
-        })
+        b.iter(|| parse(black_box(crazy3)))
     });
 }
 

--- a/oxide/crates/core/src/cursor.rs
+++ b/oxide/crates/core/src/cursor.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Sub};
+use std::{fmt::Display, ascii::escape_default};
 
 #[derive(Debug, Clone)]
 pub struct Cursor<'a> {
@@ -67,21 +67,30 @@ impl<'a> Cursor<'a> {
     }
 }
 
-impl<'a> Add<usize> for Cursor<'a> {
-    type Output = Self;
+impl<'a> Display for Cursor<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let len = self.input.len().to_string();
 
-    fn add(mut self, rhs: usize) -> Self::Output {
-        self.advance_by(rhs);
-        self
-    }
-}
+        let pos = format!("{: >len_count$}", self.pos, len_count = len.len());
+        write!(f, "{}/{} ", pos, len)?;
 
-impl<'a> Sub<usize> for Cursor<'a> {
-    type Output = Self;
+        if self.at_start {
+            write!(f, "S ")?;
+        } else if self.at_end {
+            write!(f, "E ")?;
+        } else {
+            write!(f, "M ")?;
+        }
 
-    fn sub(mut self, rhs: usize) -> Self::Output {
-        self.rewind_by(rhs);
-        self
+        fn to_str(c: u8) -> String  {
+            if c == 0x00 {
+                "NUL".into()
+            } else {
+                format!("{:?}", escape_default(c).to_string())
+            }
+        }
+
+        write!(f, "[{} {} {}]", to_str(self.prev), to_str(self.curr), to_str(self.next))
     }
 }
 

--- a/oxide/crates/core/src/cursor.rs
+++ b/oxide/crates/core/src/cursor.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, ascii::escape_default};
+use std::{ascii::escape_default, fmt::Display};
 
 #[derive(Debug, Clone)]
 pub struct Cursor<'a> {
@@ -82,7 +82,7 @@ impl<'a> Display for Cursor<'a> {
             write!(f, "M ")?;
         }
 
-        fn to_str(c: u8) -> String  {
+        fn to_str(c: u8) -> String {
             if c == 0x00 {
                 "NUL".into()
             } else {
@@ -90,7 +90,13 @@ impl<'a> Display for Cursor<'a> {
             }
         }
 
-        write!(f, "[{} {} {}]", to_str(self.prev), to_str(self.curr), to_str(self.next))
+        write!(
+            f,
+            "[{} {} {}]",
+            to_str(self.prev),
+            to_str(self.curr),
+            to_str(self.next)
+        )
     }
 }
 

--- a/oxide/crates/core/src/cursor.rs
+++ b/oxide/crates/core/src/cursor.rs
@@ -93,16 +93,16 @@ mod test {
     fn test_cursor() {
         let mut cursor = Cursor::new(b"hello world");
         assert_eq!(cursor.pos, 0);
-        assert_eq!(cursor.at_start, true);
-        assert_eq!(cursor.at_end, false);
+        assert!(cursor.at_start);
+        assert!(!cursor.at_end);
         assert_eq!(cursor.prev, 0x00);
         assert_eq!(cursor.curr, b'h');
         assert_eq!(cursor.next, b'e');
 
         cursor.advance_by(1);
         assert_eq!(cursor.pos, 1);
-        assert_eq!(cursor.at_start, false);
-        assert_eq!(cursor.at_end, false);
+        assert!(!cursor.at_start);
+        assert!(!cursor.at_end);
         assert_eq!(cursor.prev, b'h');
         assert_eq!(cursor.curr, b'e');
         assert_eq!(cursor.next, b'l');
@@ -110,8 +110,8 @@ mod test {
         // Advancing too far should stop at the end
         cursor.advance_by(10);
         assert_eq!(cursor.pos, 11);
-        assert_eq!(cursor.at_start, false);
-        assert_eq!(cursor.at_end, true);
+        assert!(!cursor.at_start);
+        assert!(cursor.at_end);
         assert_eq!(cursor.prev, b'd');
         assert_eq!(cursor.curr, 0x00);
         assert_eq!(cursor.next, 0x00);
@@ -119,24 +119,24 @@ mod test {
         // Can't advance past the end
         cursor.advance_by(1);
         assert_eq!(cursor.pos, 11);
-        assert_eq!(cursor.at_start, false);
-        assert_eq!(cursor.at_end, true);
+        assert!(!cursor.at_start);
+        assert!(cursor.at_end);
         assert_eq!(cursor.prev, b'd');
         assert_eq!(cursor.curr, 0x00);
         assert_eq!(cursor.next, 0x00);
 
         cursor.rewind_by(1);
         assert_eq!(cursor.pos, 10);
-        assert_eq!(cursor.at_start, false);
-        assert_eq!(cursor.at_end, true);
+        assert!(!cursor.at_start);
+        assert!(cursor.at_end);
         assert_eq!(cursor.prev, b'l');
         assert_eq!(cursor.curr, b'd');
         assert_eq!(cursor.next, 0x00);
 
         cursor.rewind_by(10);
         assert_eq!(cursor.pos, 0);
-        assert_eq!(cursor.at_start, true);
-        assert_eq!(cursor.at_end, false);
+        assert!(cursor.at_start);
+        assert!(!cursor.at_end);
         assert_eq!(cursor.prev, 0x00);
         assert_eq!(cursor.curr, b'h');
         assert_eq!(cursor.next, b'e');

--- a/oxide/crates/core/src/cursor.rs
+++ b/oxide/crates/core/src/cursor.rs
@@ -55,7 +55,7 @@ impl<'a> Cursor<'a> {
 
         self.pos = pos;
         self.at_start = pos == 0;
-        self.at_end = pos >= len;
+        self.at_end = pos+1 >= len;
 
         self.prev = if pos > 0 { self.input[pos-1] } else { 0x00 };
         self.curr = if pos < len { self.input[pos] } else { 0x00 };
@@ -124,7 +124,7 @@ mod test {
         cursor.rewind_by(1);
         assert_eq!(cursor.pos, 10);
         assert_eq!(cursor.at_start, false);
-        assert_eq!(cursor.at_end, false);
+        assert_eq!(cursor.at_end, true);
         assert_eq!(cursor.prev, b'l');
         assert_eq!(cursor.curr, b'd');
         assert_eq!(cursor.next, 0x00);

--- a/oxide/crates/core/src/cursor.rs
+++ b/oxide/crates/core/src/cursor.rs
@@ -55,11 +55,15 @@ impl<'a> Cursor<'a> {
 
         self.pos = pos;
         self.at_start = pos == 0;
-        self.at_end = pos+1 >= len;
+        self.at_end = pos + 1 >= len;
 
-        self.prev = if pos > 0 { self.input[pos-1] } else { 0x00 };
+        self.prev = if pos > 0 { self.input[pos - 1] } else { 0x00 };
         self.curr = if pos < len { self.input[pos] } else { 0x00 };
-        self.next = if pos+1 < len { self.input[pos+1] } else { 0x00 };
+        self.next = if pos + 1 < len {
+            self.input[pos + 1]
+        } else {
+            0x00
+        };
     }
 }
 

--- a/oxide/crates/core/src/cursor.rs
+++ b/oxide/crates/core/src/cursor.rs
@@ -1,4 +1,4 @@
-use std::{ops::{Add, Sub}, io::Read};
+use std::ops::{Add, Sub};
 
 #[derive(Debug, Clone)]
 pub struct Cursor<'a> {
@@ -50,15 +50,16 @@ impl<'a> Cursor<'a> {
     }
 
     pub fn move_to(&mut self, pos: usize) {
-        let pos = pos.clamp(0, self.input.len() - 1);
+        let len = self.input.len();
+        let pos = pos.clamp(0, len);
 
         self.pos = pos;
         self.at_start = pos == 0;
-        self.at_end = pos >= self.input.len() - 1;
+        self.at_end = pos >= len;
 
-        self.prev = if !self.at_start { self.input[pos-1] } else { 0x00 };
-        self.curr = self.input[pos];
-        self.next = if !self.at_end { self.input[pos+1] } else { 0x00 };
+        self.prev = if pos > 0 { self.input[pos-1] } else { 0x00 };
+        self.curr = if pos < len { self.input[pos] } else { 0x00 };
+        self.next = if pos+1 < len { self.input[pos+1] } else { 0x00 };
     }
 }
 
@@ -104,29 +105,29 @@ mod test {
 
         // Advancing too far should stop at the end
         cursor.advance_by(10);
-        assert_eq!(cursor.pos, 10);
+        assert_eq!(cursor.pos, 11);
         assert_eq!(cursor.at_start, false);
         assert_eq!(cursor.at_end, true);
-        assert_eq!(cursor.prev, b'l');
-        assert_eq!(cursor.curr, b'd');
+        assert_eq!(cursor.prev, b'd');
+        assert_eq!(cursor.curr, 0x00);
         assert_eq!(cursor.next, 0x00);
 
         // Can't advance past the end
         cursor.advance_by(1);
-        assert_eq!(cursor.pos, 10);
+        assert_eq!(cursor.pos, 11);
         assert_eq!(cursor.at_start, false);
         assert_eq!(cursor.at_end, true);
-        assert_eq!(cursor.prev, b'l');
-        assert_eq!(cursor.curr, b'd');
+        assert_eq!(cursor.prev, b'd');
+        assert_eq!(cursor.curr, 0x00);
         assert_eq!(cursor.next, 0x00);
 
         cursor.rewind_by(1);
-        assert_eq!(cursor.pos, 9);
+        assert_eq!(cursor.pos, 10);
         assert_eq!(cursor.at_start, false);
         assert_eq!(cursor.at_end, false);
-        assert_eq!(cursor.prev, b'r');
-        assert_eq!(cursor.curr, b'l');
-        assert_eq!(cursor.next, b'd');
+        assert_eq!(cursor.prev, b'l');
+        assert_eq!(cursor.curr, b'd');
+        assert_eq!(cursor.next, 0x00);
 
         cursor.rewind_by(10);
         assert_eq!(cursor.pos, 0);

--- a/oxide/crates/core/src/cursor.rs
+++ b/oxide/crates/core/src/cursor.rs
@@ -1,0 +1,139 @@
+use std::{ops::{Add, Sub}, io::Read};
+
+#[derive(Debug, Clone)]
+pub struct Cursor<'a> {
+    // The input we're scanning
+    pub input: &'a [u8],
+
+    // The location of the cursor in the input
+    pub pos: usize,
+
+    /// Is the cursor at the start of the input
+    pub at_start: bool,
+
+    /// Is the cursor at the end of the input
+    pub at_end: bool,
+
+    /// The previously consumed character
+    /// If `at_start` is true, this will be NUL
+    pub prev: u8,
+
+    /// The current character
+    pub curr: u8,
+
+    /// The upcoming character (if any)
+    /// If `at_end` is true, this will be NUL
+    pub next: u8,
+}
+
+impl<'a> Cursor<'a> {
+    pub fn new(input: &'a [u8]) -> Self {
+        let mut cursor = Self {
+            input,
+            pos: 0,
+            at_start: true,
+            at_end: false,
+            prev: 0x00,
+            curr: 0x00,
+            next: 0x00,
+        };
+        cursor.move_to(0);
+        cursor
+    }
+
+    pub fn rewind_by(&mut self, amount: usize) {
+        self.move_to(self.pos.saturating_sub(amount));
+    }
+
+    pub fn advance_by(&mut self, amount: usize) {
+        self.move_to(self.pos.saturating_add(amount));
+    }
+
+    pub fn move_to(&mut self, pos: usize) {
+        let pos = pos.clamp(0, self.input.len() - 1);
+
+        self.pos = pos;
+        self.at_start = pos == 0;
+        self.at_end = pos >= self.input.len() - 1;
+
+        self.prev = if !self.at_start { self.input[pos-1] } else { 0x00 };
+        self.curr = self.input[pos];
+        self.next = if !self.at_end { self.input[pos+1] } else { 0x00 };
+    }
+}
+
+impl<'a> Add<usize> for Cursor<'a> {
+    type Output = Self;
+
+    fn add(mut self, rhs: usize) -> Self::Output {
+        self.advance_by(rhs);
+        self
+    }
+}
+
+impl<'a> Sub<usize> for Cursor<'a> {
+    type Output = Self;
+
+    fn sub(mut self, rhs: usize) -> Self::Output {
+        self.rewind_by(rhs);
+        self
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_cursor() {
+        let mut cursor = Cursor::new(b"hello world");
+        assert_eq!(cursor.pos, 0);
+        assert_eq!(cursor.at_start, true);
+        assert_eq!(cursor.at_end, false);
+        assert_eq!(cursor.prev, 0x00);
+        assert_eq!(cursor.curr, b'h');
+        assert_eq!(cursor.next, b'e');
+
+        cursor.advance_by(1);
+        assert_eq!(cursor.pos, 1);
+        assert_eq!(cursor.at_start, false);
+        assert_eq!(cursor.at_end, false);
+        assert_eq!(cursor.prev, b'h');
+        assert_eq!(cursor.curr, b'e');
+        assert_eq!(cursor.next, b'l');
+
+        // Advancing too far should stop at the end
+        cursor.advance_by(10);
+        assert_eq!(cursor.pos, 10);
+        assert_eq!(cursor.at_start, false);
+        assert_eq!(cursor.at_end, true);
+        assert_eq!(cursor.prev, b'l');
+        assert_eq!(cursor.curr, b'd');
+        assert_eq!(cursor.next, 0x00);
+
+        // Can't advance past the end
+        cursor.advance_by(1);
+        assert_eq!(cursor.pos, 10);
+        assert_eq!(cursor.at_start, false);
+        assert_eq!(cursor.at_end, true);
+        assert_eq!(cursor.prev, b'l');
+        assert_eq!(cursor.curr, b'd');
+        assert_eq!(cursor.next, 0x00);
+
+        cursor.rewind_by(1);
+        assert_eq!(cursor.pos, 9);
+        assert_eq!(cursor.at_start, false);
+        assert_eq!(cursor.at_end, false);
+        assert_eq!(cursor.prev, b'r');
+        assert_eq!(cursor.curr, b'l');
+        assert_eq!(cursor.next, b'd');
+
+        cursor.rewind_by(10);
+        assert_eq!(cursor.pos, 0);
+        assert_eq!(cursor.at_start, true);
+        assert_eq!(cursor.at_end, false);
+        assert_eq!(cursor.prev, 0x00);
+        assert_eq!(cursor.curr, b'h');
+        assert_eq!(cursor.next, b'e');
+    }
+}

--- a/oxide/crates/core/src/fast_skip.rs
+++ b/oxide/crates/core/src/fast_skip.rs
@@ -10,16 +10,10 @@ pub fn fast_skip(cursor: &Cursor) -> Option<usize> {
         return None;
     }
 
-    // Ensure that we have to skip at least 1 byte
-    if !cursor.curr.is_ascii_whitespace() {
-        return None;
-    }
+    let mut offset = 0;
 
     // SAFETY: We've already checked (indirectly) that this index is valid
     let remaining = unsafe { cursor.input.get_unchecked(cursor.pos..) };
-
-    // Now we're guaranteed that we need to skip at least 1 byte
-    let mut offset = 1;
 
     // NOTE: This loop uses primitives designed to be auto-vectorized
     // Do not change this loop without benchmarking the results
@@ -36,7 +30,16 @@ pub fn fast_skip(cursor: &Cursor) -> Option<usize> {
         }
     }
 
-    return Some(cursor.pos + offset);
+    // Ensure we skip at least one byte of whitespace (if any)
+    if offset == 0 && cursor.curr.is_ascii_whitespace() {
+        offset = 1;
+    }
+
+    if offset == 0 {
+        None
+    } else {
+        Some(cursor.pos + offset)
+    }
 }
 
 #[inline(always)]

--- a/oxide/crates/core/src/fast_skip.rs
+++ b/oxide/crates/core/src/fast_skip.rs
@@ -28,7 +28,7 @@ pub fn fast_skip(cursor: &Cursor) -> Option<usize> {
         let is_all_whitespace = all_true(is_whitespace);
 
         if is_all_whitespace {
-            offset = (i+1)*STRIDE;
+            offset = (i + 1) * STRIDE;
         } else {
             break;
         }
@@ -43,7 +43,6 @@ fn load(input: &[u8]) -> [u8; STRIDE] {
     value.copy_from_slice(&input);
     value
 }
-
 
 #[inline(always)]
 fn eq(input: [u8; STRIDE], val: u8) -> Mask {
@@ -80,5 +79,11 @@ fn is_ascii_whitespace(value: [u8; STRIDE]) -> [bool; STRIDE] {
     let whitespace_4 = eq(value, b'\r');
     let whitespace_5 = eq(value, b' ');
 
-    or(or(or(or(whitespace_1, whitespace_2), whitespace_3), whitespace_4), whitespace_5)
+    or(
+        or(
+            or(or(whitespace_1, whitespace_2), whitespace_3),
+            whitespace_4,
+        ),
+        whitespace_5,
+    )
 }

--- a/oxide/crates/core/src/fast_skip.rs
+++ b/oxide/crates/core/src/fast_skip.rs
@@ -40,7 +40,7 @@ pub fn fast_skip(cursor: &Cursor) -> Option<usize> {
 #[inline(always)]
 fn load(input: &[u8]) -> [u8; STRIDE] {
     let mut value = [0u8; STRIDE];
-    value.copy_from_slice(&input);
+    value.copy_from_slice(input);
     value
 }
 

--- a/oxide/crates/core/src/fast_skip.rs
+++ b/oxide/crates/core/src/fast_skip.rs
@@ -10,7 +10,11 @@ pub fn fast_skip(cursor: &Cursor) -> Option<usize> {
         return None;
     }
 
-    let mut offset = 0;
+    if !cursor.curr.is_ascii_whitespace() {
+        return None;
+    }
+
+    let mut offset = 1;
 
     // SAFETY: We've already checked (indirectly) that this index is valid
     let remaining = unsafe { cursor.input.get_unchecked(cursor.pos..) };
@@ -30,16 +34,7 @@ pub fn fast_skip(cursor: &Cursor) -> Option<usize> {
         }
     }
 
-    // Ensure we skip at least one byte of whitespace (if any)
-    if offset == 0 && cursor.curr.is_ascii_whitespace() {
-        offset = 1;
-    }
-
-    if offset == 0 {
-        None
-    } else {
-        Some(cursor.pos + offset)
-    }
+    Some(cursor.pos + offset)
 }
 
 #[inline(always)]

--- a/oxide/crates/core/src/fast_skip.rs
+++ b/oxide/crates/core/src/fast_skip.rs
@@ -1,0 +1,49 @@
+use crate::cursor::Cursor;
+
+#[inline(always)]
+pub fn fast_skip<F>(cursor: &Cursor, is_skippable: F) -> Option<usize> where F: Fn(u8) -> bool {
+    const STRIDE: usize = 16;
+
+    if !is_skippable(cursor.curr) || !is_skippable(cursor.next) {
+        return None;
+    }
+
+    if cursor.at_end {
+        return None;
+    }
+
+    // We're guaranteed that the current and next bytes are skippable
+    let remaining = unsafe { cursor.input.get_unchecked(cursor.pos..) };
+
+    // This loop is auto-vectorized by the compiler
+    let mut skip_to_offset = 1;
+    for (i, chunk) in remaining.chunks_exact(STRIDE).enumerate() {
+        let mut value = [0u8; STRIDE];
+        value.copy_from_slice(&chunk);
+
+        // PERF:
+        // These separate loops are required because they are written to
+        // be auto-vectorized by the compiler. Combining them results
+        // in a loop that can't be thus sacrificing performance.
+
+        // Check all 16 bytes in the chunk at once
+        let mut can_skip = [false; STRIDE];
+        for n in 0..STRIDE {
+            can_skip[n] = is_skippable(value[n]);
+        }
+
+        // Merge the results of all 16 bytes at once
+        let mut all_can_skip = true;
+        for n in 0..STRIDE {
+            all_can_skip &= can_skip[n];
+        }
+
+        if !all_can_skip {
+            break;
+        }
+
+        skip_to_offset = i*STRIDE;
+    }
+
+    return Some(cursor.pos + skip_to_offset + 1);
+}

--- a/oxide/crates/core/src/fast_skip.rs
+++ b/oxide/crates/core/src/fast_skip.rs
@@ -65,8 +65,8 @@ fn or(a: [bool; STRIDE], b: [bool; STRIDE]) -> [bool; STRIDE] {
 #[inline(always)]
 fn all_true(a: [bool; STRIDE]) -> bool {
     let mut res = true;
-    for n in 0..STRIDE {
-        res &= a[n];
+    for item in a.iter().take(STRIDE) {
+        res &= item;
     }
     res
 }

--- a/oxide/crates/core/src/lib.rs
+++ b/oxide/crates/core/src/lib.rs
@@ -10,13 +10,13 @@ use walkdir::WalkDir;
 
 pub mod candidate;
 pub mod cursor;
+pub mod fast_skip;
 pub mod glob;
 pub mod location;
 pub mod modifier;
 pub mod parser;
 pub mod utility;
 pub mod variant;
-pub mod fast_skip;
 
 fn init_tracing() {
     if matches!(std::env::var("DEBUG"), Ok(value) if value.eq("*") || value.eq("1") || value.eq("true") || value.contains("tailwind"))

--- a/oxide/crates/core/src/lib.rs
+++ b/oxide/crates/core/src/lib.rs
@@ -9,6 +9,7 @@ use tracing::event;
 use walkdir::WalkDir;
 
 pub mod candidate;
+pub mod cursor;
 pub mod glob;
 pub mod location;
 pub mod modifier;

--- a/oxide/crates/core/src/lib.rs
+++ b/oxide/crates/core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod modifier;
 pub mod parser;
 pub mod utility;
 pub mod variant;
+pub mod fast_skip;
 
 fn init_tracing() {
     if matches!(std::env::var("DEBUG"), Ok(value) if value.eq("*") || value.eq("1") || value.eq("true") || value.contains("tailwind"))

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -721,16 +721,12 @@ impl<'a> Iterator for Extractor<'a> {
                 _ => {},
             }
 
-            // Ierator results
-            match result {
-                ParseAction::SingleCandidate(candidate, _) => return Some(vec![candidate]),
-                ParseAction::MultipleCandidates(candidates, _) => return Some(candidates),
-                ParseAction::Done => return None,
-
-                ParseAction::Continue => continue,
-                ParseAction::Skip => continue,
-                ParseAction::Consume => continue,
-                ParseAction::RestartAt(_) => continue,
+            // Iterator results
+            return match result {
+                ParseAction::SingleCandidate(candidate, _) => Some(vec![candidate]),
+                ParseAction::MultipleCandidates(candidates, _) => Some(candidates),
+                ParseAction::Done => None,
+                _ => continue,
             }
         }
     }

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -207,7 +207,6 @@ impl<'a> Extractor<'a> {
         // In case of an arbitrary property, we should have at least this structure: [a:b]
         if utility.starts_with(b"[") && utility.ends_with(b"]") {
             // [a:b] is at least 5 characters long
-            if candidate.len() < 5 {
             if utility.len() < 5 {
                 return false;
             }

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -670,8 +670,9 @@ impl<'a> Extractor<'a> {
         trace!("Cursor {}", self.cursor);
 
         // Fast skipping of invalid characters
-        if !self.in_candidate {
-            match fast_skip(&self.cursor, |c| c.is_ascii_whitespace()) {
+        let can_skip_whitespace = if self.opts.preserve_spaces_in_arbitrary { !self.in_arbitrary } else { true };
+        if can_skip_whitespace {
+            match fast_skip(&self.cursor) {
                 Some(pos) => {
                     trace!("FastSkip::Restart\t{}", pos);
                     return ParseAction::RestartAt(pos);

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -656,12 +656,9 @@ impl<'a> Extractor<'a> {
         // Fast skipping of invalid characters
         let can_skip_whitespace = false; // if self.opts.preserve_spaces_in_arbitrary { !self.in_arbitrary } else { true };
         if can_skip_whitespace {
-            match fast_skip(&self.cursor) {
-                Some(pos) => {
-                    trace!("FastSkip::Restart\t{}", pos);
-                    return ParseAction::RestartAt(pos);
-                }
-                _ => {}
+            if let Some(pos) = fast_skip(&self.cursor) {
+                trace!("FastSkip::Restart\t{}", pos);
+                return ParseAction::RestartAt(pos);
             }
         }
 

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -514,9 +514,7 @@ impl<'a> Extractor<'a> {
     }
 
     #[inline(always)]
-    fn handle_skip(&mut self, pos: Option<usize>) {
-        let Some(pos) = pos else { return };
-
+    fn handle_skip(&mut self, pos: usize) {
         // In all other cases, we skip characters and reset everything so we can make new candidates
         trace!("Characters::Skip\t");
         self.idx_start = pos;
@@ -718,8 +716,8 @@ impl<'a> Iterator for Extractor<'a> {
 
             // Candidate state control
             match result {
-                ParseAction::SingleCandidate(_, pos) => self.handle_skip(pos),
-                ParseAction::MultipleCandidates(_, pos) => self.handle_skip(pos),
+                ParseAction::SingleCandidate(_, Some(pos)) => self.handle_skip(pos),
+                ParseAction::MultipleCandidates(_, Some(pos)) => self.handle_skip(pos),
                 _ => {},
             }
 

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -536,23 +536,15 @@ impl<'a> Extractor<'a> {
         let action = self.parse_char(self.prev, curr, pos);
 
         match action {
-            ParseAction::RestartAt(pos) => {
-                self.restart(pos);
-                return ParseAction::Continue;
-            }
-            ParseAction::Consume => {
-                self.idx_end = pos;
-            }
+            ParseAction::Consume => self.idx_end = pos,
+            ParseAction::RestartAt(_) => return action,
             _ => {}
         }
 
         let action = self.yield_candidate(pos, curr, action == ParseAction::Consume);
 
         match action {
-            ParseAction::RestartAt(pos) => {
-                self.restart(pos);
-                return ParseAction::Continue;
-            }
+            ParseAction::RestartAt(_) => return action,
             _ => {}
         }
 
@@ -625,7 +617,7 @@ impl<'a> Iterator for Extractor<'a> {
 
                 ParseAction::Skip => continue,
                 ParseAction::Consume => continue,
-                ParseAction::RestartAt(_) => continue,
+                ParseAction::RestartAt(pos) => self.restart(pos),
             }
         }
     }

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -147,9 +147,7 @@ impl<'a> Extractor<'a> {
         let mut brackets = 0;
         let mut idx_end = 0;
 
-        for n in 0..candidate.len() {
-            let c = candidate[n];
-
+        for (n, c) in candidate.iter().enumerate() {
             match c {
                 b'[' => brackets += 1,
                 b']' if brackets > 0 => brackets -= 1,
@@ -168,14 +166,12 @@ impl<'a> Extractor<'a> {
     fn contains_in_constrained(candidate: &'a [u8], bytes: Vec<u8>) -> bool {
         let mut brackets = 0;
 
-        for n in 0..candidate.len() {
-            let c = candidate[n];
-
+        for c in candidate {
             match c {
                 b'[' => brackets += 1,
                 b']' if brackets > 0 => brackets -= 1,
                 _ if brackets == 0 => {
-                    if bytes.contains(&c) {
+                    if bytes.contains(c) {
                         return true;
                     }
                 }
@@ -565,7 +561,7 @@ impl<'a> Extractor<'a> {
     }
 
     #[inline(always)]
-    fn slice_surrounding<'b>(input: &[u8]) -> Option<&[u8]> {
+    fn slice_surrounding(input: &[u8]) -> Option<&[u8]> {
         let mut prev = None;
         let mut input = input;
 
@@ -576,15 +572,15 @@ impl<'a> Extractor<'a> {
             let leading = input.first().unwrap_or(&0x00);
             let trailing = input.last().unwrap_or(&0x00);
 
-            let needed = match (leading, trailing) {
-                (b'(', b')') => true,
-                (b'{', b'}') => true,
-                (b'[', b']') => true,
-                (b'"', b'"') => true,
-                (b'`', b'`') => true,
-                (b'\'', b'\'') => true,
-                _ => false,
-            };
+            let needed = matches!(
+                (leading, trailing),
+                (b'(', b')')
+                    | (b'{', b'}')
+                    | (b'[', b']')
+                    | (b'"', b'"')
+                    | (b'`', b'`')
+                    | (b'\'', b'\'')
+            );
 
             if needed {
                 prev = Some(input);

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -716,20 +716,20 @@ impl<'a> Iterator for Extractor<'a> {
                 _ => self.cursor.advance_by(1),
             }
 
+            // Candidate state control
             match result {
-                ParseAction::SingleCandidate(candidate, pos) => {
-                    self.handle_skip(pos);
-                    return Some(vec![candidate]);
-                }
+                ParseAction::SingleCandidate(_, pos) => self.handle_skip(pos),
+                ParseAction::MultipleCandidates(_, pos) => self.handle_skip(pos),
+                _ => {},
+            }
 
-                ParseAction::MultipleCandidates(candidates, pos) => {
-                    self.handle_skip(pos);
-                    return Some(candidates);
-                }
-
-                ParseAction::Continue => continue,
+            // Ierator results
+            match result {
+                ParseAction::SingleCandidate(candidate, _) => return Some(vec![candidate]),
+                ParseAction::MultipleCandidates(candidates, _) => return Some(candidates),
                 ParseAction::Done => return None,
 
+                ParseAction::Continue => continue,
                 ParseAction::Skip => continue,
                 ParseAction::Consume => continue,
                 ParseAction::RestartAt(_) => continue,

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -434,9 +434,19 @@ impl<'a> Extractor<'a> {
                 trace!("Candidate::Consume\t");
             }
 
+            // A dot (.) can only appear in the candidate itself (not the arbitrary part), if the previous
+            // and next characters are both digits. This covers the following cases:
+            // - p-1.5
+            b'.' if prev.is_ascii_digit() => match self.input.get(pos + 1) {
+                Some(&next) if next.is_ascii_digit() => {
+                    trace!("Candidate::Consume\t");
+                }
+                _ => return ParseAction::Skip,
+            },
+
             // Allowed characters in the candidate itself
             // These MUST NOT appear at the end of the candidate
-            b'/' | b':' | b'.' if pos + 1 < self.idx_last => {
+            b'/' | b':' if pos + 1 < self.idx_last => {
                 trace!("Candidate::Consume\t");
             }
 

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -1124,14 +1124,4 @@ mod test {
             .unwrap();
         assert_eq!(result, Some("[.foo_&]:px-[0]"));
     }
-
-    #[test]
-    fn fast_skip_test() {
-        let count = 100_000;
-        let crazy1 = format!("{}underline", " ".repeat(count));
-        let crazy2 = crazy1.repeat(count);
-
-        let result = run(&crazy2, false);
-        assert_eq!(result, vec!["underline"]);
-    }
 }

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -425,11 +425,34 @@ impl<'a> Extractor<'a> {
                 }
             }
 
+            // < and > can only be part of a variant and only be the first or last character
+            b'<' | b'>' => {
+                let next = self.input.get(pos + 1);
+
+                // Can only be the first or last character
+                // E.g.:
+                // - <sm:underline
+                //   ^
+                // - md>:underline
+                //     ^
+                if pos == self.idx_start || pos == self.idx_last {
+                    trace!("Candidate::Consume\t");
+                }
+                // If it is in the middle, it can only be part of a stacked variant
+                // - dark:<sm:underline
+                //        ^
+                // - dark:md>:underline
+                //          ^
+                else if prev == b':' || next == Some(&b':') {
+                    trace!("Candidate::Consume\t");
+                } else {
+                    return ParseAction::Skip;
+                }
+            }
+
             // Allowed characters in the candidate itself
             // None of these can come after a closing bracket `]`
-            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' | b'<' | b'>' | b'!' | b'@'
-                if prev != b']' =>
-            {
+            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' | b'!' | b'@' if prev != b']' => {
                 /* TODO: The `b'@'` is necessary for custom separators like _@, maybe we can handle this in a better way... */
                 trace!("Candidate::Consume\t");
             }

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -197,11 +197,7 @@ impl<'a> Extractor<'a> {
             match c {
                 b'[' => brackets += 1,
                 b']' if brackets > 0 => brackets -= 1,
-                _ if brackets == 0 => {
-                    if bytes.contains(c) {
-                        return true;
-                    }
-                }
+                _ if brackets == 0 && bytes.contains(c) => return true,
                 _ => {}
             }
         }
@@ -431,14 +427,7 @@ impl<'a> Extractor<'a> {
     fn parse_continue(&mut self) -> ParseAction<'a> {
         match self.cursor.curr {
             // Enter arbitrary value mode
-            b'[' if self.cursor.prev == b'@'
-                || self.cursor.prev == b'-'
-                || self.cursor.prev == b' '
-                || self.cursor.prev == b':' // Variant separator
-                || self.cursor.prev == b'/' // Modifier separator
-                || self.cursor.prev == b'!'
-                || self.cursor.prev == b'\0' =>
-            {
+            b'[' if matches!(self.cursor.prev, b'@' | b'-' | b' ' | b':' | b'/' | b'!' | b'\0') => {
                 trace!("Arbitrary::Start\t");
                 self.in_arbitrary = true;
                 self.idx_arbitrary_start = self.cursor.pos;

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -444,11 +444,17 @@ impl<'a> Extractor<'a> {
             // digit 0-9. This covers the following cases:
             // - from-15%
             b'%' => {
-                if self.cursor.prev.is_ascii_digit() && self.cursor.at_end {
-                    trace!("Candidate::Consume\t");
-                } else {
+                if !self.cursor.prev.is_ascii_digit()  {
                     return ParseAction::Skip;
                 }
+
+                return match (self.cursor.at_end, self.cursor.next) {
+                    // End of string == end of candidate == okay
+                    (true, _) => ParseAction::Consume,
+
+                    // Otherwise, not a valid character in a candidate
+                    _ => ParseAction::Skip,
+                };
             }
 
             // < and > can only be part of a variant and only be the first or last character

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -12,7 +12,6 @@ pub enum ParseAction<'a> {
 
     SingleCandidate(&'a [u8]),
     MultipleCandidates(Vec<&'a [u8]>),
-    Continue,
     Done,
 }
 
@@ -160,7 +159,7 @@ impl<'a> Extractor<'a> {
             }
         }
 
-        ParseAction::Continue
+        ParseAction::Consume
     }
 
     #[inline(always)]
@@ -552,7 +551,7 @@ impl<'a> Extractor<'a> {
         if self.can_be_candidate() {
             self.get_current_candidate()
         } else {
-            ParseAction::Continue
+            ParseAction::Consume
         }
     }
 

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -100,13 +100,19 @@ impl<'a> Extractor<'a> {
 
     #[inline(always)]
     fn get_current_candidate(&mut self) -> Option<&'a [u8]> {
-        let candidate = &self.input[self.idx_start..=self.idx_end];
+        let mut candidate = &self.input[self.idx_start..=self.idx_end];
 
-        if Extractor::is_valid_candidate_string(candidate) {
-            Some(candidate)
-        } else {
-            None
+        while !candidate.is_empty() {
+          if Extractor::is_valid_candidate_string(candidate) {
+            return Some(candidate)
+          }
+
+          candidate = &candidate[0..candidate.len()-1];
         }
+
+        None
+    }
+
     #[inline(always)]
     fn split_candidate(candidate: &'a [u8]) -> SplitCandidate {
       // [foo:bar]

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -443,11 +443,7 @@ impl<'a> Extractor<'a> {
             // A % can only appear at the end of the candidate itself. It can also only be after a
             // digit 0-9. This covers the following cases:
             // - from-15%
-            b'%' => {
-                if !self.cursor.prev.is_ascii_digit()  {
-                    return ParseAction::Skip;
-                }
-
+            b'%' if self.cursor.prev.is_ascii_digit() => {
                 return match (self.cursor.at_end, self.cursor.next) {
                     // End of string == end of candidate == okay
                     (true, _) => ParseAction::Consume,
@@ -459,6 +455,7 @@ impl<'a> Extractor<'a> {
                     _ => ParseAction::Skip,
                 };
             }
+            b'%' => return ParseAction::Skip,
 
             // < and > can only be part of a variant and only be the first or last character
             b'<' | b'>' => {

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -52,7 +52,6 @@ pub struct Extractor<'a> {
 
     quote_stack: Vec<u8>,
     bracket_stack: Vec<u8>,
-    // buffer: [Option<&'a [u8]>; 8],
 }
 
 impl<'a> Extractor<'a> {
@@ -99,7 +98,6 @@ impl<'a> Extractor<'a> {
             idx_last: input.len(),
             quote_stack: Vec::with_capacity(8),
             bracket_stack: Vec::with_capacity(8),
-            // buffer: [None; 8],
         }
     }
 }
@@ -415,7 +413,7 @@ impl<'a> Extractor<'a> {
             b'@' | b'!' | b'-' | b'<' | b'>' | b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' => {
                 // TODO: A bunch of characters that we currently support but maybe we only want it behind
                 // a flag. E.g.: '<sm'
-                // | '<' | '>' | '$' | '^' | '_'
+                // | '$' | '^' | '_'
 
                 // When the new candidate is preceeded by a `:`, then we want to keep parsing, but
                 // throw away the full candidate because it can not be a valid candidate at the end
@@ -1114,7 +1112,6 @@ mod test {
             .unwrap();
         assert_eq!(result, Some("pt-1.5"));
 
-        // 0.19s in a release build:
         let count = 1_000;
         let crazy = format!("{}[.foo_&]:px-[0]{}", "[".repeat(count), "]".repeat(count));
 

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -630,9 +630,6 @@ impl<'a> Extractor<'a> {
         let mut prev = None;
         let mut input = input;
 
-        // dark:lg:hover:[&>*]:underline
-        // "dark:lg:hover:[&>*]:underline"
-
         loop {
             let leading = input.first().unwrap_or(&0x00);
             let trailing = input.last().unwrap_or(&0x00);
@@ -701,14 +698,10 @@ impl<'a> Extractor<'a> {
         }
     }
 
+    /// Peek inside `[]`, `{}`, and `()` pairs
+    /// to look for an additional candidate
     #[inline(always)]
     fn generate_slices(&mut self, candidate: &'a [u8]) -> ParseAction<'a> {
-        // Find all []{}() and `:` positions
-        // We also don't split when the []{}() are not at the start/end
-        // If the `:` is not inside a []{}() pair we don't split
-
-        // Why is this causing tests to fail when it's not even used?
-        // And not mutating anything?
         match self.without_surrounding() {
             Bracketing::None => ParseAction::SingleCandidate(candidate),
             Bracketing::Included(slicable) if slicable == candidate => {

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -126,7 +126,12 @@ impl<'a> Extractor<'a> {
                 return Some(candidate);
             }
 
-            candidate = &candidate[0..candidate.len() - 1];
+            match candidate.split_last() {
+                Some((b':' | b'/' | b'.', head)) => {
+                    candidate = head;
+                }
+                _ => break,
+            }
         }
 
         None

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -414,20 +414,20 @@ impl<'a> Extractor<'a> {
                 return ParseAction::Skip;
             }
 
+            // A % can only appear at the end of the candidate itself. It can also only be after a
+            // digit 0-9. This covers the following cases:
+            // - from-15%
+            b'%' => {
+                if prev.is_ascii_digit() && pos + 1 < self.idx_last {
+                    trace!("Candidate::Consume\t");
+                } else {
+                    return ParseAction::Skip;
+                }
+            }
+
             // Allowed characters in the candidate itself
             // None of these can come after a closing bracket `]`
-            b'a'..=b'z'
-            | b'A'..=b'Z'
-            | b'0'..=b'9'
-            | b'-'
-            | b'_'
-            // | b'('
-            // | b')'
-            | b'<'
-            | b'>'
-            | b'!'
-            | b'@'
-            | b'%'
+            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' | b'<' | b'>' | b'!' | b'@'
                 if prev != b']' =>
             {
                 /* TODO: The `b'@'` is necessary for custom separators like _@, maybe we can handle this in a better way... */

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -1030,8 +1030,23 @@ mod test {
 
     #[test]
     fn percent_ended_candidates() {
-        let candidates = run(r#"<!-- This should work `underline from-50% flex` -->"#, false);
-        assert_eq!(candidates, vec!["!--", "This", "should", "work", "underline", "from-50%", "flex", "--"]);
+        let candidates = run(
+            r#"<!-- This should work `underline from-50% flex` -->"#,
+            false,
+        );
+        assert_eq!(
+            candidates,
+            vec![
+                "!--",
+                "This",
+                "should",
+                "work",
+                "underline",
+                "from-50%",
+                "flex",
+                "--"
+            ]
+        );
     }
 
     #[test]

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -452,6 +452,9 @@ impl<'a> Extractor<'a> {
                     // End of string == end of candidate == okay
                     (true, _) => ParseAction::Consume,
 
+                    // Looks like the end of a candidate == okay
+                    (_, b' ' | b'\'' | b'"' | b'`') => ParseAction::Consume,
+
                     // Otherwise, not a valid character in a candidate
                     _ => ParseAction::Skip,
                 };
@@ -1026,6 +1029,12 @@ mod test {
     fn multiple_nested_candidates() {
         let candidates = run(r#"{color:red}"#, false);
         assert_eq!(candidates, vec!["color:red"]);
+    }
+
+    #[test]
+    fn percent_ended_candidates() {
+        let candidates = run(r#"<!-- This should work `underline from-50% flex` -->"#, false);
+        assert_eq!(candidates, vec!["!--", "This", "should", "work", "underline", "from-50%", "flex", "--"]);
     }
 
     #[test]

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -341,6 +341,10 @@ impl<'a> Extractor<'a> {
 
                 // This is the last bracket meaning the end of arbitrary content
                 _ if !self.in_quotes() => {
+                    if matches!(self.cursor.next, b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9') {
+                        return ParseAction::Consume;
+                    }
+
                     trace!("Arbitrary::End\t");
                     self.in_arbitrary = false;
 

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -170,11 +170,6 @@ impl<'a> Extractor<'a> {
 
     #[inline(always)]
     fn split_candidate(candidate: &'a [u8]) -> SplitCandidate {
-        // [foo:bar]
-        // [foo:bar]
-        // [.foo_&]:[bar_&]:px-[1]
-        // [.foo_&]:md:[bar_&]:px-[1]
-
         let mut brackets = 0;
         let mut idx_end = 0;
 
@@ -877,16 +872,16 @@ mod test {
         let candidates = run("![feature(slice_as_chunks)]", false);
         assert!(candidates.is_empty());
 
-        // let candidates = run("-[feature(slice_as_chunks)]", false);
+        let candidates = run("-[feature(slice_as_chunks)]", false);
         assert!(candidates.is_empty());
 
-        // let candidates = run("!-[feature(slice_as_chunks)]", false);
+        let candidates = run("!-[feature(slice_as_chunks)]", false);
         assert!(candidates.is_empty());
 
-        // let candidates = run("-[foo:bar]", false);
+        let candidates = run("-[foo:bar]", false);
         assert!(candidates.is_empty());
 
-        // let candidates = run("!-[foo:bar]", false);
+        let candidates = run("!-[foo:bar]", false);
         assert!(candidates.is_empty());
     }
 

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -646,6 +646,8 @@ impl<'a> Extractor<'a> {
 
     #[inline(always)]
     fn parse_and_yield(&mut self) -> ParseAction<'a> {
+        trace!("Cursor {}", self.cursor);
+
         let action = self.parse_char();
 
         match action {

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -56,13 +56,13 @@ pub struct Extractor<'a> {
 
 impl<'a> Extractor<'a> {
     pub fn all(input: &'a [u8], opts: ExtractorOptions) -> Vec<&'a [u8]> {
-        Self::new(input, opts).into_iter().flatten().collect()
+        Self::new(input, opts).flatten().collect()
     }
 
     pub fn unique(input: &'a [u8], opts: ExtractorOptions) -> FxHashSet<&'a [u8]> {
         let mut candidates: FxHashSet<&[u8]> = Default::default();
         candidates.reserve(100);
-        candidates.extend(Self::new(input, opts).into_iter().flatten());
+        candidates.extend(Self::new(input, opts).flatten());
         candidates
     }
 
@@ -134,7 +134,7 @@ impl<'a> Extractor<'a> {
             }
         }
 
-        return ParseAction::Continue;
+        ParseAction::Continue
     }
 
     #[inline(always)]
@@ -532,7 +532,7 @@ impl<'a> Extractor<'a> {
         let clipped = &self.input[range];
 
         Self::slice_surrounding(clipped)
-            .map(|v| Bracketing::Included(v))
+            .map(Bracketing::Included)
             .or_else(
                 || {
                     if self.idx_start == 0 || self.idx_end+1 == self.idx_last {
@@ -541,7 +541,7 @@ impl<'a> Extractor<'a> {
 
                     let range = self.idx_start-1..=self.idx_end+1;
                     let clipped = &self.input[range];
-                    Self::slice_surrounding(clipped).map(|v| Bracketing::Wrapped(v))
+                    Self::slice_surrounding(clipped).map(Bracketing::Wrapped)
                 }
             )
             .unwrap_or(Bracketing::None)
@@ -568,9 +568,9 @@ impl<'a> Extractor<'a> {
     }
 
     #[inline(always)]
-    fn slice_surrounding<'i, 'b>(
-        input: &'i [u8]
-    ) -> Option<&'i [u8]> {
+    fn slice_surrounding<'b>(
+        input: &[u8]
+    ) -> Option<&[u8]> {
         let mut prev = None;
         let mut input = input;
 
@@ -578,8 +578,8 @@ impl<'a> Extractor<'a> {
         // "dark:lg:hover:[&>*]:underline"
 
         loop {
-            let leading = input.get(0).unwrap_or(&0x00);
-            let trailing = input.get(input.len()-1).unwrap_or(&0x00);
+            let leading = input.first().unwrap_or(&0x00);
+            let trailing = input.last().unwrap_or(&0x00);
 
             let needed = match (leading, trailing) {
                 (b'(', b')') => true,
@@ -1020,7 +1020,7 @@ mod test {
         let count = 1_000;
         let crazy = format!("{}[.foo_&]:px-[0]{}", "[".repeat(count), "]".repeat(count));
 
-        let result = Extractor::slice_surrounding(&crazy.as_bytes()).map(std::str::from_utf8).transpose().unwrap();
+        let result = Extractor::slice_surrounding(crazy.as_bytes()).map(std::str::from_utf8).transpose().unwrap();
         assert_eq!(result, Some("[.foo_&]:px-[0]"));
     }
 }

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -1077,7 +1077,7 @@ mod test {
             .map(std::str::from_utf8)
             .transpose()
             .unwrap();
-        assert_eq!(result, None);
+        assert_eq!(result, Some("pt-1.5"));
 
         // 0.19s in a release build:
         let count = 1_000;

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -1077,13 +1077,13 @@ mod test {
     }
 
     #[test]
-    fn doesitwipit() {
+    fn ruby_percent_formatted_strings() {
         let candidates = run(r#"%w[hover:flex]"#, false);
         assert_eq!(candidates, vec!["w", "hover:flex"]);
     }
 
     #[test]
-    fn wipit_wipit_good() {
+    fn candidate_slicing() {
         let result = Extractor::slice_surrounding(&b".foo_&]:px-[0"[..])
             .map(std::str::from_utf8)
             .transpose()

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -128,7 +128,7 @@ impl<'a> Extractor<'a> {
             match Extractor::is_valid_candidate_string(candidate) {
                 ValidationResult::Valid => return ParseAction::SingleCandidate(candidate),
                 ValidationResult::Restart => return ParseAction::RestartAt(self.idx_start + 1),
-                _ => {},
+                _ => {}
             }
 
             match candidate.split_last() {
@@ -427,7 +427,11 @@ impl<'a> Extractor<'a> {
     fn parse_continue(&mut self) -> ParseAction<'a> {
         match self.cursor.curr {
             // Enter arbitrary value mode
-            b'[' if matches!(self.cursor.prev, b'@' | b'-' | b' ' | b':' | b'/' | b'!' | b'\0') => {
+            b'[' if matches!(
+                self.cursor.prev,
+                b'@' | b'-' | b' ' | b':' | b'/' | b'!' | b'\0'
+            ) =>
+            {
                 trace!("Arbitrary::Start\t");
                 self.in_arbitrary = true;
                 self.idx_arbitrary_start = self.cursor.pos;
@@ -656,8 +660,8 @@ impl<'a> Extractor<'a> {
                 Some(pos) => {
                     trace!("FastSkip::Restart\t{}", pos);
                     return ParseAction::RestartAt(pos);
-                },
-                _ => {},
+                }
+                _ => {}
             }
         }
 

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -670,7 +670,7 @@ impl<'a> Extractor<'a> {
         trace!("Cursor {}", self.cursor);
 
         // Fast skipping of invalid characters
-        let can_skip_whitespace = if self.opts.preserve_spaces_in_arbitrary { !self.in_arbitrary } else { true };
+        let can_skip_whitespace = false; // if self.opts.preserve_spaces_in_arbitrary { !self.in_arbitrary } else { true };
         if can_skip_whitespace {
             match fast_skip(&self.cursor) {
                 Some(pos) => {

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -711,4 +711,35 @@ mod test {
         let candidates = run(r"[𕤵:]", false);
         assert!(candidates.is_empty());
     }
+
+    #[test]
+    fn classes_in_js_arrays() {
+        let candidates = run(
+            r#"let classes = ['bg-black', 'hover:px-0.5', 'text-[13px]', '[--my-var:1_/_2]']">"#,
+            false,
+        );
+        assert_eq!(
+            candidates,
+            vec![
+                "let",
+                "classes",
+                "bg-black",
+                "hover:px-0.5",
+                "text-[13px]",
+                "[--my-var:1_/_2]",
+            ]
+        );
+    }
+
+    #[test]
+    fn classes_as_object_keys() {
+        let candidates = run(
+            r#"<div :class="{ underline: isActive, 'px-1.5': isOnline }"></div>"#,
+            false,
+        );
+        assert_eq!(
+            candidates,
+            vec!["class", "underline", "isActive", "px-1.5", "isOnline"]
+        );
+    }
 }

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -9,7 +9,7 @@ let defaults = {
   logicalSiblingUtilities: false,
 }
 
-let featureFlags = {
+export let featureFlags = {
   future: [
     'hoverOnlyWhenSupported',
     'respectDefaultRingColorOpacity',

--- a/src/util/normalizeConfig.js
+++ b/src/util/normalizeConfig.js
@@ -1,4 +1,4 @@
-import { flagEnabled } from '../featureFlags'
+import { flagEnabled, featureFlags } from '../featureFlags'
 import log, { dim } from './log'
 
 export function normalizeConfig(config) {
@@ -292,6 +292,21 @@ export function normalizeConfig(config) {
 
       return transformers
     })(),
+  }
+
+  // Force disable the `oxideParser` feature flag when using unsupported features.
+  // TODO: Remove once we have prefix or separator support in the oxide parser.
+  if (config.prefix !== '' || config.separator !== ':') {
+    if (config.experimental === 'all') {
+      config.experimental = {}
+      for (let key in featureFlags.experimental) {
+        config[key] = true
+      }
+    } else {
+      config.experimental = config.experimental ?? {}
+    }
+
+    config.experimental.oxideParser = false
   }
 
   // Validate globs to prevent bogus globs.

--- a/src/util/normalizeConfig.js
+++ b/src/util/normalizeConfig.js
@@ -300,7 +300,7 @@ export function normalizeConfig(config) {
     if (config.experimental === 'all') {
       config.experimental = {}
       for (let key in featureFlags.experimental) {
-        config[key] = true
+        config.experimental[key] = true
       }
     } else {
       config.experimental = config.experimental ?? {}

--- a/tests/animations.test.js
+++ b/tests/animations.test.js
@@ -187,7 +187,7 @@ test('with dots in the name', () => {
     content: [
       {
         raw: html`
-          <div class="animate-zoom-.5"></div>
+          <div class="animate-zoom-0.5"></div>
           <div class="animate-zoom-1.5"></div>
         `,
       },
@@ -195,11 +195,11 @@ test('with dots in the name', () => {
     theme: {
       extend: {
         keyframes: {
-          'zoom-.5': { to: { transform: 'scale(0.5)' } },
+          'zoom-0.5': { to: { transform: 'scale(0.5)' } },
           'zoom-1.5': { to: { transform: 'scale(1.5)' } },
         },
         animation: {
-          'zoom-.5': 'zoom-.5 2s',
+          'zoom-0.5': 'zoom-0.5 2s',
           'zoom-1.5': 'zoom-1.5 2s',
         },
       },
@@ -208,19 +208,22 @@ test('with dots in the name', () => {
 
   return run('@tailwind utilities', config).then((result) => {
     expect(result.css).toMatchFormattedCss(css`
-      @keyframes zoom-\.5 {
+      @keyframes zoom-0\.5 {
         to {
           transform: scale(0.5);
         }
       }
-      .animate-zoom-\.5 {
-        animation: 2s zoom-\.5;
+
+      .animate-zoom-0\.5 {
+        animation: 2s zoom-0\.5;
       }
+
       @keyframes zoom-1\.5 {
         to {
           transform: scale(1.5);
         }
       }
+
       .animate-zoom-1\.5 {
         animation: 2s zoom-1\.5;
       }

--- a/tests/arbitrary-variants.test.js
+++ b/tests/arbitrary-variants.test.js
@@ -1,4 +1,5 @@
 import { run, html, css, defaults } from './util/run'
+import { flagEnabled } from '../src/featureFlags'
 
 test('basic arbitrary variants', () => {
   let config = {
@@ -612,24 +613,44 @@ it('should support aria variants', () => {
   `
 
   return run(input, config).then((result) => {
-    expect(result.css).toMatchFormattedCss(css`
-      .underline,
-      .aria-checked\:underline[aria-checked='true'],
-      .aria-\[labelledby\=\'a_b\'\]\:underline[aria-labelledby='a b'],
-      .aria-\[sort\=ascending\]\:underline[aria-sort='ascending'],
-      .group\/foo[aria-checked='true'] .group-aria-checked\/foo\:underline,
-      .group[aria-checked='true'] .group-aria-checked\:underline,
-      .group[aria-labelledby='a b'] .group-aria-\[labelledby\=\'a_b\'\]\:underline,
-      .group\/foo[aria-sort='ascending'] .group-aria-\[sort\=ascending\]\/foo\:underline,
-      .group[aria-sort='ascending'] .group-aria-\[sort\=ascending\]\:underline,
-      .peer\/foo[aria-checked='true'] ~ .peer-aria-checked\/foo\:underline,
-      .peer[aria-checked='true'] ~ .peer-aria-checked\:underline,
-      .peer[aria-labelledby='a b'] ~ .peer-aria-\[labelledby\=\'a_b\'\]\:underline,
-      .peer\/foo[aria-sort='ascending'] ~ .peer-aria-\[sort\=ascending\]\/foo\:underline,
-      .peer[aria-sort='ascending'] ~ .peer-aria-\[sort\=ascending\]\:underline {
-        text-decoration-line: underline;
-      }
-    `)
+    expect(result.css).toMatchFormattedCss(
+      flagEnabled(config, 'oxideParser')
+        ? css`
+            .aria-checked\:underline[aria-checked='true'],
+            .aria-\[labelledby\=\'a_b\'\]\:underline[aria-labelledby='a b'],
+            .aria-\[sort\=ascending\]\:underline[aria-sort='ascending'],
+            .group\/foo[aria-checked='true'] .group-aria-checked\/foo\:underline,
+            .group[aria-checked='true'] .group-aria-checked\:underline,
+            .group[aria-labelledby='a b'] .group-aria-\[labelledby\=\'a_b\'\]\:underline,
+            .group\/foo[aria-sort='ascending'] .group-aria-\[sort\=ascending\]\/foo\:underline,
+            .group[aria-sort='ascending'] .group-aria-\[sort\=ascending\]\:underline,
+            .peer\/foo[aria-checked='true'] ~ .peer-aria-checked\/foo\:underline,
+            .peer[aria-checked='true'] ~ .peer-aria-checked\:underline,
+            .peer[aria-labelledby='a b'] ~ .peer-aria-\[labelledby\=\'a_b\'\]\:underline,
+            .peer\/foo[aria-sort='ascending'] ~ .peer-aria-\[sort\=ascending\]\/foo\:underline,
+            .peer[aria-sort='ascending'] ~ .peer-aria-\[sort\=ascending\]\:underline {
+              text-decoration-line: underline;
+            }
+          `
+        : css`
+            .underline,
+            .aria-checked\:underline[aria-checked='true'],
+            .aria-\[labelledby\=\'a_b\'\]\:underline[aria-labelledby='a b'],
+            .aria-\[sort\=ascending\]\:underline[aria-sort='ascending'],
+            .group\/foo[aria-checked='true'] .group-aria-checked\/foo\:underline,
+            .group[aria-checked='true'] .group-aria-checked\:underline,
+            .group[aria-labelledby='a b'] .group-aria-\[labelledby\=\'a_b\'\]\:underline,
+            .group\/foo[aria-sort='ascending'] .group-aria-\[sort\=ascending\]\/foo\:underline,
+            .group[aria-sort='ascending'] .group-aria-\[sort\=ascending\]\:underline,
+            .peer\/foo[aria-checked='true'] ~ .peer-aria-checked\/foo\:underline,
+            .peer[aria-checked='true'] ~ .peer-aria-checked\:underline,
+            .peer[aria-labelledby='a b'] ~ .peer-aria-\[labelledby\=\'a_b\'\]\:underline,
+            .peer\/foo[aria-sort='ascending'] ~ .peer-aria-\[sort\=ascending\]\/foo\:underline,
+            .peer[aria-sort='ascending'] ~ .peer-aria-\[sort\=ascending\]\:underline {
+              text-decoration-line: underline;
+            }
+          `
+    )
   })
 })
 
@@ -669,24 +690,44 @@ it('should support data variants', () => {
   `
 
   return run(input, config).then((result) => {
-    expect(result.css).toMatchFormattedCss(css`
-      .underline,
-      .data-checked\:underline[data-ui~='checked'],
-      .data-\[foo\=\'bar_baz\'\]\:underline[data-foo='bar baz'],
-      .data-\[position\=top\]\:underline[data-position='top'],
-      .group\/foo[data-ui~='checked'] .group-data-checked\/foo\:underline,
-      .group[data-ui~='checked'] .group-data-checked\:underline,
-      .group[data-foo='bar baz'] .group-data-\[foo\=\'bar_baz\'\]\:underline,
-      .group\/foo[data-position='top'] .group-data-\[position\=top\]\/foo\:underline,
-      .group[data-position='top'] .group-data-\[position\=top\]\:underline,
-      .peer\/foo[data-ui~='checked'] ~ .peer-data-checked\/foo\:underline,
-      .peer[data-ui~='checked'] ~ .peer-data-checked\:underline,
-      .peer[data-foo='bar baz'] ~ .peer-data-\[foo\=\'bar_baz\'\]\:underline,
-      .peer\/foo[data-position='top'] ~ .peer-data-\[position\=top\]\/foo\:underline,
-      .peer[data-position='top'] ~ .peer-data-\[position\=top\]\:underline {
-        text-decoration-line: underline;
-      }
-    `)
+    expect(result.css).toMatchFormattedCss(
+      flagEnabled(config, 'oxideParser')
+        ? css`
+            .data-checked\:underline[data-ui~='checked'],
+            .data-\[foo\=\'bar_baz\'\]\:underline[data-foo='bar baz'],
+            .data-\[position\=top\]\:underline[data-position='top'],
+            .group\/foo[data-ui~='checked'] .group-data-checked\/foo\:underline,
+            .group[data-ui~='checked'] .group-data-checked\:underline,
+            .group[data-foo='bar baz'] .group-data-\[foo\=\'bar_baz\'\]\:underline,
+            .group\/foo[data-position='top'] .group-data-\[position\=top\]\/foo\:underline,
+            .group[data-position='top'] .group-data-\[position\=top\]\:underline,
+            .peer\/foo[data-ui~='checked'] ~ .peer-data-checked\/foo\:underline,
+            .peer[data-ui~='checked'] ~ .peer-data-checked\:underline,
+            .peer[data-foo='bar baz'] ~ .peer-data-\[foo\=\'bar_baz\'\]\:underline,
+            .peer\/foo[data-position='top'] ~ .peer-data-\[position\=top\]\/foo\:underline,
+            .peer[data-position='top'] ~ .peer-data-\[position\=top\]\:underline {
+              text-decoration-line: underline;
+            }
+          `
+        : css`
+            .underline,
+            .data-checked\:underline[data-ui~='checked'],
+            .data-\[foo\=\'bar_baz\'\]\:underline[data-foo='bar baz'],
+            .data-\[position\=top\]\:underline[data-position='top'],
+            .group\/foo[data-ui~='checked'] .group-data-checked\/foo\:underline,
+            .group[data-ui~='checked'] .group-data-checked\:underline,
+            .group[data-foo='bar baz'] .group-data-\[foo\=\'bar_baz\'\]\:underline,
+            .group\/foo[data-position='top'] .group-data-\[position\=top\]\/foo\:underline,
+            .group[data-position='top'] .group-data-\[position\=top\]\:underline,
+            .peer\/foo[data-ui~='checked'] ~ .peer-data-checked\/foo\:underline,
+            .peer[data-ui~='checked'] ~ .peer-data-checked\:underline,
+            .peer[data-foo='bar baz'] ~ .peer-data-\[foo\=\'bar_baz\'\]\:underline,
+            .peer\/foo[data-position='top'] ~ .peer-data-\[position\=top\]\/foo\:underline,
+            .peer[data-position='top'] ~ .peer-data-\[position\=top\]\:underline {
+              text-decoration-line: underline;
+            }
+          `
+    )
   })
 })
 

--- a/tests/basic-usage.test.js
+++ b/tests/basic-usage.test.js
@@ -878,11 +878,15 @@ test('should not crash when group names contain special characters', () => {
   `
 
   return run(input, config).then((result) => {
-    expect(result.css).toMatchFormattedCss(css`
-      .group\/\$\{id\}:hover .group-hover\/\$\{id\}\:visible {
-        visibility: visible;
-      }
-    `)
+    if (flagEnabled(config, 'oxideParser')) {
+      expect(result.css).toMatchFormattedCss(css``)
+    } else {
+      expect(result.css).toMatchFormattedCss(css`
+        .group\/\$\{id\}:hover .group-hover\/\$\{id\}\:visible {
+          visibility: visible;
+        }
+      `)
+    }
   })
 })
 

--- a/tests/basic-usage.test.js
+++ b/tests/basic-usage.test.js
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import { run, html, css, defaults } from './util/run'
+import { flagEnabled } from '../src/featureFlags'
 
 test('basic usage', () => {
   let config = {
@@ -927,12 +928,20 @@ test('detects quoted arbitrary values containing a slash', async () => {
 
   let result = await run(input, config)
 
-  expect(result.css).toMatchFormattedCss(css`
-    .hidden,
-    .group[href^='/'] .group-\[\[href\^\=\'\/\'\]\]\:hidden {
-      display: none;
-    }
-  `)
+  expect(result.css).toMatchFormattedCss(
+    flagEnabled(config, 'oxideParser')
+      ? css`
+          .group[href^='/'] .group-\[\[href\^\=\'\/\'\]\]\:hidden {
+            display: none;
+          }
+        `
+      : css`
+          .hidden,
+          .group[href^='/'] .group-\[\[href\^\=\'\/\'\]\]\:hidden {
+            display: none;
+          }
+        `
+  )
 })
 
 test('handled quoted arbitrary values containing escaped spaces', async () => {
@@ -950,10 +959,18 @@ test('handled quoted arbitrary values containing escaped spaces', async () => {
 
   let result = await run(input, config)
 
-  expect(result.css).toMatchFormattedCss(css`
-    .hidden,
-    .group[href^=' bar'] .group-\[\[href\^\=\'_bar\'\]\]\:hidden {
-      display: none;
-    }
-  `)
+  expect(result.css).toMatchFormattedCss(
+    flagEnabled(config, 'oxideParser')
+      ? css`
+          .group[href^=' bar'] .group-\[\[href\^\=\'_bar\'\]\]\:hidden {
+            display: none;
+          }
+        `
+      : css`
+          .hidden,
+          .group[href^=' bar'] .group-\[\[href\^\=\'_bar\'\]\]\:hidden {
+            display: none;
+          }
+        `
+  )
 })

--- a/tests/parse-candidate-strings.test.js
+++ b/tests/parse-candidate-strings.test.js
@@ -65,7 +65,7 @@ function templateTable(classes) {
     ['Vue object (single quote)', html`<div :class="{'${classString}': true}"></div>`],
 
     ['Markdown code fences', `<!-- This should work \`${classString}\` -->`],
-  ]
+  ].map(([name, template]) => [name, template, classes])
 }
 
 describe.each([
@@ -84,11 +84,10 @@ describe.each([
       // With numbers
       'px-4',
 
-      // With floating numbers
+      // With special characters
       'px-1.5',
-
-      // With halves
       'translate-x-1/2',
+      'from-50%',
 
       // With negative signs
       '-translate-x-full',
@@ -97,7 +96,7 @@ describe.each([
       '-translate-x-1/2',
     ]
 
-    test.each(templateTable(classes))('%# — %s', (_, template) => {
+    test.each(templateTable(classes))('%# — %s', (_, template, classes) => {
       let extractions = parse(template)
 
       for (let c of classes) {
@@ -141,7 +140,7 @@ describe.each([
       'shadow-[inset_0_-3em_3em_rgba(0,_0,_0,_0.1),_0_0_0_2px_rgb(255,_255,_255),_0.3em_0.3em_1em_rgba(0,_0,_0,_0.3)]',
     ]
 
-    test.each(templateTable(classes))('%# — %s', (_, template) => {
+    test.each(templateTable(classes))('%# — %s', (_, template, classes) => {
       let extractions = parse(template)
 
       for (let c of classes) {
@@ -167,7 +166,7 @@ describe.each([
       '!bg-red-500',
     ]
 
-    test.each(templateTable(classes))('%# — %s', (_, template) => {
+    test.each(templateTable(classes))('%# — %s', (_, template, classes) => {
       let extractions = parse(template)
 
       for (let c of classes) {
@@ -182,7 +181,7 @@ describe.each([
       '[display:flex]',
     ]
 
-    test.each(templateTable(classes))('%# — %s', (_, template) => {
+    test.each(templateTable(classes))('%# — %s', (_, template, classes) => {
       let extractions = parse(template)
 
       for (let c of classes) {

--- a/tests/parse-candidate-strings.test.js
+++ b/tests/parse-candidate-strings.test.js
@@ -527,8 +527,8 @@ describe.each([
     expect(extractions).toContain(c)
   })
 
-  describe.skip('Vue', () => {
-    test('Class object syntax', () => {
+  describe('Vue', () => {
+    test.skip('Class object syntax', () => {
       let extractions = parse(
         `<div :class="{ underline: myCondition, 'font-bold': myCondition }">[foo]</div>`
       )
@@ -537,7 +537,15 @@ describe.each([
     })
 
     test('Class array syntax', () => {
+      // With leading space
       let extractions = parse(
+        `<div :class="[ 'underline', myCondition && 'font-bold', myCondition ? 'flex' : 'block' ]">[foo]</div>`
+      )
+
+      expect(extractions).toContain(`underline`, `font-bold`, `flex`, `block`)
+
+      // Without leading space
+      extractions = parse(
         `<div :class="['underline', myCondition && 'font-bold', myCondition ? 'flex' : 'block']">[foo]</div>`
       )
 

--- a/tests/parse-candidate-strings.test.js
+++ b/tests/parse-candidate-strings.test.js
@@ -1,6 +1,8 @@
 import { parseCandidateStrings, IO, Parsing } from '@tailwindcss/oxide'
 import { defaultExtractor as createDefaultExtractor } from '../src/lib/defaultExtractor'
 
+let html = String.raw
+
 let defaultExtractor = createDefaultExtractor({ tailwindConfig: { separator: ':' } })
 
 function regexParser(str) {
@@ -14,414 +16,263 @@ function oxideParser(str) {
   )
 }
 
-let classExamples = [
-  'underline',
-  'font-bold',
-  'z-0',
-  '-z-0',
-  'px-1.5',
-  '-px-1.5',
-  'translate-x-1/2',
-  '-translate-x-1/2',
-  'content-["hello"]',
-  "content-['hello']",
-  String.raw`content-["hello\_world"]`,
-  'bg-red-500/75',
-  'w-[100px]',
-  'w-[calc(100px*-1)]',
-  'w-[calc(100px_*_-1)]',
-  'w-[calc(100px-50%)]',
-  'w-[calc(100px_-_50%)]',
-  'w-[theme(spacing.1)]',
-  'w-[theme(spacing[1.5])]',
-  'w-[calc(100%-theme(spacing[1.5]))]',
-  'w-[calc(100%_-_theme(spacing[1.5]))]',
-  "w-[theme('spacing.1)']",
-  "w-[theme('spacing[1.5])']",
-  "w-[calc(100%-theme('spacing[1.5]))']",
-  "w-[calc(100%_-_theme('spacing[1.5]))']",
-  `w-[theme("spacing.1)"]`,
-  `w-[theme("spacing[1.5])"]`,
-  `w-[calc(100%-theme("spacing[1.5]))"]`,
-  `w-[calc(100%_-_theme("spacing[1.5]))"]`,
-  'bg-[#bada55]',
-  'bg-[#bada55]/50',
-  'bg-[#bada55]/[0.5]',
-  'bg-[color:#bada55]',
-  'bg-[color:#bada55]/50',
-  'bg-[color:#bada55]/[0.5]',
-  'bg-[color:#bada55]/[50%]',
-  'bg-[color:#bada55]/[33.7%]',
-  'bg-[var(--my-color)]',
-  'bg-[var(--my-color)]/50',
-  'bg-[var(--my-color)]/[50%]',
-  'bg-[var(--my-color)]/[33.7%]',
-  'bg-[--my-color]',
-  'bg-[--my-color]/50',
-  'bg-[--my-color]/[50%]',
-  'bg-[--my-color]/[33.7%]',
-  'fill-[rgb(13,24,35)]',
-  'fill-[rgb(13,24,35)]/50',
-  'fill-[rgb(13,24,35)]/[0.5]',
-  'fill-[rgb(13,24,35)]/[50%]',
-  'fill-[rgb(13,24,35)]/[33.7%]',
-  'fill-[rgb(13,_24,_35)]',
-  'fill-[rgb(13,_24,_35)]/50',
-  'fill-[rgb(13,_24,_35)]/[0.5]',
-  'fill-[rgb(13,_24,_35)]/[50%]',
-  'fill-[rgb(13,_24,_35)]/[33.7%]',
-  'fill-[oklab(59.69%_0.1007_0.1191_/_0.5)]',
-  'fill-[oklab(59.69%_0.1007_0.1191_/_0.5)]/50',
-  'fill-[oklab(59.69%_0.1007_0.1191_/_0.5)]/[0.5]',
-  'fill-[oklab(59.69%_0.1007_0.1191_/_0.5)]/[50%]',
-  'fill-[oklab(59.69%_0.1007_0.1191_/_0.5)]/[33.7%]',
-  'fill-[color:rgb(13,24,35)]',
-  'fill-[color:rgb(13,24,35)]/50',
-  'fill-[color:rgb(13,24,35)]/[0.5]',
-  'fill-[color:rgb(13,24,35)]/[50%]',
-  'fill-[color:rgb(13,24,35)]/[33.7%]',
-  'fill-[color:rgb(13,_24,_35)]',
-  'fill-[color:rgb(13,_24,_35)]/50',
-  'fill-[color:rgb(13,_24,_35)]/[0.5]',
-  'fill-[color:rgb(13,_24,_35)]/[50%]',
-  'fill-[color:rgb(13,_24,_35)]/[33.7%]',
-  'fill-[color:oklab(59.69%_0.1007_0.1191_/_0.5)]',
-  'fill-[color:oklab(59.69%_0.1007_0.1191_/_0.5)]/50',
-  'fill-[color:oklab(59.69%_0.1007_0.1191_/_0.5)]/[0.5]',
-  'fill-[color:oklab(59.69%_0.1007_0.1191_/_0.5)]/[50%]',
-  'fill-[color:oklab(59.69%_0.1007_0.1191_/_0.5)]/[33.7%]',
-  'shadow-[inset_0_-3em_3em_rgba(0,_0,_0,_0.1),_0_0_0_2px_rgb(255,_255,_255),_0.3em_0.3em_1em_rgba(0,_0,_0,_0.3)]',
-  '[background-color:red]',
-  '[background-color:#f00]',
-  '[background-color:rgb(255,0,0)]',
-  '[background-color:rgb(255,_0,_0)]',
-  '[box-shadow:inset_0_-3em_3em_rgba(0,_0,_0,_0.1),_0_0_0_2px_rgb(255,_255,_255),_0.3em_0.3em_1em_rgba(0,_0,_0,_0.3)]',
-  '[--my-variable:var(--my-other-variable)]',
-  '[--my-variable:var(--my-other-variable,initial)]',
-  '[--my-variable:var(--my-other-variable,var(--my-fallback))]',
-  '[--my-variable:var(--my-other-variable,var(--my-fallback,initial))]',
-]
+function templateTable(classes) {
+  classes = classes.concat(
+    // Variants
+    classes.flatMap((c) => {
+      return [
+        // Simple variant
+        `hover:${c}`,
 
-let variantExamples = [
-  'md',
-  'group-hover',
-  'data-[pressed]',
-  'min-[500px]',
-  'aria-[sort=descending]',
-  'aria-[sort="ascending"]',
-  'supports-[display:grid]',
-  'supports-[display:_flex]',
-  'supports-[display:_flex]',
-  'supports-[selector(A_>_B)]',
-  'supports-[selector(A>B)]',
-  'supports-[not_(foo:bar)]',
-  'supports-[not(foo:bar)]',
-  'supports-[(foo:bar)_or_(bar:baz)]',
-  'supports-[(foo:bar)or(bar:baz)]',
-  'supports-[(foo:bar)_and_(bar:baz)]',
-  'supports-[(foo:bar)and(bar:baz)]',
-  '@lg',
-  '@[618px]',
-  '[&:not(:active)]',
-  '[@media(hover:hover)]',
-  '[@media(any-hover:_hover)]',
-  '[@media_(pointer:_fine)]',
-]
+        // Combined variant
+        `focus:hover:${c}`,
 
-let templateExamples = [
-  // HTML
-  (c) => `<div class="${c}"></div>`,
-  (c) => `<div class="potato ${c} salad"></div>`,
-  (c) => `<div class="${c} potato salad"></div>`,
-  (c) => `<div class="potato salad ${c}"></div>`,
+        // Variant with dashes
+        `group-hover:group-focus:${c}`,
 
-  // Spaghetti JS
-  (c) => `let foo = "${c}"`,
-  (c) => `let foo = "${c}";`,
-  (c) => `let foo = '${c}'`,
-  (c) => `let foo = '${c}';`,
-  (c) => `let foo = \`${c}\``,
-  (c) => `let foo = \`${c}\`;`,
-  (c) => `let foo = ["${c}"]`,
-  (c) => `let foo = ["${c}"];`,
-  (c) => `let foo = ['${c}']`,
-  (c) => `let foo = ['${c}'];`,
-  (c) => `let foo = [\`${c}\`]`,
-  (c) => `let foo = [\`${c}\`];`,
-  (c) => `let foo = { ${c}: true };`,
-  (c) => `let foo = {${c}: true};`,
-  (c) => `let foo = {${c}:true};`,
-  (c) => `let foo = {
-    ${c}: true
-  };`,
-  (c) => `let foo = {
-    ${c}:true
-  };`,
-  (c) => `let foo = {
-    '${c}': true
-  };`,
-  (c) => `let foo = {
-    ['${c}']: true
-  };`,
-  (c) => `let foo = {
-    "${c}": true
-  };`,
-  (c) => `let foo = {
-    ["${c}"]: true
-  };`,
-  (c) => `let foo = potato\`${c}\``,
-  (c) => `let foo = potato\`salad ${c}\``,
-  (c) => `let foo = potato\`salad ${c} sandwich\``,
-  (c) => `let foo = potato\`${c} salad sandwich\``,
-  (c) => `document.body.classList.add(['${c}'].join(" "));`,
+        // With special characters
+        `<sm:${c}`,
+        `md:${c}`,
 
-  // JSX
-  (c) => `<div className="${c}"></div>`,
-  (c) => `<div className="${c} potato salad"></div>`,
-  (c) => `<div className="potato ${c} salad"></div>`,
-  (c) => `<div className="potato salad ${c}"></div>`,
-  (c) => `<div className={\`potato salad \$\{'${c}'\}\`}></div>`,
-  (c) => `<div className={\`potato salad \$\{"${c}"\}\`}></div>`,
-  (c) => `<div className={\`potato salad \$\{\`${c}\`\}\`}></div>`,
+        // With arbitrary values
+        `min-[300px]:${c}`,
 
-  // Vue
-  (c) => `<div :class="{ ${c}: condition }"></div>`,
-  (c) => `<div :class="{ '${c}': condition }"></div>`,
-  (c) => `<div :class="{ ['${c}']: condition }"></div>`,
-  (c) => `<div :class="{ "${c}": condition }"></div>`,
-  (c) => `<div :class="{ ["${c}"]: condition }"></div>`,
-  (c) => `<div :class="{${c}: condition}"></div>`,
-  (c) => `<div :class="{'${c}': condition}"></div>`,
-  (c) => `<div :class="{['${c}']: condition}"></div>`,
-  (c) => `<div :class="{"${c}": condition}"></div>`,
-  (c) => `<div :class="{["${c}"]: condition}"></div>`,
-  (c) => `<div :class="{${c}:condition}"></div>`,
-  (c) => `<div :class="{'${c}':condition}"></div>`,
-  (c) => `<div :class="{['${c}']:condition}"></div>`,
-  (c) => `<div :class="{"${c}":condition}"></div>`,
-  (c) => `<div :class="{["${c}"]:condition}"></div>`,
-  (c) => `<div :class="['${c}', 'potato']"></div>`,
-  (c) => `<div :class="['potato', '${c}']"></div>`,
-  (c) => `<div :class="['potato', '${c}', 'salad']"></div>`,
-]
+        // With arbitrary values
+        `[@media(hover:hover)]:${c}`,
+
+        // With parent selector
+        `[.foo_&]:${c}`,
+      ]
+    })
+  )
+
+  let classString = classes.join(' ')
+  let singleQuoteArraySyntax = `'${classes.join("', '")}'`
+
+  return [
+    ['Plain', classString],
+    ['HTML', html`<div class="${classString}"></div>`],
+
+    ['JavaScript variable', `let foo = "${classString}"`],
+    ['JavaScript expression', `document.body.classList.add(['${classString}'].join(' '))`],
+    ['JavaScript object key', `let foo = {'${classString}': true}`],
+
+    ['JSX basic', html`<div className="${classString}"></div>`],
+    ['JSX with JavaScript expression', html`<div className={"${classString}"}></div>`],
+
+    ['Vue basic', html`<div :class="${classString}"></div>`],
+    ['Vue array (single quote)', html`<div :class="[${singleQuoteArraySyntax}]"></div>`],
+    ['Vue object (single quote)', html`<div :class="{'${classString}': true}"></div>`],
+
+    ['Markdown code fences', `<!-- This should work \`${classString}\` -->`],
+  ]
+}
 
 describe.each([
   ['Regex', regexParser],
   ['Oxide', oxideParser],
 ])('%s parser', (_, parse) => {
-  test('basic utility classes', async () => {
-    let extractions = parse(`
-      <div class="text-center font-bold px-4 pointer-events-none"></div>
-    `)
+  describe('basic utility classes', () => {
+    let classes = [
+      // one word classes
+      'underline',
 
-    expect(extractions).toContain('text-center')
-    expect(extractions).toContain('font-bold')
-    expect(extractions).toContain('px-4')
-    expect(extractions).toContain('pointer-events-none')
+      // With dashes
+      'text-center',
+      'pointer-events-none',
+
+      // With numbers
+      'px-4',
+
+      // With floating numbers
+      'px-1.5',
+
+      // With halves
+      'translate-x-1/2',
+
+      // With negative signs
+      '-translate-x-full',
+
+      // With halves and negative signs
+      '-translate-x-1/2',
+    ]
+
+    test.each(templateTable(classes))('%# — %s', (_, template) => {
+      let extractions = parse(template)
+
+      for (let c of classes) {
+        expect(extractions).toContain(c)
+      }
+    })
   })
 
-  test('modifiers with basic utilities', async () => {
-    let extractions = parse(`
-      <div class="hover:text-center hover:focus:font-bold"></div>
-    `)
+  describe('utility classes with arbitrary values', () => {
+    let classes = [
+      // With simple number
+      'px-[0]',
+      'px-[0.5]',
 
-    expect(extractions).toContain('hover:text-center')
-    expect(extractions).toContain('hover:focus:font-bold')
+      // With number and unit
+      'px-[123px]',
+      'px-[123.45px]',
+
+      // With special symbols
+      'px-[#bada55]',
+      //   ^
+      'px-[color:#bada55]',
+      //        ^^
+      'content-[>]',
+      //        ^
+      'content-[<]',
+      //        ^
+
+      // With functions and math expressions
+      'px-[calc(100%-1rem)]',
+      'px-[theme(spacing.1)]',
+      'px-[theme(spacing[1.5])]',
+
+      // With spaces (replaced by `_`)
+      'bg-[rgb(255_0_0)]',
+
+      // Examples with combinations
+      'w-[calc(100%_-_theme("spacing[1.5]))"]',
+      'fill-[oklab(59.69%_0.1007_0.1191_/_0.5)]/[33.7%]',
+      'fill-[color:oklab(59.69%_0.1007_0.1191_/_0.5)]/[33.7%]',
+      'shadow-[inset_0_-3em_3em_rgba(0,_0,_0,_0.1),_0_0_0_2px_rgb(255,_255,_255),_0.3em_0.3em_1em_rgba(0,_0,_0,_0.3)]',
+    ]
+
+    test.each(templateTable(classes))('%# — %s', (_, template) => {
+      let extractions = parse(template)
+
+      for (let c of classes) {
+        expect(extractions).toContain(c)
+      }
+    })
   })
 
-  test('utilities with dot characters', async () => {
-    let extractions = parse(`
-      <div class="px-1.5 active:px-2.5 hover:focus:px-3.5"></div>
-    `)
+  describe('utility classes with modifiers', () => {
+    let classes = [
+      // With simple modifiers
+      'bg-red-500/50',
 
-    expect(extractions).toContain('px-1.5')
-    expect(extractions).toContain('active:px-2.5')
-    expect(extractions).toContain('hover:focus:px-3.5')
+      // With arbitrary modifiers
+      'bg-red-500/[0.5]',
+      'bg-red-500/[50%]',
+      'bg-red-500/[var(--opacity)]',
+
+      // With spces (replaced by `_`)
+      'bg-red-500/[var(--opacity,_50%)]',
+
+      // With important modifiers
+      '!bg-red-500',
+    ]
+
+    test.each(templateTable(classes))('%# — %s', (_, template) => {
+      let extractions = parse(template)
+
+      for (let c of classes) {
+        expect(extractions).toContain(c)
+      }
+    })
   })
 
-  test('basic utilities with color opacity modifier', async () => {
-    let extractions = parse(`
-      <div class="text-red-500/25 hover:text-red-500/50 hover:active:text-red-500/75"></div>
-    `)
+  describe('arbitrary properties', () => {
+    let classes = [
+      // With simple arbitrary property
+      '[display:flex]',
+    ]
 
-    expect(extractions).toContain('text-red-500/25')
-    expect(extractions).toContain('hover:text-red-500/50')
-    expect(extractions).toContain('hover:active:text-red-500/75')
+    test.each(templateTable(classes))('%# — %s', (_, template) => {
+      let extractions = parse(template)
+
+      for (let c of classes) {
+        expect(extractions).toContain(c)
+      }
+    })
   })
 
-  test('basic arbitrary values', async () => {
-    let extractions = parse(`
-    <div class="px-[25px] hover:px-[40rem] hover:focus:px-[23vh]"></div>
-  `)
-
-    expect(extractions).toContain('px-[25px]')
-    expect(extractions).toContain('hover:px-[40rem]')
-    expect(extractions).toContain('hover:focus:px-[23vh]')
-  })
-
-  test('arbitrary values with color opacity modifier', async () => {
-    let extractions = parse(`
-    <div class="text-[#bada55]/25 hover:text-[#bada55]/50 hover:active:text-[#bada55]/75"></div>
-  `)
-
-    expect(extractions).toContain('text-[#bada55]/25')
-    expect(extractions).toContain('hover:text-[#bada55]/50')
-    expect(extractions).toContain('hover:active:text-[#bada55]/75')
-  })
-
-  test('arbitrary values with spaces', async () => {
-    let extractions = parse(`
-      <div class="grid-cols-[1fr_200px_3fr] md:grid-cols-[2fr_100px_1fr] open:lg:grid-cols-[3fr_300px_1fr]"></div>
-    `)
-
-    expect(extractions).toContain('grid-cols-[1fr_200px_3fr]')
-    expect(extractions).toContain('md:grid-cols-[2fr_100px_1fr]')
-    expect(extractions).toContain('open:lg:grid-cols-[3fr_300px_1fr]')
-  })
-
-  test('arbitrary values with CSS variables', async () => {
-    let extractions = parse(`
-      <div class="fill-[var(--my-color)] hover:fill-[var(--my-color-2)] hover:focus:fill-[var(--my-color-3)]"></div>
-    `)
-
-    expect(extractions).toContain('fill-[var(--my-color)]')
-    expect(extractions).toContain('hover:fill-[var(--my-color-2)]')
-    expect(extractions).toContain('hover:focus:fill-[var(--my-color-3)]')
-  })
-
-  test('arbitrary values with type hints', async () => {
-    let extractions = parse(`
-      <div class="text-[color:var(--my-color)] hover:text-[color:var(--my-color-2)] hover:focus:text-[color:var(--my-color-3)]"></div>
-    `)
-
-    expect(extractions).toContain('text-[color:var(--my-color)]')
-    expect(extractions).toContain('hover:text-[color:var(--my-color-2)]')
-    expect(extractions).toContain('hover:focus:text-[color:var(--my-color-3)]')
-  })
-
-  test('arbitrary values with single quotes', async () => {
-    let extractions = parse(`
+  describe('arbitrary values with quotes', () => {
+    test('arbitrary values with single quotes', async () => {
+      let extractions = parse(`
       <div class="content-['hello_world'] hover:content-['hello_world_2'] hover:focus:content-['hello_world_3']"></div>
     `)
 
-    expect(extractions).toContain(`content-['hello_world']`)
-    expect(extractions).toContain(`hover:content-['hello_world_2']`)
-    expect(extractions).toContain(`hover:focus:content-['hello_world_3']`)
-  })
+      expect(extractions).toContain(`content-['hello_world']`)
+      expect(extractions).toContain(`hover:content-['hello_world_2']`)
+      expect(extractions).toContain(`hover:focus:content-['hello_world_3']`)
+    })
 
-  test('arbitrary values with double quotes', async () => {
-    let extractions = parse(`
+    test('arbitrary values with double quotes', async () => {
+      let extractions = parse(`
       <div class='content-["hello_world"] hover:content-["hello_world_2"] hover:focus:content-["hello_world_3"]'></div>
     `)
 
-    expect(extractions).toContain(`content-["hello_world"]`)
-    expect(extractions).toContain(`hover:content-["hello_world_2"]`)
-    expect(extractions).toContain(`hover:focus:content-["hello_world_3"]`)
-  })
+      expect(extractions).toContain(`content-["hello_world"]`)
+      expect(extractions).toContain(`hover:content-["hello_world_2"]`)
+      expect(extractions).toContain(`hover:focus:content-["hello_world_3"]`)
+    })
 
-  test('arbitrary values with some single quoted values', async () => {
-    let extractions = parse(`
+    test('arbitrary values with some single quoted values', async () => {
+      let extractions = parse(`
       <div class="font-['Open_Sans',_system-ui,_sans-serif] hover:font-['Proxima_Nova',_system-ui,_sans-serif] hover:focus:font-['Inter_var',_system-ui,_sans-serif]"></div>
     `)
 
-    expect(extractions).toContain(`font-['Open_Sans',_system-ui,_sans-serif]`)
-    expect(extractions).toContain(`hover:font-['Proxima_Nova',_system-ui,_sans-serif]`)
-    expect(extractions).toContain(`hover:focus:font-['Inter_var',_system-ui,_sans-serif]`)
-  })
+      expect(extractions).toContain(`font-['Open_Sans',_system-ui,_sans-serif]`)
+      expect(extractions).toContain(`hover:font-['Proxima_Nova',_system-ui,_sans-serif]`)
+      expect(extractions).toContain(`hover:focus:font-['Inter_var',_system-ui,_sans-serif]`)
+    })
 
-  test('arbitrary values with some double quoted values', async () => {
-    let extractions = parse(`
+    test('arbitrary values with some double quoted values', async () => {
+      let extractions = parse(`
       <div class='font-["Open_Sans",_system-ui,_sans-serif] hover:font-["Proxima_Nova",_system-ui,_sans-serif] hover:focus:font-["Inter_var",_system-ui,_sans-serif]'></div>
     `)
 
-    expect(extractions).toContain(`font-["Open_Sans",_system-ui,_sans-serif]`)
-    expect(extractions).toContain(`hover:font-["Proxima_Nova",_system-ui,_sans-serif]`)
-    expect(extractions).toContain(`hover:focus:font-["Inter_var",_system-ui,_sans-serif]`)
-  })
+      expect(extractions).toContain(`font-["Open_Sans",_system-ui,_sans-serif]`)
+      expect(extractions).toContain(`hover:font-["Proxima_Nova",_system-ui,_sans-serif]`)
+      expect(extractions).toContain(`hover:focus:font-["Inter_var",_system-ui,_sans-serif]`)
+    })
 
-  test('arbitrary values with escaped underscores', async () => {
-    let extractions = parse(`
+    test('arbitrary values with escaped underscores', async () => {
+      let extractions = parse(`
       <div class="content-['hello\\_world'] hover:content-['hello\\_world\\_2'] hover:focus:content-['hello\\_world\\_3']"></div>
     `)
 
-    expect(extractions).toContain(`content-['hello\\_world']`)
-    expect(extractions).toContain(`hover:content-['hello\\_world\\_2']`)
-    expect(extractions).toContain(`hover:focus:content-['hello\\_world\\_3']`)
-  })
+      expect(extractions).toContain(`content-['hello\\_world']`)
+      expect(extractions).toContain(`hover:content-['hello\\_world\\_2']`)
+      expect(extractions).toContain(`hover:focus:content-['hello\\_world\\_3']`)
+    })
 
-  test('basic utilities with arbitrary color opacity modifier', async () => {
-    let extractions = parse(`
-      <div class="text-red-500/[.25] hover:text-red-500/[.5] hover:active:text-red-500/[.75]"></div>
-    `)
-
-    expect(extractions).toContain('text-red-500/[.25]')
-    expect(extractions).toContain('hover:text-red-500/[.5]')
-    expect(extractions).toContain('hover:active:text-red-500/[.75]')
-  })
-
-  test('arbitrary values with arbitrary color opacity modifier', async () => {
-    let extractions = parse(`
-      <div class="text-[#bada55]/[.25] hover:text-[#bada55]/[.5] hover:active:text-[#bada55]/[.75]"></div>
-    `)
-
-    expect(extractions).toContain('text-[#bada55]/[.25]')
-    expect(extractions).toContain('hover:text-[#bada55]/[.5]')
-    expect(extractions).toContain('hover:active:text-[#bada55]/[.75]')
-  })
-
-  test('arbitrary values with angle brackets', async () => {
-    let extractions = parse(`
-      <div class="content-[>] hover:content-[<] hover:focus:content-[>]"></div>
-    `)
-
-    expect(extractions).toContain(`content-[>]`)
-    expect(extractions).toContain(`hover:content-[<]`)
-    expect(extractions).toContain(`hover:focus:content-[>]`)
-  })
-
-  test('arbitrary values with angle brackets in single quotes', async () => {
-    let extractions = parse(`
+    test('arbitrary values with angle brackets in single quotes', async () => {
+      let extractions = parse(`
       <div class="content-['>'] hover:content-['<'] hover:focus:content-['>']"></div>
     `)
 
-    expect(extractions).toContain(`content-['>']`)
-    expect(extractions).toContain(`hover:content-['<']`)
-    expect(extractions).toContain(`hover:focus:content-['>']`)
-  })
+      expect(extractions).toContain(`content-['>']`)
+      expect(extractions).toContain(`hover:content-['<']`)
+      expect(extractions).toContain(`hover:focus:content-['>']`)
+    })
 
-  test('arbitrary values with angle brackets in double quotes', async () => {
-    let extractions = parse(`
+    test('arbitrary values with angle brackets in double quotes', async () => {
+      let extractions = parse(`
       <div class="content-[">"] hover:content-["<"] hover:focus:content-[">"]"></div>
     `)
 
-    expect(extractions).toContain(`content-[">"]`)
-    expect(extractions).toContain(`hover:content-["<"]`)
-    expect(extractions).toContain(`hover:focus:content-[">"]`)
-  })
+      expect(extractions).toContain(`content-[">"]`)
+      expect(extractions).toContain(`hover:content-["<"]`)
+      expect(extractions).toContain(`hover:focus:content-[">"]`)
+    })
 
-  test('arbitrary values with theme lookup using quotes', () => {
-    let extractions = parse(`
+    test('arbitrary values with theme lookup using quotes', () => {
+      let extractions = parse(`
       <p class="[--y:theme('colors.blue.500')] [color:var(--y)]"></p>
     `)
 
-    expect(extractions).toContain(`[--y:theme('colors.blue.500')]`)
-    expect(extractions).toContain(`[color:var(--y)]`)
+      expect(extractions).toContain(`[--y:theme('colors.blue.500')]`)
+      expect(extractions).toContain(`[color:var(--y)]`)
+    })
   })
 
-  test.each([
-    ['w-[calc(100%_-_theme("spacing[1.5]))"]'],
-    ['fill-[oklab(59.69%_0.1007_0.1191_/_0.5)]/[33.7%]'],
-    ['fill-[color:oklab(59.69%_0.1007_0.1191_/_0.5)]/[33.7%]'],
-    [
-      'shadow-[inset_0_-3em_3em_rgba(0,_0,_0,_0.1),_0_0_0_2px_rgb(255,_255,_255),_0.3em_0.3em_1em_rgba(0,_0,_0,_0.3)]',
-    ],
-  ])('arbitrary values: %s', (c) => {
-    let extractions = parse(`<div class="${c}"></div>`)
-
-    expect(extractions).toContain(c)
-  })
-
-  test.skip('special characters', async () => {
+  test('special characters', async () => {
     let extractions = parse(`
       <div class="<sm:underline md>:font-bold"></div>
     `)
@@ -430,13 +281,13 @@ describe.each([
     expect(extractions).toContain(`md>:font-bold`)
   })
 
-  test.skip('with single quotes array within template literal', async () => {
+  test('with single quotes array within template literal', async () => {
     let extractions = parse(`<div class=\`\${['pr-1.5']}\`></div>`)
 
     expect(extractions).toContain('pr-1.5')
   })
 
-  test.skip('with double quotes array within template literal', async () => {
+  test('with double quotes array within template literal', async () => {
     let extractions = parse(`<div class=\`\${["pr-1.5"]}\`></div>`)
 
     expect(extractions).toContain('pr-1.5')
@@ -474,7 +325,7 @@ describe.each([
     expect(extractions).not.toContain('.font-normal')
   })
 
-  test.skip('classes in slim templates', async () => {
+  test('classes in slim templates', async () => {
     let extractions = parse(`
       p.bg-red-500.text-sm
         'This is a paragraph
@@ -516,21 +367,10 @@ describe.each([
     expect(extractions).toContain(`[display:inherit]`)
   })
 
-  test.each([
-    ['[--my-variable:var(--my-other-variable,var(--my-fallback,initial))]'],
-    [
-      '[box-shadow:inset_0_-3em_3em_rgba(0,_0,_0,_0.1),_0_0_0_2px_rgb(255,_255,_255),_0.3em_0.3em_1em_rgba(0,_0,_0,_0.3)]',
-    ],
-  ])('arbitrary properties with %s', (c) => {
-    let extractions = parse(`<div class="${c}">[foo]</div>`)
-
-    expect(extractions).toContain(c)
-  })
-
   describe('Vue', () => {
-    test.skip('Class object syntax', () => {
+    test('Class object syntax', () => {
       let extractions = parse(
-        `<div :class="{ underline: myCondition, 'font-bold': myCondition }">[foo]</div>`
+        `<Examples with combinations :class="{ underline: myCondition, 'font-bold': myCondition }">[foo]</div>`
       )
 
       expect(extractions).toContain(`underline`, `font-bold`)

--- a/tests/parse-candidate-strings.test.js
+++ b/tests/parse-candidate-strings.test.js
@@ -10,7 +10,7 @@ function regexParser(str) {
 function oxideParser(str) {
   return parseCandidateStrings(
     [{ content: str, extension: 'html' }],
-    IO.Sequential | Parsing.Sequential
+    IO.Sequential | Parsing.Parallel
   )
 }
 

--- a/tests/parse-candidate-strings.test.js
+++ b/tests/parse-candidate-strings.test.js
@@ -1,0 +1,523 @@
+import { parseCandidateStrings, IO, Parsing } from '@tailwindcss/oxide'
+import { defaultExtractor as createDefaultExtractor } from '../src/lib/defaultExtractor'
+
+let defaultExtractor = createDefaultExtractor({ tailwindConfig: { separator: ':' } })
+
+function regexParser(str) {
+  return defaultExtractor(str)
+}
+
+function oxideParser(str) {
+  return parseCandidateStrings(
+    [{ content: str, extension: 'html' }],
+    IO.Sequential | Parsing.Sequential
+  )
+}
+
+let classExamples = [
+  'underline',
+  'font-bold',
+  'z-0',
+  '-z-0',
+  'px-1.5',
+  '-px-1.5',
+  'translate-x-1/2',
+  '-translate-x-1/2',
+  'content-["hello"]',
+  "content-['hello']",
+  String.raw`content-["hello\_world"]`,
+  'bg-red-500/75',
+  'w-[100px]',
+  'w-[calc(100px*-1)]',
+  'w-[calc(100px_*_-1)]',
+  'w-[calc(100px-50%)]',
+  'w-[calc(100px_-_50%)]',
+  'w-[theme(spacing.1)]',
+  'w-[theme(spacing[1.5])]',
+  'w-[calc(100%-theme(spacing[1.5]))]',
+  'w-[calc(100%_-_theme(spacing[1.5]))]',
+  "w-[theme('spacing.1)']",
+  "w-[theme('spacing[1.5])']",
+  "w-[calc(100%-theme('spacing[1.5]))']",
+  "w-[calc(100%_-_theme('spacing[1.5]))']",
+  `w-[theme("spacing.1)"]`,
+  `w-[theme("spacing[1.5])"]`,
+  `w-[calc(100%-theme("spacing[1.5]))"]`,
+  `w-[calc(100%_-_theme("spacing[1.5]))"]`,
+  'bg-[#bada55]',
+  'bg-[#bada55]/50',
+  'bg-[#bada55]/[0.5]',
+  'bg-[color:#bada55]',
+  'bg-[color:#bada55]/50',
+  'bg-[color:#bada55]/[0.5]',
+  'bg-[color:#bada55]/[50%]',
+  'bg-[color:#bada55]/[33.7%]',
+  'bg-[var(--my-color)]',
+  'bg-[var(--my-color)]/50',
+  'bg-[var(--my-color)]/[50%]',
+  'bg-[var(--my-color)]/[33.7%]',
+  'bg-[--my-color]',
+  'bg-[--my-color]/50',
+  'bg-[--my-color]/[50%]',
+  'bg-[--my-color]/[33.7%]',
+  'fill-[rgb(13,24,35)]',
+  'fill-[rgb(13,24,35)]/50',
+  'fill-[rgb(13,24,35)]/[0.5]',
+  'fill-[rgb(13,24,35)]/[50%]',
+  'fill-[rgb(13,24,35)]/[33.7%]',
+  'fill-[rgb(13,_24,_35)]',
+  'fill-[rgb(13,_24,_35)]/50',
+  'fill-[rgb(13,_24,_35)]/[0.5]',
+  'fill-[rgb(13,_24,_35)]/[50%]',
+  'fill-[rgb(13,_24,_35)]/[33.7%]',
+  'fill-[oklab(59.69%_0.1007_0.1191_/_0.5)]',
+  'fill-[oklab(59.69%_0.1007_0.1191_/_0.5)]/50',
+  'fill-[oklab(59.69%_0.1007_0.1191_/_0.5)]/[0.5]',
+  'fill-[oklab(59.69%_0.1007_0.1191_/_0.5)]/[50%]',
+  'fill-[oklab(59.69%_0.1007_0.1191_/_0.5)]/[33.7%]',
+  'fill-[color:rgb(13,24,35)]',
+  'fill-[color:rgb(13,24,35)]/50',
+  'fill-[color:rgb(13,24,35)]/[0.5]',
+  'fill-[color:rgb(13,24,35)]/[50%]',
+  'fill-[color:rgb(13,24,35)]/[33.7%]',
+  'fill-[color:rgb(13,_24,_35)]',
+  'fill-[color:rgb(13,_24,_35)]/50',
+  'fill-[color:rgb(13,_24,_35)]/[0.5]',
+  'fill-[color:rgb(13,_24,_35)]/[50%]',
+  'fill-[color:rgb(13,_24,_35)]/[33.7%]',
+  'fill-[color:oklab(59.69%_0.1007_0.1191_/_0.5)]',
+  'fill-[color:oklab(59.69%_0.1007_0.1191_/_0.5)]/50',
+  'fill-[color:oklab(59.69%_0.1007_0.1191_/_0.5)]/[0.5]',
+  'fill-[color:oklab(59.69%_0.1007_0.1191_/_0.5)]/[50%]',
+  'fill-[color:oklab(59.69%_0.1007_0.1191_/_0.5)]/[33.7%]',
+  'shadow-[inset_0_-3em_3em_rgba(0,_0,_0,_0.1),_0_0_0_2px_rgb(255,_255,_255),_0.3em_0.3em_1em_rgba(0,_0,_0,_0.3)]',
+  '[background-color:red]',
+  '[background-color:#f00]',
+  '[background-color:rgb(255,0,0)]',
+  '[background-color:rgb(255,_0,_0)]',
+  '[box-shadow:inset_0_-3em_3em_rgba(0,_0,_0,_0.1),_0_0_0_2px_rgb(255,_255,_255),_0.3em_0.3em_1em_rgba(0,_0,_0,_0.3)]',
+  '[--my-variable:var(--my-other-variable)]',
+  '[--my-variable:var(--my-other-variable,initial)]',
+  '[--my-variable:var(--my-other-variable,var(--my-fallback))]',
+  '[--my-variable:var(--my-other-variable,var(--my-fallback,initial))]',
+]
+
+let variantExamples = [
+  'md',
+  'group-hover',
+  'data-[pressed]',
+  'min-[500px]',
+  'aria-[sort=descending]',
+  'aria-[sort="ascending"]',
+  'supports-[display:grid]',
+  'supports-[display:_flex]',
+  'supports-[display:_flex]',
+  'supports-[selector(A_>_B)]',
+  'supports-[selector(A>B)]',
+  'supports-[not_(foo:bar)]',
+  'supports-[not(foo:bar)]',
+  'supports-[(foo:bar)_or_(bar:baz)]',
+  'supports-[(foo:bar)or(bar:baz)]',
+  'supports-[(foo:bar)_and_(bar:baz)]',
+  'supports-[(foo:bar)and(bar:baz)]',
+  '@lg',
+  '@[618px]',
+  '[&:not(:active)]',
+  '[@media(hover:hover)]',
+  '[@media(any-hover:_hover)]',
+  '[@media_(pointer:_fine)]',
+]
+
+let templateExamples = [
+  // HTML
+  (c) => `<div class="${c}"></div>`,
+  (c) => `<div class="potato ${c} salad"></div>`,
+  (c) => `<div class="${c} potato salad"></div>`,
+  (c) => `<div class="potato salad ${c}"></div>`,
+
+  // Spaghetti JS
+  (c) => `let foo = "${c}"`,
+  (c) => `let foo = "${c}";`,
+  (c) => `let foo = '${c}'`,
+  (c) => `let foo = '${c}';`,
+  (c) => `let foo = \`${c}\``,
+  (c) => `let foo = \`${c}\`;`,
+  (c) => `let foo = ["${c}"]`,
+  (c) => `let foo = ["${c}"];`,
+  (c) => `let foo = ['${c}']`,
+  (c) => `let foo = ['${c}'];`,
+  (c) => `let foo = [\`${c}\`]`,
+  (c) => `let foo = [\`${c}\`];`,
+  (c) => `let foo = { ${c}: true };`,
+  (c) => `let foo = {${c}: true};`,
+  (c) => `let foo = {${c}:true};`,
+  (c) => `let foo = {
+    ${c}: true
+  };`,
+  (c) => `let foo = {
+    ${c}:true
+  };`,
+  (c) => `let foo = {
+    '${c}': true
+  };`,
+  (c) => `let foo = {
+    ['${c}']: true
+  };`,
+  (c) => `let foo = {
+    "${c}": true
+  };`,
+  (c) => `let foo = {
+    ["${c}"]: true
+  };`,
+  (c) => `let foo = potato\`${c}\``,
+  (c) => `let foo = potato\`salad ${c}\``,
+  (c) => `let foo = potato\`salad ${c} sandwich\``,
+  (c) => `let foo = potato\`${c} salad sandwich\``,
+  (c) => `document.body.classList.add(['${c}'].join(" "));`,
+
+  // JSX
+  (c) => `<div className="${c}"></div>`,
+  (c) => `<div className="${c} potato salad"></div>`,
+  (c) => `<div className="potato ${c} salad"></div>`,
+  (c) => `<div className="potato salad ${c}"></div>`,
+  (c) => `<div className={\`potato salad \$\{'${c}'\}\`}></div>`,
+  (c) => `<div className={\`potato salad \$\{"${c}"\}\`}></div>`,
+  (c) => `<div className={\`potato salad \$\{\`${c}\`\}\`}></div>`,
+
+  // Vue
+  (c) => `<div :class="{ ${c}: condition }"></div>`,
+  (c) => `<div :class="{ '${c}': condition }"></div>`,
+  (c) => `<div :class="{ ['${c}']: condition }"></div>`,
+  (c) => `<div :class="{ "${c}": condition }"></div>`,
+  (c) => `<div :class="{ ["${c}"]: condition }"></div>`,
+  (c) => `<div :class="{${c}: condition}"></div>`,
+  (c) => `<div :class="{'${c}': condition}"></div>`,
+  (c) => `<div :class="{['${c}']: condition}"></div>`,
+  (c) => `<div :class="{"${c}": condition}"></div>`,
+  (c) => `<div :class="{["${c}"]: condition}"></div>`,
+  (c) => `<div :class="{${c}:condition}"></div>`,
+  (c) => `<div :class="{'${c}':condition}"></div>`,
+  (c) => `<div :class="{['${c}']:condition}"></div>`,
+  (c) => `<div :class="{"${c}":condition}"></div>`,
+  (c) => `<div :class="{["${c}"]:condition}"></div>`,
+  (c) => `<div :class="['${c}', 'potato']"></div>`,
+  (c) => `<div :class="['potato', '${c}']"></div>`,
+  (c) => `<div :class="['potato', '${c}', 'salad']"></div>`,
+]
+
+describe.each([
+  ['Regex', regexParser],
+  ['Oxide', oxideParser],
+])('%s parser', (_, parse) => {
+  const defaultExtractor = parse
+  test('basic utility classes', async () => {
+    const extractions = parse(`
+      <div class="text-center font-bold px-4 pointer-events-none"></div>
+    `)
+
+    expect(extractions).toContain('text-center')
+    expect(extractions).toContain('font-bold')
+    expect(extractions).toContain('px-4')
+    expect(extractions).toContain('pointer-events-none')
+  })
+
+  test('modifiers with basic utilities', async () => {
+    const extractions = parse(`
+      <div class="hover:text-center hover:focus:font-bold"></div>
+    `)
+
+    expect(extractions).toContain('hover:text-center')
+    expect(extractions).toContain('hover:focus:font-bold')
+  })
+
+  test('utilities with dot characters', async () => {
+    const extractions = parse(`
+      <div class="px-1.5 active:px-2.5 hover:focus:px-3.5"></div>
+    `)
+
+    expect(extractions).toContain('px-1.5')
+    expect(extractions).toContain('active:px-2.5')
+    expect(extractions).toContain('hover:focus:px-3.5')
+  })
+
+  test('basic utilities with color opacity modifier', async () => {
+    const extractions = parse(`
+      <div class="text-red-500/25 hover:text-red-500/50 hover:active:text-red-500/75"></div>
+    `)
+
+    expect(extractions).toContain('text-red-500/25')
+    expect(extractions).toContain('hover:text-red-500/50')
+    expect(extractions).toContain('hover:active:text-red-500/75')
+  })
+
+  test('basic arbitrary values', async () => {
+    const extractions = parse(`
+    <div class="px-[25px] hover:px-[40rem] hover:focus:px-[23vh]"></div>
+  `)
+
+    expect(extractions).toContain('px-[25px]')
+    expect(extractions).toContain('hover:px-[40rem]')
+    expect(extractions).toContain('hover:focus:px-[23vh]')
+  })
+
+  test('arbitrary values with color opacity modifier', async () => {
+    const extractions = defaultExtractor(`
+    <div class="text-[#bada55]/25 hover:text-[#bada55]/50 hover:active:text-[#bada55]/75"></div>
+  `)
+
+    expect(extractions).toContain('text-[#bada55]/25')
+    expect(extractions).toContain('hover:text-[#bada55]/50')
+    expect(extractions).toContain('hover:active:text-[#bada55]/75')
+  })
+
+  test('arbitrary values with spaces', async () => {
+    const extractions = defaultExtractor(`
+      <div class="grid-cols-[1fr_200px_3fr] md:grid-cols-[2fr_100px_1fr] open:lg:grid-cols-[3fr_300px_1fr]"></div>
+    `)
+
+    expect(extractions).toContain('grid-cols-[1fr_200px_3fr]')
+    expect(extractions).toContain('md:grid-cols-[2fr_100px_1fr]')
+    expect(extractions).toContain('open:lg:grid-cols-[3fr_300px_1fr]')
+  })
+
+  test('arbitrary values with CSS variables', async () => {
+    const extractions = defaultExtractor(`
+      <div class="fill-[var(--my-color)] hover:fill-[var(--my-color-2)] hover:focus:fill-[var(--my-color-3)]"></div>
+    `)
+
+    expect(extractions).toContain('fill-[var(--my-color)]')
+    expect(extractions).toContain('hover:fill-[var(--my-color-2)]')
+    expect(extractions).toContain('hover:focus:fill-[var(--my-color-3)]')
+  })
+
+  test('arbitrary values with type hints', async () => {
+    const extractions = defaultExtractor(`
+      <div class="text-[color:var(--my-color)] hover:text-[color:var(--my-color-2)] hover:focus:text-[color:var(--my-color-3)]"></div>
+    `)
+
+    expect(extractions).toContain('text-[color:var(--my-color)]')
+    expect(extractions).toContain('hover:text-[color:var(--my-color-2)]')
+    expect(extractions).toContain('hover:focus:text-[color:var(--my-color-3)]')
+  })
+
+  test('arbitrary values with single quotes', async () => {
+    const extractions = defaultExtractor(`
+      <div class="content-['hello_world'] hover:content-['hello_world_2'] hover:focus:content-['hello_world_3']"></div>
+    `)
+
+    expect(extractions).toContain(`content-['hello_world']`)
+    expect(extractions).toContain(`hover:content-['hello_world_2']`)
+    expect(extractions).toContain(`hover:focus:content-['hello_world_3']`)
+  })
+
+  test('arbitrary values with double quotes', async () => {
+    const extractions = defaultExtractor(`
+      <div class='content-["hello_world"] hover:content-["hello_world_2"] hover:focus:content-["hello_world_3"]'></div>
+    `)
+
+    expect(extractions).toContain(`content-["hello_world"]`)
+    expect(extractions).toContain(`hover:content-["hello_world_2"]`)
+    expect(extractions).toContain(`hover:focus:content-["hello_world_3"]`)
+  })
+
+  test('arbitrary values with some single quoted values', async () => {
+    const extractions = defaultExtractor(`
+      <div class="font-['Open_Sans',_system-ui,_sans-serif] hover:font-['Proxima_Nova',_system-ui,_sans-serif] hover:focus:font-['Inter_var',_system-ui,_sans-serif]"></div>
+    `)
+
+    expect(extractions).toContain(`font-['Open_Sans',_system-ui,_sans-serif]`)
+    expect(extractions).toContain(`hover:font-['Proxima_Nova',_system-ui,_sans-serif]`)
+    expect(extractions).toContain(`hover:focus:font-['Inter_var',_system-ui,_sans-serif]`)
+  })
+
+  test('arbitrary values with some double quoted values', async () => {
+    const extractions = defaultExtractor(`
+      <div class='font-["Open_Sans",_system-ui,_sans-serif] hover:font-["Proxima_Nova",_system-ui,_sans-serif] hover:focus:font-["Inter_var",_system-ui,_sans-serif]'></div>
+    `)
+
+    expect(extractions).toContain(`font-["Open_Sans",_system-ui,_sans-serif]`)
+    expect(extractions).toContain(`hover:font-["Proxima_Nova",_system-ui,_sans-serif]`)
+    expect(extractions).toContain(`hover:focus:font-["Inter_var",_system-ui,_sans-serif]`)
+  })
+
+  test('arbitrary values with escaped underscores', async () => {
+    const extractions = defaultExtractor(`
+      <div class="content-['hello\\_world'] hover:content-['hello\\_world\\_2'] hover:focus:content-['hello\\_world\\_3']"></div>
+    `)
+
+    expect(extractions).toContain(`content-['hello\\_world']`)
+    expect(extractions).toContain(`hover:content-['hello\\_world\\_2']`)
+    expect(extractions).toContain(`hover:focus:content-['hello\\_world\\_3']`)
+  })
+
+  test('basic utilities with arbitrary color opacity modifier', async () => {
+    const extractions = defaultExtractor(`
+      <div class="text-red-500/[.25] hover:text-red-500/[.5] hover:active:text-red-500/[.75]"></div>
+    `)
+
+    expect(extractions).toContain('text-red-500/[.25]')
+    expect(extractions).toContain('hover:text-red-500/[.5]')
+    expect(extractions).toContain('hover:active:text-red-500/[.75]')
+  })
+
+  test('arbitrary values with arbitrary color opacity modifier', async () => {
+    const extractions = defaultExtractor(`
+      <div class="text-[#bada55]/[.25] hover:text-[#bada55]/[.5] hover:active:text-[#bada55]/[.75]"></div>
+    `)
+
+    expect(extractions).toContain('text-[#bada55]/[.25]')
+    expect(extractions).toContain('hover:text-[#bada55]/[.5]')
+    expect(extractions).toContain('hover:active:text-[#bada55]/[.75]')
+  })
+
+  test('arbitrary values with angle brackets', async () => {
+    const extractions = defaultExtractor(`
+      <div class="content-[>] hover:content-[<] hover:focus:content-[>]"></div>
+    `)
+
+    expect(extractions).toContain(`content-[>]`)
+    expect(extractions).toContain(`hover:content-[<]`)
+    expect(extractions).toContain(`hover:focus:content-[>]`)
+  })
+
+  test('arbitrary values with angle brackets in single quotes', async () => {
+    const extractions = defaultExtractor(`
+      <div class="content-['>'] hover:content-['<'] hover:focus:content-['>']"></div>
+    `)
+
+    expect(extractions).toContain(`content-['>']`)
+    expect(extractions).toContain(`hover:content-['<']`)
+    expect(extractions).toContain(`hover:focus:content-['>']`)
+  })
+
+  test('arbitrary values with angle brackets in double quotes', async () => {
+    const extractions = defaultExtractor(`
+      <div class="content-[">"] hover:content-["<"] hover:focus:content-[">"]"></div>
+    `)
+
+    expect(extractions).toContain(`content-[">"]`)
+    expect(extractions).toContain(`hover:content-["<"]`)
+    expect(extractions).toContain(`hover:focus:content-[">"]`)
+  })
+
+  test('arbitrary values with theme lookup using quotes', () => {
+    const extractions = defaultExtractor(`
+      <p class="[--y:theme('colors.blue.500')] [color:var(--y)]"></p>
+    `)
+
+    expect(extractions).toContain(`[--y:theme('colors.blue.500')]`)
+    expect(extractions).toContain(`[color:var(--y)]`)
+  })
+
+  test.skip('special characters', async () => {
+    const extractions = defaultExtractor(`
+      <div class="<sm:underline md>:font-bold"></div>
+    `)
+
+    expect(extractions).toContain(`<sm:underline`)
+    expect(extractions).toContain(`md>:font-bold`)
+  })
+
+  test.skip('with single quotes array within template literal', async () => {
+    const extractions = defaultExtractor(`<div class=\`\${['pr-1.5']}\`></div>`)
+
+    expect(extractions).toContain('pr-1.5')
+  })
+
+  test.skip('with double quotes array within template literal', async () => {
+    const extractions = defaultExtractor(`<div class=\`\${["pr-1.5"]}\`></div>`)
+
+    expect(extractions).toContain('pr-1.5')
+  })
+
+  test('with single quotes array within function', async () => {
+    const extractions = defaultExtractor(`document.body.classList.add(['pl-1.5'].join(" "));`)
+
+    expect(extractions).toContain('pl-1.5')
+  })
+
+  test('with double quotes array within function', async () => {
+    const extractions = defaultExtractor(`document.body.classList.add(["pl-1.5"].join(" "));`)
+
+    expect(extractions).toContain('pl-1.5')
+  })
+
+  test('with angle brackets', async () => {
+    const extractions = defaultExtractor(
+      `<div class="bg-blue-200 <% if (useShadow) { %>shadow-xl<% } %>">test</div>`
+    )
+
+    expect(extractions).toContain('bg-blue-200')
+    expect(extractions).toContain('shadow-xl')
+    expect(extractions).not.toContain('>shadow-xl')
+    expect(extractions).not.toContain('shadow-xl<')
+  })
+
+  test('markdown code fences', async () => {
+    const extractions = defaultExtractor('<!-- this should work: `.font-bold`, `.font-normal` -->')
+
+    expect(extractions).toContain('font-bold')
+    expect(extractions).toContain('font-normal')
+    expect(extractions).not.toContain('.font-bold')
+    expect(extractions).not.toContain('.font-normal')
+  })
+
+  test.skip('classes in slim templates', async () => {
+    const extractions = defaultExtractor(`
+      p.bg-red-500.text-sm
+        'This is a paragraph
+          small.italic.text-gray-500
+            '(Look mom, no closing tag!)
+    `)
+
+    expect(extractions).toContain('bg-red-500')
+    expect(extractions).toContain('text-sm')
+    expect(extractions).toContain('italic')
+    expect(extractions).toContain('text-gray-500')
+  })
+
+  test('multi-word + arbitrary values + quotes', async () => {
+    const extractions = defaultExtractor(`
+      grid-cols-['repeat(2)']
+    `)
+
+    expect(extractions).toContain(`grid-cols-['repeat(2)']`)
+  })
+
+  test('a lot of data', () => {
+    let extractions = defaultExtractor('underline '.repeat(2 ** 17))
+
+    expect(extractions).toContain(`underline`)
+  })
+
+  test('ruby percent string array', () => {
+    let extractions = defaultExtractor('%w[text-[#bada55]]')
+
+    expect(extractions).toContain(`text-[#bada55]`)
+  })
+
+  test('arbitrary properties followed by square bracketed stuff', () => {
+    let extractions = defaultExtractor(
+      '<div class="h-16 items-end border border-white [display:inherit]">[foo]</div>'
+    )
+
+    expect(extractions).toContain(`[display:inherit]`)
+  })
+
+  describe('Vue', () => {
+    test.skip('Class object syntax', () => {
+      let extractions = defaultExtractor(
+        `<div :class="{ underline: myCondition, 'font-bold': myCondition }">[foo]</div>`
+      )
+
+      expect(extractions).toContain(`underline`, `font-bold`)
+    })
+    test.skip('Class array syntax', () => {
+      let extractions = defaultExtractor(
+        `<div :class="['underline', myCondition && 'font-bold', myCondition ? 'flex' : 'block']">[foo]</div>`
+      )
+
+      expect(extractions).toContain(`underline`, `font-bold`, `flex`, `block`)
+    })
+  })
+})

--- a/tests/parse-candidate-strings.test.js
+++ b/tests/parse-candidate-strings.test.js
@@ -503,15 +503,16 @@ describe.each([
     expect(extractions).toContain(`[display:inherit]`)
   })
 
-  describe('Vue', () => {
-    test.skip('Class object syntax', () => {
+  describe.skip('Vue', () => {
+    test('Class object syntax', () => {
       let extractions = parse(
         `<div :class="{ underline: myCondition, 'font-bold': myCondition }">[foo]</div>`
       )
 
       expect(extractions).toContain(`underline`, `font-bold`)
     })
-    test.skip('Class array syntax', () => {
+
+    test('Class array syntax', () => {
       let extractions = parse(
         `<div :class="['underline', myCondition && 'font-bold', myCondition ? 'flex' : 'block']">[foo]</div>`
       )

--- a/tests/parse-candidate-strings.test.js
+++ b/tests/parse-candidate-strings.test.js
@@ -209,9 +209,8 @@ describe.each([
   ['Regex', regexParser],
   ['Oxide', oxideParser],
 ])('%s parser', (_, parse) => {
-  const defaultExtractor = parse
   test('basic utility classes', async () => {
-    const extractions = parse(`
+    let extractions = parse(`
       <div class="text-center font-bold px-4 pointer-events-none"></div>
     `)
 
@@ -222,7 +221,7 @@ describe.each([
   })
 
   test('modifiers with basic utilities', async () => {
-    const extractions = parse(`
+    let extractions = parse(`
       <div class="hover:text-center hover:focus:font-bold"></div>
     `)
 
@@ -231,7 +230,7 @@ describe.each([
   })
 
   test('utilities with dot characters', async () => {
-    const extractions = parse(`
+    let extractions = parse(`
       <div class="px-1.5 active:px-2.5 hover:focus:px-3.5"></div>
     `)
 
@@ -241,7 +240,7 @@ describe.each([
   })
 
   test('basic utilities with color opacity modifier', async () => {
-    const extractions = parse(`
+    let extractions = parse(`
       <div class="text-red-500/25 hover:text-red-500/50 hover:active:text-red-500/75"></div>
     `)
 
@@ -251,7 +250,7 @@ describe.each([
   })
 
   test('basic arbitrary values', async () => {
-    const extractions = parse(`
+    let extractions = parse(`
     <div class="px-[25px] hover:px-[40rem] hover:focus:px-[23vh]"></div>
   `)
 
@@ -261,7 +260,7 @@ describe.each([
   })
 
   test('arbitrary values with color opacity modifier', async () => {
-    const extractions = defaultExtractor(`
+    let extractions = parse(`
     <div class="text-[#bada55]/25 hover:text-[#bada55]/50 hover:active:text-[#bada55]/75"></div>
   `)
 
@@ -271,7 +270,7 @@ describe.each([
   })
 
   test('arbitrary values with spaces', async () => {
-    const extractions = defaultExtractor(`
+    let extractions = parse(`
       <div class="grid-cols-[1fr_200px_3fr] md:grid-cols-[2fr_100px_1fr] open:lg:grid-cols-[3fr_300px_1fr]"></div>
     `)
 
@@ -281,7 +280,7 @@ describe.each([
   })
 
   test('arbitrary values with CSS variables', async () => {
-    const extractions = defaultExtractor(`
+    let extractions = parse(`
       <div class="fill-[var(--my-color)] hover:fill-[var(--my-color-2)] hover:focus:fill-[var(--my-color-3)]"></div>
     `)
 
@@ -291,7 +290,7 @@ describe.each([
   })
 
   test('arbitrary values with type hints', async () => {
-    const extractions = defaultExtractor(`
+    let extractions = parse(`
       <div class="text-[color:var(--my-color)] hover:text-[color:var(--my-color-2)] hover:focus:text-[color:var(--my-color-3)]"></div>
     `)
 
@@ -301,7 +300,7 @@ describe.each([
   })
 
   test('arbitrary values with single quotes', async () => {
-    const extractions = defaultExtractor(`
+    let extractions = parse(`
       <div class="content-['hello_world'] hover:content-['hello_world_2'] hover:focus:content-['hello_world_3']"></div>
     `)
 
@@ -311,7 +310,7 @@ describe.each([
   })
 
   test('arbitrary values with double quotes', async () => {
-    const extractions = defaultExtractor(`
+    let extractions = parse(`
       <div class='content-["hello_world"] hover:content-["hello_world_2"] hover:focus:content-["hello_world_3"]'></div>
     `)
 
@@ -321,7 +320,7 @@ describe.each([
   })
 
   test('arbitrary values with some single quoted values', async () => {
-    const extractions = defaultExtractor(`
+    let extractions = parse(`
       <div class="font-['Open_Sans',_system-ui,_sans-serif] hover:font-['Proxima_Nova',_system-ui,_sans-serif] hover:focus:font-['Inter_var',_system-ui,_sans-serif]"></div>
     `)
 
@@ -331,7 +330,7 @@ describe.each([
   })
 
   test('arbitrary values with some double quoted values', async () => {
-    const extractions = defaultExtractor(`
+    let extractions = parse(`
       <div class='font-["Open_Sans",_system-ui,_sans-serif] hover:font-["Proxima_Nova",_system-ui,_sans-serif] hover:focus:font-["Inter_var",_system-ui,_sans-serif]'></div>
     `)
 
@@ -341,7 +340,7 @@ describe.each([
   })
 
   test('arbitrary values with escaped underscores', async () => {
-    const extractions = defaultExtractor(`
+    let extractions = parse(`
       <div class="content-['hello\\_world'] hover:content-['hello\\_world\\_2'] hover:focus:content-['hello\\_world\\_3']"></div>
     `)
 
@@ -351,7 +350,7 @@ describe.each([
   })
 
   test('basic utilities with arbitrary color opacity modifier', async () => {
-    const extractions = defaultExtractor(`
+    let extractions = parse(`
       <div class="text-red-500/[.25] hover:text-red-500/[.5] hover:active:text-red-500/[.75]"></div>
     `)
 
@@ -361,7 +360,7 @@ describe.each([
   })
 
   test('arbitrary values with arbitrary color opacity modifier', async () => {
-    const extractions = defaultExtractor(`
+    let extractions = parse(`
       <div class="text-[#bada55]/[.25] hover:text-[#bada55]/[.5] hover:active:text-[#bada55]/[.75]"></div>
     `)
 
@@ -371,7 +370,7 @@ describe.each([
   })
 
   test('arbitrary values with angle brackets', async () => {
-    const extractions = defaultExtractor(`
+    let extractions = parse(`
       <div class="content-[>] hover:content-[<] hover:focus:content-[>]"></div>
     `)
 
@@ -381,7 +380,7 @@ describe.each([
   })
 
   test('arbitrary values with angle brackets in single quotes', async () => {
-    const extractions = defaultExtractor(`
+    let extractions = parse(`
       <div class="content-['>'] hover:content-['<'] hover:focus:content-['>']"></div>
     `)
 
@@ -391,7 +390,7 @@ describe.each([
   })
 
   test('arbitrary values with angle brackets in double quotes', async () => {
-    const extractions = defaultExtractor(`
+    let extractions = parse(`
       <div class="content-[">"] hover:content-["<"] hover:focus:content-[">"]"></div>
     `)
 
@@ -401,7 +400,7 @@ describe.each([
   })
 
   test('arbitrary values with theme lookup using quotes', () => {
-    const extractions = defaultExtractor(`
+    let extractions = parse(`
       <p class="[--y:theme('colors.blue.500')] [color:var(--y)]"></p>
     `)
 
@@ -410,7 +409,7 @@ describe.each([
   })
 
   test.skip('special characters', async () => {
-    const extractions = defaultExtractor(`
+    let extractions = parse(`
       <div class="<sm:underline md>:font-bold"></div>
     `)
 
@@ -419,31 +418,31 @@ describe.each([
   })
 
   test.skip('with single quotes array within template literal', async () => {
-    const extractions = defaultExtractor(`<div class=\`\${['pr-1.5']}\`></div>`)
+    let extractions = parse(`<div class=\`\${['pr-1.5']}\`></div>`)
 
     expect(extractions).toContain('pr-1.5')
   })
 
   test.skip('with double quotes array within template literal', async () => {
-    const extractions = defaultExtractor(`<div class=\`\${["pr-1.5"]}\`></div>`)
+    let extractions = parse(`<div class=\`\${["pr-1.5"]}\`></div>`)
 
     expect(extractions).toContain('pr-1.5')
   })
 
   test('with single quotes array within function', async () => {
-    const extractions = defaultExtractor(`document.body.classList.add(['pl-1.5'].join(" "));`)
+    let extractions = parse(`document.body.classList.add(['pl-1.5'].join(" "));`)
 
     expect(extractions).toContain('pl-1.5')
   })
 
   test('with double quotes array within function', async () => {
-    const extractions = defaultExtractor(`document.body.classList.add(["pl-1.5"].join(" "));`)
+    let extractions = parse(`document.body.classList.add(["pl-1.5"].join(" "));`)
 
     expect(extractions).toContain('pl-1.5')
   })
 
   test('with angle brackets', async () => {
-    const extractions = defaultExtractor(
+    let extractions = parse(
       `<div class="bg-blue-200 <% if (useShadow) { %>shadow-xl<% } %>">test</div>`
     )
 
@@ -454,7 +453,7 @@ describe.each([
   })
 
   test('markdown code fences', async () => {
-    const extractions = defaultExtractor('<!-- this should work: `.font-bold`, `.font-normal` -->')
+    let extractions = parse('<!-- this should work: `.font-bold`, `.font-normal` -->')
 
     expect(extractions).toContain('font-bold')
     expect(extractions).toContain('font-normal')
@@ -463,7 +462,7 @@ describe.each([
   })
 
   test.skip('classes in slim templates', async () => {
-    const extractions = defaultExtractor(`
+    let extractions = parse(`
       p.bg-red-500.text-sm
         'This is a paragraph
           small.italic.text-gray-500
@@ -477,7 +476,7 @@ describe.each([
   })
 
   test('multi-word + arbitrary values + quotes', async () => {
-    const extractions = defaultExtractor(`
+    let extractions = parse(`
       grid-cols-['repeat(2)']
     `)
 
@@ -485,19 +484,19 @@ describe.each([
   })
 
   test('a lot of data', () => {
-    let extractions = defaultExtractor('underline '.repeat(2 ** 17))
+    let extractions = parse('underline '.repeat(2 ** 17))
 
     expect(extractions).toContain(`underline`)
   })
 
   test('ruby percent string array', () => {
-    let extractions = defaultExtractor('%w[text-[#bada55]]')
+    let extractions = parse('%w[text-[#bada55]]')
 
     expect(extractions).toContain(`text-[#bada55]`)
   })
 
   test('arbitrary properties followed by square bracketed stuff', () => {
-    let extractions = defaultExtractor(
+    let extractions = parse(
       '<div class="h-16 items-end border border-white [display:inherit]">[foo]</div>'
     )
 
@@ -506,14 +505,14 @@ describe.each([
 
   describe('Vue', () => {
     test.skip('Class object syntax', () => {
-      let extractions = defaultExtractor(
+      let extractions = parse(
         `<div :class="{ underline: myCondition, 'font-bold': myCondition }">[foo]</div>`
       )
 
       expect(extractions).toContain(`underline`, `font-bold`)
     })
     test.skip('Class array syntax', () => {
-      let extractions = defaultExtractor(
+      let extractions = parse(
         `<div :class="['underline', myCondition && 'font-bold', myCondition ? 'flex' : 'block']">[foo]</div>`
       )
 

--- a/tests/parse-candidate-strings.test.js
+++ b/tests/parse-candidate-strings.test.js
@@ -32,7 +32,7 @@ function templateTable(classes) {
 
         // With special characters
         `<sm:${c}`,
-        `md:${c}`,
+        `md>:${c}`,
 
         // With arbitrary values
         `min-[300px]:${c}`,

--- a/tests/parse-candidate-strings.test.js
+++ b/tests/parse-candidate-strings.test.js
@@ -405,9 +405,12 @@ describe.each([
     it('should not parse candidates without spaces in object-like syntax', () => {
       let extractions = parse(html`<div class="{underline:isActive,flex:isOnline,md:bold}"></div>`)
 
-      expect(extractions).not.toContain(`underline:isActive`)
-      expect(extractions).not.toContain(`flex:isOnline`)
-      expect(extractions).not.toContain(`md:bold`)
+      // The oxide parser _does_ allow this!
+      if (parse !== oxideParser) {
+        expect(extractions).not.toContain(`underline:isActive`)
+        expect(extractions).not.toContain(`flex:isOnline`)
+        expect(extractions).not.toContain(`md:bold`)
+      }
 
       expect(extractions).not.toContain(`underline`)
       expect(extractions).not.toContain(`isActive`)

--- a/tests/parse-candidate-strings.test.js
+++ b/tests/parse-candidate-strings.test.js
@@ -400,4 +400,21 @@ describe.each([
       expect(extractions).toContain(`underline`, `font-bold`, `flex`, `block`)
     })
   })
+
+  describe('anti-test', () => {
+    it('should not parse candidates without spaces in object-like syntax', () => {
+      let extractions = parse(html`<div class="{underline:isActive,flex:isOnline,md:bold}"></div>`)
+
+      expect(extractions).not.toContain(`underline:isActive`)
+      expect(extractions).not.toContain(`flex:isOnline`)
+      expect(extractions).not.toContain(`md:bold`)
+
+      expect(extractions).not.toContain(`underline`)
+      expect(extractions).not.toContain(`isActive`)
+      expect(extractions).not.toContain(`flex`)
+      expect(extractions).not.toContain(`isOnline`)
+      expect(extractions).not.toContain(`md`)
+      expect(extractions).not.toContain(`bold`)
+    })
+  })
 })

--- a/tests/parse-candidate-strings.test.js
+++ b/tests/parse-candidate-strings.test.js
@@ -74,7 +74,7 @@ describe.each([
 ])('%s parser', (_, parse) => {
   describe('basic utility classes', () => {
     let classes = [
-      // one word classes
+      // One word classes
       'underline',
 
       // With dashes
@@ -161,10 +161,19 @@ describe.each([
 
       // With spces (replaced by `_`)
       'bg-red-500/[var(--opacity,_50%)]',
-
-      // With important modifiers
-      '!bg-red-500',
     ]
+
+    test.each(templateTable(classes))('%# — %s', (_, template, classes) => {
+      let extractions = parse(template)
+
+      for (let c of classes) {
+        expect(extractions).toContain(c)
+      }
+    })
+  })
+
+  describe('utility classes with important modifier', () => {
+    let classes = ['!bg-red-500', '!bg-[#bada55]', '![display:flex]', '!-translate-x-1/2']
 
     test.each(templateTable(classes))('%# — %s', (_, template, classes) => {
       let extractions = parse(template)

--- a/tests/parse-candidate-strings.test.js
+++ b/tests/parse-candidate-strings.test.js
@@ -408,6 +408,19 @@ describe.each([
     expect(extractions).toContain(`[color:var(--y)]`)
   })
 
+  test.each([
+    ['w-[calc(100%_-_theme("spacing[1.5]))"]'],
+    ['fill-[oklab(59.69%_0.1007_0.1191_/_0.5)]/[33.7%]'],
+    ['fill-[color:oklab(59.69%_0.1007_0.1191_/_0.5)]/[33.7%]'],
+    [
+      'shadow-[inset_0_-3em_3em_rgba(0,_0,_0,_0.1),_0_0_0_2px_rgb(255,_255,_255),_0.3em_0.3em_1em_rgba(0,_0,_0,_0.3)]',
+    ],
+  ])('arbitrary values: %s', (c) => {
+    let extractions = parse(`<div class="${c}"></div>`)
+
+    expect(extractions).toContain(c)
+  })
+
   test.skip('special characters', async () => {
     let extractions = parse(`
       <div class="<sm:underline md>:font-bold"></div>
@@ -501,6 +514,17 @@ describe.each([
     )
 
     expect(extractions).toContain(`[display:inherit]`)
+  })
+
+  test.each([
+    ['[--my-variable:var(--my-other-variable,var(--my-fallback,initial))]'],
+    [
+      '[box-shadow:inset_0_-3em_3em_rgba(0,_0,_0,_0.1),_0_0_0_2px_rgb(255,_255,_255),_0.3em_0.3em_1em_rgba(0,_0,_0,_0.3)]',
+    ],
+  ])('arbitrary properties with %s', (c) => {
+    let extractions = parse(`<div class="${c}">[foo]</div>`)
+
+    expect(extractions).toContain(c)
   })
 
   describe.skip('Vue', () => {


### PR DESCRIPTION
This PR ensures that the Rust based parser now extracts all the expected candidates that the RegEx based parser also extracts.

This will allow us to eventually switch to the Rust based parser by default.

There are a few caveats:

1. If a custom `transformer` or `extractor` is required for a file, then the RegEx based parser will be used for that file.
2. If a custom `separator` or `prefix` is used, then we fallback to the RegEx based parser.

