### PR TITLE
fix: doesn't work spaces inside calc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Support any spaces inside calc ([#13529](https://github.com/tailwindlabs/tailwindcss/pull/13529))
 
 ## [3.4.3] - 2024-03-27
 

--- a/src/lib/expandTailwindAtRules.js
+++ b/src/lib/expandTailwindAtRules.js
@@ -39,6 +39,10 @@ function getTransformer(tailwindConfig, fileExtension) {
   )
 }
 
+function removeSpacesInsideCalc(content) {
+  return content.replace(/calc\(([^)]*)\)/g, (_, p1) => `calc(${p1.replace(/\s+/g, '')})`)
+}
+
 let extractorCache = new WeakMap()
 
 // Scans template contents for possible classes. This is a hot path on initial build but
@@ -51,6 +55,7 @@ function getClassCandidates(content, extractor, candidates, seen) {
 
   for (let line of content.split('\n')) {
     line = line.trim()
+    line = removeSpacesInsideCalc(line)
 
     if (seen.has(line)) {
       continue

--- a/tests/arbitrary-values.test.js
+++ b/tests/arbitrary-values.test.js
@@ -639,3 +639,30 @@ it('should not insert spaces around `-` in arbitrary values that use `max-conten
     `)
   })
 })
+
+it('should support arbitrary calc values with spaces`', () => {
+  let config = {
+    content: [
+      {
+        raw: html`<div
+          class="w-[calc(100px + 200px)] h-[calc(3rem - 1rem)] text-lg/[calc(50px / 1rem)]"
+        ></div>`,
+      },
+    ],
+  }
+
+  return run('@tailwind utilities', config).then((result) => {
+    expect(result.css).toMatchFormattedCss(css`
+      .h-\[calc\(3rem-1rem\)\] {
+        height: 2rem;
+      }
+      .w-\[calc\(100px\+200px\)\] {
+        width: 300px;
+      }
+      .text-lg\/\[calc\(50px\/1rem\)\] {
+        font-size: 1.125rem;
+        line-height: calc(50px / 1rem);
+      }
+    `)
+  })
+})


### PR DESCRIPTION
This PR fix a uncomfortable thing that spaces inside calc doesn't work.

When i use arbitrary calc values with spaces `<div class="w-[calc(100px + 200px)]></div>`, tailwind extract separate words.
Finally, It doesn't work.

So I've added a function that remove spaces inside calc. It can remove spaces inside calc before using extractor.

#### before

`w-[calc(100px + 200px)]` -> `w-[calc(100px` , `+` , `200px)]`

#### after

`w-[calc(100px + 200px)]` -> `w-[calc(100px+200px)]`