### PR TITLE
[v4] Always honor git ignore files

### DIFF
--- a/oxide/crates/core/src/lib.rs
+++ b/oxide/crates/core/src/lib.rs
@@ -293,6 +293,7 @@ fn resolve_files(root: &Path) -> (Vec<PathBuf>, Vec<PathBuf>) {
 pub fn resolve_allowed_paths(root: &Path) -> impl Iterator<Item = DirEntry> {
     WalkBuilder::new(root)
         .hidden(false)
+        .require_git(false)
         .filter_entry(|entry| match entry.file_type() {
             Some(file_type) if file_type.is_dir() => match entry.file_name().to_str() {
                 Some(dir) => !IGNORED_CONTENT_DIRS.contains(&dir),


### PR DESCRIPTION
Automatic content detection looks at your git ignore files but only when in a git repo. We want to _always_ honor them even when not in a git repo as it's not uncommon to do some small setup / development before initializing a git repo.