### PR TITLE
Don't remove keyframe stops when using important utilities

### DIFF
--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -118,10 +118,20 @@ function applyImportant(matches, classCandidate) {
 
   let result = []
 
+  function isInKeyframes(rule) {
+    return rule.parent && rule.parent.type === 'atrule' && rule.parent.name === 'keyframes'
+  }
+
   for (let [meta, rule] of matches) {
     let container = postcss.root({ nodes: [rule.clone()] })
 
     container.walkRules((r) => {
+      // Declarations inside keyframes cannot be marked as important
+      // They will be ignored by the browser
+      if (isInKeyframes(r)) {
+        return
+      }
+
       let ast = selectorParser().astSync(r.selector)
 
       // Remove extraneous selectors that do not include the base candidate

--- a/tests/important-modifier.test.js
+++ b/tests/important-modifier.test.js
@@ -166,7 +166,7 @@ test('the important modifier does not break keyframes', () => {
     expect(result.css).toMatchFormattedCss(css`
       @keyframes pulse {
         50% {
-          opacity: .5;
+          opacity: 0.5;
         }
       }
 

--- a/tests/important-modifier.test.js
+++ b/tests/important-modifier.test.js
@@ -171,7 +171,7 @@ test('the important modifier does not break keyframes', () => {
       }
 
       .\!animate-pulse {
-        animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite !important;
+        animation: 2s cubic-bezier(0.4, 0, 0.6, 1) infinite pulse !important;
       }
     `)
   })

--- a/tests/important-modifier.test.js
+++ b/tests/important-modifier.test.js
@@ -147,3 +147,32 @@ test('the important modifier works on utilities using :where()', () => {
     `)
   })
 })
+
+test('the important modifier does not break keyframes', () => {
+  let config = {
+    content: [
+      {
+        raw: html` <div class="!animate-pulse"></div> `,
+      },
+    ],
+    corePlugins: { preflight: false },
+  }
+
+  let input = css`
+    @tailwind utilities;
+  `
+
+  return run(input, config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      @keyframes pulse {
+        50% {
+          opacity: .5;
+        }
+      }
+
+      .\!animate-pulse {
+        animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite !important;
+      }
+    `)
+  })
+})


### PR DESCRIPTION
Fixes #12623

Before:
```css
@keyframes pulse {
  {
    opacity: .5 !important;
  }
}

.\!animate-pulse {
  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite !important;
}
```

After:
```css
@keyframes pulse {
  50% {
    opacity: .5;
  }
}

.\!animate-pulse {
  animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite !important;
}
```

There's two differences here:
1. We no longer replace the keyframe stops with an empty string — this snuck through because the assumption that all rules are "style" rules is incorrect. This meant that we were looking for classes in this rule when there can never be any.
2. We no longer mark declarations of keyframes as important — browsers ignore these declarations.