### PR TITLE
Add integration test setup and tests for the Vite integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
 
       - name: Build
         run: pnpm run build
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
       # TODO: Put this at the right place
       - name: Integration Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,13 +59,6 @@ jobs:
 
       - name: Build
         run: pnpm run build
-        env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-
-      # TODO: Put this at the right place
-      - name: Integration Tests
-        run: pnpm run test:integrations
 
       - name: Lint
         run: pnpm run lint
@@ -74,6 +67,9 @@ jobs:
 
       - name: Test
         run: pnpm run test
+
+      - name: Integration Tests
+        run: pnpm run test:integrations
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Build
+        run: pnpm run build
+
       # TODO: Put this at the right place
       - name: Integration Tests
         run: pnpm run test:integrations
-
-      - name: Build
-        run: pnpm run build
 
       - name: Lint
         run: pnpm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      # TODO: Put this at the right place
+      - name: Integration Tests
+        run: pnpm run test:integrations
+
       - name: Build
         run: pnpm run build
 
@@ -67,9 +71,6 @@ jobs:
 
       - name: Test
         run: pnpm run test
-
-      - name: Integration Tests
-        run: pnpm run test:integrations
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Test
         run: pnpm run test
 
+      - name: Integration Tests
+        run: pnpm run test:integrations
+
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
 

--- a/integrations/package.json
+++ b/integrations/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {
-    "@types/tcp-port-used": "^1.0.4",
     "dedent": "1.5.3",
     "fast-glob": "^3.3.2",
     "kill-port": "^2.0.1"

--- a/integrations/package.json
+++ b/integrations/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {
-    "dedent": "1.5.3"
+    "dedent": "1.5.3",
+    "fast-glob": "^3.3.2"
   }
 }

--- a/integrations/package.json
+++ b/integrations/package.json
@@ -6,7 +6,6 @@
     "@types/tcp-port-used": "^1.0.4",
     "dedent": "1.5.3",
     "fast-glob": "^3.3.2",
-    "kill-port": "^2.0.1",
-    "tcp-port-used": "^1.0.2"
+    "kill-port": "^2.0.1"
   }
 }

--- a/integrations/package.json
+++ b/integrations/package.json
@@ -3,8 +3,10 @@
   "version": "0.0.0",
   "private": true,
   "devDependencies": {
+    "@types/tcp-port-used": "^1.0.4",
     "dedent": "1.5.3",
     "fast-glob": "^3.3.2",
-    "kill-port": "^2.0.1"
+    "kill-port": "^2.0.1",
+    "tcp-port-used": "^1.0.2"
   }
 }

--- a/integrations/package.json
+++ b/integrations/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "devDependencies": {
     "dedent": "1.5.3",
-    "fast-glob": "^3.3.2"
+    "fast-glob": "^3.3.2",
+    "kill-port": "^2.0.1"
   }
 }

--- a/integrations/package.json
+++ b/integrations/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "internal-integrations",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "dedent": "1.5.3"
+  }
+}

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -203,7 +203,6 @@ export function test(
                   // server that is no longer running, we check if the port is
                   // still in use first.
                   let isPortTaken = await testIfPortTaken(port)
-                  console.log({ isPortTaken })
                   if (!isPortTaken) {
                     return
                   }

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -17,8 +17,8 @@ const REPO_ROOT = path.join(__dirname, '..')
 
 interface SpawnedProcess {
   dispose: () => void
-  onStdout: (predicate: (message: string) => boolean) => void
-  onStderr: (predicate: (message: string) => boolean) => void
+  onStdout: (predicate: (message: string) => boolean) => Promise<void>
+  onStderr: (predicate: (message: string) => boolean) => Promise<void>
 }
 
 interface TestConfig {
@@ -55,7 +55,7 @@ export function test(
       ),
     )
 
-    async function write(filename, content): Promise<void> {
+    async function write(filename: string, content: string): Promise<void> {
       let full = path.join(root, filename)
 
       if (filename.endsWith('package.json')) {
@@ -115,7 +115,7 @@ export function test(
           child.kill()
 
           let timer = setTimeout(
-            () => rejectDisposal?.(new Error(`spawned proccess (${command}) did not exit in time`)),
+            () => rejectDisposal?.(new Error(`spawned process (${command}) did not exit in time`)),
             1000,
           )
           disposePromise.finally(() => clearTimeout(timer))
@@ -246,12 +246,12 @@ function pkgToFilename(name: string) {
 function overwriteVersionsInPackageJson(content: string): string {
   let json = JSON.parse(content)
 
-  // Resolve all worksplace:^ versions to local tarballs
+  // Resolve all workspace:^ versions to local tarballs
   ;['dependencies', 'devDependencies', 'peerDependencies'].forEach((key) => {
-    let desp = json[key] || {}
-    for (let dependecy in desp) {
-      if (desp[dependecy] === 'workspace:^') {
-        desp[dependecy] = resolveVersion(dependecy)
+    let dependencies = json[key] || {}
+    for (let dependency in dependencies) {
+      if (dependencies[dependency] === 'workspace:^') {
+        dependencies[dependency] = resolveVersion(dependency)
       }
     }
   })

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -1,0 +1,209 @@
+import dedent from 'dedent'
+import fastGlob from 'fast-glob'
+import { execSync, spawn } from 'node:child_process'
+import fs from 'node:fs/promises'
+import net from 'node:net'
+import { homedir, platform, tmpdir } from 'node:os'
+import path from 'node:path'
+import { test as defaultTest } from 'vitest'
+
+export let css = dedent
+export let html = dedent
+export let ts = dedent
+export let json = dedent
+
+interface TestConfig {
+  fs: {
+    [filePath: string]: string
+  }
+}
+interface TestContext {
+  exec: (command: string) => Promise<string>
+  spawn: (command: string) => { dispose: () => void }
+  fs: {
+    glob: (pattern: string) => Promise<[string, string][]>
+  }
+}
+type TestCallback = (context: TestContext) => Promise<void> | void
+
+const REPO_ROOT = path.join(__dirname, '..')
+
+export function test(
+  name: string,
+  config: TestConfig,
+  testCallback: TestCallback,
+  { only = false } = {},
+) {
+  return (only ? defaultTest.only : defaultTest)(name, { timeout: 30000 }, async (options) => {
+    let root = await fs.mkdtemp(
+      // On Windows CI, tmpdir returns a path containing a weird RUNNER~1 folder
+      // that apparently causes the vite builds to not work.
+      path.join(
+        process.env.CI && platform() === 'win32' ? homedir() : tmpdir(),
+        'tailwind-integrations',
+      ),
+    )
+
+    for (let [filename, content] of Object.entries(config.fs)) {
+      let full = path.join(root, filename)
+
+      if (filename.endsWith('package.json')) {
+        content = overwriteVersionsInPackageJson(content)
+      }
+
+      // Ensure that files written on Windows use \r\n line ending
+      if (platform() === 'win32') {
+        content = content.replace(/\n/g, '\r\n')
+      }
+
+      let dir = path.dirname(full)
+      await fs.mkdir(dir, { recursive: true })
+      await fs.writeFile(full, content)
+    }
+
+    try {
+      execSync('pnpm install', { cwd: root })
+    } catch (error: any) {
+      console.error(error.stdout.toString())
+      console.error(error.stderr.toString())
+      throw error
+    }
+
+    let disposables: (() => Promise<void>)[] = []
+
+    async function dispose() {
+      await Promise.all(disposables.map((dispose) => dispose()))
+      await fs.rm(root, { recursive: true, maxRetries: 3, force: true })
+    }
+    options.onTestFinished(dispose)
+
+    let context = {
+      async exec(command: string) {
+        return execSync(command, { cwd: root }).toString()
+      },
+      spawn(command: string) {
+        let resolveDisposal: (() => void) | undefined
+        let rejectDisposal: ((error: Error) => void) | undefined
+        let disposePromise = new Promise<void>((resolve, reject) => {
+          resolveDisposal = resolve
+          rejectDisposal = reject
+        })
+
+        let child = spawn(command, {
+          cwd: root,
+          shell: true,
+          env: {
+            ...process.env,
+          },
+        })
+
+        let dispose = () => {
+          child.kill()
+
+          let timer = setTimeout(
+            () => rejectDisposal?.(new Error(`spawned proccess (${command}) did not exit in time`)),
+            1000,
+          )
+          disposePromise.finally(() => clearTimeout(timer))
+          return disposePromise
+        }
+        disposables.push(dispose)
+        function onExit() {
+          console.log(`spawned proccess (${command}) exited`)
+          resolveDisposal?.()
+        }
+
+        let stdout = ''
+        let stderr = ''
+        child.stdout.on('data', (result) => (stdout += result.toString()))
+        child.stderr.on('data', (result) => (stderr += result.toString()))
+        child.on('exit', onExit)
+        child.on('error', (error) => {
+          if (error.name !== 'AbortError') {
+            throw error
+          }
+        })
+
+        options.onTestFailed(() => {
+          console.log(stdout)
+          console.error(stderr)
+        })
+
+        return { dispose }
+      },
+      fs: {
+        async glob(pattern: string) {
+          let files = await fastGlob(pattern, { cwd: root })
+          return Promise.all(
+            files.map(async (file) => {
+              let content = await fs.readFile(path.join(root, file), 'utf8')
+              return [file, content]
+            }),
+          )
+        },
+      },
+    } satisfies TestContext
+
+    await testCallback(context)
+  })
+}
+test.only = (name: string, config: TestConfig, testCallback: TestCallback) => {
+  return test(name, config, testCallback, { only: true })
+}
+
+export async function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let server = net.createServer()
+    server.listen(0, () => {
+      let address = server.address()
+      let port = address === null || typeof address === 'string' ? null : address.port
+
+      server.close(() => {
+        if (port === null) {
+          reject(new Error(`Failed to get a free port: address is ${address}`))
+        } else {
+          resolve(port)
+        }
+      })
+    })
+  })
+}
+
+// Maps package names to their tarball filenames. See scripts/pack-packages.ts
+// for more details.
+function pkgToFilename(name: string) {
+  return `${name.replace('@', '').replace('/', '-')}.tgz`
+}
+
+function overwriteVersionsInPackageJson(content: string): string {
+  let json = JSON.parse(content)
+
+  // Resolve all worksplace:^ versions to local tarballs
+  ;['dependencies', 'devDependencies', 'peerDependencies'].forEach((key) => {
+    let desp = json[key] || {}
+    for (let dependecy in desp) {
+      if (desp[dependecy] === 'workspace:^') {
+        desp[dependecy] = resolveVersion(dependecy)
+      }
+    }
+  })
+
+  // Inject transitive dependency overwrite. This is necessary because
+  // @tailwindcss/vite internally depends on a specific version of
+  // @tailwindcss/oxide and we instead want to resolve it to the locally built
+  // version.
+  json.pnpm ||= {}
+  json.pnpm.overrides ||= {}
+  json.pnpm.overrides['@tailwindcss/oxide'] = resolveVersion('@tailwindcss/oxide')
+
+  return JSON.stringify(json, null, 2)
+}
+
+function resolveVersion(dependency: string) {
+  let tarball = path.join(REPO_ROOT, 'dist', pkgToFilename(dependency))
+  return `file:${tarball}`
+}
+
+export function stripTailwindComment(content: string) {
+  return content.replace(/\/\*! tailwindcss .*? \*\//g, '').trim()
+}

--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -114,7 +114,7 @@ test(
       `,
     },
   },
-  async ({ spawn, getFreePort, fs: { write } }) => {
+  async ({ spawn, getFreePort, fs }) => {
     let port = await getFreePort()
     let process = await spawn(`pnpm vite dev --port ${port}`)
 
@@ -129,7 +129,7 @@ test(
     `,
     )
 
-    await write(
+    await fs.write(
       'index.html',
       html`
         <head>

--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -1,10 +1,11 @@
 import dedent from 'dedent'
-import { execSync } from 'node:child_process'
+import { execSync, spawn } from 'node:child_process'
 import fs from 'node:fs/promises'
 import { platform, homedir, tmpdir } from 'node:os'
 import path from 'node:path'
 import { test as defaultTest, expect } from 'vitest'
 import fastGlob from 'fast-glob'
+import net from 'node:net'
 
 interface TestConfig {
   fs: {
@@ -12,7 +13,8 @@ interface TestConfig {
   }
 }
 interface TestContext {
-  root: string
+  exec: (command: string) => Promise<string>
+  spawn: (command: string) => { dispose: () => void }
   fs: {
     glob: (pattern: string) => Promise<[string, string][]>
   }
@@ -38,8 +40,9 @@ function test(
   name: string,
   config: TestConfig,
   test: (context: TestContext) => Promise<void> | void,
+  { only = false } = {},
 ) {
-  return defaultTest(name, { timeout: 30000 }, async (options) => {
+  return (only ? defaultTest.only : defaultTest)(name, { timeout: 30000 }, async (options) => {
     let root = await fs.mkdtemp(
       // On Windows CI, tmpdir returns a path containing a weird RUNNER~1 folder
       // that apparently causes the vite builds to not work.
@@ -97,7 +100,46 @@ function test(
     options.onTestFinished(cleanup)
 
     let context = {
-      root,
+      async exec(command: string) {
+        return execSync(command, { cwd: root }).toString()
+      },
+      spawn(command: string) {
+        const abortController = new AbortController()
+        let child = spawn(command, {
+          cwd: root,
+          signal: abortController.signal,
+          shell: true,
+          env: {
+            ...process.env,
+          },
+        })
+        let stdout = '',
+          stderr = ''
+        child.stdout.on('data', (result) => {
+          console.log(result.toString())
+          stdout += result.toString()
+        })
+        child.stderr.on('data', (result) => {
+          console.error(result.toString())
+          stderr += result.toString()
+        })
+        child.on('error', (err) => {
+          if (err.name !== 'AbortError') {
+            throw err
+          }
+        })
+
+        options.onTestFailed(() => {
+          console.log(stdout)
+          console.error(stderr)
+        })
+        options.onTestFinished(() => abortController.abort())
+        return {
+          dispose() {
+            abortController.abort()
+          },
+        }
+      },
       fs: {
         async glob(pattern: string) {
           let files = await fastGlob(pattern, { cwd: root })
@@ -114,6 +156,52 @@ function test(
     await test(context)
   })
 }
+test.only = (
+  name: string,
+  config: TestConfig,
+  testCallback: (context: TestContext) => Promise<void> | void,
+) => {
+  return test(name, config, testCallback, { only: true })
+}
+
+async function getPortFree(): Promise<number> {
+  return new Promise((res) => {
+    let srv = net.createServer()
+    srv.listen(0, () => {
+      let adress = srv.address()
+      let port = adress === null || typeof adress === 'string' ? 5173 : adress.port
+      srv.close((err) => res(port))
+    })
+  })
+}
+
+async function fetchCSS(port: number) {
+  const start = Date.now()
+  let error
+  while (Date.now() - start < 5000) {
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    try {
+      // We need to fetch the main index.html file to populate the list of
+      // candidates.
+      let body = await fetch(`http://localhost:${port}`)
+      // Make sure the main request is garbage collected.
+      body.blob()
+
+      let response = await fetch(`http://localhost:${port}/src/index.css`, {
+        headers: {
+          Accept: 'text/css',
+        },
+      })
+      if (response.status === 200) {
+        return response.text()
+      }
+      console.log(response.status)
+    } catch (e) {
+      error = e
+    }
+  }
+  throw error
+}
 
 function pkgToFilename(name: string) {
   return `${name.replace('@', '').replace('/', '-')}.tgz`
@@ -125,6 +213,67 @@ test(
     fs: {
       'package.json': json`
         {
+          "type": "module",
+          "dependencies": {
+            "@tailwindcss/vite": "workspace:^",
+            "tailwindcss": "workspace:^"
+          },
+          "devDependencies": {
+            "vite": "^5.3.5"
+          }
+        }
+      `,
+      'vite.config.ts': ts`
+        import tailwindcss from '@tailwindcss/vite'
+        import { defineConfig } from 'vite'
+
+        export default defineConfig({
+          build: { cssMinify: false },
+          plugins: [tailwindcss()],
+        })
+      `,
+      'index.html': html`
+        <head>
+          <link rel="stylesheet" href="./src/index.css">
+        </head>
+        <body>
+          <div class="underline m-2">Hello, world!</div>
+        </body>
+      `,
+      'src/index.css': css`
+        @import 'tailwindcss/theme' reference;
+        @import 'tailwindcss/utilities';
+      `,
+    },
+  },
+  async ({ fs, exec }) => {
+    await exec('pnpm vite build')
+
+    expect.assertions(2)
+    for (let [path, content] of await fs.glob('dist/**/*.css')) {
+      expect(path).toMatch(/\.css$/)
+      expect(stripTailwindComment(content)).toMatchInlineSnapshot(
+        `
+        ".m-2 {
+          margin: var(--spacing-2, .5rem);
+        }
+
+        .underline {
+          text-decoration-line: underline;
+        }"
+      `,
+      )
+    }
+  },
+)
+
+test(
+  'works with Vite in dev mode',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "type": "module",
           "dependencies": {
             "@tailwindcss/vite": "workspace:^",
             "tailwindcss": "workspace:^"
@@ -157,23 +306,21 @@ test(
       `,
     },
   },
-  async ({ root, fs }) => {
-    execSync('pnpm vite build', { cwd: root })
+  async ({ spawn }) => {
+    let port = await getPortFree()
+    spawn(`pnpm vite dev --port ${port}`)
 
-    expect.assertions(2)
-    for (let [path, content] of await fs.glob('dist/**/*.css')) {
-      expect(path).toMatch(/\.css$/)
-      expect(stripTailwindComment(content)).toMatchInlineSnapshot(
-        `
-        ".m-2 {
-          margin: var(--spacing-2, .5rem);
-        }
+    const css = await fetchCSS(port)
 
-        .underline {
-          text-decoration-line: underline;
-        }"
-      `,
-      )
-    }
+    expect(stripTailwindComment(css)).toMatchInlineSnapshot(
+      `
+      ".m-2 {
+        margin: var(--spacing-2, 0.5rem);
+      }
+      .underline {
+        text-decoration-line: underline;
+      }"
+    `,
+    )
   },
 )

--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -43,7 +43,7 @@ test(
       `,
       'index.html': html`
         <head>
-          <link rel="stylesheet" href="./src/index.css">
+          <link rel="stylesheet" href="./src/index.css" />
         </head>
         <body>
           <div class="underline m-2">Hello, world!</div>
@@ -103,7 +103,7 @@ test(
       `,
       'index.html': html`
         <head>
-          <link rel="stylesheet" href="./src/index.css">
+          <link rel="stylesheet" href="./src/index.css" />
         </head>
         <body>
           <div class="underline">Hello, world!</div>
@@ -133,13 +133,13 @@ test(
     await write(
       'index.html',
       html`
-      <head>
-        <link rel="stylesheet" href="./src/index.css">
-      </head>
-      <body>
-        <div class="underline m-2">Hello, world!</div>
-      </body>
-    `,
+        <head>
+          <link rel="stylesheet" href="./src/index.css" />
+        </head>
+        <body>
+          <div class="underline m-2">Hello, world!</div>
+        </body>
+      `,
     )
     await process.onStdout((message) => message.includes('page reload'))
 

--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -58,11 +58,11 @@ test(
   async ({ fs, exec }) => {
     await exec('pnpm vite build')
 
-    expect.assertions(2)
-    for (let [path, content] of await fs.glob('dist/**/*.css')) {
-      expect(path).toMatch(/\.css$/)
-      expect(stripTailwindComment(content)).toMatchInlineSnapshot(
-        `
+    let files = await fs.glob('dist/**/*.css')
+    expect(files).toHaveLength(1)
+    let [, content] = files[0]
+    expect(stripTailwindComment(content)).toMatchInlineSnapshot(
+      `
         ".m-2 {
           margin: var(--spacing-2, .5rem);
         }
@@ -71,8 +71,7 @@ test(
           text-decoration-line: underline;
         }"
       `,
-      )
-    }
+    )
   },
 )
 

--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -1,3 +1,4 @@
+import dedent from 'dedent'
 import fs from 'node:fs/promises'
 import { platform, tmpdir } from 'node:os'
 import path from 'node:path'
@@ -12,24 +13,6 @@ interface TestContext {
   root: string
 }
 
-function dedent(content: string) {
-  let minIndent = Infinity
-  let lines = content.trim().split('z§')
-  for (let [idx, line] of lines.entries()) {
-    if (line.trim() === '') continue
-    if (idx === 0 && !line.startsWith(' ')) continue
-
-    let indent = line.match(/^\s+/)?.[0].length ?? 0
-    if (indent < minIndent) minIndent = indent
-  }
-  return lines
-    .map((line, idx) => {
-      if (idx === 0 && !line.startsWith(' ')) return line
-      return line.slice(minIndent)
-    })
-    .join('\n')
-}
-
 function windowsify(content: string) {
   if (platform() === 'win32') {
     return content.replace(/\n/g, '\r\n')
@@ -37,10 +20,10 @@ function windowsify(content: string) {
   return content
 }
 
-const css = String.raw
-const html = String.raw
-const js = String.raw
-const json = String.raw
+const css = dedent
+const html = dedent
+const js = dedent
+const json = dedent
 
 function test(
   name: string,
@@ -54,7 +37,7 @@ function test(
       let full = path.join(root, filename)
       let dir = path.dirname(full)
       await fs.mkdir(dir, { recursive: true })
-      await fs.writeFile(full, windowsify(dedent(content)))
+      await fs.writeFile(full, windowsify(content))
     }
 
     function cleanup() {

--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -49,7 +49,7 @@ function test(
       if (filename.endsWith('package.json')) {
         content = content.replace(/"(.*?)": ?\"(@references)\"/g, (_, key, ref) => {
           let tarball = path.join(__dirname, '..', '..', 'dist', pkgToFilename(key))
-          return `"${key}": "file:${tarball}"`
+          return `"${key}": "file:${tarball.replace(/\\/g, '\\\\')}"`
         })
       }
 

--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -41,6 +41,7 @@ function test(
 ) {
   return defaultTest(name, { timeout: 30000 }, async (options) => {
     let root = await fs.mkdtemp(path.join(tmpdir(), 'tailwind-integrations'))
+    root = path.relative(__dirname, root)
 
     for (let [filename, content] of Object.entries(config.fs)) {
       let full = path.join(root, filename)

--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -1,3 +1,4 @@
+import kill from 'kill-port'
 import { expect } from 'vitest'
 import { css, getFreePort, html, json, stripTailwindComment, test, ts } from '../utils'
 
@@ -143,5 +144,7 @@ test(
       }"
     `,
     )
+
+    await kill(port)
   },
 )

--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -131,12 +131,12 @@ test(
         }
       `,
       'vite.config.ts': ts`
-        // import tailwindcss from '@tailwindcss/vite'
+        import tailwindcss from '@tailwindcss/vite'
         import { defineConfig } from 'vite'
 
         export default defineConfig({
           build: {
-            // cssMinify: false,
+            cssMinify: false,
             // // Windows Vite builds don't work unless we manually rename the
             // // output HTML file.
             // rollupOptions: {
@@ -144,7 +144,7 @@ test(
             //   output: { assetFileNames: 'assets/[name].[ext]' },
             // },
           },
-          // plugins: [tailwindcss()],
+          plugins: [tailwindcss()],
         })
       `,
       'index.html': html`
@@ -161,7 +161,7 @@ test(
     },
   },
   async ({ root, fs }) => {
-    execSync('pnpm vite dev', { cwd: root })
+    execSync('pnpm vite build', { cwd: root })
 
     for (let [path, content] of await fs.glob('dist/**/*.css')) {
       expect(path).toMatch(/\.css$/)

--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -1,6 +1,5 @@
-import kill from 'kill-port'
 import { expect } from 'vitest'
-import { css, getFreePort, html, json, stripTailwindComment, test, ts } from '../utils'
+import { css, html, json, stripTailwindComment, test, ts } from '../utils'
 
 async function fetchCSS(pathname: string, port: number) {
   const start = Date.now()
@@ -128,7 +127,7 @@ test(
       `,
     },
   },
-  async ({ spawn }) => {
+  async ({ spawn, getFreePort }) => {
     let port = await getFreePort()
     spawn(`pnpm vite dev --port ${port}`)
 
@@ -144,7 +143,5 @@ test(
       }"
     `,
     )
-
-    await kill(port)
   },
 )

--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -26,7 +26,7 @@ function windowsify(content: string) {
 }
 
 function stripTailwindComment(content: string) {
-  return content.replace(/\/\*! tailwindcss .*? \*\//g, '').trim()
+  return content.replace(/\/\*! tailwindcss .*? \*\//g, '')
 }
 
 const css = dedent
@@ -64,7 +64,7 @@ function test(
           return Promise.all(
             files.map(async (file) => {
               let content = await fs.readFile(path.join(root, file), 'utf8')
-              return [file, content]
+              return [file, content.trim()]
             }),
           )
         },

--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -1,0 +1,108 @@
+import fs from 'node:fs/promises'
+import { platform, tmpdir } from 'node:os'
+import path from 'node:path'
+import { test as defaultTest, expect } from 'vitest'
+
+interface TestConfig {
+  fs: {
+    [filePath: string]: string
+  }
+}
+interface TestContext {
+  root: string
+}
+
+function dedent(content: string) {
+  let minIndent = Infinity
+  let lines = content.trim().split('z§')
+  for (let [idx, line] of lines.entries()) {
+    if (line.trim() === '') continue
+    if (idx === 0 && !line.startsWith(' ')) continue
+
+    let indent = line.match(/^\s+/)?.[0].length ?? 0
+    if (indent < minIndent) minIndent = indent
+  }
+  return lines
+    .map((line, idx) => {
+      if (idx === 0 && !line.startsWith(' ')) return line
+      return line.slice(minIndent)
+    })
+    .join('\n')
+}
+
+function windowsify(content: string) {
+  if (platform() === 'win32') {
+    return content.replace(/\n/g, '\r\n')
+  }
+  return content
+}
+
+const css = String.raw
+const html = String.raw
+const js = String.raw
+const json = String.raw
+
+function test(
+  name: string,
+  config: TestConfig,
+  test: (context: TestContext) => Promise<void> | void,
+) {
+  return defaultTest(name, async (options) => {
+    let root = await fs.mkdtemp(path.join(tmpdir(), 'tailwind-integrations'))
+
+    for (let [filename, content] of Object.entries(config.fs)) {
+      let full = path.join(root, filename)
+      let dir = path.dirname(full)
+      await fs.mkdir(dir, { recursive: true })
+      await fs.writeFile(full, windowsify(dedent(content)))
+    }
+
+    function cleanup() {
+      fs.rm(root, { recursive: true })
+    }
+    options.onTestFinished(cleanup)
+
+    const context = { root } satisfies TestContext
+
+    await test(context)
+  })
+}
+
+test(
+  'adding a glob outside of the content works',
+  {
+    fs: {
+      'foo/index.html': html`
+        <body>
+          <div>Hello, world!</div>
+        </body>
+      `,
+      'foo/index.css': css`
+        div {
+          color: red;
+        }
+      `,
+    },
+  },
+  async ({ root }) => {
+    console.log({ root })
+    let files = await fs.readdir(path.join(root, 'foo'))
+    for (let file of files) {
+      let content = await fs.readFile(path.join(root, 'foo', file), 'utf-8')
+      console.log({ file, content })
+    }
+
+    //   ...defaultViteSetup,
+    //   "index.html": html`
+    //     <div>
+    //   `,s
+    //   "index.css": css`
+    //   `
+    // }}, ({fs}) =>{
+
+    //   // run vite
+    //   fs.write()
+    //   // run vite
+    expect(1).toBe(1)
+  },
+)

--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -94,6 +94,23 @@ function pkgToFilename(name: string) {
   return `${name.replace('@', '').replace('/', '-')}.tgz`
 }
 
+/**
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ * Don't look up!
+ */
+
 test(
   'builds with Vite',
   {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "singleQuote": true,
     "printWidth": 100,
     "plugins": [
-      "prettier-plugin-embed",
       "prettier-plugin-organize-imports"
     ],
     "overrides": [
@@ -18,15 +17,18 @@
         "options": {
           "parser": "jsonc"
         }
+      },
+      {
+        "files": [
+          "integrations/**/*.ts"
+        ],
+        "options": {
+          "plugins": [
+            "prettier-plugin-embed",
+            "prettier-plugin-organize-imports"
+          ]
+        }
       }
-    ],
-    "embeddedNoopComments": [
-      "css",
-      "html"
-    ],
-    "embeddedNoopTags": [
-      "css",
-      "html"
     ]
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "build": "turbo build --filter=!./playgrounds/*",
     "dev": "turbo dev --filter=!./playgrounds/*",
     "test": "cargo test && vitest run",
+    "test:integrations": "vitest --root=./integrations",
     "test:ui": "pnpm run --filter=tailwindcss test:ui",
     "tdd": "vitest",
     "bench": "vitest bench",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "format": "prettier --write .",
     "lint": "prettier --check . && turbo lint",
-    "build": "turbo build --filter=!./playgrounds/*",
+    "build": "turbo build --filter=!./playgrounds/* && node ./scripts/pack-packages.mjs",
     "dev": "turbo dev --filter=!./playgrounds/*",
     "test": "cargo test && vitest run",
     "test:integrations": "vitest --root=./integrations",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "singleQuote": true,
     "printWidth": 100,
     "plugins": [
-      "prettier-plugin-organize-imports"
+      "prettier-plugin-organize-imports",
+      "prettier-plugin-embed"
     ],
     "overrides": [
       {
@@ -42,6 +43,7 @@
     "postcss": "8.4.24",
     "postcss-import": "^16.1.0",
     "prettier": "^3.2.5",
+    "prettier-plugin-embed": "^0.4.15",
     "prettier-plugin-organize-imports": "^3.2.4",
     "tsup": "^8.0.2",
     "turbo": "^1.13.3",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,14 @@
           "parser": "jsonc"
         }
       }
+    ],
+    "embeddedNoopComments": [
+      "css",
+      "html"
+    ],
+    "embeddedNoopTags": [
+      "css",
+      "html"
     ]
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "singleQuote": true,
     "printWidth": 100,
     "plugins": [
-      "prettier-plugin-organize-imports",
-      "prettier-plugin-embed"
+      "prettier-plugin-embed",
+      "prettier-plugin-organize-imports"
     ],
     "overrides": [
       {

--- a/packages/tailwindcss/vitest.config.ts
+++ b/packages/tailwindcss/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    exclude: ['**/*.spec.?(c|m)[jt]s?(x)'],
+    exclude: ['**/*.spec.?(c|m)[jt]s?(x)', 'integrations/**/*'],
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
 
   integrations:
     devDependencies:
+      '@types/tcp-port-used':
+        specifier: ^1.0.4
+        version: 1.0.4
       dedent:
         specifier: 1.5.3
         version: 1.5.3
@@ -115,6 +118,9 @@ importers:
       kill-port:
         specifier: ^2.0.1
         version: 2.0.1
+      tcp-port-used:
+        specifier: ^1.0.2
+        version: 1.0.2
 
   packages/@tailwindcss-cli:
     dependencies:
@@ -1059,6 +1065,9 @@ packages:
   '@types/react@18.3.3':
     resolution: {integrity: sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==}
 
+  '@types/tcp-port-used@1.0.4':
+    resolution: {integrity: sha512-0vQ4fz9TTM4bCdllYWEJ2JHBUXR9xqPtc70dJ7BMRDVfvZyYdrgey3nP5RRcVj+qAgnHJM8r9fvgrfnPMxdnhA==}
+
   '@typescript-eslint/parser@6.21.0':
     resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -1353,6 +1362,15 @@ packages:
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.3.1:
+    resolution: {integrity: sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==}
+    engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -1811,6 +1829,10 @@ packages:
     resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
     engines: {node: '>= 0.4'}
 
+  ip-regex@4.3.0:
+    resolution: {integrity: sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==}
+    engines: {node: '>=8'}
+
   is-array-buffer@3.0.4:
     resolution: {integrity: sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==}
     engines: {node: '>= 0.4'}
@@ -1916,6 +1938,9 @@ packages:
     resolution: {integrity: sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==}
     engines: {node: '>= 0.4'}
 
+  is-url@1.2.4:
+    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
+
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
     engines: {node: '>= 0.4'}
@@ -1926,6 +1951,10 @@ packages:
   is-weakset@2.0.3:
     resolution: {integrity: sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==}
     engines: {node: '>= 0.4'}
+
+  is2@2.0.9:
+    resolution: {integrity: sha512-rZkHeBn9Zzq52sd9IUIV3a5mfwBY+o2HePMh0wkGBM4z4qjvy2GwVxQ6nNXSfw6MmVP6gf1QIlWjiOavhM3x5g==}
+    engines: {node: '>=v0.10.0'}
 
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -2669,6 +2698,9 @@ packages:
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
+
+  tcp-port-used@1.0.2:
+    resolution: {integrity: sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==}
 
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
@@ -3554,6 +3586,8 @@ snapshots:
       '@types/prop-types': 15.7.12
       csstype: 3.1.3
 
+  '@types/tcp-port-used@1.0.4': {}
+
   '@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.21.0
@@ -3935,6 +3969,10 @@ snapshots:
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
+
+  debug@4.3.1:
+    dependencies:
+      ms: 2.1.2
 
   debug@4.3.4:
     dependencies:
@@ -4581,6 +4619,8 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.0.6
 
+  ip-regex@4.3.0: {}
+
   is-array-buffer@3.0.4:
     dependencies:
       call-bind: 1.0.7
@@ -4672,6 +4712,8 @@ snapshots:
     dependencies:
       which-typed-array: 1.1.15
 
+  is-url@1.2.4: {}
+
   is-weakmap@2.0.2: {}
 
   is-weakref@1.0.2:
@@ -4682,6 +4724,12 @@ snapshots:
     dependencies:
       call-bind: 1.0.7
       get-intrinsic: 1.2.4
+
+  is2@2.0.9:
+    dependencies:
+      deep-is: 0.1.4
+      ip-regex: 4.3.0
+      is-url: 1.2.4
 
   isarray@2.0.5: {}
 
@@ -5421,6 +5469,13 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   tapable@2.2.1: {}
+
+  tcp-port-used@1.0.2:
+    dependencies:
+      debug: 4.3.1
+      is2: 2.0.9
+    transitivePeerDependencies:
+      - supports-color
 
   test-exclude@6.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       prettier:
         specifier: ^3.2.5
         version: 3.2.5
+      prettier-plugin-embed:
+        specifier: ^0.4.15
+        version: 0.4.15
       prettier-plugin-organize-imports:
         specifier: ^3.2.4
         version: 3.2.4(prettier@3.2.5)(typescript@5.4.5)
@@ -106,6 +109,9 @@ importers:
       dedent:
         specifier: 1.5.3
         version: 1.5.3
+      fast-glob:
+        specifier: ^3.3.2
+        version: 3.3.2
 
   packages/@tailwindcss-cli:
     dependencies:
@@ -1243,6 +1249,7 @@ packages:
 
   bun@1.1.10:
     resolution: {integrity: sha512-qOJXrQZSzJ5DbJMt47GZGWtUSmIkbwD7fPSN/XS/T46D4cTTnPK46QDHlyC8VD+Anvs6uKNwuwKIyB31kUdHmQ==}
+    cpu: [arm64, x64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -1610,6 +1617,10 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  find-up-simple@1.0.0:
+    resolution: {integrity: sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==}
+    engines: {node: '>=18'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -2112,6 +2123,9 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
+  micro-memoize@4.1.2:
+    resolution: {integrity: sha512-+HzcV2H+rbSJzApgkj0NdTakkC+bnyeiUxgT6/m7mjcz1CmM22KYFKp+EVj1sWe4UYcnriJr5uqHQD/gMHLD+g==}
+
   micromatch@4.0.7:
     resolution: {integrity: sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==}
     engines: {node: '>=8.6'}
@@ -2265,6 +2279,10 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  package-up@5.0.0:
+    resolution: {integrity: sha512-MQEgDUvXCa3sGvqHg3pzHO8e9gqTCMPVrWUko3vPQGntwegmFo52mZb2abIVTjFnUcW0BcPz0D93jV5Cas1DWA==}
+    engines: {node: '>=18'}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -2370,6 +2388,9 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier-plugin-embed@0.4.15:
+    resolution: {integrity: sha512-9pZVIp3bw2jw+Ge+iAMZ4j+sIVC9cPruZ93H2tj5Wa/3YDFDJ/uYyVWdUGfcFUnv28drhW2Bmome9xSGXsPKOw==}
 
   prettier-plugin-organize-imports@3.2.4:
     resolution: {integrity: sha512-6m8WBhIp0dfwu0SkgfOxJqh+HpdyfqSSLfKKRZSFbDuEQXDDndb8fTpRWkUrX/uBenkex3MgnVk0J3b3Y5byog==}
@@ -2650,6 +2671,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tiny-jsonc@1.0.1:
+    resolution: {integrity: sha512-ik6BCxzva9DoiEfDX/li0L2cWKPPENYvixUprFdl3YPi4bZZUhDnNI9YUkacrv+uIG90dnxR5mNqaoD6UhD6Bw==}
+
   tinybench@2.8.0:
     resolution: {integrity: sha512-1/eK7zUnIklz4JUUlL+658n58XO2hHLQfSk1Zf2LKieUjxidN16eKFEoDEfjHc3ohofSSqK3X5yO6VGb6iW8Lw==}
 
@@ -2755,6 +2779,10 @@ packages:
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
+
+  type-fest@4.23.0:
+    resolution: {integrity: sha512-ZiBujro2ohr5+Z/hZWHESLz3g08BBdrdLMieYFULJO+tWc437sn8kQsWLJoZErY8alNhxre9K4p3GURAG11n+w==}
+    engines: {node: '>=16'}
 
   typed-array-buffer@1.0.2:
     resolution: {integrity: sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==}
@@ -4108,7 +4136,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.1(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -4132,7 +4160,7 @@ snapshots:
       enhanced-resolve: 5.16.1
       eslint: 8.57.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.13.1
@@ -4154,7 +4182,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -4348,6 +4376,8 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  find-up-simple@1.0.0: {}
 
   find-up@5.0.0:
     dependencies:
@@ -4821,6 +4851,8 @@ snapshots:
 
   merge2@1.4.1: {}
 
+  micro-memoize@4.1.2: {}
+
   micromatch@4.0.7:
     dependencies:
       braces: 3.0.3
@@ -4987,6 +5019,10 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-up@5.0.0:
+    dependencies:
+      find-up-simple: 1.0.0
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -5071,6 +5107,17 @@ snapshots:
       source-map-js: 1.2.0
 
   prelude-ls@1.2.1: {}
+
+  prettier-plugin-embed@0.4.15:
+    dependencies:
+      '@types/estree': 1.0.5
+      dedent: 1.5.3
+      micro-memoize: 4.1.2
+      package-up: 5.0.0
+      tiny-jsonc: 1.0.1
+      type-fest: 4.23.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
 
   prettier-plugin-organize-imports@3.2.4(prettier@3.2.5)(typescript@5.4.5):
     dependencies:
@@ -5369,6 +5416,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tiny-jsonc@1.0.1: {}
+
   tinybench@2.8.0: {}
 
   tinypool@0.8.4: {}
@@ -5459,6 +5508,8 @@ snapshots:
   type-detect@4.0.8: {}
 
   type-fest@0.20.2: {}
+
+  type-fest@4.23.0: {}
 
   typed-array-buffer@1.0.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,12 @@ importers:
 
   crates/node/npm/win32-x64-msvc: {}
 
+  integrations:
+    devDependencies:
+      dedent:
+        specifier: 1.5.3
+        version: 1.5.3
+
   packages/@tailwindcss-cli:
     dependencies:
       '@parcel/watcher':
@@ -1350,6 +1356,14 @@ packages:
       supports-color: '*'
     peerDependenciesMeta:
       supports-color:
+        optional: true
+
+  dedent@1.5.3:
+    resolution: {integrity: sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
         optional: true
 
   deep-eql@4.1.3:
@@ -3884,6 +3898,8 @@ snapshots:
   debug@4.3.4:
     dependencies:
       ms: 2.1.2
+
+  dedent@1.5.3: {}
 
   deep-eql@4.1.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.2
+      kill-port:
+        specifier: ^2.0.1
+        version: 2.0.1
 
   packages/@tailwindcss-cli:
     dependencies:
@@ -1686,6 +1689,9 @@ packages:
     resolution: {integrity: sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==}
     engines: {node: '>= 0.4'}
 
+  get-them-args@1.3.2:
+    resolution: {integrity: sha512-LRn8Jlk+DwZE4GTlDbT3Hikd1wSHgLMme/+7ddlqKd7ldwR6LjJgTVWzBnR01wnYGe4KgrXjg287RaI22UHmAw==}
+
   get-tsconfig@4.7.5:
     resolution: {integrity: sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==}
 
@@ -1997,6 +2003,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kill-port@2.0.1:
+    resolution: {integrity: sha512-e0SVOV5jFo0mx8r7bS29maVWp17qGqLBZ5ricNSajON6//kmb7qqqNnml4twNE8Dtj97UQD+gNFOaipS/q1zzQ==}
+    hasBin: true
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -2532,6 +2542,9 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-exec@1.0.2:
+    resolution: {integrity: sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg==}
 
   side-channel@1.0.6:
     resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
@@ -4442,6 +4455,8 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.2.4
 
+  get-them-args@1.3.2: {}
+
   get-tsconfig@4.7.5:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -4747,6 +4762,11 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kill-port@2.0.1:
+    dependencies:
+      get-them-args: 1.3.2
+      shell-exec: 1.0.2
 
   language-subtag-registry@0.3.23: {}
 
@@ -5277,6 +5297,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-exec@1.0.2: {}
 
   side-channel@1.0.6:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,9 +118,6 @@ importers:
       kill-port:
         specifier: ^2.0.1
         version: 2.0.1
-      tcp-port-used:
-        specifier: ^1.0.2
-        version: 1.0.2
 
   packages/@tailwindcss-cli:
     dependencies:
@@ -1261,7 +1258,6 @@ packages:
 
   bun@1.1.10:
     resolution: {integrity: sha512-qOJXrQZSzJ5DbJMt47GZGWtUSmIkbwD7fPSN/XS/T46D4cTTnPK46QDHlyC8VD+Anvs6uKNwuwKIyB31kUdHmQ==}
-    cpu: [arm64, x64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -1362,15 +1358,6 @@ packages:
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  debug@4.3.1:
-    resolution: {integrity: sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==}
-    engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -1829,10 +1816,6 @@ packages:
     resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
     engines: {node: '>= 0.4'}
 
-  ip-regex@4.3.0:
-    resolution: {integrity: sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==}
-    engines: {node: '>=8'}
-
   is-array-buffer@3.0.4:
     resolution: {integrity: sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==}
     engines: {node: '>= 0.4'}
@@ -1938,9 +1921,6 @@ packages:
     resolution: {integrity: sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==}
     engines: {node: '>= 0.4'}
 
-  is-url@1.2.4:
-    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
-
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
     engines: {node: '>= 0.4'}
@@ -1951,10 +1931,6 @@ packages:
   is-weakset@2.0.3:
     resolution: {integrity: sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==}
     engines: {node: '>= 0.4'}
-
-  is2@2.0.9:
-    resolution: {integrity: sha512-rZkHeBn9Zzq52sd9IUIV3a5mfwBY+o2HePMh0wkGBM4z4qjvy2GwVxQ6nNXSfw6MmVP6gf1QIlWjiOavhM3x5g==}
-    engines: {node: '>=v0.10.0'}
 
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -2698,9 +2674,6 @@ packages:
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
-
-  tcp-port-used@1.0.2:
-    resolution: {integrity: sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==}
 
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
@@ -3970,10 +3943,6 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.3.1:
-    dependencies:
-      ms: 2.1.2
-
   debug@4.3.4:
     dependencies:
       ms: 2.1.2
@@ -4187,7 +4156,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.1(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -4211,7 +4180,7 @@ snapshots:
       enhanced-resolve: 5.16.1
       eslint: 8.57.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.13.1
@@ -4233,7 +4202,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -4619,8 +4588,6 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.0.6
 
-  ip-regex@4.3.0: {}
-
   is-array-buffer@3.0.4:
     dependencies:
       call-bind: 1.0.7
@@ -4712,8 +4679,6 @@ snapshots:
     dependencies:
       which-typed-array: 1.1.15
 
-  is-url@1.2.4: {}
-
   is-weakmap@2.0.2: {}
 
   is-weakref@1.0.2:
@@ -4724,12 +4689,6 @@ snapshots:
     dependencies:
       call-bind: 1.0.7
       get-intrinsic: 1.2.4
-
-  is2@2.0.9:
-    dependencies:
-      deep-is: 0.1.4
-      ip-regex: 4.3.0
-      is-url: 1.2.4
 
   isarray@2.0.5: {}
 
@@ -5469,13 +5428,6 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   tapable@2.2.1: {}
-
-  tcp-port-used@1.0.2:
-    dependencies:
-      debug: 4.3.1
-      is2: 2.0.9
-    transitivePeerDependencies:
-      - supports-color
 
   test-exclude@6.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,9 +106,6 @@ importers:
 
   integrations:
     devDependencies:
-      '@types/tcp-port-used':
-        specifier: ^1.0.4
-        version: 1.0.4
       dedent:
         specifier: 1.5.3
         version: 1.5.3
@@ -1061,9 +1058,6 @@ packages:
 
   '@types/react@18.3.3':
     resolution: {integrity: sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==}
-
-  '@types/tcp-port-used@1.0.4':
-    resolution: {integrity: sha512-0vQ4fz9TTM4bCdllYWEJ2JHBUXR9xqPtc70dJ7BMRDVfvZyYdrgey3nP5RRcVj+qAgnHJM8r9fvgrfnPMxdnhA==}
 
   '@typescript-eslint/parser@6.21.0':
     resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
@@ -3558,8 +3552,6 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.12
       csstype: 3.1.3
-
-  '@types/tcp-port-used@1.0.4': {}
 
   '@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.4.5)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ packages:
   - 'crates/node/npm/*'
   - 'packages/*'
   - 'playgrounds/*'
+  - 'integrations'

--- a/scripts/pack-packages.mjs
+++ b/scripts/pack-packages.mjs
@@ -47,7 +47,10 @@ Promise.all(
 
     let filename = await pack()
     // Remove version suffix
-    await fs.rename(path.join(root, 'dist', filename), path.join(root, 'dist', pkgToFilename(name)))
+    await fs.rename(
+      path.join(root, 'dist', path.basename(filename)),
+      path.join(root, 'dist', pkgToFilename(name)),
+    )
   }),
 ).then(() => {
   console.log('Done.')
@@ -58,6 +61,7 @@ function pkgToFilename(name) {
 }
 
 function lastLine(str) {
-  let lines = str.split(/\r?\n/)
-  return lines[lines.length - 1]
+  const index = str.lastIndexOf('\n')
+  if (index === -1) return str
+  return str.slice(index + 1)
 }

--- a/scripts/pack-packages.mjs
+++ b/scripts/pack-packages.mjs
@@ -61,7 +61,7 @@ function pkgToFilename(name) {
 }
 
 function lastLine(str) {
-  const index = str.lastIndexOf('\n')
+  let index = str.lastIndexOf('\n')
   if (index === -1) return str
   return str.slice(index + 1)
 }

--- a/scripts/pack-packages.mjs
+++ b/scripts/pack-packages.mjs
@@ -1,0 +1,61 @@
+import { execSync, exec, spawnSync } from 'node:child_process'
+import fs from 'node:fs/promises'
+import path, { dirname } from 'node:path'
+import url from 'node:url'
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+let root = path.resolve(__dirname, '..')
+
+let rawPaths = execSync('pnpm --silent --filter=!./playgrounds/* -r exec pwd').toString()
+
+let paths = rawPaths
+  .trim()
+  .split('\n')
+  .map((x) => path.resolve(x, 'package.json'))
+
+let workspaces = new Map()
+
+// Track all the workspaces
+for (let path of paths) {
+  let pkg = await fs.readFile(path, 'utf8').then(JSON.parse)
+  if (pkg.private) continue
+  workspaces.set(pkg.name, { version: pkg.version ?? '', dir: dirname(path) })
+}
+
+// Clean dist folder
+await fs.rm(path.join(root, 'dist'), { recursive: true, force: true })
+
+Promise.all(
+  [...workspaces.entries()].map(async ([name, { version, dir }]) => {
+    function pack() {
+      return new Promise((resovle) => {
+        exec(
+          `pnpm pack --pack-destination='${path.join(root, 'dist')}'`,
+          {
+            cwd: dir,
+          },
+          (err, stdout, stderr) => {
+            if (err) {
+              console.error(err, stdout, stderr)
+            }
+
+            resovle()
+          },
+        )
+      })
+    }
+
+    await pack()
+    // Remove version suffix
+    await fs.rename(
+      path.join(root, 'dist', pkgToFilename(name, version)),
+      path.join(root, 'dist', pkgToFilename(name)),
+    )
+  }),
+).then(() => {
+  console.log('Done.')
+})
+
+function pkgToFilename(name, version) {
+  return `${name.replace('@', '').replace('/', '-')}${version ? `-${version}` : ''}.tgz`
+}


### PR DESCRIPTION
This PR adds a new root `/integrations` folder that will be the home of integration tests. The idea of these tests is to use Tailwind in various setups just like our users would (by only using the publishable npm builds). 

To avoid issues with concurrent tests making changes to the file system, to make it very easy to test through a range of versions, and to avoid changing configuration objects over and over in test runs, we decided to inline the scaffolding completely into the test file and have no examples checked into the repo. 

Here's an example of how this can look like for a simple Vite test:

```ts
test('works with production builds', {
    fs: {
      'package.json': json`
        {
          "type": "module",
          "dependencies": {
            "@tailwindcss/vite": "workspace:^",
            "tailwindcss": "workspace:^"
          },
          "devDependencies": {
            "vite": "^5.3.5"
          }
        }
      `,
      'vite.config.ts': ts`
        import tailwindcss from '@tailwindcss/vite'
        import { defineConfig } from 'vite'

        export default defineConfig({
          build: { cssMinify: false },
          plugins: [tailwindcss()],
        })
      `,
      'index.html': html`
        <head>
          <link rel="stylesheet" href="./src/index.css">
        </head>
        <body>
          <div class="underline m-2">Hello, world!</div>
        </body>
      `,
      'src/index.css': css`
        @import 'tailwindcss/theme' reference;
        @import 'tailwindcss/utilities';
      `,
    },
  },
  async ({ fs, exec }) => {
    await exec('pnpm vite build')

    expect.assertions(2)
    for (let [path, content] of await fs.glob('dist/**/*.css')) {
      expect(path).toMatch(/\.css$/)
      expect(stripTailwindComment(content)).toMatchInlineSnapshot(
        `
        ".m-2 {
          margin: var(--spacing-2, .5rem);
        }

        .underline {
          text-decoration-line: underline;
        }"
      `,
      )
    }
  },
)
```

By defining all dependencies this way, we never have to worry about which fixtures are checked in and can more easily describe changes to the setup. 

For ergonomics, we've also added the [`embed` prettier plugin](https://github.com/Sec-ant/prettier-plugin-embed). This will mean that files inlined in the `fs` setup are properly indented. No extra work needed! 

If you're using VS Code, I can also recommend the [Language Literals](https://marketplace.visualstudio.com/items?itemName=sissel.language-literals) extension so that syntax highlighting also _just works_.

A neat feature of inlining the scaffolding like this is to make it very simple to test through a variety of versions. For example, here's how we can set up a test against Vite 5 and Vite 4:

```js
;['^4.5.3', '^5.3.5'].forEach(viteVersion => {
    test(`works with production builds for Vite ${viteVersion}`, {
      fs: {
        'package.json': json`
          {
            "type": "module",
            "devDependencies": {
              "vite": "${viteVersion}"
            }
          }
        `,
    async () => {
      // Do something
    },
  )
})
```

## Philosophy

Before we dive into the specifics, I want to clearly state the design considerations we have chosen for this new test suite:

- All file mutations should be done in temp folders, nothing should ever mess with your working directory
- Windows as a first-class citizen
- Have a clean and simple API that describes the test setup only using public APIs
- Focus on reliability (make sure cleanup scripts work and are tolerant to various error scenarios)
- If a user reports an issue with a specific configuration, we want to be able to reproduce them with integration tests, no matter how obscure the setup (this means the test need to be in control of most of the variables)
- Tests should be reasonably fast (obviously this depends on the integration. If we use a slow build tool, we can't magically speed it up, but our overhead should be minimal).

## How it works

The current implementation provides a custom `test` helper function that, when used, sets up the environment according to the configuration. It'll create a new temporary directory and create all files, ensuring things like proper `\r\n` line endings on Windows. 

We do have to patch the `package.json` specifically, since we can not use public versions of the tailwindcss packages as we want to be able to test against a development build. To make this happen, every `pnpm build` run now creates tarballs of the npm modules (that contain only the files that would also in the published build). We then patch the `package.json` to rewrite `workspace:^` versions to link to those tarballs. We found this to work reliably on Windows and macOS as well as being fast enough to not cause any issues. Furthermore we also decided to use `pnpm` as the version manager for integration tests because of it's global module cache (so installing `vite` is fast as soon as you installed it once).

The test function will receive a few utilities that it can use to more easily interact with the temp dir. One example is a `fs.glob` function that you can use to easily find files in eventual `dist/` directories or helpers around `spawn` and `exec` that make sure that processes are cleaned up correctly.

Because we use tarballs from our build dependencies, working on changes requires a workflow where you run `pnpm build` before running `pnpm test:integrations`. However it also means we can run clients like our CLI client with no additional overhead—just install the dependency like any user would and set up your test cases this way.

## Test plan

This PR also includes two Vite specific integration tests: One testing a static build (`pnpm vite build`) and one a dev mode build (`pnpm vite dev`) that also makes changes to the file system and asserts that the resources properly update.