### PR TITLE
Improve automatic `var` injection

### DIFF
--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -491,7 +491,7 @@ function extractArbitraryProperty(classCandidate, context) {
     return null
   }
 
-  let normalized = normalize(value)
+  let normalized = normalize(value, { property })
 
   if (!isParsableCssValue(property, normalized)) {
     return null

--- a/src/util/dataTypes.js
+++ b/src/util/dataTypes.js
@@ -26,6 +26,7 @@ const AUTO_VAR_INJECTION_EXCEPTIONS = new Set([
   'scroll-timeline-name',
   'timeline-scope',
   'view-timeline-name',
+  'font-palette',
 
   // Shorthand properties
   'scroll-timeline',

--- a/src/util/dataTypes.js
+++ b/src/util/dataTypes.js
@@ -37,10 +37,8 @@ const AUTO_VAR_INJECTION_EXCEPTIONS = new Set([
 // This is not a data type, but rather a function that can normalize the
 // correct values.
 export function normalize(value, context = null, isRoot = true) {
-  if (
-    (context ? !AUTO_VAR_INJECTION_EXCEPTIONS.has(context.property) : true) &&
-    value.startsWith('--')
-  ) {
+  let isVarException = context && AUTO_VAR_INJECTION_EXCEPTIONS.has(context.property)
+  if (value.startsWith('--') && !isVarException) {
     return `var(${value})`
   }
 

--- a/tests/normalize-data-types.test.js
+++ b/tests/normalize-data-types.test.js
@@ -1,3 +1,4 @@
+import { css, run } from './util/run'
 import { normalize } from '../src/util/dataTypes'
 
 let table = [
@@ -74,4 +75,32 @@ let table = [
 
 it.each(table)('normalize data: %s', (input, output) => {
   expect(normalize(input)).toBe(output)
+})
+
+it('should not automatically inject the `var()` for properties that accept `<dashed-ident>` as the value', () => {
+  let config = {
+    content: [
+      // Automatic var injection
+      { raw: '[color:--foo]' },
+
+      // Automatic var injection is skipped
+      { raw: '[timeline-scope:--foo]' },
+    ],
+  }
+
+  let input = css`
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .\[color\:--foo\] {
+        color: var(--foo);
+      }
+
+      .\[timeline-scope\:--foo\] {
+        timeline-scope: --foo;
+      }
+    `)
+  })
 })


### PR DESCRIPTION
This PR improves the automatic `var` injection behaviour.

When using arbitrary properties such as:
```html
<div class="[timeline-scope:--foo]"></div>
```

Then the compiled CSS will be:
```css
.\[timeline-scope\:--foo\]{
  timeline-scope: var(--foo)
}
```

However, the `timeline-scope` property accepts a `<dashed-ident>` data type, which means that the value should stay as `--foo`, and not `var(--foo)`.

This PR has an exceptions list for these properties, and won't wrap the variable with `var()` for properties that accept `<dashed-ident>`.

More info:
- https://drafts.csswg.org/scroll-animations/#propdef-timeline-scope
- https://developer.mozilla.org/en-US/docs/Web/CSS/timeline-scope#dashed-ident

Fixes: #12205

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
