### PR TITLE
Sort classes using position of first matching rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fallback to RegEx based parser when using custom transformers or extractors ([#11335](https://github.com/tailwindlabs/tailwindcss/pull/11335))
 - Move unknown pseudo-elements outside of `:is` by default ([#11345](https://github.com/tailwindlabs/tailwindcss/pull/11345))
 - Escape animation names when prefixes contain special characters ([#11470](https://github.com/tailwindlabs/tailwindcss/pull/11470))
+- Sort classes using position of first matching rule ([#11504](https://github.com/tailwindlabs/tailwindcss/pull/11504))
 
 ### Added
 

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -944,7 +944,9 @@ function registerPlugins(plugins, context) {
     for (const [, rule] of rules) {
       let candidate = rule.raws.tailwind.candidate
 
-      sortedClassNames.set(candidate, idx++)
+      // When multiple rules match a candidate
+      // always take the position of the first one
+      sortedClassNames.set(candidate, sortedClassNames.get(candidate) ?? idx++)
     }
 
     return classes.map((className) => {

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -942,7 +942,9 @@ function registerPlugins(plugins, context) {
     let idx = BigInt(parasiteUtilities.length)
 
     for (const [, rule] of rules) {
-      sortedClassNames.set(rule.raws.tailwind.candidate, idx++)
+      let candidate = rule.raws.tailwind.candidate
+
+      sortedClassNames.set(candidate, idx++)
     }
 
     return classes.map((className) => {

--- a/tests/getSortOrder.test.js
+++ b/tests/getSortOrder.test.js
@@ -162,7 +162,7 @@ it('sorts based on first occurence of a candidate / rule', () => {
           // position for `foo` so we should use it
           '.bar .foo': { display: 'block' },
         })
-      }
+      },
     ],
   }
 

--- a/tests/getSortOrder.test.js
+++ b/tests/getSortOrder.test.js
@@ -140,3 +140,42 @@ it('sorts classes deterministically across multiple class lists', () => {
     expect(defaultSort(context.getClassOrder(input.split(' ')))).toEqual(output)
   }
 })
+
+it('sorts based on first occurence of a candidate / rule', () => {
+  let classes = [
+    ['foo-1 foo', 'foo foo-1'],
+    ['bar', 'bar'],
+    ['foo-1 foo', 'foo foo-1'],
+  ]
+
+  let config = {
+    theme: {},
+    plugins: [
+      function ({ addComponents }) {
+        addComponents({
+          '.foo': { display: 'block' },
+          '.foo-1': { display: 'block' },
+          '.foo-2': { display: 'block' },
+          '.bar': { display: 'block' },
+
+          // This rule matches both the candidate `foo` and `bar`
+          // But when sorting `foo` — we've already got a
+          // position for `foo` so we should use it
+          '.bar .foo': { display: 'block' },
+        })
+      }
+    ],
+  }
+
+  // Same context, different class lists
+  let context = createContext(resolveConfig(config))
+  for (const [input, output] of classes) {
+    expect(defaultSort(context.getClassOrder(input.split(' ')))).toEqual(output)
+  }
+
+  // Different context, different class lists
+  for (const [input, output] of classes) {
+    context = createContext(resolveConfig(config))
+    expect(defaultSort(context.getClassOrder(input.split(' ')))).toEqual(output)
+  }
+})

--- a/tests/getSortOrder.test.js
+++ b/tests/getSortOrder.test.js
@@ -155,7 +155,6 @@ it('sorts based on first occurence of a candidate / rule', () => {
         addComponents({
           '.foo': { display: 'block' },
           '.foo-1': { display: 'block' },
-          '.foo-2': { display: 'block' },
           '.bar': { display: 'block' },
 
           // This rule matches both the candidate `foo` and `bar`


### PR DESCRIPTION
Fixes https://github.com/tailwindlabs/prettier-plugin-tailwindcss/issues/174

Given a list of components like this:
```js
addComponents({
  '.foo': { display: 'block' },
  '.foo-1': { display: 'block' },
  '.bar': { display: 'block' },

  // This rule matches both the utility `foo` and `bar`
  // But when sorting `foo` — we've already got a
  // position for `foo` so we should use it
  '.bar .foo': { display: 'block' },
})
```

Note that the last rule matches both the utilities `foo` and `bar`.

When sorting lists of classes we would iterate over all generated rules. Given that last rule matches both `foo` and `bar` it would win for any instance of `foo` used. This means that the utility `foo` would have a much "later" position than expected. For example, `foo-1 foo` would be sorted and stay as-is instead of becoming the expected `foo foo-1`.

Now, given that we cache rules, the internal utility we used to match against them could be overwritten. As such, once you used `bar` the utility was permanently changed and no longer matched the utility `foo` causing the sort order to change for any list of classes _after_ the one that used the utility `bar`.

All that to say, given this HTML:

We would see the following HTML file as having sorted classes:
```html
<span class="foo-1 foo"></span>
<span class="bar"></span>
<span class="foo foo-2"></span>
```

When in reality it should be this:
```html
<span class="foo foo-1"></span>
<span class="bar"></span>
<span class="foo foo-2"></span>
```