### PR TITLE
[Issue] font-[inherit] is assigned to font-family

### DIFF
--- a/tests/plugins/fontWeight.test.js
+++ b/tests/plugins/fontWeight.test.js
@@ -6,6 +6,7 @@ quickPluginTest('fontWeight', {
     'font-[bold]',
     'font-[650]',
     'font-[var(--my-value)]',
+    'font-[inherit],
   ],
 }).toMatchFormattedCss(css`
   .font-\[650\] {
@@ -16,6 +17,9 @@ quickPluginTest('fontWeight', {
   }
   .font-\[var\(--my-value\)\] {
     font-weight: var(--my-value);
+  }
+  .font-\[inherit\] {
+    font-weight: inherit;
   }
   .font-black {
     font-weight: 900;

--- a/tests/plugins/fontWeight.test.js
+++ b/tests/plugins/fontWeight.test.js
@@ -6,7 +6,7 @@ quickPluginTest('fontWeight', {
     'font-[bold]',
     'font-[650]',
     'font-[var(--my-value)]',
-    'font-[inherit],
+    'font-[inherit]' ,
   ],
 }).toMatchFormattedCss(css`
   .font-\[650\] {


### PR DESCRIPTION
Hey folks.

Today I tried to `font-[inherit]` (with prose), and saw that the generated style is font-family.
I'd think more relevant to have it in font-weight. 
WDYT?

More generaly, how have you though this kind of conflict?

Thanks.

In the commit, the failing test.

See you. 
👋
Mathieu.