### PR TITLE
fix(corePlugins): more browser compatibility for rtl/ltr

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -206,8 +206,8 @@ export let variantPlugins = {
   },
 
   directionVariants: ({ addVariant }) => {
-    addVariant('ltr', '&:where([dir="ltr"], [dir="ltr"] *)')
-    addVariant('rtl', '&:where([dir="rtl"], [dir="rtl"] *)')
+    addVariant('ltr', ['[dir="ltr"] &', '&[dir="ltr"]'])
+    addVariant('rtl', ['[dir="rtl"] &', '&[dir="rtl"]'])
   },
 
   reducedMotionVariants: ({ addVariant }) => {


### PR DESCRIPTION
I'd like to propose an improvement to the `rtl/ltr` core plugin that addresses compatibility issues on certain browsers and devices.

**Current Issue:**

The existing implementation uses the `:where` CSS selector to achieve bidirectionality support. While this approach offers certain advantages, it has limited browser compatibility, particularly on iPhone devices before September 2020. This can cause layout and rendering problems for users on these browsers.

**Proposed Solution:**

I propose replacing the `:where` selector with the `[dir="ltr"]` selector. This alternative:

- Offers broader browser compatibility, ensuring that the plugin functions correctly on all major browsers and devices, including older iPhones.
- Maintains the desired functionality of providing LTR/RTL support.
- Is generally considered a more widely supported and reliable approach for achieving bidirectionality.

**Benefits:**

By adopting this change, we can:

- **Improve user experience** for a wider range of users by ensuring consistent plugin functionality across different browsers and devices.
- **Reduce potential bugs and support issues** related to browser compatibility.
- **Align with standard practices** for achieving bidirectionality in CSS.

**Testing:**

I have thoroughly tested this change on various browsers and devices.  
These tests confirm that the `[dir="rtl"]` selector functions as expected and addresses the compatibility issues associated with `:where`.

**Request:**

I kindly request that you review my proposed change and consider merging this pull request to improve the plugin's compatibility and user experience. I am confident that this modification will have a positive impact on the project and its users.

Thank you for your time and consideration.
