### PR TITLE
Make `isColor` faster

### DIFF
--- a/packages/tailwindcss/src/utils/infer-data-type.bench.ts
+++ b/packages/tailwindcss/src/utils/infer-data-type.bench.ts
@@ -3,6 +3,8 @@ import { inferDataType } from './infer-data-type'
 
 const colors = [
   'slateblue',
+  'black',
+  'orange',
   'rgb(255, 255, 255)',
   'rgba(255, 255, 255, 1)',
   'hsl(0, 0%, 100%)',

--- a/packages/tailwindcss/src/utils/is-color.ts
+++ b/packages/tailwindcss/src/utils/is-color.ts
@@ -1,4 +1,4 @@
-const NAMED_COLORS = [
+const NAMED_COLORS = new Set([
   // CSS Level 1 colors
   'black',
   'silver',
@@ -191,7 +191,7 @@ const NAMED_COLORS = [
   'graytext',
   'accentcolor',
   'accentcolortext',
-]
+])
 
 const IS_COLOR_FN = /^(rgba?|hsla?|hwb|color|(ok)?(lab|lch)|light-dark|color-mix)\(/i
 
@@ -199,6 +199,6 @@ export function isColor(value: string): boolean {
   return (
     value.charCodeAt(0) === 35 /* "#" */ ||
     IS_COLOR_FN.test(value) ||
-    NAMED_COLORS.includes(value.toLowerCase())
+    NAMED_COLORS.has(value.toLowerCase())
   )
 }


### PR DESCRIPTION
When the arrays of colors were split, both smaller, and had different values (one check was incorrectly case-sensitive) to lookup an `includes` check was faster. They’ve been merged for a while so now a Set is beneficial to perf.