### PR TITLE
Correct repository fields in package.json files

### DIFF
--- a/packages/@tailwindcss-cli/package.json
+++ b/packages/@tailwindcss-cli/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tailwindlabs/tailwindcss.git",
+    "url": "https://github.com/tailwindlabs/tailwindcss.git",
     "directory": "packages/@tailwindcss-cli"
   },
   "bugs": "https://github.com/tailwindlabs/tailwindcss/issues",

--- a/packages/@tailwindcss-postcss/package.json
+++ b/packages/@tailwindcss-postcss/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tailwindlabs/tailwindcss.git",
+    "url": "https://github.com/tailwindlabs/tailwindcss.git",
     "directory": "packages/@tailwindcss-postcss"
   },
   "bugs": "https://github.com/tailwindlabs/tailwindcss/issues",

--- a/packages/@tailwindcss-vite/package.json
+++ b/packages/@tailwindcss-vite/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tailwindlabs/tailwindcss.git",
+    "url": "https://github.com/tailwindlabs/tailwindcss.git",
     "directory": "packages/@tailwindcss-vite"
   },
   "bugs": "https://github.com/tailwindlabs/tailwindcss/issues",

--- a/packages/tailwindcss/package.json
+++ b/packages/tailwindcss/package.json
@@ -3,7 +3,11 @@
   "version": "4.0.0-alpha.11",
   "description": "A utility-first CSS framework for rapidly building custom user interfaces.",
   "license": "MIT",
-  "repository": "https://github.com/tailwindlabs/tailwindcss.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tailwindlabs/tailwindcss.git",
+    "directory": "packages/tailwindcss"
+  },
   "bugs": "https://github.com/tailwindlabs/tailwindcss/issues",
   "homepage": "https://tailwindcss.com",
   "scripts": {


### PR DESCRIPTION
This is a super minor thing, but the `package.json` files currently have inconsistent/invalid repository metadata.

I noticed because I configured Renovate to group this repo's updates on a `tailwindcss-monorepo` branch, but `@tailwindcss/vite` updates remained ungrouped. I am pretty sure it's the slightly invalid metadata that's the problem.

This PR would update `"repository"` to exactly match [the examples in the NPM docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository).

This change may also fix the [missing repository links on the NPM pages for your new packages](https://www.npmjs.com/package/@tailwindcss/vite/v/4.0.0-alpha.11), though I'm a lot less sure of that!