### PR TITLE
Don't reset ::first-letter in Preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Enable Vite's `waitForRequestsIdle()` for client requests only ([#13394](https://github.com/tailwindlabs/tailwindcss/pull/13394))
+- Make sure `::first-letter` respectes `::selection` styles ([#13408](https://github.com/tailwindlabs/tailwindcss/pull/13408))
 
 ## [4.0.0-alpha.11] - 2024-03-27
 

--- a/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
@@ -406,7 +406,7 @@ exports[`\`@import 'tailwindcss'\` is replaced with the generated CSS 1`] = `
 }
 
 @layer base {
-  *, :after, :before, ::backdrop, :first-letter {
+  *, :after, :before, ::backdrop {
     box-sizing: border-box;
     border: 0 solid;
     margin: 0;

--- a/packages/tailwindcss/preflight.css
+++ b/packages/tailwindcss/preflight.css
@@ -8,7 +8,6 @@
 ::after,
 ::before,
 ::backdrop,
-::first-letter,
 ::file-selector-button {
   box-sizing: border-box; /* 1 */
   margin: 0; /* 2 */


### PR DESCRIPTION
Resolves https://github.com/tailwindlabs/tailwindcss/issues/13405

Previously we were applying our global reset rules to the `::first-letter` pseudo to ensure it interacted with utility classes the same way as other elements, but touching that pseudo has some unfortunate side effects, including causing `::selection` styles to not apply to the first letter as well as showing the default mouse cursor when hovering over the first letter instead of the text selection cursor.

I don't think there's anything really lost by removing this, because `::first-letter` already has no padding or margin applied and doesn't support `box-sizing`. The only place it would have mattered previously is border styles, but now that we don't actually rely on Preflight in order to set `border-style` when adding a `border-*` utility, this will work fine anyways. Even if it didn't, it would be a better trade off to have to add `first-letter:border-solid` when necessary vs. dealing with the side-effects I've mentioned of touching that pseudo-element.