### PR TITLE
Don't add spaces to gradients and grid track names when followed by `calc()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Don't remove keyframe stops when using important utilities ([#12639](https://github.com/tailwindlabs/tailwindcss/pull/12639))
+- Don't add spaces to gradients and grid track names when followed by `calc()` ([#12704](https://github.com/tailwindlabs/tailwindcss/pull/12704))
 
 ### Added
 

--- a/src/util/dataTypes.js
+++ b/src/util/dataTypes.js
@@ -107,6 +107,13 @@ function normalizeMathOperatorSpacing(value) {
     'keyboard-inset-left',
     'keyboard-inset-width',
     'keyboard-inset-height',
+
+    'radial-gradient',
+    'linear-gradient',
+    'conic-gradient',
+    'repeating-radial-gradient',
+    'repeating-linear-gradient',
+    'repeating-conic-gradient',
   ]
 
   return value.replace(/(calc|min|max|clamp)\(.+\)/g, (match) => {

--- a/src/util/dataTypes.js
+++ b/src/util/dataTypes.js
@@ -169,6 +169,11 @@ function normalizeMathOperatorSpacing(value) {
         result += consumeUntil([')'])
       }
 
+      // Don't break CSS grid track names
+      else if (peek('[')) {
+        result += consumeUntil([']'])
+      }
+
       // Handle operators
       else if (
         ['+', '-', '*', '/'].includes(char) &&

--- a/tests/normalize-data-types.test.js
+++ b/tests/normalize-data-types.test.js
@@ -91,6 +91,10 @@ let table = [
     'radial-gradient(calc(1+2)),radial-gradient(calc(1+2))',
     'radial-gradient(calc(1 + 2)),radial-gradient(calc(1 + 2))',
   ],
+  [
+    '[content-start]_calc(100%-1px)_[content-end]_minmax(1rem,1fr)',
+    '[content-start] calc(100% - 1px) [content-end] minmax(1rem,1fr)',
+  ],
 
   // Misc
   ['color(0_0_0/1.0)', 'color(0 0 0/1.0)'],

--- a/tests/normalize-data-types.test.js
+++ b/tests/normalize-data-types.test.js
@@ -86,6 +86,12 @@ let table = [
   // Prevent formatting keywords
   ['minmax(min-content,25%)', 'minmax(min-content,25%)'],
 
+  // Prevent formatting keywords
+  [
+    'radial-gradient(calc(1+2)),radial-gradient(calc(1+2))',
+    'radial-gradient(calc(1 + 2)),radial-gradient(calc(1 + 2))',
+  ],
+
   // Misc
   ['color(0_0_0/1.0)', 'color(0 0 0/1.0)'],
   ['color(0_0_0_/_1.0)', 'color(0 0 0 / 1.0)'],


### PR DESCRIPTION
We do spacing normalization around operators so you can write things like `w-[calc(100%-2px)]` and not have to worry about inserting spaces. We use a combination of regex and a mini lexer for this but the regexes are prone to over matching.

This PR adds a targeted fix that prevents us from inserting spaces for the following CSS functions:
- `radial-gradient`
- `linear-gradient`
- `conic-gradient`
- `repeating-radial-gradient`
- `repeating-linear-gradient`
- `repeating-conic-gradient`

Additionally, I've added a fix that prevents the addition of spaces around `-` when inside a CSS grid track name that's encased in square brackets.

Before:
```css
.bg-\[radial-gradient\(calc\(\)\)\2c radial-gradient\(calc\(\)\)\]{
  background-image: radial-gradient(calc()),radial - gradient(calc())
}

.grid-cols-\[\[content-start\]_calc\(100\%-1px\)_\[content-end\]_calc\(1rem\+1px\)\]{
  grid-template-columns: [content-start] calc(100% - 1px) [content - end] calc(1rem + 1px)
}
```

After:
```css
.bg-\[radial-gradient\(calc\(\)\)\2c radial-gradient\(calc\(\)\)\]{
  background-image: radial-gradient(calc()),radial-gradient(calc())
}

.grid-cols-\[\[content-start\]_calc\(100\%-1px\)_\[content-end\]_calc\(1rem\+1px\)\]{
  grid-template-columns: [content-start] calc(100% - 1px) [content-end] calc(1rem + 1px)
}
```

An even better solution would be to eventually introduce a lexer that's more top-level and understands CSS function syntax but that will have to happen another day.

Fixes #12654
Fixes #12665