### PR TITLE
Support loading plugins by package / file name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Explicitly configure Lightning CSS features, and prefer user browserslist over default browserslist ([#11402](https://github.com/tailwindlabs/tailwindcss/pull/11402), [#11412](https://github.com/tailwindlabs/tailwindcss/pull/11412))
 - Extend default `opacity` scale to include all steps of 5 ([#11832](https://github.com/tailwindlabs/tailwindcss/pull/11832))
 - Update Preflight `html` styles to include shadow DOM `:host` pseudo-class ([#11200](https://github.com/tailwindlabs/tailwindcss/pull/11200))
+- Support loading plugins by package / file name ([#12087](https://github.com/tailwindlabs/tailwindcss/pull/12087))
 
 ### Changed
 

--- a/src/util/resolveConfig.js
+++ b/src/util/resolveConfig.js
@@ -220,6 +220,20 @@ function resolvePlugins(configs) {
     let plugins = []
 
     for (let plugin of config?.plugins ?? []) {
+      // TODO: If we want to support ESM plugins then a handful of things will have to become async
+      if (typeof plugin === 'string') {
+        // If the plugin is specified as a string then it's just the package name
+        plugin = require(plugin)
+        plugin = plugin.default ?? plugin
+      } else if (Array.isArray(plugin)) {
+        // If the plugin is specified as an array then it's a package name and optional options object
+        // [name] or [name, options]
+        let [pkg, options = undefined] = plugin
+        plugin = require(pkg)
+        plugin = plugin.default ?? plugin
+        plugin = plugin(options)
+      }
+
       if (plugin.__isOptionsFunction) {
         plugin = plugin()
       }

--- a/tests/custom-plugins.test.js
+++ b/tests/custom-plugins.test.js
@@ -1914,3 +1914,63 @@ test('custom properties are not converted to kebab-case when added to base layer
     expect(result.css).toContain(`--colors-primaryThing-500: 0, 0, 255;`)
   })
 })
+
+test('plugins can loaded by package name / path', async () => {
+  let config = {
+    content: [{ raw: 'example-1' }],
+    plugins: [`${__dirname}/fixtures/plugins/example.cjs`],
+  }
+
+  let result = await run('@tailwind utilities', config)
+
+  expect(result.css).toMatchFormattedCss(css`
+    .example-1 {
+      color: red;
+    }
+  `)
+})
+
+test('named plugins can specify options', async () => {
+  let config = {
+    content: [{ raw: 'ex-example-1 example-1' }],
+    plugins: [[`${__dirname}/fixtures/plugins/example.cjs`, { prefix: 'ex-' }]],
+  }
+
+  let result = await run('@tailwind utilities', config)
+
+  expect(result.css).toMatchFormattedCss(css`
+    .ex-example-1 {
+      color: red;
+    }
+  `)
+})
+
+test('named plugins resolve default export', async () => {
+  let config = {
+    content: [{ raw: 'example-1' }],
+    plugins: [`${__dirname}/fixtures/plugins/example.default.cjs`],
+  }
+
+  let result = await run('@tailwind utilities', config)
+
+  expect(result.css).toMatchFormattedCss(css`
+    .example-1 {
+      color: red;
+    }
+  `)
+})
+
+test('named plugins resolve default export when using options', async () => {
+  let config = {
+    content: [{ raw: 'example-1 ex-example-1' }],
+    plugins: [[`${__dirname}/fixtures/plugins/example.default.cjs`, { prefix: 'ex-' }]],
+  }
+
+  let result = await run('@tailwind utilities', config)
+
+  expect(result.css).toMatchFormattedCss(css`
+    .ex-example-1 {
+      color: red;
+    }
+  `)
+})

--- a/tests/fixtures/plugins/example.cjs
+++ b/tests/fixtures/plugins/example.cjs
@@ -1,0 +1,11 @@
+const plugin = require('../../../plugin.js')
+
+module.exports = plugin.withOptions(function ({ prefix = '' } = {}) {
+  return function ({ addUtilities }) {
+    addUtilities({
+      [`.${prefix}example-1`]: {
+        color: 'red',
+      },
+    })
+  }
+})

--- a/tests/fixtures/plugins/example.default.cjs
+++ b/tests/fixtures/plugins/example.default.cjs
@@ -1,0 +1,11 @@
+const plugin = require('../../../plugin.js')
+
+module.exports.default = plugin.withOptions(function ({ prefix = '' } = {}) {
+  return function ({ addUtilities }) {
+    addUtilities({
+      [`.${prefix}example-1`]: {
+        color: 'red',
+      },
+    })
+  }
+})

--- a/tests/resolveConfig.test.js
+++ b/tests/resolveConfig.test.js
@@ -1680,16 +1680,20 @@ test('core plugin configurations stack', () => {
 })
 
 test('plugins are merged', () => {
+  let p1 = { config: { order: '1' } }
+  let p2 = { config: { order: '2' } }
+  let p3 = { config: { order: '3' } }
+
   const userConfig = {
-    plugins: ['3'],
+    plugins: [p3],
   }
 
   const otherConfig = {
-    plugins: ['2'],
+    plugins: [p2],
   }
 
   const defaultConfig = {
-    plugins: ['1'],
+    plugins: [p1],
     prefix: '',
     important: false,
     separator: ':',
@@ -1704,7 +1708,7 @@ test('plugins are merged', () => {
     important: false,
     separator: ':',
     theme: {},
-    plugins: ['1', '2', '3'],
+    plugins: [p1, p2, p3],
   })
 })
 

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -342,6 +342,8 @@ export type PluginsConfig = (
       (options: any): { handler: PluginCreator; config?: Partial<Config> }
       __isOptionsFunction: true
     }
+  | string
+  | [string, Record<string, any>]
 )[]
 
 // Top level config related


### PR DESCRIPTION
Today we require that plugins be required in the config (or imported in some cases) to be used. Additionally, when passing options to a plugin you have to _call_ that plugin as a function to pass in the options.

Today, you have to write this:

```js
module.exports = {
  // …
  plugins: [
    // Including our forms plugin
    require("@tailwindcss/forms"),
    
    // Including our typography plugin while changing `prose` to `wysiwyg`
    require('@tailwindcss/typography')({
      className: 'wysiwyg',
    }),
  ]
}
```

This PR allows us to simplify this a bit such that, if you have no options to pass, you can specify just the name of the package or file and Tailwind CSS will `require()` it for you. And, if you need to pass options, you can use a tuple with the name of the package and the options you want to pass.

Turning the above config into this:

```js
module.exports = {
  // …
  plugins: [
    // Including our forms plugin
    "@tailwindcss/forms",

    // Including our typography plugin while changing `prose` to `wysiwyg`
    ["@tailwindcss/typography", { className: 'wysiwyg' }],
  ]
}
```

Now, the old plugin format is still supported — and you can freely mix and match!

```js
module.exports = {
  // …
  plugins: [
    require("@tailwindcss/forms"),
    "@tailwindcss/container-queries",
    ["@tailwindcss/typography", { className: 'wysiwyg' }],
  ]
}
```

### A note about TypeScript and ES Modules support

Due to implementation details this way of loading plugins does not support plugins written in TypeScript or ESM. ESM is not supported because many of the things that would need to be async are not and doing so would be a breaking change for people relying on APIs like `resolveConfig`. Similarly, for TS support — we use Jiti to compile our config to TypeScript and would not want to package `jiti` in every bundle that happens to use `resolveConfig`.

In these cases we recommend you stick to using the typical `import` syntax you are using today!