### PR TITLE
Enhancing Text Clarity: The Impact of the `font-smooth` Property in `preflight.css` 📝

### DIFF
--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -39,11 +39,15 @@ html {
 /*
 1. Remove the margin in all browsers.
 2. Inherit line-height from `html` so users can set them as a class directly on the `html` element.
+3. Smooth the font on the level of the pixel, as opposed to the subpixel. Switching from subpixel rendering to anti-aliasing for light text on dark backgrounds makes it look lighter.
+4. Render text with grayscale anti-aliasing, as opposed to the subpixel. Switching from subpixel rendering to anti-aliasing for light text on dark backgrounds makes it look lighter.
 */
 
 body {
   margin: 0; /* 1 */
   line-height: inherit; /* 2 */
+  -webkit-font-smoothing: antialiased; /* 3 */
+  -moz-osx-font-smoothing: grayscale; /* 4 */
 }
 
 /*


### PR DESCRIPTION
Adding the `font-smooth` property in `preflight.css` helps render text with grayscale anti-aliasing instead of subpixel rendering. Switching from subpixel rendering to anti-aliasing for light text on dark backgrounds gives it a lighter appearance. This property has currently been added in Material-UI. For reference, you can check the following link: https://github.com/mui/material-ui/blob/ddf840bf3cc72ff863d91dabf65408fed3f5d046/packages/mui-material/src/CssBaseline/CssBaseline.js#L8.

I apologize if I've made any mistakes :(