### PR TITLE
Improve RegEx parser, reduce possibilities as the key for arbitrary properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update types to work with `Node16` module resolution ([#12097](https://github.com/tailwindlabs/tailwindcss/pull/12097))
 - Don’t crash when important and parent selectors are equal in `@apply` ([#12112](https://github.com/tailwindlabs/tailwindcss/pull/12112))
 - Eliminate irrelevant rules when applying variants ([#12113](https://github.com/tailwindlabs/tailwindcss/pull/12113))
+- Improve RegEx parser, reduce possibilities as the key for arbitrary properties ([#12121](https://github.com/tailwindlabs/tailwindcss/pull/12121))
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
       "name": "@tailwindcss/integrations-content-resolution",
       "version": "0.0.0",
       "devDependencies": {
-        "postcss": "8.4.30",
+        "postcss": "^8.4.30",
         "postcss-cli": "^10.1.0"
       }
     },
@@ -83,7 +83,7 @@
       "name": "@tailwindcss/integrations-postcss-cli",
       "version": "0.0.0",
       "devDependencies": {
-        "postcss": "8.4.30",
+        "postcss": "^8.4.30",
         "postcss-cli": "^10.1.0"
       }
     },
@@ -19061,7 +19061,7 @@
     "@tailwindcss/integrations-content-resolution": {
       "version": "file:integrations/content-resolution",
       "requires": {
-        "postcss": "8.4.30",
+        "postcss": "^8.4.30",
         "postcss-cli": "^10.1.0"
       }
     },
@@ -19074,7 +19074,7 @@
     "@tailwindcss/integrations-postcss-cli": {
       "version": "file:integrations/postcss-cli",
       "requires": {
-        "postcss": "8.4.30",
+        "postcss": "^8.4.30",
         "postcss-cli": "^10.1.0"
       }
     },
@@ -27050,7 +27050,7 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.29",
+        "postcss": "^8.4.30",
         "postcss-import": "^15.1.0",
         "postcss-js": "^4.0.1",
         "postcss-load-config": "^4.0.1",
@@ -29678,7 +29678,7 @@
         "@tailwindcss/integrations-content-resolution": {
           "version": "file:integrations/content-resolution",
           "requires": {
-            "postcss": "8.4.30",
+            "postcss": "^8.4.30",
             "postcss-cli": "^10.1.0"
           }
         },
@@ -29691,7 +29691,7 @@
         "@tailwindcss/integrations-postcss-cli": {
           "version": "file:integrations/postcss-cli",
           "requires": {
-            "postcss": "8.4.30",
+            "postcss": "^8.4.30",
             "postcss-cli": "^10.1.0"
           }
         },

--- a/src/lib/defaultExtractor.js
+++ b/src/lib/defaultExtractor.js
@@ -35,7 +35,7 @@ function* buildRegExps(context) {
     // This is a targeted fix to continue to allow theme()
     // with square brackets to work in arbitrary properties
     // while fixing a problem with the regex matching too much
-    /\[[^\s:'"`]+:[^\s]+?\[[^\s]+\][^\s]+?\]/,
+    /\[[^\s:'"`\]]+:[^\s]+?\[[^\s]+\][^\s]+?\]/,
 
     // Utilities
     regex.pattern([

--- a/src/lib/defaultExtractor.js
+++ b/src/lib/defaultExtractor.js
@@ -11,10 +11,12 @@ export function defaultExtractor(context) {
     let results = []
 
     for (let pattern of patterns) {
-      results = [...results, ...(content.match(pattern) ?? [])]
+      for (let result of content.match(pattern) ?? []) {
+        results.push(clipAtBalancedParens(result))
+      }
     }
 
-    return results.filter((v) => v !== undefined).map(clipAtBalancedParens)
+    return results
   }
 }
 

--- a/tests/parse-candidate-strings.test.js
+++ b/tests/parse-candidate-strings.test.js
@@ -438,4 +438,25 @@ describe.each([
       expect(extractions).not.toContain(`bold`)
     })
   })
+
+  describe('real world', () => {
+    it.each([
+      [
+        'const myCVAComponent = cva([],{defaultVariants:{size:"md"},variants:{size:{sm:["p-1"],md:["p-1.5"],lg:["p-2"],xl:["p-2.5"]}}});',
+      ],
+      [
+        'const myCVAComponent = cva([],{defaultVariants:{size:"md"}, variants:{size:{sm:["p-1"],md:["p-1.5"],lg:["p-2"],xl:["p-2.5"]}}});',
+      ],
+      [
+        'const myCVAComponent = cva("",{defaultVariants:{size:"md"},variants:{size:{sm:["p-1"],md:["p-1.5"],lg:["p-2"],xl:["p-2.5"]}}});',
+      ],
+    ])('should work for issue #12109 (%#)', async (content) => {
+      let extractions = parse(content)
+
+      expect(extractions).toContain('p-1')
+      expect(extractions).toContain('p-1.5')
+      expect(extractions).toContain('p-2')
+      expect(extractions).toContain('p-2.5')
+    })
+  })
 })


### PR DESCRIPTION
This PR improves the RegEx parser, by handling a few more edge cases especially around minified code. In this case, the RegEx saw square brackets and considered it an arbitrary property which is incorrect. 

This PR reduces the valid possibilities for the "key" of the arbitrary property, which in turn solves the bug.

Internal note: The Oxide parser already handled this correctly.

Fixes: #12109
