### PR TITLE
[v4] Support old important modifier position

### DIFF
--- a/packages/tailwindcss/src/candidate.ts
+++ b/packages/tailwindcss/src/candidate.ts
@@ -264,14 +264,15 @@ export function parseCandidate(
 
   // Candidates that end with an exclamation mark are the important version with
   // higher specificity of the non-important candidate, e.g. `mx-4!`.
-  if (base[0] === '!') {
-    state.important = true
-    base = base.slice(1)
-  }
-  // Legacy syntax with leading `!`, e.g. `!mx-4`.
-  else if (base[base.length - 1] === '!') {
+  if (base[base.length - 1] === '!') {
     state.important = true
     base = base.slice(0, -1)
+  }
+
+  // Legacy syntax with leading `!`, e.g. `!mx-4`.
+  else if (base[0] === '!') {
+    state.important = true
+    base = base.slice(1)
   }
 
   // Arbitrary properties

--- a/packages/tailwindcss/src/candidate.ts
+++ b/packages/tailwindcss/src/candidate.ts
@@ -264,7 +264,12 @@ export function parseCandidate(
 
   // Candidates that end with an exclamation mark are the important version with
   // higher specificity of the non-important candidate, e.g. `mx-4!`.
-  if (base[base.length - 1] === '!') {
+  if (base[0] === '!') {
+    state.important = true
+    base = base.slice(1)
+  }
+  // Legacy syntax with leading `!`, e.g. `!mx-4`.
+  else if (base[base.length - 1] === '!') {
     state.important = true
     base = base.slice(0, -1)
   }

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -341,6 +341,14 @@ describe('important', () => {
     `)
   })
 
+  it('should generate an important utility with legacy syntax', () => {
+    expect(run(['!underline'])).toMatchInlineSnapshot(`
+      ".\\!underline {
+        text-decoration-line: underline !important;
+      }"
+    `)
+  })
+
   it('should not mark declarations inside of @keyframes as important', () => {
     expect(
       compileCss(


### PR DESCRIPTION
This PR introduces backwards compatibility for the old important modifier position, making it possible to include it at the beginning of a utility (legacy) or at the end (recommended).