### PR TITLE
[v4] Use `fs.readFileSync` instead of importing `json` file

### DIFF
--- a/packages/@tailwindcss-cli/src/utils/renderer.ts
+++ b/packages/@tailwindcss-cli/src/utils/renderer.ts
@@ -1,6 +1,7 @@
+import fs from 'node:fs'
 import path from 'node:path'
 import pc from 'picocolors'
-import { version } from 'tailwindcss/package.json'
+import { resolve } from '../utils/resolve'
 import { formatNanoseconds } from './format-ns'
 
 export const UI = {
@@ -8,6 +9,7 @@ export const UI = {
 }
 
 export function header() {
+  let { version } = JSON.parse(fs.readFileSync(resolve('tailwindcss/package.json'), 'utf-8'))
   return `${pc.italic(pc.bold(pc.blue('\u2248')))} tailwindcss ${pc.blue(`v${version}`)}`
 }
 


### PR DESCRIPTION
In some environments, depending on the Node version importing a `.json` file without a `with` or `assert` doesn't work.

Let's play it safe and use an `fs.readFileSync` instead.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
