### PR TITLE
Support `@theme reference` without `@import`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Nothing yet!
+### Added
+
+- Support `@theme reference { … }` for defining theme values without emitting variables ([#13222](https://github.com/tailwindlabs/tailwindcss/pull/13222))
 
 ## [4.0.0-alpha.8] - 2024-03-11
 

--- a/packages/tailwindcss/src/intellisense.test.ts
+++ b/packages/tailwindcss/src/intellisense.test.ts
@@ -6,16 +6,16 @@ function loadDesignSystem() {
   return buildDesignSystem(
     new Theme(
       new Map([
-        ['--spacing-0_5', '0.125rem'],
-        ['--spacing-1', '0.25rem'],
-        ['--spacing-3', '0.75rem'],
-        ['--spacing-4', '1rem'],
-        ['--width-4', '1rem'],
-        ['--colors-red-500', 'red'],
-        ['--colors-blue-500', 'blue'],
-        ['--breakpoint-sm', '640px'],
-        ['--font-size-xs', '0.75rem'],
-        ['--font-size-xs--line-height', '1rem'],
+        ['--spacing-0_5', { value: '0.125rem', isReference: true }],
+        ['--spacing-1', { value: '0.25rem', isReference: true }],
+        ['--spacing-3', { value: '0.75rem', isReference: true }],
+        ['--spacing-4', { value: '1rem', isReference: true }],
+        ['--width-4', { value: '1rem', isReference: true }],
+        ['--colors-red-500', { value: 'red', isReference: true }],
+        ['--colors-blue-500', { value: 'blue', isReference: true }],
+        ['--breakpoint-sm', { value: '640px', isReference: true }],
+        ['--font-size-xs', { value: '0.75rem', isReference: true }],
+        ['--font-size-xs--line-height', { value: '1rem', isReference: true }],
       ]),
     ),
   )

--- a/packages/tailwindcss/src/intellisense.test.ts
+++ b/packages/tailwindcss/src/intellisense.test.ts
@@ -3,22 +3,18 @@ import { buildDesignSystem } from './design-system'
 import { Theme } from './theme'
 
 function loadDesignSystem() {
-  return buildDesignSystem(
-    new Theme(
-      new Map([
-        ['--spacing-0_5', { value: '0.125rem', isReference: true }],
-        ['--spacing-1', { value: '0.25rem', isReference: true }],
-        ['--spacing-3', { value: '0.75rem', isReference: true }],
-        ['--spacing-4', { value: '1rem', isReference: true }],
-        ['--width-4', { value: '1rem', isReference: true }],
-        ['--colors-red-500', { value: 'red', isReference: true }],
-        ['--colors-blue-500', { value: 'blue', isReference: true }],
-        ['--breakpoint-sm', { value: '640px', isReference: true }],
-        ['--font-size-xs', { value: '0.75rem', isReference: true }],
-        ['--font-size-xs--line-height', { value: '1rem', isReference: true }],
-      ]),
-    ),
-  )
+  let theme = new Theme()
+  theme.add('--spacing-0_5', '0.125rem')
+  theme.add('--spacing-1', '0.25rem')
+  theme.add('--spacing-3', '0.75rem')
+  theme.add('--spacing-4', '1rem')
+  theme.add('--width-4', '1rem')
+  theme.add('--colors-red-500', 'red')
+  theme.add('--colors-blue-500', 'blue')
+  theme.add('--breakpoint-sm', '640px')
+  theme.add('--font-size-xs', '0.75rem')
+  theme.add('--font-size-xs--line-height', '1rem')
+  return buildDesignSystem(theme)
 }
 
 test('getClassList', () => {

--- a/packages/tailwindcss/src/sort.bench.ts
+++ b/packages/tailwindcss/src/sort.bench.ts
@@ -4,17 +4,15 @@ import { Theme } from './theme'
 
 const input = 'a-class px-3 p-1 b-class py-3 bg-red-500 bg-blue-500'.split(' ')
 const emptyDesign = buildDesignSystem(new Theme())
-const simpleDesign = buildDesignSystem(
-  new Theme(
-    new Map([
-      ['--spacing-1', '0.25rem'],
-      ['--spacing-3', '0.75rem'],
-      ['--spacing-4', '1rem'],
-      ['--color-red-500', 'red'],
-      ['--color-blue-500', 'blue'],
-    ]),
-  ),
-)
+const simpleDesign = (() => {
+  let simpleTheme = new Theme()
+  simpleTheme.add('--spacing-1', '0.25rem')
+  simpleTheme.add('--spacing-3', '0.75rem')
+  simpleTheme.add('--spacing-4', '1rem')
+  simpleTheme.add('--color-red-500', 'red')
+  simpleTheme.add('--color-blue-500', 'blue')
+  return buildDesignSystem(simpleTheme)
+})()
 
 bench('getClassOrder (empty theme)', () => {
   emptyDesign.getClassOrder(input)

--- a/packages/tailwindcss/src/theme.ts
+++ b/packages/tailwindcss/src/theme.ts
@@ -3,7 +3,7 @@ import { escape } from './utils/escape'
 export class Theme {
   constructor(private values = new Map<string, { value: string; isReference: boolean }>()) {}
 
-  add(key: string, value: string, isReference: boolean): void {
+  add(key: string, value: string, isReference = false): void {
     if (key.endsWith('-*')) {
       if (value !== 'initial') {
         throw new Error(`Invalid theme value \`${value}\` for namespace \`${key}\``)

--- a/packages/tailwindcss/src/theme.ts
+++ b/packages/tailwindcss/src/theme.ts
@@ -1,9 +1,9 @@
 import { escape } from './utils/escape'
 
 export class Theme {
-  constructor(private values: Map<string, string> = new Map<string, string>()) {}
+  constructor(private values = new Map<string, { value: string; isReference: boolean }>()) {}
 
-  add(key: string, value: string): void {
+  add(key: string, value: string, isReference: boolean): void {
     if (key.endsWith('-*')) {
       if (value !== 'initial') {
         throw new Error(`Invalid theme value \`${value}\` for namespace \`${key}\``)
@@ -18,7 +18,7 @@ export class Theme {
     if (value === 'initial') {
       this.values.delete(key)
     } else {
-      this.values.set(key, value)
+      this.values.set(key, { value, isReference })
     }
   }
 
@@ -46,7 +46,7 @@ export class Theme {
     for (let key of themeKeys) {
       let value = this.values.get(key)
       if (value) {
-        return value
+        return value.value
       }
     }
 
@@ -82,7 +82,7 @@ export class Theme {
 
     if (!themeKey) return null
 
-    return this.values.get(themeKey)!
+    return this.values.get(themeKey)!.value
   }
 
   resolveWith(
@@ -98,11 +98,11 @@ export class Theme {
     for (let name of nestedKeys) {
       let nestedValue = this.values.get(`${themeKey}${name}`)
       if (nestedValue) {
-        extra[name] = nestedValue
+        extra[name] = nestedValue.value
       }
     }
 
-    return [this.values.get(themeKey)!, extra]
+    return [this.values.get(themeKey)!.value, extra]
   }
 
   namespace(namespace: string) {
@@ -111,9 +111,9 @@ export class Theme {
 
     for (let [key, value] of this.values) {
       if (key === namespace) {
-        values.set(null, value)
+        values.set(null, value.value)
       } else if (key.startsWith(prefix)) {
-        values.set(key.slice(prefix.length), value)
+        values.set(key.slice(prefix.length), value.value)
       }
     }
 


### PR DESCRIPTION
This PR adds support for using `@theme reference { … }` as a way to define theme values that you don't want emitted in the final CSS but do want to be used as a source of truth for utility values.

This fleshes out what we already loosely supported with `@import "./my-theme.css" reference`, while fixing some bugs we actually had in that implementation surrounding multiple `@theme` definitions.

The main motivating use case for this is to support having access to your theme in CSS module scopes like Vue's `<style>` blocks, where you may want to use `@apply`:

```html
<template>
  <h1>Hello world!</h1>
</template>

<style>
@import "tailwindcss/theme" reference;

h1 {
  @apply text-4xl text-indigo-500 py-6;
}
</style>
```

For `@apply` to work here it's necessary for your theme values to be "in scope" from Tailwind's perspective, and since all of these `<style>` blocks are processed completely independently, Tailwind has no idea what theme values you're using in your global CSS file when this block is processed.

This also makes it possible for people to suppress the output of all of the CSS variables if that's something they want to do, but this isn't a use case I personally think makes sense to advertise — I think we should be opinionated about pushing people to want to output these variables so they can access their theme values with `var(…)` in arbitrary values or in JS contexts.