### PR TITLE
Correct formatting for inconsistent comments

### DIFF
--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -371,7 +371,7 @@ video {
 }
 
 /*
-Make elements with the HTML hidden attribute stay hidden by default
+Make elements with the HTML hidden attribute stay hidden by default.
 */
 
 [hidden] {

--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -337,6 +337,7 @@ button,
 /*
 Make sure disabled buttons don't get the pointer cursor.
 */
+
 :disabled {
   cursor: default;
 }
@@ -369,7 +370,10 @@ video {
   height: auto;
 }
 
-/* Make elements with the HTML hidden attribute stay hidden by default */
+/*
+Make elements with the HTML hidden attribute stay hidden by default
+*/
+
 [hidden] {
   display: none;
 }


### PR DESCRIPTION
Updated the formatting for several comments to be consistent with the rest of the document.

I was incorporating the preflight in a non-Tailwind project and noticed the difference in comment styles.