### PR TITLE
Apply general feedback for `@sources`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support for `inline` option when defining `@theme` values ([#14095](https://github.com/tailwindlabs/tailwindcss/pull/14095))
 - Add `inert` variant ([#14129](https://github.com/tailwindlabs/tailwindcss/pull/14129))
-- Add `@source` support ([#14078](https://github.com/tailwindlabs/tailwindcss/pull/14078), [14063](https://github.com/tailwindlabs/tailwindcss/pull/14063), [14085](https://github.com/tailwindlabs/tailwindcss/pull/14085), [14079](https://github.com/tailwindlabs/tailwindcss/pull/14079), [14067](https://github.com/tailwindlabs/tailwindcss/pull/14067), [14076](https://github.com/tailwindlabs/tailwindcss/pull/14076), [14080](https://github.com/tailwindlabs/tailwindcss/pull/14080), [14127](https://github.com/tailwindlabs/tailwindcss/pull/14127))
+- Add `@source` support ([#14078](https://github.com/tailwindlabs/tailwindcss/pull/14078), [14063](https://github.com/tailwindlabs/tailwindcss/pull/14063), [14085](https://github.com/tailwindlabs/tailwindcss/pull/14085), [14079](https://github.com/tailwindlabs/tailwindcss/pull/14079), [14067](https://github.com/tailwindlabs/tailwindcss/pull/14067), [14076](https://github.com/tailwindlabs/tailwindcss/pull/14076), [14080](https://github.com/tailwindlabs/tailwindcss/pull/14080), [14127](https://github.com/tailwindlabs/tailwindcss/pull/14127), [14135](https://github.com/tailwindlabs/tailwindcss/pull/14135))
 
 ## [4.0.0-alpha.18] - 2024-07-25
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -26,7 +26,7 @@ impl From<ChangedContent> for tailwindcss_oxide::ChangedContent {
 pub struct ScanResult {
   // Private information necessary for incremental rebuilds. Note: these fields are not exposed
   // to JS
-  base: String,
+  base: Option<String>,
   sources: Vec<GlobEntry>,
 
   // Public API:
@@ -77,7 +77,7 @@ impl From<tailwindcss_oxide::GlobEntry> for GlobEntry {
 #[napi(object)]
 pub struct ScanOptions {
   /// Base path to start scanning from
-  pub base: String,
+  pub base: Option<String>,
   /// Glob sources
   pub sources: Option<Vec<GlobEntry>>,
 }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -52,23 +52,23 @@ impl ScanResult {
 #[napi(object)]
 pub struct GlobEntry {
   pub base: String,
-  pub glob: String,
+  pub pattern: String,
 }
 
 impl From<GlobEntry> for tailwindcss_oxide::GlobEntry {
-  fn from(globs: GlobEntry) -> Self {
+  fn from(glob: GlobEntry) -> Self {
     tailwindcss_oxide::GlobEntry {
-      base: globs.base,
-      glob: globs.glob,
+      base: glob.base,
+      pattern: glob.pattern,
     }
   }
 }
 
 impl From<tailwindcss_oxide::GlobEntry> for GlobEntry {
-  fn from(globs: tailwindcss_oxide::GlobEntry) -> Self {
+  fn from(glob: tailwindcss_oxide::GlobEntry) -> Self {
     GlobEntry {
-      base: globs.base,
-      glob: globs.glob,
+      base: glob.base,
+      pattern: glob.pattern,
     }
   }
 }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -70,8 +70,8 @@ impl From<tailwindcss_oxide::GlobEntry> for GlobEntry {
 pub struct ScanOptions {
   /// Base path to start scanning from
   pub base: String,
-  /// Glob content paths
-  pub content_paths: Option<Vec<GlobEntry>>,
+  /// Glob sources
+  pub sources: Option<Vec<GlobEntry>>,
 }
 
 #[napi]
@@ -83,8 +83,8 @@ pub fn clear_cache() {
 pub fn scan_dir(args: ScanOptions) -> ScanResult {
   let result = tailwindcss_oxide::scan_dir(tailwindcss_oxide::ScanOptions {
     base: args.base,
-    content_paths: args
-      .content_paths
+    sources: args
+      .sources
       .unwrap_or_default()
       .into_iter()
       .map(Into::into)

--- a/crates/oxide/src/glob.rs
+++ b/crates/oxide/src/glob.rs
@@ -47,7 +47,7 @@ pub fn get_fast_patterns(patterns: &Vec<GlobEntry>) -> Vec<(PathBuf, Vec<String>
 
     for pattern in patterns {
         let base_path = PathBuf::from(&pattern.base);
-        let pattern = &pattern.glob;
+        let pattern = &pattern.pattern;
 
         let is_negated = pattern.starts_with('!');
         let mut pattern = pattern.clone();
@@ -141,7 +141,7 @@ pub fn path_matches_globs(path: &Path, globs: &[GlobEntry]) -> bool {
 
     globs
         .iter()
-        .any(|g| glob_match(&format!("{}/{}", g.base, g.glob), &path))
+        .any(|g| glob_match(&format!("{}/{}", g.base, g.pattern), &path))
 }
 
 /// Given this input: a-{b,c}-d-{e,f}
@@ -248,7 +248,7 @@ mod tests {
     fn it_should_keep_globs_that_start_with_file_wildcards_as_is() {
         let actual = get_fast_patterns(&vec![GlobEntry {
             base: "/projects".to_string(),
-            glob: "*.html".to_string(),
+            pattern: "*.html".to_string(),
         }]);
         let expected = vec![(PathBuf::from("/projects"), vec!["*.html".to_string()])];
 
@@ -259,7 +259,7 @@ mod tests {
     fn it_should_keep_globs_that_start_with_folder_wildcards_as_is() {
         let actual = get_fast_patterns(&vec![GlobEntry {
             base: "/projects".to_string(),
-            glob: "**/*.html".to_string(),
+            pattern: "**/*.html".to_string(),
         }]);
 
         let expected = vec![(PathBuf::from("/projects"), vec!["**/*.html".to_string()])];
@@ -271,7 +271,7 @@ mod tests {
     fn it_should_move_the_starting_folder_to_the_path() {
         let actual = get_fast_patterns(&vec![GlobEntry {
             base: "/projects".to_string(),
-            glob: "example/*.html".to_string(),
+            pattern: "example/*.html".to_string(),
         }]);
         let expected = vec![(
             PathBuf::from("/projects/example"),
@@ -285,7 +285,7 @@ mod tests {
     fn it_should_move_the_starting_folders_to_the_path() {
         let actual = get_fast_patterns(&vec![GlobEntry {
             base: "/projects".to_string(),
-            glob: "example/other/*.html".to_string(),
+            pattern: "example/other/*.html".to_string(),
         }]);
         let expected = vec![(
             PathBuf::from("/projects/example/other"),
@@ -299,7 +299,7 @@ mod tests {
     fn it_should_branch_expandable_folders() {
         let actual = get_fast_patterns(&vec![GlobEntry {
             base: "/projects".to_string(),
-            glob: "{foo,bar}/*.html".to_string(),
+            pattern: "{foo,bar}/*.html".to_string(),
         }]);
 
         let expected = vec![
@@ -314,7 +314,7 @@ mod tests {
     fn it_should_expand_multiple_expansions_in_the_same_folder() {
         let actual = get_fast_patterns(&vec![GlobEntry {
             base: "/projects".to_string(),
-            glob: "a-{b,c}-d-{e,f}-g/*.html".to_string(),
+            pattern: "a-{b,c}-d-{e,f}-g/*.html".to_string(),
         }]);
         let expected = vec![
             (
@@ -342,7 +342,7 @@ mod tests {
     fn multiple_expansions_per_folder_starting_at_the_root() {
         let actual = get_fast_patterns(&vec![GlobEntry {
             base: "/projects".to_string(),
-            glob: "{a,b}-c-{d,e}-f/{b,c}-d-{e,f}-g/*.html".to_string(),
+            pattern: "{a,b}-c-{d,e}-f/{b,c}-d-{e,f}-g/*.html".to_string(),
         }]);
         let expected = vec![
             (
@@ -418,7 +418,7 @@ mod tests {
     fn it_should_stop_expanding_once_we_hit_a_wildcard() {
         let actual = get_fast_patterns(&vec![GlobEntry {
             base: "/projects".to_string(),
-            glob: "{foo,bar}/example/**/{baz,qux}/*.html".to_string(),
+            pattern: "{foo,bar}/example/**/{baz,qux}/*.html".to_string(),
         }]);
 
         let expected = vec![
@@ -439,7 +439,7 @@ mod tests {
     fn it_should_keep_the_negation_symbol_for_all_new_patterns() {
         let actual = get_fast_patterns(&vec![GlobEntry {
             base: "/projects".to_string(),
-            glob: "!{foo,bar}/*.html".to_string(),
+            pattern: "!{foo,bar}/*.html".to_string(),
         }]);
         let expected = vec![
             (PathBuf::from("/projects/foo"), vec!["!*.html".to_string()]),
@@ -453,7 +453,7 @@ mod tests {
     fn it_should_expand_a_complex_example() {
         let actual = get_fast_patterns(&vec![GlobEntry {
             base: "/projects".to_string(),
-            glob: "a/{b,c}/d/{e,f}/g/*.html".to_string(),
+            pattern: "a/{b,c}/d/{e,f}/g/*.html".to_string(),
         }]);
         let expected = vec![
             (

--- a/crates/oxide/src/lib.rs
+++ b/crates/oxide/src/lib.rs
@@ -57,7 +57,7 @@ pub struct ScanResult {
 #[derive(Debug, Clone)]
 pub struct GlobEntry {
     pub base: String,
-    pub glob: String,
+    pub pattern: String,
 }
 
 pub fn clear_cache() {
@@ -106,7 +106,10 @@ pub fn scan_dir(opts: ScanOptions) -> ScanResult {
 
                     let base = root.display().to_string();
                     let glob = glob.to_string();
-                    Some(GlobEntry { base, glob })
+                    Some(GlobEntry {
+                        base,
+                        pattern: glob,
+                    })
                 })
             })
             .collect::<Vec<GlobEntry>>();
@@ -299,12 +302,12 @@ fn resolve_globs(root: &Path, dirs: Vec<PathBuf>) -> Vec<GlobEntry> {
     // Build the globs for all globable directories.
     let shallow_globs = shallow_globable_directories.iter().map(|path| GlobEntry {
         base: path.display().to_string(),
-        glob: format!("*/*.{{{}}}", extension_list),
+        pattern: format!("*/*.{{{}}}", extension_list),
     });
 
     let deep_globs = deep_globable_directories.iter().map(|path| GlobEntry {
         base: path.display().to_string(),
-        glob: format!("**/*.{{{}}}", extension_list),
+        pattern: format!("**/*.{{{}}}", extension_list),
     });
 
     shallow_globs.chain(deep_globs).collect::<Vec<_>>()

--- a/crates/oxide/src/lib.rs
+++ b/crates/oxide/src/lib.rs
@@ -1,4 +1,3 @@
-use crate::glob::path_matches_globs;
 use crate::parser::Extractor;
 use bstr::ByteSlice;
 use cache::Cache;
@@ -439,26 +438,6 @@ pub fn scan_files(input: Vec<ChangedContent>, options: u8) -> Vec<String> {
         (IO::Parallel, Parsing::Sequential) => parse_all_blobs_sync(read_all_files(input)),
         (IO::Parallel, Parsing::Parallel) => parse_all_blobs(read_all_files(input)),
     }
-}
-
-#[tracing::instrument(skip(input, globs))]
-pub fn scan_files_with_globs(input: Vec<ChangedContent>, globs: Vec<GlobEntry>) -> Vec<String> {
-    parse_all_blobs_sync(read_all_files_sync(
-        input
-            .into_iter()
-            .flat_map(|c| {
-                // Verify that the file is actually allowed by the globs
-                if let Some(ref file) = c.file {
-                    if !path_matches_globs(file, &globs) {
-                        return None;
-                    }
-                }
-
-                // ChangedContent is allowed
-                Some(c)
-            })
-            .collect(),
-    ))
 }
 
 fn read_changed_content(c: ChangedContent) -> Option<Vec<u8>> {

--- a/crates/oxide/src/lib.rs
+++ b/crates/oxide/src/lib.rs
@@ -44,8 +44,8 @@ pub struct ChangedContent {
 pub struct ScanOptions {
     /// Base path to start scanning from
     pub base: String,
-    /// Glob content paths
-    pub content_paths: Vec<GlobEntry>,
+    /// Glob sources
+    pub sources: Vec<GlobEntry>,
 }
 
 #[derive(Debug, Clone)]
@@ -75,9 +75,9 @@ pub fn scan_dir(opts: ScanOptions) -> ScanResult {
 
     let mut globs = resolve_globs(base, dirs);
 
-    // If we have additional content paths, then we have to resolve them as well.
-    if !opts.content_paths.is_empty() {
-        let resolved_files: Vec<_> = match fast_glob(&opts.content_paths) {
+    // If we have additional sources, then we have to resolve them as well.
+    if !opts.sources.is_empty() {
+        let resolved_files: Vec<_> = match fast_glob(&opts.sources) {
             Ok(matches) => matches
                 .filter_map(|x| dunce::canonicalize(&x).ok())
                 .collect(),
@@ -89,7 +89,7 @@ pub fn scan_dir(opts: ScanOptions) -> ScanResult {
 
         files.extend(resolved_files);
 
-        let optimized_incoming_globs = get_fast_patterns(&opts.content_paths)
+        let optimized_incoming_globs = get_fast_patterns(&opts.sources)
             .iter()
             .flat_map(|(root, globs)| {
                 globs.iter().filter_map(|glob| {

--- a/crates/oxide/tests/scan_dir.rs
+++ b/crates/oxide/tests/scan_dir.rs
@@ -40,7 +40,7 @@ mod scan_dir {
         // Resolve all content paths for the (temporary) current working directory
         let result = scan_dir(ScanOptions {
             base: base.clone(),
-            content_paths: globs
+            sources: globs
                 .iter()
                 .map(|x| GlobEntry {
                     base: base.clone(),

--- a/crates/oxide/tests/scan_dir.rs
+++ b/crates/oxide/tests/scan_dir.rs
@@ -39,7 +39,7 @@ mod scan_dir {
 
         // Resolve all content paths for the (temporary) current working directory
         let result = scan_dir(ScanOptions {
-            base: base.clone(),
+            base: Some(base.clone()),
             sources: globs
                 .iter()
                 .map(|x| GlobEntry {

--- a/crates/oxide/tests/scan_dir.rs
+++ b/crates/oxide/tests/scan_dir.rs
@@ -44,7 +44,7 @@ mod scan_dir {
                 .iter()
                 .map(|x| GlobEntry {
                     base: base.clone(),
-                    glob: x.to_string(),
+                    pattern: x.to_string(),
                 })
                 .collect(),
         });
@@ -60,7 +60,7 @@ mod scan_dir {
                 "{}{}{}",
                 glob.base,
                 path::MAIN_SEPARATOR,
-                glob.glob
+                glob.pattern
             ));
         }
 

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -228,23 +228,13 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
 
           // Scan changed files only for incremental rebuilds.
           else if (rebuildStrategy === 'incremental') {
-            // TODO: use `scanDirResult.scanFiles(changedFiles)` for incremental
-            // rebuilds to prevent scanning the entire directory.
-
-            // Re-scan the directory to get the new `candidates`
-            scanDirResult = scanDir({
-              base, // Root directory, mainly used for auto content detection
-              sources: compiler.globs.map((glob) => ({
-                base: inputBasePath, // Globs are relative to the input.css file
-                glob,
-              })),
-            })
+            let candidates = scanDirResult.scanFiles(changedFiles)
 
             // No candidates found which means we don't need to rebuild. This can
             // happen if a file is detected but doesn't match any of the globs.
-            if (scanDirResult.candidates.length === 0) return
+            if (candidates.length === 0) return
 
-            compiledCss = compiler.build(scanDirResult.candidates)
+            compiledCss = compiler.build(candidates)
           }
 
           await write(compiledCss, args)

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -342,7 +342,7 @@ async function createWatchers(dirs: string[], handle: (files: string[]) => void)
           if (event.type === 'delete') return
 
           // Ignore directory changes. We only care about file changes
-          const stats = await fs.lstat(event.path)
+          let stats = await fs.lstat(event.path)
           if (stats.isDirectory()) {
             return
           }

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -297,7 +297,7 @@ function watchDirectories(base: string, scanDirResult: ReturnType<typeof scanDir
   )
 }
 
-async function createWatchers(dirs: string[], handle: (files: string[]) => void) {
+async function createWatchers(dirs: string[], cb: (files: string[]) => void) {
   // Track all Parcel watchers for each glob.
   //
   // When we encounter a change in a CSS file, we need to setup new watchers and
@@ -313,13 +313,13 @@ async function createWatchers(dirs: string[], handle: (files: string[]) => void)
   // A changed file can be watched by multiple watchers, but we only want to
   // handle the file once. We debounce the handle function with the collected
   // files to handle them in a single batch and to avoid multiple rebuilds.
-  function enqueueFlush() {
+  function enqueueCallback() {
     // Dispose all existing macrotask.
     debounceQueue.dispose()
 
     // Setup a new macrotask to handle the files in batch.
     debounceQueue.queueMacrotask(() => {
-      handle(Array.from(files))
+      cb(Array.from(files))
       files.clear()
     })
   }
@@ -353,7 +353,7 @@ async function createWatchers(dirs: string[], handle: (files: string[]) => void)
       )
 
       // Handle the tracked files at some point in the future.
-      enqueueFlush()
+      enqueueCallback()
     })
 
     // Ensure we cleanup the watcher when we're done.

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -146,9 +146,9 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
   let compiler = compile(input)
   let scanDirResult = scanDir({
     base, // Root directory, mainly used for auto content detection
-    sources: compiler.globs.map((glob) => ({
+    sources: compiler.globs.map((pattern) => ({
       base: inputBasePath, // Globs are relative to the input.css file
-      glob,
+      pattern,
     })),
   })
 
@@ -213,9 +213,9 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
             // Re-scan the directory to get the new `candidates`
             scanDirResult = scanDir({
               base, // Root directory, mainly used for auto content detection
-              sources: compiler.globs.map((glob) => ({
+              sources: compiler.globs.map((pattern) => ({
                 base: inputBasePath, // Globs are relative to the input.css file
-                glob,
+                pattern,
               })),
             })
 
@@ -276,7 +276,7 @@ function watchDirectories(base: string, scanDirResult: ReturnType<typeof scanDir
   return [base].concat(
     scanDirResult.globs.flatMap((globEntry) => {
       // We don't want a watcher for negated globs.
-      if (globEntry.glob[0] === '!') return []
+      if (globEntry.pattern[0] === '!') return []
 
       // We don't want a watcher for nested directories, these will be covered
       // by the `base` directory already.

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -376,7 +376,7 @@ function handleImports(
   // Relevant specification:
   //   - CSS Import Resolve: https://csstools.github.io/css-import-resolve/
 
-  if (!input.includes('@import') && !input.includes('@plugin') && !input.includes('@source')) {
+  if (!input.includes('@import')) {
     return [input, [file]]
   }
 

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -10,7 +10,7 @@ import postcss from 'postcss'
 import atImport from 'postcss-import'
 import * as tailwindcss from 'tailwindcss'
 import type { Arg, Result } from '../../utils/args'
-import { disposables } from '../../utils/disposables'
+import { Disposables } from '../../utils/disposables'
 import {
   eprintln,
   formatDuration,
@@ -302,13 +302,13 @@ async function createWatchers(dirs: string[], handle: (files: string[]) => void)
   //
   // When we encounter a change in a CSS file, we need to setup new watchers and
   // we want to cleanup the old ones we captured here.
-  let watchers = disposables()
+  let watchers = new Disposables()
 
   // Track all files that were added or changed.
   let files = new Set<string>()
 
   // Keep track of the debounce queue to avoid multiple rebuilds.
-  let debounceQueue = disposables()
+  let debounceQueue = new Disposables()
 
   // A changed file can be watched by multiple watchers, but we only want to
   // handle the file once. We debounce the handle function with the collected

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -146,7 +146,7 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
   let compiler = compile(input)
   let scanDirResult = scanDir({
     base, // Root directory, mainly used for auto content detection
-    contentPaths: compiler.globs.map((glob) => ({
+    sources: compiler.globs.map((glob) => ({
       base: inputBasePath, // Globs are relative to the input.css file
       glob,
     })),
@@ -213,7 +213,7 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
             // Re-scan the directory to get the new `candidates`
             scanDirResult = scanDir({
               base, // Root directory, mainly used for auto content detection
-              contentPaths: compiler.globs.map((glob) => ({
+              sources: compiler.globs.map((glob) => ({
                 base: inputBasePath, // Globs are relative to the input.css file
                 glob,
               })),
@@ -234,7 +234,7 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
             // Re-scan the directory to get the new `candidates`
             scanDirResult = scanDir({
               base, // Root directory, mainly used for auto content detection
-              contentPaths: compiler.globs.map((glob) => ({
+              sources: compiler.globs.map((glob) => ({
                 base: inputBasePath, // Globs are relative to the input.css file
                 glob,
               })),

--- a/packages/@tailwindcss-cli/src/utils/disposables.ts
+++ b/packages/@tailwindcss-cli/src/utils/disposables.ts
@@ -4,46 +4,42 @@
  *
  * The `dispose` method can be called to clean up all resources at once.
  */
-export function disposables() {
+export class Disposables {
   // Track all disposables
-  let _disposables = new Set<Function>([])
+  #disposables = new Set<Function>([])
 
-  let api = {
-    /**
-     * Enqueue a callback in the macrotasks queue.
-     */
-    queueMacrotask(cb: () => void) {
-      let timer = setTimeout(cb, 0)
+  /**
+   * Enqueue a callback in the macrotasks queue.
+   */
+  queueMacrotask(cb: () => void) {
+    let timer = setTimeout(cb, 0)
 
-      return api.add(() => {
-        clearTimeout(timer)
-      })
-    },
-
-    /**
-     * General purpose disposable function that can be cleaned up.
-     */
-    add(dispose: () => void) {
-      _disposables.add(dispose)
-
-      return () => {
-        _disposables.delete(dispose)
-
-        dispose()
-      }
-    },
-
-    /**
-     * Dispose all disposables at once.
-     */
-    dispose() {
-      for (let dispose of _disposables) {
-        dispose()
-      }
-
-      _disposables.clear()
-    },
+    return this.add(() => {
+      clearTimeout(timer)
+    })
   }
 
-  return api
+  /**
+   * General purpose disposable function that can be cleaned up.
+   */
+  add(dispose: () => void) {
+    this.#disposables.add(dispose)
+
+    return () => {
+      this.#disposables.delete(dispose)
+
+      dispose()
+    }
+  }
+
+  /**
+   * Dispose all disposables at once.
+   */
+  dispose() {
+    for (let dispose of this.#disposables) {
+      dispose()
+    }
+
+    this.#disposables.clear()
+  }
 }

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -91,7 +91,7 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
           }
 
           // Setup the compiler if it doesn't exist yet. This way we can
-          // guarantee a `compile()` function is available.
+          // guarantee a `build()` function is available.
           context.compiler ??= createCompiler()
 
           let rebuildStrategy: 'full' | 'incremental' = 'incremental'

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -128,9 +128,9 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
           // Look for candidates used to generate the CSS
           let scanDirResult = scanDir({
             base, // Root directory, mainly used for auto content detection
-            sources: context.compiler.globs.map((glob) => ({
+            sources: context.compiler.globs.map((pattern) => ({
               base: inputBasePath, // Globs are relative to the input.css file
-              glob,
+              pattern,
             })),
           })
 
@@ -147,12 +147,12 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
           // Register dependencies so changes in `base` cause a rebuild while
           // giving tools like Vite or Parcel a glob that can be used to limit
           // the files that cause a rebuild to only those that match it.
-          for (let { base, glob } of scanDirResult.globs) {
+          for (let { base, pattern } of scanDirResult.globs) {
             result.messages.push({
               type: 'dir-dependency',
               plugin: '@tailwindcss/postcss',
               dir: base,
-              glob,
+              glob: pattern,
               parent: result.opts.from,
             })
           }

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -128,7 +128,7 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
           // Look for candidates used to generate the CSS
           let scanDirResult = scanDir({
             base, // Root directory, mainly used for auto content detection
-            contentPaths: context.compiler.globs.map((glob) => ({
+            sources: context.compiler.globs.map((glob) => ({
               base: inputBasePath, // Globs are relative to the input.css file
               glob,
             })),

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -1,11 +1,11 @@
 import { scanDir } from '@tailwindcss/oxide'
 import fs from 'fs'
+import fixRelativePathsPlugin from 'internal-postcss-fix-relative-paths'
 import { Features, transform } from 'lightningcss'
 import path from 'path'
 import postcss, { AtRule, type AcceptedPlugin, type PluginCreator } from 'postcss'
 import postcssImport from 'postcss-import'
 import { compile } from 'tailwindcss'
-import fixRelativePathsPlugin from '../../internal-postcss-fix-relative-paths/src'
 
 /**
  * A Map that can generate default values for keys that don't exist.

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -91,9 +91,9 @@ export default function tailwindcss(): Plugin[] {
       // TODO: This might not be necessary if we enable/disabled auto content
       // detection.
       base: config!.root, // Root directory, mainly used for auto content detection
-      sources: globs.map((glob) => ({
+      sources: globs.map((pattern) => ({
         base: inputBasePath, // Globs are relative to the input.css file
-        glob,
+        pattern,
       })),
     })
 
@@ -108,7 +108,7 @@ export default function tailwindcss(): Plugin[] {
 
     // Watch globs
     for (let glob of scanDirResult.globs) {
-      if (glob.glob[0] === '!') continue
+      if (glob.pattern[0] === '!') continue
 
       let relative = path.relative(config!.root, glob.base)
       if (relative[0] !== '.') {
@@ -118,7 +118,7 @@ export default function tailwindcss(): Plugin[] {
       // the glob.
       relative = normalizePath(relative)
 
-      addWatchFile(path.posix.join(relative, glob.glob))
+      addWatchFile(path.posix.join(relative, glob.pattern))
     }
 
     return build(Array.from(candidates))

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -88,9 +88,6 @@ export default function tailwindcss(): Plugin[] {
     })
 
     scanDirResult = scanDir({
-      // TODO: This might not be necessary if we enable/disabled auto content
-      // detection.
-      base: config!.root, // Root directory, mainly used for auto content detection
       sources: globs.map((pattern) => ({
         base: inputBasePath, // Globs are relative to the input.css file
         pattern,

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -89,8 +89,8 @@ export default function tailwindcss(): Plugin[] {
 
     scanDirResult = scanDir({
       // TODO: This might not be necessary if we enable/disabled auto content
-      // detection
-      base: inputBasePath, // Root directory, mainly used for auto content detection
+      // detection.
+      base: config!.root, // Root directory, mainly used for auto content detection
       sources: globs.map((glob) => ({
         base: inputBasePath, // Globs are relative to the input.css file
         glob,

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -91,7 +91,7 @@ export default function tailwindcss(): Plugin[] {
       // TODO: This might not be necessary if we enable/disabled auto content
       // detection
       base: inputBasePath, // Root directory, mainly used for auto content detection
-      contentPaths: globs.map((glob) => ({
+      sources: globs.map((glob) => ({
         base: inputBasePath, // Globs are relative to the input.css file
         glob,
       })),


### PR DESCRIPTION
Part of #14078

This PR applies general feedback to the `@sources` umbrella PR.

This PR includes the following changes:
- Used real classes instead of class-like objects.
- Only handle PostCSS imports when `@import` is used.
- Improve some comments
- Improve naming of `GlobEntry` (`glob.glob` -> `glob.pattern`)
- Use `scanFiles` on the `scanDirResult` as-if it's an incremental scan (under
  the hood we still do a full scan right now).
- Renamed `content_paths` to `sources`

This is a separate PR just so that we can merge the umbrella PR un-squashed for each sub-PR. This way all the commits here won't show up in the `next` branch as-is.
