### PR TITLE
Only read from stdin when using `—input -`

### DIFF
--- a/src/cli/build/index.js
+++ b/src/cli/build/index.js
@@ -37,8 +37,6 @@ export async function build(args) {
       process.stdin.on('end', () => process.exit(0))
     }
 
-    process.stdin.resume()
-
     await processor.watch()
   } else {
     await processor.build().catch((e) => {

--- a/src/cli/build/utils.js
+++ b/src/cli/build/utils.js
@@ -54,8 +54,12 @@ export async function readFileWithRetries(path, tries = 5) {
 export function drainStdin() {
   return new Promise((resolve, reject) => {
     let result = ''
-    process.stdin.on('data', (chunk) => {
-      result += chunk
+    process.stdin.on('readable', () => {
+      while (true) {
+        let chunk = process.stdin.read()
+        if (chunk === null) break
+        result += chunk
+      }
     })
     process.stdin.on('end', () => resolve(result))
     process.stdin.on('error', (err) => reject(err))


### PR DESCRIPTION
Using `process.stdin.resume()` causes stdin to be consumed and buffered in Node immediately — even when using a file as input. It’d be better for our process to not read data from stdin at all in this case.
