### PR TITLE
[v4] Pretty print generated CSS

### DIFF
--- a/packages/tailwindcss/src/ast.test.ts
+++ b/packages/tailwindcss/src/ast.test.ts
@@ -1,0 +1,15 @@
+import { expect, it } from 'vitest'
+import { toCss } from './ast'
+import * as CSS from './css-parser'
+
+it('should pretty print an AST', () => {
+  expect(toCss(CSS.parse('.foo{color:red;&:hover{color:blue;}}'))).toMatchInlineSnapshot(`
+    ".foo {
+      color: red;
+      &:hover {
+        color: blue;
+      }
+    }
+    "
+  `)
+})


### PR DESCRIPTION
This PR pretty prints the generated CSS by default.

This also removes the custom parser / formatter we use in the intellisense plugin.

This change has a negative `~0.7ms` performance impact on a big codebases such as `tailwindcss.com` and `tailwindui.com`. However, I have a follow up PR that has a positive `~2ms` performance impact on the same codebases.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
