### PR TITLE
Skip over classes inside `:not(…)` when nested in an at-rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make `content` optional for presets in TypeScript types ([#11730](https://github.com/tailwindlabs/tailwindcss/pull/11730))
 - Handle variable colors that have variable fallback values ([#12049](https://github.com/tailwindlabs/tailwindcss/pull/12049))
 - Batch reading content files to prevent `too many open files` error ([#12079](https://github.com/tailwindlabs/tailwindcss/pull/12079))
+- Skip over classes inside `:not(…)` when nested in an at-rule ([#12105](https://github.com/tailwindlabs/tailwindcss/pull/12105))
 
 ### Added
 

--- a/tests/basic-usage.test.js
+++ b/tests/basic-usage.test.js
@@ -760,3 +760,35 @@ test('handled quoted arbitrary values containing escaped spaces', async () => {
         `
   )
 })
+
+test('Skips classes inside :not() when nested inside an at-rule', async () => {
+  let config = {
+    content: [
+      {
+        raw: html` <div class="disabled !disabled"></div> `,
+      },
+    ],
+    corePlugins: { preflight: false },
+    plugins: [
+      function ({ addUtilities }) {
+        addUtilities({
+          '.hand:not(.disabled)': {
+            '@supports (cursor: pointer)': {
+              cursor: 'pointer',
+            },
+          },
+        })
+      },
+    ],
+  }
+
+  let input = css`
+    @tailwind utilities;
+  `
+
+  // We didn't find the hand class therefore
+  // nothing should be generated
+  let result = await run(input, config)
+
+  expect(result.css).toMatchFormattedCss(css``)
+})


### PR DESCRIPTION
When defining a utility we skip over classes inside `:not(…)` but we missed doing this when classes were contained within an at-rule. This fixes that.

Fixes #12099