### PR TITLE
Add `font-stretch` utilities

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -2072,6 +2072,10 @@ export let corePlugins = {
     type: ['lookup', 'number', 'any'],
   }),
 
+  fontStretch: createUtilityPlugin('fontStretch', [['stretch', ['fontStretch']]], {
+    type: ['lookup', 'percentage', 'any'],
+  }),
+
   textTransform: ({ addUtilities }) => {
     addUtilities({
       '.uppercase': { 'text-transform': 'uppercase' },

--- a/stubs/config.full.js
+++ b/stubs/config.full.js
@@ -347,6 +347,17 @@ module.exports = {
       extrabold: '800',
       black: '900',
     },
+    fontStretch: {
+      normal: 'normal',
+      'ultra-condensed': 'ultra-condensed',
+      'extra-condensed': 'extra-condensed',
+      condensed: 'condensed',
+      'semi-condensed': 'semi-condensed',
+      'semi-expanded': 'semi-expanded',
+      expanded: 'expanded',
+      'extra-expanded': 'extra-expanded',
+      'ultra-expanded': 'ultra-expanded',
+    },
     gap: ({ theme }) => theme('spacing'),
     gradientColorStops: ({ theme }) => theme('colors'),
     gradientColorStopPositions: {

--- a/tests/plugins/__snapshots__/fontStretch.test.js.snap
+++ b/tests/plugins/__snapshots__/fontStretch.test.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should test the 'fontStretch' plugin 1`] = `
+"
+.stretch-\\[100\\%\\] {
+  font-stretch: 100%;
+}
+
+.stretch-\\[var\\(--my-value\\)\\] {
+  font-stretch: var(--my-value);
+}
+
+.stretch-condensed {
+  font-stretch: condensed;
+}
+
+.stretch-expanded {
+  font-stretch: expanded;
+}
+
+.stretch-extra-condensed {
+  font-stretch: extra-condensed;
+}
+
+.stretch-extra-expanded {
+  font-stretch: extra-expanded;
+}
+
+.stretch-normal {
+  font-stretch: normal;
+}
+
+.stretch-semi-condensed {
+  font-stretch: semi-condensed;
+}
+
+.stretch-semi-expanded {
+  font-stretch: semi-expanded;
+}
+
+.stretch-ultra-condensed {
+  font-stretch: ultra-condensed;
+}
+
+.stretch-ultra-expanded {
+  font-stretch: ultra-expanded;
+}
+"
+`;

--- a/tests/plugins/fontStretch.test.js
+++ b/tests/plugins/fontStretch.test.js
@@ -1,0 +1,9 @@
+import { quickPluginTest } from '../util/run'
+
+quickPluginTest('fontStretch', {
+  safelist: [
+    // Arbitrary values
+    'stretch-[100%]',
+    'stretch-[var(--my-value)]',
+  ],
+}).toMatchSnapshot()

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -189,6 +189,7 @@ interface ThemeConfig {
     >
   >
   fontWeight: ResolvableTo<KeyValuePair>
+  fontStretch: ResolvableTo<KeyValuePair>
   lineHeight: ResolvableTo<KeyValuePair>
   letterSpacing: ResolvableTo<KeyValuePair>
   textColor: ThemeConfig['colors']


### PR DESCRIPTION
Hey there!

First-time contributor to Tailwind CSS, if there's anything specific you'd like me to adjust or if you have any questions, please don't hesitate to let me know. 

**Goal**

I've added the `.stretch-*` classes to manage the `font-stretch` property. This addition is approximately 96% compatible overall, as per the information available on [caniuse.com](https://caniuse.com/).

Stretch should allow percentage value or any config value. I've relied on the `fontWeight` property for this new feature. I hesitated between adding statics utilities or the version I sent, but I think that being able to use arbitrary values and extend configurations is interesting because this property accepts percentage values in addition to global values.

I found myself deliberating between using `font-stretch` and simply `stretch`. I would appreciate your guidance on which option is more suitable for this.

**Documentation**

Additional documentation of `font-stretch` property on [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/font-stretch)

If this feature is accepted, I could also take care of creating the corresponding documentation in https://github.com/tailwindlabs/tailwindcss.com.

**Related discussions**

https://github.com/tailwindlabs/tailwindcss/discussions/10156
https://github.com/tailwindlabs/tailwindcss/discussions/5686
https://github.com/tailwindlabs/tailwindcss/discussions/8324