### PR TITLE
Use no value instead of `blur(0px)` for `backdrop-blur-none` and `blur-none` utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Disable automatic `var()` injection for anchor properties ([#13826](https://github.com/tailwindlabs/tailwindcss/pull/13826))
+- Use no value instead of `blur(0px)` for `backdrop-blur-none` and `blur-none` utilities ([#13830](https://github.com/tailwindlabs/tailwindcss/pull/13830))
 
 ## [3.4.4] - 2024-06-05
 

--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -2596,7 +2596,7 @@ export let corePlugins = {
       {
         blur: (value) => {
           return {
-            '--tw-blur': `blur(${value})`,
+            '--tw-blur': value.trim() === '' ? ' ' : `blur(${value})`,
             '@defaults filter': {},
             filter: cssFilterValue,
           }
@@ -2751,7 +2751,7 @@ export let corePlugins = {
       {
         'backdrop-blur': (value) => {
           return {
-            '--tw-backdrop-blur': `blur(${value})`,
+            '--tw-backdrop-blur': value.trim() === '' ? ' ' : `blur(${value})`,
             '@defaults backdrop-filter': {},
             'backdrop-filter': cssBackdropFilterValue,
           }

--- a/stubs/config.full.js
+++ b/stubs/config.full.js
@@ -70,7 +70,7 @@ module.exports = {
     },
     blur: {
       0: '0',
-      none: '0',
+      none: '',
       sm: '4px',
       DEFAULT: '8px',
       md: '12px',

--- a/tests/basic-usage.test.css
+++ b/tests/basic-usage.test.css
@@ -974,6 +974,11 @@
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale)
     var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
+.blur-none {
+  --tw-blur: ;
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale)
+    var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
 .brightness-150 {
   --tw-brightness: brightness(1.5);
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale)
@@ -1023,6 +1028,12 @@
 }
 .backdrop-blur-lg {
   --tw-backdrop-blur: blur(16px);
+  backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast)
+    var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert)
+    var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+}
+.backdrop-blur-none {
+  --tw-backdrop-blur: ;
   backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast)
     var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert)
     var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);

--- a/tests/basic-usage.test.js
+++ b/tests/basic-usage.test.js
@@ -129,7 +129,7 @@ test('basic usage', () => {
           <div
             class="
               filter filter-none
-              blur-md
+              blur-md blur-none
               brightness-150
               contrast-50
               drop-shadow-md
@@ -144,7 +144,7 @@ test('basic usage', () => {
             class="
               backdrop-filter
               backdrop-filter-none
-              backdrop-blur-lg
+              backdrop-blur-lg backdrop-blur-none
               backdrop-brightness-50
               backdrop-contrast-0
               backdrop-grayscale


### PR DESCRIPTION
This PR maps the values for `backdrop-blur-none` and `blur-none` to no value at all instead of `blur(0px)`. This makes sure that filter is completely gone.

```diff
    .backdrop-blur-none {
-     --tw-backdrop-blur: blur(0);
+     --tw-backdrop-blur: ;
      backdrop-filter: var(--tw-backdrop-blur)
        var(--tw-backdrop-brightness) var(--tw-backdrop-contrast)
        var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate)
        var(--tw-backdrop-invert) var(--tw-backdrop-opacity)
        var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
    }
```

```diff
    .blur-none {
-     --tw-blur: blur(0);
+     --tw-blur: ;
      filter: var(--tw-blur) var(--tw-brightness)
        var(--tw-contrast) var(--tw-grayscale)
        var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate)
        var(--tw-sepia) var(--tw-drop-shadow);
    }
```

Fixes: #13821

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
