### PR TITLE
Batch reading content files to prevent `too many open files` error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix incorrectly generated CSS when using square brackets inside arbitrary properties ([#11709](https://github.com/tailwindlabs/tailwindcss/pull/11709))
 - Make `content` optional for presets in TypeScript types ([#11730](https://github.com/tailwindlabs/tailwindcss/pull/11730))
 - Handle variable colors that have variable fallback values ([#12049](https://github.com/tailwindlabs/tailwindcss/pull/12049))
+- Batch reading content files to prevent `too many open files` error ([#12079](https://github.com/tailwindlabs/tailwindcss/pull/12079))
 
 ### Added
 

--- a/oxide/crates/core/src/lib.rs
+++ b/oxide/crates/core/src/lib.rs
@@ -342,8 +342,8 @@ pub fn parse_candidate_strings(input: Vec<ChangedContent>, options: u8) -> Vec<S
 
     match (IO::from(options), Parsing::from(options)) {
         (IO::Sequential, Parsing::Sequential) => parse_all_blobs_sync(read_all_files_sync(input)),
-        (IO::Sequential, Parsing::Parallel) => parse_all_blobs_sync(read_all_files(input)),
-        (IO::Parallel, Parsing::Sequential) => parse_all_blobs(read_all_files_sync(input)),
+        (IO::Sequential, Parsing::Parallel) => parse_all_blobs(read_all_files_sync(input)),
+        (IO::Parallel, Parsing::Sequential) => parse_all_blobs_sync(read_all_files(input)),
         (IO::Parallel, Parsing::Parallel) => parse_all_blobs(read_all_files(input)),
     }
 }


### PR DESCRIPTION
This should help prevent Node from keeping too many files open at one time. The batching limit is still pretty high (up to 500 files at one time) and we probably have some room to reduce it but we can look into doing that in the future if we end up needing to.

Now, this implementation isn't technically as efficient as it could be. An asynchronous queue could be used to process all files while keeping 500 reads in flight at any given time until there are fewer than 500 files left to process. The implementation for this would probably be more complexity than necessary. So this simple batching solution should suffice for now.

Fixes #12069 
 