### PR TITLE
Expose variants to matchUtilities

### DIFF
--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -601,7 +601,7 @@ function* resolveMatches(candidate, context) {
       let matchesPerPlugin = []
 
       if (typeof plugin === 'function') {
-        for (let ruleSet of [].concat(plugin(modifier, { isOnlyPlugin }))) {
+        for (let ruleSet of [].concat(plugin(modifier, variants.slice(), { isOnlyPlugin }))) {
           let [rules, options] = parseRules(ruleSet, context.postCssNodeCache)
           for (let rule of rules) {
             matchesPerPlugin.push([{ ...sort, options: { ...sort.options, ...options } }, rule])

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -393,7 +393,7 @@ function buildPluginApi(tailwindConfig, context, { variantList, variantMap, offs
 
         classList.add([prefixedIdentifier, options])
 
-        function wrapped(modifier, { isOnlyPlugin }) {
+        function wrapped(modifier, variants, { isOnlyPlugin }) {
           let [value, coercedType, utilityModifier] = coerceValue(
             options.types,
             modifier,
@@ -433,6 +433,7 @@ function buildPluginApi(tailwindConfig, context, { variantList, variantMap, offs
 
               return utilityModifier
             },
+            variants,
           }
 
           let ruleSets = []
@@ -471,7 +472,7 @@ function buildPluginApi(tailwindConfig, context, { variantList, variantMap, offs
 
         classList.add([prefixedIdentifier, options])
 
-        function wrapped(modifier, { isOnlyPlugin }) {
+        function wrapped(modifier, variants, { isOnlyPlugin }) {
           let [value, coercedType, utilityModifier] = coerceValue(
             options.types,
             modifier,
@@ -511,6 +512,7 @@ function buildPluginApi(tailwindConfig, context, { variantList, variantMap, offs
 
               return utilityModifier
             },
+            variants,
           }
 
           let ruleSets = []

--- a/tests/match-components.test.js
+++ b/tests/match-components.test.js
@@ -80,3 +80,38 @@ it('should be possible to matchComponents', () => {
     `)
   })
 })
+
+test('matching components with variants', () => {
+  let config = {
+    content: [{ raw: html`<div class="hover:group-focus:test-foo"></div>` }],
+    theme: {},
+    plugins: [
+      function ({ matchComponents }) {
+        matchComponents(
+          {
+            test: (value, { modifier, variants }) => ({
+              value,
+              variants: variants.sort().join('_'),
+              modifier,
+            }),
+          },
+          {
+            values: {
+              foo: 'foo',
+            }
+          }
+        )
+      },
+    ],
+    corePlugins: [],
+  }
+
+  return run('@tailwind components', config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .group:focus .hover\:group-focus\:test-foo:hover {
+        value: foo;
+        variants: group-focus_hover;
+      }
+    `)
+  })
+})

--- a/tests/match-components.test.js
+++ b/tests/match-components.test.js
@@ -98,7 +98,7 @@ test('matching components with variants', () => {
           {
             values: {
               foo: 'foo',
-            }
+            },
           }
         )
       },

--- a/tests/match-utilities.test.js
+++ b/tests/match-utilities.test.js
@@ -580,16 +580,19 @@ test('matching utilities with variants', () => {
       function ({ matchUtilities }) {
         matchUtilities(
           {
-            test: (value, { modifier, variants }) => ({
-              value,
-              variants: variants.sort().join('_'),
-              modifier,
-            }),
+            test: (value, { modifier, variants }) => {
+              variants.push('sm') // test that the original array isn't overwritten
+              return {
+                value,
+                variants: variants.slice(0, -1).join('_'),
+                modifier,
+              }
+            },
           },
           {
             values: {
               foo: 'foo',
-            }
+            },
           }
         )
       },

--- a/tests/match-utilities.test.js
+++ b/tests/match-utilities.test.js
@@ -571,3 +571,38 @@ test('matching utilities with a lookup value that does not match the configured 
     `)
   })
 })
+
+test('matching utilities with variants', () => {
+  let config = {
+    content: [{ raw: html`<div class="hover:group-focus:test-foo"></div>` }],
+    theme: {},
+    plugins: [
+      function ({ matchUtilities }) {
+        matchUtilities(
+          {
+            test: (value, { modifier, variants }) => ({
+              value,
+              variants: variants.sort().join('_'),
+              modifier,
+            }),
+          },
+          {
+            values: {
+              foo: 'foo',
+            }
+          }
+        )
+      },
+    ],
+    corePlugins: [],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .group:focus .hover\:group-focus\:test-foo:hover {
+        value: foo;
+        variants: group-focus_hover;
+      }
+    `)
+  })
+})

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -273,7 +273,7 @@ export interface PluginAPI {
   matchUtilities<T = string, U = string>(
     utilities: KeyValuePair<
       string,
-      (value: T | string, extra: { modifier: U | string | null }) => CSSRuleObject | null
+      (value: T | string, extra: { modifier: U | string | null, variants: string[] }) => CSSRuleObject | null
     >,
     options?: Partial<{
       respectPrefix: boolean
@@ -296,7 +296,7 @@ export interface PluginAPI {
   matchComponents<T = string, U = string>(
     components: KeyValuePair<
       string,
-      (value: T | string, extra: { modifier: U | string | null }) => CSSRuleObject | null
+      (value: T | string, extra: { modifier: U | string | null, variants: string[] }) => CSSRuleObject | null
     >,
     options?: Partial<{
       respectPrefix: boolean


### PR DESCRIPTION
Hello Tailwind team! I didn't ask first about this one because it's so tiny; I hope that's OK!

I'm in the process of writing a fluid type utility and encountered an unusual situation where I wanted to know from within the utility if it was being used with a screen variant, so I could change some values accordingly. I figured it would make most sense to pass the `variants` through to `matchUtilities`/`matchComponents` in the `extra` object that already holds `modifiers`. I can't think of any negative side effects, because the variants still get applied. For simplicity, I'm only passing through the variant names for now but I could potentially expand it to perhaps show selectors as well (similar to `context.getVariants()`). Any thoughts?

Thanks!