### PR TITLE
Fix incorrect syntax for `translate-z`'s `@property` definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Remove percentage values for `translate-z` utilities ([#13321](https://github.com/tailwindlabs/tailwindcss/pull/13321))
+- Remove percentage values for `translate-z` utilities ([#13321](https://github.com/tailwindlabs/tailwindcss/pull/13321), [#13327](https://github.com/tailwindlabs/tailwindcss/pull/13327))
 
 ## [4.0.0-alpha.10] - 2024-03-19
 

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -230,7 +230,7 @@ describe('@apply', () => {
       }
 
       @property --tw-translate-z {
-        syntax: "<length-percentage>";
+        syntax: "<length>";
         inherits: false;
         initial-value: 0;
       }"

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -2485,7 +2485,7 @@ test('translate', () => {
     }
 
     @property --tw-translate-z {
-      syntax: "<length-percentage>";
+      syntax: "<length>";
       inherits: false;
       initial-value: 0;
     }"
@@ -2496,88 +2496,88 @@ test('translate', () => {
 test('translate-x', () => {
   expect(run(['translate-x-full', '-translate-x-full', 'translate-x-px', '-translate-x-[--value]']))
     .toMatchInlineSnapshot(`
-    ".-translate-x-\\[--value\\] {
-      --tw-translate-x: calc(var(--value) * -1);
-      translate: var(--tw-translate-x) var(--tw-translate-y);
-    }
+      ".-translate-x-\\[--value\\] {
+        --tw-translate-x: calc(var(--value) * -1);
+        translate: var(--tw-translate-x) var(--tw-translate-y);
+      }
 
-    .-translate-x-full {
-      --tw-translate-x: -100%;
-      translate: var(--tw-translate-x) var(--tw-translate-y);
-    }
+      .-translate-x-full {
+        --tw-translate-x: -100%;
+        translate: var(--tw-translate-x) var(--tw-translate-y);
+      }
 
-    .translate-x-full {
-      --tw-translate-x: 100%;
-      translate: var(--tw-translate-x) var(--tw-translate-y);
-    }
+      .translate-x-full {
+        --tw-translate-x: 100%;
+        translate: var(--tw-translate-x) var(--tw-translate-y);
+      }
 
-    .translate-x-px {
-      --tw-translate-x: 1px;
-      translate: var(--tw-translate-x) var(--tw-translate-y);
-    }
+      .translate-x-px {
+        --tw-translate-x: 1px;
+        translate: var(--tw-translate-x) var(--tw-translate-y);
+      }
 
-    @property --tw-translate-x {
-      syntax: "<length-percentage>";
-      inherits: false;
-      initial-value: 0;
-    }
+      @property --tw-translate-x {
+        syntax: "<length-percentage>";
+        inherits: false;
+        initial-value: 0;
+      }
 
-    @property --tw-translate-y {
-      syntax: "<length-percentage>";
-      inherits: false;
-      initial-value: 0;
-    }
+      @property --tw-translate-y {
+        syntax: "<length-percentage>";
+        inherits: false;
+        initial-value: 0;
+      }
 
-    @property --tw-translate-z {
-      syntax: "<length-percentage>";
-      inherits: false;
-      initial-value: 0;
-    }"
-  `)
+      @property --tw-translate-z {
+        syntax: "<length>";
+        inherits: false;
+        initial-value: 0;
+      }"
+    `)
   expect(run(['translate-x'])).toEqual('')
 })
 
 test('translate-y', () => {
   expect(run(['translate-y-full', '-translate-y-full', 'translate-y-px', '-translate-y-[--value]']))
     .toMatchInlineSnapshot(`
-    ".-translate-y-\\[--value\\] {
-      --tw-translate-y: calc(var(--value) * -1);
-      translate: var(--tw-translate-x) var(--tw-translate-y);
-    }
+      ".-translate-y-\\[--value\\] {
+        --tw-translate-y: calc(var(--value) * -1);
+        translate: var(--tw-translate-x) var(--tw-translate-y);
+      }
 
-    .-translate-y-full {
-      --tw-translate-y: -100%;
-      translate: var(--tw-translate-x) var(--tw-translate-y);
-    }
+      .-translate-y-full {
+        --tw-translate-y: -100%;
+        translate: var(--tw-translate-x) var(--tw-translate-y);
+      }
 
-    .translate-y-full {
-      --tw-translate-y: 100%;
-      translate: var(--tw-translate-x) var(--tw-translate-y);
-    }
+      .translate-y-full {
+        --tw-translate-y: 100%;
+        translate: var(--tw-translate-x) var(--tw-translate-y);
+      }
 
-    .translate-y-px {
-      --tw-translate-y: 1px;
-      translate: var(--tw-translate-x) var(--tw-translate-y);
-    }
+      .translate-y-px {
+        --tw-translate-y: 1px;
+        translate: var(--tw-translate-x) var(--tw-translate-y);
+      }
 
-    @property --tw-translate-x {
-      syntax: "<length-percentage>";
-      inherits: false;
-      initial-value: 0;
-    }
+      @property --tw-translate-x {
+        syntax: "<length-percentage>";
+        inherits: false;
+        initial-value: 0;
+      }
 
-    @property --tw-translate-y {
-      syntax: "<length-percentage>";
-      inherits: false;
-      initial-value: 0;
-    }
+      @property --tw-translate-y {
+        syntax: "<length-percentage>";
+        inherits: false;
+        initial-value: 0;
+      }
 
-    @property --tw-translate-z {
-      syntax: "<length-percentage>";
-      inherits: false;
-      initial-value: 0;
-    }"
-  `)
+      @property --tw-translate-z {
+        syntax: "<length>";
+        inherits: false;
+        initial-value: 0;
+      }"
+    `)
   expect(run(['translate-y'])).toEqual('')
 })
 
@@ -2606,7 +2606,7 @@ test('translate-z', () => {
     }
 
     @property --tw-translate-z {
-      syntax: "<length-percentage>";
+      syntax: "<length>";
       inherits: false;
       initial-value: 0;
     }"
@@ -2635,7 +2635,7 @@ test('translate-3d', () => {
     }
 
     @property --tw-translate-z {
-      syntax: "<length-percentage>";
+      syntax: "<length>";
       inherits: false;
       initial-value: 0;
     }"

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -1216,7 +1216,7 @@ export function createUtilities(theme: Theme) {
     atRoot([
       property('--tw-translate-x', '0', '<length-percentage>'),
       property('--tw-translate-y', '0', '<length-percentage>'),
-      property('--tw-translate-z', '0', '<length-percentage>'),
+      property('--tw-translate-z', '0', '<length>'),
     ])
 
   /**


### PR DESCRIPTION
This PR is a continuation of #13321. This used to be `<length-percentage>`, but we dropped percentage support because it's not valid in #13321 and I forgot about this one.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
