### PR TITLE
Avoid over-extracting utilities from candidates with decimal values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Disable automatic `var()` injection for anchor properties ([#13826](https://github.com/tailwindlabs/tailwindcss/pull/13826))
 - Use no value instead of `blur(0px)` for `backdrop-blur-none` and `blur-none` utilities ([#13830](https://github.com/tailwindlabs/tailwindcss/pull/13830))
 - Add `.mts` and `.cts` config file detection ([#13940](https://github.com/tailwindlabs/tailwindcss/pull/13940))
+- Don't generate utilities like `px-1` unnecessarily when using utilities like `px-1.5` ([#13959](https://github.com/tailwindlabs/tailwindcss/pull/13959))
 
 ## [3.4.4] - 2024-06-05
 

--- a/tests/default-extractor.test.js
+++ b/tests/default-extractor.test.js
@@ -476,6 +476,19 @@ test('classes in slim templates', async () => {
   expect(extractions).toContain('text-gray-500')
 })
 
+test("classes with fractional numeric values don't also generate the whole number utility", async () => {
+  const extractions = defaultExtractor(`
+    <div class="px-1.5 py-2.75">Hello world!</div>
+  `)
+
+  expect(extractions).toContain('px-1.5')
+  expect(extractions).toContain('py-2.75')
+  expect(extractions).not.toContain('px-1')
+  expect(extractions).not.toContain('5')
+  expect(extractions).not.toContain('py-2')
+  expect(extractions).not.toContain('75')
+})
+
 test('multi-word + arbitrary values + quotes', async () => {
   const extractions = defaultExtractor(`
     grid-cols-['repeat(2)']


### PR DESCRIPTION
Prevents candidates like `px-1.5` from generating both the `px-1.5` class and the `px-1` class.

There's a chance that the inner matches regex we're throwing away here handles some other cases that aren't currently tested, but since they aren't tested I'm assuming it's not needed. We'll find out quickly from our users if they were and can fix it then :)

Fixes #13952 and #9354 and probably a bunch of other issues that have been opened for the same thing.