### PR TITLE
[v4] Only allow CSS variables in `@theme`

### DIFF
--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -51,6 +51,33 @@ describe('compiling CSS', () => {
     `)
   })
 
+  test('that only CSS variables are allowed', () => {
+    expect(() =>
+      compileCss(
+        css`
+          @theme {
+            --color-primary: red;
+            .foo {
+              --color-primary: blue;
+            }
+          }
+          @tailwind utilities;
+        `,
+        ['bg-primary'],
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      [Error: Invalid \`@theme\` detected:
+
+      @theme {
+        /* Only CSS variables are allowed, this is not allowed: */
+        .foo {
+          --color-primary: blue;
+        }
+      }
+      ]
+    `)
+  })
+
   test('`@tailwind utilities` is only processed once', () => {
     expect(
       compileCss(

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -66,15 +66,14 @@ describe('compiling CSS', () => {
         ['bg-primary'],
       ),
     ).toThrowErrorMatchingInlineSnapshot(`
-      [Error: Invalid \`@theme\` detected:
+      [Error: \`@theme\` blocks must only contain custom properties or \`@keyframes\`.
 
-      @theme {
-        /* Only CSS variables are allowed, this is not allowed: */
-        .foo {
-          --color-primary: blue;
+        @theme {
+      >   .foo {
+      >     --color-primary: blue;
+      >   }
         }
-      }
-      ]
+        ]
     `)
   })
 

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -23,7 +23,7 @@ export function compile(css: string, rawCandidates: string[]) {
     if (node.selector !== '@theme') return
 
     // Record all custom properties in the `@theme` declaration
-    walk([node], (node, { replaceWith }) => {
+    walk(node.nodes, (node, { replaceWith }) => {
       // Collect `@keyframes` rules to re-insert with theme variables later,
       // since the `@theme` rule itself will be removed.
       if (node.kind === 'rule' && node.selector.startsWith('@keyframes ')) {

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -1,6 +1,6 @@
 import { Features, transform } from 'lightningcss'
 import { version } from '../package.json'
-import { comment, decl, rule, toCss, walk, type AstNode, type Rule } from './ast'
+import { WalkAction, comment, decl, rule, toCss, walk, type AstNode, type Rule } from './ast'
 import { compileCandidates } from './compile'
 import * as CSS from './css-parser'
 import { buildDesignSystem } from './design-system'
@@ -29,7 +29,7 @@ export function compile(css: string, rawCandidates: string[]) {
       if (node.kind === 'rule' && node.selector.startsWith('@keyframes ')) {
         keyframesRules.push(node)
         replaceWith([])
-        return
+        return WalkAction.Skip
       }
 
       if (node.kind !== 'declaration') return
@@ -94,7 +94,7 @@ export function compile(css: string, rawCandidates: string[]) {
       // Stop walking after finding `@tailwind utilities` to avoid walking all
       // of the generated CSS. This means `@tailwind utilities` can only appear
       // once per file but that's the intended usage at this point in time.
-      return false
+      return WalkAction.Stop
     }
   })
 

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -45,6 +45,7 @@ export function compile(css: string, rawCandidates: string[]) {
     } else {
       replaceWith([])
     }
+    return WalkAction.Skip
   })
 
   // Output final set of theme variables at the position of the first `@theme`
@@ -145,6 +146,7 @@ export function compile(css: string, rawCandidates: string[]) {
     walk(ast, (node, { replaceWith }) => {
       if (node.kind === 'rule' && node.selector === '@media reference') {
         replaceWith([])
+        return WalkAction.Skip
       }
     })
   }

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -32,10 +32,17 @@ export function compile(css: string, rawCandidates: string[]) {
         return WalkAction.Skip
       }
 
-      if (node.kind !== 'declaration') return
-      if (!node.property.startsWith('--')) return
+      if (node.kind === 'comment') return
+      if (node.kind === 'declaration' && node.property.startsWith('--')) {
+        theme.add(node.property, node.value)
+        return
+      }
 
-      theme.add(node.property, node.value)
+      let tree = rule('@theme', [
+        comment(' Only CSS variables are allowed, this is not allowed: '),
+        node,
+      ])
+      throw new Error(`Invalid \`@theme\` detected:\n\n${toCss([tree])}`)
     })
 
     // Keep a reference to the first `@theme` rule to update with the full theme

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -38,11 +38,14 @@ export function compile(css: string, rawCandidates: string[]) {
         return
       }
 
-      let tree = rule('@theme', [
-        comment(' Only CSS variables are allowed, this is not allowed: '),
-        node,
-      ])
-      throw new Error(`Invalid \`@theme\` detected:\n\n${toCss([tree])}`)
+      let snippet = toCss([rule('@theme', [node])])
+        .split('\n')
+        .map((line, idx, all) => `${idx === 0 || idx >= all.length - 2 ? ' ' : '>'} ${line}`)
+        .join('\n')
+
+      throw new Error(
+        `\`@theme\` blocks must only contain custom properties or \`@keyframes\`.\n\n${snippet}`,
+      )
     })
 
     // Keep a reference to the first `@theme` rule to update with the full theme


### PR DESCRIPTION
This PR ensures that only CSS variables are allowed inside a `@theme` block.

If we detect something else (apart from comments and `@keyframes`), then we throw an error.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
