### PR TITLE
Inherit letter spacing in form controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove percentage values for `translate-z` utilities ([#13321](https://github.com/tailwindlabs/tailwindcss/pull/13321), [#13327](https://github.com/tailwindlabs/tailwindcss/pull/13327))
 - `@tailwind/vite` now generates unique CSS bundle hashes when the Tailwind-generated CSS changes ([#13218](https://github.com/tailwindlabs/tailwindcss/pull/13218))
+- Inherit letter spacing in form controls ([#13328](https://github.com/tailwindlabs/tailwindcss/pull/13328))
 
 ## [4.0.0-alpha.10] - 2024-03-19
 

--- a/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
@@ -497,6 +497,7 @@ exports[`\`@import 'tailwindcss'\` is replaced with the generated CSS 1`] = `
     font: inherit;
     font-feature-settings: inherit;
     font-variation-settings: inherit;
+    letter-spacing: inherit;
     color: inherit;
     background: none;
   }
@@ -505,6 +506,7 @@ exports[`\`@import 'tailwindcss'\` is replaced with the generated CSS 1`] = `
     font: inherit;
     font-feature-settings: inherit;
     font-variation-settings: inherit;
+    letter-spacing: inherit;
     color: inherit;
     background: none;
   }

--- a/packages/tailwindcss/preflight.css
+++ b/packages/tailwindcss/preflight.css
@@ -189,6 +189,7 @@ textarea,
   font: inherit; /* 1 */
   font-feature-settings: inherit; /* 1 */
   font-variation-settings: inherit; /* 1 */
+  letter-spacing: inherit; /* 1 */
   color: inherit; /* 1 */
   background: transparent; /* 2 */
 }


### PR DESCRIPTION
(Same as #13150 but for v4)

Some browsers set `letter-spacing: normal` for form elements. This PR inherits `letter-spacing` styles for consistency since we also inherit other font attributes like family, style, line-height, etc…
