### PR TITLE
Skip newlines when parsing selectors

### DIFF
--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -610,6 +610,18 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         },
       ])
     })
+
+    it('should parse a multi-line selector and preserves important whitespace', () => {
+      expect(
+        parse(['.foo,', '.bar,', '.baz\t\n \n .qux', '{', 'color:red;', '}'].join('\n')),
+      ).toEqual([
+        {
+          kind: 'rule',
+          selector: '.foo, .bar, .baz .qux',
+          nodes: [{ kind: 'declaration', property: 'color', value: 'red', important: false }],
+        },
+      ])
+    })
   })
 
   describe('at-rules', () => {

--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -600,6 +600,16 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         },
       ])
     })
+
+    it('should parse a multi-line selector', () => {
+      expect(parse(['.foo,', '.bar,', '.baz', '{', 'color:red;', '}'].join('\n'))).toEqual([
+        {
+          kind: 'rule',
+          selector: '.foo, .bar, .baz',
+          nodes: [{ kind: 'declaration', property: 'color', value: 'red', important: false }],
+        },
+      ])
+    })
   })
 
   describe('at-rules', () => {

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -142,6 +142,16 @@ export function parse(input: string) {
       continue
     }
 
+    // Replace new lines with spaces.
+    else if (char === '\n') {
+      if (current.length === 0) continue
+
+      let last = current[current.length - 1]
+      if (last !== ' ' && last !== '\n' && last !== '\t') {
+        current += ' '
+      }
+    }
+
     // Start of a custom property.
     //
     // Custom properties are very permissive and can contain almost any


### PR DESCRIPTION
This PR introduces a small improvement when parsing CSS where selectors including newlines (`\n`) are replaced with a space.

This means that the preflight in Tailwind Play looked like this:
```css
/*! tailwindcss v4.0.0-alpha.9 | MIT License | https://tailwindcss.com */
@layer base {
  *,
::after,
::before,
::backdrop,
::first-letter,
::file-selector-button {
    box-sizing: border-box;
    margin: 0;
    padding: 0;
    border: 0 solid;
  }
  html,
:host {
    line-height: 1.5;
    -webkit-text-size-adjust: 100%;
    tab-size: 4;
    font-family: var( --default-font-family, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji' );
    font-feature-settings: var(--default-font-feature-settings, normal);
    font-variation-settings: var(--default-font-variation-settings, normal);
    -webkit-tap-highlight-color: transparent;
  }
  body {
    line-height: inherit;
  }
  hr {
    height: 0;
    color: inherit;
    border-top-width: 1px;
  }
  abbr:where([title]) {
    -webkit-text-decoration: underline dotted;
    text-decoration: underline dotted;
  }
  h1,
h2,
h3,
h4,
h5,
h6 {
    font-size: inherit;
    font-weight: inherit;
  }
  a {
    color: inherit;
    -webkit-text-decoration: inherit;
    text-decoration: inherit;
  }
  b,
strong {
    font-weight: bolder;
  }
  code,
kbd,
samp,
pre {
    font-family: var( --default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace );
    font-feature-settings: var(--default-mono-font-feature-settings, normal);
    font-variation-settings: var(--default-mono-font-variation-settings, normal);
    font-size: 1em;
  }
  small {
    font-size: 80%;
  }
  sub,
sup {
    font-size: 75%;
    line-height: 0;
    position: relative;
    vertical-align: baseline;
  }
  sub {
    bottom: -0.25em;
  }
  sup {
    top: -0.5em;
  }
  table {
    text-indent: 0;
    border-color: inherit;
    border-collapse: collapse;
  }
  button,
input,
optgroup,
select,
textarea,
::file-selector-button {
    font: inherit;
    font-feature-settings: inherit;
    font-variation-settings: inherit;
    color: inherit;
    background: transparent;
  }
  input:where(:not([type='button'], [type='reset'], [type='submit'])),
select,
textarea {
    border: 1px solid;
  }
  button,
input:where([type='button'], [type='reset'], [type='submit']),
::file-selector-button {
    appearance: button;
  }
  :-moz-focusring {
    outline: auto;
  }
  :-moz-ui-invalid {
    box-shadow: none;
  }
  progress {
    vertical-align: baseline;
  }
  ::-webkit-inner-spin-button,
::-webkit-outer-spin-button {
    height: auto;
  }
  ::-webkit-search-decoration {
    -webkit-appearance: none;
  }
  summary {
    display: list-item;
  }
  ol,
ul,
menu {
    list-style: none;
  }
  textarea {
    resize: vertical;
  }
  ::placeholder {
    opacity: 1;
    color: color-mix(in srgb, currentColor 50%, transparent);
  }
  :disabled {
    cursor: default;
  }
  img,
svg,
video,
canvas,
audio,
iframe,
embed,
object {
    display: block;
    vertical-align: middle;
  }
  img,
video {
    max-width: 100%;
    height: auto;
  }
  [hidden] {
    display: none!important;
  }
}
```

Now looks like this:
```css
/*! tailwindcss v4.0.0-alpha.9 | MIT License | https://tailwindcss.com */
@layer base {
  *, ::after, ::before, ::backdrop, ::first-letter, ::file-selector-button {
    box-sizing: border-box;
    margin: 0;
    padding: 0;
    border: 0 solid;
  }
  html, :host {
    line-height: 1.5;
    -webkit-text-size-adjust: 100%;
    tab-size: 4;
    font-family: var( --default-font-family, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji' );
    font-feature-settings: var(--default-font-feature-settings, normal);
    font-variation-settings: var(--default-font-variation-settings, normal);
    -webkit-tap-highlight-color: transparent;
  }
  body {
    line-height: inherit;
  }
  hr {
    height: 0;
    color: inherit;
    border-top-width: 1px;
  }
  abbr:where([title]) {
    -webkit-text-decoration: underline dotted;
    text-decoration: underline dotted;
  }
  h1, h2, h3, h4, h5, h6 {
    font-size: inherit;
    font-weight: inherit;
  }
  a {
    color: inherit;
    -webkit-text-decoration: inherit;
    text-decoration: inherit;
  }
  b, strong {
    font-weight: bolder;
  }
  code, kbd, samp, pre {
    font-family: var( --default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace );
    font-feature-settings: var(--default-mono-font-feature-settings, normal);
    font-variation-settings: var(--default-mono-font-variation-settings, normal);
    font-size: 1em;
  }
  small {
    font-size: 80%;
  }
  sub, sup {
    font-size: 75%;
    line-height: 0;
    position: relative;
    vertical-align: baseline;
  }
  sub {
    bottom: -0.25em;
  }
  sup {
    top: -0.5em;
  }
  table {
    text-indent: 0;
    border-color: inherit;
    border-collapse: collapse;
  }
  button, input, optgroup, select, textarea, ::file-selector-button {
    font: inherit;
    font-feature-settings: inherit;
    font-variation-settings: inherit;
    color: inherit;
    background: transparent;
  }
  input:where(:not([type='button'], [type='reset'], [type='submit'])), select, textarea {
    border: 1px solid;
  }
  button, input:where([type='button'], [type='reset'], [type='submit']), ::file-selector-button {
    appearance: button;
  }
  :-moz-focusring {
    outline: auto;
  }
  :-moz-ui-invalid {
    box-shadow: none;
  }
  progress {
    vertical-align: baseline;
  }
  ::-webkit-inner-spin-button, ::-webkit-outer-spin-button {
    height: auto;
  }
  ::-webkit-search-decoration {
    -webkit-appearance: none;
  }
  summary {
    display: list-item;
  }
  ol, ul, menu {
    list-style: none;
  }
  textarea {
    resize: vertical;
  }
  ::placeholder {
    opacity: 1;
    color: color-mix(in srgb, currentColor 50%, transparent);
  }
  :disabled {
    cursor: default;
  }
  img, svg, video, canvas, audio, iframe, embed, object {
    display: block;
    vertical-align: middle;
  }
  img, video {
    max-width: 100%;
    height: auto;
  }
  [hidden] {
    display: none!important;
  }
}
```
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
