### PR TITLE
Skip `calc()` normalisation in nested `theme()` calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make PostCSS plugin async to improve performance ([#11548](https://github.com/tailwindlabs/tailwindcss/pull/11548))
 - Allow variant to be an at-rule without a prelude ([#11589](https://github.com/tailwindlabs/tailwindcss/pull/11589))
 - Improve normalisation of `calc()`-like functions ([#11686](https://github.com/tailwindlabs/tailwindcss/pull/11686))
+- Skip `calc()` normalisation in nested `theme()` calls ([#11705](https://github.com/tailwindlabs/tailwindcss/pull/11705))
 
 ### Added
 

--- a/src/util/dataTypes.js
+++ b/src/util/dataTypes.js
@@ -59,6 +59,8 @@ export function normalize(value, isRoot = true) {
  * @returns {string}
  */
 function normalizeMathOperatorSpacing(value) {
+  let preventFormattingInFunctions = ['theme']
+
   return value.replace(/(calc|min|max|clamp)\(.+\)/g, (match) => {
     let result = ''
 
@@ -98,6 +100,11 @@ function normalizeMathOperatorSpacing(value) {
         //
         //   In this case we do want to "format", the default value as well
         result += consumeUntil([')', ','])
+      }
+
+      // Skip formatting inside known functions
+      else if (preventFormattingInFunctions.some((fn) => peek(fn))) {
+        result += consumeUntil([')'])
       }
 
       // Handle operators

--- a/tests/normalize-data-types.test.js
+++ b/tests/normalize-data-types.test.js
@@ -60,6 +60,12 @@ let table = [
     'calc(var(--10-10px,calc(-20px-(-30px--40px)-50px)',
     'calc(var(--10-10px,calc(-20px - (-30px - -40px) - 50px)',
   ],
+  ['calc(theme(spacing.1-bar))', 'calc(theme(spacing.1-bar))'],
+  ['theme(spacing.1-bar)', 'theme(spacing.1-bar)'],
+  ['calc(theme(spacing.1-bar))', 'calc(theme(spacing.1-bar))'],
+  ['calc(1rem-theme(spacing.1-bar))', 'calc(1rem - theme(spacing.1-bar))'],
+  ['calc(theme(spacing.foo-2))', 'calc(theme(spacing.foo-2))'],
+  ['calc(theme(spacing.foo-bar))', 'calc(theme(spacing.foo-bar))'],
 
   // Misc
   ['color(0_0_0/1.0)', 'color(0 0 0/1.0)'],


### PR DESCRIPTION
This PR fixes an issue where the normalisation of whitespace around operators inside `calc()` wasn't working as expected if a nested `theme()` was used that happens to contain "operators" as well.

If you have the following utility:
```
top-[calc(1rem-theme(spacing.1-bar))]
```

Then it looks like there is a spacing value with a name of `1-bar`, we don't want to format this to `1 - bar`, but the result of this before this PR looked like this:
```
calc(1rem - theme(spacing.1 - bar))
```

After this PR, the result now looks like this:
```
calc(1rem - theme(spacing.1-bar))
```

Fixes: #11704

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
