### PR TITLE
Don't read variables for shadow sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Enable Vite's `waitForRequestsIdle()` for client requests only ([#13394](https://github.com/tailwindlabs/tailwindcss/pull/13394))
 - Make sure `::first-letter` respectes `::selection` styles ([#13408](https://github.com/tailwindlabs/tailwindcss/pull/13408))
+- Always inline values for `shadow-*` utilities to ensure shadow colors work correctly ([#13449](https://github.com/tailwindlabs/tailwindcss/pull/13449))
 
 ## [4.0.0-alpha.11] - 2024-03-27
 

--- a/packages/tailwindcss/src/theme.ts
+++ b/packages/tailwindcss/src/theme.ts
@@ -194,6 +194,7 @@ export type ThemeKey =
   | '--hue-rotate'
   | '--inset'
   | '--inset-shadow'
+  | `--inset-shadow-${string}`
   | '--invert'
   | '--letter-spacing'
   | '--line-height'
@@ -227,6 +228,7 @@ export type ThemeKey =
   | '--scroll-padding'
   | '--sepia'
   | '--shadow'
+  | `--shadow-${string}`
   | '--size'
   | '--skew'
   | '--space'

--- a/packages/tailwindcss/src/theme.ts
+++ b/packages/tailwindcss/src/theme.ts
@@ -194,7 +194,6 @@ export type ThemeKey =
   | '--hue-rotate'
   | '--inset'
   | '--inset-shadow'
-  | `--inset-shadow`
   | '--invert'
   | '--letter-spacing'
   | '--line-height'
@@ -228,7 +227,6 @@ export type ThemeKey =
   | '--scroll-padding'
   | '--sepia'
   | '--shadow'
-  | `--shadow`
   | '--size'
   | '--skew'
   | '--space'

--- a/packages/tailwindcss/src/theme.ts
+++ b/packages/tailwindcss/src/theme.ts
@@ -42,7 +42,7 @@ export class Theme {
     return keys
   }
 
-  get(themeKeys: ThemeKey[]): string | null {
+  get(themeKeys: (ThemeKey | `${ThemeKey}-${string}`)[]): string | null {
     for (let key of themeKeys) {
       let value = this.values.get(key)
       if (value) {
@@ -194,7 +194,7 @@ export type ThemeKey =
   | '--hue-rotate'
   | '--inset'
   | '--inset-shadow'
-  | `--inset-shadow-${string}`
+  | `--inset-shadow`
   | '--invert'
   | '--letter-spacing'
   | '--line-height'
@@ -228,7 +228,7 @@ export type ThemeKey =
   | '--scroll-padding'
   | '--sepia'
   | '--shadow'
-  | `--shadow-${string}`
+  | `--shadow`
   | '--size'
   | '--skew'
   | '--space'

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -11492,8 +11492,8 @@ test('shadow', () => {
     }
 
     .shadow-xl {
-      --tw-shadow: var(--shadow-xl, 0 20px 25px -5px #0000001a, 0 8px 10px -6px #0000001a);
-      --tw-shadow-colored: var(--shadow-xl, 0 20px 25px -5px #0000001a, 0 8px 10px -6px #0000001a);
+      --tw-shadow: 0 20px 25px -5px #0000001a, 0 8px 10px -6px #0000001a;
+      --tw-shadow-colored: 0 20px 25px -5px var(--tw-shadow-color), 0 8px 10px -6px var(--tw-shadow-color);
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
 
@@ -11725,8 +11725,8 @@ test('inset-shadow', () => {
     }
 
     .inset-shadow-sm {
-      --tw-inset-shadow: var(--inset-shadow-sm, inset 0 1px 1px #0000000d);
-      --tw-inset-shadow-colored: var(--inset-shadow-sm, inset 0 1px 1px #0000000d);
+      --tw-inset-shadow: inset 0 1px 1px #0000000d;
+      --tw-inset-shadow-colored: inset 0 1px 1px var(--tw-inset-shadow-color);
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
 

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -4171,7 +4171,7 @@ export function createUtilities(theme: Theme) {
 
       // Shadow size
       {
-        let value = theme.resolve(candidate.value.value, ['--shadow'])
+        let value = theme.get([`--shadow-${candidate.value.value}`])
         if (value) {
           return [
             boxShadowProperties(),
@@ -4268,7 +4268,8 @@ export function createUtilities(theme: Theme) {
 
       // Shadow size
       {
-        let value = theme.resolve(candidate.value.value, ['--inset-shadow'])
+        let value = theme.get([`--inset-shadow-${candidate.value.value}`])
+
         if (value) {
           return [
             boxShadowProperties(),

--- a/packages/tailwindcss/tests/ui.spec.ts
+++ b/packages/tailwindcss/tests/ui.spec.ts
@@ -160,6 +160,33 @@ test('composing shadow, inset shadow, ring, and inset ring', async ({ page }) =>
   )
 })
 
+test('shadow colors', async ({ page }) => {
+  let { getPropertyValue } = await render(
+    page,
+    html`<div id="x" class="shadow shadow-red-500"></div>
+      <div id="y" class="shadow-xl shadow-red-500"></div>`,
+  )
+
+  expect(await getPropertyValue('#x', 'box-shadow')).toEqual(
+    [
+      'rgba(0, 0, 0, 0) 0px 0px 0px 0px',
+      'rgba(0, 0, 0, 0) 0px 0px 0px 0px',
+      'rgba(0, 0, 0, 0) 0px 0px 0px 0px',
+      'rgba(0, 0, 0, 0) 0px 0px 0px 0px',
+      'rgb(239, 68, 68) 0px 1px 3px 0px, rgb(239, 68, 68) 0px 1px 2px -1px',
+    ].join(', '),
+  )
+  expect(await getPropertyValue('#y', 'box-shadow')).toEqual(
+    [
+      'rgba(0, 0, 0, 0) 0px 0px 0px 0px',
+      'rgba(0, 0, 0, 0) 0px 0px 0px 0px',
+      'rgba(0, 0, 0, 0) 0px 0px 0px 0px',
+      'rgba(0, 0, 0, 0) 0px 0px 0px 0px',
+      'rgb(239, 68, 68) 0px 20px 25px -5px, rgb(239, 68, 68) 0px 8px 10px -6px',
+    ].join(', '),
+  )
+})
+
 test('outline style is optional', async ({ page }) => {
   let { getPropertyValue } = await render(
     page,

--- a/packages/tailwindcss/tests/ui.spec.ts
+++ b/packages/tailwindcss/tests/ui.spec.ts
@@ -163,8 +163,10 @@ test('composing shadow, inset shadow, ring, and inset ring', async ({ page }) =>
 test('shadow colors', async ({ page }) => {
   let { getPropertyValue } = await render(
     page,
-    html`<div id="x" class="shadow shadow-red-500"></div>
-      <div id="y" class="shadow-xl shadow-red-500"></div>`,
+    html`
+      <div id="x" class="shadow shadow-red-500"></div>
+      <div id="y" class="shadow-xl shadow-red-500"></div>
+    `,
   )
 
   expect(await getPropertyValue('#x', 'box-shadow')).toEqual(

--- a/playgrounds/vite/src/app.tsx
+++ b/playgrounds/vite/src/app.tsx
@@ -2,7 +2,7 @@ import { Foo } from './foo'
 
 export function App() {
   return (
-    <div className="m-3 p-3 border shadow-xl shadow-red-500">
+    <div className="m-3 p-3 border">
       <h1 className="text-blue-500">Hello World</h1>
       <Foo />
     </div>

--- a/playgrounds/vite/src/app.tsx
+++ b/playgrounds/vite/src/app.tsx
@@ -2,7 +2,7 @@ import { Foo } from './foo'
 
 export function App() {
   return (
-    <div className="m-3 p-3 border">
+    <div className="m-3 p-3 border shadow-xl shadow-red-500">
       <h1 className="text-blue-500">Hello World</h1>
       <Foo />
     </div>


### PR DESCRIPTION
Resolves https://github.com/tailwindlabs/tailwindcss/issues/13438

In https://github.com/tailwindlabs/tailwindcss/pull/13177 we changed the way utility values are referenced in utility classes to use variables with fallbacks instead of raw values:

```diff
  .pt-4 {
-   padding-top: 1rem;
+   padding-top: var(--spacing-4, 1rem);
  }
```

This creates an issue with colored shadows, because colored shadows rely on being able to override the value of a sub-variable that is reference by the actual shadow variable created based on your theme configuration.

Simplified but representative code:

```css
:root {
  --shadow-sm: 0 1px 2px 0 var(--tw-shadow-color, black);
}

.shadow-sm {
  box-shadow: var(--shadow-sm, 0 1px 2px 0 var(--tw-shadow-color, black));
}

.shadow-blue {
  --tw-shadow-color: blue;
}
```

The problem here is that `var(--shadow-sm, ...)` will see that `--shadow-sm` is defined on `:root`, and use the computed value of that variable from `:root`, where `--tw-shadow-color` is yet to be defined, so the color falls back to `black` even when using the `shadow-blue` utility:

```html
<!-- Shadow is still black, not blue like you might expect -->
<div class="shadow-sm shadow-blue">
  <!-- ... -->
</div>
```

This caught me by surprise personally as I expected CSS variables to be evaluated lazily but it seems like they are not. The only solution I've found here is to _not_ reference the `--shadow-sm` variable in the `.shadow-sm` class, to make sure the value of `--tw-shadow-color` on the current element is respected, rather than looking for the value of `--tw-shadow-color` where `--shadow-sm` is defined:

```diff
  :root {
    --shadow-sm: 0 1px 2px 0 var(--tw-shadow-color, black);
  }
  
  .shadow-sm {
-   box-shadow: var(--shadow-sm, 0 1px 2px 0 var(--tw-shadow-color, black));
+   box-shadow: 0 1px 2px 0 var(--tw-shadow-color, black);
  }
  
  .shadow-blue {
    --tw-shadow-color: blue;
  }
```

This is pretty unfortunate because now our box shadow utilities behave subtly differently than every other utility in the framework. I'm hoping we can find some trick to make these variables lazily evaluated, and [tweeted about it](https://twitter.com/adamwathan/status/1775937299919859961) in case someone else out there has any ideas.

For now though we should merge this to effectively selectively revert https://github.com/tailwindlabs/tailwindcss/pull/13177 for the affected utilities.