### PR TITLE
Improve resolveConfig return type: merge themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fallback to RegEx based parser when using custom transformers or extractors ([#11335](https://github.com/tailwindlabs/tailwindcss/pull/11335))
 - Bump `lightningcss` and reflect related improvements in tests ([#11550](https://github.com/tailwindlabs/tailwindcss/pull/11550))
 - Fix incorrect spaces around `-` in `calc()` expression ([#12283](https://github.com/tailwindlabs/tailwindcss/pull/12283))
+- Improve types for `resolveConfig` ([#12272](https://github.com/tailwindlabs/tailwindcss/pull/12272))
 
 ### Added
 

--- a/resolveConfig.d.ts
+++ b/resolveConfig.d.ts
@@ -1,4 +1,4 @@
-import { Config, ResolvableTo, ThemeConfig } from "./types/config";
+import { Config, ResolvableTo, ThemeConfig } from './types/config'
 import { DefaultTheme } from './types/generated/default-theme'
 import { DefaultColors } from './types/generated/colors'
 
@@ -17,15 +17,14 @@ type ThemeConfigResolved = UnwrapResolvables<ThemeConfig>
 type DefaultThemeFull = DefaultTheme & { colors: DefaultColors }
 
 type MergeThemes<Overrides extends object, Extensions extends object> = {
-  [K in keyof ThemeConfigResolved | keyof Overrides]: (
-    K extends keyof Overrides
-      ? Overrides[K]
-      : K extends keyof DefaultThemeFull
-      ? DefaultThemeFull[K]
-      : K extends keyof ThemeConfigResolved
-      ? ThemeConfigResolved[K]
-      : never
-  ) & (K extends keyof Extensions ? Extensions[K] : {})
+  [K in keyof ThemeConfigResolved | keyof Overrides]: (K extends keyof Overrides
+    ? Overrides[K]
+    : K extends keyof DefaultThemeFull
+    ? DefaultThemeFull[K]
+    : K extends keyof ThemeConfigResolved
+    ? ThemeConfigResolved[K]
+    : never) &
+    (K extends keyof Extensions ? Extensions[K] : {})
 }
 
 declare function resolveConfig<T extends Config>(config: T): ResolvedConfig<T>

--- a/resolveConfig.d.ts
+++ b/resolveConfig.d.ts
@@ -17,12 +17,14 @@ type ThemeConfigResolved = UnwrapResolvables<ThemeConfig>
 type DefaultThemeFull = DefaultTheme & { colors: DefaultColors }
 
 type MergeThemes<Overrides extends object, Extensions extends object> = {
-  [K in keyof ThemeConfigResolved]: (
+  [K in keyof ThemeConfigResolved | keyof Overrides]: (
     K extends keyof Overrides
       ? Overrides[K]
       : K extends keyof DefaultThemeFull
       ? DefaultThemeFull[K]
-      : ThemeConfigResolved[K]
+      : K extends keyof ThemeConfigResolved
+      ? ThemeConfigResolved[K]
+      : never
   ) & (K extends keyof Extensions ? Extensions[K] : {})
 }
 

--- a/resolveConfig.d.ts
+++ b/resolveConfig.d.ts
@@ -1,4 +1,4 @@
-import { Config, ResolvableTo } from './types/config'
+import { Config, ResolvableTo, ThemeConfig } from "./types/config";
 import { DefaultTheme } from './types/generated/default-theme'
 import { DefaultColors } from './types/generated/colors'
 
@@ -10,12 +10,17 @@ type UnwrapResolvables<T> = {
   [K in keyof T]: T[K] extends ResolvableTo<infer R> ? R : T[K]
 }
 
-type DefaultThemeFull = Omit<DefaultTheme, 'extend'> & { colors: DefaultColors }
+type ThemeConfigResolved = UnwrapResolvables<ThemeConfig>
+type DefaultThemeFull = DefaultTheme & { colors: DefaultColors }
 
 type MergeThemes<Overrides extends object, Extensions extends object> = {
-  [K in keyof DefaultThemeFull]:
-    (K extends keyof Overrides ? Overrides[K] : DefaultThemeFull[K])
-    & (K extends keyof Extensions ? Extensions[K] : {})
+  [K in keyof ThemeConfig]: (
+    K extends keyof Overrides
+      ? Overrides[K]
+      : K extends keyof DefaultThemeFull
+      ? DefaultThemeFull[K]
+      : ThemeConfigResolved[K]
+  ) & (K extends keyof Extensions ? Extensions[K] : {})
 }
 
 declare function resolveConfig<T extends Config>(config: T): ResolvedConfig<T>

--- a/resolveConfig.d.ts
+++ b/resolveConfig.d.ts
@@ -5,7 +5,7 @@ import { DefaultColors } from './types/generated/colors'
 type ResolvedConfig<T extends Config> = Omit<T, 'theme'> & {
   theme: MergeThemes<
     UnwrapResolvables<Omit<T['theme'], 'extend'>>,
-    UnwrapResolvables<T['theme']['extend']>
+    T['theme'] extends { extend: infer TExtend } ? UnwrapResolvables<TExtend> : {}
   >
 }
 

--- a/resolveConfig.d.ts
+++ b/resolveConfig.d.ts
@@ -3,7 +3,7 @@ import { DefaultTheme } from './types/generated/default-theme'
 import { DefaultColors } from './types/generated/colors'
 
 type ResolvedConfig<T extends Config> = Omit<T, 'theme'> & {
-  theme: MergeThemes<UnwrapResolvables<T['theme']>>
+  theme: MergeThemes<UnwrapResolvables<T['theme']>, UnwrapResolvables<T['theme']['extend']>>
 }
 
 type UnwrapResolvables<T> = {
@@ -12,11 +12,11 @@ type UnwrapResolvables<T> = {
 
 type DefaultThemeFull = DefaultTheme & { colors: DefaultColors }
 
-type MergeThemes<T extends Config['theme']> = {
+type MergeThemes<T extends Config['theme'], E extends Config['theme']['extend']> = {
   [K in keyof DefaultThemeFull]: K extends keyof T
     ? T[K]
-    : K extends keyof T['extend']
-    ? DefaultThemeFull[K] & T['extend'][K]
+    : K extends keyof E
+    ? DefaultThemeFull[K] & E[K]
     : DefaultThemeFull[K]
 }
 

--- a/resolveConfig.d.ts
+++ b/resolveConfig.d.ts
@@ -1,11 +1,23 @@
-import type { Config, ResolvableTo } from './types/config'
+import { Config, ResolvableTo } from './types/config'
+import { DefaultTheme } from './types/generated/default-theme'
+import { DefaultColors } from './types/generated/colors'
+
+type ResolvedConfig<T extends Config> = Omit<T, 'theme'> & {
+  theme: MergeThemes<UnwrapResolvables<T['theme']>>
+}
 
 type UnwrapResolvables<T> = {
   [K in keyof T]: T[K] extends ResolvableTo<infer R> ? R : T[K]
 }
 
-type ResolvedConfig<T extends Config> = Omit<T, 'theme'> & {
-  theme: UnwrapResolvables<T['theme']>
+type DefaultThemeFull = DefaultTheme & { colors: DefaultColors }
+
+type MergeThemes<T extends Config['theme']> = {
+  [K in keyof DefaultThemeFull]: K extends keyof T
+    ? T[K]
+    : K extends keyof T['extend']
+    ? DefaultThemeFull[K] & T['extend'][K]
+    : DefaultThemeFull[K]
 }
 
 declare function resolveConfig<T extends Config>(config: T): ResolvedConfig<T>

--- a/resolveConfig.d.ts
+++ b/resolveConfig.d.ts
@@ -10,7 +10,7 @@ type UnwrapResolvables<T> = {
   [K in keyof T]: T[K] extends ResolvableTo<infer R> ? R : T[K]
 }
 
-type DefaultThemeFull = DefaultTheme & { colors: DefaultColors }
+type DefaultThemeFull = Omit<DefaultTheme, 'extend'> & { colors: DefaultColors }
 
 type MergeThemes<T extends Config['theme'], E extends Config['theme']['extend']> = {
   [K in keyof DefaultThemeFull]: (K extends keyof T ? T[K] : DefaultThemeFull[K])

--- a/resolveConfig.d.ts
+++ b/resolveConfig.d.ts
@@ -12,9 +12,10 @@ type UnwrapResolvables<T> = {
 
 type DefaultThemeFull = Omit<DefaultTheme, 'extend'> & { colors: DefaultColors }
 
-type MergeThemes<T extends Config['theme'], E extends Config['theme']['extend']> = {
-  [K in keyof DefaultThemeFull]: (K extends keyof T ? T[K] : DefaultThemeFull[K])
-    & (K extends keyof E ? E[K] : {})
+type MergeThemes<Overrides extends object, Extensions extends object> = {
+  [K in keyof DefaultThemeFull]:
+    (K extends keyof Overrides ? Overrides[K] : DefaultThemeFull[K])
+    & (K extends keyof Extensions ? Extensions[K] : {})
 }
 
 declare function resolveConfig<T extends Config>(config: T): ResolvedConfig<T>

--- a/resolveConfig.d.ts
+++ b/resolveConfig.d.ts
@@ -3,7 +3,10 @@ import { DefaultTheme } from './types/generated/default-theme'
 import { DefaultColors } from './types/generated/colors'
 
 type ResolvedConfig<T extends Config> = Omit<T, 'theme'> & {
-  theme: MergeThemes<UnwrapResolvables<T['theme']>, UnwrapResolvables<T['theme']['extend']>>
+  theme: MergeThemes<
+    UnwrapResolvables<Omit<T['theme'], 'extend'>>,
+    UnwrapResolvables<T['theme']['extend']>
+  >
 }
 
 type UnwrapResolvables<T> = {
@@ -14,7 +17,7 @@ type ThemeConfigResolved = UnwrapResolvables<ThemeConfig>
 type DefaultThemeFull = DefaultTheme & { colors: DefaultColors }
 
 type MergeThemes<Overrides extends object, Extensions extends object> = {
-  [K in keyof ThemeConfig]: (
+  [K in keyof ThemeConfigResolved]: (
     K extends keyof Overrides
       ? Overrides[K]
       : K extends keyof DefaultThemeFull

--- a/resolveConfig.d.ts
+++ b/resolveConfig.d.ts
@@ -13,11 +13,8 @@ type UnwrapResolvables<T> = {
 type DefaultThemeFull = DefaultTheme & { colors: DefaultColors }
 
 type MergeThemes<T extends Config['theme'], E extends Config['theme']['extend']> = {
-  [K in keyof DefaultThemeFull]: K extends keyof T
-    ? T[K]
-    : K extends keyof E
-    ? DefaultThemeFull[K] & E[K]
-    : DefaultThemeFull[K]
+  [K in keyof DefaultThemeFull]: (K extends keyof T ? T[K] : DefaultThemeFull[K])
+    & (K extends keyof E ? E[K] : {})
 }
 
 declare function resolveConfig<T extends Config>(config: T): ResolvedConfig<T>

--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -91,9 +91,8 @@ fs.writeFileSync(
   path.join(process.cwd(), 'types', 'generated', 'default-theme.d.ts'),
   prettier.format(
     `
-    import { Config } from '../../types'
     type CSSDeclarationList = Record<string, string>
-    export type DefaultTheme = Config['theme'] & { ${defaultThemeTypes} }
+    export type DefaultTheme = { ${defaultThemeTypes} }
   `,
     {
       semi: false,

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -237,7 +237,7 @@ export interface ThemeConfig {
   content: ResolvableTo<KeyValuePair>
 }
 
-interface ThemeConfigCustomizable extends ThemeConfig {
+interface CustomThemeConfig extends ThemeConfig {
   [key: string]: any
 }
 
@@ -362,7 +362,7 @@ interface OptionalConfig {
   future: Partial<FutureConfig>
   experimental: Partial<ExperimentalConfig>
   darkMode: Partial<DarkModeConfig>
-  theme: Partial<ThemeConfigCustomizable & { extend: Partial<ThemeConfigCustomizable> }>
+  theme: Partial<CustomThemeConfig & { extend: Partial<CustomThemeConfig> }>
   corePlugins: Partial<CorePluginsConfig>
   plugins: Partial<PluginsConfig>
   // Custom

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -80,7 +80,7 @@ type Screen = { raw: string } | { min: string } | { max: string } | { min: strin
 type ScreensConfig = string[] | KeyValuePair<string, string | Screen | Screen[]>
 
 // Theme related config
-interface ThemeConfig {
+export interface ThemeConfig {
   // Responsiveness
   screens: ResolvableTo<ScreensConfig>
   supports: ResolvableTo<Record<string, string>>

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -235,8 +235,9 @@ export interface ThemeConfig {
   transitionDuration: ResolvableTo<KeyValuePair>
   willChange: ResolvableTo<KeyValuePair>
   content: ResolvableTo<KeyValuePair>
+}
 
-  // Custom
+interface ThemeConfigCustomizable extends ThemeConfig {
   [key: string]: any
 }
 
@@ -361,7 +362,7 @@ interface OptionalConfig {
   future: Partial<FutureConfig>
   experimental: Partial<ExperimentalConfig>
   darkMode: Partial<DarkModeConfig>
-  theme: Partial<ThemeConfig & { extend: Partial<ThemeConfig> }>
+  theme: Partial<ThemeConfigCustomizable & { extend: Partial<ThemeConfigCustomizable> }>
   corePlugins: Partial<CorePluginsConfig>
   plugins: Partial<PluginsConfig>
   // Custom


### PR DESCRIPTION
This PR addresses https://github.com/tailwindlabs/tailwindcss/issues/12264, adding some special handling of the `theme` key in `ResolvedConfig` to better reflect how `theme` and `theme.extend` are merged with the default theme values. Specifically:

* Include the generated type `DefaultTheme` in the return value
* If a theme key is set in `config.theme`, it overrides the default theme value
* If a theme key is extended in `config.theme.extend`, it's intersected with the resolved theme value
* Custom theme keys set in the user config will also still show up in the return type

The generated `DefaultTheme` type doesn't itself contain all possible theme config keys (those that are defined via a callback are omitted), so we fall back to values from `ThemeConfig`, which are of a less concrete type (eg. `KeyValuePair<string, string>`).

Basically, I think I've implemented the "ridiculousness with conditional types" mentioned in [the review for this PR](https://github.com/tailwindlabs/tailwindcss/pull/9972/files#r1035948691)

### Incidental changes

A couple of small changes were necessary elsewhere in the codebase to facilitate this:

**`generate-types.js`**: Do not intersect the generated `DefaultTheme` type with `Config['theme']`. We need to use the concrete value types in here to improve the `ResolvedConfig` type, and the `Config['theme']` types get in the way of this. As far as I can see, the only place where `DefaultTheme` is currently referenced is in `defaultTheme.d.ts` where it is once again intersected with `Config['theme']`, so this change shouldn't make a difference to that.

**`config.d.ts`**: I exported `ThemeConfig` to use in `ResolvedConfig`, and I also split out a separate `ThemeConfigCustomizable` interface which includes the final `[key: string]: any`. Otherwise there was no way to avoid `ResolvedConfig` itself including a fallback `[key: string]: any`, rendering any unknown property access valid in typescript's eye.

### Testing

Given that the codebase itself isn't written in typescript, I wasn't sure of a good way to test the changes. I resorted to creating a sample ts file defining a config, resolving it, and trying to access various keys on the output---using my IDE for typescript feedback.

<details>
<summary>Example test file</summary>

```ts
import { Config } from './types/config'
import resolveConfig = require('./resolveConfig')

const config = {
  content: ['**/*.js'],
  theme: {
    gap: {
      1: '1',
      2: '2',
    },
    myCustom: {
      foo: 'custom',
      bar: 'custom',
    },
    extend: {
      colors: {
        cerulean: {
          50: 'bla',
          100: 'yeah',
          200: 'another',
        }
      },
      gap: {
        3: '3'
      }
    }
  }
} satisfies Config

const theme = resolveConfig(config).theme

theme.colors.cerulean // ✅
theme.colors.zinc // ✅
theme.gap // { 1, 2, 3 }
theme.spacing // { 0, 1, 2, 3, ... }
theme.padding // KeyValuePair<string, string>
// @ts-expect-error
theme.extend
// @ts-expect-error
theme.bla
theme.myCustom // ✅
```

</details>

I'd gladly do more real-world testing or add tests to the codebase if an approach could be suggested.

This is my first PR to a large-scale OS project. I hope it's useful!