### PR TITLE
Add `*` variant for targeting direct children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `forced-colors` variant ([#11694](https://github.com/tailwindlabs/tailwindcss/pull/11694))
 - Add `appearance-auto` utility ([#12404](https://github.com/tailwindlabs/tailwindcss/pull/12404))
 - Add logical property values for `float` and `clear` utilities ([#12480](https://github.com/tailwindlabs/tailwindcss/pull/12480))
+- Add `*` variant for targeting direct children ([#12551](https://github.com/tailwindlabs/tailwindcss/pull/12551))
 - [Oxide] New Rust template parsing engine ([#10252](https://github.com/tailwindlabs/tailwindcss/pull/10252))
 - [Oxide] Support `@import "tailwindcss"` using top-level `index.css` file ([#11205](https://github.com/tailwindlabs/tailwindcss/pull/11205), ([#11260](https://github.com/tailwindlabs/tailwindcss/pull/11260)))
 - [Oxide] Use `lightningcss` for nesting and vendor prefixes in PostCSS plugin ([#10399](https://github.com/tailwindlabs/tailwindcss/pull/10399))

--- a/oxide/crates/core/src/parser.rs
+++ b/oxide/crates/core/src/parser.rs
@@ -412,7 +412,7 @@ impl<'a> Extractor<'a> {
             }
 
             // Allowed first characters.
-            b'@' | b'!' | b'-' | b'<' | b'>' | b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' => {
+            b'@' | b'!' | b'-' | b'<' | b'>' | b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' | b'*' => {
                 // TODO: A bunch of characters that we currently support but maybe we only want it behind
                 // a flag. E.g.: '<sm'
                 // | '$' | '^' | '_'
@@ -473,7 +473,7 @@ impl<'a> Extractor<'a> {
             b'%' => return ParseAction::Skip,
 
             // < and > can only be part of a variant and only be the first or last character
-            b'<' | b'>' => {
+            b'<' | b'>' | b'*' => {
                 // Can only be the first or last character
                 // E.g.:
                 // - <sm:underline
@@ -795,6 +795,15 @@ mod test {
     fn it_can_parse_simple_candidates_with_variants() {
         let candidates = run("hover:underline", false);
         assert_eq!(candidates, vec!["hover:underline"]);
+    }
+
+    #[test]
+    fn it_can_parse_start_variants() {
+        let candidates = run("*:underline", false);
+        assert_eq!(candidates, vec!["*:underline"]);
+
+        let candidates = run("hover:*:underline", false);
+        assert_eq!(candidates, vec!["hover:*:underline"]);
     }
 
     #[test]

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -24,6 +24,9 @@ import { normalize } from './util/dataTypes'
 import { INTERNAL_FEATURES } from './lib/setupContextUtils'
 
 export let variantPlugins = {
+  childVariant: ({ addVariant }) => {
+    addVariant('*', '& > *')
+  },
   pseudoElementVariants: ({ addVariant }) => {
     addVariant('first-letter', '&::first-letter')
     addVariant('first-line', '&::first-line')

--- a/src/lib/setupContextUtils.js
+++ b/src/lib/setupContextUtils.js
@@ -746,6 +746,7 @@ function resolvePlugins(context, root) {
   // TODO: This is a workaround for backwards compatibility, since custom variants
   // were historically sorted before screen/stackable variants.
   let beforeVariants = [
+    variantPlugins['childVariant'],
     variantPlugins['pseudoElementVariants'],
     variantPlugins['pseudoClassVariants'],
     variantPlugins['hasVariants'],

--- a/tests/plugins/variants/__snapshots__/childVariant.test.js.snap
+++ b/tests/plugins/variants/__snapshots__/childVariant.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should test the 'childVariant' plugin 1`] = `
+"
+.\\*\\:flex > * {
+  display: flex;
+}
+"
+`;

--- a/tests/plugins/variants/childVariant.test.js
+++ b/tests/plugins/variants/childVariant.test.js
@@ -1,0 +1,3 @@
+import { quickVariantPluginTest } from '../../util/run'
+
+quickVariantPluginTest('childVariant').toMatchSnapshot()

--- a/tests/variants.test.js
+++ b/tests/variants.test.js
@@ -1167,3 +1167,44 @@ test('stacking dark and rtl variants with pseudo elements', async () => {
     }
   `)
 })
+
+test('* is matched by the parser as the children variant', async () => {
+  let config = {
+    content: [
+      {
+        raw: html`
+          <div class="*:italic" />
+          <div class="*:hover:italic" />
+          <div class="hover:*:italic" />
+          <div class="data-[slot=label]:*:hover:italic" />
+          <div class="[&_p]:*:hover:italic" />
+        `,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind utilities;
+  `
+
+  let result = await run(input, config)
+
+  expect(result.css).toMatchFormattedCss(css`
+    .\*\:italic > * {
+      font-style: italic;
+    }
+    .\*\:hover\:italic:hover > * {
+      font-style: italic;
+    }
+    .hover\:\*\:italic > *:hover {
+      font-style: italic;
+    }
+    .data-\[slot\=label\]\:\*\:hover\:italic:hover > *[data-slot='label'] {
+      font-style: italic;
+    }
+    .\[\&\_p\]\:\*\:hover\:italic:hover > * p {
+      font-style: italic;
+    }
+  `)
+})

--- a/tests/variants.test.js
+++ b/tests/variants.test.js
@@ -1191,19 +1191,11 @@ test('* is matched by the parser as the children variant', async () => {
   let result = await run(input, config)
 
   expect(result.css).toMatchFormattedCss(css`
-    .\*\:italic > * {
-      font-style: italic;
-    }
-    .\*\:hover\:italic:hover > * {
-      font-style: italic;
-    }
-    .hover\:\*\:italic > *:hover {
-      font-style: italic;
-    }
-    .data-\[slot\=label\]\:\*\:hover\:italic:hover > *[data-slot='label'] {
-      font-style: italic;
-    }
-    .\[\&\_p\]\:\*\:hover\:italic:hover > * p {
+    .\*\:italic > *,
+    .\*\:hover\:italic:hover > *,
+    .hover\:\*\:italic > :hover,
+    .data-\[slot\=label\]\:\*\:hover\:italic:hover > [data-slot='label'],
+    .\[\&_p\]\:\*\:hover\:italic:hover > * p {
       font-style: italic;
     }
   `)


### PR DESCRIPTION
This PR adds a new `*` variant for targeting direct children of an element:

```html
<nav class="*:underline">
  <a href="#">One</a>
  <a href="#">Two</a>
  <a href="#">Three</a>
</nav>
```

This can also be combined with other variants, such as `hover`:

```html
<nav class="hover:*:underline">
  <a href="#">One</a>
  <a href="#">Two</a>
  <a href="#">Three</a>
</nav>
```

The above example would only add an underline to each link when each link is hovered, as per [our documentation on stacked variants/modifiers](https://tailwindcss.com/docs/hover-focus-and-other-states#ordering-stacked-modifiers).

### Known limitations

One thing you'd probably expect to work that won't currently work is overriding a child selector style with a utility directly on the child itself:

```html
<nav class="*:underline">
  <a href="#">One</a>
  <a href="#" class="no-underline">Two</a> <!-- Will still be underlined -->
  <a href="#">Three</a>
</nav>
```

This is because the generated selector for a child variant has the same specificity as a regular utility class, but appears later in the CSS file so it takes precedence.

We can reduce the specificity of this selector using `:where`:

```css
:where(.\*\:underline) > * {
  text-decoration: underline
}
```

However this reduces the specificity `0,0,0` which is lower than the styles in Preflight, which means Preflight styles would now defeat child variant styles, which is no good.

This can be solved by taking advantage of the new proper CSS `@layer` rule, which ensures that rules in later layers always take precedence over rules in earlier layers, regardless of their specificity.

We don't want to do that in the v3.* series of Tailwind because it could be considered a breaking change due to the fact that Tailwind would stop working in browsers it currently works in, but we do intend to make this change for v4. So in v4, we can introduce the use of both `:where()` in the child variant, and native `@layer` rules which will make it possible to override child variants with utilities the way you'd expect.

We originally resisted adding this feature because of this limitation and because we didn't know what the best solution for it would be, but now that the correct solution is clear we feel comfortable introducing this feature despite the limitation because the path forward will not require drastically re-imagining the API or how the feature should work.