### PR TITLE
Improve Windows support for escaped glob syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Ensure max specificity of `0,0,1` for button and input Preflight rules  ([#12735](https://github.com/tailwindlabs/tailwindcss/pull/12735))
-- Improve glob handling for folders with `(`, `)`, `[` or `]` in the file path ([#12715](https://github.com/tailwindlabs/tailwindcss/pull/12715))
+- Improve glob handling for folders with `(`, `)`, `[` or `]` in the file path ([#12715](https://github.com/tailwindlabs/tailwindcss/pull/12715), [#12718](https://github.com/tailwindlabs/tailwindcss/pull/12718))
 - Split `:has` rules when using `experimental.optimizeUniversalDefaults` ([#12736](https://github.com/tailwindlabs/tailwindcss/pull/12736))
 
 ### Added

--- a/integrations/content-resolution/package.json
+++ b/integrations/content-resolution/package.json
@@ -4,7 +4,9 @@
   "version": "0.0.0",
   "scripts": {
     "build": "NODE_ENV=production postcss ./src/index.css -o ./dist/main.css --verbose",
-    "test": "jest --runInBand --forceExit"
+    "test": "jest --runInBand --forceExit",
+    "prewip": "npm run --prefix=../../ build",
+    "wip": "npx postcss ./src/index.css -o ./dist/main.css"
   },
   "jest": {
     "testTimeout": 10000,

--- a/integrations/content-resolution/src/escapes/(test)/2.html
+++ b/integrations/content-resolution/src/escapes/(test)/2.html
@@ -1,0 +1,1 @@
+<div class="mr-2"></div>

--- a/integrations/content-resolution/src/escapes/(test)/[test]/3.html
+++ b/integrations/content-resolution/src/escapes/(test)/[test]/3.html
@@ -1,0 +1,1 @@
+<div class="mr-3"></div>

--- a/integrations/content-resolution/src/escapes/1.html
+++ b/integrations/content-resolution/src/escapes/1.html
@@ -1,0 +1,1 @@
+<div class="mr-1"></div>

--- a/integrations/content-resolution/src/escapes/[test]/(test)/5.html
+++ b/integrations/content-resolution/src/escapes/[test]/(test)/5.html
@@ -1,0 +1,1 @@
+<div class="mr-5"></div>

--- a/integrations/content-resolution/src/escapes/[test]/4.html
+++ b/integrations/content-resolution/src/escapes/[test]/4.html
@@ -1,0 +1,1 @@
+<div class="mr-4"></div>

--- a/integrations/content-resolution/tests/content.test.js
+++ b/integrations/content-resolution/tests/content.test.js
@@ -285,3 +285,30 @@ it('it can resolve symlinks for files when relative to the config', async () => 
     }
   `)
 })
+
+it('handles some special glob characters in paths', async () => {
+  await writeConfigs({
+    both: {
+      content: {
+        relative: true,
+        files: [
+          './src/escapes/1.html',
+          './src/escapes/(test)/2.html',
+          './src/escapes/(test)/[test]/3.html',
+          './src/escapes/[test]/4.html',
+          './src/escapes/[test]/(test)/5.html',
+        ],
+      },
+    },
+  })
+
+  let result = await build({ cwd: path.resolve(__dirname, '..') })
+
+  expect(result.css).toMatchFormattedCss(css`
+    .mr-1 { margin-right: 0.25rem; }
+    .mr-2 { margin-right: 0.5rem; }
+    .mr-3 { margin-right: 0.75rem; }
+    .mr-4 { margin-right: 1rem; }
+    .mr-5 { margin-right: 1.25rem; }
+  `)
+})

--- a/integrations/content-resolution/tests/content.test.js
+++ b/integrations/content-resolution/tests/content.test.js
@@ -305,10 +305,20 @@ it('handles some special glob characters in paths', async () => {
   let result = await build({ cwd: path.resolve(__dirname, '..') })
 
   expect(result.css).toMatchFormattedCss(css`
-    .mr-1 { margin-right: 0.25rem; }
-    .mr-2 { margin-right: 0.5rem; }
-    .mr-3 { margin-right: 0.75rem; }
-    .mr-4 { margin-right: 1rem; }
-    .mr-5 { margin-right: 1.25rem; }
+    .mr-1 {
+      margin-right: 0.25rem;
+    }
+    .mr-2 {
+      margin-right: 0.5rem;
+    }
+    .mr-3 {
+      margin-right: 0.75rem;
+    }
+    .mr-4 {
+      margin-right: 1rem;
+    }
+    .mr-5 {
+      margin-right: 1.25rem;
+    }
   `)
 })

--- a/integrations/execute.js
+++ b/integrations/execute.js
@@ -53,10 +53,7 @@ module.exports = function $(command, options = {}) {
     : (() => {
         let args = command.trim().split(/\s+/)
         command = args.shift()
-        command =
-          command === 'node'
-            ? command
-            : resolveCommandPath(root, command)
+        command = command === 'node' ? command : resolveCommandPath(root, command)
         return [command, args]
       })()
 

--- a/integrations/resolve-tool-root.js
+++ b/integrations/resolve-tool-root.js
@@ -2,13 +2,12 @@ let path = require('path')
 
 module.exports = function resolveToolRoot() {
   let { testPath } = expect.getState()
-  let separator = '/' // TODO: Does this resolve correctly on windows, or should we use `path.sep` instead.
 
   return path.resolve(
     __dirname,
     testPath
-      .replace(__dirname + separator, '')
-      .split(separator)
+      .replace(__dirname + path.sep, '')
+      .split(path.sep)
       .shift()
   )
 }

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -132,22 +132,22 @@ export function parseCandidateFiles(context, tailwindConfig) {
 
   let paths = [...included, ...excluded]
 
-  console.log("parseCandidateFiles 0", { paths })
+  console.log('parseCandidateFiles 0', { paths })
 
   // Resolve paths relative to the config file or cwd
   paths = resolveRelativePaths(context, paths)
 
-  console.log("parseCandidateFiles 1", { paths })
+  console.log('parseCandidateFiles 1', { paths })
 
   // Resolve symlinks if possible
   paths = paths.flatMap(resolvePathSymlinks)
 
-  console.log("parseCandidateFiles 2", { paths })
+  console.log('parseCandidateFiles 2', { paths })
 
   // Update cached patterns
   paths = paths.map(resolveGlobPattern)
 
-  console.log("parseCandidateFiles 3", { paths })
+  console.log('parseCandidateFiles 3', { paths })
 
   return paths
 }
@@ -201,9 +201,7 @@ function resolveGlobPattern(contentPath) {
     ? `${contentPath.base}/${contentPath.glob}`
     : contentPath.base
 
-  contentPath.pattern = contentPath.ignore
-    ? `!${contentPath.pattern}`
-    : contentPath.pattern
+  contentPath.pattern = contentPath.ignore ? `!${contentPath.pattern}` : contentPath.pattern
 
   return contentPath
 }
@@ -227,7 +225,11 @@ function resolveRelativePaths(context, contentPaths) {
   return contentPaths.map((contentPath) => {
     contentPath.base = path.posix.resolve(...resolveFrom, contentPath.base)
 
-    if (path.sep === '\\' && contentPath.base.startsWith('/') && !contentPath.base.startsWith('//?/')) {
+    if (
+      path.sep === '\\' &&
+      contentPath.base.startsWith('/') &&
+      !contentPath.base.startsWith('//?/')
+    ) {
       contentPath.base = `C:${contentPath.base}`
     }
 


### PR DESCRIPTION
This PR is a continuation of #12715 to apply the same improvements for Windows.

On Windows the path separator is `\\` and `\\` is also used for escaping the `[`, `]`, `(` and `)` characters. This will result in `\\\\[` for example. In this case it means that the first `\\` is the path separator and the second `\\` is the escape for the `[` or `(` characters.

Additionally, we also ensure that we only escape `[`, `]` and `(`, `)` when the balanced pairs are _both_ not escaped yet. Right now it was going over the individual characters and escaping them accordingly.

This is not enough, because in case of this path:

```js
let path = ".\\src\\**\\[foo]\\bar.html"
```

The first `\\[` looks like it is escaped, but on Windows this is just the path separator. The `foo]` part is _not_ escaped therefor we should escape the whole thing. As a first step, this will result in:

```js
let path = ".\\src\\**\\\\[foo\\]\\bar.html"
```

Now we do have the 4 backslashes `\\\\`, then in the normalization step, we normalize `\\` to `/`. If we do this _as is_, then it would look like this, which is also incorrect:

```js
let path = "./src/**/[foo/]/bar.html"
```

... it's incorrect because we have `/[foo/]` and we expected `/\\[foo\\]` instead. 

If we apply the logic I mentioned earlier where the first `\\` is the path separator and the second `\\` is the escape, then we can convert: 

```js
let path = ".\\src\\**\\\\[foo\\]\\bar.html"
``` 

... to this first: 


```js
let path = ".\\src\\**/\\[foo\\]\\bar.html"
```

Then we can apply the rest of the normalization, which looks like this:

```js
let path = "./src/**/\\[foo\\]/bar.html"
```

... and now the `[foo]` part is properly escaped as `\\[foo\\]`.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
