### PR TITLE
Don’t add spaces to negative numbers following a comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Improve types for `resolveConfig` ([#12272](https://github.com/tailwindlabs/tailwindcss/pull/12272))
+- Don’t add spaces to negative numbers following a comma ([#12324](https://github.com/tailwindlabs/tailwindcss/pull/12324))
 - [Oxide] Remove `autoprefixer` dependency ([#11315](https://github.com/tailwindlabs/tailwindcss/pull/11315))
 - [Oxide] Fix source maps issue resulting in a crash ([#11319](https://github.com/tailwindlabs/tailwindcss/pull/11319))
 - [Oxide] Fallback to RegEx based parser when using custom transformers or extractors ([#11335](https://github.com/tailwindlabs/tailwindcss/pull/11335))

--- a/src/util/dataTypes.js
+++ b/src/util/dataTypes.js
@@ -78,7 +78,7 @@ export function normalize(value, context = null, isRoot = true) {
 
 /**
  * Add spaces around operators inside math functions
- * like calc() that do not follow an operator or '('.
+ * like calc() that do not follow an operator, '(', or `,`.
  *
  * @param {string} value
  * @returns {string}
@@ -165,7 +165,7 @@ function normalizeMathOperatorSpacing(value) {
       // Handle operators
       else if (
         ['+', '-', '*', '/'].includes(char) &&
-        !['(', '+', '-', '*', '/'].includes(lastChar())
+        !['(', '+', '-', '*', '/', ','].includes(lastChar())
       ) {
         result += ` ${char} `
       } else {

--- a/tests/normalize-data-types.test.js
+++ b/tests/normalize-data-types.test.js
@@ -68,6 +68,9 @@ let table = [
   ['calc(theme(spacing.foo-2))', 'calc(theme(spacing.foo-2))'],
   ['calc(theme(spacing.foo-bar))', 'calc(theme(spacing.foo-bar))'],
 
+  // A negative number immediately after a `,` should not have spaces inserted
+  ['clamp(-3px+4px,-3px+4px,-3px+4px)', 'clamp(-3px + 4px,-3px + 4px,-3px + 4px)'],
+
   // Prevent formatting inside `var()` functions
   ['calc(var(--foo-bar-bar)*2)', 'calc(var(--foo-bar-bar) * 2)'],
 


### PR DESCRIPTION
Given an arbitrary value like `mt-[clamp(0.25rem,-0.6731rem+4.1026vw,4.25rem)]` we would incorrectly "fix" the operator spacing for the negative number if it followed a comma by inserting a space. However, the only valid incantation here is to *not* have a space.

Before:
```css
.mt-\[clamp\(0\2c -0\.5rem\+4vw\2c 4rem\)\] {
  margin-top: clamp(0, - 0.5rem + 4vw,4rem);
}
```

After:
```css
.mt-\[clamp\(0\2c -0\.5rem\+4vw\2c 4rem\)\] {
  margin-top: clamp(0,-0.5rem + 4vw,4rem);
}
```

Fixes #12318