### PR TITLE
Remove matrix.setup from release-insiders.yml

### DIFF
--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -225,10 +225,6 @@ jobs:
         run: |
           rustup default stable
 
-      - name: Setup cross compile toolchain
-        if: ${{ matrix.setup }}
-        run: ${{ matrix.setup }}
-
       - name: Setup rust target
         run: rustup target add ${{ matrix.target }}
 


### PR DESCRIPTION
`setup` was never part of the matrix.
