### PR TITLE
feat: add contain utilities

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -2946,5 +2946,5 @@ export let corePlugins = {
       '.contain-style': { contain: 'style' },
       '.contain-unset': { contain: 'unset' },
     })
-  }
+  },
 }

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -2934,4 +2934,17 @@ export let corePlugins = {
       '.forced-color-adjust-none': { 'forced-color-adjust': 'none' },
     })
   },
+  contain: ({ addUtilities }) => {
+    addUtilities({
+      '.contain-content': { contain: 'content' },
+      '.contain-inline-size': { contain: 'inline-size' },
+      '.contain-layout': { contain: 'layout' },
+      '.contain-none': { contain: 'none' },
+      '.contain-paint': { contain: 'paint' },
+      '.contain-size': { contain: 'size' },
+      '.contain-strict': { contain: 'strict' },
+      '.contain-style': { contain: 'style' },
+      '.contain-unset': { contain: 'unset' },
+    })
+  }
 }

--- a/tests/plugins/__snapshots__/contain.test.js.snap
+++ b/tests/plugins/__snapshots__/contain.test.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should test the 'contain' plugin 1`] = `
+"
+.contain-content {
+  contain: content;
+}
+
+.contain-inline-size {
+  contain: inline-size;
+}
+
+.contain-layout {
+  contain: layout;
+}
+
+.contain-none {
+  contain: none;
+}
+
+.contain-paint {
+  contain: paint;
+}
+
+.contain-size {
+  contain: size;
+}
+
+.contain-strict {
+  contain: strict;
+}
+
+.contain-style {
+  contain: style;
+}
+
+.contain-unset {
+  contain: unset;
+}
+"
+`;

--- a/tests/plugins/contain.test.js
+++ b/tests/plugins/contain.test.js
@@ -1,0 +1,3 @@
+import { quickPluginTest } from '../util/run'
+
+quickPluginTest('contain').toMatchSnapshot()


### PR DESCRIPTION
This adds utilities for the [contain](https://developer.mozilla.org/en-US/docs/Web/CSS/contain) property, which is supported in all evergreen browsers by now 🙏👌

After that, contain-intrinsic-* (height/width/size) could be a nice addition too (but lacks browser support right now).