### PR TITLE
Update release profile with optimization options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,7 @@ resolver = "2"
 members = ["crates/*"]
 
 [profile.release]
+opt-level = 3
+codegen-units = 1
 lto = true
+strip = "symbols"


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->

## Description

This commit adds the following options to the release profile:
- `opt-level = 3` for maximum optimization
- `codegen-units = 1` to ensure maximum optimization across the whole crate
- `strip = "symbols"` to reduce binary size by stripping symbols
More information [here](https://doc.rust-lang.org/cargo/reference/profiles.html)

## Benchmarks

### Before
```sh
 ✓ src/utils/segment.bench.ts (1) 849ms
     name             hz     min      max    mean     p75     p99    p995    p999      rme  samples
   · segment  748,571.09  0.0007  24.8952  0.0013  0.0012  0.0119  0.0183  0.0449  ±10.22%   374286   fastest
 ✓ src/utils/decode-arbitrary-value.bench.ts (1) 691ms
     name                          hz     min      max    mean     p75     p99    p995    p999      rme  samples
   · decodeArbitraryValue  151,582.72  0.0038  31.6623  0.0066  0.0051  0.0284  0.0444  0.2131  ±12.51%    75792   fastest
 ✓ src/utils/infer-data-type.bench.ts (2) 995ms
     name              hz     min      max    mean     p75     p99    p995    p999     rme  samples
   · colors  1,003,309.42  0.0007  11.5130  0.0010  0.0008  0.0019  0.0023  0.0189  ±5.21%   501655   fastest
   · colors
 ✓ src/css-parser.bench.ts (1) 619ms
     name                                hz     min      max    mean     p75     p99    p995    p999     rme  samples
   · css-parser on preflight.css  10,516.72  0.0599  19.8800  0.0951  0.1088  0.4483  0.4842  1.0035  ±8.06%     5259   fastest
 ✓ src/index.bench.ts (1) 1090ms
     name          hz      min      max     mean      p75      p99     p995     p999      rme  samples
   · compile  33.4793  21.7361  51.8996  29.8692  31.7829  51.8996  51.8996  51.8996  ±12.42%       17   fastest
 ✓ src/sort.bench.ts (2) 1557ms
     name                                  hz     min      max    mean     p75     p99    p995    p999      rme  samples
   · getClassOrder (empty theme)   722,504.87  0.0007  27.6115  0.0014  0.0009  0.0043  0.0181  0.0325  ±11.12%   361253   fastest
   · getClassOrder (simple theme)  519,604.65  0.0016   0.6393  0.0019  0.0018  0.0035  0.0041  0.0121   ±1.14%   259803
 ✓ src/candidate.bench.ts (1) 688ms
     name                hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · parseCandidate  301.32  2.7103  5.8892  3.3188  3.3856  5.8533  5.8892  5.8892  ±3.23%      151   fastest
```

### After

```sh
 ✓ src/utils/segment.bench.ts (1) 845ms
     name             hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · segment  945,756.24  0.0006  2.8714  0.0011  0.0014  0.0020  0.0026  0.0071  ±1.46%   472879   fastest
 ✓ src/css-parser.bench.ts (1) 612ms
     name                                hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · css-parser on preflight.css  11,757.72  0.0597  0.5512  0.0851  0.1177  0.2720  0.3188  0.4137  ±1.22%     5882   fastest
 ✓ src/utils/decode-arbitrary-value.bench.ts (1) 672ms
     name                          hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · decodeArbitraryValue  160,415.66  0.0039  0.6538  0.0062  0.0075  0.0121  0.0154  0.1888  ±1.06%    80208   fastest
 ✓ src/utils/infer-data-type.bench.ts (2) 838ms
     name              hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · colors  1,122,455.24  0.0006  1.1840  0.0009  0.0013  0.0017  0.0021  0.0045  ±0.86%   561228   fastest
   · colors
 ✓ src/index.bench.ts (1) 802ms
     name          hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · compile  35.4800  19.5675  41.2061  28.1849  31.3982  41.2061  41.2061  41.2061  ±8.71%       18   fastest
 ✓ src/sort.bench.ts (2) 1526ms
     name                                  hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · getClassOrder (empty theme)   864,019.92  0.0008  0.6574  0.0012  0.0014  0.0026  0.0029  0.0077  ±1.22%   432010   fastest
   · getClassOrder (simple theme)  539,544.41  0.0016  0.5345  0.0019  0.0018  0.0033  0.0036  0.0092  ±0.77%   269773
 ✓ src/candidate.bench.ts (1) 617ms
     name                hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · parseCandidate  282.75  2.6976  6.8881  3.5367  4.0406  5.9480  6.8881  6.8881  ±4.62%      142   fastest
```

### Summary

Performance improvement: 

- `decode-arbitrary-value` : 2.7% 
- `infer-data-type`: 15.7%
- `compile`:  26.4%
- `candidate`: 10.3%

