### PR TITLE
Remove bare value support for `translate` utilities

### DIFF
--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -3500,6 +3500,9 @@ export function createUtilities(theme: Theme) {
     })
 
     functionalUtility('backdrop-opacity', {
+      // TODO: Do we want to remove this or not? Named opacity utilities (apart
+      // form like `opacity-disabled` do not make a lot of sense). Just bare
+      // values make more sense.
       themeKeys: ['--backdrop-opacity', '--opacity'],
       handleBareValue: ({ value }) => {
         if (Number.isNaN(Number(value))) return null

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -626,7 +626,6 @@ export function createUtilities(theme: Theme) {
     {
       supportsNegative: true,
       values: Array.from({ length: 12 }, (_, i) => `${i + 1}`),
-      valueThemeKeys: ['--order'],
     },
   ])
 
@@ -837,7 +836,6 @@ export function createUtilities(theme: Theme) {
   suggest('line-clamp', () => [
     {
       values: ['1', '2', '3', '4', '5', '6'],
-      valueThemeKeys: ['--line-clamp'],
     },
   ])
 
@@ -1307,7 +1305,6 @@ export function createUtilities(theme: Theme) {
     {
       supportsNegative: true,
       values: ['0', '1', '2', '3', '6', '12', '45', '90', '180'],
-      valueThemeKeys: ['--rotate'],
     },
   ])
 
@@ -1325,7 +1322,6 @@ export function createUtilities(theme: Theme) {
       {
         supportsNegative: true,
         values: ['0', '1', '2', '3', '6', '12', '45', '90', '180'],
-        valueThemeKeys: ['--rotate'],
       },
     ])
   }
@@ -1389,7 +1385,6 @@ export function createUtilities(theme: Theme) {
     {
       supportsNegative: true,
       values: ['0', '1', '2', '3', '6', '12'],
-      valueThemeKeys: ['--skew'],
     },
   ])
 
@@ -1397,7 +1392,6 @@ export function createUtilities(theme: Theme) {
     {
       supportsNegative: true,
       values: ['0', '1', '2', '3', '6', '12'],
-      valueThemeKeys: ['--skew'],
     },
   ])
 
@@ -1405,7 +1399,6 @@ export function createUtilities(theme: Theme) {
     {
       supportsNegative: true,
       values: ['0', '1', '2', '3', '6', '12'],
-      valueThemeKeys: ['--skew'],
     },
   ])
 
@@ -1445,7 +1438,6 @@ export function createUtilities(theme: Theme) {
     {
       supportsNegative: true,
       values: ['0', '50', '75', '90', '95', '100', '105', '110', '125', '150', '200'],
-      valueThemeKeys: ['--scale'],
     },
   ])
 
@@ -1473,7 +1465,6 @@ export function createUtilities(theme: Theme) {
       {
         supportsNegative: true,
         values: ['0', '50', '75', '90', '95', '100', '105', '110', '125', '150', '200'],
-        valueThemeKeys: ['--scale'],
       },
     ])
   }
@@ -1891,14 +1882,12 @@ export function createUtilities(theme: Theme) {
   suggest('grid-cols', () => [
     {
       values: Array.from({ length: 12 }, (_, i) => `${i + 1}`),
-      valueThemeKeys: ['--grid-template-columns'],
     },
   ])
 
   suggest('grid-rows', () => [
     {
       values: Array.from({ length: 12 }, (_, i) => `${i + 1}`),
-      valueThemeKeys: ['--grid-template-rows'],
     },
   ])
 

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -3519,9 +3519,6 @@ export function createUtilities(theme: Theme) {
     })
 
     functionalUtility('backdrop-opacity', {
-      // TODO: Do we want to remove this or not? Named opacity utilities (apart
-      // form like `opacity-disabled` do not make a lot of sense). Just bare
-      // values make more sense.
       themeKeys: ['--backdrop-opacity', '--opacity'],
       handleBareValue: ({ value }) => {
         if (Number.isNaN(Number(value))) return null

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -619,7 +619,6 @@ export function createUtilities(theme: Theme) {
       if (!Number.isInteger(Number(value))) return null
       return value
     },
-    themeKeys: ['--order'],
     handle: (value) => [decl('order', value)],
   })
 
@@ -823,7 +822,6 @@ export function createUtilities(theme: Theme) {
     ['-webkit-line-clamp', 'unset'],
   ])
   functionalUtility('line-clamp', {
-    themeKeys: ['--line-clamp'],
     handleBareValue: ({ value }) => {
       if (!Number.isInteger(Number(value))) return null
       return value
@@ -1317,7 +1315,6 @@ export function createUtilities(theme: Theme) {
   for (let axis of ['x', 'y']) {
     functionalUtility(`rotate-${axis}`, {
       supportsNegative: true,
-      themeKeys: ['--rotate'],
       handleBareValue: ({ value }) => {
         if (Number.isNaN(Number(value))) return null
         return `${value}deg`
@@ -1343,7 +1340,6 @@ export function createUtilities(theme: Theme) {
    */
   functionalUtility('skew', {
     supportsNegative: true,
-    themeKeys: ['--skew'],
     handleBareValue: ({ value }) => {
       if (Number.isNaN(Number(value))) return null
       return `${value}deg`
@@ -1362,7 +1358,6 @@ export function createUtilities(theme: Theme) {
    */
   functionalUtility('skew-x', {
     supportsNegative: true,
-    themeKeys: ['--skew'],
     handleBareValue: ({ value }) => {
       if (Number.isNaN(Number(value))) return null
       return `${value}deg`
@@ -1380,7 +1375,6 @@ export function createUtilities(theme: Theme) {
    */
   functionalUtility('skew-y', {
     supportsNegative: true,
-    themeKeys: ['--skew'],
     handleBareValue: ({ value }) => {
       if (Number.isNaN(Number(value))) return null
       return `${value}deg`
@@ -1463,7 +1457,6 @@ export function createUtilities(theme: Theme) {
      */
     functionalUtility(`scale-${axis}`, {
       supportsNegative: true,
-      themeKeys: ['--scale'],
       handleBareValue: ({ value }) => {
         if (Number.isNaN(Number(value))) return null
         return `${value}%`
@@ -1879,7 +1872,6 @@ export function createUtilities(theme: Theme) {
   staticUtility('grid-cols-none', [['grid-template-columns', 'none']])
   staticUtility('grid-cols-subgrid', [['grid-template-columns', 'subgrid']])
   functionalUtility('grid-cols', {
-    themeKeys: ['--grid-template-columns'],
     handleBareValue: ({ value }) => {
       if (!Number.isInteger(Number(value))) return null
       return `repeat(${value}, minmax(0, 1fr))`
@@ -1890,7 +1882,6 @@ export function createUtilities(theme: Theme) {
   staticUtility('grid-rows-none', [['grid-template-rows', 'none']])
   staticUtility('grid-rows-subgrid', [['grid-template-rows', 'subgrid']])
   functionalUtility('grid-rows', {
-    themeKeys: ['--grid-template-rows'],
     handleBareValue: ({ value }) => {
       if (!Number.isInteger(Number(value))) return null
       return `repeat(${value}, minmax(0, 1fr))`

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -1290,7 +1290,8 @@ export function createUtilities(theme: Theme) {
         return [decl('rotate', value)]
       }
     } else {
-      if (!Number.isNaN(Number(candidate.value.value))) {
+      value = theme.resolve(candidate.value.value, ['--rotate'])
+      if (!value && !Number.isNaN(Number(candidate.value.value))) {
         value = `${candidate.value.value}deg`
       }
       if (!value) return
@@ -1421,7 +1422,8 @@ export function createUtilities(theme: Theme) {
       value = candidate.value.value
       return [decl('scale', value)]
     } else {
-      if (!Number.isNaN(Number(candidate.value.value))) {
+      value = theme.resolve(candidate.value.value, ['--scale'])
+      if (!value && !Number.isNaN(Number(candidate.value.value))) {
         value = `${candidate.value.value}%`
       }
       if (!value) return
@@ -1810,8 +1812,7 @@ export function createUtilities(theme: Theme) {
   staticUtility('columns-auto', [['columns', 'auto']])
 
   functionalUtility('columns', {
-    // TODO: Do we want to remove the `--columns` or not?
-    themeKeys: ['--width'],
+    themeKeys: ['--columns', '--width'],
     handleBareValue: ({ value }) => {
       if (!Number.isInteger(Number(value))) return null
       return value
@@ -2328,8 +2329,7 @@ export function createUtilities(theme: Theme) {
 
     functionalUtility('divide-x', {
       defaultValue: theme.get(['--default-border-width']) ?? '1px',
-      // TODO: Do we want to remove `--divide-width` or not?
-      themeKeys: ['--border-width'],
+      themeKeys: ['--divide-width', '--border-width'],
       handleBareValue: ({ value }) => {
         if (Number.isNaN(Number(value))) return null
         return `${value}px`
@@ -2352,8 +2352,7 @@ export function createUtilities(theme: Theme) {
 
     functionalUtility('divide-y', {
       defaultValue: theme.get(['--default-border-width']) ?? '1px',
-      // TODO: Do we want to remove `--divide-width` or not?
-      themeKeys: ['--border-width'],
+      themeKeys: ['--divide-width', '--border-width'],
       handleBareValue: ({ value }) => {
         if (Number.isNaN(Number(value))) return null
         return `${value}px`
@@ -2375,7 +2374,7 @@ export function createUtilities(theme: Theme) {
     suggest('divide-x', () => [
       {
         values: ['0', '2', '4', '8'],
-        valueThemeKeys: ['--border-width'],
+        valueThemeKeys: ['--divide-width', '--border-width'],
         hasDefaultValue: true,
       },
     ])
@@ -2383,7 +2382,7 @@ export function createUtilities(theme: Theme) {
     suggest('divide-y', () => [
       {
         values: ['0', '2', '4', '8'],
-        valueThemeKeys: ['--border-width'],
+        valueThemeKeys: ['--divide-width', '--border-width'],
         hasDefaultValue: true,
       },
     ])

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -290,7 +290,7 @@ export function createUtilities(theme: Theme) {
   type UtilityDescription = {
     supportsNegative?: boolean
     supportsFractions?: boolean
-    themeKeys: ThemeKey[]
+    themeKeys?: ThemeKey[]
     defaultValue?: string | null
     handleBareValue?: (value: NamedUtilityValue) => string | null
     handle: (value: string) => AstNode[] | undefined
@@ -315,11 +315,14 @@ export function createUtilities(theme: Theme) {
         // ever support both of these — `defaultValue` is for things like
         // `grayscale` whereas the `DEFAULT` in theme is for things like
         // `shadow` or `blur`.
-        value = desc.defaultValue ?? theme.get(desc.themeKeys)
+        value = desc.defaultValue ?? theme.get(desc.themeKeys ?? [])
       } else if (candidate.value.kind === 'arbitrary') {
         value = candidate.value.value
       } else {
-        value = theme.resolve(candidate.value.fraction ?? candidate.value.value, desc.themeKeys)
+        value = theme.resolve(
+          candidate.value.fraction ?? candidate.value.value,
+          desc.themeKeys ?? [],
+        )
 
         // Automatically handle things like `w-1/2` without requiring `1/2` to
         // exist as a theme value.
@@ -344,7 +347,7 @@ export function createUtilities(theme: Theme) {
     suggest(classRoot, () => [
       {
         supportsNegative: desc.supportsNegative,
-        valueThemeKeys: desc.themeKeys,
+        valueThemeKeys: desc.themeKeys ?? [],
         hasDefaultValue: desc.defaultValue !== undefined && desc.defaultValue !== null,
       },
     ])
@@ -638,7 +641,6 @@ export function createUtilities(theme: Theme) {
   })
   staticUtility('col-span-full', [['grid-column', '1 / -1']])
   functionalUtility('col-span', {
-    themeKeys: [],
     handleBareValue: ({ value }) => {
       if (!Number.isInteger(Number(value))) return null
       return value
@@ -1063,7 +1065,6 @@ export function createUtilities(theme: Theme) {
    */
   functionalUtility('shrink', {
     defaultValue: '1',
-    themeKeys: [],
     handleBareValue: ({ value }) => {
       if (Number.isNaN(Number(value))) return null
       return value
@@ -1076,7 +1077,6 @@ export function createUtilities(theme: Theme) {
    */
   functionalUtility('grow', {
     defaultValue: '1',
-    themeKeys: [],
     handleBareValue: ({ value }) => {
       if (Number.isNaN(Number(value))) return null
       return value
@@ -2997,7 +2997,6 @@ export function createUtilities(theme: Theme) {
   staticUtility('font-stretch-extra-expanded', [['font-stretch', 'extra-expanded']])
   staticUtility('font-stretch-ultra-expanded', [['font-stretch', 'ultra-expanded']])
   functionalUtility('font-stretch', {
-    themeKeys: [],
     handleBareValue: ({ value }) => {
       if (!value.endsWith('%')) return null
       let num = Number(value.slice(0, -1))

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -1294,8 +1294,7 @@ export function createUtilities(theme: Theme) {
         return [decl('rotate', value)]
       }
     } else {
-      value = theme.resolve(candidate.value.value, ['--rotate'])
-      if (!value && !Number.isNaN(Number(candidate.value.value))) {
+      if (!Number.isNaN(Number(candidate.value.value))) {
         value = `${candidate.value.value}deg`
       }
       if (!value) return
@@ -1427,8 +1426,7 @@ export function createUtilities(theme: Theme) {
       value = candidate.value.value
       return [decl('scale', value)]
     } else {
-      value = theme.resolve(candidate.value.value, ['--scale'])
-      if (!value && !Number.isNaN(Number(candidate.value.value))) {
+      if (!Number.isNaN(Number(candidate.value.value))) {
         value = `${candidate.value.value}%`
       }
       if (!value) return
@@ -1818,7 +1816,8 @@ export function createUtilities(theme: Theme) {
   staticUtility('columns-auto', [['columns', 'auto']])
 
   functionalUtility('columns', {
-    themeKeys: ['--columns', '--width'],
+    // TODO: Do we want to remove the `--columns` or not?
+    themeKeys: ['--width'],
     handleBareValue: ({ value }) => {
       if (!Number.isInteger(Number(value))) return null
       return value
@@ -2335,7 +2334,8 @@ export function createUtilities(theme: Theme) {
 
     functionalUtility('divide-x', {
       defaultValue: theme.get(['--default-border-width']) ?? '1px',
-      themeKeys: ['--divide-width', '--border-width'],
+      // TODO: Do we want to remove `--divide-width` or not?
+      themeKeys: ['--border-width'],
       handleBareValue: ({ value }) => {
         if (Number.isNaN(Number(value))) return null
         return `${value}px`
@@ -2358,7 +2358,8 @@ export function createUtilities(theme: Theme) {
 
     functionalUtility('divide-y', {
       defaultValue: theme.get(['--default-border-width']) ?? '1px',
-      themeKeys: ['--divide-width', '--border-width'],
+      // TODO: Do we want to remove `--divide-width` or not?
+      themeKeys: ['--border-width'],
       handleBareValue: ({ value }) => {
         if (Number.isNaN(Number(value))) return null
         return `${value}px`
@@ -2380,7 +2381,7 @@ export function createUtilities(theme: Theme) {
     suggest('divide-x', () => [
       {
         values: ['0', '2', '4', '8'],
-        valueThemeKeys: ['--divide-width', '--border-width'],
+        valueThemeKeys: ['--border-width'],
         hasDefaultValue: true,
       },
     ])
@@ -2388,7 +2389,7 @@ export function createUtilities(theme: Theme) {
     suggest('divide-y', () => [
       {
         values: ['0', '2', '4', '8'],
-        valueThemeKeys: ['--divide-width', '--border-width'],
+        valueThemeKeys: ['--border-width'],
         hasDefaultValue: true,
       },
     ])

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -1251,10 +1251,6 @@ export function createUtilities(theme: Theme) {
       supportsNegative: true,
       supportsFractions: true,
       themeKeys: ['--translate', '--spacing'],
-      handleBareValue: ({ value }) => {
-        if (Number.isNaN(Number(value))) return null
-        return `${value}%`
-      },
       handle,
     })
     utilities.static(`translate-${axis}-px`, (candidate) => {

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -619,6 +619,7 @@ export function createUtilities(theme: Theme) {
       if (!Number.isInteger(Number(value))) return null
       return value
     },
+    themeKeys: ['--order'],
     handle: (value) => [decl('order', value)],
   })
 
@@ -821,6 +822,7 @@ export function createUtilities(theme: Theme) {
     ['-webkit-line-clamp', 'unset'],
   ])
   functionalUtility('line-clamp', {
+    themeKeys: ['--line-clamp'],
     handleBareValue: ({ value }) => {
       if (!Number.isInteger(Number(value))) return null
       return value
@@ -1307,6 +1309,7 @@ export function createUtilities(theme: Theme) {
   for (let axis of ['x', 'y']) {
     functionalUtility(`rotate-${axis}`, {
       supportsNegative: true,
+      themeKeys: ['--rotate'],
       handleBareValue: ({ value }) => {
         if (Number.isNaN(Number(value))) return null
         return `${value}deg`
@@ -1331,6 +1334,7 @@ export function createUtilities(theme: Theme) {
    */
   functionalUtility('skew', {
     supportsNegative: true,
+    themeKeys: ['--skew'],
     handleBareValue: ({ value }) => {
       if (Number.isNaN(Number(value))) return null
       return `${value}deg`
@@ -1349,6 +1353,7 @@ export function createUtilities(theme: Theme) {
    */
   functionalUtility('skew-x', {
     supportsNegative: true,
+    themeKeys: ['--skew'],
     handleBareValue: ({ value }) => {
       if (Number.isNaN(Number(value))) return null
       return `${value}deg`
@@ -1366,6 +1371,7 @@ export function createUtilities(theme: Theme) {
    */
   functionalUtility('skew-y', {
     supportsNegative: true,
+    themeKeys: ['--skew'],
     handleBareValue: ({ value }) => {
       if (Number.isNaN(Number(value))) return null
       return `${value}deg`
@@ -1443,6 +1449,7 @@ export function createUtilities(theme: Theme) {
      */
     functionalUtility(`scale-${axis}`, {
       supportsNegative: true,
+      themeKeys: ['--scale'],
       handleBareValue: ({ value }) => {
         if (Number.isNaN(Number(value))) return null
         return `${value}%`
@@ -1858,6 +1865,7 @@ export function createUtilities(theme: Theme) {
   staticUtility('grid-cols-none', [['grid-template-columns', 'none']])
   staticUtility('grid-cols-subgrid', [['grid-template-columns', 'subgrid']])
   functionalUtility('grid-cols', {
+    themeKeys: ['--grid-template-columns'],
     handleBareValue: ({ value }) => {
       if (!Number.isInteger(Number(value))) return null
       return `repeat(${value}, minmax(0, 1fr))`
@@ -1868,6 +1876,7 @@ export function createUtilities(theme: Theme) {
   staticUtility('grid-rows-none', [['grid-template-rows', 'none']])
   staticUtility('grid-rows-subgrid', [['grid-template-rows', 'subgrid']])
   functionalUtility('grid-rows', {
+    themeKeys: ['--grid-template-rows'],
     handleBareValue: ({ value }) => {
       if (!Number.isInteger(Number(value))) return null
       return `repeat(${value}, minmax(0, 1fr))`

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -627,6 +627,7 @@ export function createUtilities(theme: Theme) {
     {
       supportsNegative: true,
       values: Array.from({ length: 12 }, (_, i) => `${i + 1}`),
+      valueThemeKeys: ['--order'],
     },
   ])
 
@@ -838,6 +839,7 @@ export function createUtilities(theme: Theme) {
   suggest('line-clamp', () => [
     {
       values: ['1', '2', '3', '4', '5', '6'],
+      valueThemeKeys: ['--line-clamp'],
     },
   ])
 
@@ -1304,6 +1306,7 @@ export function createUtilities(theme: Theme) {
     {
       supportsNegative: true,
       values: ['0', '1', '2', '3', '6', '12', '45', '90', '180'],
+      valueThemeKeys: ['--rotate'],
     },
   ])
 
@@ -1322,6 +1325,7 @@ export function createUtilities(theme: Theme) {
       {
         supportsNegative: true,
         values: ['0', '1', '2', '3', '6', '12', '45', '90', '180'],
+        valueThemeKeys: ['--rotate'],
       },
     ])
   }
@@ -1388,6 +1392,7 @@ export function createUtilities(theme: Theme) {
     {
       supportsNegative: true,
       values: ['0', '1', '2', '3', '6', '12'],
+      valueThemeKeys: ['--skew'],
     },
   ])
 
@@ -1395,6 +1400,7 @@ export function createUtilities(theme: Theme) {
     {
       supportsNegative: true,
       values: ['0', '1', '2', '3', '6', '12'],
+      valueThemeKeys: ['--skew'],
     },
   ])
 
@@ -1402,6 +1408,7 @@ export function createUtilities(theme: Theme) {
     {
       supportsNegative: true,
       values: ['0', '1', '2', '3', '6', '12'],
+      valueThemeKeys: ['--skew'],
     },
   ])
 
@@ -1442,6 +1449,7 @@ export function createUtilities(theme: Theme) {
     {
       supportsNegative: true,
       values: ['0', '50', '75', '90', '95', '100', '105', '110', '125', '150', '200'],
+      valueThemeKeys: ['--scale'],
     },
   ])
 
@@ -1470,6 +1478,7 @@ export function createUtilities(theme: Theme) {
       {
         supportsNegative: true,
         values: ['0', '50', '75', '90', '95', '100', '105', '110', '125', '150', '200'],
+        valueThemeKeys: ['--scale'],
       },
     ])
   }
@@ -1888,12 +1897,14 @@ export function createUtilities(theme: Theme) {
   suggest('grid-cols', () => [
     {
       values: Array.from({ length: 12 }, (_, i) => `${i + 1}`),
+      valueThemeKeys: ['--grid-template-columns'],
     },
   ])
 
   suggest('grid-rows', () => [
     {
       values: Array.from({ length: 12 }, (_, i) => `${i + 1}`),
+      valueThemeKeys: ['--grid-template-rows'],
     },
   ])
 


### PR DESCRIPTION
This PR removes bare value support for the `translate` utilities.

For example, `translate-x-48` would pick `48` from the theme, which maps to `12rem`, but `translate-x-50` doesn't exist in the theme, so it would just use bare values and in this case it would map to `50%`.


<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
