### PR TITLE
Add logical properties support for float and clear

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -684,6 +684,8 @@ export let corePlugins = {
 
   float: ({ addUtilities }) => {
     addUtilities({
+      '.float-start': { float: 'inline-start' },
+      '.float-end': { float: 'inline-end' },
       '.float-right': { float: 'right' },
       '.float-left': { float: 'left' },
       '.float-none': { float: 'none' },
@@ -692,6 +694,8 @@ export let corePlugins = {
 
   clear: ({ addUtilities }) => {
     addUtilities({
+      '.clear-start': { clear: 'inline-start' },
+      '.clear-end': { clear: 'inline-end' },
       '.clear-left': { clear: 'left' },
       '.clear-right': { clear: 'right' },
       '.clear-both': { clear: 'both' },

--- a/tests/plugins/__snapshots__/clear.test.js.snap
+++ b/tests/plugins/__snapshots__/clear.test.js.snap
@@ -2,6 +2,14 @@
 
 exports[`should test the 'clear' plugin 1`] = `
 "
+.clear-start {
+  clear: inline-start;
+}
+
+.clear-end {
+  clear: inline-end;
+}
+
 .clear-left {
   clear: left;
 }

--- a/tests/plugins/__snapshots__/float.test.js.snap
+++ b/tests/plugins/__snapshots__/float.test.js.snap
@@ -2,6 +2,14 @@
 
 exports[`should test the 'float' plugin 1`] = `
 "
+.float-start {
+  float: inline-start;
+}
+
+.float-end {
+  float: inline-end;
+}
+
 .float-right {
   float: right;
 }


### PR DESCRIPTION
This update introduces support for logical properties related to floating and clearing elements in TailwindCSS. Following this: https://github.com/tailwindlabs/tailwindcss/discussions/12469.

By adding classes like `.float-start`, `.float-end,` `.clear-start`, and `.clear-end`, this enhancement aligns TailwindCSS with modern browser capabilities.

![image](https://github.com/tailwindlabs/tailwindcss/assets/56961917/1ef0d07f-6029-4aaf-90e3-b79db537ab58)

![image](https://github.com/tailwindlabs/tailwindcss/assets/56961917/26bff9a7-6948-4b67-acf3-679d1c25b768)
