### PR TITLE
Include variable in output for bare utilities like `rounded`

### DIFF
--- a/packages/tailwindcss/src/theme.ts
+++ b/packages/tailwindcss/src/theme.ts
@@ -65,9 +65,10 @@ export class Theme {
     }
   }
 
-  #resolveKey(candidateValue: string, themeKeys: ThemeKey[]): string | null {
+  #resolveKey(candidateValue: string | null, themeKeys: ThemeKey[]): string | null {
     for (let key of themeKeys) {
-      let themeKey = escape(`${key}-${candidateValue.replaceAll('.', '_')}`)
+      let themeKey =
+        candidateValue !== null ? escape(`${key}-${candidateValue.replaceAll('.', '_')}`) : key
 
       if (this.values.has(themeKey)) {
         return themeKey
@@ -85,7 +86,7 @@ export class Theme {
     return `var(${themeKey}, ${this.values.get(themeKey)?.value})`
   }
 
-  resolve(candidateValue: string, themeKeys: ThemeKey[]): string | null {
+  resolve(candidateValue: string | null, themeKeys: ThemeKey[]): string | null {
     let themeKey = this.#resolveKey(candidateValue, themeKeys)
 
     if (!themeKey) return null
@@ -93,7 +94,7 @@ export class Theme {
     return this.#var(themeKey)
   }
 
-  resolveValue(candidateValue: string, themeKeys: ThemeKey[]): string | null {
+  resolveValue(candidateValue: string | null, themeKeys: ThemeKey[]): string | null {
     let themeKey = this.#resolveKey(candidateValue, themeKeys)
 
     if (!themeKey) return null

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -6735,7 +6735,7 @@ test('rounded', () => {
     }
 
     .rounded {
-      border-radius: .25rem;
+      border-radius: var(--radius, .25rem);
     }
 
     .rounded-\\[4px\\] {
@@ -6782,8 +6782,8 @@ test('rounded-s', () => {
     }
 
     .rounded-s {
-      border-start-start-radius: .25rem;
-      border-end-start-radius: .25rem;
+      border-start-start-radius: var(--radius, .25rem);
+      border-end-start-radius: var(--radius, .25rem);
     }
 
     .rounded-s-\\[4px\\] {
@@ -6834,8 +6834,8 @@ test('rounded-e', () => {
     }
 
     .rounded-e {
-      border-start-end-radius: .25rem;
-      border-end-end-radius: .25rem;
+      border-start-end-radius: var(--radius, .25rem);
+      border-end-end-radius: var(--radius, .25rem);
     }
 
     .rounded-e-\\[4px\\] {
@@ -6886,8 +6886,8 @@ test('rounded-t', () => {
     }
 
     .rounded-t {
-      border-top-left-radius: .25rem;
-      border-top-right-radius: .25rem;
+      border-top-left-radius: var(--radius, .25rem);
+      border-top-right-radius: var(--radius, .25rem);
     }
 
     .rounded-t-\\[4px\\] {
@@ -6938,8 +6938,8 @@ test('rounded-r', () => {
     }
 
     .rounded-r {
-      border-top-right-radius: .25rem;
-      border-bottom-right-radius: .25rem;
+      border-top-right-radius: var(--radius, .25rem);
+      border-bottom-right-radius: var(--radius, .25rem);
     }
 
     .rounded-r-\\[4px\\] {
@@ -6990,8 +6990,8 @@ test('rounded-b', () => {
     }
 
     .rounded-b {
-      border-bottom-right-radius: .25rem;
-      border-bottom-left-radius: .25rem;
+      border-bottom-right-radius: var(--radius, .25rem);
+      border-bottom-left-radius: var(--radius, .25rem);
     }
 
     .rounded-b-\\[4px\\] {
@@ -7042,8 +7042,8 @@ test('rounded-l', () => {
     }
 
     .rounded-l {
-      border-top-left-radius: .25rem;
-      border-bottom-left-radius: .25rem;
+      border-top-left-radius: var(--radius, .25rem);
+      border-bottom-left-radius: var(--radius, .25rem);
     }
 
     .rounded-l-\\[4px\\] {
@@ -7094,7 +7094,7 @@ test('rounded-ss', () => {
     }
 
     .rounded-ss {
-      border-start-start-radius: .25rem;
+      border-start-start-radius: var(--radius, .25rem);
     }
 
     .rounded-ss-\\[4px\\] {
@@ -7147,7 +7147,7 @@ test('rounded-se', () => {
     }
 
     .rounded-se {
-      border-start-end-radius: .25rem;
+      border-start-end-radius: var(--radius, .25rem);
     }
 
     .rounded-se-\\[4px\\] {
@@ -7200,7 +7200,7 @@ test('rounded-ee', () => {
     }
 
     .rounded-ee {
-      border-end-end-radius: .25rem;
+      border-end-end-radius: var(--radius, .25rem);
     }
 
     .rounded-ee-\\[4px\\] {
@@ -7253,7 +7253,7 @@ test('rounded-es', () => {
     }
 
     .rounded-es {
-      border-end-start-radius: .25rem;
+      border-end-start-radius: var(--radius, .25rem);
     }
 
     .rounded-es-\\[4px\\] {
@@ -7306,7 +7306,7 @@ test('rounded-tl', () => {
     }
 
     .rounded-tl {
-      border-top-left-radius: .25rem;
+      border-top-left-radius: var(--radius, .25rem);
     }
 
     .rounded-tl-\\[4px\\] {
@@ -7359,7 +7359,7 @@ test('rounded-tr', () => {
     }
 
     .rounded-tr {
-      border-top-right-radius: .25rem;
+      border-top-right-radius: var(--radius, .25rem);
     }
 
     .rounded-tr-\\[4px\\] {
@@ -7412,7 +7412,7 @@ test('rounded-br', () => {
     }
 
     .rounded-br {
-      border-bottom-right-radius: .25rem;
+      border-bottom-right-radius: var(--radius, .25rem);
     }
 
     .rounded-br-\\[4px\\] {
@@ -7465,7 +7465,7 @@ test('rounded-bl', () => {
     }
 
     .rounded-bl {
-      border-bottom-left-radius: .25rem;
+      border-bottom-left-radius: var(--radius, .25rem);
     }
 
     .rounded-bl-\\[4px\\] {

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -310,12 +310,11 @@ export function createUtilities(theme: Theme) {
       let value: string | null = null
 
       if (!candidate.value) {
-        // If the candidate has no value segment (like `shadow`), use the
-        // `defaultValue` or the `DEFAULT` value in the theme. No utility will
-        // ever support both of these — `defaultValue` is for things like
-        // `grayscale` whereas the `DEFAULT` in theme is for things like
-        // `shadow` or `blur`.
-        value = desc.defaultValue ?? theme.get(desc.themeKeys ?? [])
+        // If the candidate has no value segment (like `rounded`), use the
+        // `defaultValue` (for candidates like `grow` that have no theme values)
+        // or a bare theme value (like `--radius` for `rounded`). No utility
+        // will ever support both of these.
+        value = desc.defaultValue ?? theme.resolve(null, desc.themeKeys ?? [])
       } else if (candidate.value.kind === 'arbitrary') {
         value = candidate.value.value
       } else {


### PR DESCRIPTION
This PR ensures that utilities like `rounded` still include their associated CSS variable in the generated CSS.

Previously, utilities like `rounded-sm` would generate this output:

```css
.rounded-sm {
  border-radius: var(--radius-sm, 0.125rem /* 2px */);
}
```

...but `rounded` generated this:

```css
.rounded {
  border-radius: 0.25rem /* 4px */;
}
```

This PR fixes things so `rounded` generates this:

```css
.rounded {
  border-radius: var(--radius, 0.25rem /* 4px */);
}
```

Open to feedback from @RobinMalfait and @thecrypticace on the implementation — I reworked `theme.resolveValue` to be able to handle this situation by accepting `null` in the slot that you'd normally pass the candidate value like `sm` or `md` which works but I'm not sure feels 100% great. It doesn't feel wrong though either, feels reasonable to need to resolve a theme value for a namespace but provide no value, since that literally is the case with things like `--radius`.

It's kind of weird that we use `desc.themeKeys` (as an array) at all in the default case because there are no utilities that would ever check multiple namespaces for a default value, but maybe there could be in the future?

Resolves #13834.