### PR TITLE
Transpile `import.meta.url` in config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `mix-blend-plus-darker` utility ([#12923](https://github.com/tailwindlabs/tailwindcss/pull/12923))
 - Ensure dashes are allowed in variant modifiers ([#13303](https://github.com/tailwindlabs/tailwindcss/pull/13303))
 - Fix crash showing completions in Intellisense when using a custom separator ([#13306](https://github.com/tailwindlabs/tailwindcss/pull/13306))
+- Transpile `import.meta.url` in config files ([#13322](https://github.com/tailwindlabs/tailwindcss/pull/13322))
 
 ## [3.4.1] - 2024-01-05
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "fast-glob": "^3.3.0",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "jiti": "^1.19.1",
+        "jiti": "^1.21.0",
         "lilconfig": "^2.1.0",
         "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
@@ -5849,9 +5849,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.20.0.tgz",
-      "integrity": "sha512-3TV69ZbrvV6U5DfQimop50jE9Dl6J8O1ja1dvBbMba/sZ3YBEQqJ2VZRoQPVnhlzjNtU1vaXRZVrVjU4qtm8yA==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
+      "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -12636,9 +12636,9 @@
       }
     },
     "jiti": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.20.0.tgz",
-      "integrity": "sha512-3TV69ZbrvV6U5DfQimop50jE9Dl6J8O1ja1dvBbMba/sZ3YBEQqJ2VZRoQPVnhlzjNtU1vaXRZVrVjU4qtm8yA=="
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
+      "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q=="
     },
     "js-sdsl": {
       "version": "4.1.4",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "fast-glob": "^3.3.0",
     "glob-parent": "^6.0.2",
     "is-glob": "^4.0.3",
-    "jiti": "^1.19.1",
+    "jiti": "^1.21.0",
     "lilconfig": "^2.1.0",
     "micromatch": "^4.0.5",
     "normalize-path": "^3.0.0",

--- a/src/lib/load-config.ts
+++ b/src/lib/load-config.ts
@@ -18,6 +18,11 @@ function lazyJiti() {
     (jiti = jitiFactory(__filename, {
       interopDefault: true,
       transform: (opts) => {
+        // Sucrase can't transform import.meta so we have to use Babel
+        if (opts.source.includes('import.meta')) {
+          return require('jiti/dist/babel.js')(opts)
+        }
+
         return transform(opts.source, {
           transforms: ['typescript', 'imports'],
         })

--- a/standalone-cli/standalone.js
+++ b/standalone-cli/standalone.js
@@ -33,6 +33,11 @@ useCustomJiti(() =>
     interopDefault: true,
     nativeModules: Object.keys(localModules),
     transform: (opts) => {
+      // Sucrase can't transform import.meta so we have to use Babel
+      if (opts.source.includes('import.meta')) {
+        return require('jiti/dist/babel.js')(opts)
+      }
+
       return transform(opts.source, {
         transforms: ['typescript', 'imports'],
       })


### PR DESCRIPTION
Right now if you try to use `import.meta.url` in a `tailwind.config.js` file (or a dependency) Node will throw an error. This happens because config files are compiled to Common JS internally using Jiti and Sucrase. However, Sucrase doesn't rewrite `import.meta.url` so we must use Jiti's built-in Babel transform in this case.

Fixes https://github.com/tailwindlabs/tailwindcss-intellisense/issues/909