### PR TITLE
Fix missing `xx-large` and remove double `x-large` absolute size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix crash showing completions in Intellisense when using a custom separator ([#13306](https://github.com/tailwindlabs/tailwindcss/pull/13306))
 - Transpile `import.meta.url` in config files ([#13322](https://github.com/tailwindlabs/tailwindcss/pull/13322))
 - Reset letter spacing for form elements ([#13150](https://github.com/tailwindlabs/tailwindcss/pull/13150))
+- Fix missing `xx-large` and remove double `x-large` absolute size ([#13324](https://github.com/tailwindlabs/tailwindcss/pull/13324))
 
 ## [3.4.1] - 2024-01-05
 

--- a/src/util/dataTypes.js
+++ b/src/util/dataTypes.js
@@ -393,7 +393,7 @@ let absoluteSizes = new Set([
   'medium',
   'large',
   'x-large',
-  'x-large',
+  'xx-large',
   'xxx-large',
 ])
 export function absoluteSize(value) {


### PR DESCRIPTION
x-large appears twice in the set of absolute sizes.

I believe the second one is meant to be 'xx-large'.
