### PR TITLE
Add `forced-colors` variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add utilities for CSS subgrid ([#12298](https://github.com/tailwindlabs/tailwindcss/pull/12298))
 - Add spacing scale to `min-w-*`, `min-h-*`, and `max-w-*` utilities ([#12300](https://github.com/tailwindlabs/tailwindcss/pull/12300))
 - Add `forced-color-adjust` utilities ([#11931](https://github.com/tailwindlabs/tailwindcss/pull/11931))
+- Add `forced-colors` variant ([#11694](https://github.com/tailwindlabs/tailwindcss/pull/11694))
 - [Oxide] New Rust template parsing engine ([#10252](https://github.com/tailwindlabs/tailwindcss/pull/10252))
 - [Oxide] Support `@import "tailwindcss"` using top-level `index.css` file ([#11205](https://github.com/tailwindlabs/tailwindcss/pull/11205), ([#11260](https://github.com/tailwindlabs/tailwindcss/pull/11260)))
 - [Oxide] Use `lightningcss` for nesting and vendor prefixes in PostCSS plugin ([#10399](https://github.com/tailwindlabs/tailwindcss/pull/10399))

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -459,7 +459,6 @@ export let variantPlugins = {
   prefersContrastVariants: ({ addVariant }) => {
     addVariant('contrast-more', '@media (prefers-contrast: more)')
     addVariant('contrast-less', '@media (prefers-contrast: less)')
-    addVariant('contrast-custom', '@media (prefers-contrast: custom)')
   },
 
   forcedColorsVariants: ({ addVariant }) => {

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -459,6 +459,11 @@ export let variantPlugins = {
   prefersContrastVariants: ({ addVariant }) => {
     addVariant('contrast-more', '@media (prefers-contrast: more)')
     addVariant('contrast-less', '@media (prefers-contrast: less)')
+    addVariant('contrast-custom', '@media (prefers-contrast: custom)')
+  },
+
+  forcedColorsVariants: ({ addVariant }) => {
+    addVariant('forced-colors', '@media (forced-colors: active)')
   },
 }
 

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -761,6 +761,7 @@ function resolvePlugins(context, root) {
     variantPlugins['printVariant'],
     variantPlugins['screenVariants'],
     variantPlugins['orientationVariants'],
+    variantPlugins['forcedColorsVariants'],
   ]
 
   return [...corePluginList, ...beforeVariants, ...userPlugins, ...afterVariants, ...layerPlugins]

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -757,11 +757,11 @@ function resolvePlugins(context, root) {
     variantPlugins['directionVariants'],
     variantPlugins['reducedMotionVariants'],
     variantPlugins['prefersContrastVariants'],
+    variantPlugins['forcedColorsVariants'],
     variantPlugins['darkVariants'],
     variantPlugins['printVariant'],
     variantPlugins['screenVariants'],
     variantPlugins['orientationVariants'],
-    variantPlugins['forcedColorsVariants'],
   ]
 
   return [...corePluginList, ...beforeVariants, ...userPlugins, ...afterVariants, ...layerPlugins]

--- a/tests/plugins/variants/__snapshots__/forcedColorsVariants.test.js.snap
+++ b/tests/plugins/variants/__snapshots__/forcedColorsVariants.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should test the 'forcedColorsVariants' plugin 1`] = `
+"
+@media (forced-colors: active) {
+  .forced-colors\\:flex {
+    display: flex;
+  }
+}
+"
+`;

--- a/tests/plugins/variants/__snapshots__/prefersContrastVariants.test.js.snap
+++ b/tests/plugins/variants/__snapshots__/prefersContrastVariants.test.js.snap
@@ -13,5 +13,11 @@ exports[`should test the 'prefersContrastVariants' plugin 1`] = `
     display: flex;
   }
 }
+
+@media (prefers-contrast: custom) {
+  .contrast-custom\\:flex {
+    display: flex;
+  }
+}
 "
 `;

--- a/tests/plugins/variants/__snapshots__/prefersContrastVariants.test.js.snap
+++ b/tests/plugins/variants/__snapshots__/prefersContrastVariants.test.js.snap
@@ -13,11 +13,5 @@ exports[`should test the 'prefersContrastVariants' plugin 1`] = `
     display: flex;
   }
 }
-
-@media (prefers-contrast: custom) {
-  .contrast-custom\\:flex {
-    display: flex;
-  }
-}
 "
 `;

--- a/tests/plugins/variants/forcedColorsVariants.test.js
+++ b/tests/plugins/variants/forcedColorsVariants.test.js
@@ -1,9 +1,3 @@
-import { css, quickVariantPluginTest } from '../../util/run'
+import { quickVariantPluginTest } from '../../util/run'
 
-quickVariantPluginTest('forcedColorsVariants').toMatchFormattedCss(css`
-  @media (forced-colors: active) {
-    .forced-colors\:flex {
-      display: flex;
-    }
-  }
-`)
+quickVariantPluginTest('forcedColorsVariants').toMatchSnapshot()

--- a/tests/plugins/variants/forcedColorsVariants.test.js
+++ b/tests/plugins/variants/forcedColorsVariants.test.js
@@ -1,0 +1,9 @@
+import { css, quickVariantPluginTest } from '../../util/run'
+
+quickVariantPluginTest('forcedColorsVariants').toMatchFormattedCss(css`
+  @media (forced-colors: active) {
+    .forced-colors\:flex {
+      display: flex;
+    }
+  }
+`)


### PR DESCRIPTION
Add a variant for the [`forced-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors) media query.

Also add a contrast-custom variant to match [custom contrast](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-contrast#:~:text=level%20of%20contrast.-,custom,-Indicates%20that%20user) preferences

Like with #11693 i've only added a variant for `forced-colors: active` because the `forced-colors: none` case isn't overly useful.

This has widespread browser support across multiple platforms
