### PR TITLE
Refactor length function to utilize a pre-compiled RegExp

### DIFF
--- a/src/util/dataTypes.js
+++ b/src/util/dataTypes.js
@@ -173,10 +173,11 @@ let lengthUnits = [
   'cqmax',
 ]
 let lengthUnitsPattern = `(?:${lengthUnits.join('|')})`
+let lengthRegExp = new RegExp(`^[+-]?[0-9]*\.?[0-9]+(?:[eE][+-]?[0-9]+)?${lengthUnitsPattern}$`);
 export function length(value) {
   return (
     value === '0' ||
-    new RegExp(`^[+-]?[0-9]*\.?[0-9]+(?:[eE][+-]?[0-9]+)?${lengthUnitsPattern}$`).test(value) ||
+    lengthRegExp.test(value) ||
     isCSSFunction(value)
   )
 }

--- a/src/util/dataTypes.js
+++ b/src/util/dataTypes.js
@@ -173,13 +173,9 @@ let lengthUnits = [
   'cqmax',
 ]
 let lengthUnitsPattern = `(?:${lengthUnits.join('|')})`
-let lengthRegExp = new RegExp(`^[+-]?[0-9]*\.?[0-9]+(?:[eE][+-]?[0-9]+)?${lengthUnitsPattern}$`);
+let lengthRegExp = new RegExp(`^[+-]?[0-9]*\.?[0-9]+(?:[eE][+-]?[0-9]+)?${lengthUnitsPattern}$`)
 export function length(value) {
-  return (
-    value === '0' ||
-    lengthRegExp.test(value) ||
-    isCSSFunction(value)
-  )
+  return value === '0' || lengthRegExp.test(value) || isCSSFunction(value)
 }
 
 let lineWidths = new Set(['thin', 'medium', 'thick'])


### PR DESCRIPTION
This PR refactors the `length` function by extracting the regular expression used for validation into a separate, pre-compiled RegExp. This change aims to improve the performance of the function, especially in scenarios where it's called frequently, by avoiding the overhead of compiling the RegExp each time the function is called.