### PR TITLE
Fix custom config loading in Standalone CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix support for container query utilities with arbitrary values ([#12534](https://github.com/tailwindlabs/tailwindcss/pull/12534))
+- Fix custom config loading in Standalone CLI ([#12616](https://github.com/tailwindlabs/tailwindcss/pull/12616))
 
 ### Added
 

--- a/src/lib/load-config.ts
+++ b/src/lib/load-config.ts
@@ -8,8 +8,8 @@ let jiti: ReturnType<typeof jitiFactory> | null = null
 // @internal
 // This WILL be removed in some future release
 // If you rely on this your stuff WILL break
-export function useCustomJiti(_jiti: ReturnType<typeof jitiFactory>) {
-  jiti = _jiti
+export function useCustomJiti(_jiti: () => ReturnType<typeof jitiFactory>) {
+  jiti = _jiti()
 }
 
 function lazyJiti() {


### PR DESCRIPTION
Looks like we broke ESM and TypeScript config loading in the Standalone CLI by accident. This fixes that.