### PR TITLE
Add ESM build of the `@tailwindcss/postcss` package

### DIFF
--- a/packages/@tailwindcss-postcss/package.json
+++ b/packages/@tailwindcss-postcss/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://tailwindcss.com",
   "scripts": {
     "lint": "tsc --noEmit",
-    "build": "tsup-node ./src/index.ts --format cjs --dts --cjsInterop --splitting --minify --clean",
+    "build": "tsup-node ./src/index.ts --format cjs,esm --dts --cjsInterop --splitting --minify --clean",
     "dev": "pnpm run build -- --watch"
   },
   "files": [
@@ -25,7 +25,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }
   },

--- a/packages/@tailwindcss-postcss/package.json
+++ b/packages/@tailwindcss-postcss/package.json
@@ -25,6 +25,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
       "require": "./dist/index.js"
     }
   },


### PR DESCRIPTION
This PR adds the ability to import the postcss plugin into esm files.

the package is currently published as CJS, but does not provide an export for ESM files to consume it. I ran into this when  trying to use the postcss plugin inside my esm `vite.config.ts` file.

See: https://nodejs.org/api/packages.html#conditional-exports

"import" - matches when the package is loaded via import or import(), or via any top-level import or resolve operation by the ECMAScript module loader. Applies **regardless of the module format of the target file**.
