### PR TITLE
Fix typo "envionment" -> "environment"

### DIFF
--- a/packages/tailwindcss/src/utils/segment.ts
+++ b/packages/tailwindcss/src/utils/segment.ts
@@ -27,7 +27,7 @@ const CLOSE_CURLY = 0x7d
  */
 export function segment(input: string, separator: string) {
   // SAFETY: We can use an index into a shared buffer because this function is
-  // synchronous, non-recursive, and runs in a single-threaded envionment.
+  // synchronous, non-recursive, and runs in a single-threaded environment.
   let stackPos = 0
   let parts: string[] = []
   let lastPos = 0


### PR DESCRIPTION
Very small PR, but this fixes a typo from "envionment" to "environment".
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
