### PR TITLE
Validate bare values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Inline `@import` rules in `tailwindcss/index.css` at publish time for better performance ([#13233](https://github.com/tailwindlabs/tailwindcss/pull/13233))
 
+### Fixed
+
+- Validate bare values ([#13245](https://github.com/tailwindlabs/tailwindcss/pull/13245))
+
 ## [4.0.0-alpha.9] - 2024-03-13
 
 ### Added

--- a/packages/tailwindcss/src/candidate.ts
+++ b/packages/tailwindcss/src/candidate.ts
@@ -426,6 +426,13 @@ export function parseCandidate(input: string, designSystem: DesignSystem): Candi
           ? null
           : value.slice(valueWithoutModifier.lastIndexOf('-') + 1)
 
+      // If the leftover value is an empty string, it means that the value is an
+      // invalid named value. This makes the candidate invalid and we can
+      // skip continue parsing it.
+      if (valueWithoutModifier === '') {
+        return null
+      }
+
       candidate.value = {
         kind: 'named',
         value: valueWithoutModifier,

--- a/packages/tailwindcss/src/candidate.ts
+++ b/packages/tailwindcss/src/candidate.ts
@@ -428,7 +428,7 @@ export function parseCandidate(input: string, designSystem: DesignSystem): Candi
 
       // If the leftover value is an empty string, it means that the value is an
       // invalid named value. This makes the candidate invalid and we can
-      // skip continue parsing it.
+      // skip any further parsing.
       if (valueWithoutModifier === '') {
         return null
       }

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -614,7 +614,7 @@ test('z-index', () => {
       z-index: auto;
     }"
   `)
-  expect(run(['z', '-z-auto'])).toEqual('')
+  expect(run(['z', '-z-auto', 'z-unknown', 'z-123.5'])).toEqual('')
 })
 
 test('order', () => {
@@ -657,7 +657,9 @@ test('order', () => {
       order: 0;
     }"
   `)
-  expect(run(['order', '-order-first', '-order-last', '-order-none'])).toEqual('')
+  expect(
+    run(['order', '-order-first', '-order-last', '-order-none', 'order-unknown', 'order-123.5']),
+  ).toEqual('')
 })
 
 test('col', () => {
@@ -1352,7 +1354,16 @@ test('line-clamp', () => {
         overflow: visible;
       }"
     `)
-  expect(run(['line-clamp', '-line-clamp-4', '-line-clamp-[123]', '-line-clamp-none'])).toEqual('')
+  expect(
+    run([
+      'line-clamp',
+      '-line-clamp-4',
+      '-line-clamp-[123]',
+      '-line-clamp-none',
+      'line-clamp-unknown',
+      'line-clamp-123.5',
+    ]),
+  ).toEqual('')
 })
 
 test('display', () => {
@@ -1506,7 +1517,9 @@ test('aspect-ratio', () => {
       aspect-ratio: 16 / 9;
     }"
   `)
-  expect(run(['aspect', 'aspect-potato', '-aspect-video', '-aspect-[10/9]'])).toEqual('')
+  expect(
+    run(['aspect', 'aspect-potato', '-aspect-video', '-aspect-[10/9]', 'aspect-foo/bar']),
+  ).toEqual('')
 })
 
 test('size', () => {
@@ -2063,7 +2076,7 @@ test('flex-shrink', () => {
       flex-shrink: 123;
     }"
   `)
-  expect(run(['-shrink', '-shrink-0', '-shrink-[123]'])).toEqual('')
+  expect(run(['-shrink', '-shrink-0', '-shrink-[123]', 'shrink-unknown'])).toEqual('')
 })
 
 test('flex-grow', () => {
@@ -2080,7 +2093,7 @@ test('flex-grow', () => {
       flex-grow: 123;
     }"
   `)
-  expect(run(['-grow', '-grow-0', '-grow-[123]'])).toEqual('')
+  expect(run(['-grow', '-grow-0', '-grow-[123]', 'grow-unknown'])).toEqual('')
 })
 
 test('flex-basis', () => {
@@ -2484,7 +2497,7 @@ test('rotate', () => {
       rotate: 123deg;
     }"
   `)
-  expect(run(['rotate'])).toEqual('')
+  expect(run(['rotate', 'rotate-unknown'])).toEqual('')
 })
 
 test('skew', () => {
@@ -2519,7 +2532,7 @@ test('skew', () => {
       initial-value: 0deg;
     }"
   `)
-  expect(run(['skew'])).toEqual('')
+  expect(run(['skew', 'skew-unknown'])).toEqual('')
 })
 
 test('skew-x', () => {
@@ -2551,7 +2564,7 @@ test('skew-x', () => {
       initial-value: 0deg;
     }"
   `)
-  expect(run(['skew-x'])).toEqual('')
+  expect(run(['skew-x', 'skew-x-unknown'])).toEqual('')
 })
 
 test('skew-y', () => {
@@ -2583,7 +2596,7 @@ test('skew-y', () => {
       initial-value: 0deg;
     }"
   `)
-  expect(run(['skew-y'])).toEqual('')
+  expect(run(['skew-y', 'skew-y-unknown'])).toEqual('')
 })
 
 test('scale', () => {
@@ -2618,7 +2631,7 @@ test('scale', () => {
       initial-value: 1;
     }"
   `)
-  expect(run(['scale'])).toEqual('')
+  expect(run(['scale', 'scale-unknown'])).toEqual('')
 })
 
 test('scale-x', () => {
@@ -2650,7 +2663,7 @@ test('scale-x', () => {
       initial-value: 1;
     }"
   `)
-  expect(run(['scale-x'])).toEqual('')
+  expect(run(['scale-x', 'scale-x-unknown'])).toEqual('')
 })
 
 test('scale-y', () => {
@@ -2682,7 +2695,7 @@ test('scale-y', () => {
       initial-value: 1;
     }"
   `)
-  expect(run(['scale-y'])).toEqual('')
+  expect(run(['scale-y', 'scale-y-unknown'])).toEqual('')
 })
 
 test('transform', () => {
@@ -3967,7 +3980,9 @@ test('columns', () => {
       columns: auto;
     }"
   `)
-  expect(run(['columns', '-columns-4', '-columns-[123]', '-columns-[--value]'])).toEqual('')
+  expect(
+    run(['columns', '-columns-4', '-columns-[123]', '-columns-[--value]', 'columns-unknown']),
+  ).toEqual('')
 })
 
 test('break-before', () => {
@@ -4253,6 +4268,7 @@ test('grid-cols', () => {
       '-grid-cols-subgrid',
       '-grid-cols-12',
       '-grid-cols-[123]',
+      'grid-cols-unknown',
     ]),
   ).toEqual('')
 })
@@ -4288,6 +4304,7 @@ test('grid-rows', () => {
       '-grid-rows-subgrid',
       '-grid-rows-12',
       '-grid-rows-[123]',
+      'grid-rows-unknown',
     ]),
   ).toEqual('')
 })
@@ -4866,7 +4883,7 @@ test('divide-x', () => {
       initial-value: solid;
     }"
   `)
-  expect(run(['-divide-x', '-divide-x-4', '-divide-x-123'])).toEqual('')
+  expect(run(['-divide-x', '-divide-x-4', '-divide-x-123', 'divide-x-unknown'])).toEqual('')
 })
 
 test('divide-x with custom default border width', () => {
@@ -4954,7 +4971,7 @@ test('divide-y', () => {
       initial-value: solid;
     }"
   `)
-  expect(run(['-divide-y', '-divide-y-4', '-divide-y-123'])).toEqual('')
+  expect(run(['-divide-y', '-divide-y-4', '-divide-y-123', 'divide-y-unknown'])).toEqual('')
 })
 
 test('divide-y with custom default border width', () => {
@@ -9405,25 +9422,32 @@ test('filter', () => {
       '-blur-[4px]',
       '-brightness-50',
       '-brightness-[1.23]',
+      'brightness-unknown',
       '-contrast-50',
       '-contrast-[1.23]',
+      'contrast-unknown',
       '-grayscale',
       '-grayscale-0',
       '-grayscale-[--value]',
+      'grayscale-unknown',
       '-hue-rotate-15',
       '-hue-rotate-[45deg]',
+      'hue-rotate-unknown',
       '-invert',
       '-invert-0',
       '-invert-[--value]',
+      'invert-unknown',
       '-drop-shadow-xl',
       '-drop-shadow-[0_0_red]',
       '-saturate-0',
       '-saturate-[1.75]',
       '-saturate-[--value]',
+      'saturate-saturate',
       '-sepia',
       '-sepia-0',
       '-sepia-[50%]',
       '-sepia-[--value]',
+      'sepia-unknown',
     ]),
   ).toEqual('')
 })
@@ -9685,25 +9709,33 @@ test('backdrop-filter', () => {
       '-backdrop-blur-[4px]',
       '-backdrop-brightness-50',
       '-backdrop-brightness-[1.23]',
+      'backdrop-brightness-unknown',
       '-backdrop-contrast-50',
       '-backdrop-contrast-[1.23]',
+      'backdrop-contrast-unknown',
       '-backdrop-grayscale',
       '-backdrop-grayscale-0',
       '-backdrop-grayscale-[--value]',
+      'backdrop-grayscale-unknown',
       '-backdrop-hue-rotate-15',
       '-backdrop-hue-rotate-[45deg]',
+      'backdrop-hue-rotate-unknown',
       '-backdrop-invert',
       '-backdrop-invert-0',
       '-backdrop-invert-[--value]',
+      'backdrop-invert-unknown',
       '-backdrop-opacity-50',
       '-backdrop-opacity-[0.5]',
+      'backdrop-opacity-unknown',
       '-backdrop-saturate-0',
       '-backdrop-saturate-[1.75]',
       '-backdrop-saturate-[--value]',
+      'backdrop-saturate-unknown',
       '-backdrop-sepia',
       '-backdrop-sepia-0',
       '-backdrop-sepia-[50%]',
       '-backdrop-sepia-[--value]',
+      'backdrop-sepia-unknown',
     ]),
   ).toEqual('')
 })
@@ -9827,7 +9859,7 @@ test('delay', () => {
       transition-delay: .3s;
     }"
   `)
-  expect(run(['delay', '-delay-200', '-delay-[300ms]'])).toEqual('')
+  expect(run(['delay', '-delay-200', '-delay-[300ms]', 'delay-unknown'])).toEqual('')
 })
 
 test('duration', () => {
@@ -10450,7 +10482,7 @@ test('outline-offset', () => {
       outline-offset: var(--value);
     }"
   `)
-  expect(run(['outline-offset'])).toEqual('')
+  expect(run(['outline-offset', 'outline-offset-unknown'])).toEqual('')
 })
 
 test('opacity', () => {
@@ -10463,7 +10495,7 @@ test('opacity', () => {
       opacity: var(--value);
     }"
   `)
-  expect(run(['opacity', '-opacity-15', '-opacity-[--value]'])).toEqual('')
+  expect(run(['opacity', '-opacity-15', '-opacity-[--value]', 'opacity-unknown'])).toEqual('')
 })
 
 test('underline-offset', () => {
@@ -10513,7 +10545,9 @@ test('underline-offset', () => {
       text-underline-offset: auto;
     }"
   `)
-  expect(run(['underline-offset', '-underline-offset-auto'])).toEqual('')
+  expect(run(['underline-offset', '-underline-offset-auto', 'underline-offset-unknown'])).toEqual(
+    '',
+  )
 })
 
 test('text', () => {

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -2059,7 +2059,9 @@ test('flex', () => {
       flex: none;
     }"
   `)
-  expect(run(['-flex-1', '-flex-auto', '-flex-initial', '-flex-none', '-flex-[123]'])).toEqual('')
+  expect(
+    run(['-flex-1', '-flex-auto', '-flex-initial', '-flex-none', '-flex-[123]', 'flex-unknown']),
+  ).toEqual('')
 })
 
 test('flex-shrink', () => {
@@ -7029,6 +7031,8 @@ test('bg', () => {
   expect(
     run([
       'bg',
+      'bg-unknown',
+
       // background-color
       '-bg-inherit',
       '-bg-red-500',
@@ -8065,6 +8069,7 @@ test('fill', () => {
   expect(
     run([
       'fill',
+      'fill-unknown',
       '-fill-red-500',
       '-fill-red-500/50',
       '-fill-red-500/[0.5]',
@@ -8212,6 +8217,8 @@ test('stroke', () => {
   expect(
     run([
       'stroke',
+      'stroke-unknown',
+
       // Color
       '-stroke-red-500',
       '-stroke-red-500/50',

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -697,7 +697,7 @@ test('col', () => {
       grid-column: 1 / -1;
     }"
   `)
-  expect(run(['col', 'col-span', '-col-span-4'])).toEqual('')
+  expect(run(['col', 'col-span', '-col-span-4', 'col-span-unknown'])).toEqual('')
 })
 
 test('col-start', () => {
@@ -719,7 +719,7 @@ test('col-start', () => {
         grid-column-start: auto;
       }"
     `)
-  expect(run(['col-start', '-col-start-4'])).toEqual('')
+  expect(run(['col-start', '-col-start-4', 'col-start-unknown'])).toEqual('')
 })
 
 test('col-end', () => {
@@ -740,7 +740,7 @@ test('col-end', () => {
       grid-column-end: auto;
     }"
   `)
-  expect(run(['col-end', '-col-end-4'])).toEqual('')
+  expect(run(['col-end', '-col-end-4', 'col-end-unknown'])).toEqual('')
 })
 
 test('row', () => {
@@ -778,7 +778,7 @@ test('row', () => {
       grid-row: 1 / -1;
     }"
   `)
-  expect(run(['row', 'row-span', '-row-span-4'])).toEqual('')
+  expect(run(['row', 'row-span', '-row-span-4', 'row-span-unknown'])).toEqual('')
 })
 
 test('row-start', () => {
@@ -800,7 +800,7 @@ test('row-start', () => {
         grid-row-start: auto;
       }"
     `)
-  expect(run(['row-start', '-row-start-4'])).toEqual('')
+  expect(run(['row-start', '-row-start-4', 'row-start-unknown'])).toEqual('')
 })
 
 test('row-end', () => {
@@ -821,7 +821,7 @@ test('row-end', () => {
       grid-row-end: auto;
     }"
   `)
-  expect(run(['row-end', '-row-end-4'])).toEqual('')
+  expect(run(['row-end', '-row-end-4', 'row-end-unknown'])).toEqual('')
 })
 
 test('float', () => {

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -7287,6 +7287,8 @@ test('from', () => {
     run([
       'from',
       'from-123',
+      'from-unknown',
+      'from-unknown%',
 
       // --tw-gradient-from
       '-from-red-500',
@@ -7498,6 +7500,10 @@ test('via', () => {
   expect(
     run([
       'via',
+      'via-123',
+      'via-unknown',
+      'via-unknown%',
+
       // --tw-gradient-stops
       '-via-red-500',
       '-via-red-500/50',
@@ -7697,6 +7703,10 @@ test('to', () => {
   expect(
     run([
       'to',
+      'to-123',
+      'to-unknown',
+      'to-unknown%',
+
       // --tw-gradient-to
       '-to-red-500',
       '-to-red-500/50',

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -1048,7 +1048,9 @@ export function createUtilities(theme: Theme) {
       return [decl('flex', `calc(${candidate.value.fraction} * 100%)`)]
     }
 
-    return [decl('flex', candidate.value.value)]
+    if (Number.isInteger(Number(candidate.value.value))) {
+      return [decl('flex', candidate.value.value)]
+    }
   })
 
   /**

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -2500,7 +2500,10 @@ export function createUtilities(theme: Theme) {
         let value = theme.resolve(candidate.value.value, ['--gradient-color-stop-positions'])
         if (value) {
           return desc.position(value)
-        } else if (candidate.value.value[candidate.value.value.length - 1] === '%') {
+        } else if (
+          candidate.value.value[candidate.value.value.length - 1] === '%' &&
+          !Number.isNaN(Number(candidate.value.value.slice(0, -1)))
+        ) {
           return desc.position(candidate.value.value)
         }
       }

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -583,7 +583,10 @@ export function createUtilities(theme: Theme) {
   staticUtility('z-auto', [['z-index', 'auto']])
   functionalUtility('z', {
     supportsNegative: true,
-    handleBareValue: ({ value }) => value,
+    handleBareValue: ({ value }) => {
+      if (!Number.isInteger(Number(value))) return null
+      return value
+    },
     themeKeys: ['--z-index'],
     handle: (value) => [decl('z-index', value)],
   })
@@ -604,7 +607,10 @@ export function createUtilities(theme: Theme) {
   staticUtility('order-none', [['order', '0']])
   functionalUtility('order', {
     supportsNegative: true,
-    handleBareValue: ({ value }) => value,
+    handleBareValue: ({ value }) => {
+      if (!Number.isInteger(Number(value))) return null
+      return value
+    },
     themeKeys: ['--order'],
     handle: (value) => [decl('order', value)],
   })
@@ -793,7 +799,10 @@ export function createUtilities(theme: Theme) {
   ])
   functionalUtility('line-clamp', {
     themeKeys: ['--line-clamp'],
-    handleBareValue: ({ value }) => value,
+    handleBareValue: ({ value }) => {
+      if (!Number.isInteger(Number(value))) return null
+      return value
+    },
     handle: (value) => [
       decl('overflow', 'hidden'),
       decl('display', '-webkit-box'),
@@ -842,7 +851,13 @@ export function createUtilities(theme: Theme) {
   staticUtility('aspect-video', [['aspect-ratio', '16 / 9']])
   functionalUtility('aspect', {
     themeKeys: ['--aspect-ratio'],
-    handleBareValue: ({ fraction }) => fraction,
+    handleBareValue: ({ fraction }) => {
+      if (fraction === null) return null
+      let [lhs, rhs] = segment(fraction, '/')
+      if (!Number.isInteger(Number(lhs))) return null
+      if (!Number.isInteger(Number(rhs))) return null
+      return fraction
+    },
     handle: (value) => [decl('aspect-ratio', value)],
   })
 
@@ -1024,7 +1039,10 @@ export function createUtilities(theme: Theme) {
   functionalUtility('shrink', {
     defaultValue: '1',
     themeKeys: [],
-    handleBareValue: ({ value }) => value,
+    handleBareValue: ({ value }) => {
+      if (Number.isNaN(Number(value))) return null
+      return value
+    },
     handle: (value) => [decl('flex-shrink', value)],
   })
 
@@ -1034,7 +1052,10 @@ export function createUtilities(theme: Theme) {
   functionalUtility('grow', {
     defaultValue: '1',
     themeKeys: [],
-    handleBareValue: ({ value }) => value,
+    handleBareValue: ({ value }) => {
+      if (Number.isNaN(Number(value))) return null
+      return value
+    },
     handle: (value) => [decl('flex-grow', value)],
   })
 
@@ -1226,7 +1247,10 @@ export function createUtilities(theme: Theme) {
   functionalUtility('rotate', {
     supportsNegative: true,
     themeKeys: ['--rotate'],
-    handleBareValue: ({ value }) => `${value}deg`,
+    handleBareValue: ({ value }) => {
+      if (Number.isNaN(Number(value))) return null
+      return `${value}deg`
+    },
     handle: (value) => [decl('rotate', value)],
   })
 
@@ -1248,7 +1272,10 @@ export function createUtilities(theme: Theme) {
   functionalUtility('skew', {
     supportsNegative: true,
     themeKeys: ['--skew'],
-    handleBareValue: ({ value }) => `${value}deg`,
+    handleBareValue: ({ value }) => {
+      if (Number.isNaN(Number(value))) return null
+      return `${value}deg`
+    },
     handle: (value) => [
       skewProperties(),
       decl('--tw-skew-x', value),
@@ -1264,7 +1291,10 @@ export function createUtilities(theme: Theme) {
   functionalUtility('skew-x', {
     supportsNegative: true,
     themeKeys: ['--skew'],
-    handleBareValue: ({ value }) => `${value}deg`,
+    handleBareValue: ({ value }) => {
+      if (Number.isNaN(Number(value))) return null
+      return `${value}deg`
+    },
     handle: (value) => [
       skewProperties(),
       decl('--tw-skew-x', value),
@@ -1279,7 +1309,10 @@ export function createUtilities(theme: Theme) {
   functionalUtility('skew-y', {
     supportsNegative: true,
     themeKeys: ['--skew'],
-    handleBareValue: ({ value }) => `${value}deg`,
+    handleBareValue: ({ value }) => {
+      if (Number.isNaN(Number(value))) return null
+      return `${value}deg`
+    },
     handle: (value) => [
       skewProperties(),
       decl('--tw-skew-y', value),
@@ -1323,7 +1356,10 @@ export function createUtilities(theme: Theme) {
   functionalUtility('scale', {
     supportsNegative: true,
     themeKeys: ['--scale'],
-    handleBareValue: ({ value }) => `${value}%`,
+    handleBareValue: ({ value }) => {
+      if (Number.isNaN(Number(value))) return null
+      return `${value}%`
+    },
     handle: (value) => [
       scaleProperties(),
       decl('--tw-scale-x', value),
@@ -1338,7 +1374,10 @@ export function createUtilities(theme: Theme) {
   functionalUtility('scale-x', {
     supportsNegative: true,
     themeKeys: ['--scale'],
-    handleBareValue: ({ value }) => `${value}%`,
+    handleBareValue: ({ value }) => {
+      if (Number.isNaN(Number(value))) return null
+      return `${value}%`
+    },
     handle: (value) => [
       scaleProperties(),
       decl('--tw-scale-x', value),
@@ -1352,7 +1391,10 @@ export function createUtilities(theme: Theme) {
   functionalUtility('scale-y', {
     supportsNegative: true,
     themeKeys: ['--scale'],
-    handleBareValue: ({ value }) => `${value}%`,
+    handleBareValue: ({ value }) => {
+      if (Number.isNaN(Number(value))) return null
+      return `${value}%`
+    },
     handle: (value) => [
       scaleProperties(),
       decl('--tw-scale-y', value),
@@ -1665,7 +1707,10 @@ export function createUtilities(theme: Theme) {
 
   functionalUtility('columns', {
     themeKeys: ['--columns', '--width'],
-    handleBareValue: ({ value }) => value,
+    handleBareValue: ({ value }) => {
+      if (!Number.isInteger(Number(value))) return null
+      return value
+    },
     handle: (value) => [decl('columns', value)],
   })
 
@@ -1716,7 +1761,10 @@ export function createUtilities(theme: Theme) {
   staticUtility('grid-cols-subgrid', [['grid-template-columns', 'subgrid']])
   functionalUtility('grid-cols', {
     themeKeys: ['--grid-template-columns'],
-    handleBareValue: ({ value }) => `repeat(${value}, minmax(0, 1fr))`,
+    handleBareValue: ({ value }) => {
+      if (!Number.isInteger(Number(value))) return null
+      return `repeat(${value}, minmax(0, 1fr))`
+    },
     handle: (value) => [decl('grid-template-columns', value)],
   })
 
@@ -1724,7 +1772,10 @@ export function createUtilities(theme: Theme) {
   staticUtility('grid-rows-subgrid', [['grid-template-rows', 'subgrid']])
   functionalUtility('grid-rows', {
     themeKeys: ['--grid-template-rows'],
-    handleBareValue: ({ value }) => `repeat(${value}, minmax(0, 1fr))`,
+    handleBareValue: ({ value }) => {
+      if (!Number.isInteger(Number(value))) return null
+      return `repeat(${value}, minmax(0, 1fr))`
+    },
     handle: (value) => [decl('grid-template-rows', value)],
   })
 
@@ -2175,7 +2226,10 @@ export function createUtilities(theme: Theme) {
     functionalUtility('divide-x', {
       defaultValue: theme.get(['--default-border-width']) ?? '1px',
       themeKeys: ['--divide-width', '--border-width'],
-      handleBareValue: ({ value }) => `${value}px`,
+      handleBareValue: ({ value }) => {
+        if (Number.isNaN(Number(value))) return null
+        return `${value}px`
+      },
       handle: (value) => [
         atRoot([property('--tw-divide-x-reverse', '0', '<number>')]),
 
@@ -2195,7 +2249,10 @@ export function createUtilities(theme: Theme) {
     functionalUtility('divide-y', {
       defaultValue: theme.get(['--default-border-width']) ?? '1px',
       themeKeys: ['--divide-width', '--border-width'],
-      handleBareValue: ({ value }) => `${value}px`,
+      handleBareValue: ({ value }) => {
+        if (Number.isNaN(Number(value))) return null
+        return `${value}px`
+      },
       handle: (value) => [
         atRoot([property('--tw-divide-y-reverse', '0', '<number>')]),
 
@@ -3033,7 +3090,10 @@ export function createUtilities(theme: Theme) {
 
     functionalUtility('brightness', {
       themeKeys: ['--brightness'],
-      handleBareValue: ({ value }) => `${value}%`,
+      handleBareValue: ({ value }) => {
+        if (Number.isNaN(Number(value))) return null
+        return `${value}%`
+      },
       handle: (value) => [
         filterProperties(),
         decl('--tw-brightness', `brightness(${value})`),
@@ -3043,7 +3103,10 @@ export function createUtilities(theme: Theme) {
 
     functionalUtility('backdrop-brightness', {
       themeKeys: ['--backdrop-brightness', '--brightness'],
-      handleBareValue: ({ value }) => `${value}%`,
+      handleBareValue: ({ value }) => {
+        if (Number.isNaN(Number(value))) return null
+        return `${value}%`
+      },
       handle: (value) => [
         backdropFilterProperties(),
         decl('--tw-backdrop-brightness', `brightness(${value})`),
@@ -3068,7 +3131,10 @@ export function createUtilities(theme: Theme) {
 
     functionalUtility('contrast', {
       themeKeys: ['--contrast'],
-      handleBareValue: ({ value }) => `${value}%`,
+      handleBareValue: ({ value }) => {
+        if (Number.isNaN(Number(value))) return null
+        return `${value}%`
+      },
       handle: (value) => [
         filterProperties(),
         decl('--tw-contrast', `contrast(${value})`),
@@ -3078,7 +3144,10 @@ export function createUtilities(theme: Theme) {
 
     functionalUtility('backdrop-contrast', {
       themeKeys: ['--backdrop-contrast', '--contrast'],
-      handleBareValue: ({ value }) => `${value}%`,
+      handleBareValue: ({ value }) => {
+        if (Number.isNaN(Number(value))) return null
+        return `${value}%`
+      },
       handle: (value) => [
         backdropFilterProperties(),
         decl('--tw-backdrop-contrast', `contrast(${value})`),
@@ -3103,7 +3172,10 @@ export function createUtilities(theme: Theme) {
 
     functionalUtility('grayscale', {
       themeKeys: ['--grayscale'],
-      handleBareValue: ({ value }) => `${value}%`,
+      handleBareValue: ({ value }) => {
+        if (Number.isNaN(Number(value))) return null
+        return `${value}%`
+      },
       defaultValue: '100%',
       handle: (value) => [
         filterProperties(),
@@ -3114,7 +3186,10 @@ export function createUtilities(theme: Theme) {
 
     functionalUtility('backdrop-grayscale', {
       themeKeys: ['--backdrop-grayscale', '--grayscale'],
-      handleBareValue: ({ value }) => `${value}%`,
+      handleBareValue: ({ value }) => {
+        if (Number.isNaN(Number(value))) return null
+        return `${value}%`
+      },
       defaultValue: '100%',
       handle: (value) => [
         backdropFilterProperties(),
@@ -3142,7 +3217,10 @@ export function createUtilities(theme: Theme) {
 
     functionalUtility('hue-rotate', {
       themeKeys: ['--hue-rotate'],
-      handleBareValue: ({ value }) => `${value}deg`,
+      handleBareValue: ({ value }) => {
+        if (Number.isNaN(Number(value))) return null
+        return `${value}deg`
+      },
       handle: (value) => [
         filterProperties(),
         decl('--tw-hue-rotate', `hue-rotate(${value})`),
@@ -3152,7 +3230,10 @@ export function createUtilities(theme: Theme) {
 
     functionalUtility('backdrop-hue-rotate', {
       themeKeys: ['--backdrop-hue-rotate', '--hue-rotate'],
-      handleBareValue: ({ value }) => `${value}deg`,
+      handleBareValue: ({ value }) => {
+        if (Number.isNaN(Number(value))) return null
+        return `${value}deg`
+      },
       handle: (value) => [
         backdropFilterProperties(),
         decl('--tw-backdrop-hue-rotate', `hue-rotate(${value})`),
@@ -3177,7 +3258,10 @@ export function createUtilities(theme: Theme) {
 
     functionalUtility('invert', {
       themeKeys: ['--invert'],
-      handleBareValue: ({ value }) => `${value}%`,
+      handleBareValue: ({ value }) => {
+        if (Number.isNaN(Number(value))) return null
+        return `${value}%`
+      },
       defaultValue: '100%',
       handle: (value) => [
         filterProperties(),
@@ -3188,7 +3272,10 @@ export function createUtilities(theme: Theme) {
 
     functionalUtility('backdrop-invert', {
       themeKeys: ['--backdrop-invert', '--invert'],
-      handleBareValue: ({ value }) => `${value}%`,
+      handleBareValue: ({ value }) => {
+        if (Number.isNaN(Number(value))) return null
+        return `${value}%`
+      },
       defaultValue: '100%',
       handle: (value) => [
         backdropFilterProperties(),
@@ -3216,7 +3303,10 @@ export function createUtilities(theme: Theme) {
 
     functionalUtility('saturate', {
       themeKeys: ['--saturate'],
-      handleBareValue: ({ value }) => `${value}%`,
+      handleBareValue: ({ value }) => {
+        if (Number.isNaN(Number(value))) return null
+        return `${value}%`
+      },
       handle: (value) => [
         filterProperties(),
         decl('--tw-saturate', `saturate(${value})`),
@@ -3226,7 +3316,10 @@ export function createUtilities(theme: Theme) {
 
     functionalUtility('backdrop-saturate', {
       themeKeys: ['--backdrop-saturate', '--saturate'],
-      handleBareValue: ({ value }) => `${value}%`,
+      handleBareValue: ({ value }) => {
+        if (Number.isNaN(Number(value))) return null
+        return `${value}%`
+      },
       handle: (value) => [
         backdropFilterProperties(),
         decl('--tw-backdrop-saturate', `saturate(${value})`),
@@ -3251,7 +3344,10 @@ export function createUtilities(theme: Theme) {
 
     functionalUtility('sepia', {
       themeKeys: ['--sepia'],
-      handleBareValue: ({ value }) => `${value}%`,
+      handleBareValue: ({ value }) => {
+        if (Number.isNaN(Number(value))) return null
+        return `${value}%`
+      },
       defaultValue: '100%',
       handle: (value) => [
         filterProperties(),
@@ -3262,7 +3358,10 @@ export function createUtilities(theme: Theme) {
 
     functionalUtility('backdrop-sepia', {
       themeKeys: ['--backdrop-sepia', '--sepia'],
-      handleBareValue: ({ value }) => `${value}%`,
+      handleBareValue: ({ value }) => {
+        if (Number.isNaN(Number(value))) return null
+        return `${value}%`
+      },
       defaultValue: '100%',
       handle: (value) => [
         backdropFilterProperties(),
@@ -3304,7 +3403,10 @@ export function createUtilities(theme: Theme) {
 
     functionalUtility('backdrop-opacity', {
       themeKeys: ['--backdrop-opacity', '--opacity'],
-      handleBareValue: ({ value }) => `${value}%`,
+      handleBareValue: ({ value }) => {
+        if (Number.isNaN(Number(value))) return null
+        return `${value}%`
+      },
       handle: (value) => [
         backdropFilterProperties(),
         decl('--tw-backdrop-opacity', `opacity(${value})`),
@@ -3367,7 +3469,10 @@ export function createUtilities(theme: Theme) {
     })
 
     functionalUtility('delay', {
-      handleBareValue: ({ value }) => `${value}ms`,
+      handleBareValue: ({ value }) => {
+        if (Number.isNaN(Number(value))) return null
+        return `${value}ms`
+      },
       themeKeys: ['--transition-delay'],
       handle: (value) => [decl('transition-delay', value)],
     })
@@ -3693,7 +3798,10 @@ export function createUtilities(theme: Theme) {
     functionalUtility('outline-offset', {
       supportsNegative: true,
       themeKeys: ['--outline-offset'],
-      handleBareValue: ({ value }) => `${value}px`,
+      handleBareValue: ({ value }) => {
+        if (Number.isNaN(Number(value))) return null
+        return `${value}px`
+      },
       handle: (value) => [decl('outline-offset', value)],
     })
 
@@ -3707,7 +3815,10 @@ export function createUtilities(theme: Theme) {
 
   functionalUtility('opacity', {
     themeKeys: ['--opacity'],
-    handleBareValue: ({ value }) => `${value}%`,
+    handleBareValue: ({ value }) => {
+      if (Number.isNaN(Number(value))) return null
+      return `${value}%`
+    },
     handle: (value) => [decl('opacity', value)],
   })
 
@@ -3722,7 +3833,10 @@ export function createUtilities(theme: Theme) {
   functionalUtility('underline-offset', {
     supportsNegative: true,
     themeKeys: ['--text-underline-offset'],
-    handleBareValue: ({ value }) => `${value}px`,
+    handleBareValue: ({ value }) => {
+      if (Number.isNaN(Number(value))) return null
+      return `${value}px`
+    },
     handle: (value) => [decl('text-underline-offset', value)],
   })
 

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -634,7 +634,10 @@ export function createUtilities(theme: Theme) {
   staticUtility('col-span-full', [['grid-column', '1 / -1']])
   functionalUtility('col-span', {
     themeKeys: [],
-    handleBareValue: ({ value }) => value,
+    handleBareValue: ({ value }) => {
+      if (!Number.isInteger(Number(value))) return null
+      return value
+    },
     handle: (value) => [decl('grid-column', `span ${value} / span ${value}`)],
   })
 
@@ -643,7 +646,10 @@ export function createUtilities(theme: Theme) {
    */
   staticUtility('col-start-auto', [['grid-column-start', 'auto']])
   functionalUtility('col-start', {
-    handleBareValue: ({ value }) => value,
+    handleBareValue: ({ value }) => {
+      if (!Number.isInteger(Number(value))) return null
+      return value
+    },
     themeKeys: ['--grid-column-start'],
     handle: (value) => [decl('grid-column-start', value)],
   })
@@ -653,7 +659,10 @@ export function createUtilities(theme: Theme) {
    */
   staticUtility('col-end-auto', [['grid-column-end', 'auto']])
   functionalUtility('col-end', {
-    handleBareValue: ({ value }) => value,
+    handleBareValue: ({ value }) => {
+      if (!Number.isInteger(Number(value))) return null
+      return value
+    },
     themeKeys: ['--grid-column-end'],
     handle: (value) => [decl('grid-column-end', value)],
   })
@@ -690,7 +699,10 @@ export function createUtilities(theme: Theme) {
   staticUtility('row-span-full', [['grid-row', '1 / -1']])
   functionalUtility('row-span', {
     themeKeys: [],
-    handleBareValue: ({ value }) => value,
+    handleBareValue: ({ value }) => {
+      if (!Number.isInteger(Number(value))) return null
+      return value
+    },
     handle: (value) => [decl('grid-row', `span ${value} / span ${value}`)],
   })
 
@@ -699,7 +711,10 @@ export function createUtilities(theme: Theme) {
    */
   staticUtility('row-start-auto', [['grid-row-start', 'auto']])
   functionalUtility('row-start', {
-    handleBareValue: ({ value }) => value,
+    handleBareValue: ({ value }) => {
+      if (!Number.isInteger(Number(value))) return null
+      return value
+    },
     themeKeys: ['--grid-row-start'],
     handle: (value) => [decl('grid-row-start', value)],
   })
@@ -709,7 +724,10 @@ export function createUtilities(theme: Theme) {
    */
   staticUtility('row-end-auto', [['grid-row-end', 'auto']])
   functionalUtility('row-end', {
-    handleBareValue: ({ value }) => value,
+    handleBareValue: ({ value }) => {
+      if (!Number.isInteger(Number(value))) return null
+      return value
+    },
     themeKeys: ['--grid-row-end'],
     handle: (value) => [decl('grid-row-end', value)],
   })


### PR DESCRIPTION
This PR validates incoming bare values to ensure we generate CSS that makes sense.

Before this PR, we would generate values such as:

```css
.z-index {
  z-index: index;
}

.flex-foo {
  flex: foo;
}
```

Which is invalid, after this PR, these vaues would not be generated at all.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
