### PR TITLE
Add Next.js integration test

### DIFF
--- a/integrations/postcss/next.test.ts
+++ b/integrations/postcss/next.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'vitest'
-import { candidate, css, fetchStylesheetsFromIndex, js, json, test } from '../utils'
+import { candidate, css, fetchStylesFromIndex, js, json, test } from '../utils'
 
 test(
   'production build',
@@ -70,175 +70,86 @@ test(
     ])
   },
 )
-
-test(
-  'dev mode (webpack)',
-  {
-    fs: {
-      'package.json': json`
-        {
-          "dependencies": {
-            "react": "^18",
-            "react-dom": "^18",
-            "next": "^14"
-          },
-          "devDependencies": {
-            "@tailwindcss/postcss": "workspace:^",
-            "tailwindcss": "workspace:^"
+;['turbo', 'webpack'].forEach((bundler) => {
+  test(
+    `dev mode (${bundler})`,
+    {
+      fs: {
+        'package.json': json`
+          {
+            "dependencies": {
+              "react": "^18",
+              "react-dom": "^18",
+              "next": "^14"
+            },
+            "devDependencies": {
+              "@tailwindcss/postcss": "workspace:^",
+              "tailwindcss": "workspace:^"
+            }
           }
-        }
-      `,
-      'postcss.config.mjs': js`
-        /** @type {import('postcss-load-config').Config} */
-        const config = {
-          plugins: {
-            '@tailwindcss/postcss': {},
-          },
-        }
-
-        export default config
-      `,
-      'next.config.mjs': js`
-        /** @type {import('next').NextConfig} */
-        const nextConfig = {}
-
-        export default nextConfig
-      `,
-      'app/layout.js': js`
-        import './globals.css'
-
-        export default function RootLayout({ children }) {
-          return (
-            <html>
-              <body>{children}</body>
-            </html>
-          )
-        }
-      `,
-      'app/page.js': js`
-        export default function Page() {
-          return <h1 className="underline">Hello, Next.js!</h1>
-        }
-      `,
-      'app/globals.css': css`
-        @import 'tailwindcss/theme' theme(reference);
-        @import 'tailwindcss/utilities';
-      `,
-    },
-  },
-  async ({ fs, spawn, getFreePort }) => {
-    let port = await getFreePort()
-    let process = await spawn(`pnpm next dev --port ${port}`)
-
-    await process.onStdout((message) => message.includes('Ready in'))
-
-    let stylesheets = await fetchStylesheetsFromIndex(port)
-    expect(stylesheets).toHaveLength(1)
-    let [, css] = stylesheets[0]
-
-    expect(css).toContain(candidate`underline`)
-
-    await fs.write(
-      'app/page.js',
-      js`
-        export default function Page() {
-          return <h1 className="underline text-red-500">Hello, Next.js!</h1>
-        }
-      `,
-    )
-    await process.onStdout((message) => message.includes('Compiled in'))
-
-    stylesheets = await fetchStylesheetsFromIndex(port)
-    expect(stylesheets).toHaveLength(1)
-    ;[, css] = stylesheets[0]
-
-    expect(css).toContain(candidate`underline`)
-    expect(css).toContain(candidate`text-red-500`)
-  },
-)
-
-test(
-  'dev mode (turbo)',
-  {
-    fs: {
-      'package.json': json`
-        {
-          "dependencies": {
-            "react": "^18",
-            "react-dom": "^18",
-            "next": "^14"
-          },
-          "devDependencies": {
-            "@tailwindcss/postcss": "workspace:^",
-            "tailwindcss": "workspace:^"
+        `,
+        'postcss.config.mjs': js`
+          /** @type {import('postcss-load-config').Config} */
+          const config = {
+            plugins: {
+              '@tailwindcss/postcss': {},
+            },
           }
-        }
-      `,
-      'postcss.config.mjs': js`
-        /** @type {import('postcss-load-config').Config} */
-        const config = {
-          plugins: {
-            '@tailwindcss/postcss': {},
-          },
-        }
 
-        export default config
-      `,
-      'next.config.mjs': js`
-        /** @type {import('next').NextConfig} */
-        const nextConfig = {}
+          export default config
+        `,
+        'next.config.mjs': js`
+          /** @type {import('next').NextConfig} */
+          const nextConfig = {}
 
-        export default nextConfig
-      `,
-      'app/layout.js': js`
-        import './globals.css'
+          export default nextConfig
+        `,
+        'app/layout.js': js`
+          import './globals.css'
 
-        export default function RootLayout({ children }) {
-          return (
-            <html>
-              <body>{children}</body>
-            </html>
-          )
-        }
-      `,
-      'app/page.js': js`
-        export default function Page() {
-          return <h1 className="underline">Hello, Next.js!</h1>
-        }
-      `,
-      'app/globals.css': css`
-        @import 'tailwindcss/theme' theme(reference);
-        @import 'tailwindcss/utilities';
-      `,
+          export default function RootLayout({ children }) {
+            return (
+              <html>
+                <body>{children}</body>
+              </html>
+            )
+          }
+        `,
+        'app/page.js': js`
+          export default function Page() {
+            return <h1 className="underline">Hello, Next.js!</h1>
+          }
+        `,
+        'app/globals.css': css`
+          @import 'tailwindcss/theme' theme(reference);
+          @import 'tailwindcss/utilities';
+        `,
+      },
     },
-  },
-  async ({ fs, spawn, getFreePort }) => {
-    let port = await getFreePort()
-    let process = await spawn(`pnpm next dev --turbo --port ${port}`)
+    async ({ fs, spawn, getFreePort }) => {
+      let port = await getFreePort()
+      let process = await spawn(
+        `pnpm next dev ${bundler === 'turbo' ? '--turbo' : ''} --port ${port}`,
+      )
 
-    await process.onStdout((message) => message.includes('Ready in'))
+      await process.onStdout((message) => message.includes('Ready in'))
 
-    let stylesheets = await fetchStylesheetsFromIndex(port)
-    expect(stylesheets).toHaveLength(1)
-    let [, css] = stylesheets[0]
+      let css = await fetchStylesFromIndex(port)
+      expect(css).toContain(candidate`underline`)
 
-    expect(css).toContain(candidate`underline`)
+      await fs.write(
+        'app/page.js',
+        js`
+          export default function Page() {
+            return <h1 className="underline text-red-500">Hello, Next.js!</h1>
+          }
+        `,
+      )
+      await process.onStdout((message) => message.includes('Compiled in'))
 
-    await fs.write(
-      'app/page.js',
-      js`
-        export default function Page() {
-          return <h1 className="underline text-red-500">Hello, Next.js!</h1>
-        }
-      `,
-    )
-    await process.onStdout((message) => message.includes('Compiled in'))
-
-    stylesheets = await fetchStylesheetsFromIndex(port)
-    expect(stylesheets).toHaveLength(1)
-    ;[, css] = stylesheets[0]
-
-    expect(css).toContain(candidate`underline`)
-    expect(css).toContain(candidate`text-red-500`)
-  },
-)
+      css = await fetchStylesFromIndex(port)
+      expect(css).toContain(candidate`underline`)
+      expect(css).toContain(candidate`text-red-500`)
+    },
+  )
+})

--- a/integrations/postcss/next.test.ts
+++ b/integrations/postcss/next.test.ts
@@ -127,6 +127,8 @@ test(
       },
     },
     async ({ fs, spawn, getFreePort }) => {
+      const start = Date.now()
+      console.log('start test for', bundler)
       let port = await getFreePort()
       let process = await spawn(
         `pnpm next dev ${bundler === 'turbo' ? '--turbo' : ''} --port ${port}`,
@@ -134,8 +136,10 @@ test(
 
       await process.onStdout((message) => message.includes('Ready in'))
 
+      console.log('so far:', Date.now() - start)
       let css = await fetchStylesFromIndex(port)
       expect(css).toContain(candidate`underline`)
+      console.log('so far:', Date.now() - start)
 
       await fs.write(
         'app/page.js',
@@ -145,11 +149,16 @@ test(
           }
         `,
       )
+      console.log('so far:', Date.now() - start)
       await process.onStdout((message) => message.includes('Compiled in'))
 
+      console.log('so far:', Date.now() - start)
       css = await fetchStylesFromIndex(port)
+      console.log('so far:', Date.now() - start)
       expect(css).toContain(candidate`underline`)
       expect(css).toContain(candidate`text-red-500`)
+      console.log('end test for', bundler)
+      console.log('took:', Date.now() - start)
     },
   )
 })

--- a/integrations/postcss/next.test.ts
+++ b/integrations/postcss/next.test.ts
@@ -127,11 +127,9 @@ test(
       },
     },
     async ({ fs, spawn, getFreePort }) => {
-      console.log('start of test' + bundler)
       let port = await getFreePort()
       await spawn(`pnpm next dev ${bundler === 'turbo' ? '--turbo' : ''} --port ${port}`)
 
-      console.log('retryAssertion #1' + bundler)
       await retryAssertion(async () => {
         let css = await fetchStylesFromIndex(port)
         expect(css).toContain(candidate`underline`)
@@ -145,15 +143,12 @@ test(
           }
         `,
       )
-      console.log('retryAssertion #2' + bundler)
 
       await retryAssertion(async () => {
         let css = await fetchStylesFromIndex(port)
         expect(css).toContain(candidate`underline`)
         expect(css).toContain(candidate`text-red-500`)
       })
-
-      console.log('end of test' + bundler)
     },
   )
 })

--- a/integrations/postcss/next.test.ts
+++ b/integrations/postcss/next.test.ts
@@ -1,0 +1,167 @@
+import { expect } from 'vitest'
+import { candidate, css, js, json, test } from '../utils'
+
+test(
+  'production build',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "dependencies": {
+            "react": "^18",
+            "react-dom": "^18",
+            "next": "14.2.5"
+          },
+          "devDependencies": {
+            "@tailwindcss/postcss": "workspace:^",
+            "tailwindcss": "workspace:^"
+          }
+        }
+      `,
+      'postcss.config.mjs': js`
+        /** @type {import('postcss-load-config').Config} */
+        const config = {
+          plugins: {
+            '@tailwindcss/postcss': {},
+          },
+        }
+
+        export default config
+      `,
+      'next.config.mjs': js`
+        /** @type {import('next').NextConfig} */
+        const nextConfig = {}
+
+        export default nextConfig
+      `,
+      'app/layout.js': js`
+        import './globals.css'
+
+        export default function RootLayout({ children }) {
+          return (
+            <html>
+              <body>{children}</body>
+            </html>
+          )
+        }
+      `,
+      'app/page.js': js`
+        export default function Page() {
+          return <h1 className="text-3xl font-bold underline">Hello, Next.js!</h1>
+        }
+      `,
+      'app/globals.css': css`
+        @import 'tailwindcss/theme' theme(reference);
+        @import 'tailwindcss/utilities';
+      `,
+    },
+  },
+  async ({ fs, exec }) => {
+    await exec('pnpm next build')
+
+    let files = await fs.glob('.next/static/css/**/*.css')
+    expect(files).toHaveLength(1)
+    let [filename] = files[0]
+
+    await fs.expectFileToContain(filename, [
+      candidate`underline`,
+      candidate`font-bold`,
+      candidate`text-3xl`,
+    ])
+  },
+)
+
+test(
+  'dev mode',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "dependencies": {
+            "react": "^18",
+            "react-dom": "^18",
+            "next": "14.2.5"
+          },
+          "devDependencies": {
+            "@tailwindcss/postcss": "workspace:^",
+            "tailwindcss": "workspace:^"
+          }
+        }
+      `,
+      'postcss.config.mjs': js`
+        /** @type {import('postcss-load-config').Config} */
+        const config = {
+          plugins: {
+            '@tailwindcss/postcss': {},
+          },
+        }
+
+        export default config
+      `,
+      'next.config.mjs': js`
+        /** @type {import('next').NextConfig} */
+        const nextConfig = {}
+
+        export default nextConfig
+      `,
+      'app/layout.js': js`
+        import './globals.css'
+
+        export default function RootLayout({ children }) {
+          return (
+            <html>
+              <body>{children}</body>
+            </html>
+          )
+        }
+      `,
+      'app/page.js': js`
+        export default function Page() {
+          return <h1 className="underline">Hello, Next.js!</h1>
+        }
+      `,
+      'app/globals.css': css`
+        @import 'tailwindcss/theme' theme(reference);
+        @import 'tailwindcss/utilities';
+      `,
+    },
+  },
+  async ({ fs, spawn, getFreePort }) => {
+    let port = await getFreePort()
+    let process = await spawn(`pnpm next dev --port ${port}`)
+
+    await process.onStdout((message) => message.includes('Ready in'))
+
+    let css = await fetchCSS('/_next/static/css/app/layout.css', port)
+    expect(css).toContain(candidate`underline`)
+
+    await fs.write(
+      'app/page.js',
+      js`
+        export default function Page() {
+          return <h1 className="underline text-red-500">Hello, Next.js!</h1>
+        }
+      `,
+    )
+    await process.onStdout((message) => message.includes('Compiled in'))
+
+    css = await fetchCSS('/_next/static/css/app/layout.css', port)
+    expect(css).toContain(candidate`underline`)
+    expect(css).toContain(candidate`text-red-500`)
+  },
+)
+
+async function fetchCSS(path: string, port: number) {
+  // We need to fetch the main index.html file, to simulate a real browser.
+  let body = await fetch(`http://localhost:${port}`)
+  // Make sure the main request is garbage collected.
+  body.blob()
+
+  let response = await fetch(`http://localhost:${port}${path}`, {
+    headers: {
+      Accept: 'text/css',
+    },
+  })
+  let text = await response.text()
+  return text
+}

--- a/integrations/postcss/next.test.ts
+++ b/integrations/postcss/next.test.ts
@@ -127,9 +127,11 @@ test(
       },
     },
     async ({ fs, spawn, getFreePort }) => {
+      console.log('start of test' + bundler)
       let port = await getFreePort()
       await spawn(`pnpm next dev ${bundler === 'turbo' ? '--turbo' : ''} --port ${port}`)
 
+      console.log('retryAssertion #1' + bundler)
       await retryAssertion(async () => {
         let css = await fetchStylesFromIndex(port)
         expect(css).toContain(candidate`underline`)
@@ -143,12 +145,15 @@ test(
           }
         `,
       )
+      console.log('retryAssertion #2' + bundler)
 
       await retryAssertion(async () => {
         let css = await fetchStylesFromIndex(port)
         expect(css).toContain(candidate`underline`)
         expect(css).toContain(candidate`text-red-500`)
       })
+
+      console.log('end of test' + bundler)
     },
   )
 })

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -316,7 +316,7 @@ export function test(
           await fs.rm(root, { recursive: true, force: true })
         }
 
-        console.log('end disposal for test', options.task.file, options.task.name)
+        console.log('end disposal for test', options.task.file.name, options.task.name)
         console.log('disposal took', Date.now() - now, 'ms')
       }
 

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -307,12 +307,17 @@ export function test(
       let disposables: (() => Promise<void>)[] = []
 
       async function dispose() {
+        const now = Date.now()
+        console.log('start disposal for test', options.task.file, options.task.name)
         await Promise.all(disposables.map((dispose) => dispose()))
 
         // Skip removing the directory in CI beause it can stall on Windows
         if (!process.env.CI && !debug) {
           await fs.rm(root, { recursive: true, force: true })
         }
+
+        console.log('end disposal for test', options.task.file, options.task.name)
+        console.log('disposal took', Date.now() - now, 'ms')
       }
 
       options.onTestFinished(dispose)

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -501,7 +501,7 @@ async function retryUntil<T>(
   throw error
 }
 
-export async function fetchStylesheetsFromIndex(port: number): Promise<[string, string][]> {
+export async function fetchStylesFromIndex(port: number): Promise<string> {
   let index = await fetch(`http://localhost:${port}`)
   let html = await index.text()
 
@@ -512,19 +512,23 @@ export async function fetchStylesheetsFromIndex(port: number): Promise<[string, 
   while ((match = regex.exec(html)) !== null) {
     let path: string = match[1]
     if (path.startsWith('./')) {
-      path = path.substring(1)
+      path = path.slice(1)
     }
     paths.push(path)
   }
 
-  return Promise.all(
+  let stylesheets = await Promise.all(
     paths.map(async (path) => {
       let css = await fetch(`http://localhost:${port}${path}`, {
         headers: {
           Accept: 'text/css',
         },
       })
-      return [path, await css.text()]
+      return await css.text()
     }),
   )
+
+  return stylesheets.reduce((acc, css) => {
+    return acc + '\n' + css
+  })
 }

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -50,7 +50,7 @@ type SpawnActor = { predicate: (message: string) => boolean; resolve: () => void
 
 const IS_WINDOWS = platform() === 'win32'
 
-const TEST_TIMEOUT = IS_WINDOWS ? 60000 : 30000
+const TEST_TIMEOUT = IS_WINDOWS ? 120000 : 60000
 const ASSERTION_TIMEOUT = IS_WINDOWS ? 10000 : 5000
 
 export function test(
@@ -63,6 +63,9 @@ export function test(
     name,
     { timeout: TEST_TIMEOUT },
     async (options) => {
+      const startSetup = Date.now()
+      console.log('start setup for', options.task.file.name, options.task.name)
+
       let rootDir = debug
         ? path.join(REPO_ROOT, '.debug')
         : // On Windows CI, tmpdir returns a path containing a weird RUNNER~1
@@ -291,6 +294,8 @@ export function test(
         await context.fs.write(filename, content)
       }
 
+      console.log('setup so far:', Date.now() - startSetup)
+
       try {
         // In debug mode, the directory is going to be inside the pnpm workspace
         // of the tailwindcss package. This means that `pnpm install` will run
@@ -303,6 +308,8 @@ export function test(
         console.error(error)
         throw error
       }
+
+      console.log('setup so far:', Date.now() - startSetup)
 
       let disposables: (() => Promise<void>)[] = []
 
@@ -322,6 +329,8 @@ export function test(
 
       options.onTestFinished(dispose)
 
+      console.log('end setup for test', options.task.file.name, options.task.name)
+      console.log('setup took', Date.now() - startSetup, 'ms')
       return await testCallback(context)
     },
   )

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -48,8 +48,10 @@ interface TestFlags {
 
 type SpawnActor = { predicate: (message: string) => boolean; resolve: () => void }
 
-const TEST_TIMEOUT = 30000
-const ASSERTION_TIMEOUT = 5000
+const IS_WINDOWS = platform() === 'win32'
+
+const TEST_TIMEOUT = IS_WINDOWS ? 60000 : 30000
+const ASSERTION_TIMEOUT = IS_WINDOWS ? 10000 : 5000
 
 export function test(
   name: string,
@@ -65,7 +67,7 @@ export function test(
         ? path.join(REPO_ROOT, '.debug')
         : // On Windows CI, tmpdir returns a path containing a weird RUNNER~1
           // folder  that apparently causes the vite builds to not work.
-          process.env.CI && platform() === 'win32'
+          process.env.CI && IS_WINDOWS
           ? homedir()
           : tmpdir()
       await fs.mkdir(rootDir, { recursive: true })
@@ -250,7 +252,7 @@ export function test(
             }
 
             // Ensure that files written on Windows use \r\n line ending
-            if (platform() === 'win32') {
+            if (IS_WINDOWS) {
               content = content.replace(/\n/g, '\r\n')
             }
 

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -308,10 +308,10 @@ export function test(
 
       async function dispose() {
         const now = Date.now()
-        console.log('start disposal for test', options.task.file, options.task.name)
+        console.log('start disposal for test', options.task.file.name, options.task.name)
         await Promise.all(disposables.map((dispose) => dispose()))
 
-        // Skip removing the directory in CI beause it can stall on Windows
+        // Skip removing the directory in CI because it can stall on Windows
         if (!process.env.CI && !debug) {
           await fs.rm(root, { recursive: true, force: true })
         }

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -300,17 +300,8 @@ export function test(
       }
 
       try {
-        try {
-          // Copy the contents of a potential node_modules folder from
-          // the nodeModulesCacheDir to the root dir, to quickly restore
-          // in the next text run
-          let nodeModulesDir = path.join(nodeModulesCacheDir!, 'node_modules')
-          if (await dirExists(nodeModulesDir)) {
-            await fs.cp(nodeModulesDir, path.join(root, 'node_modules'), {
-              recursive: true,
-            })
-          }
-        } catch {}
+        // Create a symlink from the node_modules dir to the nodeModulesCacheDir
+        await fs.symlink(nodeModulesCacheDir!, path.join(root, 'node_modules'))
 
         // In debug mode, the directory is going to be inside the pnpm workspace
         // of the tailwindcss package. This means that `pnpm install` will run
@@ -332,16 +323,6 @@ export function test(
         await Promise.all(disposables.map((dispose) => dispose()))
 
         if (!debug) {
-          try {
-            // Move a potential node_modules folder to the nodeModulesCacheDir to
-            // quickly restore in the next text run
-            await gracefullyRemove(path.join(nodeModulesCacheDir!, 'node_modules'))
-            let nodeModulesDir = path.join(root, 'node_modules')
-            if (await dirExists(nodeModulesDir)) {
-              await fs.rename(nodeModulesDir, path.join(nodeModulesCacheDir!, 'node_modules'))
-            }
-          } catch {}
-
           await gracefullyRemove(root)
         }
       }

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -320,6 +320,8 @@ export function test(
         await context.exec(`pnpm install${ignoreWorkspace ? ' --ignore-workspace' : ''}`)
       } catch (error: any) {
         console.error(error)
+        console.error(error.stdout?.toString())
+        console.error(error.stderr?.toString())
         throw error
       }
 

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -235,7 +235,11 @@ export function test(
                       return
                     }
 
-                    await killPort(port)
+                    try {
+                      await killPort(port)
+                    } catch {
+                      // If the process can not be killed, we can't do anything
+                    }
                   })
                   resolve(port)
                 }

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -77,8 +77,6 @@ export function test(
     name,
     { timeout: TEST_TIMEOUT },
     async (options) => {
-      const startSetup = Date.now()
-
       let rootDir = debug ? path.join(REPO_ROOT, '.debug') : TMP_ROOT
       await fs.mkdir(rootDir, { recursive: true })
 
@@ -303,11 +301,14 @@ export function test(
 
       try {
         try {
-          // Move a potential node_modules folder from the nodeModulesCacheDir to
-          // the root dir, to quickly restore in the next text run
+          // Copy the contents of a potential node_modules folder from
+          // the nodeModulesCacheDir to the root dir, to quickly restore
+          // in the next text run
           let nodeModulesDir = path.join(nodeModulesCacheDir!, 'node_modules')
           if (await dirExists(nodeModulesDir)) {
-            await fs.rename(nodeModulesDir, path.join(root, 'node_modules'))
+            await fs.cp(nodeModulesDir, path.join(root, 'node_modules'), {
+              recursive: true,
+            })
           }
         } catch {}
 
@@ -334,6 +335,7 @@ export function test(
           try {
             // Move a potential node_modules folder to the nodeModulesCacheDir to
             // quickly restore in the next text run
+            await gracefullyRemove(path.join(nodeModulesCacheDir!, 'node_modules'))
             let nodeModulesDir = path.join(root, 'node_modules')
             if (await dirExists(nodeModulesDir)) {
               await fs.rename(nodeModulesDir, path.join(nodeModulesCacheDir!, 'node_modules'))

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -6,7 +6,7 @@ import fs from 'node:fs/promises'
 import net from 'node:net'
 import { homedir, platform, tmpdir } from 'node:os'
 import path from 'node:path'
-import { afterAll, beforeAll, test as defaultTest, expect } from 'vitest'
+import { test as defaultTest, expect } from 'vitest'
 
 const REPO_ROOT = path.join(__dirname, '..')
 const PUBLIC_PACKAGES = (await fs.readdir(path.join(REPO_ROOT, 'dist'))).map((name) =>
@@ -56,16 +56,6 @@ const ASSERTION_TIMEOUT = IS_WINDOWS ? 10000 : 5000
 // On Windows CI, tmpdir returns a path containing a weird RUNNER~1 folder that
 // apparently causes the vite builds to not work.
 const TMP_ROOT = process.env.CI && IS_WINDOWS ? homedir() : tmpdir()
-
-// Set up a cache directory that we can move `node_modules` to in between test
-// runs so that subsequent `pnpm install`s are faster.
-let nodeModulesCacheDir: string | undefined
-beforeAll(async () => {
-  nodeModulesCacheDir = await fs.mkdtemp(
-    path.join(TMP_ROOT, 'tailwind-integrations-node_modules-cache-'),
-  )
-})
-afterAll(() => gracefullyRemove(nodeModulesCacheDir!))
 
 export function test(
   name: string,
@@ -300,9 +290,6 @@ export function test(
       }
 
       try {
-        // Create a symlink from the node_modules dir to the nodeModulesCacheDir
-        await fs.symlink(nodeModulesCacheDir!, path.join(root, 'node_modules'))
-
         // In debug mode, the directory is going to be inside the pnpm workspace
         // of the tailwindcss package. This means that `pnpm install` will run
         // pnpm install on the workspace instead (expect if the root dir defines

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -59,7 +59,7 @@ export function test(
   testCallback: TestCallback,
   { only = false, debug = false }: TestFlags = {},
 ) {
-  return (only ? defaultTest.only : defaultTest)(
+  return (only || (!process.env.CI && debug) ? defaultTest.only : defaultTest)(
     name,
     { timeout: TEST_TIMEOUT },
     async (options) => {
@@ -321,7 +321,7 @@ test.only = (name: string, config: TestConfig, testCallback: TestCallback) => {
   return test(name, config, testCallback, { only: true })
 }
 test.debug = (name: string, config: TestConfig, testCallback: TestCallback) => {
-  return test(name, config, testCallback, { only: true, debug: true })
+  return test(name, config, testCallback, { debug: true })
 }
 
 // Maps package names to their tarball filenames. See scripts/pack-packages.ts

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -302,12 +302,14 @@ export function test(
       }
 
       try {
-        // Move a potential node_modules folder from the nodeModulesCacheDir to
-        // the root dir, to quickly restore in the next text run
-        let nodeModulesDir = path.join(nodeModulesCacheDir!, 'node_modules')
-        if (await dirExists(nodeModulesDir)) {
-          await fs.rename(nodeModulesDir, path.join(root, 'node_modules'))
-        }
+        try {
+          // Move a potential node_modules folder from the nodeModulesCacheDir to
+          // the root dir, to quickly restore in the next text run
+          let nodeModulesDir = path.join(nodeModulesCacheDir!, 'node_modules')
+          if (await dirExists(nodeModulesDir)) {
+            await fs.rename(nodeModulesDir, path.join(root, 'node_modules'))
+          }
+        } catch {}
 
         // In debug mode, the directory is going to be inside the pnpm workspace
         // of the tailwindcss package. This means that `pnpm install` will run
@@ -327,12 +329,14 @@ export function test(
         await Promise.all(disposables.map((dispose) => dispose()))
 
         if (!debug) {
-          // Move a potential node_modules folder to the nodeModulesCacheDir to
-          // quickly restore in the next text run
-          let nodeModulesDir = path.join(root, 'node_modules')
-          if (await dirExists(nodeModulesDir)) {
-            await fs.rename(nodeModulesDir, path.join(nodeModulesCacheDir!, 'node_modules'))
-          }
+          try {
+            // Move a potential node_modules folder to the nodeModulesCacheDir to
+            // quickly restore in the next text run
+            let nodeModulesDir = path.join(root, 'node_modules')
+            if (await dirExists(nodeModulesDir)) {
+              await fs.rename(nodeModulesDir, path.join(nodeModulesCacheDir!, 'node_modules'))
+            }
+          } catch {}
 
           await gracefullyRemove(root)
         }

--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import { expect } from 'vitest'
-import { candidate, css, fetchStylesheetsFromIndex, html, js, json, test, ts, yaml } from '../utils'
+import { candidate, css, fetchStylesFromIndex, html, js, json, test, ts, yaml } from '../utils'
 
 test(
   'production build',
@@ -125,10 +125,7 @@ test(
 
     await process.onStdout((message) => message.includes('ready in'))
 
-    let stylesheets = await fetchStylesheetsFromIndex(port)
-    expect(stylesheets).toHaveLength(1)
-    let [, css] = stylesheets[0]
-
+    let css = await fetchStylesFromIndex(port)
     expect(css).toContain(candidate`underline`)
 
     await fs.write(
@@ -144,10 +141,7 @@ test(
     )
     await process.onStdout((message) => message.includes('page reload'))
 
-    stylesheets = await fetchStylesheetsFromIndex(port)
-    expect(stylesheets).toHaveLength(1)
-    ;[, css] = stylesheets[0]
-
+    css = await fetchStylesFromIndex(port)
     expect(css).toContain(candidate`m-2`)
 
     await fs.write(
@@ -159,10 +153,7 @@ test(
     )
     await process.onStdout((message) => message.includes('page reload'))
 
-    stylesheets = await fetchStylesheetsFromIndex(port)
-    expect(stylesheets).toHaveLength(1)
-    ;[, css] = stylesheets[0]
-
+    css = await fetchStylesFromIndex(port)
     expect(css).toContain(candidate`[.changed_&]:content-['project-b/src/index.js']`)
   },
 )

--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -1,21 +1,6 @@
 import path from 'node:path'
 import { expect } from 'vitest'
-import { candidate, css, html, js, json, test, ts, yaml } from '../utils'
-
-async function fetchCSS(pathname: string, port: number) {
-  // We need to fetch the main index.html file to populate the list of
-  // candidates.
-  let body = await fetch(`http://localhost:${port}`)
-  // Make sure the main request is garbage collected.
-  body.blob()
-
-  let response = await fetch(`http://localhost:${port}${pathname}`, {
-    headers: {
-      Accept: 'text/css',
-    },
-  })
-  return response.text()
-}
+import { candidate, css, fetchStylesheetsFromIndex, html, js, json, test, ts, yaml } from '../utils'
 
 test(
   'production build',
@@ -140,7 +125,10 @@ test(
 
     await process.onStdout((message) => message.includes('ready in'))
 
-    let css = await fetchCSS('/src/index.css', port)
+    let stylesheets = await fetchStylesheetsFromIndex(port)
+    expect(stylesheets).toHaveLength(1)
+    let [, css] = stylesheets[0]
+
     expect(css).toContain(candidate`underline`)
 
     await fs.write(
@@ -156,7 +144,10 @@ test(
     )
     await process.onStdout((message) => message.includes('page reload'))
 
-    css = await fetchCSS('/src/index.css', port)
+    stylesheets = await fetchStylesheetsFromIndex(port)
+    expect(stylesheets).toHaveLength(1)
+    ;[, css] = stylesheets[0]
+
     expect(css).toContain(candidate`m-2`)
 
     await fs.write(
@@ -168,7 +159,10 @@ test(
     )
     await process.onStdout((message) => message.includes('page reload'))
 
-    css = await fetchCSS('/src/index.css', port)
+    stylesheets = await fetchStylesheetsFromIndex(port)
+    expect(stylesheets).toHaveLength(1)
+    ;[, css] = stylesheets[0]
+
     expect(css).toContain(candidate`[.changed_&]:content-['project-b/src/index.js']`)
   },
 )

--- a/packages/tailwindcss/tests/ui.spec.ts
+++ b/packages/tailwindcss/tests/ui.spec.ts
@@ -9,7 +9,7 @@ const html = String.raw
 const css = String.raw
 
 test('touch action', async ({ page }) => {
-  let { getPropertyValue, nextFrame } = await render(
+  let { getPropertyValue } = await render(
     page,
     html`<div id="x" class="touch-pan-x touch-pan-y hover:touch-pinch-zoom">Hello world</div>`,
   )
@@ -17,7 +17,6 @@ test('touch action', async ({ page }) => {
   expect(await getPropertyValue('#x', 'touch-action')).toEqual('pan-x pan-y')
 
   await page.locator('#x').hover()
-  await nextFrame()
 
   expect([
     // `manipulation` is an alias for `pan-x pan-y pinch-zoom` and some engines
@@ -59,7 +58,7 @@ for (let [classes, expected] of [
 }
 
 test('background gradient, going from 2 to 3', async ({ page }) => {
-  let { getPropertyValue, nextFrame } = await render(
+  let { getPropertyValue } = await render(
     page,
     html`
       <div id="x" class="bg-gradient-to-r from-red-500 hover:via-green-500 to-blue-500">
@@ -73,7 +72,6 @@ test('background gradient, going from 2 to 3', async ({ page }) => {
   )
 
   await page.locator('#x').hover()
-  await nextFrame()
 
   expect(await getPropertyValue('#x', 'background-image')).toEqual(
     'linear-gradient(to right, rgb(239, 68, 68) 0%, rgb(34, 197, 94) 50%, rgb(59, 130, 246) 100%)',
@@ -81,7 +79,7 @@ test('background gradient, going from 2 to 3', async ({ page }) => {
 })
 
 test('background gradient, going from 3 to 2', async ({ page }) => {
-  let { getPropertyValue, nextFrame } = await render(
+  let { getPropertyValue } = await render(
     page,
     html`
       <div id="x" class="bg-gradient-to-r from-red-500 via-green-500 hover:via-none to-blue-500">
@@ -95,7 +93,6 @@ test('background gradient, going from 3 to 2', async ({ page }) => {
   )
 
   await page.locator('#x').hover()
-  await nextFrame()
 
   expect(await getPropertyValue('#x', 'background-image')).toEqual(
     'linear-gradient(to right, rgb(239, 68, 68) 0%, rgb(59, 130, 246) 100%)',
@@ -212,7 +209,7 @@ test('outline style is optional', async ({ page }) => {
 })
 
 test('outline style is preserved when changing outline width', async ({ page }) => {
-  let { getPropertyValue, nextFrame } = await render(
+  let { getPropertyValue } = await render(
     page,
     html`<div id="x" class="outline-2 outline-dotted outline-white hover:outline-4">
       Hello world
@@ -222,7 +219,6 @@ test('outline style is preserved when changing outline width', async ({ page }) 
   expect(await getPropertyValue('#x', 'outline')).toEqual('rgb(255, 255, 255) dotted 2px')
 
   await page.locator('#x').hover()
-  await nextFrame()
 
   expect(await getPropertyValue('#x', 'outline')).toEqual('rgb(255, 255, 255) dotted 4px')
 })
@@ -237,7 +233,7 @@ test('borders can be added without a border-style utility', async ({ page }) => 
 })
 
 test('borders can be added to a single side without a border-style utility', async ({ page }) => {
-  let { getPropertyValue, nextFrame } = await render(
+  let { getPropertyValue } = await render(
     page,
     html`<div id="x" class="text-black border-r-2 border-dashed hover:border-r-4">
       Hello world
@@ -246,7 +242,6 @@ test('borders can be added to a single side without a border-style utility', asy
   expect(await getPropertyValue('#x', 'border-right')).toEqual('2px dashed rgb(0, 0, 0)')
 
   await page.locator('#x').hover()
-  await nextFrame()
 
   expect(await getPropertyValue('#x', 'border-right')).toEqual('4px dashed rgb(0, 0, 0)')
 })
@@ -267,21 +262,20 @@ test('dividers can be added without setting border-style', async ({ page }) => {
 })
 
 test('scale can be a number or percentage', async ({ page }) => {
-  let { getPropertyValue, nextFrame } = await render(
+  let { getPropertyValue } = await render(
     page,
     html`<div id="x" class="scale-[50%] hover:scale-[1.5]">Hello world</div>`,
   )
   expect(await getPropertyValue('#x', 'scale')).toEqual('0.5')
 
   await page.locator('#x').hover()
-  await nextFrame()
 
   expect(await getPropertyValue('#x', 'scale')).toEqual('1.5')
 })
 
 // https://github.com/tailwindlabs/tailwindcss/issues/13185
 test('content-none persists when conditionally styling a pseudo-element', async ({ page }) => {
-  let { getPropertyValue, nextFrame } = await render(
+  let { getPropertyValue } = await render(
     page,
     html`<div id="x" class="after:content-none after:hover:underline">Hello world</div>`,
   )
@@ -289,7 +283,6 @@ test('content-none persists when conditionally styling a pseudo-element', async 
   expect(await getPropertyValue(['#x', '::after'], 'content')).toEqual('none')
 
   await page.locator('#x').hover()
-  await nextFrame()
 
   expect(await getPropertyValue(['#x', '::after'], 'content')).toEqual('none')
 })
@@ -339,15 +332,6 @@ async function render(page: Page, content: string) {
         Array.isArray(selector) ? selector : [selector, undefined],
         property,
       )
-    },
-
-    // Wait for the next frame to ensure the styles are applied
-    async nextFrame() {
-      await page.evaluate(() => {
-        return new Promise<void>((resolve) =>
-          requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
-        )
-      })
     },
   }
 }

--- a/packages/tailwindcss/tests/ui.spec.ts
+++ b/packages/tailwindcss/tests/ui.spec.ts
@@ -9,7 +9,7 @@ const html = String.raw
 const css = String.raw
 
 test('touch action', async ({ page }) => {
-  let { getPropertyValue } = await render(
+  let { getPropertyValue, nextFrame } = await render(
     page,
     html`<div id="x" class="touch-pan-x touch-pan-y hover:touch-pinch-zoom">Hello world</div>`,
   )
@@ -17,6 +17,7 @@ test('touch action', async ({ page }) => {
   expect(await getPropertyValue('#x', 'touch-action')).toEqual('pan-x pan-y')
 
   await page.locator('#x').hover()
+  await nextFrame()
 
   expect([
     // `manipulation` is an alias for `pan-x pan-y pinch-zoom` and some engines
@@ -58,7 +59,7 @@ for (let [classes, expected] of [
 }
 
 test('background gradient, going from 2 to 3', async ({ page }) => {
-  let { getPropertyValue } = await render(
+  let { getPropertyValue, nextFrame } = await render(
     page,
     html`
       <div id="x" class="bg-gradient-to-r from-red-500 hover:via-green-500 to-blue-500">
@@ -72,6 +73,7 @@ test('background gradient, going from 2 to 3', async ({ page }) => {
   )
 
   await page.locator('#x').hover()
+  await nextFrame()
 
   expect(await getPropertyValue('#x', 'background-image')).toEqual(
     'linear-gradient(to right, rgb(239, 68, 68) 0%, rgb(34, 197, 94) 50%, rgb(59, 130, 246) 100%)',
@@ -79,7 +81,7 @@ test('background gradient, going from 2 to 3', async ({ page }) => {
 })
 
 test('background gradient, going from 3 to 2', async ({ page }) => {
-  let { getPropertyValue } = await render(
+  let { getPropertyValue, nextFrame } = await render(
     page,
     html`
       <div id="x" class="bg-gradient-to-r from-red-500 via-green-500 hover:via-none to-blue-500">
@@ -93,6 +95,7 @@ test('background gradient, going from 3 to 2', async ({ page }) => {
   )
 
   await page.locator('#x').hover()
+  await nextFrame()
 
   expect(await getPropertyValue('#x', 'background-image')).toEqual(
     'linear-gradient(to right, rgb(239, 68, 68) 0%, rgb(59, 130, 246) 100%)',
@@ -209,7 +212,7 @@ test('outline style is optional', async ({ page }) => {
 })
 
 test('outline style is preserved when changing outline width', async ({ page }) => {
-  let { getPropertyValue } = await render(
+  let { getPropertyValue, nextFrame } = await render(
     page,
     html`<div id="x" class="outline-2 outline-dotted outline-white hover:outline-4">
       Hello world
@@ -219,6 +222,7 @@ test('outline style is preserved when changing outline width', async ({ page }) 
   expect(await getPropertyValue('#x', 'outline')).toEqual('rgb(255, 255, 255) dotted 2px')
 
   await page.locator('#x').hover()
+  await nextFrame()
 
   expect(await getPropertyValue('#x', 'outline')).toEqual('rgb(255, 255, 255) dotted 4px')
 })
@@ -233,7 +237,7 @@ test('borders can be added without a border-style utility', async ({ page }) => 
 })
 
 test('borders can be added to a single side without a border-style utility', async ({ page }) => {
-  let { getPropertyValue } = await render(
+  let { getPropertyValue, nextFrame } = await render(
     page,
     html`<div id="x" class="text-black border-r-2 border-dashed hover:border-r-4">
       Hello world
@@ -242,6 +246,7 @@ test('borders can be added to a single side without a border-style utility', asy
   expect(await getPropertyValue('#x', 'border-right')).toEqual('2px dashed rgb(0, 0, 0)')
 
   await page.locator('#x').hover()
+  await nextFrame()
 
   expect(await getPropertyValue('#x', 'border-right')).toEqual('4px dashed rgb(0, 0, 0)')
 })
@@ -262,20 +267,21 @@ test('dividers can be added without setting border-style', async ({ page }) => {
 })
 
 test('scale can be a number or percentage', async ({ page }) => {
-  let { getPropertyValue } = await render(
+  let { getPropertyValue, nextFrame } = await render(
     page,
     html`<div id="x" class="scale-[50%] hover:scale-[1.5]">Hello world</div>`,
   )
   expect(await getPropertyValue('#x', 'scale')).toEqual('0.5')
 
   await page.locator('#x').hover()
+  await nextFrame()
 
   expect(await getPropertyValue('#x', 'scale')).toEqual('1.5')
 })
 
 // https://github.com/tailwindlabs/tailwindcss/issues/13185
 test('content-none persists when conditionally styling a pseudo-element', async ({ page }) => {
-  let { getPropertyValue } = await render(
+  let { getPropertyValue, nextFrame } = await render(
     page,
     html`<div id="x" class="after:content-none after:hover:underline">Hello world</div>`,
   )
@@ -283,6 +289,7 @@ test('content-none persists when conditionally styling a pseudo-element', async 
   expect(await getPropertyValue(['#x', '::after'], 'content')).toEqual('none')
 
   await page.locator('#x').hover()
+  await nextFrame()
 
   expect(await getPropertyValue(['#x', '::after'], 'content')).toEqual('none')
 })
@@ -332,6 +339,15 @@ async function render(page: Page, content: string) {
         Array.isArray(selector) ? selector : [selector, undefined],
         property,
       )
+    },
+
+    // Wait for the next frame to ensure the styles are applied
+    async nextFrame() {
+      await page.evaluate(() => {
+        return new Promise<void>((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+        )
+      })
     },
   }
 }


### PR DESCRIPTION
Using the [new integration test setup](https://github.com/tailwindlabs/tailwindcss/pull/14089), this PR adds a test for a V4 Next.js setup using the Postcss plugin. It's testing both a full build and the dev mode (non-turbo for now).

Because of webpack, tests are quite slow which is worrisome since we probably need to add many more integrations in the future. One idea I have is that we separate tests in two buckets: _essential_ tests that run often and are fast and advanced suites that we only run on CI via custom, non-blocking, jobs.