### PR TITLE
Fix Rust build by passing through RUSTUP_HOME variable

### DIFF
--- a/crates/node/package.json
+++ b/crates/node/package.json
@@ -40,11 +40,11 @@
     "access": "public"
   },
   "scripts": {
-    "artifacts": "npx napi artifacts",
-    "build": "npx napi build --platform --release --no-const-enum",
+    "artifacts": "napi artifacts",
+    "build": "napi build --platform --release --no-const-enum",
     "dev": "cargo watch --quiet --shell 'npm run build'",
-    "build:debug": "npx napi build --platform --no-const-enum",
-    "version": "npx napi version"
+    "build:debug": "napi build --platform --no-const-enum",
+    "version": "napi version"
   },
   "optionalDependencies": {
     "@tailwindcss/oxide-android-arm64": "workspace:*",

--- a/turbo.json
+++ b/turbo.json
@@ -41,5 +41,8 @@
       "cache": false,
       "persistent": true
     }
-  }
+  },
+  // If rustup is installed outside of the default ~/.rustup directory, we need
+  // to pass the path through to the individual rust tasks.
+  "globalPassThroughEnv": ["RUSTUP_HOME"]
 }


### PR DESCRIPTION
While rebasing on the latest changes on `next`, especially #14160, I noticed that my local `pnpm build` step was no longer working and erring with the following:

```
│ > @tailwindcss/oxide@4.0.0-alpha.19 build /Users/philipp/dev/tailwindcss/crates/node
│ > npx napi build --platform --release --no-const-enum
│
│ Type Error: Could not parse the Cargo.toml: Error: Command failed: cargo metadata --format-version 1 --manifest-path "/Users/philipp/dev/
│ tailwindcss/crates/node/Cargo.toml"
│ error: rustup could not choose a version of cargo to run, because one wasn't specified explicitly, and no default is configured.
│ help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.
│
│ error: rustup could not choose a version of cargo to run, because one wasn't specified explicitly, and no default is configured.
│ help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.
```

It turns out that with the changes in turbo v2, env variables no longer propagate to the individual tasks automatically but since I installed rustup outside of the default `~/.rustup` directory, the task was no longer able to find it.

To fix this, we now define `RUSTUP_HOME` as a global env to always pass through.