### PR TITLE
Discard invalid classes such as `bg-red-[#000]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Discard invalid classes such as `bg-red-[#000]` ([#13970](https://github.com/tailwindlabs/tailwindcss/pull/13970))
 
 ## [4.0.0-alpha.17] - 2024-07-04
 

--- a/packages/tailwindcss/src/candidate.test.ts
+++ b/packages/tailwindcss/src/candidate.test.ts
@@ -436,6 +436,15 @@ it('should parse a utility with a modifier and a variant', () => {
   `)
 })
 
+it('should not parse a partial utility', () => {
+  let utilities = new Utilities()
+  utilities.static('flex', () => [])
+  utilities.functional('bg', () => [])
+
+  expect(run('flex-', { utilities })).toMatchInlineSnapshot(`null`)
+  expect(run('bg-', { utilities })).toMatchInlineSnapshot(`null`)
+})
+
 it('should parse a utility with an arbitrary value', () => {
   let utilities = new Utilities()
   utilities.functional('bg', () => [])

--- a/packages/tailwindcss/src/candidate.test.ts
+++ b/packages/tailwindcss/src/candidate.test.ts
@@ -641,6 +641,42 @@ it('should parse a utility with an explicit variable as the arbitrary value that
     `)
 })
 
+it('should not parse invalid arbitrary values', () => {
+  let utilities = new Utilities()
+  utilities.functional('bg', () => [])
+
+  for (let candidate of [
+    'bg-red-[#0088cc]',
+    'bg-red[#0088cc]',
+
+    'bg-red-[color:var(--value)]',
+    'bg-red[color:var(--value)]',
+
+    'bg-red-[#0088cc]/50',
+    'bg-red[#0088cc]/50',
+
+    'bg-red-[#0088cc]/[50%]',
+    'bg-red[#0088cc]/[50%]',
+
+    'bg-red-[#0088cc]!',
+    'bg-red[#0088cc]!',
+
+    'bg-red-[--value]',
+    'bg-red[--value]',
+
+    'bg-red-[--value]!',
+    'bg-red[--value]!',
+
+    'bg-red-[var(--value)]',
+    'bg-red[var(--value)]',
+
+    'bg-red-[var(--value)]!',
+    'bg-red[var(--value)]!',
+  ]) {
+    expect(run(candidate, { utilities })).toEqual(null)
+  }
+})
+
 it('should parse a utility with an implicit variable as the modifier', () => {
   let utilities = new Utilities()
   utilities.functional('bg', () => [])

--- a/packages/tailwindcss/src/candidate.ts
+++ b/packages/tailwindcss/src/candidate.ts
@@ -452,9 +452,7 @@ export function parseCandidate(input: string, designSystem: DesignSystem): Candi
       // If the leftover value is an empty string, it means that the value is an
       // invalid named value. This makes the candidate invalid and we can
       // skip any further parsing.
-      if (value === '') {
-        return null
-      }
+      if (value === '') return null
 
       candidate.value = {
         kind: 'named',

--- a/packages/tailwindcss/src/candidate.ts
+++ b/packages/tailwindcss/src/candidate.ts
@@ -233,21 +233,19 @@ export function parseCandidate(input: string, designSystem: DesignSystem): Candi
     parsedCandidateVariants.push(parsedVariant)
   }
 
-  let state = {
-    important: false,
-    negative: false,
-  }
+  let important = false
+  let negative = false
 
   // Candidates that end with an exclamation mark are the important version with
   // higher specificity of the non-important candidate, e.g. `mx-4!`.
   if (base[base.length - 1] === '!') {
-    state.important = true
+    important = true
     base = base.slice(0, -1)
   }
 
   // Legacy syntax with leading `!`, e.g. `!mx-4`.
   else if (base[0] === '!') {
-    state.important = true
+    important = true
     base = base.slice(1)
   }
 
@@ -298,14 +296,14 @@ export function parseCandidate(input: string, designSystem: DesignSystem): Candi
       value,
       modifier: modifierSegment === null ? null : parseModifier(modifierSegment),
       variants: parsedCandidateVariants,
-      important: state.important,
+      important,
     }
   }
 
   // Candidates that start with a dash are the negative versions of another
   // candidate, e.g. `-mx-4`.
   if (baseWithoutModifier[0] === '-') {
-    state.negative = true
+    negative = true
     baseWithoutModifier = baseWithoutModifier.slice(1)
   }
 
@@ -376,8 +374,8 @@ export function parseCandidate(input: string, designSystem: DesignSystem): Candi
       kind: 'static',
       root,
       variants: parsedCandidateVariants,
-      negative: state.negative,
-      important: state.important,
+      negative,
+      important,
     }
   }
 
@@ -387,8 +385,8 @@ export function parseCandidate(input: string, designSystem: DesignSystem): Candi
     modifier: modifierSegment === null ? null : parseModifier(modifierSegment),
     value: null,
     variants: parsedCandidateVariants,
-    negative: state.negative,
-    important: state.important,
+    negative,
+    important,
   }
 
   if (value === null) return candidate

--- a/packages/tailwindcss/src/candidate.ts
+++ b/packages/tailwindcss/src/candidate.ts
@@ -366,8 +366,8 @@ export function parseCandidate(input: string, designSystem: DesignSystem): Candi
   if (root === null) return null
 
   // If the leftover value is an empty string, it means that the value is an
-  // invalid named value. This makes the candidate invalid and we can skip any
-  // further parsing.
+  // invalid named value, e.g.: `bg-`. This makes the candidate invalid and we
+  // can skip any further parsing.
   if (value === '') return null
 
   let kind = designSystem.utilities.kind(root)

--- a/packages/tailwindcss/src/candidate.ts
+++ b/packages/tailwindcss/src/candidate.ts
@@ -365,6 +365,11 @@ export function parseCandidate(input: string, designSystem: DesignSystem): Candi
   // If there's no root, the candidate isn't a valid class and can be discarded.
   if (root === null) return null
 
+  // If the leftover value is an empty string, it means that the value is an
+  // invalid named value. This makes the candidate invalid and we can skip any
+  // further parsing.
+  if (value === '') return null
+
   let kind = designSystem.utilities.kind(root)
 
   if (kind === 'static') {
@@ -448,11 +453,6 @@ export function parseCandidate(input: string, designSystem: DesignSystem): Candi
         modifierSegment === null || candidate.modifier?.kind === 'arbitrary'
           ? null
           : `${value.slice(value.lastIndexOf('-') + 1)}/${modifierSegment}`
-
-      // If the leftover value is an empty string, it means that the value is an
-      // invalid named value. This makes the candidate invalid and we can
-      // skip any further parsing.
-      if (value === '') return null
 
       candidate.value = {
         kind: 'named',


### PR DESCRIPTION
This PR improves the candidate parser by making sure that invalid candidates are discarded earlier.

When using a utility such as `bg-red-500`, then we have to find the actual plugin by finding the `root`. In this case we will try:

- root: `bg-red-500`, value: null  <- No match yet
- root: `bg-red`, value: `500`     <- No match yet
- root: `bg`, value: `red-500`     <- Bingo, `bg` is a known root

However, if you are using arbitrary values such as `bg-[#000]`, then we know that everything before the `-[#000]` will be the root of the plugin. In this case we can do a direct lookup for `bg`.

Before this change, this wasn't the case (in v4), which means that we could write `bg-red-[#000]` and it parsed just fine.

This PR also adds a test for a case that wasn't covered by any tests, which is when you use a candidate such as `bg-`. This parsed as a root of `"bg"` and a value of `""`.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
