### PR TITLE
[v4] add extension-less exports for all exported CSS files

### DIFF
--- a/packages/tailwindcss/package.json
+++ b/packages/tailwindcss/package.json
@@ -21,9 +21,13 @@
     },
     "./package.json": "./package.json",
     "./index.css": "./index.css",
+    "./index": "./index.css",
     "./preflight.css": "./preflight.css",
+    "./preflight": "./preflight.css",
     "./theme.css": "./theme.css",
-    "./utilities.css": "./utilities.css"
+    "./theme": "./theme.css",
+    "./utilities.css": "./utilities.css",
+    "./utilities": "./utilities.css"
   },
   "publishConfig": {
     "exports": {
@@ -35,9 +39,13 @@
       },
       "./package.json": "./package.json",
       "./index.css": "./index.css",
+      "./index": "./index.css",
       "./preflight.css": "./preflight.css",
+      "./preflight": "./preflight.css",
       "./theme.css": "./theme.css",
-      "./utilities.css": "./utilities.css"
+      "./theme": "./theme.css",
+      "./utilities.css": "./utilities.css",
+      "./utilities": "./utilities.css"
     }
   },
   "style": "index.css",


### PR DESCRIPTION
This PR fixes an issue where in some tools imports such as `@import "tailwindcss/preflight"` don't work, they only work if you use `@import "tailwindcss/preflight.css"` with the extension.

This PR should solve that by also exporting these files but without the `.css` extension.
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
