### PR TITLE
Add `list-dash` class

### DIFF
--- a/tests/plugins/listStyleType.test.js
+++ b/tests/plugins/listStyleType.test.js
@@ -21,6 +21,10 @@ quickPluginTest('listStyleType', {
     list-style-type: disc;
   }
 
+  .list-dash {
+    list-style-type: '-';
+  }
+
   .list-none {
     list-style-type: none;
   }


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
### Example
```html
<ul class="list-dash">
  <li>Now this is a story all about how, my life got flipped-turned upside down</li>
  <li>And I'd like to take a minute just sit right there</li>
  <li>I'll tell you how I became the prince of a town called Bel-Air </li>
</ul>
```

### Result
```
- Now this is a story all about how, my life got flipped-turned upside down
- And I'd like to take a minute just sit right there
- I'll tell you how I became the prince of a town called Bel-Air
```