### PR TITLE
Added support for `text-size-adjust` and `vertical-align`

### DIFF
--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -19,7 +19,7 @@
 
 /*
 1. Use a consistent sensible line-height in all browsers.
-2. Prevent adjustments of font size after orientation changes in iOS.
+2. Prevent adjustments of font size after orientation changes in iOS.`
 3. Use a more readable tab size.
 4. Use the user's configured `sans` font-family by default.
 5. Use the user's configured `sans` font-feature-settings by default.
@@ -30,7 +30,11 @@
 html,
 :host {
   line-height: 1.5; /* 1 */
-  -webkit-text-size-adjust: 100%; /* 2 */
+   /* 2 */
+  -webkit-text-size-adjust: 100%;
+  -moz-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  text-size-adjust: 100%;
   -moz-tab-size: 4; /* 3 */
   tab-size: 4; /* 3 */
   font-family: theme('fontFamily.sans', ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"); /* 4 */

--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -369,7 +369,7 @@ audio,
 iframe,
 embed,
 object {
-  display: block; /* 1 */
+  display: inline-block; /* 1 */
   vertical-align: middle; /* 2 */
 }
 


### PR DESCRIPTION
- Solves the [`text-size-adjust`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-size-adjust) problem
  - '`-webkit-text-size-adjust`' is not supported by Chrome, Chrome Android, Edge 79+, Firefox, Safari, and Samsung Internet. Add '`text-size-adjust`' to support Chrome 54+, Chrome Android 54+, Edge 79+, Samsung Internet 6.0+.
  - **Mentions**: #12650, #12724
- Solves the [`vertical-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align) problem  
  - Property is ignored due to the display. With '`display: block`', '`vertical-align`' should not be used.
  - **Mentions**: #9046