### PR TITLE
CI: Add provenance to all published packages

### DIFF
--- a/.github/workflows/release-insiders-oxide.yml
+++ b/.github/workflows/release-insiders-oxide.yml
@@ -269,6 +269,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: Build and release
+    permissions:
+      contents: read
+      id-token: write
     needs:
       - build
       - build-linux
@@ -343,7 +346,7 @@ jobs:
             echo "Publishing $pkg..."
             cd $pkg
             npm version ${{ env.NPM_VERSION }} --force --no-git-tag-version
-            npm publish --tag ${{ env.RELEASE_CHANNEL }} --access public
+            npm publish --provenance --tag ${{ env.RELEASE_CHANNEL }} --access public
             cd -
           done
 
@@ -352,7 +355,7 @@ jobs:
           npm version ${{ env.NPM_VERSION }} --force --no-git-tag-version
           sed "s#\"0.0.0\"#\"${{ env.NPM_VERSION }}\"#g" package.json > package_updated.json
           mv package_updated.json package.json
-          npm publish --tag ${{ env.RELEASE_CHANNEL }} --access public
+          npm publish --provenance --tag ${{ env.RELEASE_CHANNEL }} --access public
           cd -
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -361,6 +364,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: Build and release Tailwind CSS
+    permissions:
+      contents: read
+      id-token: write
 
     needs:
       - release
@@ -401,7 +407,7 @@ jobs:
         run: npm version 0.0.0-${{ env.RELEASE_CHANNEL }}.${{ env.SHA_SHORT }} --force --no-git-tag-version
 
       - name: Publish
-        run: npm publish --tag ${{ env.RELEASE_CHANNEL }}
+        run: npm publish --provenance --tag ${{ env.RELEASE_CHANNEL }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release-insiders-stable.yml
+++ b/.github/workflows/release-insiders-stable.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 env:
   CI: true
@@ -58,7 +59,7 @@ jobs:
         run: npm version 0.0.0-${{ env.RELEASE_CHANNEL }}.${{ env.SHA_SHORT }} --force --no-git-tag-version
 
       - name: Publish
-        run: npm publish --tag ${{ env.RELEASE_CHANNEL }}
+        run: npm publish --provenance --tag ${{ env.RELEASE_CHANNEL }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release-oxide.yml
+++ b/.github/workflows/release-oxide.yml
@@ -218,6 +218,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: Build and release
+    permissions:
+      contents: read
+      id-token: write
     needs:
       - oxide-build
       - oxide-build-linux
@@ -273,7 +276,7 @@ jobs:
             echo "Publishing $pkg..."
             cd $pkg
             npm version ${{ env.NPM_VERSION }} --force --no-git-tag-version
-            npm publish --tag insiders --access public
+            npm publish --provenance --tag insiders --access public
             cd -
           done
 
@@ -282,7 +285,7 @@ jobs:
           npm version ${{ env.NPM_VERSION }} --force --no-git-tag-version
           sed "s#\"0.0.0\"#\"${{ env.NPM_VERSION }}\"#g" package.json > package_updated.json
           mv package_updated.json package.json
-          npm publish --tag insiders --access public
+          npm publish --provenance --tag insiders --access public
           cd -
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -291,6 +294,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: Build and release Tailwind CSS
+    permissions:
+      contents: read
+      id-token: write
 
     needs:
       - oxide-release
@@ -332,6 +338,6 @@ jobs:
         run: npm version 0.0.0-oxide.${{ env.SHA_SHORT }} --force --no-git-tag-version
 
       - name: Publish
-        run: npm publish --tag oxide
+        run: npm publish --provenance --tag oxide
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 env:
   CI: true
@@ -47,7 +48,7 @@ jobs:
           echo "TAILWINDCSS_VERSION=$(node -e 'console.log(require(`./package.json`).version);')" >> $GITHUB_ENV
 
       - name: Publish
-        run: npm publish --tag ${{ env.RELEASE_CHANNEL }}
+        run: npm publish --provenance --tag ${{ env.RELEASE_CHANNEL }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/oxide/crates/node/npm/darwin-arm64/package.json
+++ b/oxide/crates/node/npm/darwin-arm64/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@tailwindcss/oxide-darwin-arm64",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tailwindlabs/tailwindcss.git",
+    "directory": "oxide/crates/node/npm/darwin-arm64"
+  },
   "os": [
     "darwin"
   ],

--- a/oxide/crates/node/npm/darwin-x64/package.json
+++ b/oxide/crates/node/npm/darwin-x64/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@tailwindcss/oxide-darwin-x64",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tailwindlabs/tailwindcss.git",
+    "directory": "oxide/crates/node/npm/darwin-x64"
+  },
   "os": [
     "darwin"
   ],

--- a/oxide/crates/node/npm/freebsd-x64/package.json
+++ b/oxide/crates/node/npm/freebsd-x64/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@tailwindcss/oxide-freebsd-x64",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tailwindlabs/tailwindcss.git",
+    "directory": "oxide/crates/node/npm/freebsd-x64"
+  },
   "os": [
     "freebsd"
   ],

--- a/oxide/crates/node/npm/linux-arm-gnueabihf/package.json
+++ b/oxide/crates/node/npm/linux-arm-gnueabihf/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@tailwindcss/oxide-linux-arm-gnueabihf",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tailwindlabs/tailwindcss.git",
+    "directory": "oxide/crates/node/npm/linux-arm-gnueabihf"
+  },
   "os": [
     "linux"
   ],

--- a/oxide/crates/node/npm/linux-arm64-gnu/package.json
+++ b/oxide/crates/node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@tailwindcss/oxide-linux-arm64-gnu",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tailwindlabs/tailwindcss.git",
+    "directory": "oxide/crates/node/npm/linux-arm64-gnu"
+  },
   "os": [
     "linux"
   ],

--- a/oxide/crates/node/npm/linux-arm64-musl/package.json
+++ b/oxide/crates/node/npm/linux-arm64-musl/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@tailwindcss/oxide-linux-arm64-musl",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tailwindlabs/tailwindcss.git",
+    "directory": "oxide/crates/node/npm/linux-arm64-musl"
+  },
   "os": [
     "linux"
   ],

--- a/oxide/crates/node/npm/linux-x64-gnu/package.json
+++ b/oxide/crates/node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@tailwindcss/oxide-linux-x64-gnu",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tailwindlabs/tailwindcss.git",
+    "directory": "oxide/crates/node/npm/linux-x64-gnu"
+  },
   "os": [
     "linux"
   ],

--- a/oxide/crates/node/npm/linux-x64-musl/package.json
+++ b/oxide/crates/node/npm/linux-x64-musl/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@tailwindcss/oxide-linux-x64-musl",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tailwindlabs/tailwindcss.git",
+    "directory": "oxide/crates/node/npm/linux-x64-musl"
+  },
   "os": [
     "linux"
   ],

--- a/oxide/crates/node/npm/win32-x64-msvc/package.json
+++ b/oxide/crates/node/npm/win32-x64-msvc/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@tailwindcss/oxide-win32-x64-msvc",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tailwindlabs/tailwindcss.git",
+    "directory": "oxide/crates/node/npm/win32-x64-msvc"
+  },
   "os": [
     "win32"
   ],

--- a/oxide/crates/node/package.json
+++ b/oxide/crates/node/package.json
@@ -18,6 +18,11 @@
     }
   },
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tailwindlabs/tailwindcss.git",
+    "directory": "oxide/crates/node"
+  },
   "devDependencies": {
     "@napi-rs/cli": "^2.15.2"
   },

--- a/standalone-cli/package.json
+++ b/standalone-cli/package.json
@@ -1,6 +1,11 @@
 {
   "name": "tailwindcss-standalone",
   "version": "0.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tailwindlabs/tailwindcss.git",
+    "directory": "standalone-cli"
+  },
   "bin": "standalone.js",
   "scripts": {
     "build": "pkg . --compress Brotli --no-bytecode --public-packages \"*\" --public",


### PR DESCRIPTION
This commit adds provenance for all published packages. See the NPM documentation [0].

Provenance will allow people to verify that the tailwindcss packages were actually built on GH Actions and with the content of the corresponding commit. This will help with supply chain security.

For this to work, the `id-token` permission was added only where necessary.
Additionally, all the oxide packages + cli package were adjusted to include their repository link in the `package.json`, so that the build works and the builds can be linked to this repository.

[0]: https://docs.npmjs.com/generating-provenance-statements