### PR TITLE
Throw out compound variants using variants with nested selectors

### DIFF
--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1812,50 +1812,25 @@ describe('@variant', () => {
     `)
   })
 
-  test('combining multiple complex variants', () => {
-    let compiled = compile(css`
-      @variant one {
-        &.foo-1 {
-          &.bar-1 {
-            @slot;
+  test('at-rule-only variants cannot be used with compound variants', () => {
+    expect(
+      compileCss(
+        css`
+          @variant foo (@media foo);
+
+          @layer utilities {
+            @tailwind utilities;
           }
-        }
-      }
+        `,
 
-      @variant two {
-        &.foo-2 {
-          &.bar-2 {
-            @slot;
-          }
-        }
-      }
-
-      @layer utilities {
-        @tailwind utilities;
-      }
-    `).build([
-      'group-one:two:underline',
-      'one:group-two:underline',
-      'peer-one:two:underline',
-      'one:peer-two:underline',
-    ])
-
-    expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
+        ['foo:flex', 'group-foo:flex', 'peer-foo:flex', 'has-foo:flex', 'not-foo:flex'],
+      ),
+    ).toMatchInlineSnapshot(`
       "@layer utilities {
-        .one\\:group-two\\:underline.foo-1.bar-1:is(:where(.group).foo-2 *):is(:where(.group).bar-2 *) {
-          text-decoration-line: underline;
-        }
-
-        .one\\:peer-two\\:underline.foo-1.bar-1:is(:where(.peer).foo-2 ~ *):is(:where(.peer).bar-2 ~ *) {
-          text-decoration-line: underline;
-        }
-
-        .group-one\\:two\\:underline:is(:where(.group).foo-1 *):is(:where(.group).bar-1 *).foo-2.bar-2 {
-          text-decoration-line: underline;
-        }
-
-        .peer-one\\:two\\:underline:is(:where(.peer).foo-1 ~ *):is(:where(.peer).bar-1 ~ *).foo-2.bar-2 {
-          text-decoration-line: underline;
+        @media foo {
+          .foo\\:flex {
+            display: flex;
+          }
         }
       }"
     `)

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -738,12 +738,25 @@ test('group-[...]', () => {
 
 test('group-*', () => {
   expect(
-    run([
-      'group-hover:flex',
-      'group-focus:flex',
-      'group-hover:group-focus:flex',
-      'group-focus:group-hover:flex',
-    ]),
+    compileCss(
+      css`
+        @variant hocus {
+          &:hover,
+          &:focus {
+            @slot;
+          }
+        }
+        @tailwind utilities;
+      `,
+      [
+        'group-hover:flex',
+        'group-focus:flex',
+        'group-hocus:flex',
+
+        'group-hover:group-focus:flex',
+        'group-focus:group-hover:flex',
+      ],
+    ),
   ).toMatchInlineSnapshot(`
     ".group-hover\\:flex:is(:where(.group):hover *) {
       display: flex;
@@ -758,6 +771,10 @@ test('group-*', () => {
     }
 
     .group-hover\\:group-focus\\:flex:is(:where(.group):hover *):is(:where(.group):focus *) {
+      display: flex;
+    }
+
+    .group-hocus\\:flex:is(:is(:where(.group):hover, :where(.group):focus) *) {
       display: flex;
     }"
   `)
@@ -816,12 +833,24 @@ test('peer-[...]', () => {
 
 test('peer-*', () => {
   expect(
-    run([
-      'peer-hover:flex',
-      'peer-focus:flex',
-      'peer-hover:peer-focus:flex',
-      'peer-focus:peer-hover:flex',
-    ]),
+    compileCss(
+      css`
+        @variant hocus {
+          &:hover,
+          &:focus {
+            @slot;
+          }
+        }
+        @tailwind utilities;
+      `,
+      [
+        'peer-hover:flex',
+        'peer-focus:flex',
+        'peer-hocus:flex',
+        'peer-hover:peer-focus:flex',
+        'peer-focus:peer-hover:flex',
+      ],
+    ),
   ).toMatchInlineSnapshot(`
     ".peer-hover\\:flex:is(:where(.peer):hover ~ *) {
       display: flex;
@@ -836,6 +865,10 @@ test('peer-*', () => {
     }
 
     .peer-hover\\:peer-focus\\:flex:is(:where(.peer):hover ~ *):is(:where(.peer):focus ~ *) {
+      display: flex;
+    }
+
+    .peer-hocus\\:flex:is(:is(:where(.peer):hover, :where(.peer):focus) ~ *) {
       display: flex;
     }"
   `)
@@ -1502,23 +1535,51 @@ test('supports', () => {
 
 test('not', () => {
   expect(
-    run([
-      'not-[:checked]:flex',
+    compileCss(
+      css`
+        @variant hocus {
+          &:hover,
+          &:focus {
+            @slot;
+          }
+        }
+        @tailwind utilities;
+      `,
+      [
+        'not-[:checked]:flex',
+        'not-hocus:flex',
 
-      'group-not-[:checked]:flex',
-      'group-not-[:checked]/parent-name:flex',
-      'group-not-checked:flex',
+        'group-not-[:checked]:flex',
+        'group-not-[:checked]/parent-name:flex',
+        'group-not-checked:flex',
+        'group-not-hocus:flex',
+        'group-not-hocus/parent-name:flex',
 
-      'peer-not-[:checked]:flex',
-      'peer-not-[:checked]/parent-name:flex',
-      'peer-not-checked:flex',
-    ]),
+        'peer-not-[:checked]:flex',
+        'peer-not-[:checked]/sibling-name:flex',
+        'peer-not-checked:flex',
+        'peer-not-hocus:flex',
+        'peer-not-hocus/sibling-name:flex',
+      ],
+    ),
   ).toMatchInlineSnapshot(`
-    ".not-\\[\\:checked\\]\\:flex:not(:checked) {
+    ".not-hocus\\:flex:not(:hover, :focus) {
+      display: flex;
+    }
+
+    .not-\\[\\:checked\\]\\:flex:not(:checked) {
       display: flex;
     }
 
     .group-not-checked\\:flex:is(:where(.group):not(:checked) *) {
+      display: flex;
+    }
+
+    .group-not-hocus\\:flex:is(:where(.group):not(:hover, :focus) *) {
+      display: flex;
+    }
+
+    .group-not-hocus\\/parent-name\\:flex:is(:where(.group\\/parent-name):not(:hover, :focus) *) {
       display: flex;
     }
 
@@ -1534,11 +1595,19 @@ test('not', () => {
       display: flex;
     }
 
+    .peer-not-hocus\\:flex:is(:where(.peer):not(:hover, :focus) ~ *) {
+      display: flex;
+    }
+
+    .peer-not-hocus\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):not(:hover, :focus) ~ *) {
+      display: flex;
+    }
+
     .peer-not-\\[\\:checked\\]\\:flex:is(:where(.peer):not(:checked) ~ *) {
       display: flex;
     }
 
-    .peer-not-\\[\\:checked\\]\\/parent-name\\:flex:is(:where(.peer\\/parent-name):not(:checked) ~ *) {
+    .peer-not-\\[\\:checked\\]\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):not(:checked) ~ *) {
       display: flex;
     }"
   `)
@@ -1556,19 +1625,43 @@ test('not', () => {
 
 test('has', () => {
   expect(
-    run([
-      'has-[:checked]:flex',
+    compileCss(
+      css`
+        @variant hocus {
+          &:hover,
+          &:focus {
+            @slot;
+          }
+        }
+        @tailwind utilities;
+      `,
+      [
+        'has-[:checked]:flex',
+        'has-hocus:flex',
 
-      'group-has-[:checked]:flex',
-      'group-has-[:checked]/parent-name:flex',
-      'group-has-checked:flex',
+        'group-has-[:checked]:flex',
+        'group-has-[:checked]/parent-name:flex',
+        'group-has-checked:flex',
+        'group-has-hocus:flex',
+        'group-has-hocus/parent-name:flex',
 
-      'peer-has-[:checked]:flex',
-      'peer-has-[:checked]/sibling-name:flex',
-      'peer-has-checked:flex',
-    ]),
+        'peer-has-[:checked]:flex',
+        'peer-has-[:checked]/sibling-name:flex',
+        'peer-has-checked:flex',
+        'peer-has-hocus:flex',
+        'peer-has-hocus/sibling-name:flex',
+      ],
+    ),
   ).toMatchInlineSnapshot(`
     ".group-has-checked\\:flex:is(:where(.group):has(:checked) *) {
+      display: flex;
+    }
+
+    .group-has-hocus\\:flex:is(:where(.group):has(:hover, :focus) *) {
+      display: flex;
+    }
+
+    .group-has-hocus\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(:hover, :focus) *) {
       display: flex;
     }
 
@@ -1584,11 +1677,23 @@ test('has', () => {
       display: flex;
     }
 
+    .peer-has-hocus\\:flex:is(:where(.peer):has(:hover, :focus) ~ *) {
+      display: flex;
+    }
+
+    .peer-has-hocus\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(:hover, :focus) ~ *) {
+      display: flex;
+    }
+
     .peer-has-\\[\\:checked\\]\\:flex:is(:where(.peer):has(:checked) ~ *) {
       display: flex;
     }
 
     .peer-has-\\[\\:checked\\]\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(:checked) ~ *) {
+      display: flex;
+    }
+
+    .has-hocus\\:flex:has(:hover, :focus) {
       display: flex;
     }
 

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -725,6 +725,15 @@ test('group-[...]', () => {
       display: flex;
     }"
   `)
+
+  expect(
+    compileCss(
+      css`
+        @tailwind utilities;
+      `,
+      ['group-[@media_foo]:flex'],
+    ),
+  ).toEqual('')
 })
 
 test('group-*', () => {
@@ -752,6 +761,16 @@ test('group-*', () => {
       display: flex;
     }"
   `)
+
+  expect(
+    compileCss(
+      css`
+        @variant custom-at-rule (@media foo);
+        @tailwind utilities;
+      `,
+      ['group-custom-at-rule:flex'],
+    ),
+  ).toEqual('')
 })
 
 test('peer-[...]', () => {
@@ -784,6 +803,15 @@ test('peer-[...]', () => {
       display: flex;
     }"
   `)
+
+  expect(
+    compileCss(
+      css`
+        @tailwind utilities;
+      `,
+      ['peer-[@media_foo]:flex'],
+    ),
+  ).toEqual('')
 })
 
 test('peer-*', () => {
@@ -811,6 +839,16 @@ test('peer-*', () => {
       display: flex;
     }"
   `)
+
+  expect(
+    compileCss(
+      css`
+        @variant custom-at-rule (@media foo);
+        @tailwind utilities;
+      `,
+      ['peer-custom-at-rule:flex'],
+    ),
+  ).toEqual('')
 })
 
 test('ltr', () => {
@@ -1505,7 +1543,15 @@ test('not', () => {
     }"
   `)
 
-  expect(run(['not-[:checked]/foo:flex'])).toEqual('')
+  expect(
+    compileCss(
+      css`
+        @variant custom-at-rule (@media foo);
+        @tailwind utilities;
+      `,
+      ['not-[:checked]/foo:flex', 'not-[@media_print]:flex', 'not-custom-at-rule:flex'],
+    ),
+  ).toEqual('')
 })
 
 test('has', () => {
@@ -1518,7 +1564,7 @@ test('has', () => {
       'group-has-checked:flex',
 
       'peer-has-[:checked]:flex',
-      'peer-has-[:checked]/parent-name:flex',
+      'peer-has-[:checked]/sibling-name:flex',
       'peer-has-checked:flex',
     ]),
   ).toMatchInlineSnapshot(`
@@ -1542,7 +1588,7 @@ test('has', () => {
       display: flex;
     }
 
-    .peer-has-\\[\\:checked\\]\\/parent-name\\:flex:is(:where(.peer\\/parent-name):has(:checked) ~ *) {
+    .peer-has-\\[\\:checked\\]\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(:checked) ~ *) {
       display: flex;
     }
 
@@ -1550,7 +1596,16 @@ test('has', () => {
       display: flex;
     }"
   `)
-  expect(run(['has-[:checked]/foo:flex'])).toEqual('')
+
+  expect(
+    compileCss(
+      css`
+        @variant custom-at-rule (@media foo);
+        @tailwind utilities;
+      `,
+      ['has-[:checked]/foo:flex', 'has-[@media_print]:flex', 'has-custom-at-rule:flex'],
+    ),
+  ).toEqual('')
 })
 
 test('aria', () => {

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -783,9 +783,16 @@ test('group-*', () => {
     compileCss(
       css`
         @variant custom-at-rule (@media foo);
+        @variant nested-selectors {
+          &:hover {
+            &:focus {
+              @slot;
+            }
+          }
+        }
         @tailwind utilities;
       `,
-      ['group-custom-at-rule:flex'],
+      ['group-custom-at-rule:flex', 'group-nested-selectors:flex'],
     ),
   ).toEqual('')
 })
@@ -877,9 +884,16 @@ test('peer-*', () => {
     compileCss(
       css`
         @variant custom-at-rule (@media foo);
+        @variant nested-selectors {
+          &:hover {
+            &:focus {
+              @slot;
+            }
+          }
+        }
         @tailwind utilities;
       `,
-      ['peer-custom-at-rule:flex'],
+      ['peer-custom-at-rule:flex', 'peer-nested-selectors:flex'],
     ),
   ).toEqual('')
 })
@@ -1616,9 +1630,21 @@ test('not', () => {
     compileCss(
       css`
         @variant custom-at-rule (@media foo);
+        @variant nested-selectors {
+          &:hover {
+            &:focus {
+              @slot;
+            }
+          }
+        }
         @tailwind utilities;
       `,
-      ['not-[:checked]/foo:flex', 'not-[@media_print]:flex', 'not-custom-at-rule:flex'],
+      [
+        'not-[:checked]/foo:flex',
+        'not-[@media_print]:flex',
+        'not-custom-at-rule:flex',
+        'not-nested-selectors:flex',
+      ],
     ),
   ).toEqual('')
 })
@@ -1706,9 +1732,21 @@ test('has', () => {
     compileCss(
       css`
         @variant custom-at-rule (@media foo);
+        @variant nested-selectors {
+          &:hover {
+            &:focus {
+              @slot;
+            }
+          }
+        }
         @tailwind utilities;
       `,
-      ['has-[:checked]/foo:flex', 'has-[@media_print]:flex', 'has-custom-at-rule:flex'],
+      [
+        'has-[:checked]/foo:flex',
+        'has-[@media_print]:flex',
+        'has-custom-at-rule:flex',
+        'has-nested-selectors:flex',
+      ],
     ),
   ).toEqual('')
 })

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -216,7 +216,7 @@ export function createVariants(theme: Theme): Variants {
 
       // Replace `&` in target variant with `*`, so variants like `&:hover`
       // become `&:not(*:hover)`. The `*` will often be optimized away.
-      node.selector = `&:not(${node.selector.replace('&', '*')})`
+      node.selector = `&:not(${node.selector.replaceAll('&', '*')})`
 
       // Track that the variant was actually applied
       didApply = true
@@ -442,7 +442,7 @@ export function createVariants(theme: Theme): Variants {
 
       // Replace `&` in target variant with `*`, so variants like `&:hover`
       // become `&:has(*:hover)`. The `*` will often be optimized away.
-      node.selector = `&:has(${node.selector.replace('&', '*')})`
+      node.selector = `&:has(${node.selector.replaceAll('&', '*')})`
 
       // Track that the variant was actually applied
       didApply = true

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -214,6 +214,18 @@ export function createVariants(theme: Theme): Variants {
       // Skip past at-rules, and continue traversing the children of the at-rule
       if (node.selector[0] === '@') return WalkAction.Continue
 
+      // Throw out any candidates with variants using nested selectors
+      if (didApply) {
+        walk([node], (childNode) => {
+          if (childNode.kind !== 'rule' || childNode.selector[0] === '@') return WalkAction.Continue
+
+          didApply = false
+          return WalkAction.Stop
+        })
+
+        return didApply ? WalkAction.Skip : WalkAction.Stop
+      }
+
       // Replace `&` in target variant with `*`, so variants like `&:hover`
       // become `&:not(*:hover)`. The `*` will often be optimized away.
       node.selector = `&:not(${node.selector.replaceAll('&', '*')})`
@@ -243,6 +255,18 @@ export function createVariants(theme: Theme): Variants {
 
       // Skip past at-rules, and continue traversing the children of the at-rule
       if (node.selector[0] === '@') return WalkAction.Continue
+
+      // Throw out any candidates with variants using nested selectors
+      if (didApply) {
+        walk([node], (childNode) => {
+          if (childNode.kind !== 'rule' || childNode.selector[0] === '@') return WalkAction.Continue
+
+          didApply = false
+          return WalkAction.Stop
+        })
+
+        return didApply ? WalkAction.Skip : WalkAction.Stop
+      }
 
       // For most variants we rely entirely on CSS nesting to build-up the final
       // selector, but there is no way to use CSS nesting to make `&` refer to
@@ -290,6 +314,18 @@ export function createVariants(theme: Theme): Variants {
 
       // Skip past at-rules, and continue traversing the children of the at-rule
       if (node.selector[0] === '@') return WalkAction.Continue
+
+      // Throw out any candidates with variants using nested selectors
+      if (didApply) {
+        walk([node], (childNode) => {
+          if (childNode.kind !== 'rule' || childNode.selector[0] === '@') return WalkAction.Continue
+
+          didApply = false
+          return WalkAction.Stop
+        })
+
+        return didApply ? WalkAction.Skip : WalkAction.Stop
+      }
 
       // For most variants we rely entirely on CSS nesting to build-up the final
       // selector, but there is no way to use CSS nesting to make `&` refer to
@@ -439,6 +475,18 @@ export function createVariants(theme: Theme): Variants {
 
       // Skip past at-rules, and continue traversing the children of the at-rule
       if (node.selector[0] === '@') return WalkAction.Continue
+
+      // Throw out any candidates with variants using nested selectors
+      if (didApply) {
+        walk([node], (childNode) => {
+          if (childNode.kind !== 'rule' || childNode.selector[0] === '@') return WalkAction.Continue
+
+          didApply = false
+          return WalkAction.Stop
+        })
+
+        return didApply ? WalkAction.Skip : WalkAction.Stop
+      }
 
       // Replace `&` in target variant with `*`, so variants like `&:hover`
       // become `&:has(*:hover)`. The `*` will often be optimized away.


### PR DESCRIPTION
This prevents `not-*`, `has-*`, `group-*`, and `peer-*` from being used with variants containing nested CSS selectors.

Prior to this PR this was implemented incorrectly. Ideally this would work but requires additional significant effort to ensure that the results are functionally equivalent to the nested version.

For now we're disabling this until we can rework the implementation to handle these cases correctly.

For an example of something that does not work:
```css
@variant super-focus {
  &:focus {
    &:hover {
      @slot;
    }
  }
}
```

However, this does not affect variants nesting a _single_ selector inside `@media`:
```css
/* This still works */
@variant strict-hover {
  @media (hover: hover) {
    &:hover {
      @slot;
    }
  }
}
```