### PR TITLE
Fix incorrect spaces around `-` in `calc()` expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix source maps issue resulting in a crash ([#11319](https://github.com/tailwindlabs/tailwindcss/pull/11319))
 - Fallback to RegEx based parser when using custom transformers or extractors ([#11335](https://github.com/tailwindlabs/tailwindcss/pull/11335))
 - Bump `lightningcss` and reflect related improvements in tests ([#11550](https://github.com/tailwindlabs/tailwindcss/pull/11550))
+- Fix incorrect spaces around `-` in `calc()` expression ([#12283](https://github.com/tailwindlabs/tailwindcss/pull/12283))
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
       "devDependencies": {
         "rollup": "^3.29.4",
         "rollup-plugin-postcss": "^4.0.2",
-        "sass": "1.69.4"
+        "sass": "^1.69.4"
       }
     },
     "integrations/tailwindcss-cli": {
@@ -19178,7 +19178,7 @@
       "requires": {
         "rollup": "^3.29.4",
         "rollup-plugin-postcss": "^4.0.2",
-        "sass": "1.69.4"
+        "sass": "^1.69.4"
       }
     },
     "@tailwindcss/integrations-tailwindcss-cli": {
@@ -29825,7 +29825,7 @@
           "requires": {
             "rollup": "^3.29.4",
             "rollup-plugin-postcss": "^4.0.2",
-            "sass": "1.69.4"
+            "sass": "^1.69.4"
           }
         },
         "@tailwindcss/integrations-tailwindcss-cli": {

--- a/src/util/dataTypes.js
+++ b/src/util/dataTypes.js
@@ -84,8 +84,30 @@ export function normalize(value, context = null, isRoot = true) {
  * @returns {string}
  */
 function normalizeMathOperatorSpacing(value) {
-  let preventFormattingInFunctions = ['theme', 'env']
-  let preventFormattingKeywords = ['min-content', 'max-content', 'fit-content']
+  let preventFormattingInFunctions = ['theme']
+  let preventFormattingKeywords = [
+    'min-content',
+    'max-content',
+    'fit-content',
+
+    // Env
+    'safe-area-inset-top',
+    'safe-area-inset-right',
+    'safe-area-inset-bottom',
+    'safe-area-inset-left',
+
+    'titlebar-area-x',
+    'titlebar-area-y',
+    'titlebar-area-width',
+    'titlebar-area-height',
+
+    'keyboard-inset-top',
+    'keyboard-inset-right',
+    'keyboard-inset-bottom',
+    'keyboard-inset-left',
+    'keyboard-inset-width',
+    'keyboard-inset-height',
+  ]
 
   return value.replace(/(calc|min|max|clamp)\(.+\)/g, (match) => {
     let result = ''

--- a/src/util/dataTypes.js
+++ b/src/util/dataTypes.js
@@ -84,7 +84,7 @@ export function normalize(value, context = null, isRoot = true) {
  * @returns {string}
  */
 function normalizeMathOperatorSpacing(value) {
-  let preventFormattingInFunctions = ['theme']
+  let preventFormattingInFunctions = ['theme', 'env']
 
   return value.replace(/(calc|min|max|clamp)\(.+\)/g, (match) => {
     let result = ''

--- a/src/util/dataTypes.js
+++ b/src/util/dataTypes.js
@@ -85,6 +85,7 @@ export function normalize(value, context = null, isRoot = true) {
  */
 function normalizeMathOperatorSpacing(value) {
   let preventFormattingInFunctions = ['theme', 'env']
+  let preventFormattingKeywords = ['min-content', 'max-content', 'fit-content']
 
   return value.replace(/(calc|min|max|clamp)\(.+\)/g, (match) => {
     let result = ''
@@ -125,6 +126,13 @@ function normalizeMathOperatorSpacing(value) {
         //
         //   In this case we do want to "format", the default value as well
         result += consumeUntil([')', ','])
+      }
+
+      // Skip formatting of known keywords
+      else if (preventFormattingKeywords.some((keyword) => peek(keyword))) {
+        let keyword = preventFormattingKeywords.find((keyword) => peek(keyword))
+        result += keyword
+        i += keyword.length - 1
       }
 
       // Skip formatting inside known functions

--- a/tests/arbitrary-values.test.js
+++ b/tests/arbitrary-values.test.js
@@ -652,3 +652,17 @@ it('should not insert spaces around operators inside `env()`', () => {
     `)
   })
 })
+
+it('should not insert spaces around `-` in arbitrary values that use `max-content`', () => {
+  let config = {
+    content: [{ raw: html`<div class="grid-cols-[repeat(3,_minmax(0,_max-content))]"></div>` }],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .grid-cols-\[repeat\(3\,_minmax\(0\,_max-content\)\)\] {
+        grid-template-columns: repeat(3, minmax(0, max-content));
+      }
+    `)
+  })
+})

--- a/tests/arbitrary-values.test.js
+++ b/tests/arbitrary-values.test.js
@@ -638,3 +638,17 @@ it('should support underscores in arbitrary modifiers', () => {
     `)
   })
 })
+
+it('should not insert spaces around operators inside `env()`', () => {
+  let config = {
+    content: [{ raw: html`<div class="grid-cols-[calc(env(safe-area-inset-bottom)+1px)]"></div>` }],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .grid-cols-\[calc\(env\(safe-area-inset-bottom\)\+1px\)\] {
+        grid-template-columns: calc(env(safe-area-inset-bottom) + 1px);
+      }
+    `)
+  })
+})

--- a/tests/normalize-data-types.test.js
+++ b/tests/normalize-data-types.test.js
@@ -68,6 +68,15 @@ let table = [
   ['calc(theme(spacing.foo-2))', 'calc(theme(spacing.foo-2))'],
   ['calc(theme(spacing.foo-bar))', 'calc(theme(spacing.foo-bar))'],
 
+  // Prevent formatting inside `var()` functions
+  ['calc(var(--foo-bar-bar)*2)', 'calc(var(--foo-bar-bar) * 2)'],
+
+  // Prevent formatting inside `env()` functions
+  ['calc(env(safe-area-inset-bottom)*2)', 'calc(env(safe-area-inset-bottom) * 2)'],
+
+  // Prevent formatting keywords
+  ['minmax(min-content,25%)', 'minmax(min-content,25%)'],
+
   // Misc
   ['color(0_0_0/1.0)', 'color(0 0 0/1.0)'],
   ['color(0_0_0_/_1.0)', 'color(0 0 0 / 1.0)'],

--- a/tests/normalize-data-types.test.js
+++ b/tests/normalize-data-types.test.js
@@ -73,6 +73,12 @@ let table = [
 
   // Prevent formatting inside `env()` functions
   ['calc(env(safe-area-inset-bottom)*2)', 'calc(env(safe-area-inset-bottom) * 2)'],
+  // Should format inside `calc()` nested in `env()`
+  ['env(safe-area-inset-bottom,calc(10px+20px))', 'env(safe-area-inset-bottom,calc(10px + 20px))'],
+  [
+    'calc(env(safe-area-inset-bottom,calc(10px+20px))+5px)',
+    'calc(env(safe-area-inset-bottom,calc(10px + 20px)) + 5px)',
+  ],
 
   // Prevent formatting keywords
   ['minmax(min-content,25%)', 'minmax(min-content,25%)'],


### PR DESCRIPTION
This PR fixes a bug where incorrect spaces were added around `-` in `calc()` expressions. This is
happening in places like:

- `minmax(min-content,25%)` -> `minmax(min - content,25%)`
- `calc(env(safe-area-inset-bottom,20px))` -> `calc(env(safe - area - inset - bottom,20px))`

This PR solves that.

Fixes: #12281

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
