### PR TITLE
changed height vh per dvh, mobile bug with vh

### DIFF
--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -2338,7 +2338,7 @@ test('min-height', () => {
     }
 
     .min-h-screen {
-      min-height: 100vh;
+      min-height: 100dvh;
     }
 
     .min-h-svh {
@@ -2430,7 +2430,7 @@ test('max-height', () => {
     }
 
     .max-h-screen {
-      max-height: 100vh;
+      max-height: 100dvh;
     }
 
     .max-h-svh {

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -991,7 +991,7 @@ export function createUtilities(theme: Theme) {
   for (let [key, value] of [
     ['auto', 'auto'],
     ['full', '100%'],
-    ['screen', '100vh'],
+    ['screen', '100dvh'],
     ['svh', '100svh'],
     ['lvh', '100lvh'],
     ['dvh', '100dvh'],
@@ -1013,7 +1013,7 @@ export function createUtilities(theme: Theme) {
   for (let [key, value] of [
     ['auto', 'auto'],
     ['full', '100%'],
-    ['screen', '100vh'],
+    ['screen', '100dvh'],
     ['svh', '100svh'],
     ['lvh', '100lvh'],
     ['dvh', '100dvh'],
@@ -1034,7 +1034,7 @@ export function createUtilities(theme: Theme) {
   for (let [key, value] of [
     ['none', 'none'],
     ['full', '100%'],
-    ['screen', '100vh'],
+    ['screen', '100dvh'],
     ['svh', '100svh'],
     ['lvh', '100lvh'],
     ['dvh', '100dvh'],

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -1350,12 +1350,12 @@ test('sorting `min` and `max` should sort by unit, then by value, then alphabeti
       'max-[12rem]:flex',
       'min-[calc(1000px+12em)]:flex',
       'max-[calc(1000px+12em)]:flex',
-      'min-[calc(50vh+12em)]:flex',
-      'max-[calc(50vh+12em)]:flex',
-      'min-[10vh]:flex',
-      'min-[12vh]:flex',
-      'max-[10vh]:flex',
-      'max-[12vh]:flex',
+      'min-[calc(50dvh+12em)]:flex',
+      'max-[calc(50dvh+12em)]:flex',
+      'min-[10dvh]:flex',
+      'min-[12dvh]:flex',
+      'max-[10dvh]:flex',
+      'max-[12dvh]:flex',
     ]),
   ).toMatchInlineSnapshot(`
     "@media (width < calc(1000px + 12em)) {
@@ -1364,8 +1364,8 @@ test('sorting `min` and `max` should sort by unit, then by value, then alphabeti
       }
     }
 
-    @media (width < calc(50vh + 12em)) {
-      .max-\\[calc\\(50vh\\+12em\\)\\]\\:flex {
+    @media (width < calc(50dvh + 12em)) {
+      .max-\\[calc\\(50dvh\\+12em\\)\\]\\:flex {
         display: flex;
       }
     }
@@ -1406,14 +1406,14 @@ test('sorting `min` and `max` should sort by unit, then by value, then alphabeti
       }
     }
 
-    @media (width < 12vh) {
-      .max-\\[12vh\\]\\:flex {
+    @media (width < 12dvh) {
+      .max-\\[12dvh\\]\\:flex {
         display: flex;
       }
     }
 
-    @media (width < 10vh) {
-      .max-\\[10vh\\]\\:flex {
+    @media (width < 10dvh) {
+      .max-\\[10dvh\\]\\:flex {
         display: flex;
       }
     }
@@ -1424,8 +1424,8 @@ test('sorting `min` and `max` should sort by unit, then by value, then alphabeti
       }
     }
 
-    @media (width >= calc(50vh + 12em)) {
-      .min-\\[calc\\(50vh\\+12em\\)\\]\\:flex {
+    @media (width >= calc(50dvh + 12em)) {
+      .min-\\[calc\\(50dvh\\+12em\\)\\]\\:flex {
         display: flex;
       }
     }
@@ -1466,14 +1466,14 @@ test('sorting `min` and `max` should sort by unit, then by value, then alphabeti
       }
     }
 
-    @media (width >= 10vh) {
-      .min-\\[10vh\\]\\:flex {
+    @media (width >= 10dvh) {
+      .min-\\[10dvh\\]\\:flex {
         display: flex;
       }
     }
 
-    @media (width >= 12vh) {
-      .min-\\[12vh\\]\\:flex {
+    @media (width >= 12dvh) {
+      .min-\\[12dvh\\]\\:flex {
         display: flex;
       }
     }"

--- a/playgrounds/nextjs/app/page.module.css
+++ b/playgrounds/nextjs/app/page.module.css
@@ -4,7 +4,7 @@
   justify-content: space-between;
   align-items: center;
   padding: 6rem;
-  min-height: 100vh;
+  min-height: 100dvh;
 }
 
 .description {


### PR DESCRIPTION
In various cases, when using VH units to define the heights of components, we encountered rendering issues on mobile applications. However, by replacing VH with DVH, all these issues were resolved without impacting the behavior on desktop. This PR makes the change from VH to DVH units, ensuring a better user experience on mobile devices.