### PR TITLE
Remove Webkit Search Cancel Button

### DIFF
--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -255,6 +255,13 @@ Remove the inner padding in Chrome and Safari on macOS.
 }
 
 /*
+Remove x on Chrome and Safari.
+*/
+::-webkit-search-cancel-button {
+  display: none;
+}
+
+/*
 1. Correct the inability to style clickable types in iOS and Safari.
 2. Change font properties to `inherit` in Safari.
 */


### PR DESCRIPTION
On Chrome and Safari webkit includes a cancel button that I think Preflight should hide. [MDN lists this cancel button as nonstandard][1] and Chrome and Sarafi both style this button differently. This appears to happen in macOS and linux.

[1]: https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-search-cancel-button

Safari:
<img width="476" alt="Screenshot 2024-01-25 at 3 49 51 PM" src="https://github.com/tailwindlabs/tailwindcss/assets/61948088/bcc157a5-5cc7-4045-afa7-b1227f85d1f6">
Chrome:
<img width="469" alt="Screenshot 2024-01-25 at 3 49 23 PM" src="https://github.com/tailwindlabs/tailwindcss/assets/61948088/c75bd2ec-af22-45fa-bac2-0f541d79287c">
Firefox (no cancel button with Preflight):
![image (7)](https://github.com/tailwindlabs/tailwindcss/assets/61948088/a406ab49-69fe-40c3-b446-83fcf4cf937a)

Co-authored-by: Brooks Johnson <2008881+bkjohnson@users.noreply.github.com>
