### PR TITLE
Ensure `build` command is executed when using `--output` instead of `-o`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove percentage values for `translate-z` utilities ([#13321](https://github.com/tailwindlabs/tailwindcss/pull/13321), [#13327](https://github.com/tailwindlabs/tailwindcss/pull/13327))
 - `@tailwind/vite` now generates unique CSS bundle hashes when the Tailwind-generated CSS changes ([#13218](https://github.com/tailwindlabs/tailwindcss/pull/13218))
 - Inherit letter spacing in form controls ([#13328](https://github.com/tailwindlabs/tailwindcss/pull/13328))
+- Ensure `build` command is executed when using `--output` instead of `-o` ([#13369](https://github.com/tailwindlabs/tailwindcss/pull/13369))
 
 ## [4.0.0-alpha.10] - 2024-03-19
 

--- a/packages/@tailwindcss-cli/src/index.ts
+++ b/packages/@tailwindcss-cli/src/index.ts
@@ -9,8 +9,11 @@ const sharedOptions = {
   '--help': { type: 'boolean', description: 'Display usage information', alias: '-h' },
 } satisfies Arg
 
-const shared = args(sharedOptions)
-const command = shared._[0]
+const flags = args({
+  ...build.options(),
+  ...sharedOptions,
+})
+const command = flags._[0]
 
 // Right now we don't support any sub-commands. Let's show the help message
 // instead.
@@ -33,11 +36,7 @@ if (command) {
 //
 //   - `tailwindcss -o output.css`  // should run the build command, not show the help message
 //   - `tailwindcss > output.css`   // should run the build command, not show the help message
-if (
-  (process.stdout.isTTY &&
-    !process.argv.slice(2).some((flag) => flag === '-o' || flag === '--output')) ||
-  shared['--help']
-) {
+if ((process.stdout.isTTY && !flags['--output']) || flags['--help']) {
   help({
     usage: ['tailwindcss [--input input.css] [--output output.css] [--watch] [options…]'],
     options: { ...build.options(), ...sharedOptions },
@@ -46,4 +45,4 @@ if (
 }
 
 // Handle the build command
-build.handle(args(build.options()))
+build.handle(flags)

--- a/packages/@tailwindcss-cli/src/index.ts
+++ b/packages/@tailwindcss-cli/src/index.ts
@@ -33,7 +33,11 @@ if (command) {
 //
 //   - `tailwindcss -o output.css`  // should run the build command, not show the help message
 //   - `tailwindcss > output.css`   // should run the build command, not show the help message
-if ((process.stdout.isTTY && !process.argv.slice(2).includes('-o')) || shared['--help']) {
+if (
+  (process.stdout.isTTY &&
+    !process.argv.slice(2).some((flag) => flag === '-o' || flag === '--output')) ||
+  shared['--help']
+) {
   help({
     usage: ['tailwindcss [--input input.css] [--output output.css] [--watch] [options…]'],
     options: { ...build.options(), ...sharedOptions },


### PR DESCRIPTION
This PR fixes a bug in the `@tailwindcss/cli` if you run `tailwindcss --output output.css` then the help text is shown instead of running tailwindcss itself. 

This is because we want to show the `--help` if you run the CLI with not enough information. However, we only checked for `-o` and not `--output`. This PR fixes that.

Fixes: #13368

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
