### PR TITLE
Remove Rust installation from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,13 +62,6 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-
       - name: Check versions
         run: |
           echo "Node:" `node --version`

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -74,13 +74,6 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-
       - name: Check versions
         run: |
           echo "Node:" `node --version`

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -54,13 +54,6 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-
       - name: Check versions
         run: |
           echo "Node:" `node --version`

--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -64,13 +64,6 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-
       - name: Setup rust target
         run: rustup target add ${{ matrix.target }}
 
@@ -134,13 +127,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
 
       - name: Setup rust target
         run: rustup target add aarch64-apple-darwin
@@ -228,13 +214,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
 
       - name: Setup cross compile toolchain
         if: ${{ matrix.setup }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,13 +66,6 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-
       - name: Setup rust target
         run: rustup target add ${{ matrix.target }}
 
@@ -136,13 +129,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
 
       - name: Setup rust target
         run: rustup target add aarch64-apple-darwin
@@ -230,13 +216,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
 
       - name: Setup cross compile toolchain
         if: ${{ matrix.setup }}


### PR DESCRIPTION
Closes #11811

The latest version of Ubuntu includes Rust by default, so we don't need to use `actions-rs/toolchain` any longer. This PR removes that dependency and installation step from our various GitHub workflows.