### PR TITLE
v4: Allow hyphen character in regex pattern to use support queries as is

### DIFF
--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -1293,7 +1293,6 @@ test('supports', () => {
       'supports-[display:grid]:flex',
       'supports-[selector(A_>_B)]:flex',
       'supports-[font-format(opentype)]:grid',
-      'supports-[content:"("]:grid',
       'supports-[(display:grid)_and_font-format(opentype)]:grid',
       'supports-[font-tech(color-COLRv1)]:flex',
       'supports-[--test]:flex',

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -1288,7 +1288,16 @@ test('sorting `min` and `max` should sort by unit, then by value, then alphabeti
 
 test('supports', () => {
   expect(
-    run(['supports-gap:grid', 'supports-[display:grid]:flex', 'supports-[selector(A_>_B)]:flex']),
+    run([
+      'supports-gap:grid',
+      'supports-[display:grid]:flex',
+      'supports-[selector(A_>_B)]:flex',
+      'supports-[font-format(opentype)]:grid',
+      'supports-[content:"("]:grid',
+      'supports-[(display:grid)_and_font-format(opentype)]:grid',
+      'supports-[font-tech(color-COLRv1)]:flex',
+      'supports-[--test]:flex',
+    ]),
   ).toMatchInlineSnapshot(`
     "@supports (gap: var(--tw)) {
       .supports-gap\\:grid {
@@ -1304,6 +1313,30 @@ test('supports', () => {
 
     @supports selector(A > B) {
       .supports-\\[selector\\(A_\\>_B\\)\\]\\:flex {
+        display: flex;
+      }
+    }
+
+    @supports font-format(opentype) {
+      .supports-\\[font-format\\(opentype\\)\\]\\:grid {
+        display: grid;
+      }
+    }
+
+    @supports (display: grid) and font-format(opentype) {
+      .supports-\\[\\(display\\:grid\\)_and_font-format\\(opentype\\)\\]\\:grid {
+        display: grid;
+      }
+    }
+
+    @supports font-tech(color-COLRv1) {
+      .supports-\\[font-tech\\(color-COLRv1\\)\\]\\:flex {
+        display: flex;
+      }
+    }
+
+    @supports (--test: var(--tw)) {
+      .supports-\\[--test\\]\\:flex {
         display: flex;
       }
     }"

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -384,7 +384,7 @@ export function createVariants(theme: Theme): Variants {
       // When `supports-[...]:flex` is used, with `not()`, `and()` or
       // `selector()`, then we know that want to use this directly as the
       // supports condition as-is.
-      if (/^\w*\s*\(/.test(value)) {
+      if (/^[\w-]*\s*\(/.test(value)) {
         // Chrome has a bug where `(condition1)or(condition2)` is not valid, but
         // `(condition1) or (condition2)` is supported.
         let query = value.replace(/\b(and|or|not)\b/g, ' $1 ')


### PR DESCRIPTION
It looks like matching for the hyphen character in the existing regex to use support queries as-is resolves #13594.

This might be a good long-term solution anyway, as it covers any future function syntaxes added to support queries, as well as supporting CSS var definition rules:

Tests:
* ✅ `'supports-gap:grid'` -> `@supports (gap: var(--tw))`
* ✅ `'supports-[display:grid]:flex'` -> `@supports (display: grid)`
* ✅ `'supports-[selector(A_>_B)]:flex'` -> `@supports selector(A > B)`
* ✅ `'supports-[font-format(opentype)]:grid'` -> `@supports font-format(opentype)`
* ❌ `'supports-[content:"("]:grid'` -> `@supports (content: "(")`
* ✅ `'supports-[(display:grid)_and_font-format(opentype)]:grid'` -> `@supports (display: grid) and font-format(opentype)`
* ✅ `'supports-[font-tech(color-COLRv1)]:flex'` -> `@supports font-tech(color-COLRv1)`
* ✅ `'supports-[--test]:flex'` -> `@supports (--test: var(--tw))`

The one failing rule, recommended by @adamwathan in #13594, appears to have not worked before either and likely requires a slight change to the parser to account for consuming chars in quoted strings in arbitrary values as-is, including special chars.

Testing `supports-[content:"("]` against `supports-[content:"test"]` confirmed the parenthesis as the problematic character, as expected, so that should be a relatively simple fix.

As that effort does not appear directly related to issue #13594, I prefer to handle that one in a separate PR, and I do intend to take my best shot at it so that I can get a bit less rusty at rust 😅