### PR TITLE
Add `inverted-colors` variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- _Experimental_: Add `inverted-colors` variant ([#11693](https://github.com/tailwindlabs/tailwindcss/pull/11693))
 - _Experimental_: Add `user-valid` and `user-invalid` variants ([#12370](https://github.com/tailwindlabs/tailwindcss/pull/12370))
 - _Experimental_: Add `wrap-anywhere`, `wrap-break-word`, and `wrap-normal` utilities ([#12128](https://github.com/tailwindlabs/tailwindcss/pull/12128))
 

--- a/packages/tailwindcss/src/__snapshots__/intellisense.test.ts.snap
+++ b/packages/tailwindcss/src/__snapshots__/intellisense.test.ts.snap
@@ -8448,6 +8448,7 @@ exports[`getVariants 1`] = `
       "dark",
       "print",
       "forced-colors",
+      "inverted-colors",
     ],
   },
   {
@@ -9166,6 +9167,13 @@ exports[`getVariants 1`] = `
     "hasDash": true,
     "isArbitrary": false,
     "name": "forced-colors",
+    "selectors": [Function],
+    "values": [],
+  },
+  {
+    "hasDash": true,
+    "isArbitrary": false,
+    "name": "inverted-colors",
     "selectors": [Function],
     "values": [],
   },

--- a/packages/tailwindcss/src/feature-flags.ts
+++ b/packages/tailwindcss/src/feature-flags.ts
@@ -1,2 +1,3 @@
+export const enableInvertedColors = process.env.FEATURES_ENV !== 'stable'
 export const enableUserValid = process.env.FEATURES_ENV !== 'stable'
 export const enableWrapAnywhere = process.env.FEATURES_ENV !== 'stable'

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -1907,6 +1907,16 @@ test('forced-colors', async () => {
   expect(await run(['forced-colors/foo:flex'])).toEqual('')
 })
 
+test('inverted-colors', async () => {
+  expect(await run(['inverted-colors:flex'])).toMatchInlineSnapshot(`
+    "@media (inverted-colors: inverted) {
+      .inverted-colors\\:flex {
+        display: flex;
+      }
+    }"
+  `)
+})
+
 test('nth', async () => {
   expect(
     await run([

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -12,7 +12,7 @@ import {
   type StyleRule,
 } from './ast'
 import { type Variant } from './candidate'
-import { enableUserValid } from './feature-flags'
+import { enableInvertedColors, enableUserValid } from './feature-flags'
 import type { Theme } from './theme'
 import { compareBreakpoints } from './utils/compare-breakpoints'
 import { DefaultMap } from './utils/default-map'
@@ -1143,7 +1143,9 @@ export function createVariants(theme: Theme): Variants {
 
   staticVariant('forced-colors', ['@media (forced-colors: active)'])
 
-  staticVariant('inverted-colors', ['@media (inverted-colors: inverted)'])
+  if (enableInvertedColors) {
+    staticVariant('inverted-colors', ['@media (inverted-colors: inverted)'])
+  }
 
   return variants
 }

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -1143,6 +1143,8 @@ export function createVariants(theme: Theme): Variants {
 
   staticVariant('forced-colors', ['@media (forced-colors: active)'])
 
+  staticVariant('inverted-colors', ['@media (inverted-colors: inverted)'])
+
   return variants
 }
 


### PR DESCRIPTION
Add a variant for the [`inverted-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/inverted-colors) media query.

This has been supported in Safari for a while. I'm also implementing support in Chrome atm.

I've decided to only add the inverted-colors: inverted variant because the `none` state isn't really useful.