### PR TITLE
Fix loading of built-in plugins when using an ESM or TypeScript config with the Standalone CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't crash when given applying a variant to a negated version of a simple utility ([#12514](https://github.com/tailwindlabs/tailwindcss/pull/12514))
 - Fix support for slashes in arbitrary modifiers ([#12515](https://github.com/tailwindlabs/tailwindcss/pull/12515))
 - Fix source maps of variant utilities that come from an `@layer` rule ([#12508](https://github.com/tailwindlabs/tailwindcss/pull/12508))
+- Fix loading of built-in plugins when using an ESM or TypeScript config with the Standalone CLI ([#12506](https://github.com/tailwindlabs/tailwindcss/pull/12506))
 - [Oxide] Remove `autoprefixer` dependency ([#11315](https://github.com/tailwindlabs/tailwindcss/pull/11315))
 - [Oxide] Fix source maps issue resulting in a crash ([#11319](https://github.com/tailwindlabs/tailwindcss/pull/11319))
 - [Oxide] Fallback to RegEx based parser when using custom transformers or extractors ([#11335](https://github.com/tailwindlabs/tailwindcss/pull/11335))

--- a/src/lib/load-config.ts
+++ b/src/lib/load-config.ts
@@ -4,6 +4,14 @@ import { transform } from 'sucrase'
 import { Config } from '../../types/config'
 
 let jiti: ReturnType<typeof jitiFactory> | null = null
+
+// @internal
+// This WILL be removed in some future release
+// If you rely on this your stuff WILL break
+export function useCustomJiti(_jiti: ReturnType<typeof jitiFactory>) {
+  jiti = _jiti
+}
+
 function lazyJiti() {
   return (
     jiti ??

--- a/standalone-cli/patch-require.js
+++ b/standalone-cli/patch-require.js
@@ -1,0 +1,50 @@
+const Module = require('node:module')
+
+/**
+ * @param {Record<string, any>} mods
+ */
+module.exports.patchRequire = function patchRequire(mods, parentCache) {
+  function wrapRequire(origRequire) {
+    return Object.assign(
+      function (id) {
+        // Patch require(…) to return the cached module
+        if (mods.hasOwnProperty(id)) {
+          return mods[id]
+        }
+
+        return origRequire.apply(this, arguments)
+      },
+
+      // Make sure we carry over other properties of the original require(…)
+      origRequire,
+
+      {
+        resolve(id) {
+          // Defer to the "parent" require cache when resolving the module
+          // This also requires that the module be provided as a "native module" to JITI
+
+          // The path returned here is VERY important as it ensures that the `isNativeRe` in JITI
+          // passes which is required for the module to be loaded via the native require(…) function
+          // Thankfully, the regex just means that it needs to be in a node_modules folder which is true
+          // even when bundled using Vercel's `pkg`
+          if (parentCache.hasOwnProperty(id)) {
+            return parentCache[id].filename
+          }
+
+          return origRequire.resolve.apply(this, arguments)
+        },
+      }
+    )
+  }
+
+  let origRequire = Module.prototype.require
+  let origCreateRequire = Module.createRequire
+
+  // We have to augment the default "require" in every module
+  Module.prototype.require = wrapRequire(origRequire)
+
+  // And any "require" created by the "createRequire" method
+  Module.createRequire = function () {
+    return wrapRequire(origCreateRequire.apply(this, arguments))
+  }
+}


### PR DESCRIPTION
In the case of a config that's not directly loadable by NodeJS — for example because it is TypeScript, ESM, or uses unsupported syntax, we invoke JITI to load the config file.

Normally there are no problems caused by this. However, in the standalone CLI we provide our plugins already built-in. This becomes a problem because JITI uses a version of require that we were not patching to load the built in plugins.

Making this work is a bit more complicated than it seems at first glance and relies on an internal implementation detail of JITI. However, it's _probably_ one that's not subject to change too much (… famous last words — I know)

Basically we now:
- Patch `require` and `require.resolve` that's available natively to every module loaded by Node
- Patch `createRequire` to return patched require + resolve functions that work the same way
- Overload the JITI instance used so we can provide additional options that effectively instruct it to always use the "native" require to load the module rather than trying to find it on the filesystem

Fixes #12374