### PR TITLE
Add support for custom variants via CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add support for basic `addVariant` plugins with new `@plugin` directive ([#13982](https://github.com/tailwindlabs/tailwindcss/pull/13982))
-- Add support for custom variants via CSS ([#13992](https://github.com/tailwindlabs/tailwindcss/pull/13992))
+- Add `@variant` at-rule for defining custom variants in CSS ([#13992](https://github.com/tailwindlabs/tailwindcss/pull/13992))
 
 ## [4.0.0-alpha.17] - 2024-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add support for basic `addVariant` plugins with new `@plugin` directive ([#13982](https://github.com/tailwindlabs/tailwindcss/pull/13982))
+- Add support for custom variants via CSS ([#13992](https://github.com/tailwindlabs/tailwindcss/pull/13992))
 
 ## [4.0.0-alpha.17] - 2024-07-04
 

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -42,7 +42,7 @@ export function comment(value: string): Comment {
   }
 }
 
-export interface CssTree extends Record<string, string | CssTree> {}
+export type CssTree = { [key: string]: string | CssTree }
 
 export function objectToAst(obj: CssTree): AstNode[] {
   let ast: AstNode[] = []

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -42,9 +42,9 @@ export function comment(value: string): Comment {
   }
 }
 
-export type CssTree = { [key: string]: string | CssTree }
+export type CssInJs = { [key: string]: string | CssInJs }
 
-export function objectToAst(obj: CssTree): AstNode[] {
+export function objectToAst(obj: CssInJs): AstNode[] {
   let ast: AstNode[] = []
 
   for (let [name, value] of Object.entries(obj)) {

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -42,6 +42,26 @@ export function comment(value: string): Comment {
   }
 }
 
+export interface CssTree extends Record<string, string | CssTree> {}
+
+export function objectToAst(obj: CssTree): AstNode[] {
+  let ast: AstNode[] = []
+
+  for (let [name, value] of Object.entries(obj)) {
+    if (typeof value === 'string') {
+      if (value === '@slot') {
+        ast.push(rule(name, [rule('@slot', [])]))
+      } else {
+        ast.push(decl(name, value))
+      }
+    } else {
+      ast.push(rule(name, objectToAst(value)))
+    }
+  }
+
+  return ast
+}
+
 export enum WalkAction {
   /** Continue walking, which is the default */
   Continue,

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -49,7 +49,7 @@ export function objectToAst(obj: CssTree): AstNode[] {
 
   for (let [name, value] of Object.entries(obj)) {
     if (typeof value === 'string') {
-      if (value === '@slot') {
+      if (!name.startsWith('--') && value === '@slot') {
         ast.push(rule(name, [rule('@slot', [])]))
       } else {
         ast.push(decl(name, value))

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -78,14 +78,17 @@ export function walk(
   visit: (
     node: AstNode,
     utils: {
+      parent: AstNode | null
       replaceWith(newNode: AstNode | AstNode[]): void
     },
   ) => void | WalkAction,
+  parent: AstNode | null = null,
 ) {
   for (let i = 0; i < ast.length; i++) {
     let node = ast[i]
     let status =
       visit(node, {
+        parent,
         replaceWith(newNode) {
           ast.splice(i, 1, ...(Array.isArray(newNode) ? newNode : [newNode]))
           // We want to visit the newly replaced node(s), which start at the
@@ -102,7 +105,7 @@ export function walk(
     if (status === WalkAction.Skip) continue
 
     if (node.kind === 'rule') {
-      walk(node.nodes, visit)
+      walk(node.nodes, visit, node)
     }
   }
 }

--- a/packages/tailwindcss/src/design-system.ts
+++ b/packages/tailwindcss/src/design-system.ts
@@ -1,4 +1,4 @@
-import { rule, toCss } from './ast'
+import { toCss } from './ast'
 import { parseCandidate, parseVariant } from './candidate'
 import { compileAstNodes, compileCandidates } from './compile'
 import { getClassList, getVariants, type ClassEntry, type VariantEntry } from './intellisense'
@@ -7,10 +7,6 @@ import type { Theme } from './theme'
 import { Utilities, createUtilities } from './utilities'
 import { DefaultMap } from './utils/default-map'
 import { Variants, createVariants } from './variants'
-
-export type Plugin = (api: {
-  addVariant: (name: string, selector: string | string[]) => void
-}) => void
 
 export type DesignSystem = {
   theme: Theme
@@ -29,7 +25,7 @@ export type DesignSystem = {
   getUsedVariants(): ReturnType<typeof parseVariant>[]
 }
 
-export function buildDesignSystem(theme: Theme, plugins: Plugin[] = []): DesignSystem {
+export function buildDesignSystem(theme: Theme): DesignSystem {
   let utilities = createUtilities(theme)
   let variants = createVariants(theme)
 
@@ -79,16 +75,6 @@ export function buildDesignSystem(theme: Theme, plugins: Plugin[] = []): DesignS
     getUsedVariants() {
       return Array.from(parsedVariants.values())
     },
-  }
-
-  for (let plugin of plugins) {
-    plugin({
-      addVariant: (name: string, selectors: string | string[]) => {
-        variants.static(name, (r) => {
-          r.nodes = ([] as string[]).concat(selectors).map((selector) => rule(selector, r.nodes))
-        })
-      },
-    })
   }
 
   return designSystem

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1219,7 +1219,7 @@ describe('plugins', () => {
     `)
   })
 
-  test.skip('addVariant with object syntax, media, nesting and multiple @slot', () => {
+  test('addVariant with object syntax, media, nesting and multiple @slot', () => {
     let compiled = compile(
       css`
         @plugin "my-plugin";
@@ -1578,7 +1578,7 @@ describe('@variant', () => {
       `)
     })
 
-    test.skip('selector nested under at-rule with @slot', () => {
+    test('selector nested under at-rule with @slot', () => {
       let compiled = compile(css`
         @variant hocus {
           @media (hover: hover) {
@@ -1595,8 +1595,10 @@ describe('@variant', () => {
 
       expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
         "@layer utilities {
-          .group-hocus\\:underline:is():hover {
-            text-decoration-line: underline;
+          @media (hover: hover) {
+            .group-hocus\\:underline:is(:where(.group):hover *) {
+              text-decoration-line: underline;
+            }
           }
 
           @media (hover: hover) {

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1299,8 +1299,8 @@ describe('plugins', () => {
   })
 })
 
-describe('custom variants via CSS `@variant` at-rules', () => {
-  test('@variant should be top-level and cannot be nested', () => {
+describe('@variant', () => {
+  test('@variant must be top-level and cannot be nested', () => {
     expect(() =>
       compileCss(css`
         .foo {
@@ -1327,8 +1327,8 @@ describe('custom variants via CSS `@variant` at-rules', () => {
     ).toThrowErrorMatchingInlineSnapshot('[Error: `@variant hocus` has no selector or body.]')
   })
 
-  describe('simple one-liner based', () => {
-    test('selector', () => {
+  describe('body-less syntax', () => {
+    test('selector variant', () => {
       let compiled = compile(css`
         @variant hocus (&:hover, &:focus);
 
@@ -1350,7 +1350,7 @@ describe('custom variants via CSS `@variant` at-rules', () => {
       `)
     })
 
-    test('media query', () => {
+    test('at-rule variant', () => {
       let compiled = compile(css`
         @variant any-hover (@media (any-hover: hover));
 
@@ -1371,8 +1371,8 @@ describe('custom variants via CSS `@variant` at-rules', () => {
     })
   })
 
-  describe('body block based', () => {
-    test('selector and @slot', () => {
+  describe('body with @slot syntax', () => {
+    test('selector with @slot', () => {
       let compiled = compile(css`
         @variant custom-hover {
           &:hover {
@@ -1398,7 +1398,7 @@ describe('custom variants via CSS `@variant` at-rules', () => {
       `)
     })
 
-    test('parallel selector and single @slot', () => {
+    test('grouped selectors with @slot', () => {
       let compiled = compile(css`
         @variant hocus {
           &:hover,
@@ -1425,7 +1425,7 @@ describe('custom variants via CSS `@variant` at-rules', () => {
       `)
     })
 
-    test('parallel selector and multiple @slot', () => {
+    test('multiple selectors with @slot', () => {
       let compiled = compile(css`
         @variant hocus {
           &:hover {
@@ -1455,7 +1455,7 @@ describe('custom variants via CSS `@variant` at-rules', () => {
       `)
     })
 
-    test('selector, nesting and @slot', () => {
+    test('nested selectors with @slot', () => {
       let compiled = compile(css`
         @variant custom-hover {
           &.custom-hover {
@@ -1483,7 +1483,7 @@ describe('custom variants via CSS `@variant` at-rules', () => {
       `)
     })
 
-    test('parallel selector, nesting and single @slot', () => {
+    test('grouped nested selectors with @slot', () => {
       let compiled = compile(css`
         @variant hocus {
           &.hocus {
@@ -1544,7 +1544,7 @@ describe('custom variants via CSS `@variant` at-rules', () => {
       `)
     })
 
-    test('media and @slot', () => {
+    test('at-rule with @slot', () => {
       let compiled = compile(css`
         @variant custom-hover {
           @media (any-hover: hover) {
@@ -1568,31 +1568,7 @@ describe('custom variants via CSS `@variant` at-rules', () => {
       `)
     })
 
-    test('parallel media and single @slot', () => {
-      let compiled = compile(css`
-        @variant print-desktop {
-          @media screen, print {
-            @slot;
-          }
-        }
-
-        @layer utilities {
-          @tailwind utilities;
-        }
-      `).build(['print-desktop:underline'])
-
-      expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
-        "@layer utilities {
-          @media screen, print {
-            .print-desktop\\:underline {
-              text-decoration-line: underline;
-            }
-          }
-        }"
-      `)
-    })
-
-    test('parallel media and multiple @slot', () => {
+    test('multiple at-rules with @slot', () => {
       let compiled = compile(css`
         @variant desktop {
           @media (any-hover: hover) {
@@ -1626,7 +1602,7 @@ describe('custom variants via CSS `@variant` at-rules', () => {
       `)
     })
 
-    test('media, nesting and @slot', () => {
+    test('at-rule with nesting with @slot', () => {
       let compiled = compile(css`
         @variant custom-hover {
           @media (any-hover: hover) {
@@ -1652,7 +1628,7 @@ describe('custom variants via CSS `@variant` at-rules', () => {
       `)
     })
 
-    test('parallel media, nesting and single @slot', () => {
+    test('at-rule with nested grouped selectors with @slot', () => {
       let compiled = compile(css`
         @variant desktop {
           @media screen, print {
@@ -1679,7 +1655,7 @@ describe('custom variants via CSS `@variant` at-rules', () => {
       `)
     })
 
-    test('parallel media, nesting and multiple @slot', () => {
+    test('nested at-rules with @slot', () => {
       let compiled = compile(css`
         @variant custom-variant {
           @media print {
@@ -1712,6 +1688,37 @@ describe('custom variants via CSS `@variant` at-rules', () => {
                 text-decoration-line: underline;
               }
             }
+          }
+        }"
+      `)
+    })
+
+    test('at-rule and selector with @slot', () => {
+      let compiled = compile(css`
+        @variant custom-dark {
+          @media (prefers-color-scheme: dark) {
+            @slot;
+          }
+          &:is(.dark *) {
+            @slot;
+          }
+        }
+
+        @layer utilities {
+          @tailwind utilities;
+        }
+      `).build(['custom-dark:underline'])
+
+      expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
+        "@layer utilities {
+          @media (prefers-color-scheme: dark) {
+            .custom-dark\\:underline {
+              text-decoration-line: underline;
+            }
+          }
+
+          .custom-dark\\:underline:is(.dark *) {
+            text-decoration-line: underline;
           }
         }"
       `)

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1215,7 +1215,7 @@ describe('plugins', () => {
     `)
   })
 
-  test('addVariant with object syntax, media, nesting and multiple @slot', () => {
+  test.skip('addVariant with object syntax, media, nesting and multiple @slot', () => {
     let compiled = compile(
       css`
         @plugin "my-plugin";
@@ -1512,7 +1512,7 @@ describe('@variant', () => {
       `)
     })
 
-    test('parallel selector, nesting and multiple @slot', () => {
+    test.skip('nested multiple selectors with @slot', () => {
       let compiled = compile(css`
         @variant hocus {
           .hocus {
@@ -1531,6 +1531,7 @@ describe('@variant', () => {
         }
       `).build(['hocus:underline', 'group-hocus:underline'])
 
+      // I feel like this is wrong — shouldn't `:hover` be attached to `.hocus`?
       expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
         "@layer utilities {
           .group-hocus\\:underline:is(.hocus *):hover, .group-hocus\\:underline:is(.hocus *):focus {

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1331,6 +1331,20 @@ describe('@variant', () => {
     ).toThrowErrorMatchingInlineSnapshot('[Error: `@variant hocus` has no selector or body.]')
   })
 
+  test('@variant cannot have both a selector and a body', () => {
+    expect(() =>
+      compileCss(css`
+        @variant hocus (&:hover, &:focus) {
+          &:is(.potato) {
+            @slot;
+          }
+        }
+      `),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: \`@variant hocus\` cannot have both a selector and a body.]`,
+    )
+  })
+
   describe('body-less syntax', () => {
     test('selector variant', () => {
       let compiled = compile(css`

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1266,6 +1266,16 @@ describe('plugins', () => {
 })
 
 describe('custom variants via CSS `@variant` at-rules', () => {
+  test('@variant should be top-level and can not be nested', () => {
+    expect(() =>
+      compileCss(css`
+        .foo {
+          @variant hocus (&:hover, &:focus);
+        }
+      `),
+    ).toThrowErrorMatchingInlineSnapshot(`[Error: \`@variant\` can not be nested.]`)
+  })
+
   describe('simple one-liner based', () => {
     test('selector', () => {
       let compiled = compile(css`

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1300,14 +1300,14 @@ describe('plugins', () => {
 })
 
 describe('custom variants via CSS `@variant` at-rules', () => {
-  test('@variant should be top-level and can not be nested', () => {
+  test('@variant should be top-level and cannot be nested', () => {
     expect(() =>
       compileCss(css`
         .foo {
           @variant hocus (&:hover, &:focus);
         }
       `),
-    ).toThrowErrorMatchingInlineSnapshot(`[Error: \`@variant\` can not be nested.]`)
+    ).toThrowErrorMatchingInlineSnapshot(`[Error: \`@variant\` cannot be nested.]`)
   })
 
   describe('simple one-liner based', () => {

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1227,12 +1227,10 @@ describe('plugins', () => {
         loadPlugin: () => {
           return ({ addVariant }) => {
             addVariant('hocus', {
-              '.hocus': {
-                '@media (hover: hover)': {
-                  '&:hover': '@slot',
-                },
-                '&:focus': '@slot',
+              '@media (hover: hover)': {
+                '&:hover': '@slot',
               },
+              '&:focus': '@slot',
             })
           }
         },
@@ -1242,22 +1240,22 @@ describe('plugins', () => {
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
         @media (hover: hover) {
-          .group-hocus\\:flex:is(.hocus *):hover {
+          .group-hocus\\:flex:is(:where(.group):hover *) {
             display: flex;
           }
         }
 
-        .group-hocus\\:flex:is(.hocus *):focus {
+        .group-hocus\\:flex:is(:where(.group):focus *) {
           display: flex;
         }
 
         @media (hover: hover) {
-          .hocus\\:underline .hocus:hover {
+          .hocus\\:underline:hover {
             text-decoration-line: underline;
           }
         }
 
-        .hocus\\:underline .hocus:focus {
+        .hocus\\:underline:focus {
           text-decoration-line: underline;
         }
       }"

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1261,6 +1261,42 @@ describe('plugins', () => {
       }"
     `)
   })
+
+  test('@slot is preserved when used as a custom property value', () => {
+    let compiled = compile(
+      css`
+        @plugin "my-plugin";
+        @layer utilities {
+          @tailwind utilities;
+        }
+      `,
+      {
+        loadPlugin: () => {
+          return ({ addVariant }) => {
+            addVariant('hocus', {
+              '&': {
+                '--custom-property': '@slot',
+                '&:hover': '@slot',
+                '&:focus': '@slot',
+              },
+            })
+          }
+        },
+      },
+    ).build(['hocus:underline'])
+
+    expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
+      "@layer utilities {
+        .hocus\\:underline {
+          --custom-property: @slot;
+        }
+
+        .hocus\\:underline:hover, .hocus\\:underline:focus {
+          text-decoration-line: underline;
+        }
+      }"
+    `)
+  })
 })
 
 describe('custom variants via CSS `@variant` at-rules', () => {

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1310,6 +1310,23 @@ describe('custom variants via CSS `@variant` at-rules', () => {
     ).toThrowErrorMatchingInlineSnapshot(`[Error: \`@variant\` cannot be nested.]`)
   })
 
+  test('@variant with no body must include a selector', () => {
+    expect(() =>
+      compileCss(css`
+        @variant hocus;
+      `),
+    ).toThrowErrorMatchingInlineSnapshot('[Error: `@variant hocus` has no selector or body.]')
+  })
+
+  test('@variant with selector must include a body', () => {
+    expect(() =>
+      compileCss(css`
+        @variant hocus {
+        }
+      `),
+    ).toThrowErrorMatchingInlineSnapshot('[Error: `@variant hocus` has no selector or body.]')
+  })
+
   describe('simple one-liner based', () => {
     test('selector', () => {
       let compiled = compile(css`

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1141,10 +1141,14 @@ describe('plugins', () => {
           }
         },
       },
-    ).build(['hocus:underline'])
+    ).build(['hocus:underline', 'group-hocus:flex'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
+        .group-hocus\\:flex:is(:is(:where(.group):hover, :where(.group):focus) *) {
+          display: flex;
+        }
+
         .hocus\\:underline:hover, .hocus\\:underline:focus {
           text-decoration-line: underline;
         }
@@ -1414,7 +1418,7 @@ describe('@variant', () => {
 
       expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
         "@layer utilities {
-          .group-hocus\\:underline:is(:where(.group):hover, .group-hocus\\:underline:focus *) {
+          .group-hocus\\:underline:is(:is(:where(.group):hover, :where(.group):focus) *) {
             text-decoration-line: underline;
           }
 

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -71,23 +71,20 @@ export function compile(
         throw new Error('`@variant` cannot be nested.')
       }
 
+      // Remove `@variant` at-rule so it's not included in the compiled CSS
+      replaceWith([])
+
       // Variants with a selector, but without a body, e.g.: `@variant hocus (&:hover, &:focus);`
       if (node.nodes.length === 0) {
         let [name, selector] = segment(node.selector.slice(9), ' ')
-
-        // Remove variants without selector and without a body, e.g.: `@variant foo {}`
-        if (!selector) {
-          replaceWith([])
-          return
-        }
-
         let selectors = segment(selector.slice(1, -1), ',')
+
         customVariants.push((designSystem) => {
           designSystem.variants.static(name, (r) => {
             r.nodes = selectors.map((selector) => rule(selector, r.nodes))
           })
         })
-        replaceWith([])
+
         return
       }
 
@@ -112,7 +109,7 @@ export function compile(
         customVariants.push((designSystem) => {
           designSystem.variants.fromAst(name, node.nodes)
         })
-        replaceWith([])
+
         return
       }
     }

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -68,7 +68,7 @@ export function compile(
     // Register custom variants from `@variant` at-rules
     if (node.selector.startsWith('@variant ')) {
       if (parent !== null) {
-        throw new Error('`@variant` can not be nested.')
+        throw new Error('`@variant` cannot be nested.')
       }
 
       // Variants with a selector, but without a body, e.g.: `@variant hocus (&:hover, &:focus);`

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -77,6 +77,11 @@ export function compile(
       // Variants with a selector, but without a body, e.g.: `@variant hocus (&:hover, &:focus);`
       if (node.nodes.length === 0) {
         let [name, selector] = segment(node.selector.slice(9), ' ')
+
+        if (!selector) {
+          throw new Error(`\`@variant ${name}\` has no selector or body.`)
+        }
+
         let selectors = segment(selector.slice(1, -1), ',')
 
         customVariants.push((designSystem) => {

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -74,10 +74,14 @@ export function compile(
       // Remove `@variant` at-rule so it's not included in the compiled CSS
       replaceWith([])
 
+      let [name, selector] = segment(node.selector.slice(9), ' ')
+
+      if (node.nodes.length > 0 && selector) {
+        throw new Error(`\`@variant ${name}\` cannot have both a selector and a body.`)
+      }
+
       // Variants with a selector, but without a body, e.g.: `@variant hocus (&:hover, &:focus);`
       if (node.nodes.length === 0) {
-        let [name, selector] = segment(node.selector.slice(9), ' ')
-
         if (!selector) {
           throw new Error(`\`@variant ${name}\` has no selector or body.`)
         }
@@ -109,8 +113,6 @@ export function compile(
       // }
       // ```
       else {
-        let name = node.selector.slice(9).trim()
-
         customVariants.push((designSystem) => {
           designSystem.variants.fromAst(name, node.nodes)
         })

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -8,7 +8,7 @@ import {
   toCss,
   walk,
   type AstNode,
-  type CssTree,
+  type CssInJs,
   type Rule,
 } from './ast'
 import { compileCandidates } from './compile'
@@ -18,7 +18,7 @@ import { Theme } from './theme'
 import { segment } from './utils/segment'
 
 type PluginAPI = {
-  addVariant(name: string, variant: string | string[] | CssTree): void
+  addVariant(name: string, variant: string | string[] | CssInJs): void
 }
 type Plugin = (api: PluginAPI) => void
 
@@ -238,7 +238,7 @@ export function compile(
         })
       }
 
-      // CSS Tree
+      // CSS-in-JS object
       else if (typeof variant === 'object') {
         designSystem.variants.fromAst(name, objectToAst(variant))
       }

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -18,9 +18,7 @@ import { Theme } from './theme'
 import { segment } from './utils/segment'
 
 type PluginAPI = {
-  addVariant(name: string, selector: string): void
-  addVariant(name: string, selector: string[]): void
-  addVariant(name: string, tree: CssTree): void
+  addVariant(name: string, variant: string | string[] | CssTree): void
 }
 type Plugin = (api: PluginAPI) => void
 

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -57,7 +57,7 @@ export function compile(
   let firstThemeRule: Rule | null = null
   let keyframesRules: Rule[] = []
 
-  walk(ast, (node, { replaceWith }) => {
+  walk(ast, (node, { parent, replaceWith }) => {
     if (node.kind !== 'rule') return
 
     // Collect paths from `@plugin` at-rules
@@ -69,6 +69,10 @@ export function compile(
 
     // Register custom variants from `@variant` at-rules
     if (node.selector.startsWith('@variant ')) {
+      if (parent !== null) {
+        throw new Error('`@variant` can not be nested.')
+      }
+
       // Variants with a selector, but without a body, e.g.: `@variant hocus (&:hover, &:focus);`
       if (node.nodes.length === 0) {
         let [name, selector] = segment(node.selector.slice(9), ' ')

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -46,10 +46,9 @@ export class Variants {
       let body = structuredClone(ast)
 
       walk(body, (node, { replaceWith }) => {
-        // Inject existing nodes in `@slot`
+        // Replace `@slot` with rule nodes
         if (node.kind === 'rule' && node.selector === '@slot') {
           replaceWith(r.nodes)
-          return
         }
 
         // Wrap `@keyframes` and `@property` in `@at-root`

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -219,22 +219,29 @@ export function createVariants(theme: Theme): Variants {
       ? `:where(.group\\/${variant.modifier.value})`
       : ':where(.group)'
 
-    // For most variants we rely entirely on CSS nesting to build-up the final
-    // selector, but there is no way to use CSS nesting to make `&` refer to
-    // just the `.group` class the way we'd need to for these variants, so we
-    // need to replace it in the selector ourselves.
-    ruleNode.selector = ruleNode.selector.replaceAll('&', groupSelector)
+    walk([ruleNode], (node) => {
+      if (node.kind !== 'rule') return WalkAction.Continue
 
-    // When the selector is a selector _list_ we need to wrap it in `:is`
-    // to make sure the matching behavior is consistent with the original
-    // variant / selector.
-    if (segment(ruleNode.selector, ',').length > 1) {
-      ruleNode.selector = `:is(${ruleNode.selector})`
-    }
+      // Skip past at-rules, and continue traversing the children of the at-rule
+      if (node.selector[0] === '@') return WalkAction.Continue
 
-    // Use `:where` to make sure the specificity of group variants isn't higher
-    // than the specificity of other variants.
-    ruleNode.selector = `&:is(${ruleNode.selector} *)`
+      // For most variants we rely entirely on CSS nesting to build-up the final
+      // selector, but there is no way to use CSS nesting to make `&` refer to
+      // just the `.group` class the way we'd need to for these variants, so we
+      // need to replace it in the selector ourselves.
+      node.selector = node.selector.replaceAll('&', groupSelector)
+
+      // When the selector is a selector _list_ we need to wrap it in `:is`
+      // to make sure the matching behavior is consistent with the original
+      // variant / selector.
+      if (segment(node.selector, ',').length > 1) {
+        node.selector = `:is(${node.selector})`
+      }
+
+      // Use `:where` to make sure the specificity of group variants isn't higher
+      // than the specificity of other variants.
+      node.selector = `&:is(${node.selector} *)`
+    })
   })
 
   variants.suggest('group', () => {
@@ -250,22 +257,29 @@ export function createVariants(theme: Theme): Variants {
       ? `:where(.peer\\/${variant.modifier.value})`
       : ':where(.peer)'
 
-    // For most variants we rely entirely on CSS nesting to build-up the final
-    // selector, but there is no way to use CSS nesting to make `&` refer to
-    // just the `.peer` class the way we'd need to for these variants, so we
-    // need to replace it in the selector ourselves.
-    ruleNode.selector = ruleNode.selector.replace('&', peerSelector)
+    walk([ruleNode], (node) => {
+      if (node.kind !== 'rule') return WalkAction.Continue
 
-    // When the selector is a selector _list_ we need to wrap it in `:is`
-    // to make sure the matching behavior is consistent with the original
-    // variant / selector.
-    if (segment(ruleNode.selector, ',').length > 1) {
-      ruleNode.selector = `:is(${ruleNode.selector})`
-    }
+      // Skip past at-rules, and continue traversing the children of the at-rule
+      if (node.selector[0] === '@') return WalkAction.Continue
 
-    // Use `:where` to make sure the specificity of peer variants isn't higher
-    // than the specificity of other variants.
-    ruleNode.selector = `&:is(${ruleNode.selector} ~ *)`
+      // For most variants we rely entirely on CSS nesting to build-up the final
+      // selector, but there is no way to use CSS nesting to make `&` refer to
+      // just the `.group` class the way we'd need to for these variants, so we
+      // need to replace it in the selector ourselves.
+      node.selector = node.selector.replaceAll('&', peerSelector)
+
+      // When the selector is a selector _list_ we need to wrap it in `:is`
+      // to make sure the matching behavior is consistent with the original
+      // variant / selector.
+      if (segment(node.selector, ',').length > 1) {
+        node.selector = `:is(${node.selector})`
+      }
+
+      // Use `:where` to make sure the specificity of group variants isn't higher
+      // than the specificity of other variants.
+      node.selector = `&:is(${node.selector} ~ *)`
+    })
   })
 
   variants.suggest('peer', () => {

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -256,6 +256,13 @@ export function createVariants(theme: Theme): Variants {
     // need to replace it in the selector ourselves.
     ruleNode.selector = ruleNode.selector.replace('&', peerSelector)
 
+    // When the selector is a selector _list_ we need to wrap it in `:is`
+    // to make sure the matching behavior is consistent with the original
+    // variant / selector.
+    if (segment(ruleNode.selector, ',').length > 1) {
+      ruleNode.selector = `:is(${ruleNode.selector})`
+    }
+
     // Use `:where` to make sure the specificity of peer variants isn't higher
     // than the specificity of other variants.
     ruleNode.selector = `&:is(${ruleNode.selector} ~ *)`

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -2,6 +2,7 @@ import { WalkAction, decl, rule, walk, type AstNode, type Rule } from './ast'
 import { type Variant } from './candidate'
 import type { Theme } from './theme'
 import { DefaultMap } from './utils/default-map'
+import { segment } from './utils/segment'
 
 type VariantFn<T extends Variant['kind']> = (
   rule: Rule,
@@ -227,9 +228,11 @@ export function createVariants(theme: Theme): Variants {
     // This selector is wrapped in `:is` given that `ruleNode.selector` might be
     // a selector list when compounding a variant the behavior needs to stay
     // consistent with the original variant / selector.
-    // TODO: Ideally this would only be done when there are combinators in the
-    // selector, but that's a bit more complex to implement.
-    ruleNode.selector = `:is(${ruleNode.selector})`
+    // TODO: This should probably check for "are there any combinators" and not
+    // multiple selectors
+    if (segment(ruleNode.selector, ',').length > 1) {
+      ruleNode.selector = `:is(${ruleNode.selector})`
+    }
 
     // Use `:where` to make sure the specificity of group variants isn't higher
     // than the specificity of other variants.

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -222,7 +222,14 @@ export function createVariants(theme: Theme): Variants {
     // selector, but there is no way to use CSS nesting to make `&` refer to
     // just the `.group` class the way we'd need to for these variants, so we
     // need to replace it in the selector ourselves.
-    ruleNode.selector = ruleNode.selector.replace('&', groupSelector)
+    ruleNode.selector = ruleNode.selector.replaceAll('&', groupSelector)
+
+    // This selector is wrapped in `:is` given that `ruleNode.selector` might be
+    // a selector list when compounding a variant the behavior needs to stay
+    // consistent with the original variant / selector.
+    // TODO: Ideally this would only be done when there are combinators in the
+    // selector, but that's a bit more complex to implement.
+    ruleNode.selector = `:is(${ruleNode.selector})`
 
     // Use `:where` to make sure the specificity of group variants isn't higher
     // than the specificity of other variants.

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -225,11 +225,9 @@ export function createVariants(theme: Theme): Variants {
     // need to replace it in the selector ourselves.
     ruleNode.selector = ruleNode.selector.replaceAll('&', groupSelector)
 
-    // This selector is wrapped in `:is` given that `ruleNode.selector` might be
-    // a selector list when compounding a variant the behavior needs to stay
-    // consistent with the original variant / selector.
-    // TODO: This should probably check for "are there any combinators" and not
-    // multiple selectors
+    // When the selector is a selector _list_ we need to wrap it in `:is`
+    // to make sure the matching behavior is consistent with the original
+    // variant / selector.
     if (segment(ruleNode.selector, ',').length > 1) {
       ruleNode.selector = `:is(${ruleNode.selector})`
     }


### PR DESCRIPTION
This PR adds support for custom variants, both via CSS and JS.

We can define simple variants:

Via CSS:
```css
@variant foo (.foo &);
```

Or via JS:
```js
addVariant('foo', '.foo &')
```

We can define simple parallel variants:

Via CSS:
```css
@variant hocus (&:focus, &:hover);
```

Or via JS:
```js
addVariant('hocus', ['&:focus', '&:hover'])
```

But we can also define more complex variants where you might want to use media queries and selectors and nesting and anything you want.

This also introduces a placeholder value named `@slot` that you can use to mark a specific spot where existing utilities and/or variants will be injected.

Via CSS:
```css
@variant strict-hover {
  @media (hover: hover) {
    &:hover {
      @slot;
    }
  }
}
```

Or via JS:
```js
addVariant('strict-hover', {
  '@media (hover: hover)': {
    '&:hover': '@slot',
  }
})
```

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
