### PR TITLE
Add subgrid utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support loading plugins by package / file name ([#12087](https://github.com/tailwindlabs/tailwindcss/pull/12087))
 - Increase default values for `grid-rows-*` utilities from 1–6 to 1–12 ([#12180](https://github.com/tailwindlabs/tailwindcss/pull/12180))
 - Add `size-*` utilities ([#12287](https://github.com/tailwindlabs/tailwindcss/pull/12287))
+- Add utilities for CSS subgrid ([#12298](https://github.com/tailwindlabs/tailwindcss/pull/12298))
 
 ### Changed
 

--- a/stubs/config.full.js
+++ b/stubs/config.full.js
@@ -486,6 +486,7 @@ module.exports = {
     },
     gridTemplateColumns: {
       none: 'none',
+      subgrid: 'subgrid',
       1: 'repeat(1, minmax(0, 1fr))',
       2: 'repeat(2, minmax(0, 1fr))',
       3: 'repeat(3, minmax(0, 1fr))',
@@ -501,6 +502,7 @@ module.exports = {
     },
     gridTemplateRows: {
       none: 'none',
+      subgrid: 'subgrid',
       1: 'repeat(1, minmax(0, 1fr))',
       2: 'repeat(2, minmax(0, 1fr))',
       3: 'repeat(3, minmax(0, 1fr))',

--- a/tests/plugins/__snapshots__/gridTemplateColumns.test.js.snap
+++ b/tests/plugins/__snapshots__/gridTemplateColumns.test.js.snap
@@ -61,5 +61,9 @@ exports[`should test the 'gridTemplateColumns' plugin 1`] = `
 .grid-cols-none {
   grid-template-columns: none;
 }
+
+.grid-cols-subgrid {
+  grid-template-columns: subgrid;
+}
 "
 `;

--- a/tests/plugins/__snapshots__/gridTemplateRows.test.js.snap
+++ b/tests/plugins/__snapshots__/gridTemplateRows.test.js.snap
@@ -61,5 +61,9 @@ exports[`should test the 'gridTemplateRows' plugin 1`] = `
 .grid-rows-none {
   grid-template-rows: none;
 }
+
+.grid-rows-subgrid {
+  grid-template-rows: subgrid;
+}
 "
 `;


### PR DESCRIPTION
This PR adds `subgrid` as a default theme value for the `gridTemplateColumns` and `gridTemplateRows` plugins, which in turn generates new `grid-cols-subgrid` and `grid-rows-subgrid` utility classes.