### PR TITLE
Switch breakpoints to rem

### DIFF
--- a/packages/tailwindcss/theme.css
+++ b/packages/tailwindcss/theme.css
@@ -10,11 +10,11 @@
   --default-mono-font-variation-settings: var(--font-family-mono--font-variation-settings);
 
   /* Breakpoints */
-  --breakpoint-sm: 640px;
-  --breakpoint-md: 768px;
-  --breakpoint-lg: 1024px;
-  --breakpoint-xl: 1280px;
-  --breakpoint-2xl: 1536px;
+  --breakpoint-sm: 40rem;
+  --breakpoint-md: 48rem;
+  --breakpoint-lg: 64rem;
+  --breakpoint-xl: 80rem;
+  --breakpoint-2xl: 96rem;
 
   /* Colors */
   --color-black: #000;


### PR DESCRIPTION
This was seemingly planned for v4 (mentioned by @adamwathan in #8378), but I didn't see it in the codebase. Feel free to delete this PR if plans changed! I used `rem` instead of `em` because the functionality seems to be the same, and it's more consistent with the spacing and type scales.