### PR TITLE
Remove bare value handling for perspective utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `inherit` as a universal color ([#13258](https://github.com/tailwindlabs/tailwindcss/pull/13258))
-- Add 3D transform utilities ([#13248](https://github.com/tailwindlabs/tailwindcss/pull/13248))
+- Add 3D transform utilities ([#13248](https://github.com/tailwindlabs/tailwindcss/pull/13248), [#13288](https://github.com/tailwindlabs/tailwindcss/pull/13288))
 
 ### Fixed
 

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -3142,10 +3142,6 @@ test('perspective', () => {
       --perspective-normal: 500px;
     }
 
-    .perspective-123 {
-      perspective: 123px;
-    }
-
     .perspective-\\[456px\\] {
       perspective: 456px;
     }

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -3128,13 +3128,7 @@ test('perspective', () => {
         }
         @tailwind utilities;
       `,
-      [
-        'perspective-normal',
-        'perspective-dramatic',
-        'perspective-none',
-        'perspective-123',
-        'perspective-[456px]',
-      ],
+      ['perspective-normal', 'perspective-dramatic', 'perspective-none', 'perspective-[456px]'],
     ),
   ).toMatchInlineSnapshot(`
     ":root {
@@ -3158,7 +3152,7 @@ test('perspective', () => {
       perspective: 500px;
     }"
   `)
-  expect(run(['perspective', '-perspective', 'perspective-potato'])).toEqual('')
+  expect(run(['perspective', '-perspective', 'perspective-potato', 'perspective-123'])).toEqual('')
 })
 
 test('cursor', () => {

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -1501,10 +1501,6 @@ export function createUtilities(theme: Theme) {
   staticUtility('perspective-none', [['perspective', 'none']])
   functionalUtility('perspective', {
     themeKeys: ['--perspective'],
-    handleBareValue: ({ value }) => {
-      if (!Number.isInteger(Number(value))) return null
-      return `${value}px`
-    },
     handle: (value) => [decl('perspective', value)],
   })
 


### PR DESCRIPTION
This PR removes bare value handling from the perspective utilities, so that utilities like `perspective-300` will no longer generate declarations like `perspective: 300px`.

Generally we support bare values as a way to avoid putting things into the default theme, and since the perspective utilities already have a named scale in the theme I don't think it makes sense to support bare values. Bare values should be thought of as real API that we would include in the IntelliSense completions list when someone is typing a utility, and I don't think we want to include any numeric values in that list for `perspective` 👍 