### PR TITLE
[v4] Use builtin utility to strip control characters

### DIFF
--- a/packages/@tailwindcss-cli/src/utils/renderer.ts
+++ b/packages/@tailwindcss-cli/src/utils/renderer.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { stripVTControlCharacters } from 'node:util'
 import pc from 'picocolors'
 import { resolve } from '../utils/resolve'
 import { formatNanoseconds } from './format-ns'
@@ -48,7 +49,7 @@ export function wordWrap(text: string, width: number) {
   let line = ''
   let lineLength = 0
   for (let word of words) {
-    let wordLength = clearAnsiEscapes(word).length
+    let wordLength = stripVTControlCharacters(word).length
 
     if (lineLength + wordLength + 1 > width) {
       lines.push(line)
@@ -65,11 +66,6 @@ export function wordWrap(text: string, width: number) {
   }
 
   return lines
-}
-
-const ESCAPE = /((?:\x9B|\x1B\[)[0-?]*[ -\/]*[@-~])/g
-function clearAnsiEscapes(input: string) {
-  return input.replace(ESCAPE, '')
 }
 
 /**


### PR DESCRIPTION
This PR uses a builtin util to strip control characters instead of the homemade function that was used before.
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
