### PR TITLE
Fix allowed `--tw-scale-x/y` syntax

### DIFF
--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -2607,13 +2607,13 @@ test('scale', () => {
     }
 
     @property --tw-scale-x {
-      syntax: "<number>";
+      syntax: "<number> | <percentage>";
       inherits: false;
       initial-value: 1;
     }
 
     @property --tw-scale-y {
-      syntax: "<number>";
+      syntax: "<number> | <percentage>";
       inherits: false;
       initial-value: 1;
     }"
@@ -2639,13 +2639,13 @@ test('scale-x', () => {
     }
 
     @property --tw-scale-x {
-      syntax: "<number>";
+      syntax: "<number> | <percentage>";
       inherits: false;
       initial-value: 1;
     }
 
     @property --tw-scale-y {
-      syntax: "<number>";
+      syntax: "<number> | <percentage>";
       inherits: false;
       initial-value: 1;
     }"
@@ -2671,13 +2671,13 @@ test('scale-y', () => {
     }
 
     @property --tw-scale-x {
-      syntax: "<number>";
+      syntax: "<number> | <percentage>";
       inherits: false;
       initial-value: 1;
     }
 
     @property --tw-scale-y {
-      syntax: "<number>";
+      syntax: "<number> | <percentage>";
       inherits: false;
       initial-value: 1;
     }"

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -1312,7 +1312,10 @@ export function createUtilities(theme: Theme) {
   ])
 
   let scaleProperties = () =>
-    atRoot([property('--tw-scale-x', '1', '<number>'), property('--tw-scale-y', '1', '<number>')])
+    atRoot([
+      property('--tw-scale-x', '1', '<number> | <percentage>'),
+      property('--tw-scale-y', '1', '<number> | <percentage>'),
+    ])
 
   /**
    * @css `scale`


### PR DESCRIPTION
Fixes the issue where `scale-*` classes can't use percentages, even though they are permitted by the [CSS specification for the `scale` property](https://www.w3.org/TR/css-transforms-2/#propdef-scale) that the `scale-*` utilities use.

Related to #13180.

### Before

![image](https://github.com/tailwindlabs/tailwindcss/assets/11310624/fd234c55-29ea-42a7-9f29-4f2e253ab04b)

### After

![image](https://github.com/tailwindlabs/tailwindcss/assets/11310624/c2f7e712-88c9-4dba-ba6f-180bb7fe400a)
