### PR TITLE
Speed up segmentation

### DIFF
--- a/packages/tailwindcss/src/utils/segment.bench.ts
+++ b/packages/tailwindcss/src/utils/segment.bench.ts
@@ -1,0 +1,14 @@
+import { bench } from 'vitest'
+import { segment } from './segment'
+
+const values = [
+  ['hover:focus:underline', ':'],
+  ['var(--a, 0 0 1px rgb(0, 0, 0)), 0 0 1px rgb(0, 0, 0)', ','],
+  ['var(--some-value,env(safe-area-inset-top,var(--some-other-value,env(safe-area-inset))))', ','],
+]
+
+bench('segment', () => {
+  for (let [value, sep] of values) {
+    segment(value, sep)
+  }
+})

--- a/packages/tailwindcss/src/utils/segment.ts
+++ b/packages/tailwindcss/src/utils/segment.ts
@@ -1,3 +1,13 @@
+/* Supports up to 256 levels of nesting. This should be more than enough for any reasonable usage */
+const closingBracketStack = new Uint8Array(256)
+const OPEN_PAREN = '('.charCodeAt(0)
+const OPEN_BRACKET = '['.charCodeAt(0)
+const OPEN_BRACE = '{'.charCodeAt(0)
+const CLOSE_PAREN = ')'.charCodeAt(0)
+const CLOSE_BRACKET = ']'.charCodeAt(0)
+const CLOSE_BRACE = '}'.charCodeAt(0)
+const BACKSLASH = '\\'.charCodeAt(0)
+
 /**
  * This splits a string on a top-level character.
  *
@@ -10,15 +20,6 @@
  *        x              x  x    ╰──────── Split because top-level
  *        ╰──────────────┴──┴───────────── Ignored b/c inside >= 1 levels of parens
  */
-const closingBracketStack = new Uint8Array(256)
-const OPEN_PAREN = '('.charCodeAt(0)
-const OPEN_BRACKET = '['.charCodeAt(0)
-const OPEN_BRACE = '{'.charCodeAt(0)
-const CLOSE_PAREN = ')'.charCodeAt(0)
-const CLOSE_BRACKET = ']'.charCodeAt(0)
-const CLOSE_BRACE = '}'.charCodeAt(0)
-const BACKSLASH = '\\'.charCodeAt(0)
-
 export function segment(input: string, separator: string) {
   // Since JavaScript is single-threaded, using a shared buffer
   // is more efficient and should still be safe.

--- a/packages/tailwindcss/src/utils/segment.ts
+++ b/packages/tailwindcss/src/utils/segment.ts
@@ -7,10 +7,10 @@ const closingBracketStack = new Uint8Array(256)
 const BACKSLASH = '\\'.charCodeAt(0)
 const OPEN_PAREN = '('.charCodeAt(0)
 const OPEN_BRACKET = '['.charCodeAt(0)
-const OPEN_BRACE = '{'.charCodeAt(0)
+const OPEN_CURLY = '{'.charCodeAt(0)
 const CLOSE_PAREN = ')'.charCodeAt(0)
 const CLOSE_BRACKET = ']'.charCodeAt(0)
-const CLOSE_BRACE = '}'.charCodeAt(0)
+const CLOSE_CURLY = '}'.charCodeAt(0)
 
 /**
  * This splits a string on a top-level character.
@@ -55,12 +55,12 @@ export function segment(input: string, separator: string) {
         closingBracketStack[stackPos] = CLOSE_BRACKET
         stackPos++
         break
-      case OPEN_BRACE:
-        closingBracketStack[stackPos] = CLOSE_BRACE
+      case OPEN_CURLY:
+        closingBracketStack[stackPos] = CLOSE_CURLY
         stackPos++
         break
       case CLOSE_BRACKET:
-      case CLOSE_BRACE:
+      case CLOSE_CURLY:
       case CLOSE_PAREN:
         if (stackPos > 0 && char === closingBracketStack[stackPos - 1]) {
           // SAFETY: The buffer does not need to be mutated because the stack is

--- a/packages/tailwindcss/src/utils/segment.ts
+++ b/packages/tailwindcss/src/utils/segment.ts
@@ -4,13 +4,14 @@
 // allocations on every call to `segment`.
 const closingBracketStack = new Uint8Array(256)
 
-const BACKSLASH = '\\'.charCodeAt(0)
-const OPEN_PAREN = '('.charCodeAt(0)
-const OPEN_BRACKET = '['.charCodeAt(0)
-const OPEN_CURLY = '{'.charCodeAt(0)
-const CLOSE_PAREN = ')'.charCodeAt(0)
-const CLOSE_BRACKET = ']'.charCodeAt(0)
-const CLOSE_CURLY = '}'.charCodeAt(0)
+// All numbers are equivalent to the value returned by `String#charCodeAt(0)`
+const BACKSLASH = 0x5c
+const OPEN_PAREN = 0x28
+const OPEN_BRACKET = 0x5b
+const OPEN_CURLY = 0x7b
+const CLOSE_PAREN = 0x29
+const CLOSE_BRACKET = 0x5d
+const CLOSE_CURLY = 0x7d
 
 /**
  * This splits a string on a top-level character.

--- a/packages/tailwindcss/src/utils/segment.ts
+++ b/packages/tailwindcss/src/utils/segment.ts
@@ -1,7 +1,7 @@
 // This is a shared buffer that is used to keep track of the current nesting level
 // of parens, brackets, and braces. It is used to determine if a character is at
 // the top-level of a string. This is a performance optimization to avoid memory
-// allocations on ever call to `segment`.
+// allocations on every call to `segment`.
 const closingBracketStack = new Uint8Array(256)
 
 const BACKSLASH = '\\'.charCodeAt(0)
@@ -15,8 +15,8 @@ const CLOSE_BRACE = '}'.charCodeAt(0)
 /**
  * This splits a string on a top-level character.
  *
- * Regex doesn't support recursion (at least not the JS-flavored version).
- * So we have to use a tiny state machine to keep track of paren placement.
+ * Regex doesn't support recursion (at least not the JS-flavored version),
+ * so we have to use a tiny state machine to keep track of paren placement.
  *
  * Expected behavior using commas:
  * var(--a, 0 0 1px rgb(0, 0, 0)), 0 0 1px rgb(0, 0, 0)
@@ -63,10 +63,11 @@ export function segment(input: string, separator: string) {
       case CLOSE_BRACE:
       case CLOSE_PAREN:
         if (stackPos > 0 && char === closingBracketStack[stackPos - 1]) {
-          // SAFETY: The buffer does not need to be mutated because the stack
-          // only ever read to or written from it's current position. This means
-          // that the buffer can be dirty for the next use and still be correct
-          // since reading will start at position `0`.
+          // SAFETY: The buffer does not need to be mutated because the stack is
+          // only ever read from or written to its current position. Its current
+          // position is only ever incremented after writing to it. Meaning that
+          // the buffer can be dirty for the next use and still be correct since
+          // reading/writing always starts at position `0`.
           stackPos--
         }
         break


### PR DESCRIPTION
Saw [this tweet](https://twitter.com/adamwathan/status/1767937096214257837) and wanted to pitch in. This speeds up the `segment` function from ~1.2x to ~1.5x, at the cost of some readability.

Benchmark is below. Could use some larger or smaller test cases!
<img width="1023" alt="image" src="https://github.com/tailwindlabs/tailwindcss/assets/31470743/5993042c-23bf-4691-8789-524d09c73e61">
