### PR TITLE
Collect user-defined CSS that can be used in `@apply`

### DIFF
--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -421,6 +421,48 @@ describe('@apply', () => {
       }"
     `)
   })
+
+  it('should error when circular @apply is used', () => {
+    expect(() =>
+      compileCss(css`
+        .foo {
+          @apply bar;
+        }
+
+        .bar {
+          @apply baz;
+        }
+
+        .baz {
+          @apply foo;
+        }
+      `),
+    ).toThrowErrorMatchingInlineSnapshot(`[Error: Detected circular \`@apply\`: foo]`)
+  })
+
+  it('should error when circular @apply is used but nested', () => {
+    expect(() =>
+      compileCss(css`
+        .foo {
+          &:hover {
+            @apply bar;
+          }
+        }
+
+        .bar {
+          &:hover {
+            @apply baz;
+          }
+        }
+
+        .baz {
+          &:hover {
+            @apply foo;
+          }
+        }
+      `),
+    ).toThrowErrorMatchingInlineSnapshot(`[Error: Detected circular \`@apply\`: foo]`)
+  })
 })
 
 describe('arbitrary variants', () => {

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -437,7 +437,9 @@ describe('@apply', () => {
           @apply foo;
         }
       `),
-    ).toThrowErrorMatchingInlineSnapshot(`[Error: You cannot \`@apply\` the \`foo\` utility here because it creates a circular dependency.]`)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: You cannot \`@apply\` the \`foo\` utility here because it creates a circular dependency.]`,
+    )
   })
 
   it('should error when circular @apply is used but nested', () => {
@@ -461,7 +463,9 @@ describe('@apply', () => {
           }
         }
       `),
-    ).toThrowErrorMatchingInlineSnapshot(`[Error: You cannot \`@apply\` the \`foo\` utility here because it creates a circular dependency.]`)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: You cannot \`@apply\` the \`foo\` utility here because it creates a circular dependency.]`,
+    )
   })
 })
 

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -372,6 +372,55 @@ describe('@apply', () => {
       }"
     `)
   })
+
+  it('should apply user-defined CSS that is defined after where the `@apply` is used', () => {
+    expect(
+      compileCss(css`
+        .example {
+          @apply foo;
+        }
+
+        .foo {
+          color: red;
+        }
+      `),
+    ).toMatchInlineSnapshot(`
+      ".example, .foo {
+        color: red;
+      }"
+    `)
+  })
+
+  it('should apply user-defined CSS that is defined multiple times', () => {
+    expect(
+      compileCss(css`
+        .foo {
+          color: red;
+        }
+
+        .example {
+          @apply foo;
+        }
+
+        .foo {
+          background-color: blue;
+        }
+      `),
+    ).toMatchInlineSnapshot(`
+      ".foo {
+        color: red;
+      }
+
+      .example {
+        color: red;
+        background-color: #00f;
+      }
+
+      .foo {
+        background-color: #00f;
+      }"
+    `)
+  })
 })
 
 describe('arbitrary variants', () => {

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -437,7 +437,7 @@ describe('@apply', () => {
           @apply foo;
         }
       `),
-    ).toThrowErrorMatchingInlineSnapshot(`[Error: Detected circular \`@apply\`: foo]`)
+    ).toThrowErrorMatchingInlineSnapshot(`[Error: You cannot \`@apply\` the \`foo\` utility here because it creates a circular dependency.]`)
   })
 
   it('should error when circular @apply is used but nested', () => {
@@ -461,7 +461,7 @@ describe('@apply', () => {
           }
         }
       `),
-    ).toThrowErrorMatchingInlineSnapshot(`[Error: Detected circular \`@apply\`: foo]`)
+    ).toThrowErrorMatchingInlineSnapshot(`[Error: You cannot \`@apply\` the \`foo\` utility here because it creates a circular dependency.]`)
   })
 })
 

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -308,6 +308,70 @@ describe('@apply', () => {
       }"
     `)
   })
+
+  it('should be possible to apply user-defined CSS', () => {
+    expect(
+      compileCss(css`
+        @theme {
+          --spacing-2: 0.5rem;
+          --spacing-3: 0.75rem;
+          --color-red-600: #e53e3e;
+        }
+
+        .btn {
+          @apply py-2 px-3;
+        }
+
+        .btn-red {
+          @apply btn bg-red-600;
+        }
+      `),
+    ).toMatchInlineSnapshot(`
+      ":root {
+        --spacing-2: .5rem;
+        --spacing-3: .75rem;
+        --color-red-600: #e53e3e;
+      }
+
+      .btn {
+        padding-top: var(--spacing-2, .5rem);
+        padding-bottom: var(--spacing-2, .5rem);
+        padding-left: var(--spacing-3, .75rem);
+        padding-right: var(--spacing-3, .75rem);
+      }
+
+      .btn-red {
+        padding-top: var(--spacing-2, .5rem);
+        padding-bottom: var(--spacing-2, .5rem);
+        padding-left: var(--spacing-3, .75rem);
+        padding-right: var(--spacing-3, .75rem);
+        background-color: var(--color-red-600, #e53e3e);
+      }"
+    `)
+  })
+
+  it('should apply user-defined CSS that happens to be a utility class', () => {
+    expect(
+      compileCss(css`
+        .flex {
+          --display-mode: flex;
+        }
+
+        .example {
+          @apply flex;
+        }
+      `),
+    ).toMatchInlineSnapshot(`
+      ".flex {
+        --display-mode: flex;
+      }
+
+      .example {
+        --display-mode: flex;
+        display: flex;
+      }"
+    `)
+  })
 })
 
 describe('arbitrary variants', () => {

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -215,15 +215,13 @@ export function compile(css: string): {
             // rule with.
             let candidateAst = compileCandidates(candidates, designSystem, {
               onInvalidCandidate: (candidate) => {
-                // When a candidate is invalid, we want to first verify that the
-                // candidate is a user-defined class or not. If it is, then we
-                // can safely ignore this. If it's not, then we throw an error
-                // because the candidate is unknown.
+                // We must pass in user-defined classes and then filter them out
+                // here because, while they are usually not known utilities, the
+                // user can define a class that happens to *also* be a known
+                // utility.
                 //
-                // The reason we even have to check user-defined classes is
-                // because it could be that the user defined CSS like that is
-                // also a known utility class. For example, the following CSS
-                // would be:
+                // For example, given the following, `flex` counts as both a
+                // user-defined class and a known utility:
                 //
                 // ```css
                 // .flex {

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -4,6 +4,7 @@ import { compileCandidates } from './compile'
 import * as CSS from './css-parser'
 import { buildDesignSystem } from './design-system'
 import { Theme } from './theme'
+import { isSimpleClassSelector } from './utils/is-simple-class-selector'
 
 export function compile(css: string): {
   build(candidates: string[]): string
@@ -33,7 +34,15 @@ export function compile(css: string): {
     if (node.kind !== 'rule') return
 
     // Track all user-defined classes for `@apply` support
-    if (containsAtApply && node.selector[0] === '.' && !node.selector.includes(' ')) {
+    if (
+      containsAtApply &&
+      // Verify that it is a valid applyable-class. An applyable class is a
+      // class that is a very simple selector, like `.foo` or `.bar`, but doesn't
+      // contain any spaces, combinators, pseudo-selectors, pseudo-elements, or
+      // attribute selectors.
+      node.selector[0] === '.' &&
+      isSimpleClassSelector(node.selector)
+    ) {
       // Convert the class `.foo` into a candidate `foo`
       let candidate = node.selector.slice(1)
 

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -209,7 +209,9 @@ export function compile(css: string): {
               // If the candidate is the same as the current node we are
               // processing, we have a circular dependency.
               if (candidate === rootAsCandidate) {
-                throw new Error(`Detected circular \`@apply\`: ${candidate}`)
+                throw new Error(
+                  `You cannot \`@apply\` the \`${candidate}\` utility here because it creates a circular dependency.`,
+                )
               }
 
               let nodes = userDefinedApplyables.get(candidate)

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -22,7 +22,7 @@ export function compile(css: string): {
 
   // Track `@apply` information
   let containsAtApply = css.includes('@apply')
-  let applyables = new Map<string, AstNode[]>()
+  let userDefinedApplyables = new Map<string, AstNode[]>()
 
   // Find all `@theme` declarations
   let theme = new Theme()
@@ -39,7 +39,7 @@ export function compile(css: string): {
 
       // It could be that multiple definitions exist for the same class, so we
       // need to track all of them.
-      let nodes = applyables.get(candidate) ?? []
+      let nodes = userDefinedApplyables.get(candidate) ?? []
 
       // Add all children of the current rule to the list of nodes for the
       // current candidate.
@@ -48,7 +48,7 @@ export function compile(css: string): {
       }
 
       // Store the list of nodes for the current candidate
-      applyables.set(candidate, nodes)
+      userDefinedApplyables.set(candidate, nodes)
     }
 
     // Drop instances of `@media reference`
@@ -181,7 +181,7 @@ export function compile(css: string): {
           // Collect all user-defined classes for the current candidates that we
           // need to apply.
           for (let candidate of candidates) {
-            let nodes = applyables.get(candidate)
+            let nodes = userDefinedApplyables.get(candidate)
             if (!nodes) continue
 
             for (let child of nodes) {
@@ -209,7 +209,7 @@ export function compile(css: string): {
               //
               // When the user then uses `@apply flex`, we want to both apply
               // the user-defined class and the utility class.
-              if (applyables.has(candidate)) return
+              if (userDefinedApplyables.has(candidate)) return
 
               throw new Error(`Cannot apply unknown utility class: ${candidate}`)
             },

--- a/packages/tailwindcss/src/utils/is-simple-class-selector.test.ts
+++ b/packages/tailwindcss/src/utils/is-simple-class-selector.test.ts
@@ -1,0 +1,42 @@
+import { expect, it } from 'vitest'
+import { isSimpleClassSelector } from './is-simple-class-selector'
+
+it.each([
+  // Simple class selector
+  ['.foo', true],
+
+  // Class selectors with escaped characters
+  ['.w-\\[123px\\]', true],
+  ['.content-\\[\\+\\>\\~\\*\\]', true],
+
+  // ID selector
+  ['#foo', false],
+  ['.foo#foo', false],
+
+  // Element selector
+  ['h1', false],
+  ['h1.foo', false],
+
+  // Attribute selector
+  ['[data-foo]', false],
+  ['.foo[data-foo]', false],
+  ['[data-foo].foo', false],
+
+  // Pseudo-class selector
+  ['.foo:hover', false],
+
+  // Additional class selector
+  ['.foo.bar', false],
+
+  // Combinator
+  ['.foo>.bar', false],
+  ['.foo+.bar', false],
+  ['.foo~.bar', false],
+  ['.foo .bar', false],
+
+  // Selector list
+  ['.foo, .bar', false],
+  ['.foo,.bar', false],
+])('should validate %s', (selector, expected) => {
+  expect(isSimpleClassSelector(selector)).toBe(expected)
+})

--- a/packages/tailwindcss/src/utils/is-simple-class-selector.ts
+++ b/packages/tailwindcss/src/utils/is-simple-class-selector.ts
@@ -1,0 +1,26 @@
+export function isSimpleClassSelector(selector: string): boolean {
+  // The selector must start with a dot, otherwise it's not a class selector.
+  if (selector[0] !== '.') return false
+
+  for (let i = 1; i < selector.length; i++) {
+    switch (selector[i]) {
+      // The character is escaped, skip the next character
+      case '\\':
+        i += 1
+        continue
+
+      case ' ': // Descendat combinator
+      case '.': // Class selector
+      case '#': // ID selector
+      case '[': // Attribute selector
+      case ':': // Pseudo-classes and pseudo-elements
+      case '>': // Child combinator
+      case '+': // Next-sibling combinator
+      case '~': // Subsequent-sibling combinator
+      case ',': // Selector list
+        return false
+    }
+  }
+
+  return true
+}

--- a/packages/tailwindcss/src/utils/is-simple-class-selector.ts
+++ b/packages/tailwindcss/src/utils/is-simple-class-selector.ts
@@ -1,3 +1,10 @@
+/**
+ * Check if a selector is a simple class selector.
+ *
+ * A simple class selector is a class selector that doesn't contain any other
+ * selector types, such as ID selectors, element selectors, attribute selectors,
+ * pseudo-classes, combinators, or selector lists.
+ */
 export function isSimpleClassSelector(selector: string): boolean {
   // The selector must start with a dot, otherwise it's not a class selector.
   if (selector[0] !== '.') return false


### PR DESCRIPTION
This allows you to apply user-defined CSS inside of `@apply`. It works a tiny bit different compared to v3 because we only allow you to apply simple selectors. Only a single class can be applied such as a `.foo {}`.

If you want more complex selectors, then you can use nesting to enhance the definition of what `.foo` means exactly.

Implementing it this way allows us to keep the codebase simple and keep expectations simple. 

In v3 you can do crazy things such as:

```css
.foo .bar .baz {
  color: red;
}
```

And you can apply `@apply foo` or `@apply bar` or `@apply baz`, but that's not intuitive if you look at the final result.

This PR also ensures that you can't apply classes that would result in circular dependencies.

What this PR is not:

This PR does not make custom classes "utilities" or "components". This means that you won't be able to do this:

```css
.foo {
  color: red;
}

.example {
  @apply hover:foo;
  /*     ----- You will not be able to add variant modifiers to `.foo` */
}
```

Fixes: #13342
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
