### PR TITLE
Run CI on any PR change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master, next]
   pull_request:
-    branches: [master, next]
 
 permissions:
   contents: read


### PR DESCRIPTION
This changes the V4 CI to run on any pull request change (so an opened, reopened, and updated PR), regardless if the PR is directed into the `next` branch or not. 

This is helpful for testing stacked PRs like: https://github.com/tailwindlabs/tailwindcss/pull/14078