### PR TITLE
Use long form `<length> | <percentage>` syntax for properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use `length` data type for `background-size` instead of `background-position` ([#13771](https://github.com/tailwindlabs/tailwindcss/pull/13771))
 - Support negative values for `{col,row}-{start,end}` utilities ([#13780](https://github.com/tailwindlabs/tailwindcss/pull/13780))
+- Use long form `<length> | <percentage>` syntax for properties ([#13660](https://github.com/tailwindlabs/tailwindcss/pull/13660))
 
 ### Added
 

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -228,13 +228,13 @@ describe('@apply', () => {
       }
 
       @property --tw-translate-x {
-        syntax: "<length-percentage>";
+        syntax: "<length> | <percentage>";
         inherits: false;
         initial-value: 0;
       }
 
       @property --tw-translate-y {
-        syntax: "<length-percentage>";
+        syntax: "<length> | <percentage>";
         inherits: false;
         initial-value: 0;
       }

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -2528,13 +2528,13 @@ test('translate', () => {
     }
 
     @property --tw-translate-x {
-      syntax: "<length-percentage>";
+      syntax: "<length> | <percentage>";
       inherits: false;
       initial-value: 0;
     }
 
     @property --tw-translate-y {
-      syntax: "<length-percentage>";
+      syntax: "<length> | <percentage>";
       inherits: false;
       initial-value: 0;
     }
@@ -2582,13 +2582,13 @@ test('translate-x', () => {
       }
 
       @property --tw-translate-x {
-        syntax: "<length-percentage>";
+        syntax: "<length> | <percentage>";
         inherits: false;
         initial-value: 0;
       }
 
       @property --tw-translate-y {
-        syntax: "<length-percentage>";
+        syntax: "<length> | <percentage>";
         inherits: false;
         initial-value: 0;
       }
@@ -2636,13 +2636,13 @@ test('translate-y', () => {
       }
 
       @property --tw-translate-x {
-        syntax: "<length-percentage>";
+        syntax: "<length> | <percentage>";
         inherits: false;
         initial-value: 0;
       }
 
       @property --tw-translate-y {
-        syntax: "<length-percentage>";
+        syntax: "<length> | <percentage>";
         inherits: false;
         initial-value: 0;
       }
@@ -2679,13 +2679,13 @@ test('translate-z', () => {
     }
 
     @property --tw-translate-x {
-      syntax: "<length-percentage>";
+      syntax: "<length> | <percentage>";
       inherits: false;
       initial-value: 0;
     }
 
     @property --tw-translate-y {
-      syntax: "<length-percentage>";
+      syntax: "<length> | <percentage>";
       inherits: false;
       initial-value: 0;
     }
@@ -2718,13 +2718,13 @@ test('translate-3d', () => {
     }
 
     @property --tw-translate-x {
-      syntax: "<length-percentage>";
+      syntax: "<length> | <percentage>";
       inherits: false;
       initial-value: 0;
     }
 
     @property --tw-translate-y {
-      syntax: "<length-percentage>";
+      syntax: "<length> | <percentage>";
       inherits: false;
       initial-value: 0;
     }
@@ -8209,19 +8209,19 @@ test('from', () => {
     }
 
     @property --tw-gradient-from-position {
-      syntax: "<length-percentage>";
+      syntax: "<length> | <percentage>";
       inherits: false;
       initial-value: 0%;
     }
 
     @property --tw-gradient-via-position {
-      syntax: "<length-percentage>";
+      syntax: "<length> | <percentage>";
       inherits: false;
       initial-value: 50%;
     }
 
     @property --tw-gradient-to-position {
-      syntax: "<length-percentage>";
+      syntax: "<length> | <percentage>";
       inherits: false;
       initial-value: 100%;
     }"
@@ -8446,19 +8446,19 @@ test('via', () => {
     }
 
     @property --tw-gradient-from-position {
-      syntax: "<length-percentage>";
+      syntax: "<length> | <percentage>";
       inherits: false;
       initial-value: 0%;
     }
 
     @property --tw-gradient-via-position {
-      syntax: "<length-percentage>";
+      syntax: "<length> | <percentage>";
       inherits: false;
       initial-value: 50%;
     }
 
     @property --tw-gradient-to-position {
-      syntax: "<length-percentage>";
+      syntax: "<length> | <percentage>";
       inherits: false;
       initial-value: 100%;
     }"
@@ -8671,19 +8671,19 @@ test('to', () => {
     }
 
     @property --tw-gradient-from-position {
-      syntax: "<length-percentage>";
+      syntax: "<length> | <percentage>";
       inherits: false;
       initial-value: 0%;
     }
 
     @property --tw-gradient-via-position {
-      syntax: "<length-percentage>";
+      syntax: "<length> | <percentage>";
       inherits: false;
       initial-value: 50%;
     }
 
     @property --tw-gradient-to-position {
-      syntax: "<length-percentage>";
+      syntax: "<length> | <percentage>";
       inherits: false;
       initial-value: 100%;
     }"

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -1222,8 +1222,8 @@ export function createUtilities(theme: Theme) {
 
   let translateProperties = () =>
     atRoot([
-      property('--tw-translate-x', '0', '<length-percentage>'),
-      property('--tw-translate-y', '0', '<length-percentage>'),
+      property('--tw-translate-x', '0', '<length> | <percentage>'),
+      property('--tw-translate-y', '0', '<length> | <percentage>'),
       property('--tw-translate-z', '0', '<length>'),
     ])
 
@@ -2579,9 +2579,9 @@ export function createUtilities(theme: Theme) {
       property('--tw-gradient-to', 'transparent', '<color>'),
       property('--tw-gradient-stops'),
       property('--tw-gradient-via-stops'),
-      property('--tw-gradient-from-position', '0%', '<length-percentage>'),
-      property('--tw-gradient-via-position', '50%', '<length-percentage>'),
-      property('--tw-gradient-to-position', '100%', '<length-percentage>'),
+      property('--tw-gradient-from-position', '0%', '<length> | <percentage>'),
+      property('--tw-gradient-via-position', '50%', '<length> | <percentage>'),
+      property('--tw-gradient-to-position', '100%', '<length> | <percentage>'),
     ])
   }
 


### PR DESCRIPTION
In Firefox Nightly, when using properties that declare the shorthand syntax `<length-percentage>`, there is a bug where two properties side-by-side e.g. `var(—foo)var(—bar)` invalidate the property value when it should not. Switching the `@property` definition to use the long form syntax `<length> | <percentage>` fixes this.
