### PR TITLE
Add `@content` support to `tailwindcss`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob-match"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d"
+
+[[package]]
 name = "globset"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +617,7 @@ dependencies = [
  "bstr",
  "crossbeam",
  "fxhash",
+ "glob-match",
  "globwalk",
  "ignore",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6776fc96284a0bb647b615056fc496d1fe1644a7ab01829818a6d91cae888b84"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bstr"
@@ -197,6 +197,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +393,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,7 +438,7 @@ version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7f0a2e93526dd9c8c522d72a4d0c88678be8966fabe9fb8f2947fde6339b682"
 dependencies = [
- "bitflags 2.3.1",
+ "bitflags 2.6.0",
  "ctor",
  "napi-derive",
  "napi-sys",
@@ -424,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.2"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "overload"
@@ -435,16 +522,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.3",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.59"
+name = "pin-utils"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -487,6 +603,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -545,10 +670,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ccfb12511cdb770157ace92d7dda771e498445b78f9886e8cdbc5140a4eced"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sdd"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177258b64c0faaa9ffd3c65cd3262c2bc7e2588dbbd9c1641d0346145c1bbda8"
 
 [[package]]
 name = "semver"
@@ -563,12 +703,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 
 [[package]]
+name = "serial_test"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4b487fe2acf240a021cf57c6b2b4903b1e78ca0ecd862a71b71d2a51fed77d"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -623,6 +797,7 @@ dependencies = [
  "lazy_static",
  "log",
  "rayon",
+ "serial_test",
  "tempfile",
  "tracing",
  "tracing-subscriber",
@@ -637,7 +812,7 @@ checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
  "windows-sys 0.45.0",
 ]
@@ -822,6 +997,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,6 +1023,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -846,6 +1043,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +1059,18 @@ name = "windows_i686_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -870,6 +1085,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,6 +1101,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -894,6 +1121,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,3 +1137,9 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -40,20 +40,16 @@ pub struct GlobEntry {
 #[napi(object)]
 pub struct ScanOptions {
   pub base: String,
-  pub globs: Option<bool>,
 }
 
 #[napi]
 pub fn clear_cache() {
-    tailwindcss_oxide::clear_cache();
+  tailwindcss_oxide::clear_cache();
 }
 
 #[napi]
 pub fn scan_dir(args: ScanOptions) -> ScanResult {
-  let result = tailwindcss_oxide::scan_dir(tailwindcss_oxide::ScanOptions {
-    base: args.base,
-    globs: args.globs.unwrap_or(false),
-  });
+  let result = tailwindcss_oxide::scan_dir(tailwindcss_oxide::ScanOptions { base: args.base });
 
   ScanResult {
     files: result.files,

--- a/crates/oxide/Cargo.toml
+++ b/crates/oxide/Cargo.toml
@@ -16,6 +16,7 @@ walkdir = "2.3.3"
 ignore = "0.4.20"
 lazy_static = "1.4.0"
 glob-match = "0.2.1"
+serial_test = "3.1.1"
 
 [dev-dependencies]
 tempfile = "3.5.0"

--- a/crates/oxide/Cargo.toml
+++ b/crates/oxide/Cargo.toml
@@ -15,6 +15,7 @@ tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 walkdir = "2.3.3"
 ignore = "0.4.20"
 lazy_static = "1.4.0"
+glob-match = "0.2.1"
 
 [dev-dependencies]
 tempfile = "3.5.0"

--- a/crates/oxide/src/glob.rs
+++ b/crates/oxide/src/glob.rs
@@ -135,7 +135,7 @@ pub fn get_fast_patterns(base_path: &Path, patterns: &Vec<String>) -> Vec<(PathB
 }
 
 pub fn path_matches_globs(path: &Path, globs: &[GlobEntry]) -> bool {
-    let path = format!("{}", path.display());
+    let path = path.to_string_lossy();
 
     globs
         .iter()

--- a/crates/oxide/src/glob.rs
+++ b/crates/oxide/src/glob.rs
@@ -53,7 +53,6 @@ pub fn get_fast_patterns(base_path: &Path, patterns: &Vec<String>) -> Vec<(PathB
             pattern.remove(0);
         }
 
-        let is_absolute_pattern = pattern.starts_with('/');
         let mut folders = pattern.split('/').collect::<Vec<_>>();
 
         if folders.len() <= 1 {
@@ -64,11 +63,7 @@ pub fn get_fast_patterns(base_path: &Path, patterns: &Vec<String>) -> Vec<(PathB
             // Safety: We know that the length is greater than 1, so we can safely unwrap.
             let file_pattern = folders.pop().unwrap();
             let all_folders = folders.clone();
-            let mut temp_paths = if is_absolute_pattern {
-                vec![PathBuf::from("/")]
-            } else {
-                vec![base_path.to_path_buf()]
-            };
+            let mut temp_paths = vec![base_path.to_path_buf()];
 
             let mut bail = false;
 

--- a/crates/oxide/src/glob.rs
+++ b/crates/oxide/src/glob.rs
@@ -5,10 +5,9 @@ use std::path::{Path, PathBuf};
 use crate::GlobEntry;
 
 pub fn fast_glob(
-    base_path: &Path,
-    patterns: &Vec<String>,
+    patterns: &Vec<GlobEntry>,
 ) -> Result<impl iter::Iterator<Item = PathBuf>, std::io::Error> {
-    Ok(get_fast_patterns(base_path, patterns)
+    Ok(get_fast_patterns(patterns)
         .into_iter()
         .flat_map(|(base_path, patterns)| {
             globwalk::GlobWalkerBuilder::from_patterns(base_path, &patterns)
@@ -43,10 +42,13 @@ pub fn fast_glob(
 /// tailwind --pwd ./project/pages --content "**/*.js"
 /// tailwind --pwd ./project/components --content "**/*.js"
 /// ```
-pub fn get_fast_patterns(base_path: &Path, patterns: &Vec<String>) -> Vec<(PathBuf, Vec<String>)> {
+pub fn get_fast_patterns(patterns: &Vec<GlobEntry>) -> Vec<(PathBuf, Vec<String>)> {
     let mut optimized_patterns: Vec<(PathBuf, Vec<String>)> = vec![];
 
     for pattern in patterns {
+        let base_path = PathBuf::from(&pattern.base);
+        let pattern = &pattern.glob;
+
         let is_negated = pattern.starts_with('!');
         let mut pattern = pattern.clone();
         if is_negated {
@@ -57,13 +59,13 @@ pub fn get_fast_patterns(base_path: &Path, patterns: &Vec<String>) -> Vec<(PathB
 
         if folders.len() <= 1 {
             // No paths we can simplify, so let's use it as-is.
-            optimized_patterns.push((base_path.to_path_buf(), vec![pattern]));
+            optimized_patterns.push((base_path, vec![pattern]));
         } else {
             // We do have folders because `/` exists. Let's try to simplify the globs!
             // Safety: We know that the length is greater than 1, so we can safely unwrap.
             let file_pattern = folders.pop().unwrap();
             let all_folders = folders.clone();
-            let mut temp_paths = vec![base_path.to_path_buf()];
+            let mut temp_paths = vec![base_path];
 
             let mut bail = false;
 
@@ -239,11 +241,15 @@ fn expand_braces(input: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::get_fast_patterns;
+    use crate::GlobEntry;
     use std::path::PathBuf;
 
     #[test]
     fn it_should_keep_globs_that_start_with_file_wildcards_as_is() {
-        let actual = get_fast_patterns(&PathBuf::from("/projects"), &vec!["*.html".to_string()]);
+        let actual = get_fast_patterns(&vec![GlobEntry {
+            base: "/projects".to_string(),
+            glob: "*.html".to_string(),
+        }]);
         let expected = vec![(PathBuf::from("/projects"), vec!["*.html".to_string()])];
 
         assert_eq!(actual, expected,);
@@ -251,7 +257,11 @@ mod tests {
 
     #[test]
     fn it_should_keep_globs_that_start_with_folder_wildcards_as_is() {
-        let actual = get_fast_patterns(&PathBuf::from("/projects"), &vec!["**/*.html".to_string()]);
+        let actual = get_fast_patterns(&vec![GlobEntry {
+            base: "/projects".to_string(),
+            glob: "**/*.html".to_string(),
+        }]);
+
         let expected = vec![(PathBuf::from("/projects"), vec!["**/*.html".to_string()])];
 
         assert_eq!(actual, expected,);
@@ -259,10 +269,10 @@ mod tests {
 
     #[test]
     fn it_should_move_the_starting_folder_to_the_path() {
-        let actual = get_fast_patterns(
-            &PathBuf::from("/projects"),
-            &vec!["example/*.html".to_string()],
-        );
+        let actual = get_fast_patterns(&vec![GlobEntry {
+            base: "/projects".to_string(),
+            glob: "example/*.html".to_string(),
+        }]);
         let expected = vec![(
             PathBuf::from("/projects/example"),
             vec!["*.html".to_string()],
@@ -273,10 +283,10 @@ mod tests {
 
     #[test]
     fn it_should_move_the_starting_folders_to_the_path() {
-        let actual = get_fast_patterns(
-            &PathBuf::from("/projects"),
-            &vec!["example/other/*.html".to_string()],
-        );
+        let actual = get_fast_patterns(&vec![GlobEntry {
+            base: "/projects".to_string(),
+            glob: "example/other/*.html".to_string(),
+        }]);
         let expected = vec![(
             PathBuf::from("/projects/example/other"),
             vec!["*.html".to_string()],
@@ -287,10 +297,11 @@ mod tests {
 
     #[test]
     fn it_should_branch_expandable_folders() {
-        let actual = get_fast_patterns(
-            &PathBuf::from("/projects"),
-            &vec!["{foo,bar}/*.html".to_string()],
-        );
+        let actual = get_fast_patterns(&vec![GlobEntry {
+            base: "/projects".to_string(),
+            glob: "{foo,bar}/*.html".to_string(),
+        }]);
+
         let expected = vec![
             (PathBuf::from("/projects/foo"), vec!["*.html".to_string()]),
             (PathBuf::from("/projects/bar"), vec!["*.html".to_string()]),
@@ -301,10 +312,10 @@ mod tests {
 
     #[test]
     fn it_should_expand_multiple_expansions_in_the_same_folder() {
-        let actual = get_fast_patterns(
-            &PathBuf::from("/projects"),
-            &vec!["a-{b,c}-d-{e,f}-g/*.html".to_string()],
-        );
+        let actual = get_fast_patterns(&vec![GlobEntry {
+            base: "/projects".to_string(),
+            glob: "a-{b,c}-d-{e,f}-g/*.html".to_string(),
+        }]);
         let expected = vec![
             (
                 PathBuf::from("/projects/a-b-d-e-g"),
@@ -329,10 +340,10 @@ mod tests {
 
     #[test]
     fn multiple_expansions_per_folder_starting_at_the_root() {
-        let actual = get_fast_patterns(
-            &PathBuf::from("/projects"),
-            &vec!["{a,b}-c-{d,e}-f/{b,c}-d-{e,f}-g/*.html".to_string()],
-        );
+        let actual = get_fast_patterns(&vec![GlobEntry {
+            base: "/projects".to_string(),
+            glob: "{a,b}-c-{d,e}-f/{b,c}-d-{e,f}-g/*.html".to_string(),
+        }]);
         let expected = vec![
             (
                 PathBuf::from("/projects/a-c-d-f/b-d-e-g"),
@@ -405,10 +416,11 @@ mod tests {
 
     #[test]
     fn it_should_stop_expanding_once_we_hit_a_wildcard() {
-        let actual = get_fast_patterns(
-            &PathBuf::from("/projects"),
-            &vec!["{foo,bar}/example/**/{baz,qux}/*.html".to_string()],
-        );
+        let actual = get_fast_patterns(&vec![GlobEntry {
+            base: "/projects".to_string(),
+            glob: "{foo,bar}/example/**/{baz,qux}/*.html".to_string(),
+        }]);
+
         let expected = vec![
             (
                 PathBuf::from("/projects/foo/example"),
@@ -425,10 +437,10 @@ mod tests {
 
     #[test]
     fn it_should_keep_the_negation_symbol_for_all_new_patterns() {
-        let actual = get_fast_patterns(
-            &PathBuf::from("/projects"),
-            &vec!["!{foo,bar}/*.html".to_string()],
-        );
+        let actual = get_fast_patterns(&vec![GlobEntry {
+            base: "/projects".to_string(),
+            glob: "!{foo,bar}/*.html".to_string(),
+        }]);
         let expected = vec![
             (PathBuf::from("/projects/foo"), vec!["!*.html".to_string()]),
             (PathBuf::from("/projects/bar"), vec!["!*.html".to_string()]),
@@ -439,10 +451,10 @@ mod tests {
 
     #[test]
     fn it_should_expand_a_complex_example() {
-        let actual = get_fast_patterns(
-            &PathBuf::from("/projects"),
-            &vec!["a/{b,c}/d/{e,f}/g/*.html".to_string()],
-        );
+        let actual = get_fast_patterns(&vec![GlobEntry {
+            base: "/projects".to_string(),
+            glob: "a/{b,c}/d/{e,f}/g/*.html".to_string(),
+        }]);
         let expected = vec![
             (
                 PathBuf::from("/projects/a/b/d/e/g"),

--- a/crates/oxide/src/lib.rs
+++ b/crates/oxide/src/lib.rs
@@ -40,7 +40,6 @@ pub struct ChangedContent {
 #[derive(Debug, Clone)]
 pub struct ScanOptions {
     pub base: String,
-    pub globs: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -68,11 +67,7 @@ pub fn scan_dir(opts: ScanOptions) -> ScanResult {
 
     let (files, dirs) = resolve_files(root);
 
-    let globs = if opts.globs {
-        resolve_globs(root, dirs)
-    } else {
-        vec![]
-    };
+    let globs = resolve_globs(root, dirs);
 
     let mut cache = GLOBAL_CACHE.lock().unwrap();
 

--- a/crates/oxide/src/lib.rs
+++ b/crates/oxide/src/lib.rs
@@ -1,7 +1,10 @@
+use crate::glob::path_matches_globs;
 use crate::parser::Extractor;
 use bstr::ByteSlice;
 use cache::Cache;
 use fxhash::FxHashSet;
+use glob::fast_glob;
+use glob::get_fast_patterns;
 use ignore::DirEntry;
 use ignore::WalkBuilder;
 use lazy_static::lazy_static;
@@ -39,7 +42,10 @@ pub struct ChangedContent {
 
 #[derive(Debug, Clone)]
 pub struct ScanOptions {
+    /// Base path to start scanning from
     pub base: String,
+    /// Glob content paths
+    pub content_paths: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -65,9 +71,47 @@ pub fn scan_dir(opts: ScanOptions) -> ScanResult {
 
     let root = Path::new(&opts.base);
 
-    let (files, dirs) = resolve_files(root);
+    let (mut files, dirs) = resolve_files(root);
 
-    let globs = resolve_globs(root, dirs);
+    let mut globs = resolve_globs(root, dirs);
+
+    // If we have additional content paths, then we have to resolve them as well.
+    if !opts.content_paths.is_empty() {
+        let resolved_files: Vec<_> = match fast_glob(root, &opts.content_paths) {
+            Ok(matches) => matches.filter_map(|x| x.canonicalize().ok()).collect(),
+            Err(err) => {
+                event!(tracing::Level::ERROR, "Failed to resolve glob: {:?}", err);
+                vec![]
+            }
+        };
+
+        files.extend(resolved_files);
+
+        let optimized_incoming_globs = get_fast_patterns(root, &opts.content_paths)
+            .iter()
+            .flat_map(|(root, globs)| {
+                globs.iter().filter_map(|glob| {
+                    let root = match root.canonicalize() {
+                        Ok(root) => root,
+                        Err(err) => {
+                            event!(
+                                tracing::Level::ERROR,
+                                "Failed to canonicalize base path: {:?}",
+                                err
+                            );
+                            return None;
+                        }
+                    };
+
+                    let base = root.display().to_string();
+                    let glob = glob.to_string();
+                    Some(GlobEntry { base, glob })
+                })
+            })
+            .collect::<Vec<GlobEntry>>();
+
+        globs.extend(optimized_incoming_globs);
+    }
 
     let mut cache = GLOBAL_CACHE.lock().unwrap();
 
@@ -393,6 +437,26 @@ pub fn scan_files(input: Vec<ChangedContent>, options: u8) -> Vec<String> {
         (IO::Parallel, Parsing::Sequential) => parse_all_blobs_sync(read_all_files(input)),
         (IO::Parallel, Parsing::Parallel) => parse_all_blobs(read_all_files(input)),
     }
+}
+
+#[tracing::instrument(skip(input, globs))]
+pub fn scan_files_with_globs(input: Vec<ChangedContent>, globs: Vec<GlobEntry>) -> Vec<String> {
+    parse_all_blobs_sync(read_all_files_sync(
+        input
+            .into_iter()
+            .flat_map(|c| {
+                // Verify that the file is actually allowed by the globs
+                if let Some(ref file) = c.file {
+                    if !path_matches_globs(file, &globs) {
+                        return None;
+                    }
+                }
+
+                // ChangedContent is allowed
+                Some(c)
+            })
+            .collect(),
+    ))
 }
 
 fn read_changed_content(c: ChangedContent) -> Option<Vec<u8>> {

--- a/crates/oxide/tests/scan_dir.rs
+++ b/crates/oxide/tests/scan_dir.rs
@@ -31,10 +31,7 @@ mod scan_dir {
         let base = format!("{}", dir.display());
 
         // Resolve all content paths for the (temporary) current working directory
-        let result = scan_dir(ScanOptions {
-            base: base.clone(),
-            globs: true,
-        });
+        let result = scan_dir(ScanOptions { base: base.clone() });
 
         let mut paths: Vec<_> = result
             .files

--- a/crates/oxide/tests/scan_dir.rs
+++ b/crates/oxide/tests/scan_dir.rs
@@ -22,8 +22,8 @@ mod scan_dir {
 
         // Create the necessary files
         for (path, contents) in paths_with_content {
-            // Ensure we use the right path seperator for the current platform
-            let path = dir.join(path.replace("/", path::MAIN_SEPARATOR.to_string().as_str()));
+            // Ensure we use the right path separator for the current platform
+            let path = dir.join(path.replace('/', path::MAIN_SEPARATOR.to_string().as_str()));
             let parent = path.parent().unwrap();
             if !parent.exists() {
                 fs::create_dir_all(parent).unwrap();
@@ -64,7 +64,7 @@ mod scan_dir {
                 let parent_dir = format!("{}{}", &base.to_string(), path::MAIN_SEPARATOR);
                 x.replace(&parent_dir, "")
                     // Normalize paths to use unix style separators
-                    .replace("\\", "/")
+                    .replace('\\', "/")
             })
             .collect();
 

--- a/crates/oxide/tests/scan_dir.rs
+++ b/crates/oxide/tests/scan_dir.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-mod auto_content {
+mod scan_dir {
     use std::process::Command;
     use std::{fs, path};
 

--- a/crates/oxide/tests/scan_dir.rs
+++ b/crates/oxide/tests/scan_dir.rs
@@ -40,7 +40,13 @@ mod scan_dir {
         // Resolve all content paths for the (temporary) current working directory
         let result = scan_dir(ScanOptions {
             base: base.clone(),
-            content_paths: globs.iter().map(|x| x.to_string()).collect(),
+            content_paths: globs
+                .iter()
+                .map(|x| GlobEntry {
+                    base: base.clone(),
+                    glob: x.to_string(),
+                })
+                .collect(),
         });
 
         let mut paths: Vec<_> = result

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -109,7 +109,7 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
           let css = ''
 
           // Look for candidates used to generate the CSS
-          let { candidates, files, globs } = scanDir({ base, globs: true })
+          let { candidates, files, globs } = scanDir({ base })
 
           // Add all found files as direct dependencies
           for (let file of files) {

--- a/packages/tailwindcss/src/candidate.bench.ts
+++ b/packages/tailwindcss/src/candidate.bench.ts
@@ -8,7 +8,7 @@ import { Theme } from './theme'
 const root = process.env.FOLDER || process.cwd()
 
 // Auto content detection
-const result = scanDir({ base: root, globs: true })
+const result = scanDir({ base: root })
 
 const designSystem = buildDesignSystem(new Theme())
 

--- a/packages/tailwindcss/src/index.bench.ts
+++ b/packages/tailwindcss/src/index.bench.ts
@@ -7,7 +7,7 @@ const root = process.env.FOLDER || process.cwd()
 const css = String.raw
 
 bench('compile', async () => {
-  let { candidates } = scanDir({ base: root, globs: true })
+  let { candidates } = scanDir({ base: root })
 
   compile(css`
     @tailwind utilities;

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { describe, expect, it, test } from 'vitest'
+import { describe, expect, it, test, vi } from 'vitest'
 import { compile } from '.'
 import { compileCss, optimizeCss, run } from './test-utils/run'
 
@@ -1341,6 +1341,40 @@ describe('plugins', () => {
         }
       }"
     `)
+  })
+})
+
+describe('@content', () => {
+  test('emits @content files', () => {
+    const onContentPath = vi.fn()
+    compile(
+      css`
+        @content "./foo/bar/*.ts";
+      `,
+      {
+        loadPlugin: () => () => {},
+        onContentPath,
+      },
+    )
+
+    expect(onContentPath).toHaveBeenCalledWith('./foo/bar/*.ts')
+  })
+
+  test('emits multiple @content files', () => {
+    const onContentPath = vi.fn()
+    compile(
+      css`
+        @content "./foo/**/*.ts";
+        @content "./php/secr3t/smarty.php";
+      `,
+      {
+        loadPlugin: () => () => {},
+        onContentPath,
+      },
+    )
+
+    expect(onContentPath).toHaveBeenNthCalledWith(1, './foo/**/*.ts')
+    expect(onContentPath).toHaveBeenNthCalledWith(2, './php/secr3t/smarty.php')
   })
 })
 

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { describe, expect, it, test, vi } from 'vitest'
+import { describe, expect, it, test } from 'vitest'
 import { compile } from '.'
 import { compileCss, optimizeCss, run } from './test-utils/run'
 
@@ -1346,35 +1346,20 @@ describe('plugins', () => {
 
 describe('@content', () => {
   test('emits @content files', () => {
-    const onContentPath = vi.fn()
-    compile(
-      css`
-        @content "./foo/bar/*.ts";
-      `,
-      {
-        loadPlugin: () => () => {},
-        onContentPath,
-      },
-    )
+    let { globs } = compile(css`
+      @content "./foo/bar/*.ts";
+    `)
 
-    expect(onContentPath).toHaveBeenCalledWith('./foo/bar/*.ts')
+    expect(globs).toEqual(['./foo/bar/*.ts'])
   })
 
   test('emits multiple @content files', () => {
-    const onContentPath = vi.fn()
-    compile(
-      css`
-        @content "./foo/**/*.ts";
-        @content "./php/secr3t/smarty.php";
-      `,
-      {
-        loadPlugin: () => () => {},
-        onContentPath,
-      },
-    )
+    let { globs } = compile(css`
+      @content "./foo/**/*.ts";
+      @content "./php/secr3t/smarty.php";
+    `)
 
-    expect(onContentPath).toHaveBeenNthCalledWith(1, './foo/**/*.ts')
-    expect(onContentPath).toHaveBeenNthCalledWith(2, './php/secr3t/smarty.php')
+    expect(globs).toEqual(['./foo/**/*.ts', './php/secr3t/smarty.php'])
   })
 })
 


### PR DESCRIPTION
This PR adds `@content` support to `tailwindcss`'s core package. We will handle the `@content` and call the `onContentPath` function when it's encountered.

The `@tailwindcss/cli`, `@tailwindcss/vite` and `@tailwindcss/postcss` packages have to implement the `onContentPath` such that the necessary globs are scanned and watchers should be setup with this information.

Example usage:

```css
@content "../../packages/my-sibling-package/src/components/*.tsx";
```

If you are in a monorepo setup, then you could point to other packages if you want. Another common use case is for Laravel projects if you want to point to Laravel blade files since they won't be covered by Vite's module graph:

```css
/* ./resources/css/app.css */
@content "../views/*.blade.php"
```

Note: all globs are relative to the current file you are in.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
