### PR TITLE
Revert “Prevent Preflight from affecting list semantics”

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `rounded-4xl` utility ([#13827](https://github.com/tailwindlabs/tailwindcss/pull/13827))
 - Add `backdrop-blur-none` and `blur-none` utilities ([#13831](https://github.com/tailwindlabs/tailwindcss/pull/13831))
 - Include variable in output for bare utilities like `rounded` ([#13836](https://github.com/tailwindlabs/tailwindcss/pull/13836))
-- Preserve list semantics for `ul`, `li`, and `menu` by default ([#13815](https://github.com/tailwindlabs/tailwindcss/pull/13815))
 
 ### Fixed
 

--- a/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
@@ -553,7 +553,7 @@ exports[`\`@import 'tailwindcss'\` is replaced with the generated CSS 1`] = `
   }
 
   ol, ul, menu {
-    list-style: "";
+    list-style: none;
   }
 
   textarea {

--- a/packages/tailwindcss/preflight.css
+++ b/packages/tailwindcss/preflight.css
@@ -262,13 +262,13 @@ summary {
 }
 
 /*
-  Make lists unstyled by default, without affecting semantics. (https://www.matuzo.at/blog/2023/removing-list-styles-without-affecting-semantics)
+  Make lists unstyled by default.
 */
 
 ol,
 ul,
 menu {
-  list-style: '';
+  list-style: none;
 }
 
 /*


### PR DESCRIPTION
Unfortunately, I realized after my previous PR (#13815) got merged that there is one case where there is a visual difference between `list-style: none` and `list-style: ""`, which is when the `<li>` is empty. With `list-style: ""`, it still takes up space, as you can see in this CodePen: https://codepen.io/benface/pen/MWdRdyY. I guess we'll have to keep using `role="list"` when we want to keep the list semantics.