### PR TITLE
Add `appearance-auto` utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add spacing scale to `min-w-*`, `min-h-*`, and `max-w-*` utilities ([#12300](https://github.com/tailwindlabs/tailwindcss/pull/12300))
 - Add `forced-color-adjust` utilities ([#11931](https://github.com/tailwindlabs/tailwindcss/pull/11931))
 - Add `forced-colors` variant ([#11694](https://github.com/tailwindlabs/tailwindcss/pull/11694))
+- Add `appearance-none` utility ([#12404](https://github.com/tailwindlabs/tailwindcss/pull/12404))
 - [Oxide] New Rust template parsing engine ([#10252](https://github.com/tailwindlabs/tailwindcss/pull/10252))
 - [Oxide] Support `@import "tailwindcss"` using top-level `index.css` file ([#11205](https://github.com/tailwindlabs/tailwindcss/pull/11205), ([#11260](https://github.com/tailwindlabs/tailwindcss/pull/11260)))
 - [Oxide] Use `lightningcss` for nesting and vendor prefixes in PostCSS plugin ([#10399](https://github.com/tailwindlabs/tailwindcss/pull/10399))

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -1129,6 +1129,7 @@ export let corePlugins = {
   appearance: ({ addUtilities }) => {
     addUtilities({
       '.appearance-none': { appearance: 'none' },
+      '.appearance-auto': { appearance: 'auto' },
     })
   },
 

--- a/tests/plugins/__snapshots__/appearance.test.js.snap
+++ b/tests/plugins/__snapshots__/appearance.test.js.snap
@@ -6,5 +6,10 @@ exports[`should test the 'appearance' plugin 1`] = `
   -webkit-appearance: none;
   appearance: none;
 }
+
+.appearance-auto {
+  -webkit-appearance: auto;
+  appearance: auto;
+}
 "
 `;


### PR DESCRIPTION
This PR adds a new `appearance-auto` utility for setting `appearance: auto`.

The `auto` value is quite a bit newer than the `none` value we've supported for years, but has quite good browser support now:

https://caniuse.com/mdn-css_properties_appearance_auto

Resolves #12401.