### PR TITLE
Loosen :is() wrapping rules in applyImportantSelector for more readable output

### DIFF
--- a/src/util/applyImportantSelector.js
+++ b/src/util/applyImportantSelector.js
@@ -5,13 +5,12 @@ export function applyImportantSelector(selector, important) {
   let sel = parser().astSync(selector)
 
   sel.each((sel) => {
-    // Wrap with :is if it's not already wrapped
-    let isWrapped =
-      sel.nodes[0].type === 'pseudo' &&
-      sel.nodes[0].value === ':is' &&
-      sel.nodes.every((node) => node.type !== 'combinator')
+    // For nesting, we only need to wrap a selector with :is() if it has a top-level combinator,
+    // e.g. `.dark .text-white`, to be independent of DOM order. Any other selector, including
+    // combinators inside of pseudos like `:where()`, are ok to nest.
+    let shouldWrap = sel.nodes.some((node) => node.type === 'combinator')
 
-    if (!isWrapped) {
+    if (shouldWrap) {
       sel.nodes = [
         parser.pseudo({
           value: ':is',

--- a/tests/util/apply-important-selector.test.js
+++ b/tests/util/apply-important-selector.test.js
@@ -2,24 +2,23 @@ import { applyImportantSelector } from '../../src/util/applyImportantSelector'
 
 it.each`
   before                                                        | after
-  ${'.foo'}                                                     | ${'#app :is(.foo)'}
+  ${'.foo'}                                                     | ${'#app .foo'}
   ${'.foo .bar'}                                                | ${'#app :is(.foo .bar)'}
-  ${'.foo:hover'}                                               | ${'#app :is(.foo:hover)'}
+  ${'.foo:hover'}                                               | ${'#app .foo:hover'}
   ${'.foo .bar:hover'}                                          | ${'#app :is(.foo .bar:hover)'}
-  ${'.foo::before'}                                             | ${'#app :is(.foo)::before'}
-  ${'.foo::before'}                                             | ${'#app :is(.foo)::before'}
-  ${'.foo::file-selector-button'}                               | ${'#app :is(.foo)::file-selector-button'}
-  ${'.foo::-webkit-progress-bar'}                               | ${'#app :is(.foo)::-webkit-progress-bar'}
-  ${'.foo:hover::before'}                                       | ${'#app :is(.foo:hover)::before'}
+  ${'.foo::before'}                                             | ${'#app .foo::before'}
+  ${'.foo::file-selector-button'}                               | ${'#app .foo::file-selector-button'}
+  ${'.foo::-webkit-progress-bar'}                               | ${'#app .foo::-webkit-progress-bar'}
+  ${'.foo:hover::before'}                                       | ${'#app .foo:hover::before'}
   ${':is(:where(.dark) :is(:where([dir="rtl"]) .foo::before))'} | ${'#app :is(:where(.dark) :is(:where([dir="rtl"]) .foo))::before'}
   ${':is(:where(.dark) .foo) .bar'}                             | ${'#app :is(:is(:where(.dark) .foo) .bar)'}
   ${':is(.foo) :is(.bar)'}                                      | ${'#app :is(:is(.foo) :is(.bar))'}
   ${':is(.foo)::before'}                                        | ${'#app :is(.foo)::before'}
-  ${'.foo:before'}                                              | ${'#app :is(.foo):before'}
-  ${'.foo::some-uknown-pseudo'}                                 | ${'#app :is(.foo)::some-uknown-pseudo'}
-  ${'.foo::some-uknown-pseudo:hover'}                           | ${'#app :is(.foo)::some-uknown-pseudo:hover'}
-  ${'.foo:focus::some-uknown-pseudo:hover'}                     | ${'#app :is(.foo:focus)::some-uknown-pseudo:hover'}
-  ${'.foo:hover::some-uknown-pseudo:focus'}                     | ${'#app :is(.foo:hover)::some-uknown-pseudo:focus'}
+  ${'.foo:before'}                                              | ${'#app .foo:before'}
+  ${'.foo::some-uknown-pseudo'}                                 | ${'#app .foo::some-uknown-pseudo'}
+  ${'.foo::some-uknown-pseudo:hover'}                           | ${'#app .foo::some-uknown-pseudo:hover'}
+  ${'.foo:focus::some-uknown-pseudo:hover'}                     | ${'#app .foo:focus::some-uknown-pseudo:hover'}
+  ${'.foo:hover::some-uknown-pseudo:focus'}                     | ${'#app .foo:hover::some-uknown-pseudo:focus'}
 `('should generate "$after" from "$before"', ({ before, after }) => {
   expect(applyImportantSelector(before, '#app')).toEqual(after)
 })


### PR DESCRIPTION
Hi, this is just a small quality of life improvement to the changes made in #10835, intended for a v3.x.

I'm using the `important` selector strategy, and noticed that for most cases, output like

```css
.tw :is(.text-citrine-500) {
  --tw-text-opacity: 1;
  color: rgb(246 220 82 / var(--tw-text-opacity)) /* #f6dc52 */;
}
```

can be reduced to simply

```css
.tw .text-citrine-500 {
  --tw-text-opacity: 1;
  color: rgb(246 220 82 / var(--tw-text-opacity)) /* #f6dc52 */;
}
```

because the nested selector doesn't contain a descendant selector like `.dark .text-citrine-500`. I'm sure the unnecessary `:is()` would be removed in minification, but having the "cleanest" possible output for Intellisense would be nice. (Trying to convince my coworkers to get on board, and making the previews feel more "hand-written" might help! 😁)

As far as I can tell, this change can't affect the behavior of any possible selector passed in. Feel free to close if you can find a counterexample. Thank you!

**Edit:** we're switching from the important selector strategy to prefixing, so we won't actually need this, if that affects whether you'll consider it.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
