### PR TITLE
fixed bg-clip-text invalid property value error in Brave Version 1.29.80 (Chromium: 93.0.4577.63)

### DIFF
--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -8732,6 +8732,7 @@ test('bg-clip', () => {
     }
 
     .bg-clip-text {
+      -webkit-background-clip: text;
       background-clip: text;
     }"
   `)

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -2696,7 +2696,7 @@ export function createUtilities(theme: Theme) {
   /**
    * @css `background-clip`
    */
-  staticUtility('bg-clip-text', [['background-clip', 'text']])
+  staticUtility('bg-clip-text', [['-webkit-background-clip', 'text'], ['background-clip', 'text']])
   staticUtility('bg-clip-border', [['background-clip', 'border-box']])
   staticUtility('bg-clip-padding', [['background-clip', 'padding-box']])
   staticUtility('bg-clip-content', [['background-clip', 'content-box']])


### PR DESCRIPTION
`bg-clip-text`, which translates to `background-clip: text` does not work on the latest Brave version (1.29.80).

It says: "Invalid property value".

By simply adding the -webkit-background-clip counterpart  similarly to other classes (e.g., box-decoration), it works like a charm !

Cheers