### PR TITLE
Fix background position value of `bg-right-top`, `bg-right-bottom`, `bg-left-bottom` and `bg-left-top`

### DIFF
--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -7973,19 +7973,19 @@ test('bg', () => {
     }
 
     .bg-left-bottom {
-      background-position: left-bottom;
+      background-position: 0 100%;
     }
 
     .bg-left-top {
-      background-position: left-top;
+      background-position: 0 0;
     }
 
     .bg-right-bottom {
-      background-position: right-bottom;
+      background-position: 100% 100%;
     }
 
     .bg-right-top {
-      background-position: right-top;
+      background-position: 100% 0;
     }
 
     .bg-top {

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -2467,13 +2467,13 @@ export function createUtilities(theme: Theme) {
 
   staticUtility('bg-center', [['background-position', 'center']])
   staticUtility('bg-top', [['background-position', 'top']])
-  staticUtility('bg-right-top', [['background-position', 'right-top']])
+  staticUtility('bg-right-top', [['background-position', 'right top']])
   staticUtility('bg-right', [['background-position', 'right']])
-  staticUtility('bg-right-bottom', [['background-position', 'right-bottom']])
+  staticUtility('bg-right-bottom', [['background-position', 'right bottom']])
   staticUtility('bg-bottom', [['background-position', 'bottom']])
-  staticUtility('bg-left-bottom', [['background-position', 'left-bottom']])
+  staticUtility('bg-left-bottom', [['background-position', 'left bottom']])
   staticUtility('bg-left', [['background-position', 'left']])
-  staticUtility('bg-left-top', [['background-position', 'left-top']])
+  staticUtility('bg-left-top', [['background-position', 'left top']])
 
   staticUtility('bg-repeat', [['background-repeat', 'repeat']])
   staticUtility('bg-no-repeat', [['background-repeat', 'no-repeat']])


### PR DESCRIPTION
This PR fixes the values of the `bg-right-top`, `bg-right-bottom`, `bg-left-bottom` and `bg-left-top` utilities.

In the tests they are normalized to percentage values by Lightning CSS.
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
