### PR TITLE
Allow :global selector around @tailwind

### DIFF
--- a/src/lib/detectNesting.js
+++ b/src/lib/detectNesting.js
@@ -6,6 +6,12 @@ function isAtLayer(node) {
   return node.type === 'atrule' && node.name === 'layer'
 }
 
+function isGlobalRoot(node) {
+  if (node.selector !== ':global') return false
+
+  return node.parent && isRoot(node.parent)
+}
+
 export default function (_context) {
   return (root, result) => {
     let found = false
@@ -13,7 +19,10 @@ export default function (_context) {
     root.walkAtRules('tailwind', (node) => {
       if (found) return false
 
-      if (node.parent && !(isRoot(node.parent) || isAtLayer(node.parent))) {
+      if (
+        node.parent &&
+        !(isRoot(node.parent) || isAtLayer(node.parent) || isGlobalRoot(node.parent))
+      ) {
         found = true
         node.warn(
           result,

--- a/tests/detect-nesting.test.js
+++ b/tests/detect-nesting.test.js
@@ -54,6 +54,41 @@ it('should not warn when we detect nested css inside css @layer rules', () => {
   })
 })
 
+it('should not warn when we detect global @layer rules', () => {
+  let config = {
+    content: [{ raw: html`<div class="underline"></div>` }],
+  }
+
+  let input = css`
+    :global {
+      @layer tw-base, tw-components, tw-utilities;
+      @layer tw-utilities {
+        @tailwind utilities;
+      }
+    }
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.messages).toHaveLength(0)
+  })
+})
+
+it('should not warn when we detect global @tailwind at rules', () => {
+  let config = {
+    content: [{ raw: html`<div class="text-center"></div>` }],
+  }
+
+  let input = css`
+    :global {
+      @tailwind utilities;
+    }
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.messages).toHaveLength(0)
+  })
+})
+
 it('should warn when we detect namespaced @tailwind at rules', () => {
   let config = {
     content: [{ raw: html`<div class="text-center"></div>` }],


### PR DESCRIPTION
Here is an updated version of https://github.com/tailwindlabs/tailwindcss/pull/8418

The full explanation is there but essentially comes down to using CSS Modules with the default of a local scope. It helps prevent any custom css from conflicting in a large project while allowing the developer to use Tailwind for most components.