### PR TITLE
Ensure `require` is possible in `esm` file

### DIFF
--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -3,6 +3,7 @@ import { IO, Parsing, scanDir, scanFiles, type ChangedContent } from '@tailwindc
 import { Features, transform } from 'lightningcss'
 import { existsSync } from 'node:fs'
 import fs from 'node:fs/promises'
+import { createRequire } from 'node:module'
 import path from 'node:path'
 import postcss from 'postcss'
 import atImport from 'postcss-import'
@@ -20,6 +21,7 @@ import { resolve } from '../../utils/resolve'
 import { drainStdin, outputFile } from './utils'
 
 const css = String.raw
+const require = createRequire(import.meta.url)
 
 export function options() {
   return {


### PR DESCRIPTION
When using the `@plugin "…";` in CSS, then the `@tailwindcss/cli` will currently crash with `Dynamic require` error:

```
Error: Dynamic require of "./plugin.js" is not supported
    at file:///private/var/folders/…/T/tailwind-integrations…/node_modules/@tailwindcss/cli/dist/index.mjs:2:195
    at loadPlugin (file:///private/var/folders/…/T/tailwind-integrations…/node_modules/@tailwindcss/cli/dist/index.mjs:6:439)
    at file:///private/var/folders/…/T/tailwind-integrations…/node_modules/tailwindcss/dist/lib.mjs:8:4328
    at S (file:///private/var/folders/…/T/tailwind-integrations…/node_modules/tailwindcss/dist/lib.mjs:1:445)
    at Module._r (file:///private/var/folders/…/T/tailwind-integrations…/node_modules/tailwindcss/dist/lib.mjs:8:4222)
    at p (file:///private/var/folders/…/T/tailwind-integrations…/node_modules/@tailwindcss/cli/dist/index.mjs:6:414)
    at le (file:///private/var/folders/…/T/tailwind-integrations…/node_modules/@tailwindcss/cli/dist/index.mjs:6:452)
```

To solve this, we will make sure that we create a `require` based on the `import.meta.url`.
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
