### PR TITLE
Ensure strings are consumed as-is when using internal `segment()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Make sure `contain-*` utility variables resolve to a valid value ([#13521](https://github.com/tailwindlabs/tailwindcss/pull/13521))
-- Ensure strings are consumed as-is when using internal `segment()` ([#13608](https://github.com/tailwindlabs/tailwindcss/pull/13608))
+- Support unbalanced parentheses and braces in quotes in arbitrary values and variants ([#13608](https://github.com/tailwindlabs/tailwindcss/pull/13608))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Make sure `contain-*` utility variables resolve to a valid value ([#13521](https://github.com/tailwindlabs/tailwindcss/pull/13521))
+- Ensure strings are consumed as-is when using internal `segment()` ([#13608](https://github.com/tailwindlabs/tailwindcss/pull/13608))
 
 ### Changed
 

--- a/packages/tailwindcss/src/candidate.test.ts
+++ b/packages/tailwindcss/src/candidate.test.ts
@@ -1031,5 +1031,11 @@ it('should parse arbitrary properties that are important and using stacked arbit
 })
 
 it('should not parse compound group with a non-compoundable variant', () => {
-  expect(run('group-*:flex')).toMatchInlineSnapshot(`null`)
+  let utilities = new Utilities()
+  utilities.static('flex', () => [])
+
+  let variants = new Variants()
+  variants.compound('group', () => {})
+
+  expect(run('group-*:flex', { utilities, variants })).toMatchInlineSnapshot(`null`)
 })

--- a/packages/tailwindcss/src/candidate.test.ts
+++ b/packages/tailwindcss/src/candidate.test.ts
@@ -1039,3 +1039,32 @@ it('should not parse compound group with a non-compoundable variant', () => {
 
   expect(run('group-*:flex', { utilities, variants })).toMatchInlineSnapshot(`null`)
 })
+
+it('should parse a variant containing an arbitrary string with unbalanced parens, brackets, curlies and other quotes', () => {
+  let utilities = new Utilities()
+  utilities.static('flex', () => [])
+
+  let variants = new Variants()
+  variants.functional('string', () => {})
+
+  expect(run(`string-['}[("\\'']:flex`, { utilities, variants })).toMatchInlineSnapshot(`
+    {
+      "important": false,
+      "kind": "static",
+      "negative": false,
+      "root": "flex",
+      "variants": [
+        {
+          "compounds": true,
+          "kind": "functional",
+          "modifier": null,
+          "root": "string",
+          "value": {
+            "kind": "arbitrary",
+            "value": "'}[("\\''",
+          },
+        },
+      ],
+    }
+  `)
+})

--- a/packages/tailwindcss/src/utils/segment.test.ts
+++ b/packages/tailwindcss/src/utils/segment.test.ts
@@ -45,10 +45,6 @@ it('should skip escaped single quotes', () => {
   expect(segment(String.raw`a:'b:c\':d':e`, ':')).toEqual(['a', String.raw`'b:c\':d'`, 'e'])
 })
 
-it('should not crash when single quotes are unbalanced', () => {
-  expect(segment("a:'b:c:d", ':')).toEqual(['a', "'b:c:d"])
-})
-
 it('should split by the escape sequence which is escape as well', () => {
   expect(segment('a\\b\\c\\d', '\\')).toEqual(['a', 'b', 'c', 'd'])
   expect(segment('a\\(b\\c)\\d', '\\')).toEqual(['a', '(b\\c)', 'd'])

--- a/packages/tailwindcss/src/utils/segment.test.ts
+++ b/packages/tailwindcss/src/utils/segment.test.ts
@@ -21,6 +21,34 @@ it('should not split inside of curlies', () => {
   expect(segment('a:{b:c}:d', ':')).toEqual(['a', '{b:c}', 'd'])
 })
 
+it('should not split inside of double quotes', () => {
+  expect(segment('a:"b:c":d', ':')).toEqual(['a', '"b:c"', 'd'])
+})
+
+it('should not split inside of single quotes', () => {
+  expect(segment("a:'b:c':d", ':')).toEqual(['a', "'b:c'", 'd'])
+})
+
+it('should not crash when double quotes are unbalanced', () => {
+  expect(segment('a:"b:c:d', ':')).toEqual(['a', '"b:c:d'])
+})
+
+it('should not crash when single quotes are unbalanced', () => {
+  expect(segment("a:'b:c:d", ':')).toEqual(['a', "'b:c:d"])
+})
+
+it('should skip escaped double quotes', () => {
+  expect(segment(String.raw`a:"b:c\":d":e`, ':')).toEqual(['a', String.raw`"b:c\":d"`, 'e'])
+})
+
+it('should skip escaped single quotes', () => {
+  expect(segment(String.raw`a:'b:c\':d':e`, ':')).toEqual(['a', String.raw`'b:c\':d'`, 'e'])
+})
+
+it('should not crash when single quotes are unbalanced', () => {
+  expect(segment("a:'b:c:d", ':')).toEqual(['a', "'b:c:d"])
+})
+
 it('should split by the escape sequence which is escape as well', () => {
   expect(segment('a\\b\\c\\d', '\\')).toEqual(['a', 'b', 'c', 'd'])
   expect(segment('a\\(b\\c)\\d', '\\')).toEqual(['a', '(b\\c)', 'd'])

--- a/packages/tailwindcss/src/utils/segment.ts
+++ b/packages/tailwindcss/src/utils/segment.ts
@@ -54,10 +54,8 @@ export function segment(input: string, separator: string) {
       // worry about balancing parens, brackets, or curlies inside a string.
       case SINGLE_QUOTE:
       case DOUBLE_QUOTE:
-        while (
-          // Ensure we don't go out of bounds.
-          ++idx < len
-        ) {
+        // Ensure we don't go out of bounds.
+        while (++idx < len) {
           let nextChar = input.charCodeAt(idx)
 
           // The next character is escaped, so we skip it.


### PR DESCRIPTION
This PR fixes an issue where parens, bracket and curlies needed to be balanced inside of strings instead of consuming the string until the end.

When encountering strings when using `segment` we didn't really treat them as actual strings. This means that if you used any parens, brackets, or curlies then we wanted them to be properly balanced.

This should not be the case, whenever we encounter a string, we want to consume it as-is and don't want to worry about bracket balancing. We will now consume it until the end of the string (and make sure that escaped closing quotes are not seen as real closing quotes).

Fixes: #13607

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
