### PR TITLE
Handle variable colors that have variable fallback values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Skip `calc()` normalisation in nested `theme()` calls ([#11705](https://github.com/tailwindlabs/tailwindcss/pull/11705))
 - Fix incorrectly generated CSS when using square brackets inside arbitrary properties ([#11709](https://github.com/tailwindlabs/tailwindcss/pull/11709))
 - Make `content` optional for presets in TypeScript types ([#11730](https://github.com/tailwindlabs/tailwindcss/pull/11730))
+- Handle variable colors that have variable fallback values ([#12049](https://github.com/tailwindlabs/tailwindcss/pull/12049))
 
 ### Added
 

--- a/src/util/color.js
+++ b/src/util/color.js
@@ -5,7 +5,7 @@ let SHORT_HEX = /^#([a-f\d])([a-f\d])([a-f\d])([a-f\d])?$/i
 let VALUE = /(?:\d+|\d*\.\d+)%?/
 let SEP = /(?:\s*,\s*|\s+)/
 let ALPHA_SEP = /\s*[,/]\s*/
-let CUSTOM_PROPERTY = /var\(--(?:[^ )]*?)\)/
+let CUSTOM_PROPERTY = /var\(--(?:[^ )]*?)(?:,(?:[^ )]*?|var\(--[^ )]*?\)))?\)/
 
 let RGB = new RegExp(
   `^(rgba?)\\(\\s*(${VALUE.source}|${CUSTOM_PROPERTY.source})(?:${SEP.source}(${VALUE.source}|${CUSTOM_PROPERTY.source}))?(?:${SEP.source}(${VALUE.source}|${CUSTOM_PROPERTY.source}))?(?:${ALPHA_SEP.source}(${VALUE.source}|${CUSTOM_PROPERTY.source}))?\\s*\\)$`

--- a/tests/opacity.test.js
+++ b/tests/opacity.test.js
@@ -1045,3 +1045,21 @@ it('can replace the potential alpha value in rgba/hsla syntax', async () => {
     }
   `)
 })
+
+it('variables with variable fallback values can use opacity modifier', async () => {
+  let config = {
+    content: [
+      {
+        raw: html`<div class="bg-[rgb(var(--some-var,var(--some-other-var)))]/50"></div>`,
+      },
+    ],
+  }
+
+  let result = await run(`@tailwind utilities;`, config)
+
+  expect(result.css).toMatchFormattedCss(css`
+    .bg-\[rgb\(var\(--some-var\,var\(--some-other-var\)\)\)\]\/50 {
+      background-color: rgb(var(--some-var, var(--some-other-var)) / 0.5);
+    }
+  `)
+})


### PR DESCRIPTION
We couldn't parse variables in arbitrary values which had a fallback that was itself a variable and as a result would produce nothing when such a color was used in `bg-*` or `text-*` or any other color utility.

Basically this didn't work because the presence of the alpha value forces us to parse the color format:
```
bg-[rgb(var(--some-var,var(--some-other-var)))]/50
```

This PR fixes it and it now produces the following CSS:
```css
.bg-\[rgb\(var\(--some-var\,var\(--some-other-var\)\)\)\]\/50 {
  background-color: rgb(var(--some-var, var(--some-other-var)) / 0.5);
}
```


This implementation is limited because regexes are not recursive. For example, it can't handle _another_ variable fallback like this:
```
bg-[rgb(var(--some-var,var(--some-other-var,var(--some-other-var-3))))]/50
```

Doing so would require replacing these regexes with an actual mini tokenizer and parser but that's a task for another day.

Fixes #12048