### PR TITLE
Add `@starting-style` variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extend default `opacity` scale to include all steps of 5 ([#11832](https://github.com/tailwindlabs/tailwindcss/pull/11832))
 - Update Preflight `html` styles to include shadow DOM `:host` pseudo-class ([#11200](https://github.com/tailwindlabs/tailwindcss/pull/11200))
 - Support loading plugins by package / file name ([#12087](https://github.com/tailwindlabs/tailwindcss/pull/12087))
+- Add `@starting-style` variant ([#12040](https://github.com/tailwindlabs/tailwindcss/pull/12040))
 
 ### Changed
 

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -460,6 +460,10 @@ export let variantPlugins = {
     addVariant('contrast-more', '@media (prefers-contrast: more)')
     addVariant('contrast-less', '@media (prefers-contrast: less)')
   },
+
+  startingStyleVariant: ({ addVariant }) => {
+    addVariant('starting', '@starting-style')
+  },
 }
 
 let cssTransformValue = [

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -761,6 +761,7 @@ function resolvePlugins(context, root) {
     variantPlugins['printVariant'],
     variantPlugins['screenVariants'],
     variantPlugins['orientationVariants'],
+    variantPlugins['startingStyleVariant'],
   ]
 
   return [...corePluginList, ...beforeVariants, ...userPlugins, ...afterVariants, ...layerPlugins]

--- a/tests/plugins/variants/__snapshots__/startingStyleVariant.test.js.snap
+++ b/tests/plugins/variants/__snapshots__/startingStyleVariant.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should test the 'startingStyleVariant' plugin 1`] = `
+"
+@starting-style {
+  .starting\\:flex {
+    display: flex;
+  }
+}
+"
+`;

--- a/tests/plugins/variants/startingStyleVariant.test.js
+++ b/tests/plugins/variants/startingStyleVariant.test.js
@@ -1,9 +1,3 @@
-import { css, quickVariantPluginTest } from '../../util/run'
+import { quickVariantPluginTest } from '../../util/run'
 
-quickVariantPluginTest('startingStyleVariant').toMatchFormattedCss(css`
-  @starting-style {
-    .starting\:flex {
-      display: flex;
-    }
-  }
-`)
+quickVariantPluginTest('startingStyleVariant').toMatchSnapshot()

--- a/tests/plugins/variants/startingStyleVariant.test.js
+++ b/tests/plugins/variants/startingStyleVariant.test.js
@@ -1,0 +1,9 @@
+import { css, quickVariantPluginTest } from '../../util/run'
+
+quickVariantPluginTest('startingStyleVariant').toMatchFormattedCss(css`
+  @starting-style {
+    .starting\:flex {
+      display: flex;
+    }
+  }
+`)


### PR DESCRIPTION
This PR adds support for `@starting-style` through the `starting:` variant.

`@starting-style` was [shipped in Chrome 117](https://chromestatus.com/feature/4515377717968896)

Further Reading:
- https://www.bram.us/2023/05/24/the-yellow-fade-technique-with-modern-css-using-starting-style/