### PR TITLE
Update preflight.css to fix Tailwind CSS linter warnings in VSCode

### DIFF
--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -199,6 +199,7 @@ input:where([type='button']),
 input:where([type='reset']),
 input:where([type='submit']) {
   -webkit-appearance: button; /* 1 */
+  appearance: menulist-button; /* 1 */
   background-color: transparent; /* 2 */
   background-image: none; /* 2 */
 }
@@ -243,6 +244,7 @@ Correct the cursor style of increment and decrement buttons in Safari.
 
 [type='search'] {
   -webkit-appearance: textfield; /* 1 */
+  appearance: menulist-textfield; /* 1 */
   outline-offset: -2px; /* 2 */
 }
 
@@ -252,6 +254,7 @@ Remove the inner padding in Chrome and Safari on macOS.
 
 ::-webkit-search-decoration {
   -webkit-appearance: none;
+  appearance: none;
 }
 
 /*
@@ -261,6 +264,7 @@ Remove the inner padding in Chrome and Safari on macOS.
 
 ::-webkit-file-upload-button {
   -webkit-appearance: button; /* 1 */
+  appearance: menulist-button; /* 1 */
   font: inherit; /* 2 */
 }
 
@@ -366,7 +370,6 @@ iframe,
 embed,
 object {
   display: block; /* 1 */
-  vertical-align: middle; /* 2 */
 }
 
 /*


### PR DESCRIPTION
Tailwind CSS, when set as the linter for CSS files in VSCode through the [Tailwind CSS IntelliSense extension](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss), picks up on three warnings fixed via these changes:

`Also define the standard property 'appearance' for compatibility`
This one appears twice, for the button/textfield CSS compatibility classes.
`Property is ignored due to the display. With 'display: block', vertical-align should not be used.`
This one appears once and due to 'display: block', 'vertical-align: middle' will never take effect.

Other potential causes for warnings in the same vein from the Tailwind CSS linter have also been fixed in this PR.

If there are other options to fix the last warning, I'd like to hear them as 'vertical-align: middle' may have been there for a reason initially.

Description carried from PR #13009 as it seems to have borked.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
