### PR TITLE
Add missing Android packages to `version-packages` script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add Android builds ([#13115](https://github.com/tailwindlabs/tailwindcss/pull/13115))
+- Add Android builds ([#13115](https://github.com/tailwindlabs/tailwindcss/pull/13115), [#13161](https://github.com/tailwindlabs/tailwindcss/pull/13161))
 - Make CSS optimization and minification configurable ([#13130](https://github.com/tailwindlabs/tailwindcss/pull/13130))
 
 ## [4.0.0-alpha.6] - 2024-03-07

--- a/scripts/version-packages.mjs
+++ b/scripts/version-packages.mjs
@@ -17,6 +17,8 @@ const syncedWorkspaces = new Map([
   [
     '@tailwindcss/oxide',
     [
+      'oxide/crates/node/npm/android-arm-eabi',
+      'oxide/crates/node/npm/android-arm64',
       'oxide/crates/node/npm/darwin-arm64',
       'oxide/crates/node/npm/darwin-x64',
       'oxide/crates/node/npm/freebsd-x64',


### PR DESCRIPTION
This PR adds the missing package paths for the Android builds to the `version-packages` script.
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
