### PR TITLE
Add `:popover-open` variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sort arbitrary properties alphabetically across multiple class lists ([#12911](https://github.com/tailwindlabs/tailwindcss/pull/12911))
 - Add `mix-blend-plus-darker` utility ([#12923](https://github.com/tailwindlabs/tailwindcss/pull/12923))
 
+### Added
+
+- Add `:popover-open` variant ([#12148](https://github.com/tailwindlabs/tailwindcss/pull/12148))
+
 ## [3.4.1] - 2024-01-05
 
 ### Fixed

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -111,6 +111,7 @@ export let variantPlugins = {
       ],
       'target',
       ['open', '&[open]'],
+      'popover-open',
 
       // Forms
       'default',

--- a/tests/variants.oxide.test.css
+++ b/tests/variants.oxide.test.css
@@ -145,6 +145,9 @@
 .open\:bg-red-200[open] {
   background-color: #fecaca;
 }
+.popover-open\:bg-red-200:popover-open {
+  background-color: #fecaca;
+}
 .default\:shadow-md:default,
 .checked\:shadow-md:checked,
 .indeterminate\:shadow-md:indeterminate,
@@ -184,6 +187,9 @@
 .open\:hover\:bg-red-200:hover[open] {
   background-color: #fecaca;
 }
+.popover-open\:hover\:bg-red-200:hover:popover-open {
+  background-color: #fecaca;
+}
 .focus\:shadow-md:focus,
 .focus\:hover\:shadow-md:hover:focus,
 .focus-visible\:shadow-md:focus-visible,
@@ -206,6 +212,9 @@
     var(--tw-shadow);
 }
 .group[open] .group-open\:bg-red-200 {
+  background-color: #fecaca;
+}
+.group:popover-open .group-popover-open\:bg-red-200 {
   background-color: #fecaca;
 }
 .group:default .group-default\:shadow-md,
@@ -265,6 +274,9 @@
     var(--tw-shadow);
 }
 .peer[open] ~ .peer-open\:bg-red-200 {
+  background-color: #fecaca;
+}
+.peer:popover-open ~ .peer-popover-open\:bg-red-200 {
   background-color: #fecaca;
 }
 .peer:default ~ .peer-default\:shadow-md,

--- a/tests/variants.test.css
+++ b/tests/variants.test.css
@@ -208,6 +208,10 @@
   --tw-bg-opacity: 1;
   background-color: rgb(254 202 202 / var(--tw-bg-opacity));
 }
+.popover-open\:bg-red-200:popover-open {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 202 202 / var(--tw-bg-opacity));
+}
 .default\:shadow-md:default,
 .checked\:shadow-md:checked,
 .indeterminate\:shadow-md:indeterminate,
@@ -249,6 +253,10 @@
   --tw-bg-opacity: 1;
   background-color: rgb(254 202 202 / var(--tw-bg-opacity));
 }
+.popover-open\:hover\:bg-red-200:hover:popover-open {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 202 202 / var(--tw-bg-opacity));
+}
 .focus\:shadow-md:focus,
 .focus\:hover\:shadow-md:hover:focus,
 .focus-visible\:shadow-md:focus-visible,
@@ -271,6 +279,10 @@
     var(--tw-shadow);
 }
 .group[open] .group-open\:bg-red-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 202 202 / var(--tw-bg-opacity));
+}
+.group:popover-open .group-popover-open\:bg-red-200 {
   --tw-bg-opacity: 1;
   background-color: rgb(254 202 202 / var(--tw-bg-opacity));
 }
@@ -332,6 +344,10 @@
     var(--tw-shadow);
 }
 .peer[open] ~ .peer-open\:bg-red-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 202 202 / var(--tw-bg-opacity));
+}
+.peer:popover-open ~ .peer-popover-open\:bg-red-200 {
   --tw-bg-opacity: 1;
   background-color: rgb(254 202 202 / var(--tw-bg-opacity));
 }

--- a/tests/variants.test.html
+++ b/tests/variants.test.html
@@ -14,6 +14,7 @@
 <div class="active:shadow-md"></div>
 <div class="target:shadow-md"></div>
 <div class="open:bg-red-200"></div>
+<div class="popover-open:bg-red-200"></div>
 <div class="visited:shadow-md"></div>
 <div class="default:shadow-md"></div>
 <div class="checked:shadow-md"></div>
@@ -46,6 +47,7 @@
 
 <!-- Group variants -->
 <div class="group-open:bg-red-200"></div>
+<div class="group-popover-open:bg-red-200"></div>
 <div class="group-first:shadow-md"></div>
 <div class="group-last:shadow-md"></div>
 <div class="group-only:shadow-md"></div>
@@ -79,6 +81,7 @@
 
 <!-- Peer variants -->
 <div class="peer-open:bg-red-200"></div>
+<div class="peer-popover-open:bg-red-200"></div>
 <div class="peer-first:shadow-md"></div>
 <div class="peer-last:shadow-md"></div>
 <div class="peer-only:shadow-md"></div>
@@ -146,6 +149,7 @@
 
 <!-- Stacked variants -->
 <div class="open:hover:bg-red-200"></div>
+<div class="popover-open:hover:bg-red-200"></div>
 <div class="file:hover:bg-blue-600"></div>
 <div class="focus:hover:shadow-md"></div>
 <div class="sm:active:shadow-md"></div>


### PR DESCRIPTION
[`:popover-open`](https://developer.mozilla.org/en-US/docs/Web/CSS/:popover-open) is used to style elements with the [`popover`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover) attribute when they're open.

This is supported in Chromium 114, Safari 17, and Firefox 125.