### PR TITLE
Fix crash when watching renamed files on FreeBSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve RegEx parser, reduce possibilities as the key for arbitrary properties ([#12121](https://github.com/tailwindlabs/tailwindcss/pull/12121))
 - Fix sorting of utilities that share multiple candidates ([#12173](https://github.com/tailwindlabs/tailwindcss/pull/12173))
 - Ensure variants with arbitrary values and a modifier are correctly matched in the RegEx based parser ([#12179](https://github.com/tailwindlabs/tailwindcss/pull/12179))
+- Fix crash when watching renamed files on FreeBSD ([#12193](https://github.com/tailwindlabs/tailwindcss/pull/12193))
 
 ### Added
 

--- a/integrations/rollup-sass/tests/integration.test.js
+++ b/integrations/rollup-sass/tests/integration.test.js
@@ -295,6 +295,8 @@ describe('watcher', () => {
     )
     await runningProcess.onStderr(ready)
 
+    await new Promise((resolve) => setTimeout(resolve, 5000))
+
     expect(await readOutputFile('index.css')).toIncludeCss(
       css`
         .btn {

--- a/integrations/rollup-sass/tests/integration.test.js
+++ b/integrations/rollup-sass/tests/integration.test.js
@@ -295,7 +295,7 @@ describe('watcher', () => {
     )
     await runningProcess.onStderr(ready)
 
-    await new Promise((resolve) => setTimeout(resolve, 5000))
+    await new Promise((resolve) => setTimeout(resolve, 10000))
 
     expect(await readOutputFile('index.css')).toIncludeCss(
       css`

--- a/integrations/rollup-sass/tests/integration.test.js
+++ b/integrations/rollup-sass/tests/integration.test.js
@@ -295,7 +295,7 @@ describe('watcher', () => {
     )
     await runningProcess.onStderr(ready)
 
-    await new Promise((resolve) => setTimeout(resolve, 10000))
+    await new Promise((resolve) => setTimeout(resolve, 5000))
 
     expect(await readOutputFile('index.css')).toIncludeCss(
       css`
@@ -336,5 +336,5 @@ describe('watcher', () => {
     )
 
     return runningProcess.stop()
-  })
+  }, 30000)
 })

--- a/src/cli/build/watching.js
+++ b/src/cli/build/watching.js
@@ -164,7 +164,7 @@ export function createWatcher(args, { state, rebuild }) {
   // This is very likely a chokidar bug but it's one we need to work around
   // We treat this as a change event and rebuild the CSS
   watcher.on('raw', (evt, filePath, meta) => {
-    if (evt !== 'rename') {
+    if (evt !== 'rename' || filePath === null) {
       return
     }
 


### PR DESCRIPTION
Looks like, according to node docs, the filePath passed to the callback provided to `fs.watch()` can be `null` which we should account for.

I'm not certain the exact scenario in which this happens but we can at least guard against it so the watcher doesn't crash.

Fixes #12189
