### PR TITLE
Don't warn about broad globs in vendor folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- No longer warns when broad glob patterns are detecting `vendor` folders
 
 ## [3.4.8] - 2024-08-07
 

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -185,7 +185,6 @@ export function resolvedChangedContent(context, candidateFiles, fileModifiedMap)
 
 const LARGE_DIRECTORIES = [
   'node_modules', // Node
-  'vendor', // PHP
 ]
 
 // Ensures that `node_modules` has to match as-is, otherwise `mynode_modules`


### PR DESCRIPTION
After shipping the new warning that prevents unexpected scanning of all dependencies in 3.4.8, we noticed that it was firing more often than we wanted to. 

The heuristics we added works by finding broad glob patterns (once that contain `/**/`) and when those are found and are the _sole pattern used to match a file of a known-large directory_, we were showing the warning. The motivation for this is that we have seen time and time again that an incorrect config like `/**/*.js` can cause recursive scans through _all_ dependencies including many minified libraries which greatly impacts performance. 

In #14140, we were adding two known-large directory names: 

- `node_modules` (used by npm)
- `vendor` (used by PHP)

The problem with the `vendor` name though is that it is more generic than we would like it and there are legit use cases to have a folder named `vendor` inside your component folder. Additionally, PHP vendors behave a bit differently and it's not super common to have minified build files in that folder (which is one of the main reasons for the slow builds). Because of this, we decided to revert the change for `vendor` and only scan for `node_modules` going forward.