### PR TITLE
Ensure `@apply` works inside `@utility`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `inert` variant ([#14129](https://github.com/tailwindlabs/tailwindcss/pull/14129))
 - Add support for explicitly registering content paths using new `@source` at-rule ([#14078](https://github.com/tailwindlabs/tailwindcss/pull/14078))
 
+### Fixed
+
+- Ensure `@apply` works inside `@utility` ([#14144](https://github.com/tailwindlabs/tailwindcss/pull/14144))
+
 ## [4.0.0-alpha.18] - 2024-07-25
 
 ### Added

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -327,9 +327,9 @@ describe('@apply', () => {
     `)
   })
 
-  it('should be possible to apply a custom utility', () => {
+  it('should be possible to apply a custom utility', async () => {
     expect(
-      compileCss(css`
+      await compileCss(css`
         @utility bar {
           &:before {
             content: 'bar';

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -326,6 +326,39 @@ describe('@apply', () => {
       }"
     `)
   })
+
+  it('should be possible to apply a custom utility', () => {
+    expect(
+      compileCss(css`
+        @utility bar {
+          &:before {
+            content: 'bar';
+          }
+        }
+
+        .foo {
+          /* Baz is defined after this rule, but should work */
+          @apply bar baz;
+        }
+
+        @utility baz {
+          &:after {
+            content: 'baz';
+          }
+        }
+
+        @tailwind utilities;
+      `),
+    ).toMatchInlineSnapshot(`
+      ".foo:before {
+        content: "bar";
+      }
+
+      .foo:after {
+        content: "baz";
+      }"
+    `)
+  })
 })
 
 describe('arbitrary variants', () => {

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -111,11 +111,26 @@ export async function compile(
       }
 
       customUtilities.push((designSystem) => {
+        // Track if the utility has been seen before to prevent circular
+        // dependencies. If there is a circular dependency, it means that we
+        // will apply the utility to itself, which is not allowed.
+        let seen = false
+
         designSystem.utilities.static(name, (candidate) => {
           if (candidate.negative) return
           let ast = structuredClone(node.nodes)
 
+          if (seen) {
+            throw new Error(
+              `You cannot \`@apply\` the \`${name}\` utility here because it creates a circular dependency.`,
+            )
+          }
+
+          seen = true
+
           substituteAtApply(ast, designSystem)
+
+          seen = false
 
           return ast
         })

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -115,7 +115,7 @@ export async function compile(
           if (candidate.negative) return
           let ast = structuredClone(node.nodes)
 
-          apply(ast, designSystem)
+          substituteAtApply(ast, designSystem)
 
           return ast
         })
@@ -357,7 +357,7 @@ export async function compile(
 
   // Replace `@apply` rules with the actual utility classes.
   if (css.includes('@apply')) {
-    apply(ast, designSystem)
+    substituteAtApply(ast, designSystem)
   }
 
   // Track all valid candidates, these are the incoming `rawCandidate` that
@@ -410,7 +410,7 @@ export async function compile(
   }
 }
 
-function apply(ast: AstNode[], designSystem: DesignSystem) {
+function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
   walk(ast, (node, { replaceWith }) => {
     if (node.kind === 'rule' && node.selector[0] === '@' && node.selector.startsWith('@apply')) {
       let candidates = node.selector

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -463,30 +463,22 @@ function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
         //
         // Figure out which candidate caused the circular dependency. This will
         // help to create a useful error message for the end user.
-        let candidate = candidates.find((candidate) => {
+        for (let candidate of candidates) {
           let selector = `.${escape(candidate)}`
-          let found = false
 
           for (let rule of candidateAst) {
             if (rule.kind !== 'rule') continue
             if (rule.selector !== selector) continue
 
             walk(rule.nodes, (child) => {
-              if (child === node) {
-                found = true
-                return WalkAction.Stop
-              }
+              if (child !== node) return
+
+              throw new Error(
+                `You cannot \`@apply\` the \`${candidate}\` utility here because it creates a circular dependency.`,
+              )
             })
-
-            if (found) return found
           }
-
-          return found
-        })
-
-        throw new Error(
-          `You cannot \`@apply\` the \`${candidate}\` utility here because it creates a circular dependency.`,
-        )
+        }
       })
 
       replaceWith(newNodes)

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -342,8 +342,8 @@ export async function compile(
 
   let tailwindUtilitiesNode: Rule | null = null
 
-  // Find `@tailwind utilities` and replace it with the actual generated utility
-  // class CSS.
+  // Find `@tailwind utilities` so that we can later replace it with the actual
+  // generated utility class CSS.
   walk(ast, (node) => {
     if (node.kind === 'rule' && node.selector === '@tailwind utilities') {
       tailwindUtilitiesNode = node

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -127,22 +127,22 @@ export async function compile(
         // Track if the utility has been seen before to prevent circular
         // dependencies. If there is a circular dependency, it means that we
         // will apply the utility to itself, which is not allowed.
-        let seen = false
+        let inProgress = false
 
         designSystem.utilities.static(name, (candidate) => {
           if (candidate.negative) return
           let ast = structuredClone(node.nodes)
 
           if (usesAtApply) {
-            if (seen) {
+            if (inProgress) {
               throw new Error(
                 `You cannot \`@apply\` the \`${name}\` utility here because it creates a circular dependency.`,
               )
             }
 
-            seen = true
+            inProgress = true
             substituteAtApply(ast, designSystem)
-            seen = false
+            inProgress = false
           }
 
           return ast

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -113,7 +113,11 @@ export async function compile(
       customUtilities.push((designSystem) => {
         designSystem.utilities.static(name, (candidate) => {
           if (candidate.negative) return
-          return structuredClone(node.nodes)
+          let ast = structuredClone(node.nodes)
+
+          apply(ast, designSystem)
+
+          return ast
         })
       })
 

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -15344,7 +15344,7 @@ describe('custom utilities', () => {
   })
 
   test('custom utilities with `@apply` causing circular dependencies should error', async () => {
-    await expect(
+    await expect(() =>
       compileCss(
         css`
           @utility foo {
@@ -15352,7 +15352,7 @@ describe('custom utilities', () => {
           }
 
           @utility bar {
-            @apply dark:foo;
+            @apply flex dark:foo;
           }
 
           @tailwind utilities;
@@ -15360,7 +15360,7 @@ describe('custom utilities', () => {
         ['foo', 'bar'],
       ),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: You cannot \`@apply\` the \`foo\` utility here because it creates a circular dependency.]`,
+      `[Error: You cannot \`@apply\` the \`dark:foo\` utility here because it creates a circular dependency.]`,
     )
   })
 })

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -15363,4 +15363,35 @@ describe('custom utilities', () => {
       `[Error: You cannot \`@apply\` the \`dark:foo\` utility here because it creates a circular dependency.]`,
     )
   })
+
+  test('custom utilities with `@apply` causing circular dependencies should error (deeply nesting)', async () => {
+    await expect(() =>
+      compileCss(
+        css`
+          @utility foo {
+            .bar {
+              .baz {
+                .qux {
+                  @apply font-bold hover:bar;
+                }
+              }
+            }
+          }
+
+          @utility bar {
+            .baz {
+              .qux {
+                @apply flex dark:foo;
+              }
+            }
+          }
+
+          @tailwind utilities;
+        `,
+        ['foo', 'bar'],
+      ),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: You cannot \`@apply\` the \`dark:foo\` utility here because it creates a circular dependency.]`,
+    )
+  })
 })

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -15268,4 +15268,31 @@ describe('custom utilities', () => {
       `),
     ).rejects.toThrowError(/should be alphanumeric/)
   })
+
+  test('custom utilities work with `@apply`', () => {
+    expect(
+      compileCss(
+        css`
+          @utility foo {
+            @apply flex flex-col underline;
+          }
+
+          @tailwind utilities;
+        `,
+        ['foo', 'hover:foo'],
+      ),
+    ).toMatchInlineSnapshot(`
+      ".foo {
+        flex-direction: column;
+        text-decoration-line: underline;
+        display: flex;
+      }
+
+      .hover\\:foo:hover {
+        flex-direction: column;
+        text-decoration-line: underline;
+        display: flex;
+      }"
+    `)
+  })
 })

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -15312,6 +15312,37 @@ describe('custom utilities', () => {
     `)
   })
 
+  test('referencing custom utilities in custom utilities via `@apply` should work', () => {
+    expect(
+      compileCss(
+        css`
+          @utility foo {
+            @apply flex flex-col underline;
+          }
+
+          @utility bar {
+            @apply dark:foo font-bold;
+          }
+
+          @tailwind utilities;
+        `,
+        ['bar'],
+      ),
+    ).toMatchInlineSnapshot(`
+      ".bar {
+        font-weight: 700;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .bar {
+          flex-direction: column;
+          text-decoration-line: underline;
+          display: flex;
+        }
+      }"
+    `)
+  })
+
   test('custom utilities with `@apply` causing circular dependencies should error', () => {
     expect(() =>
       compileCss(

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -15269,9 +15269,9 @@ describe('custom utilities', () => {
     ).rejects.toThrowError(/should be alphanumeric/)
   })
 
-  test('custom utilities work with `@apply`', () => {
+  test('custom utilities work with `@apply`', async () => {
     expect(
-      compileCss(
+      await compileCss(
         css`
           @utility foo {
             @apply flex flex-col underline;
@@ -15312,9 +15312,9 @@ describe('custom utilities', () => {
     `)
   })
 
-  test('referencing custom utilities in custom utilities via `@apply` should work', () => {
+  test('referencing custom utilities in custom utilities via `@apply` should work', async () => {
     expect(
-      compileCss(
+      await compileCss(
         css`
           @utility foo {
             @apply flex flex-col underline;
@@ -15343,8 +15343,8 @@ describe('custom utilities', () => {
     `)
   })
 
-  test('custom utilities with `@apply` causing circular dependencies should error', () => {
-    expect(() =>
+  test('custom utilities with `@apply` causing circular dependencies should error', async () => {
+    await expect(
       compileCss(
         css`
           @utility foo {
@@ -15359,7 +15359,7 @@ describe('custom utilities', () => {
         `,
         ['foo', 'bar'],
       ),
-    ).toThrowErrorMatchingInlineSnapshot(
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
       `[Error: You cannot \`@apply\` the \`foo\` utility here because it creates a circular dependency.]`,
     )
   })

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -15359,6 +15359,8 @@ describe('custom utilities', () => {
         `,
         ['foo', 'bar'],
       ),
-    ).toThrowError(/Maximum call stack/)
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: You cannot \`@apply\` the \`foo\` utility here because it creates a circular dependency.]`,
+    )
   })
 })

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -15311,4 +15311,23 @@ describe('custom utilities', () => {
       }"
     `)
   })
+
+  test('custom utilities with `@apply` causing circular dependencies should error', () => {
+    expect(() =>
+      compileCss(
+        css`
+          @utility foo {
+            @apply font-bold hover:bar;
+          }
+
+          @utility bar {
+            @apply dark:foo;
+          }
+
+          @tailwind utilities;
+        `,
+        ['foo', 'bar'],
+      ),
+    ).toThrowError(/Maximum call stack/)
+  })
 })

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -15277,12 +15277,28 @@ describe('custom utilities', () => {
             @apply flex flex-col underline;
           }
 
+          @utility bar {
+            @apply z-10;
+
+            .baz {
+              @apply z-20;
+            }
+          }
+
           @tailwind utilities;
         `,
-        ['foo', 'hover:foo'],
+        ['foo', 'hover:foo', 'bar'],
       ),
     ).toMatchInlineSnapshot(`
-      ".foo {
+      ".bar {
+        z-index: 10;
+      }
+
+      .bar .baz {
+        z-index: 20;
+      }
+
+      .foo {
         flex-direction: column;
         text-decoration-line: underline;
         display: flex;

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -15122,7 +15122,7 @@ describe('custom utilities', () => {
     `)
   })
 
-  test('custom utilities support some special chracters', async () => {
+  test('custom utilities support some special characters', async () => {
     let { build } = await compile(css`
       @layer utilities {
         @tailwind utilities;


### PR DESCRIPTION
This PR fixes an issue where `@apply` was not handled if it was used inside of `@utility`.

You should now be able to do something like this:
```css
@utility btn {
  @apply flex flex-col bg-white p-4 rounded-lg shadow-md;
}
```

If you then use `btn` as a class, the following CSS will be generated:
```css
.btn {
  border-radius: var(--radius-lg, .5rem);
  background-color: var(--color-white, #fff);
  padding: var(--spacing-4, 1rem);
  --tw-shadow: 0 4px 6px -1px #0000001a, 0 2px 4px -2px #0000001a;
  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
  box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
  flex-direction: column;
  display: flex;
}
```

This PR also makes sure that you can use custom `@utility` inside other `@utility` via `@apply`. E.g.:
```css
@utility foo {
  color: red;
}

@utility bar {
  color: red;
  @apply hover:foo;
}
```

If we detect a circular dependency, then we will throw an error since circular dependencies are not allowed. E.g.:
```css
@utility foo {
  @apply hover:bar;
}

@utility bar {
  @apply focus:baz;
}

@utility baz {
  @apply dark:foo;
}
```
Regardless of which utility you use, eventually it will apply itself.

Fixes: #14143
