### PR TITLE
Fix incorrect release date for v3.4.1 in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Oxide] Deprecate `--no-autoprefixer` flag in the CLI ([#11280](https://github.com/tailwindlabs/tailwindcss/pull/11280))
 - [Oxide] Make the Rust based parser the default ([#11394](https://github.com/tailwindlabs/tailwindcss/pull/11394))
 
-## [3.4.1] - 2014-01-05
+## [3.4.1] - 2024-01-05
 
 ### Fixed
 


### PR DESCRIPTION
Noticed that the release date was marked as 2014 instead of 2024 :)