### PR TITLE
Add `.mts` and `.cts` config file detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Disable automatic `var()` injection for anchor properties ([#13826](https://github.com/tailwindlabs/tailwindcss/pull/13826))
 - Use no value instead of `blur(0px)` for `backdrop-blur-none` and `blur-none` utilities ([#13830](https://github.com/tailwindlabs/tailwindcss/pull/13830))
+- Add `.mts` and `.cts` config file detection ([#13940](https://github.com/tailwindlabs/tailwindcss/pull/13940))
 
 ## [3.4.4] - 2024-06-05
 

--- a/integrations/tailwindcss-cli/tests/integration.test.js
+++ b/integrations/tailwindcss-cli/tests/integration.test.js
@@ -134,51 +134,54 @@ describe('static build', () => {
     )
   })
 
-  it('can use a tailwind.config.ts configuration file', async () => {
-    await removeFile('tailwind.config.js')
-    await writeInputFile('index.html', html`<div class="bg-primary"></div>`)
-    await writeInputFile(
-      'index.css',
-      css`
-        @tailwind base;
-        @tailwind components;
-        @tailwind utilities;
-      `
-    )
-    await writeInputFile(
-      '../tailwind.config.ts',
-      javascript`
-        import type { Config } from 'tailwindcss'
+  it.each([['../tailwind.config.ts'], ['../tailwind.config.cts'], ['../tailwind.config.mts']])(
+    'can use a %s configuration file',
+    async (path) => {
+      await removeFile('tailwind.config.js')
+      await writeInputFile('index.html', html`<div class="bg-primary"></div>`)
+      await writeInputFile(
+        'index.css',
+        css`
+          @tailwind base;
+          @tailwind components;
+          @tailwind utilities;
+        `
+      )
+      await writeInputFile(
+        path,
+        javascript`
+          import type { Config } from 'tailwindcss'
 
-        export default {
-          content: ['./src/index.html'],
-          theme: {
-            extend: {
-              colors: {
-                primary: 'black',
+          export default {
+            content: ['./src/index.html'],
+            theme: {
+              extend: {
+                colors: {
+                  primary: 'black',
+                },
               },
             },
-          },
-          corePlugins: {
-            preflight: false,
-          },
-        } satisfies Config
-      `
-    )
+            corePlugins: {
+              preflight: false,
+            },
+          } satisfies Config
+        `
+      )
 
-    await $('node ../../lib/cli.js -i ./src/index.css -o ./dist/main.css', {
-      env: { NODE_ENV: 'production' },
-    })
+      await $('node ../../lib/cli.js -i ./src/index.css -o ./dist/main.css', {
+        env: { NODE_ENV: 'production' },
+      })
 
-    expect(await readOutputFile('main.css')).toIncludeCss(
-      css`
-        .bg-primary {
-          --tw-bg-opacity: 1;
-          background-color: rgb(0 0 0 / var(--tw-bg-opacity));
-        }
-      `
-    )
-  })
+      expect(await readOutputFile('main.css')).toIncludeCss(
+        css`
+          .bg-primary {
+            --tw-bg-opacity: 1;
+            background-color: rgb(0 0 0 / var(--tw-bg-opacity));
+          }
+        `
+      )
+    }
+  )
 
   it('can read from a config file from an @config directive', async () => {
     await writeInputFile('index.html', html`<div class="bg-yellow"></div>`)

--- a/src/lib/load-config.ts
+++ b/src/lib/load-config.ts
@@ -33,6 +33,17 @@ function lazyJiti() {
 
 export function loadConfig(path: string): Config {
   let config = (function () {
+    // Always use jiti for ESM or TS files
+    if (
+      path &&
+      (path.endsWith('.mjs') ||
+        path.endsWith('.ts') ||
+        path.endsWith('.cts') ||
+        path.endsWith('.mts'))
+    ) {
+      return lazyJiti()(path)
+    }
+
     try {
       return path ? require(path) : {}
     } catch {

--- a/src/util/resolveConfigPath.js
+++ b/src/util/resolveConfigPath.js
@@ -6,6 +6,8 @@ const defaultConfigFiles = [
   './tailwind.config.cjs',
   './tailwind.config.mjs',
   './tailwind.config.ts',
+  './tailwind.config.cts',
+  './tailwind.config.mts',
 ]
 
 function isObject(value) {


### PR DESCRIPTION
This PR will add support for detecting `tailwind.config.cts` and `tailwind.config.mts` files by default.

This PR will also remove some warnings that Node v22 was showing in the terminal when using ESM files (or TS files). If you happen to use an ESM file (`.mjs`) or any TS file (`.ts`, `.cts` or `.mts`), then we will immediately use `jiti` instead of first trying to `require` the file. Requiring these files triggers Node in logging the warning.

Fixes: #13927

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
