### PR TITLE
Automate checksum generation for standalone CLI

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -83,3 +83,4 @@ jobs:
             standalone-cli/dist/tailwindcss-macos-x64
             standalone-cli/dist/tailwindcss-windows-x64.exe
             standalone-cli/dist/tailwindcss-windows-arm64.exe
+            standalone-cli/dist/sha256sums.txt

--- a/standalone-cli/package.json
+++ b/standalone-cli/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "build": "pkg . --compress Brotli --no-bytecode --public-packages \"*\" --public",
     "prebuild": "rimraf dist",
-    "postbuild": "move-file dist/tailwindcss-standalone-macos-x64 dist/tailwindcss-macos-x64 && move-file dist/tailwindcss-standalone-macos-arm64 dist/tailwindcss-macos-arm64 && move-file dist/tailwindcss-standalone-win-x64.exe dist/tailwindcss-windows-x64.exe && move-file dist/tailwindcss-standalone-win-arm64.exe dist/tailwindcss-windows-arm64.exe && move-file dist/tailwindcss-standalone-linuxstatic-x64 dist/tailwindcss-linux-x64 && move-file dist/tailwindcss-standalone-linuxstatic-arm64 dist/tailwindcss-linux-arm64 && move-file dist/tailwindcss-standalone-linuxstatic-armv7 dist/tailwindcss-linux-armv7",
+    "postbuild": "move-file dist/tailwindcss-standalone-macos-x64 dist/tailwindcss-macos-x64 && move-file dist/tailwindcss-standalone-macos-arm64 dist/tailwindcss-macos-arm64 && move-file dist/tailwindcss-standalone-win-x64.exe dist/tailwindcss-windows-x64.exe && move-file dist/tailwindcss-standalone-win-arm64.exe dist/tailwindcss-windows-arm64.exe && move-file dist/tailwindcss-standalone-linuxstatic-x64 dist/tailwindcss-linux-x64 && move-file dist/tailwindcss-standalone-linuxstatic-arm64 dist/tailwindcss-linux-arm64 && move-file dist/tailwindcss-standalone-linuxstatic-armv7 dist/tailwindcss-linux-armv7 && npm run generate-checksums",
+    "generate-checksums": "node ./scripts/checksum.mjs",
     "test": "jest"
   },
   "devDependencies": {

--- a/standalone-cli/scripts/checksum.mjs
+++ b/standalone-cli/scripts/checksum.mjs
@@ -1,0 +1,27 @@
+import { createHash } from 'node:crypto'
+import { readFile, writeFile } from 'node:fs/promises'
+import * as path from 'node:path'
+
+const files = [
+  './tailwindcss-linux-arm64',
+  './tailwindcss-linux-armv7',
+  './tailwindcss-linux-x64',
+  './tailwindcss-macos-arm64',
+  './tailwindcss-macos-x64',
+  './tailwindcss-windows-arm64.exe',
+  './tailwindcss-windows-x64.exe',
+]
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname)
+
+const lines = await Promise.all(
+  files.map(async (file) => {
+    let sum = createHash('sha256')
+      .update(await readFile(path.resolve(__dirname, '../dist', file)))
+      .digest('hex')
+
+    return `${sum}  ${file}`
+  })
+)
+
+await writeFile(path.resolve(__dirname, '../dist', 'sha256sums.txt'), lines.join('\n') + '\n')


### PR DESCRIPTION
We've done this manually until now which is _fine_ but not ideal so this PR automates it so it cannot be forgotten.

@RobinMalfait do you know of a good way to test this w/o creating a tag? Should I add a `workflow_dispatch` trigger to the prepare release workflow?