### PR TITLE
Add size-text shorthand

### DIFF
--- a/stubs/config.full.js
+++ b/stubs/config.full.js
@@ -1001,6 +1001,7 @@ module.exports = {
       min: 'min-content',
       max: 'max-content',
       fit: 'fit-content',
+      text: '1em',
     }),
     width: ({ theme }) => ({
       auto: 'auto',

--- a/tests/plugins/__snapshots__/size.test.js.snap
+++ b/tests/plugins/__snapshots__/size.test.js.snap
@@ -343,5 +343,10 @@ exports[`should test the 'size' plugin 1`] = `
   width: 1px;
   height: 1px;
 }
+
+.size-text {
+  width: 1em;
+  height: 1em;
+}
 "
 `;


### PR DESCRIPTION
This PR adds a `size-text` utility that sets `width` and `height` to `1em`. 

This is super useful when making icons and other elements that can then be controlled by setting a font-size on the parent or the element itself.

Relates to #12287 