### PR TITLE
fix: add color resolver with opacity type to colors property

### DIFF
--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -14,12 +14,14 @@ interface RecursiveKeyValuePair<K extends keyof any = string, V = string> {
 export type ResolvableTo<T> = T | ((utils: PluginUtils) => T)
 type CSSRuleObject = RecursiveKeyValuePair<string, null | string | string[]>
 
+type ColorResolverWithOpacity = (arg: Partial<{ opacityVariable: string; opacityValue: number }>) => string
+
 interface PluginUtils {
   colors: DefaultColors
   theme(path: string, defaultValue?: unknown): any
   breakpoints<I = Record<string, unknown>, O = I>(arg: I): O
-  rgb(arg: string): (arg: Partial<{ opacityVariable: string; opacityValue: number }>) => string
-  hsl(arg: string): (arg: Partial<{ opacityVariable: string; opacityValue: number }>) => string
+  rgb(arg: string): ColorResolverWithOpacity
+  hsl(arg: string):ColorResolverWithOpacity
 }
 
 // Content related config
@@ -93,7 +95,7 @@ export interface ThemeConfig {
   data: ResolvableTo<Record<string, string>>
 
   // Reusable base configs
-  colors: ResolvableTo<RecursiveKeyValuePair>
+  colors: ResolvableTo<RecursiveKeyValuePair<string, string | ColorResolverWithOpacity>> 
   spacing: ResolvableTo<KeyValuePair>
 
   // Components


### PR DESCRIPTION
PR is for missing type in custom color property.
and refactor some duplicated types. 

After this PR type is correctly like below screenshot.
### Screenshot
![Screenshot 2024-07-11 at 2 31 07 AM](https://github.com/tailwindlabs/tailwindcss/assets/66503450/e0b3cd68-cc2a-43a0-be26-62778583a526)

More information linked issue.
resolves: #13917