### PR TITLE
Don't crash when given applying a variant to a negated version of a simple utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't emit `@config` in CSS when watching via the CLI ([#12327](https://github.com/tailwindlabs/tailwindcss/pull/12327))
 - Ensure configured `font-feature-settings` for `mono` are included in Preflight ([#12342](https://github.com/tailwindlabs/tailwindcss/pull/12342))
 - Improve candidate detection in minified JS arrays (without spaces) ([#12396](https://github.com/tailwindlabs/tailwindcss/pull/12396))
+- Don't crash when given applying a variant to a negated version of a simple utility ([#12514](https://github.com/tailwindlabs/tailwindcss/pull/12514))
 - [Oxide] Remove `autoprefixer` dependency ([#11315](https://github.com/tailwindlabs/tailwindcss/pull/11315))
 - [Oxide] Fix source maps issue resulting in a crash ([#11319](https://github.com/tailwindlabs/tailwindcss/pull/11319))
 - [Oxide] Fallback to RegEx based parser when using custom transformers or extractors ([#11335](https://github.com/tailwindlabs/tailwindcss/pull/11335))

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -840,6 +840,11 @@ function applyFinalFormat(match, { context, candidate }) {
     return null
   }
 
+  // If all rules have been eliminated we can skip this candidate entirely
+  if (container.nodes.length === 0) {
+    return null
+  }
+
   match[1] = container.nodes[0]
 
   return match

--- a/tests/negative-prefix.test.js
+++ b/tests/negative-prefix.test.js
@@ -339,4 +339,24 @@ test('arbitrary value keywords should be ignored', () => {
   return run('@tailwind utilities', config).then((result) => {
     return expect(result.css).toMatchFormattedCss(css``)
   })
+
+  // This is a weird test but it used to crash because the negative prefix + variant used to cause an undefined utility to be generated
+  test('addUtilities without negative prefix + variant + negative prefix in content should not crash', async () => {
+    let config = {
+      content: [{ raw: html`<div class="hover:-top-lg"></div>` }],
+      plugins: [
+        ({ addUtilities }) => {
+          addUtilities({
+            '.top-lg': {
+              top: '6rem',
+            },
+          })
+        },
+      ],
+    }
+
+    let result = await run('@tailwind utilities', config)
+
+    expect(result.css).toMatchCss(css``)
+  })
 })


### PR DESCRIPTION
Given a simple utility like the following:
```
addUtilities({
  '.top-lg': {
    top: '6rem',
  },
})
```

If we encountered `hover:-top-lg` we didn't handle candidate elimination properly and an `undefined` utility snuck in causing a crash. We now handle this appropriately and emit no CSS. We still emit CSS for `.top-lg` when we process `-top-lg` by itself but that's technically a separate bug that can be addressed later.

Fixes #12435