### PR TITLE
Normalize attribute selectors for `data-*` and `aria-*` modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add missing utilities that exist in v3, such as `resize`, `fill-none`, `accent-none`, `drop-shadow-none`, and negative `hue-rotate` and `backdrop-hue-rotate` utilities ([#13971](https://github.com/tailwindlabs/tailwindcss/pull/13971))
 - Don’t allow at-rule-only variants to be compounded ([#14015](https://github.com/tailwindlabs/tailwindcss/pull/14015))
 - Ensure compound variants work with variants with multiple selectors ([#14016](https://github.com/tailwindlabs/tailwindcss/pull/14016))
-- Attribute selectors in `data-` and `aria-` modifiers are now wrapped in quotation marks by default, allowing numbers and spaces in them ([#])(https://github.com/tailwindlabs/tailwindcss/pull/14037)
+- Attribute selectors in `data-` and `aria-` modifiers are now wrapped in quotation marks by default, allowing numbers and spaces in them ([#14040])(https://github.com/tailwindlabs/tailwindcss/pull/14037)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add missing utilities that exist in v3, such as `resize`, `fill-none`, `accent-none`, `drop-shadow-none`, and negative `hue-rotate` and `backdrop-hue-rotate` utilities ([#13971](https://github.com/tailwindlabs/tailwindcss/pull/13971))
 - Don’t allow at-rule-only variants to be compounded ([#14015](https://github.com/tailwindlabs/tailwindcss/pull/14015))
 - Ensure compound variants work with variants with multiple selectors ([#14016](https://github.com/tailwindlabs/tailwindcss/pull/14016))
+- Attribute selectors in `data-` and `aria-` modifiers are now wrapped in quotation marks by default, allowing numbers and spaces in them ([#])(https://github.com/tailwindlabs/tailwindcss/pull/14037)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add missing utilities that exist in v3, such as `resize`, `fill-none`, `accent-none`, `drop-shadow-none`, and negative `hue-rotate` and `backdrop-hue-rotate` utilities ([#13971](https://github.com/tailwindlabs/tailwindcss/pull/13971))
 - Don’t allow at-rule-only variants to be compounded ([#14015](https://github.com/tailwindlabs/tailwindcss/pull/14015))
 - Ensure compound variants work with variants with multiple selectors ([#14016](https://github.com/tailwindlabs/tailwindcss/pull/14016))
-- Attribute selectors in `data-` and `aria-` modifiers are now wrapped in quotation marks by default, allowing numbers and spaces in them ([#14040])(https://github.com/tailwindlabs/tailwindcss/pull/14037)
+- Attribute selectors in `data-*` and `aria-*` modifiers are now wrapped in quotation marks by default, allowing numbers and spaces in them ([#14040])(https://github.com/tailwindlabs/tailwindcss/pull/14037)
 
 ### Added
 

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -1844,6 +1844,7 @@ test('data', () => {
       'data-[foo=1]:flex',
       'data-[foo=bar_baz]:flex',
       "data-[foo$='bar'_i]:flex",
+      'data-[foo$=bar_baz_i]:flex',
 
       'group-data-[disabled]:flex',
       'group-data-[disabled]/parent-name:flex',
@@ -1851,6 +1852,7 @@ test('data', () => {
       'group-data-[foo=1]/parent-name:flex',
       'group-data-[foo=bar baz]/parent-name:flex',
       "group-data-[foo$='bar'_i]/parent-name:flex",
+      'group-data-[foo$=bar_baz_i]/parent-name:flex',
 
       'peer-data-[disabled]:flex',
       'peer-data-[disabled]/parent-name:flex',
@@ -1858,6 +1860,7 @@ test('data', () => {
       'peer-data-[foo=1]/parent-name:flex',
       'peer-data-[foo=bar baz]/parent-name:flex',
       "peer-data-[foo$='bar'_i]/parent-name:flex",
+      'peer-data-[foo$=bar_baz_i]/parent-name:flex',
     ]),
   ).toMatchInlineSnapshot(`
     ".group-data-\\[disabled\\]\\:flex:is(:where(.group)[data-disabled] *) {
@@ -1881,6 +1884,10 @@ test('data', () => {
     }
 
     .group-data-\\[foo\\$\\=\\'bar\\'_i\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name)[data-foo$="bar" i] *) {
+      display: flex;
+    }
+
+    .group-data-\\[foo\\$\\=bar_baz_i\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name)[data-foo$="bar baz" i] *) {
       display: flex;
     }
 
@@ -1908,6 +1915,10 @@ test('data', () => {
       display: flex;
     }
 
+    .peer-data-\\[foo\\$\\=bar_baz_i\\]\\/parent-name\\:flex:is(:where(.peer\\/parent-name)[data-foo$="bar baz" i] ~ *) {
+      display: flex;
+    }
+
     .data-disabled\\:flex[data-disabled] {
       display: flex;
     }
@@ -1925,6 +1936,10 @@ test('data', () => {
     }
 
     .data-\\[foo\\$\\=\\'bar\\'_i\\]\\:flex[data-foo$="bar" i] {
+      display: flex;
+    }
+
+    .data-\\[foo\\$\\=bar_baz_i\\]\\:flex[data-foo$="bar baz" i] {
       display: flex;
     }"
   `)

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -1756,16 +1756,21 @@ test('aria', () => {
     run([
       'aria-checked:flex',
       'aria-[invalid=spelling]:flex',
+      'aria-[valuenow=1]:flex',
 
       'group-aria-[modal]:flex',
       'group-aria-checked:flex',
+      'group-aria-[valuenow=1]:flex',
       'group-aria-[modal]/parent-name:flex',
       'group-aria-checked/parent-name:flex',
+      'group-aria-[valuenow=1]/parent-name:flex',
 
       'peer-aria-[modal]:flex',
       'peer-aria-checked:flex',
+      'peer-aria-[valuenow=1]:flex',
       'peer-aria-[modal]/parent-name:flex',
       'peer-aria-checked/parent-name:flex',
+      'peer-aria-[valuenow=1]/parent-name:flex',
     ]),
   ).toMatchInlineSnapshot(`
     ".group-aria-\\[modal\\]\\:flex:is(:where(.group)[aria-modal] *) {
@@ -1773,6 +1778,10 @@ test('aria', () => {
     }
 
     .group-aria-checked\\:flex:is(:where(.group)[aria-checked="true"] *) {
+      display: flex;
+    }
+
+    .group-aria-\\[valuenow\\=1\\]\\:flex:is(:where(.group)[aria-valuenow="1"] *) {
       display: flex;
     }
 
@@ -1784,11 +1793,19 @@ test('aria', () => {
       display: flex;
     }
 
+    .group-aria-\\[valuenow\\=1\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name)[aria-valuenow="1"] *) {
+      display: flex;
+    }
+
     .peer-aria-\\[modal\\]\\:flex:is(:where(.peer)[aria-modal] ~ *) {
       display: flex;
     }
 
     .peer-aria-checked\\:flex:is(:where(.peer)[aria-checked="true"] ~ *) {
+      display: flex;
+    }
+
+    .peer-aria-\\[valuenow\\=1\\]\\:flex:is(:where(.peer)[aria-valuenow="1"] ~ *) {
       display: flex;
     }
 
@@ -1800,11 +1817,19 @@ test('aria', () => {
       display: flex;
     }
 
+    .peer-aria-\\[valuenow\\=1\\]\\/parent-name\\:flex:is(:where(.peer\\/parent-name)[aria-valuenow="1"] ~ *) {
+      display: flex;
+    }
+
     .aria-checked\\:flex[aria-checked="true"] {
       display: flex;
     }
 
     .aria-\\[invalid\\=spelling\\]\\:flex[aria-invalid="spelling"] {
+      display: flex;
+    }
+
+    .aria-\\[valuenow\\=1\\]\\:flex[aria-valuenow="1"] {
       display: flex;
     }"
   `)
@@ -1816,12 +1841,23 @@ test('data', () => {
     run([
       'data-disabled:flex',
       'data-[potato=salad]:flex',
+      'data-[foo=1]:flex',
+      'data-[foo=bar baz]:flex',
+      "data-[foo$='bar' i]:flex",
 
       'group-data-[disabled]:flex',
       'group-data-[disabled]/parent-name:flex',
+      'group-data-[foo=1]:flex',
+      'group-data-[foo=1]/parent-name:flex',
+      'group-data-[foo=bar baz]/parent-name:flex',
+      "group-data-[foo$='bar' i]/parent-name:flex",
 
       'peer-data-[disabled]:flex',
       'peer-data-[disabled]/parent-name:flex',
+      'peer-data-[foo=1]:flex',
+      'peer-data-[foo=1]/parent-name:flex',
+      'peer-data-[foo=bar baz]/parent-name:flex',
+      "peer-data-[foo$='bar' i]/parent-name:flex",
     ]),
   ).toMatchInlineSnapshot(`
     ".group-data-\\[disabled\\]\\:flex:is(:where(.group)[data-disabled] *) {
@@ -1829,6 +1865,22 @@ test('data', () => {
     }
 
     .group-data-\\[disabled\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name)[data-disabled] *) {
+      display: flex;
+    }
+
+    .group-data-\\[foo\\=1\\]\\:flex:is(:where(.group)[data-foo="1"] *) {
+      display: flex;
+    }
+
+    .group-data-\\[foo\\=1\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name)[data-foo="1"] *) {
+      display: flex;
+    }
+
+    .group-data-\\[foo\\=bar\\ baz\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name)[data-foo="bar baz"] *) {
+      display: flex;
+    }
+
+    .group-data-\\[foo\\$\\=\\'bar\\'\\ i\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name)[data-foo$="bar" i] *) {
       display: flex;
     }
 
@@ -1840,11 +1892,39 @@ test('data', () => {
       display: flex;
     }
 
+    .peer-data-\\[foo\\=1\\]\\:flex:is(:where(.peer)[data-foo="1"] ~ *) {
+      display: flex;
+    }
+
+    .peer-data-\\[foo\\=1\\]\\/parent-name\\:flex:is(:where(.peer\\/parent-name)[data-foo="1"] ~ *) {
+      display: flex;
+    }
+
+    .peer-data-\\[foo\\=bar\\ baz\\]\\/parent-name\\:flex:is(:where(.peer\\/parent-name)[data-foo="bar baz"] ~ *) {
+      display: flex;
+    }
+
+    .peer-data-\\[foo\\$\\=\\'bar\\'\\ i\\]\\/parent-name\\:flex:is(:where(.peer\\/parent-name)[data-foo$="bar" i] ~ *) {
+      display: flex;
+    }
+
     .data-disabled\\:flex[data-disabled] {
       display: flex;
     }
 
     .data-\\[potato\\=salad\\]\\:flex[data-potato="salad"] {
+      display: flex;
+    }
+
+    .data-\\[foo\\=1\\]\\:flex[data-foo="1"] {
+      display: flex;
+    }
+
+    .data-\\[foo\\=bar\\ baz\\]\\:flex[data-foo="bar baz"] {
+      display: flex;
+    }
+
+    .data-\\[foo\\$\\=\\'bar\\'\\ i\\]\\:flex[data-foo$="bar" i] {
       display: flex;
     }"
   `)

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -1842,22 +1842,22 @@ test('data', () => {
       'data-disabled:flex',
       'data-[potato=salad]:flex',
       'data-[foo=1]:flex',
-      'data-[foo=bar baz]:flex',
-      "data-[foo$='bar' i]:flex",
+      'data-[foo=bar_baz]:flex',
+      "data-[foo$='bar'_i]:flex",
 
       'group-data-[disabled]:flex',
       'group-data-[disabled]/parent-name:flex',
       'group-data-[foo=1]:flex',
       'group-data-[foo=1]/parent-name:flex',
       'group-data-[foo=bar baz]/parent-name:flex',
-      "group-data-[foo$='bar' i]/parent-name:flex",
+      "group-data-[foo$='bar'_i]/parent-name:flex",
 
       'peer-data-[disabled]:flex',
       'peer-data-[disabled]/parent-name:flex',
       'peer-data-[foo=1]:flex',
       'peer-data-[foo=1]/parent-name:flex',
       'peer-data-[foo=bar baz]/parent-name:flex',
-      "peer-data-[foo$='bar' i]/parent-name:flex",
+      "peer-data-[foo$='bar'_i]/parent-name:flex",
     ]),
   ).toMatchInlineSnapshot(`
     ".group-data-\\[disabled\\]\\:flex:is(:where(.group)[data-disabled] *) {
@@ -1880,7 +1880,7 @@ test('data', () => {
       display: flex;
     }
 
-    .group-data-\\[foo\\$\\=\\'bar\\'\\ i\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name)[data-foo$="bar" i] *) {
+    .group-data-\\[foo\\$\\=\\'bar\\'_i\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name)[data-foo$="bar" i] *) {
       display: flex;
     }
 
@@ -1904,7 +1904,7 @@ test('data', () => {
       display: flex;
     }
 
-    .peer-data-\\[foo\\$\\=\\'bar\\'\\ i\\]\\/parent-name\\:flex:is(:where(.peer\\/parent-name)[data-foo$="bar" i] ~ *) {
+    .peer-data-\\[foo\\$\\=\\'bar\\'_i\\]\\/parent-name\\:flex:is(:where(.peer\\/parent-name)[data-foo$="bar" i] ~ *) {
       display: flex;
     }
 
@@ -1920,11 +1920,11 @@ test('data', () => {
       display: flex;
     }
 
-    .data-\\[foo\\=bar\\ baz\\]\\:flex[data-foo="bar baz"] {
+    .data-\\[foo\\=bar_baz\\]\\:flex[data-foo="bar baz"] {
       display: flex;
     }
 
-    .data-\\[foo\\$\\=\\'bar\\'\\ i\\]\\:flex[data-foo$="bar" i] {
+    .data-\\[foo\\$\\=\\'bar\\'_i\\]\\:flex[data-foo$="bar" i] {
       display: flex;
     }"
   `)

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -514,7 +514,7 @@ export function createVariants(theme: Theme): Variants {
 
     if (variant.value.kind === 'arbitrary') {
       ruleNode.nodes = [
-        rule(`&[aria-${normalizeAttributeSelectors(variant.value.value)}]`, ruleNode.nodes),
+        rule(`&[aria-${quoteAtteributeValue(variant.value.value)}]`, ruleNode.nodes),
       ]
     } else {
       ruleNode.nodes = [rule(`&[aria-${variant.value.value}="true"]`, ruleNode.nodes)]
@@ -536,9 +536,7 @@ export function createVariants(theme: Theme): Variants {
   variants.functional('data', (ruleNode, variant) => {
     if (!variant.value || variant.modifier) return null
 
-    ruleNode.nodes = [
-      rule(`&[data-${normalizeAttributeSelectors(variant.value.value)}]`, ruleNode.nodes),
-    ]
+    ruleNode.nodes = [rule(`&[data-${quoteAtteributeValue(variant.value.value)}]`, ruleNode.nodes)]
   })
 
   variants.functional('nth', (ruleNode, variant) => {
@@ -909,10 +907,10 @@ export function createVariants(theme: Theme): Variants {
   return variants
 }
 
-function normalizeAttributeSelectors(value: string) {
-  // Wrap values in attribute selectors with quotes
+function quoteAtteributeValue(value: string) {
   if (value.includes('=')) {
     value = value.replace(/(=.*)/g, (_fullMatch, match) => {
+      // If the value is already quoted, skip.
       if (match[1] === "'" || match[1] === '"') {
         return match
       }

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -912,6 +912,21 @@ function quoteAttributeValue(value: string) {
       if (match[1] === "'" || match[1] === '"') {
         return match
       }
+
+      // Handle regex flags on unescaped values
+      if (match.length > 2) {
+        let trailingCharacter = match[match.length - 1]
+        if (
+          match[match.length - 2] === ' ' &&
+          (trailingCharacter === 'i' ||
+            trailingCharacter === 'I' ||
+            trailingCharacter === 's' ||
+            trailingCharacter === 'S')
+        ) {
+          return `="${match.slice(1, -2)}" ${match[match.length - 1]}`
+        }
+      }
+
       return `="${match.slice(1)}"`
     })
   }

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -513,9 +513,7 @@ export function createVariants(theme: Theme): Variants {
     if (!variant.value || variant.modifier) return null
 
     if (variant.value.kind === 'arbitrary') {
-      ruleNode.nodes = [
-        rule(`&[aria-${quoteAtteributeValue(variant.value.value)}]`, ruleNode.nodes),
-      ]
+      ruleNode.nodes = [rule(`&[aria-${quoteAttributeValue(variant.value.value)}]`, ruleNode.nodes)]
     } else {
       ruleNode.nodes = [rule(`&[aria-${variant.value.value}="true"]`, ruleNode.nodes)]
     }
@@ -536,7 +534,7 @@ export function createVariants(theme: Theme): Variants {
   variants.functional('data', (ruleNode, variant) => {
     if (!variant.value || variant.modifier) return null
 
-    ruleNode.nodes = [rule(`&[data-${quoteAtteributeValue(variant.value.value)}]`, ruleNode.nodes)]
+    ruleNode.nodes = [rule(`&[data-${quoteAttributeValue(variant.value.value)}]`, ruleNode.nodes)]
   })
 
   variants.functional('nth', (ruleNode, variant) => {
@@ -907,7 +905,7 @@ export function createVariants(theme: Theme): Variants {
   return variants
 }
 
-function quoteAtteributeValue(value: string) {
+function quoteAttributeValue(value: string) {
   if (value.includes('=')) {
     value = value.replace(/(=.*)/g, (_fullMatch, match) => {
       // If the value is already quoted, skip.

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -536,8 +536,6 @@ export function createVariants(theme: Theme): Variants {
   variants.functional('data', (ruleNode, variant) => {
     if (!variant.value || variant.modifier) return null
 
-    console.log(variant.value, ruleNode.nodes)
-
     ruleNode.nodes = [
       rule(`&[data-${normalizeAttributeSelectors(variant.value.value)}]`, ruleNode.nodes),
     ]

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -513,7 +513,9 @@ export function createVariants(theme: Theme): Variants {
     if (!variant.value || variant.modifier) return null
 
     if (variant.value.kind === 'arbitrary') {
-      ruleNode.nodes = [rule(`&[aria-${variant.value.value}]`, ruleNode.nodes)]
+      ruleNode.nodes = [
+        rule(`&[aria-${normalizeAttributeSelectors(variant.value.value)}]`, ruleNode.nodes),
+      ]
     } else {
       ruleNode.nodes = [rule(`&[aria-${variant.value.value}="true"]`, ruleNode.nodes)]
     }
@@ -534,7 +536,11 @@ export function createVariants(theme: Theme): Variants {
   variants.functional('data', (ruleNode, variant) => {
     if (!variant.value || variant.modifier) return null
 
-    ruleNode.nodes = [rule(`&[data-${variant.value.value}]`, ruleNode.nodes)]
+    console.log(variant.value, ruleNode.nodes)
+
+    ruleNode.nodes = [
+      rule(`&[data-${normalizeAttributeSelectors(variant.value.value)}]`, ruleNode.nodes),
+    ]
   })
 
   variants.functional('nth', (ruleNode, variant) => {
@@ -903,4 +909,17 @@ export function createVariants(theme: Theme): Variants {
   staticVariant('forced-colors', ['@media (forced-colors: active)'], { compounds: false })
 
   return variants
+}
+
+function normalizeAttributeSelectors(value: string) {
+  // Wrap values in attribute selectors with quotes
+  if (value.includes('=')) {
+    value = value.replace(/(=.*)/g, (_fullMatch, match) => {
+      if (match[1] === "'" || match[1] === '"') {
+        return match
+      }
+      return `="${match.slice(1)}"`
+    })
+  }
+  return value
 }


### PR DESCRIPTION
Fixes #14026 
See https://github.com/tailwindlabs/tailwindcss/pull/14037 for the v3 fix

When translating `data-` and `aria-` modifiers with attribute selectors, we currently do not wrap the target attribute in quotes. This only works for keywords (purely alphabetic words) but breaks as soon as there are numbers or things like spaces in the attribute:

```html
<div data-id="foo" class="data-[id=foo]:underline">underlined</div>
<div data-id="f1" class="data-[id=1]:underline">not underlined</div>
<div data-id="foo bar" class="data-[id=foo_bar]:underline">not underlined</div>
```

Since it's fairly common to have attribute selectors with `data-` and `aria-` modifiers, this PR will now wrap the attribute in quotes unless these are already wrapped. 

| Tailwind Modifier  | CSS Selector |
| ------------- | ------------- |
| `.data-[id=foo]`  | `[data-id='foo']`  |
| `.data-[id='foo']`  | `[data-id='foo']`  |
| `.data-[id=foo_i]`  | `[data-id='foo i']`  |
| `.data-[id='foo'_i]`  | `[data-id='foo' i]`  |
| `.data-[id=123]`  | `[data-id='123']`  |