### PR TITLE
[v4] Make CSS optimization and minification configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add Android builds ([#13115](https://github.com/tailwindlabs/tailwindcss/pull/13115))
+- Make CSS optimization and minification configurable ([#13130](https://github.com/tailwindlabs/tailwindcss/pull/13130))
 
 ## [4.0.0-alpha.6] - 2024-03-07
 

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -46,7 +46,7 @@ export function options() {
     },
     '--minify': {
       type: 'boolean',
-      description: 'Minify the output',
+      description: 'Optimize and minify the output',
       alias: '-m',
     },
     '--optimize': {

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -96,10 +96,15 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
   )
 
   // Compile the input
-  let result = optimizeCss(compile(input, candidates), {
-    file: args['--input'] ?? 'input.css',
-    minify: args['--minify'],
-  })
+  let result = compile(input, candidates)
+
+  // Optimize the output
+  if (args['--minify']) {
+    result = optimizeCss(result, {
+      file: args['--input'] ?? 'input.css',
+      minify: true,
+    })
+  }
 
   // Write the output
   if (args['--output']) {
@@ -184,10 +189,15 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
         }
 
         // Compile the input
-        let result = optimizeCss(compile(input, candidates), {
-          file: args['--input'] ?? 'input.css',
-          minify: args['--minify'],
-        })
+        let result = compile(input, candidates)
+
+        // Optimize the output
+        if (args['--minify']) {
+          result = optimizeCss(result, {
+            file: args['--input'] ?? 'input.css',
+            minify: true,
+          })
+        }
 
         // Write the output
         if (args['--output']) {

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -49,6 +49,10 @@ export function options() {
       description: 'Minify the output',
       alias: '-m',
     },
+    '--optimize': {
+      type: 'boolean',
+      description: 'Optimize the output without minifying',
+    },
     '--cwd': {
       type: 'string',
       description: 'The current working directory',
@@ -99,10 +103,10 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
   let result = compile(input, candidates)
 
   // Optimize the output
-  if (args['--minify']) {
+  if (args['--minify'] || args['--optimize']) {
     result = optimizeCss(result, {
       file: args['--input'] ?? 'input.css',
-      minify: true,
+      minify: args['--minify'] ?? false,
     })
   }
 
@@ -192,10 +196,10 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
         let result = compile(input, candidates)
 
         // Optimize the output
-        if (args['--minify']) {
+        if (args['--minify'] || args['--optimize']) {
           result = optimizeCss(result, {
             file: args['--input'] ?? 'input.css',
-            minify: true,
+            minify: args['--minify'] ?? false,
           })
         }
 

--- a/packages/@tailwindcss-postcss/src/index.test.ts
+++ b/packages/@tailwindcss-postcss/src/index.test.ts
@@ -18,7 +18,9 @@ beforeEach(async () => {
 })
 
 test("`@import 'tailwindcss'` is replaced with the generated CSS", async () => {
-  let processor = postcss([tailwindcss({ base: `${__dirname}/fixtures/example-project` })])
+  let processor = postcss([
+    tailwindcss({ base: `${__dirname}/fixtures/example-project`, optimize: { minify: false } }),
+  ])
 
   let result = await processor.process(`@import 'tailwindcss'`, { from: INPUT_CSS_PATH })
 
@@ -47,7 +49,9 @@ test("`@import 'tailwindcss'` is replaced with the generated CSS", async () => {
 })
 
 test('output is optimized by Lightning CSS', async () => {
-  let processor = postcss([tailwindcss({ base: `${__dirname}/fixtures/example-project` })])
+  let processor = postcss([
+    tailwindcss({ base: `${__dirname}/fixtures/example-project`, optimize: { minify: false } }),
+  ])
 
   // `@apply` is used because Lightning is skipped if neither `@tailwind` nor
   // `@apply` is used.
@@ -82,7 +86,9 @@ test('output is optimized by Lightning CSS', async () => {
 })
 
 test('@apply can be used without emitting the theme in the CSS file', async () => {
-  let processor = postcss([tailwindcss({ base: `${__dirname}/fixtures/example-project` })])
+  let processor = postcss([
+    tailwindcss({ base: `${__dirname}/fixtures/example-project`, optimize: { minify: false } }),
+  ])
 
   // `@apply` is used because Lightning is skipped if neither `@tailwind` nor
   // `@apply` is used.
@@ -112,7 +118,7 @@ describe('processing without specifying a base path', () => {
   afterEach(() => unlink(filepath))
 
   test('the current working directory is used by default', async () => {
-    let processor = postcss([tailwindcss()])
+    let processor = postcss([tailwindcss({ optimize: { minify: false } })])
 
     let result = await processor.process(`@import "tailwindcss"`, { from: INPUT_CSS_PATH })
 

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -13,6 +13,7 @@ type PluginOptions = {
 
 function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
   let base = opts.base ?? process.cwd()
+  let optimize = opts.optimize ?? process.env.NODE_ENV === 'production'
 
   return {
     postcssPlugin: 'tailwindcss-v4',
@@ -42,9 +43,9 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
         function replaceCss(css: string) {
           root.removeAll()
           let output = css
-          if (opts.optimize) {
+          if (optimize) {
             output = optimizeCss(output, {
-              minify: typeof opts.optimize === 'object' ? opts.optimize.minify : false,
+              minify: typeof optimize === 'object' ? optimize.minify : false,
             })
           }
           root.append(postcss.parse(output, result.opts))

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -6,6 +6,9 @@ import { compile, optimizeCss } from 'tailwindcss'
 type PluginOptions = {
   // The base directory to scan for class candidates.
   base?: string
+
+  // Optimize the output CSS.
+  optimize?: boolean | { minify?: boolean }
 }
 
 function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
@@ -38,7 +41,13 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
 
         function replaceCss(css: string) {
           root.removeAll()
-          root.append(postcss.parse(optimizeCss(css), result.opts))
+          let output = css
+          if (opts.optimize) {
+            output = optimizeCss(output, {
+              minify: typeof opts.optimize === 'object' ? opts.optimize.minify : false,
+            })
+          }
+          root.append(postcss.parse(output, result.opts))
         }
 
         // No `@tailwind` means we don't have to look for candidates

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -61,7 +61,11 @@ export default function tailwindcss(): Plugin[] {
   }
 
   function generateCss(css: string) {
-    return optimizeCss(compile(css, Array.from(candidates)), { minify })
+    return compile(css, Array.from(candidates))
+  }
+
+  function generateOptimizedCss(css: string) {
+    return optimizeCss(generateCss(css), { minify })
   }
 
   // In dev mode, there isn't a hook to signal that we've seen all files. We use
@@ -168,7 +172,7 @@ export default function tailwindcss(): Plugin[] {
             rawSource instanceof Uint8Array ? new TextDecoder().decode(rawSource) : rawSource
 
           if (source.includes('@tailwind')) {
-            item.source = generateCss(source)
+            item.source = generateOptimizedCss(source)
           }
         }
       },


### PR DESCRIPTION
This PR disables Lightning CSS by default in development to improve the performance of incremental builds.

This means that during development, the compiled CSS will still use native CSS nesting, modern color syntax without fallbacks, and be missing vendor prefixes for older browsers.

While incremental builds in v4 are already faster than they were in v3, this further improves the performance in projects we've tested. For example in the tailwindcss.com codebase, this reduces incremental build times from 40ms to 30ms.

In the CLI build, the following flags are available:

- `--minify` — this will optimize the CSS output and minify it.
- `--optimize` — this will optimize the CSS output but **not** minify it.

In the Vite plugin, the Lightning CSS optimizations are only enabled for production builds.

In the PostCSS plugin, we added a new option `optimize` that can be used to enable the optimizations.

```ts
module.exports = {
  plugins: {
    '@tailwindcss/postcss': {
      // This will optimize and minify the CSS output.
      optimize: true
    }
  }
}
```

```ts
module.exports = {
  plugins: {
    '@tailwindcss/postcss': {
      optimize: {
        // This will optimize but not minify the CSS output.
        minify: false
      } 
    }
  }
}
```

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
