### PR TITLE
Enable Vite's `waitForRequestsIdle()` for client requests only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Enable Vite's `waitForRequestsIdle()` for client requests only ([#13394](https://github.com/tailwindlabs/tailwindcss/pull/13394))
 
 ## [4.0.0-alpha.11] - 2024-03-27
 

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -166,9 +166,9 @@ export default function tailwindcss(): Plugin[] {
         cssModules[id] = ''
 
         if (!options?.ssr) {
-          // Wait until all other files have been processed, so we can extract all
-          // candidates before generating CSS.
-          // NOTE: This must not be called during SSR, as it will block the server.
+          // Wait until all other files have been processed, so we can extract
+          // all candidates before generating CSS. This must not be called
+          // during SSR or it will block the server.
           await server?.waitForRequestsIdle?.(id)
         }
 

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -159,19 +159,18 @@ export default function tailwindcss(): Plugin[] {
       name: '@tailwindcss/vite:generate:serve',
       apply: 'serve',
 
-      async transform(src, id) {
+      async transform(src, id, options) {
         if (!isTailwindCssFile(id, src)) return
 
         // In serve mode, we treat cssModules as a set, ignoring the value.
         cssModules[id] = ''
 
-        // TODO: Re-enable waitForRequestsIdle once issues with it hanging are
-        // fixed. Until then, this transformation may run multiple times in
-        // serve mode, possibly giving a FOUC.
-        //
-        // Wait until all other files have been processed, so we can extract all
-        // candidates before generating CSS.
-        // await server?.waitForRequestsIdle?.(id)
+        if (!options?.ssr) {
+          // Wait until all other files have been processed, so we can extract all
+          // candidates before generating CSS.
+          // NOTE: This must not be called during SSR, as it will block the server.
+          await server?.waitForRequestsIdle?.(id)
+        }
 
         let code = await transformWithPlugins(this, id, generateCss(src))
         return { code }


### PR DESCRIPTION
The `waitForRequestsIdle()` API should **not** be called when doing SSR as it was not designed to be used then. The API is also slightly misnamed and will be deprecated and have a more appropriate name and place in Vite 5.3 to make this more clear. Vite's own logic skips some of the steps during SSR but _we did not_ which is why using this API with Remix resulted in pages not loading.