### PR TITLE
Ensure CI jobs don't run for longer than 15 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       matrix:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     strategy:
       matrix:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -18,6 +18,7 @@ jobs:
       contents: write # for softprops/action-gh-release to create GitHub release
 
     runs-on: macos-11
+    timeout-minutes: 15
 
     strategy:
       matrix:

--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -26,6 +26,7 @@ jobs:
 
     name: Build ${{ matrix.target }} (OXIDE)
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -97,6 +97,7 @@ jobs:
   build-apple-silicon:
     name: Build Apple Silicon (OXIDE)
     runs-on: macos-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
 
@@ -187,6 +188,7 @@ jobs:
 
     name: Build ${{ matrix.target }} (OXIDE)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     container:
       image: ${{ matrix.image }}
 
@@ -263,6 +265,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     name: Build and release
     needs:
       - build
@@ -354,6 +357,7 @@ jobs:
 
   tailwind-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     name: Build and release Tailwind CSS
 
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
 
     name: Build ${{ matrix.target }} (OXIDE)
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
 
@@ -98,6 +99,7 @@ jobs:
   build-apple-silicon:
     name: Build Apple Silicon (OXIDE)
     runs-on: macos-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
 
@@ -188,6 +190,7 @@ jobs:
 
     name: Build ${{ matrix.target }} (OXIDE)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     container:
       image: ${{ matrix.image }}
 
@@ -264,6 +267,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     name: Build and release
     needs:
       - build
@@ -355,6 +359,7 @@ jobs:
 
   tailwind-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     name: Build and release Tailwind CSS
 
     needs:


### PR DESCRIPTION
This prevents long unwanted gh action runs!

<img width="274" alt="Screenshot 2023-06-26 at 21 56 23" src="https://github.com/tailwindlabs/tailwindcss/assets/124286495/df32d5f8-a4eb-41fe-9d4f-61a4b4d5d52c">

This one is still running:
https://github.com/tailwindlabs/tailwindcss/actions/runs/5374805685/jobs/9750589528

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
