### PR TITLE
Update types to work with Node16 module resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handle variable colors that have variable fallback values ([#12049](https://github.com/tailwindlabs/tailwindcss/pull/12049))
 - Batch reading content files to prevent `too many open files` error ([#12079](https://github.com/tailwindlabs/tailwindcss/pull/12079))
 - Skip over classes inside `:not(…)` when nested in an at-rule ([#12105](https://github.com/tailwindlabs/tailwindcss/pull/12105))
+- Update types to work with `Node16` module resolution ([#12097](https://github.com/tailwindlabs/tailwindcss/pull/12097))
 
 ### Added
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,11 @@
-import { PluginCreator } from 'postcss'
+import type { PluginCreator } from 'postcss'
 import type { Config } from './config.d'
 
 declare const plugin: PluginCreator<string | Config | { config: string | Config }>
 
-export { Config }
-export default plugin
+declare type _Config = Config
+declare namespace plugin {
+  export type { _Config as Config }
+}
+
+export = plugin


### PR DESCRIPTION
`Node16` / `NodeNext` module resolution in TypeScript now produces objects with a default key when using `export default`.

The "correct" way to type CJS in TypeScript is via `export = …` but the problem here is there is a significant number of random limitations on what works and what doesn't. For example, you have to use namespaces to export any times — BUT — you cannot directly export a type that wasn't created in the same file — and in some cases — in the namespace.

Fixes #12092