### PR TITLE
Ensure that arbitrary properties respect `important` configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reset letter spacing for form elements ([#13150](https://github.com/tailwindlabs/tailwindcss/pull/13150))
 - Fix missing `xx-large` and remove double `x-large` absolute size ([#13324](https://github.com/tailwindlabs/tailwindcss/pull/13324))
 - Don't error when encountering nested CSS unless trying to `@apply` a class that uses nesting ([#13325](https://github.com/tailwindlabs/tailwindcss/pull/13325))
+- Ensure that arbitrary properties respect the important configuration ([#13353](https://github.com/tailwindlabs/tailwindcss/pull/13353))
 
 ## [3.4.1] - 2024-01-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reset letter spacing for form elements ([#13150](https://github.com/tailwindlabs/tailwindcss/pull/13150))
 - Fix missing `xx-large` and remove double `x-large` absolute size ([#13324](https://github.com/tailwindlabs/tailwindcss/pull/13324))
 - Don't error when encountering nested CSS unless trying to `@apply` a class that uses nesting ([#13325](https://github.com/tailwindlabs/tailwindcss/pull/13325))
-- Ensure that arbitrary properties respect the important configuration ([#13353](https://github.com/tailwindlabs/tailwindcss/pull/13353))
+- Ensure that arbitrary properties respect `important` configuration ([#13353](https://github.com/tailwindlabs/tailwindcss/pull/13353))
 
 ## [3.4.1] - 2024-01-05
 

--- a/src/lib/generateRules.js
+++ b/src/lib/generateRules.js
@@ -516,7 +516,7 @@ function extractArbitraryProperty(classCandidate, context) {
 
   return [
     [
-      { sort, layer: 'utilities' },
+      { sort, layer: 'utilities', options: { respectImportant: true } },
       () => ({
         [asClass(classCandidate)]: {
           [property]: normalized,

--- a/tests/important-selector.test.js
+++ b/tests/important-selector.test.js
@@ -21,6 +21,7 @@ test('important selector', () => {
           <div class="rtl:active:text-center"></div>
           <div class="dark:before:underline"></div>
           <div class="hover:[&::file-selector-button]:rtl:dark:bg-black/100"></div>
+          <div class="[color:red]"></div>
         `,
       },
     ],
@@ -131,6 +132,9 @@ test('important selector', () => {
       }
       .custom-util {
         button: no;
+      }
+      #app .\[color\:red\] {
+        color: red;
       }
       #app :is(.group:hover .group-hover\:focus-within\:text-left:focus-within) {
         text-align: left;


### PR DESCRIPTION
This PR fixes an issue where the important configuration was not respected for arbitrary properties.

If you have `important: "#app"` in your configuration, then we expect the following CSS for an arbitrary property like `[color:red]`:

```css
#app .\[color\:red\] {
  color: red;
}
```

But before this fix, the generated CSS looked like this instead:

```css
.\[color\:red\] {
  color: red;
}
```

Fixes: #13351
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
