### PR TITLE
Don't emit `@config` in CSS when watching via the CLI

### DIFF
--- a/src/cli/build/plugin.js
+++ b/src/cli/build/plugin.js
@@ -224,15 +224,15 @@ let state = {
   },
 
   getContext({ createContext, cliConfigPath, root, result, content }) {
+    env.DEBUG && console.time('Searching for config')
+    let configPath = findAtConfigPath(root, result) ?? cliConfigPath
+    env.DEBUG && console.timeEnd('Searching for config')
+
     if (this.context) {
       this.context.changedContent = this.changedContent.splice(0)
 
       return this.context
     }
-
-    env.DEBUG && console.time('Searching for config')
-    let configPath = findAtConfigPath(root, result) ?? cliConfigPath
-    env.DEBUG && console.timeEnd('Searching for config')
 
     env.DEBUG && console.time('Loading config')
     let config = this.loadConfig(configPath, content)


### PR DESCRIPTION
When using the CLI and the `@config` directive, we would not remove the directive on rebuilds caused by changes to any files covered by `content`. This would then cause the `@config` directive to appear in the output CSS file. Though, a re-save of the config file would remove the directive.

**If you're using Tailwind CSS as a PostCSS plugin this did not happen.**

This PR fixes this and now the `@config` directive is correctly removed in all cases.

Fixes #12258