### PR TITLE
Vite plugin: stop checking CSS files that no longer exist

### DIFF
--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -24,7 +24,6 @@ export default function tailwindcss(): Plugin[] {
     for (let id of cssModules.values()) {
       let cssModule = server.moduleGraph.getModuleById(id)
       if (!cssModule) {
-        console.log('Could not find css module', id)
         // It is safe to remove the item here since we're iterating on a copy of
         // the values.
         cssModules.delete(id)

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -21,10 +21,13 @@ export default function tailwindcss(): Plugin[] {
     if (!server) return
 
     let updates: Update[] = []
-    for (let id of cssModules) {
+    for (let id of cssModules.values()) {
       let cssModule = server.moduleGraph.getModuleById(id)
       if (!cssModule) {
         console.log('Could not find css module', id)
+        // It is safe to remove the item here since we're iterating on a copy of
+        // the values.
+        cssModules.delete(id)
         continue
       }
 


### PR DESCRIPTION
Fix a potential memory leak in the Vite plugin. If CSS files are created that include `@tailwind` and later deleted, remove them from the list of files checked. This could theoretically happen if some process created CSS files with `@tailwind` with different names on each build. 

Thanks to @timneutkens for highlighting this issue.