### PR TITLE
Add padding: inherit to tokens for padding

### DIFF
--- a/packages/tailwindcss/src/__snapshots__/intellisense.test.ts.snap
+++ b/packages/tailwindcss/src/__snapshots__/intellisense.test.ts.snap
@@ -1288,6 +1288,7 @@ exports[`getClassList 1`] = `
   "pe-1",
   "pe-3",
   "pe-4",
+  "p-inherit"
   "perspective-dramatic",
   "perspective-none",
   "perspective-normal",

--- a/packages/tailwindcss/src/__snapshots__/intellisense.test.ts.snap
+++ b/packages/tailwindcss/src/__snapshots__/intellisense.test.ts.snap
@@ -1280,6 +1280,7 @@ exports[`getClassList 1`] = `
   "p-1",
   "p-3",
   "p-4",
+  "p-inherit",
   "pb-0.5",
   "pb-1",
   "pb-3",
@@ -1288,7 +1289,6 @@ exports[`getClassList 1`] = `
   "pe-1",
   "pe-3",
   "pe-4",
-  "p-inherit"
   "perspective-dramatic",
   "perspective-none",
   "perspective-normal",

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -11251,6 +11251,24 @@ test('pl', async () => {
   expect(await run(['pl', '-pl-4', '-pl-[4px]', 'pl-4/foo', 'pl-[4px]/foo'])).toEqual('')
 })
 
+test('p-inherit', async () => {
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --spacing-4: 1rem;
+        }
+        @tailwind utilities;
+      `,
+      ['p-inherit'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ".p-inherit {
+      padding: inherit;
+    }"
+  `)
+})
+
 test('text-align', async () => {
   expect(
     await run(['text-left', 'text-center', 'text-right', 'text-justify', 'text-start', 'text-end']),

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -11263,7 +11263,11 @@ test('p-inherit', async () => {
       ['p-inherit'],
     ),
   ).toMatchInlineSnapshot(`
-    ".p-inherit {
+    ":root {
+      --spacing-4: 1rem;
+    }
+
+    .p-inherit {
       padding: inherit;
     }"
   `)

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -2916,6 +2916,7 @@ export function createUtilities(theme: Theme) {
     themeKeys: ['--padding', '--spacing'],
     handle: (value) => [decl('padding-left', value)],
   })
+  staticUtility('p-inherit', [['padding', 'inherit']])
 
   staticUtility('text-left', [['text-align', 'left']])
   staticUtility('text-center', [['text-align', 'center']])


### PR DESCRIPTION
Hello, I think adding a way to set `padding: inherit` in tailwind would be a good idea.
I opened up a discussion here: https://github.com/tailwindlabs/tailwindcss/discussions/14154

Cheers
