### PR TITLE
Parse candidates in `.svelte` files with `class:abc="condition"` syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Validate bare values ([#13245](https://github.com/tailwindlabs/tailwindcss/pull/13245))
+- Parse candidates in `.svelte` files with `class:abc="condition"` syntax ([#13274](https://github.com/tailwindlabs/tailwindcss/pull/13274))
 
 ### Changed
 
@@ -108,3 +109,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move the CLI into a separate `@tailwindcss/cli` package ([#13095](https://github.com/tailwindlabs/tailwindcss/pull/13095))
 
 ## [4.0.0-alpha.1] - 2024-03-06
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,4 +109,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move the CLI into a separate `@tailwindcss/cli` package ([#13095](https://github.com/tailwindlabs/tailwindcss/pull/13095))
 
 ## [4.0.0-alpha.1] - 2024-03-06
-

--- a/oxide/crates/core/src/lib.rs
+++ b/oxide/crates/core/src/lib.rs
@@ -1,4 +1,5 @@
 use crate::parser::Extractor;
+use bstr::ByteSlice;
 use cache::Cache;
 use fxhash::FxHashSet;
 use ignore::DirEntry;
@@ -399,6 +400,26 @@ pub fn scan_files(input: Vec<ChangedContent>, options: u8) -> Vec<String> {
     }
 }
 
+fn read_changed_content(c: ChangedContent) -> Option<Vec<u8>> {
+    match (c.file, c.content) {
+        (Some(file), None) => match std::fs::read(&file) {
+            Ok(content) => match file.extension() {
+                Some(extension) => match extension.to_str() {
+                    Some("svelte") => Some(content.replace(" class:", " ")),
+                    _ => Some(content),
+                },
+                _ => Some(content),
+            },
+            Err(e) => {
+                event!(tracing::Level::ERROR, "Failed to read file: {:?}", e);
+                Default::default()
+            }
+        },
+        (None, Some(content)) => Some(content.into_bytes()),
+        _ => Default::default(),
+    }
+}
+
 #[tracing::instrument(skip(changed_content))]
 fn read_all_files(changed_content: Vec<ChangedContent>) -> Vec<Vec<u8>> {
     event!(
@@ -409,17 +430,7 @@ fn read_all_files(changed_content: Vec<ChangedContent>) -> Vec<Vec<u8>> {
 
     changed_content
         .into_par_iter()
-        .map(|c| match (c.file, c.content) {
-            (Some(file), None) => match std::fs::read(file) {
-                Ok(content) => content,
-                Err(e) => {
-                    event!(tracing::Level::ERROR, "Failed to read file: {:?}", e);
-                    Default::default()
-                }
-            },
-            (None, Some(content)) => content.into_bytes(),
-            _ => Default::default(),
-        })
+        .filter_map(read_changed_content)
         .collect()
 }
 
@@ -433,11 +444,7 @@ fn read_all_files_sync(changed_content: Vec<ChangedContent>) -> Vec<Vec<u8>> {
 
     changed_content
         .into_iter()
-        .filter_map(|c| match (c.file, c.content) {
-            (Some(file), None) => std::fs::read(file).ok(),
-            (None, Some(content)) => Some(content.into_bytes()),
-            _ => Default::default(),
-        })
+        .filter_map(read_changed_content)
         .collect()
 }
 

--- a/oxide/crates/core/src/lib.rs
+++ b/oxide/crates/core/src/lib.rs
@@ -403,11 +403,8 @@ pub fn scan_files(input: Vec<ChangedContent>, options: u8) -> Vec<String> {
 fn read_changed_content(c: ChangedContent) -> Option<Vec<u8>> {
     match (c.file, c.content) {
         (Some(file), None) => match std::fs::read(&file) {
-            Ok(content) => match file.extension() {
-                Some(extension) => match extension.to_str() {
-                    Some("svelte") => Some(content.replace(" class:", " ")),
-                    _ => Some(content),
-                },
+            Ok(content) => match file.extension().map(|x| x.to_str()) {
+                Some(Some("svelte")) => Some(content.replace(" class:", " ")),
                 _ => Some(content),
             },
             Err(e) => {

--- a/oxide/crates/core/tests/auto_content.rs
+++ b/oxide/crates/core/tests/auto_content.rs
@@ -297,24 +297,14 @@ mod auto_content {
             ("foo.jpg", Some("xl:font-bold")),
             // A file that is ignored
             ("foo.html", Some("lg:font-bold")),
-        ])
-        .1;
-
-        assert_eq!(candidates, vec!["font-bold", "md:flex"]);
-    }
-
-    #[test]
-    fn it_should_scan_for_utilities_in_svelte_files() {
-        let mut ignores = String::new();
-        ignores.push_str("*\n");
-        ignores.push_str("!*.svelte\n");
-
-        let candidates = scan(&[
-            (".gitignore", Some(&ignores)),
+            // A svelte file with `class:foo="bar"` syntax
             ("index.svelte", Some("<div class:px-4='condition'></div>")),
         ])
         .1;
 
-        assert_eq!(candidates, vec!["condition", "div", "px-4"]);
+        assert_eq!(
+            candidates,
+            vec!["condition", "div", "font-bold", "md:flex", "px-4"]
+        );
     }
 }

--- a/oxide/crates/core/tests/auto_content.rs
+++ b/oxide/crates/core/tests/auto_content.rs
@@ -305,7 +305,15 @@ mod auto_content {
 
     #[test]
     fn it_should_scan_for_utilities_in_svelte_files() {
-        let candidates = scan(&[("index.svelte", Some("<div class:px-4='condition'></div>"))]).1;
+        let mut ignores = String::new();
+        ignores.push_str("*\n");
+        ignores.push_str("!*.svelte\n");
+
+        let candidates = scan(&[
+            (".gitignore", Some(&ignores)),
+            ("index.svelte", Some("<div class:px-4='condition'></div>")),
+        ])
+        .1;
 
         assert_eq!(candidates, vec!["condition", "div", "px-4"]);
     }

--- a/oxide/crates/core/tests/auto_content.rs
+++ b/oxide/crates/core/tests/auto_content.rs
@@ -302,4 +302,11 @@ mod auto_content {
 
         assert_eq!(candidates, vec!["font-bold", "md:flex"]);
     }
+
+    #[test]
+    fn it_should_scan_for_utilities_in_svelte_files() {
+        let candidates = scan(&[("index.svelte", Some("<div class:px-4='condition'></div>"))]).1;
+
+        assert_eq!(candidates, vec!["condition", "div", "px-4"]);
+    }
 }


### PR DESCRIPTION
This PR introduces backwards compatibility for the `class:` syntax in Svelte files.

In Svelte there is a convention where you can use `<div class:px-4="condition" />` which allows you to apply the `px-4` class conditionally based on a condition. This also means that we extract `class:px-4` as a utility where `class` is a variant and `px-4` is the utility.

This is obviously incorrect, to solve this we can ignore the `class:` part before parsing the whole file.

This is also what we do in v3.

In a perfect world, we have more specific parsers depending on the file type before using the generic parser we use now. But that's a bigger project on its own way beyond the scope of this PR.

Fixes: #13263

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
