### PR TITLE
Add `transition-behavior` utilities

### DIFF
--- a/packages/tailwindcss/src/__snapshots__/intellisense.test.ts.snap
+++ b/packages/tailwindcss/src/__snapshots__/intellisense.test.ts.snap
@@ -1717,6 +1717,8 @@ exports[`getClassList 1`] = `
   "transform-view",
   "transition",
   "transition-all",
+  "transition-allow-discrete",
+  "transition-behavior-normal",
   "transition-colors",
   "transition-none",
   "transition-opacity",

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -10475,6 +10475,19 @@ test('transition', () => {
   ).toEqual('')
 })
 
+test('transition-behavior', () => {
+  expect(run(['transition-allow-discrete', 'transition-behavior-normal'])).toMatchInlineSnapshot(`
+    ".transition-allow-discrete {
+      transition-behavior: allow-discrete;
+    }
+
+    .transition-behavior-normal {
+      transition-behavior: normal;
+    }"
+  `)
+  expect(run(['-transition-allow-discrete', '-transition-behavior-normal'])).toEqual('')
+})
+
 test('delay', () => {
   expect(run(['delay-123', 'delay-200', 'delay-[300ms]'])).toMatchInlineSnapshot(`
     ".delay-123 {

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -3609,6 +3609,9 @@ export function createUtilities(theme: Theme) {
       ],
     })
 
+    staticUtility('transition-allow-discrete', [['transition-behavior', 'allow-discrete']])
+    staticUtility('transition-behavior-normal', [['transition-behavior', 'normal']])
+
     functionalUtility('delay', {
       handleBareValue: ({ value }) => {
         if (Number.isNaN(Number(value))) return null


### PR DESCRIPTION
[`transition-behavior` ](https://drafts.csswg.org/css-transitions-2/#transition-behavior-property) is a new CSS property that allows you to transition on discrete properties. 

This is new in Chrome 117. See https://chromestatus.com/feature/5071230636392448

One major use case for this is styling dialog and popover transitions when showing. (See comment for exit transitions)

See https://github.com/tailwindlabs/tailwindcss/pull/12040 for a related PR to add a `@starting-style` variant.