### PR TITLE
v4 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [4.0.0-alpha.6] - 2024-03-07
+
+### Fixed
+
+- Only set border-style for appropriate border side ([#13124](https://github.com/tailwindlabs/tailwindcss/pull/13124))
+
+### Changed
+
+- Only allow CSS variables in `@theme` ([#13125](https://github.com/tailwindlabs/tailwindcss/pull/13125))
+
+## [4.0.0-alpha.5] - 2024-03-06
+
+### Fixed
+
+- Always honor git ignore files ([#13119](https://github.com/tailwindlabs/tailwindcss/pull/13119))
+
+## [4.0.0-alpha.4] - 2024-03-06
+
+### Fixed
+
+- Add extension-less exports for all exported CSS files ([#13110](https://github.com/tailwindlabs/tailwindcss/pull/13110))
+
+## [4.0.0-alpha.3] - 2024-03-06
+
+### Added
+
+- Support old important modifier position ([#13103](https://github.com/tailwindlabs/tailwindcss/pull/13103))
+
+### Fixed
+
+- Node compatability fix ([#13104](https://github.com/tailwindlabs/tailwindcss/pull/13104))
+
+### Changes
+
+- Drop deprecated decoration-slice and decoration-clone utilities ([#13107](https://github.com/tailwindlabs/tailwindcss/pull/13107))
+
+## [4.0.0-alpha.2] - 2024-03-06
+
+### Changed
+
+- Move the CLI into a separate `@tailwindcss/cli` package ([#13095](https://github.com/tailwindlabs/tailwindcss/pull/13095))
+
+## [4.0.0-alpha.1] - 2024-03-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Only set border-style for appropriate border side ([#13124](https://github.com/tailwindlabs/tailwindcss/pull/13124))
+- Only set `border-style` for appropriate border side ([#13124](https://github.com/tailwindlabs/tailwindcss/pull/13124))
 
 ### Changed
 
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
-- Drop deprecated decoration-slice and decoration-clone utilities ([#13107](https://github.com/tailwindlabs/tailwindcss/pull/13107))
+- Drop deprecated `decoration-slice` and `decoration-clone` utilities ([#13107](https://github.com/tailwindlabs/tailwindcss/pull/13107))
 
 ## [4.0.0-alpha.2] - 2024-03-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,25 +15,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Only allow CSS variables in `@theme` ([#13125](https://github.com/tailwindlabs/tailwindcss/pull/13125))
+- Error when `@theme` contains unsupported rules/declarations ([#13125](https://github.com/tailwindlabs/tailwindcss/pull/13125))
 
 ## [4.0.0-alpha.5] - 2024-03-06
 
 ### Fixed
 
-- Always honor git ignore files ([#13119](https://github.com/tailwindlabs/tailwindcss/pull/13119))
+- Don't scan ignored files even if a `.git` folder is not present ([#13119](https://github.com/tailwindlabs/tailwindcss/pull/13119))
 
 ## [4.0.0-alpha.4] - 2024-03-06
 
 ### Fixed
 
-- Add extension-less exports for all exported CSS files ([#13110](https://github.com/tailwindlabs/tailwindcss/pull/13110))
+- Support importing framework CSS files without including a `.css` extension ([#13110](https://github.com/tailwindlabs/tailwindcss/pull/13110))
 
 ## [4.0.0-alpha.3] - 2024-03-06
 
 ### Added
 
-- Support old important modifier position ([#13103](https://github.com/tailwindlabs/tailwindcss/pull/13103))
+- Support putting the important modifier at the beginning of a utility ([#13103](https://github.com/tailwindlabs/tailwindcss/pull/13103))
 
 ### Fixed
 


### PR DESCRIPTION
Only including change from `4.0.0-alpha.1` for now. Changes from previous versions and a fuller description of the major changes in v4 can be added when merging to `master`.