### PR TITLE
Allow specifying font-family, font-style & text-decoration in fontSize theme options

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -2101,7 +2101,7 @@ export let corePlugins = {
             }
           }
 
-          let { lineHeight, letterSpacing, fontWeight } = isPlainObject(options)
+          let { lineHeight, letterSpacing, fontWeight, fontFamily, fontStyle, textDecoration } = isPlainObject(options)
             ? options
             : { lineHeight: options }
 
@@ -2110,6 +2110,9 @@ export let corePlugins = {
             ...(lineHeight === undefined ? {} : { 'line-height': lineHeight }),
             ...(letterSpacing === undefined ? {} : { 'letter-spacing': letterSpacing }),
             ...(fontWeight === undefined ? {} : { 'font-weight': fontWeight }),
+            ...(fontFamily === undefined ? {} : { 'font-family': fontFamily }),
+            ...(fontStyle === undefined ? {} : { 'font-style': fontStyle }),
+            ...(textDecoration === undefined ? {} : { 'text-decoration': textDecoration }),
           }
         },
       },

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -191,6 +191,9 @@ export interface ThemeConfig {
             lineHeight: string
             letterSpacing: string
             fontWeight: string | number
+            fontFamily: string
+            fontStyle: string
+            textDecoration: string
           }>
         ]
     >


### PR DESCRIPTION
This change will allow specifying not only line-height, letter-spacing and font-weight for the `fontSize` theme option, but also font-family, font-style and text-decoration.
I feel this would be an appropriate and quite unintrusive change.