### PR TITLE
Add support for `text-wrap: pretty`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Process and inline `@import` at-rules natively ([#11239](https://github.com/tailwindlabs/tailwindcss/pull/11239))
 - Add `svh`, `lvh`, and `dvh` values to default `height`/`min-height`/`max-height` theme ([#11317](https://github.com/tailwindlabs/tailwindcss/pull/11317))
 - Add `has-*` variants for `:has(...)` pseudo-class ([#11318](https://github.com/tailwindlabs/tailwindcss/pull/11318))
-- Add `text-wrap` utilities including `text-balance` ([#11320](https://github.com/tailwindlabs/tailwindcss/pull/11320))
+- Add `text-wrap` utilities including `text-balance` and `text-pretty` ([#11320](https://github.com/tailwindlabs/tailwindcss/pull/11320), [#12031](https://github.com/tailwindlabs/tailwindcss/pull/12031))
 - Explicitly configure Lightning CSS features, and prefer user browserslist over default browserslist ([#11402](https://github.com/tailwindlabs/tailwindcss/pull/11402), [#11412](https://github.com/tailwindlabs/tailwindcss/pull/11412))
 - Extend default `opacity` scale to include all steps of 5 ([#11832](https://github.com/tailwindlabs/tailwindcss/pull/11832))
 - Update Preflight `html` styles to include shadow DOM `:host` pseudo-class ([#11200](https://github.com/tailwindlabs/tailwindcss/pull/11200))

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1528,6 +1528,7 @@ export let corePlugins = {
       '.text-wrap': { 'text-wrap': 'wrap' },
       '.text-nowrap': { 'text-wrap': 'nowrap' },
       '.text-balance': { 'text-wrap': 'balance' },
+      '.text-pretty': { 'text-wrap': 'pretty' },
     })
   },
 

--- a/tests/plugins/textWrap.test.js
+++ b/tests/plugins/textWrap.test.js
@@ -10,4 +10,7 @@ quickPluginTest('textWrap').toMatchFormattedCss(css`
   .text-balance {
     text-wrap: balance;
   }
+  .text-pretty {
+    text-wrap: pretty;
+  }
 `)


### PR DESCRIPTION
This PR adds support for `text-wrap: pretty` through the `text-pretty` utility.

`text-wrap: pretty` was [shipped in Chrome 117](https://chromestatus.com/feature/5145771917180928).

Unlike `text-wrap: balance`, where all lines are made to have equal-length, `text-wrap: pretty` prevents the final line from being excessively short. It serves as a value specifically designed to prevent widows without requiring additional formatting.

Further Reading:

- https://drafts.csswg.org/css-text-4/#valdef-text-wrap-style-pretty
- https://clagnut.com/blog/2424/

ref https://github.com/tailwindlabs/tailwindcss/pull/11320