### PR TITLE
Fix Vite serve issues

### DIFF
--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -113,8 +113,15 @@ export default function tailwindcss(): Plugin[] {
 
       async configResolved(config) {
         minify = config.build.cssMinify !== false
+        // Apply the vite:css plugin to generated CSS for transformations like
+        // URL path rewriting and image inlining.
+        //
+        // In build mode, since renderChunk runs after all transformations, we
+        // need to also apply vite:css-post.
         cssPlugins = config.plugins.filter((plugin) =>
-          ['vite:css', 'vite:css-post'].includes(plugin.name),
+          ['vite:css', ...(config.command === 'build' ? ['vite:css-post'] : [])].includes(
+            plugin.name,
+          ),
         )
       },
 

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -158,9 +158,13 @@ export default function tailwindcss(): Plugin[] {
         // In serve mode, we treat cssModules as a set, ignoring the value.
         cssModules[id] = ''
 
+        // TODO: Re-enable waitForRequestsIdle once issues with it hanging are
+        // fixed. Until then, this transformation may run multiple times in
+        // serve mode, possibly giving a FOUC.
+        //
         // Wait until all other files have been processed, so we can extract all
         // candidates before generating CSS.
-        await server?.waitForRequestsIdle?.(id)
+        // await server?.waitForRequestsIdle?.(id)
 
         let code = await transformWithPlugins(this, id, generateCss(src))
         return { code }


### PR DESCRIPTION
Fix Vite hanging in Remix builds by temporarily disabling use of the Vite `waitForReuestsIdle` (#13291) feature. This will cause multiple Tailwind CSS generations in some requests, especially the initial one. This might be visible as a FOUC, but the builds happen so quickly it may not be noticeable. This only affects dev server mode.

A second fix addresses an issue introduced in https://github.com/tailwindlabs/tailwindcss/pull/13218 (unreleased). The `vite:css-post` plugin was being double-applied in serve mode.