### PR TITLE
Specify pnpm version for corepack users

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
     "typescript": "^5.4.5",
     "vitest": "^1.6.0"
   },
-  "packageManager": "pnpm@9.5.0"
+  "packageManager": "pnpm@9.6.0"
 }

--- a/package.json
+++ b/package.json
@@ -46,5 +46,6 @@
     "turbo": "^1.13.3",
     "typescript": "^5.4.5",
     "vitest": "^1.6.0"
-  }
+  },
+  "packageManager": "pnpm@9.5.0"
 }


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->

I use [corepack](https://nodejs.org/api/corepack.html), so when I run `yarn` or `pnpm`, the command looks at the local `package.json` → `packageManager` field, downloads a specific package manager if needed and then uses it.

Most of the repos I deal with have this field, so my ‘default’ `pnpm` got a bit dated:

```sh
pnpm --version
8.10.5
```

With this PR, corepack contributors like me will automatically opt into the right pnpm version:

```sh
pnpm --version
9.6.0
```

This can prevent `pnpm-lock.yaml` spoiling which I have experienced in https://github.com/tailwindlabs/tailwindcss/pull/14061 (https://github.com/tailwindlabs/tailwindcss/pull/14061/commits/5d2d18e94dff56f5f76533b7be391238c099b15c). To be honest I discovered pnpm version mismatch quite late because I got used to correct version picking.

Going forward, pnpm version in CI can be also grabbed from `package.json` → `packageManager` field. And this field can be automatically updated on schedule, e.g. via Renovate. Happy to help if that’s interesting.