### PR TITLE
Simplify browserslist setup by relying on `defaults`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `svh`, `lvh`, and `dvh` values to default `height`/`min-height`/`max-height` theme ([#11317](https://github.com/tailwindlabs/tailwindcss/pull/11317))
 - Add `has-*` variants for `:has(...)` pseudo-class ([#11318](https://github.com/tailwindlabs/tailwindcss/pull/11318))
 - Add `text-wrap` utilities including `text-balance` ([#11320](https://github.com/tailwindlabs/tailwindcss/pull/11320))
-- Explicitly configure Lightning CSS features, and prefer user browserslist over default browserslist ([#11402](https://github.com/tailwindlabs/tailwindcss/pull/11402))
+- Explicitly configure Lightning CSS features, and prefer user browserslist over default browserslist ([#11402](https://github.com/tailwindlabs/tailwindcss/pull/11402), [#11412](https://github.com/tailwindlabs/tailwindcss/pull/11412))
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5847,9 +5847,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001495",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001495.tgz",
-      "integrity": "sha512-F6x5IEuigtUfU5ZMQK2jsy5JqUUlEFRVZq8bO2a+ysq5K7jD6PPc9YXZj78xDNS3uNchesp1Jw47YXEqr+Viyg==",
+      "version": "1.0.30001502",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001502.tgz",
+      "integrity": "sha512-AZ+9tFXw1sS0o0jcpJQIXvFTOB/xGiQ4OQ2t98QX3NDn2EZTSRBC801gxrsGgViuq2ak/NLkNgSNEPtCr5lfKg==",
       "funding": [
         {
           "type": "opencollective",
@@ -20141,9 +20141,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001495",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001495.tgz",
-      "integrity": "sha512-F6x5IEuigtUfU5ZMQK2jsy5JqUUlEFRVZq8bO2a+ysq5K7jD6PPc9YXZj78xDNS3uNchesp1Jw47YXEqr+Viyg=="
+      "version": "1.0.30001502",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001502.tgz",
+      "integrity": "sha512-AZ+9tFXw1sS0o0jcpJQIXvFTOB/xGiQ4OQ2t98QX3NDn2EZTSRBC801gxrsGgViuq2ak/NLkNgSNEPtCr5lfKg=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -30527,9 +30527,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001495",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001495.tgz",
-          "integrity": "sha512-F6x5IEuigtUfU5ZMQK2jsy5JqUUlEFRVZq8bO2a+ysq5K7jD6PPc9YXZj78xDNS3uNchesp1Jw47YXEqr+Viyg=="
+          "version": "1.0.30001502",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001502.tgz",
+          "integrity": "sha512-AZ+9tFXw1sS0o0jcpJQIXvFTOB/xGiQ4OQ2t98QX3NDn2EZTSRBC801gxrsGgViuq2ak/NLkNgSNEPtCr5lfKg=="
         },
         "chalk": {
           "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -87,8 +87,7 @@
     "sucrase": "^3.32.0"
   },
   "browserslist": [
-    "chrome >= 103",
-    "firefox >= 102",
+    "defaults and supports css-variables and supports css-matches-pseudo",
     "safari >= 14"
   ],
   "jest": {

--- a/src/cli/build/plugin.js
+++ b/src/cli/build/plugin.js
@@ -28,22 +28,11 @@ import { flagEnabled } from '../../featureFlags'
 
 async function lightningcss(result, { map = true, minify = true } = {}) {
   try {
-    let includeFeatures = Features.Nesting
-    let excludeFeatures = 0
-
     let resolvedBrowsersListConfig = browserslist.findConfig(
       result.opts.from ?? process.cwd()
     )?.defaults
     let defaultBrowsersListConfig = pkg.browserslist
     let browsersListConfig = resolvedBrowsersListConfig ?? defaultBrowsersListConfig
-
-    if (browsersListConfig.join(',') === defaultBrowsersListConfig.join(',')) {
-      includeFeatures |=
-        Features.ColorFunction | Features.OklabColors | Features.LabColors | Features.P3Colors
-
-      excludeFeatures |=
-        Features.HexAlphaColors | Features.LogicalProperties | Features.SpaceSeparatedColorNotation
-    }
 
     let transformed = lightning.transform({
       filename: result.opts.from || 'input.css',
@@ -55,8 +44,8 @@ async function lightningcss(result, { map = true, minify = true } = {}) {
       drafts: {
         nesting: true,
       },
-      include: includeFeatures,
-      exclude: excludeFeatures,
+      include: Features.Nesting,
+      exclude: Features.LogicalProperties,
     })
 
     return Object.assign(result, {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -49,24 +49,11 @@ module.exports = function tailwindcss(configOrPath) {
         let intermediateMap = intermediateResult.map?.toJSON?.() ?? map
 
         try {
-          let includeFeatures = Features.Nesting
-          let excludeFeatures = 0
-
           let resolvedBrowsersListConfig = browserslist.findConfig(
             result.opts.from ?? process.cwd()
           )?.defaults
           let defaultBrowsersListConfig = require('../package.json').browserslist
           let browsersListConfig = resolvedBrowsersListConfig ?? defaultBrowsersListConfig
-
-          if (browsersListConfig.join(',') === defaultBrowsersListConfig.join(',')) {
-            includeFeatures |=
-              Features.ColorFunction | Features.OklabColors | Features.LabColors | Features.P3Colors
-
-            excludeFeatures |=
-              Features.HexAlphaColors |
-              Features.LogicalProperties |
-              Features.SpaceSeparatedColorNotation
-          }
 
           let transformed = lightningcss.transform({
             filename: result.opts.from,
@@ -81,8 +68,8 @@ module.exports = function tailwindcss(configOrPath) {
             nonStandard: {
               deepSelectorCombinator: true,
             },
-            include: includeFeatures,
-            exclude: excludeFeatures,
+            include: Features.Nesting,
+            exclude: Features.LogicalProperties,
           })
 
           let code = transformed.code.toString()

--- a/tests/variants.test.css
+++ b/tests/variants.test.css
@@ -157,7 +157,9 @@
 .marker\:flex::marker {
   display: flex;
 }
-.selection\:flex ::selection,
+.selection\:flex ::selection {
+  display: flex;
+}
 .selection\:flex::selection {
   display: flex;
 }


### PR DESCRIPTION
This PR simplifies the browserslist setup we introduced last week.

Now we will just rely on `defaults` and `:is()` + `custom properties` support from browserslist. The explicit `:is` and `custom properties` features are important because those are needed to make Tailwind work in general.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
