### PR TITLE
[v4] Only output `@property foo` once instead of N times

### DIFF
--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -73,7 +73,6 @@ export function walk(
 
 export function toCss(ast: AstNode[]) {
   let atRoots: string = ''
-
   let seenAtProperties = new Set<string>()
 
   function stringify(node: AstNode, depth = 0): string {

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -72,7 +72,7 @@ export function walk(
 }
 
 export function toCss(ast: AstNode[]) {
-  let atRoots: string[] = []
+  let atRoots: string = ''
 
   let seenAtProperties = new Set<string>()
 
@@ -85,7 +85,7 @@ export function toCss(ast: AstNode[]) {
       // Pull out `@at-root` rules to append later
       if (node.selector === '@at-root') {
         for (let child of node.nodes) {
-          atRoots.push(stringify(child, 0))
+          atRoots += stringify(child, 0)
         }
         return css
       }
@@ -130,8 +130,13 @@ export function toCss(ast: AstNode[]) {
     return css
   }
 
-  return ast
-    .map((node) => stringify(node))
-    .concat(atRoots)
-    .join('')
+  let css = ''
+  for (let node of ast) {
+    let result = stringify(node)
+    if (result !== '') {
+      css += result
+    }
+  }
+
+  return `${css}${atRoots}`
 }

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -74,6 +74,8 @@ export function walk(
 export function toCss(ast: AstNode[]) {
   let atRoots: string[] = []
 
+  let seenAtProperties = new Set<string>()
+
   function stringify(node: AstNode, depth = 0): string {
     let css = ''
 
@@ -96,6 +98,15 @@ export function toCss(ast: AstNode[]) {
       // ```
       if (node.selector[0] === '@' && node.nodes.length === 0) {
         return `${'  '.repeat(depth)}${node.selector};\n`
+      }
+
+      if (node.selector[0] === '@' && node.selector.startsWith('@property ') && depth === 0) {
+        // Don't output duplicate `@property` rules
+        if (seenAtProperties.has(node.selector)) {
+          return ''
+        }
+
+        seenAtProperties.add(node.selector)
       }
 
       css += `${'  '.repeat(depth)}${node.selector} {\n`
@@ -121,5 +132,5 @@ export function toCss(ast: AstNode[]) {
   return ast
     .map((node) => stringify(node))
     .concat(atRoots)
-    .join('\n')
+    .join('')
 }

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -78,6 +78,7 @@ export function toCss(ast: AstNode[]) {
 
   function stringify(node: AstNode, depth = 0): string {
     let css = ''
+    let indent = '  '.repeat(depth)
 
     // Rule
     if (node.kind === 'rule') {
@@ -97,7 +98,7 @@ export function toCss(ast: AstNode[]) {
       // @layer base, components, utilities;
       // ```
       if (node.selector[0] === '@' && node.nodes.length === 0) {
-        return `${'  '.repeat(depth)}${node.selector};\n`
+        return `${indent}${node.selector};\n`
       }
 
       if (node.selector[0] === '@' && node.selector.startsWith('@property ') && depth === 0) {
@@ -109,21 +110,21 @@ export function toCss(ast: AstNode[]) {
         seenAtProperties.add(node.selector)
       }
 
-      css += `${'  '.repeat(depth)}${node.selector} {\n`
+      css += `${indent}${node.selector} {\n`
       for (let child of node.nodes) {
         css += stringify(child, depth + 1)
       }
-      css += `${'  '.repeat(depth)}}\n`
+      css += `${indent}}\n`
     }
 
     // Comment
     else if (node.kind === 'comment') {
-      css += `${'  '.repeat(depth)}/*${node.value}*/\n`
+      css += `${indent}/*${node.value}*/\n`
     }
 
     // Declaration
     else if (node.property !== '--tw-sort' && node.value !== undefined && node.value !== null) {
-      css += `${'  '.repeat(depth)}${node.property}: ${node.value}${node.important ? '!important' : ''};\n`
+      css += `${indent}${node.property}: ${node.value}${node.important ? '!important' : ''};\n`
     }
 
     return css


### PR DESCRIPTION
This PR improves the performance of the AST to CSS generation.

This now only outputs `@property foo` once, if it was already generated at the top-level then it will not be generated again.

On the tailwindcss.com codebase, this reduces the CSS generation (before the Lightning CSS step) time from `~6ms` to `~3ms`.

If we weren't using Lightning CSS at all, then it would reduce the generated CSS size from ~28k lines of code to ~14k lines of code (again, on the tailwindcss.com repo).

This means that we are sending fewer bytes to Lightning CSS to optimize, making the whole process a bit faster.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
