### PR TITLE
Colocate charcode tokens

### DIFF
--- a/packages/tailwindcss/src/candidate.ts
+++ b/packages/tailwindcss/src/candidate.ts
@@ -258,8 +258,9 @@ export function parseCandidate(input: string, designSystem: DesignSystem): Candi
     //
     // Otherwise, it is an invalid candidate, and skip continue parsing.
     let charCode = baseWithoutModifier.charCodeAt(1)
-    if (charCode !== Token.DASH && !(charCode >= Token.LOWER_A && charCode <= Token.LOWER_Z))
+    if (charCode !== Token.DASH && !(charCode >= Token.LOWER_A && charCode <= Token.LOWER_Z)) {
       return null
+    }
 
     baseWithoutModifier = baseWithoutModifier.slice(1, -1)
 

--- a/packages/tailwindcss/src/candidate.ts
+++ b/packages/tailwindcss/src/candidate.ts
@@ -1,4 +1,5 @@
 import type { DesignSystem } from './design-system'
+import * as Token from './tokens'
 import { decodeArbitraryValue } from './utils/decode-arbitrary-value'
 import { segment } from './utils/segment'
 
@@ -257,7 +258,8 @@ export function parseCandidate(input: string, designSystem: DesignSystem): Candi
     //
     // Otherwise, it is an invalid candidate, and skip continue parsing.
     let charCode = baseWithoutModifier.charCodeAt(1)
-    if (charCode !== 45 && !(charCode >= 97 && charCode <= 122)) return null
+    if (charCode !== Token.DASH && !(charCode >= Token.LOWER_A && charCode <= Token.LOWER_Z))
+      return null
 
     baseWithoutModifier = baseWithoutModifier.slice(1, -1)
 
@@ -358,14 +360,14 @@ export function parseCandidate(input: string, designSystem: DesignSystem): Candi
         let code = arbitraryValue.charCodeAt(i)
 
         // If we hit a ":", we're at the end of a typehint.
-        if (code === 58 /* ':' */) {
+        if (code === Token.COLON) {
           typehint = arbitraryValue.slice(0, i)
           arbitraryValue = arbitraryValue.slice(i + 1)
           break
         }
 
         // Keep iterating as long as we've only seen valid typehint characters.
-        if (code === 45 /* '-' */ || (code >= 97 && code <= 122) /* [a-z] */) {
+        if (code === Token.DASH || (code >= Token.LOWER_A && code <= Token.LOWER_Z)) {
           continue
         }
 

--- a/packages/tailwindcss/src/tokens.ts
+++ b/packages/tailwindcss/src/tokens.ts
@@ -18,3 +18,5 @@ export const CLOSE_BRACKET = 0x5d
 export const DASH = 0x2d
 export const AT_SIGN = 0x40
 export const EXCLAMATION_MARK = 0x21
+export const LOWER_A = 0x61
+export const LOWER_Z = 0x7a

--- a/packages/tailwindcss/src/tokens.ts
+++ b/packages/tailwindcss/src/tokens.ts
@@ -1,0 +1,20 @@
+// All numbers are equivalent to the value returned by `String#charCodeAt(0)`
+export const BACKSLASH = 0x5c
+export const SLASH = 0x2f
+export const ASTERISK = 0x2a
+export const DOUBLE_QUOTE = 0x22
+export const SINGLE_QUOTE = 0x27
+export const COLON = 0x3a
+export const SEMICOLON = 0x3b
+export const LINE_BREAK = 0x0a
+export const SPACE = 0x20
+export const TAB = 0x09
+export const OPEN_CURLY = 0x7b
+export const CLOSE_CURLY = 0x7d
+export const OPEN_PAREN = 0x28
+export const CLOSE_PAREN = 0x29
+export const OPEN_BRACKET = 0x5b
+export const CLOSE_BRACKET = 0x5d
+export const DASH = 0x2d
+export const AT_SIGN = 0x40
+export const EXCLAMATION_MARK = 0x21

--- a/packages/tailwindcss/src/tokens.ts
+++ b/packages/tailwindcss/src/tokens.ts
@@ -20,3 +20,4 @@ export const AT_SIGN = 0x40
 export const EXCLAMATION_MARK = 0x21
 export const LOWER_A = 0x61
 export const LOWER_Z = 0x7a
+export const HASH = 0x23

--- a/packages/tailwindcss/src/utils/is-color.ts
+++ b/packages/tailwindcss/src/utils/is-color.ts
@@ -1,3 +1,5 @@
+import * as Token from '../tokens'
+
 const NAMED_COLORS = new Set([
   // CSS Level 1 colors
   'black',
@@ -197,7 +199,7 @@ const IS_COLOR_FN = /^(rgba?|hsla?|hwb|color|(ok)?(lab|lch)|light-dark|color-mix
 
 export function isColor(value: string): boolean {
   return (
-    value.charCodeAt(0) === 35 /* "#" */ ||
+    value.charCodeAt(0) === Token.HASH ||
     IS_COLOR_FN.test(value) ||
     NAMED_COLORS.has(value.toLowerCase())
   )

--- a/packages/tailwindcss/src/utils/segment.ts
+++ b/packages/tailwindcss/src/utils/segment.ts
@@ -1,17 +1,10 @@
+import * as Token from '../tokens'
+
 // This is a shared buffer that is used to keep track of the current nesting level
 // of parens, brackets, and braces. It is used to determine if a character is at
 // the top-level of a string. This is a performance optimization to avoid memory
 // allocations on every call to `segment`.
 const closingBracketStack = new Uint8Array(256)
-
-// All numbers are equivalent to the value returned by `String#charCodeAt(0)`
-const BACKSLASH = 0x5c
-const OPEN_PAREN = 0x28
-const OPEN_BRACKET = 0x5b
-const OPEN_CURLY = 0x7b
-const CLOSE_PAREN = 0x29
-const CLOSE_BRACKET = 0x5d
-const CLOSE_CURLY = 0x7d
 
 /**
  * This splits a string on a top-level character.
@@ -44,25 +37,25 @@ export function segment(input: string, separator: string) {
     }
 
     switch (char) {
-      case BACKSLASH:
+      case Token.BACKSLASH:
         // The next character is escaped, so we skip it.
         idx += 1
         break
-      case OPEN_PAREN:
-        closingBracketStack[stackPos] = CLOSE_PAREN
+      case Token.OPEN_PAREN:
+        closingBracketStack[stackPos] = Token.CLOSE_PAREN
         stackPos++
         break
-      case OPEN_BRACKET:
-        closingBracketStack[stackPos] = CLOSE_BRACKET
+      case Token.OPEN_BRACKET:
+        closingBracketStack[stackPos] = Token.CLOSE_BRACKET
         stackPos++
         break
-      case OPEN_CURLY:
-        closingBracketStack[stackPos] = CLOSE_CURLY
+      case Token.OPEN_CURLY:
+        closingBracketStack[stackPos] = Token.CLOSE_CURLY
         stackPos++
         break
-      case CLOSE_BRACKET:
-      case CLOSE_CURLY:
-      case CLOSE_PAREN:
+      case Token.CLOSE_BRACKET:
+      case Token.CLOSE_CURLY:
+      case Token.CLOSE_PAREN:
         if (stackPos > 0 && char === closingBracketStack[stackPos - 1]) {
           // SAFETY: The buffer does not need to be mutated because the stack is
           // only ever read from or written to its current position. Its current


### PR DESCRIPTION
This PR moves all `charCode` constants in a shared tokens file. This allows us to remove hardcoded magic numbers (and their associated comments) from the code.

This is some cleanup as a continuation from 2 separate PRs that used constant tokens in their own files.

Note: when running a build, all the constants are inlined, so there is not performance penalty for this change.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
