### PR TITLE
Fix parsing body-less at-rule without terminating semicolon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Discard invalid classes such as `bg-red-[#000]` ([#13970](https://github.com/tailwindlabs/tailwindcss/pull/13970))
+- Fix parsing body-less at-rule without terminating semicolon ([#13978](https://github.com/tailwindlabs/tailwindcss/pull/13978))
 
 ## [4.0.0-alpha.17] - 2024-07-04
 

--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -633,6 +633,14 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
       ).toEqual([{ kind: 'rule', selector: '@charset "UTF-8"', nodes: [] }])
     })
 
+    it('should parse an at-rule without a block or semicolon', () => {
+      expect(
+        parse(`
+          @tailwind utilities
+        `),
+      ).toEqual([{ kind: 'rule', selector: '@tailwind utilities', nodes: [] }])
+    })
+
     it("should parse an at-rule without a block or semicolon when it's the last rule in a block", () => {
       expect(
         parse(`

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -461,6 +461,13 @@ export function parse(input: string) {
     }
   }
 
+  // If we have a leftover `buffer` that happens to start with an `@` then it
+  // means that we have an at-rule that is not terminated with a semicolon at
+  // the end of the input.
+  if (buffer[0] === '@') {
+    ast.push(rule(buffer.trim(), []))
+  }
+
   // When we are done parsing then everything should be balanced. If we still
   // have a leftover `parent`, then it means that we have an unterminated block.
   if (closingBracketStack.length > 0 && parent) {


### PR DESCRIPTION
This PR fixes an issue in the CSS parser where a body-less at-rule at the end of the file that is not terminated by a semicolon was missing and didn't parse correctly.

E.g.:
```css
@tailwind utilities
```

Wouldn't parse and the AST was empty. With this PR that's fixed.

When you have a body-less at-rule nested inside a block and without terminating semicolon that worked already as expected:

E.g.:
```css
@layer utilities {
  @tailwind utilities
}
```
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
