### PR TITLE
Use `length` data type for `background-size` instead of `background-position`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Use `length` data type for `background-size` instead of `background-position` ([#13771](https://github.com/tailwindlabs/tailwindcss/pull/13771))
 
 ## [4.0.0-alpha.15] - 2024-05-08
 

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -7710,7 +7710,9 @@ test('bg', () => {
         'bg-[50%]',
         'bg-[120px]',
         'bg-[120px_120px]',
+        'bg-[length:120px_120px]',
         'bg-[position:120px_120px]',
+        'bg-[size:120px_120px]',
 
         // background-repeat
         'bg-repeat',
@@ -7834,7 +7836,7 @@ test('bg', () => {
       background-size: cover;
     }
 
-    .bg-\\[size\\:120px_120px\\] {
+    .bg-\\[length\\:120px_120px\\], .bg-\\[size\\:120px_120px\\] {
       background-size: 120px 120px;
     }
 

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -2502,10 +2502,10 @@ export function createUtilities(theme: Theme) {
         inferDataType(value, [
           'image',
           'color',
-          'length',
           'percentage',
           'position',
           'bg-size',
+          'length',
           'url',
         ])
 

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -2514,9 +2514,9 @@ export function createUtilities(theme: Theme) {
         case 'position': {
           return [decl('background-position', value)]
         }
+        case 'bg-size':
         case 'length':
-        case 'size':
-        case 'bg-size': {
+        case 'size': {
           return [decl('background-size', value)]
         }
         case 'image':

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -2510,11 +2510,11 @@ export function createUtilities(theme: Theme) {
         ])
 
       switch (type) {
-        case 'length':
         case 'percentage':
         case 'position': {
           return [decl('background-position', value)]
         }
+        case 'length':
         case 'size':
         case 'bg-size': {
           return [decl('background-size', value)]


### PR DESCRIPTION
This PR fixes a backwards compatibility issue where the data type for `length` uses `background-position` instead of `background-size`:

v3:
```css
.bg-\[length\:50px_100px\] {
  background-size: 50px 100px;
}
```

v4 before this change:
```css
.bg-\[length\:50px_100px\] {
  background-position: 50px 100px;
}
```

v4 after this change:
```css
.bg-\[length\:50px_100px\] {
  background-size: 50px 100px;
}
```

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
