### PR TITLE
Make `content` optional for presets in TypeScript types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve normalisation of `calc()`-like functions ([#11686](https://github.com/tailwindlabs/tailwindcss/pull/11686))
 - Skip `calc()` normalisation in nested `theme()` calls ([#11705](https://github.com/tailwindlabs/tailwindcss/pull/11705))
 - Fix incorrectly generated CSS when using square brackets inside arbitrary properties ([#11709](https://github.com/tailwindlabs/tailwindcss/pull/11709))
+- Make `content` optional for presets in TypeScript types ([#11730](https://github.com/tailwindlabs/tailwindcss/pull/11730))
 
 ### Added
 

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -46,13 +46,13 @@ type PrefixConfig = string
 type SeparatorConfig = string
 
 // Safelist related config
-type SafelistConfig = (string | { pattern: RegExp; variants?: string[] })[]
+type SafelistConfig = string | { pattern: RegExp; variants?: string[] }
 
 // Blocklist related config
-type BlocklistConfig = string[]
+type BlocklistConfig = string
 
 // Presets related config
-type PresetsConfig = Config[]
+type PresetsConfig = Config
 
 // Future related config
 type FutureConfigValues =
@@ -353,9 +353,9 @@ interface OptionalConfig {
   important: Partial<ImportantConfig>
   prefix: Partial<PrefixConfig>
   separator: Partial<SeparatorConfig>
-  safelist: Partial<SafelistConfig>
-  blocklist: Partial<BlocklistConfig>
-  presets: Partial<PresetsConfig>
+  safelist: Array<Partial<SafelistConfig>>
+  blocklist: Array<Partial<BlocklistConfig>>
+  presets: Array<Partial<PresetsConfig>>
   future: Partial<FutureConfig>
   experimental: Partial<ExperimentalConfig>
   darkMode: Partial<DarkModeConfig>

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -52,7 +52,7 @@ type SafelistConfig = string | { pattern: RegExp; variants?: string[] }
 type BlocklistConfig = string
 
 // Presets related config
-type PresetsConfig = Config
+type PresetsConfig = Partial<Config>
 
 // Future related config
 type FutureConfigValues =
@@ -353,9 +353,9 @@ interface OptionalConfig {
   important: Partial<ImportantConfig>
   prefix: Partial<PrefixConfig>
   separator: Partial<SeparatorConfig>
-  safelist: Array<Partial<SafelistConfig>>
-  blocklist: Array<Partial<BlocklistConfig>>
-  presets: Array<Partial<PresetsConfig>>
+  safelist: Array<SafelistConfig>
+  blocklist: Array<BlocklistConfig>
+  presets: Array<PresetsConfig>
   future: Partial<FutureConfig>
   experimental: Partial<ExperimentalConfig>
   darkMode: Partial<DarkModeConfig>


### PR DESCRIPTION
Instead of `Partial<Array<Thing>>` have `Array<Partial<Thing>>`

Fixes: https://github.com/tailwindlabs/tailwindcss/issues/11725

Also applies the same fix to safelist and blocklist properties of Config type.