### PR TITLE
Make `dark:` variant fully customizable.

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -213,7 +213,7 @@ export let variantPlugins = {
   },
 
   darkVariants: ({ config, addVariant }) => {
-    let [mode, className = '.dark'] = [].concat(config('darkMode', 'media'))
+    let [mode, classNameOrAddVariantDefinition = '.dark'] = [].concat(config('darkMode', 'media'))
 
     if (mode === false) {
       mode = 'media'
@@ -225,7 +225,9 @@ export let variantPlugins = {
     }
 
     if (mode === 'class') {
-      addVariant('dark', `:is(${className} &)`)
+      addVariant('dark', `:is(${classNameOrAddVariantDefinition} &)`)
+    } else if (mode === 'custom') {
+      addVariant('dark', classNameOrAddVariantDefinition)
     } else if (mode === 'media') {
       addVariant('dark', '@media (prefers-color-scheme: dark)')
     }

--- a/tests/dark-mode.test.js
+++ b/tests/dark-mode.test.js
@@ -46,6 +46,40 @@ it('should be possible to change the class name', () => {
   })
 })
 
+it('should be possible to use the darkMode "custom" mode to fully customize the variant', () => {
+  let config = {
+    darkMode: [
+      'custom',
+      [
+        '@media (prefers-color-scheme: dark) { &:not(:root[data-mode="light"] &) }',
+        '&:is(:root[data-mode="dark"] *)',
+      ],
+    ],
+    content: [{ raw: html`<div class="dark:font-bold"></div>` }],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      ${defaults}
+      @media (prefers-color-scheme: dark) {
+        .dark\:font-bold:not(:root[data-mode='light'] .dark\:font-bold) {
+          font-weight: 700;
+        }
+      }
+      .dark\:font-bold:is(:root[data-mode='dark'] *) {
+        font-weight: 700;
+      }
+    `)
+  })
+})
+
 it('should be possible to use the darkMode "media" mode', () => {
   let config = {
     darkMode: 'media',

--- a/tests/dark-mode.test.js
+++ b/tests/dark-mode.test.js
@@ -51,7 +51,7 @@ it('should be possible to use the darkMode "custom" mode to fully customize the 
     darkMode: [
       'custom',
       [
-        '@media (prefers-color-scheme: dark) { &:not(:root[data-mode="light"] &) }',
+        '@media (prefers-color-scheme: dark) { &:not(:root[data-mode="light"] *) }',
         '&:is(:root[data-mode="dark"] *)',
       ],
     ],
@@ -69,7 +69,7 @@ it('should be possible to use the darkMode "custom" mode to fully customize the 
     expect(result.css).toMatchFormattedCss(css`
       ${defaults}
       @media (prefers-color-scheme: dark) {
-        .dark\:font-bold:not(:root[data-mode='light'] .dark\:font-bold) {
+        .dark\:font-bold:not(:root[data-mode='light'] *) {
           font-weight: 700;
         }
       }

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -75,6 +75,8 @@ type DarkModeConfig =
   | 'class'
   // Use the `class` strategy with a custom class instead of `.dark`.
   | ['class', string]
+  // Use the `custom` strategy with a fully custom `addVariant()` definition.
+  | ['custom', Parameters<PluginAPI['addVariant']>[1]]
 
 type Screen = { raw: string } | { min: string } | { max: string } | { min: string; max: string }
 type ScreensConfig = string[] | KeyValuePair<string, string | Screen | Screen[]>


### PR DESCRIPTION
This PR adds a `'custom'` strategy to the dark-mode config, in order to allow users to fully customize the `dark:` definition. It works like this:

```javascript
/** @type {import('tailwindcss').Config} */
module.exports = {
  darkMode: [
    'custom',
    [
      '@media (prefers-color-scheme: dark) { &:not(:root[data-mode="light"] *) }',
      '&:is(:root[data-mode="dark"] *)',
    ],
  ],
}
```

Note that this is extremely similar to the custom-selector flavor of the `'class'` strategy that already exists (i.e., `darkMode: ['class', '[data-mode="dark"]']`). The only difference is that with the `'custom'` strategy, the second element of the `darkMode` array is used _verbatim_ as the second argument of the `addVariant('dark',)` call.

The [rationale](https://github.com/tailwindlabs/tailwindcss/discussions/11534) for this PR is that there's currently no way for users to make their own custom `dark:` variant. This is because the core `dark:` variant is registered _after_ user-provided variants, which means that a custom `addVariant('dark',)` does nothing. And while the custom-selector flavor of the `'class'` strategy is powerful, it's not enough to let you use the media-query as a fallback when JavaScript is disabled; for that, you need something like the selectors in my snippet above.

I've added a test for the new strategy and updated the `DarkModeConfig` type.