### PR TITLE
Perf: Use charCodeAt instead of string comparison

### DIFF
--- a/packages/tailwindcss/css-parser.bench.ts
+++ b/packages/tailwindcss/css-parser.bench.ts
@@ -1,0 +1,12 @@
+import { bench } from 'vitest'
+import * as CSS from './src/css-parser.ts';
+import { readFileSync } from 'node:fs'
+
+const currentFolder = new URL('.', import.meta.url).pathname;
+const cssFile = readFileSync(currentFolder + './preflight.css', 'utf-8');
+
+bench('css-parser on preflight.css', () => {
+  CSS.parse(cssFile);
+});
+
+

--- a/packages/tailwindcss/css-parser.bench.ts
+++ b/packages/tailwindcss/css-parser.bench.ts
@@ -1,12 +1,10 @@
-import { bench } from 'vitest'
-import * as CSS from './src/css-parser.ts';
 import { readFileSync } from 'node:fs'
+import { bench } from 'vitest'
+import * as CSS from './src/css-parser.ts'
 
-const currentFolder = new URL('.', import.meta.url).pathname;
-const cssFile = readFileSync(currentFolder + './preflight.css', 'utf-8');
+const currentFolder = new URL('.', import.meta.url).pathname
+const cssFile = readFileSync(currentFolder + './preflight.css', 'utf-8')
 
 bench('css-parser on preflight.css', () => {
-  CSS.parse(cssFile);
-});
-
-
+  CSS.parse(cssFile)
+})


### PR DESCRIPTION
Using `charCodeAt` to compare instead of comparing string-string.

Before:

```
TailwindCSS  18,185.28  0.0501  0.2209  0.0550  0.0519  0.0998  0.1035  0.1612  ±0.44%     9093   fastest
```

Now:

```
TailwindCSS  20,353.52  0.0450  0.2109  0.0491  0.0469  0.0897  0.0958  0.1565  ±0.42%    10177   fastest
```