### PR TITLE
Move `css-parser.bench.ts` into the `src` folder

### DIFF
--- a/packages/tailwindcss/src/css-parser.bench.ts
+++ b/packages/tailwindcss/src/css-parser.bench.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from 'node:fs'
 import { bench } from 'vitest'
-import * as CSS from './src/css-parser.ts'
+import * as CSS from './css-parser.ts'
 
-const currentFolder = new URL('.', import.meta.url).pathname
+const currentFolder = new URL('..', import.meta.url).pathname
 const cssFile = readFileSync(currentFolder + './preflight.css', 'utf-8')
 
 bench('css-parser on preflight.css', () => {


### PR DESCRIPTION
This PR is a minor cleanup thing, but it will move the `css-parser.bench.ts` file into the `src` folder next to the `css-parser.ts` and `css-parser.test.ts` files.
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
