### PR TITLE
[v4] Ensure `{ optimize: true }` also minifies CSS in the `@tailwindcss/postcss` plugin

### DIFF
--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -7,7 +7,7 @@ type PluginOptions = {
   // The base directory to scan for class candidates.
   base?: string
 
-  // Optimize the output CSS.
+  // Optimize and minify the output CSS.
   optimize?: boolean | { minify?: boolean }
 }
 
@@ -45,7 +45,7 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
           let output = css
           if (optimize) {
             output = optimizeCss(output, {
-              minify: typeof optimize === 'object' ? optimize.minify : false,
+              minify: typeof optimize === 'object' ? optimize.minify : true,
             })
           }
           root.append(postcss.parse(output, result.opts))


### PR DESCRIPTION
This PR fixes an issue where passing `{ optimize: true }` to the `@tailwindcss/postcss` plugin would only optimize the CSS but not minify the CSS.

The default should be to optimize _and_ minify the CSS. 

If you don't want this behaviour, and you only want to optimize, then you can use:

```
{
  optimize: {
    minify: false
  }
}
```


<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
