### PR TITLE
Fix extracting utilities from slim/pug templates

### DIFF
--- a/src/lib/defaultExtractor.js
+++ b/src/lib/defaultExtractor.js
@@ -32,7 +32,7 @@ export function defaultExtractor(context) {
         // If the next segment is a number, discard both, for example seeing
         // `px-1` and `5` means the real candidate was `px-1.5` which is already
         // captured.
-        let next = parseInt(segments[idx + 1])
+        let next = Number(segments[idx + 1])
         if (isNaN(next)) {
           results.push(segment)
         } else {

--- a/tests/default-extractor.test.js
+++ b/tests/default-extractor.test.js
@@ -476,6 +476,16 @@ test('classes in slim templates', async () => {
   expect(extractions).toContain('text-gray-500')
 })
 
+test('classes in slim templates starting with number', async () => {
+  const extractions = defaultExtractor(`
+    .bg-green-300.2xl:bg-red-300
+      '(Look mom, no closing tag!)
+  `)
+
+  expect(extractions).toContain('bg-green-300')
+  expect(extractions).toContain('2xl:bg-red-300')
+})
+
 test("classes with fractional numeric values don't also generate the whole number utility", async () => {
   const extractions = defaultExtractor(`
     <div class="px-1.5 py-2.75">Hello world!</div>


### PR DESCRIPTION
This pull request addresses an issue with extracting utility classes from slim/pug templates. Specifically, it corrects the handling of segments starting with a number to avoid the loss of relevant class names.

This fixes a regression (described in #14005) of yesterday's release `v3.4.5`.

It uses `Number()` instead of `parseInt()` to check whether a string is a number. This is better because:

```js
const segment = "2xl:bg-red-500"
parseInt(segment) => 2
Number(segment) => NaN
```

I've added a test to ensure my change works as expected.