### PR TITLE
Add variant for @starting-style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Make `rotate-x/y/z-*` utilities composable ([#13319](https://github.com/tailwindlabs/tailwindcss/pull/13319))
 - `@tailwind/vite` applies the Vite CSS plugin to transform Tailwind-generated CSS (e.g. inlining images) ([#13218](https://github.com/tailwindlabs/tailwindcss/pull/13218))
+- Add `starting` variant for `@starting-style` ([#13329](https://github.com/tailwindlabs/tailwindcss/pull/13329))
 
 ### Fixed
 

--- a/packages/tailwindcss/src/__snapshots__/intellisense.test.ts.snap
+++ b/packages/tailwindcss/src/__snapshots__/intellisense.test.ts.snap
@@ -2406,6 +2406,13 @@ exports[`getVariants 1`] = `
   {
     "hasDash": true,
     "isArbitrary": false,
+    "name": "starting",
+    "selectors": [Function],
+    "values": [],
+  },
+  {
+    "hasDash": true,
+    "isArbitrary": false,
     "name": "print",
     "selectors": [Function],
     "values": [],

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -801,6 +801,16 @@ test('dark', () => {
   `)
 })
 
+test('starting', () => {
+  expect(run(['starting:opacity-0'])).toMatchInlineSnapshot(`
+    "@starting-style {
+      .starting\\:opacity-0 {
+        opacity: 0;
+      }
+    }"
+  `)
+})
+
 test('print', () => {
   expect(run(['print:flex'])).toMatchInlineSnapshot(`
     "@media print {

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -695,6 +695,8 @@ export function createVariants(theme: Theme): Variants {
 
   staticVariant('dark', ['@media (prefers-color-scheme: dark)'], { compounds: false })
 
+  staticVariant('starting', ['@starting-style'], { compounds: false })
+
   staticVariant('print', ['@media print'], { compounds: false })
 
   staticVariant('forced-colors', ['@media (forced-colors: active)'], { compounds: false })


### PR DESCRIPTION
Based on https://github.com/tailwindlabs/tailwindcss/pull/12040.

Adds a new `starting:*` variant for the [`@starting-style` at-rule](https://developer.mozilla.org/en-US/docs/Web/CSS/@starting-style).

Really simple, only real decision here was where to put it in the sort order. Decided to put it after `dark` because it feels like a very "important" state that should take precedence over most other things. Open to any convincing arguments for putting it anywhere else though.