### PR TITLE
Ensure deterministic SSR builds in `@tailwindcss/vite`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Ensure `@tailwindcss/vite#build` waits for all files before generating the CSS ([#13457](https://github.com/tailwindlabs/tailwindcss/pull/13457))
 
 ## [4.0.0-alpha.13] - 2024-04-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Ensure `@tailwindcss/vite#build` waits for all files before generating the CSS ([#13457](https://github.com/tailwindlabs/tailwindcss/pull/13457))
+- Ensure deterministic SSR builds in `@tailwindcss/vite` ([#13457](https://github.com/tailwindlabs/tailwindcss/pull/13457))
 
 ## [4.0.0-alpha.13] - 2024-04-04
 

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -187,6 +187,9 @@ export default function tailwindcss(): Plugin[] {
         cssModules[id] = src
 
         if (!options?.ssr) {
+          // Wait until all other files have been processed, so we can extract
+          // all candidates before generating CSS. This must not be called
+          // during SSR or it will block the server.
           await server?.waitForRequestsIdle?.(id)
         }
 

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -182,9 +182,16 @@ export default function tailwindcss(): Plugin[] {
       name: '@tailwindcss/vite:generate:build',
       apply: 'build',
 
-      transform(src, id) {
+      async transform(src, id, options) {
         if (!isTailwindCssFile(id, src)) return
         cssModules[id] = src
+
+        if (!options?.ssr) {
+          await server?.waitForRequestsIdle?.(id)
+        }
+
+        let code = await transformWithPlugins(this, id, generateCss(src))
+        return { code }
       },
 
       // renderChunk runs in the bundle generation stage after all transforms.

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -85,7 +85,7 @@ export default function tailwindcss(): Plugin[] {
       try {
         // Directly call the plugin's transform function to process the
         // generated CSS. In build mode, this updates the chunks later used to
-        // generate the bundle. In serve mode, the transformed souce should be
+        // generate the bundle. In serve mode, the transformed source should be
         // applied in transform.
         let result = await transformHandler.call(transformPluginContext, css, id)
         if (!result) continue

--- a/playgrounds/vite/package.json
+++ b/playgrounds/vite/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "lint": "tsc --noEmit",
     "dev": "bun --bun vite ./src --config ./vite.config.ts",
-    "build": "bun --bun vite build ./src --outDir ../dist --config ./vite.config.ts --emptyOutDir"
+    "build": "bun --bun vite build ./src --outDir ../dist --config ./vite.config.ts --emptyOutDir",
+    "preview": "bun --bun vite preview"
   },
   "dependencies": {
     "@tailwindcss/vite": "workspace:^",


### PR DESCRIPTION
This PR fixes an issue where running `astro build` doesn't generate the correct CSS when using `@tailwindcss/vite`. This issue only seems to happen when running a build, and not when running in `dev` mode.

To fix this, we apply the same code (`waitForRequestsIdle`) as we do in the `apply: "server"` step.

Adding this to the `apply: "build"` step as well does generate the correct result.

While this does fix the issue, I'm not 100% convinced that this is the correct solution /cc @thecrypticace.

Fixes: #13441

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
