### PR TITLE
Add support for the CSS `theme()` function 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for `addComponents`, `matchComponents`, `prefix` plugin APIs ([#14221](https://github.com/tailwindlabs/tailwindcss/pull/14221))
 - Add support for `tailwindcss/colors` and `tailwindcss/defaultTheme` exports for use with plugins ([#14221](https://github.com/tailwindlabs/tailwindcss/pull/14221))
 - Add support for the `@tailwindcss/typography` and `@tailwindcss/forms` plugins ([#14221](https://github.com/tailwindlabs/tailwindcss/pull/14221))
+- Add support for the `theme()` function in CSS and class names ([#14177](https://github.com/tailwindlabs/tailwindcss/pull/14177))
 
 ### Fixed
 

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -7,7 +7,7 @@ export type Rule = {
 export type Declaration = {
   kind: 'declaration'
   property: string
-  value: string
+  value: string | undefined
   important: boolean
 }
 

--- a/packages/tailwindcss/src/compat/config/resolve-config.test.ts
+++ b/packages/tailwindcss/src/compat/config/resolve-config.test.ts
@@ -181,15 +181,15 @@ test('theme keys can read from the CSS theme', ({ expect }) => {
     theme: {
       colors: {
         red: 'red',
-        green: 'var(--color-green, green)',
+        green: 'green',
       },
       accentColor: {
         red: 'red',
-        green: 'var(--color-green, green)',
+        green: 'green',
       },
       placeholderColor: {
-        primary: 'var(--color-green, green)',
-        secondary: 'var(--color-green, green)',
+        primary: 'green',
+        secondary: 'green',
       },
     },
   })

--- a/packages/tailwindcss/src/compile.ts
+++ b/packages/tailwindcss/src/compile.ts
@@ -265,7 +265,7 @@ function getPropertySort(nodes: AstNode[]) {
     let node = q.shift()!
     if (node.kind === 'declaration') {
       if (node.property === '--tw-sort') {
-        let idx = GLOBAL_PROPERTY_ORDER.indexOf(node.value)
+        let idx = GLOBAL_PROPERTY_ORDER.indexOf(node.value ?? '')
         if (idx !== -1) {
           propertySort.add(idx)
           break

--- a/packages/tailwindcss/src/functions.test.ts
+++ b/packages/tailwindcss/src/functions.test.ts
@@ -295,7 +295,7 @@ describe('theme function', () => {
             }
           `),
         ).rejects.toThrowErrorMatchingInlineSnapshot(
-          `[Error: Could not resolve value for theme function: \`theme(colors.unknown.500)\`]`,
+          `[Error: Could not resolve value for theme function: \`theme(colors.unknown.500)\`. Consider checking if the path is correct or provide a fallback value to silence this error.]`,
         ))
     })
 

--- a/packages/tailwindcss/src/functions.test.ts
+++ b/packages/tailwindcss/src/functions.test.ts
@@ -261,7 +261,7 @@ describe('theme function', () => {
         `)
         })
 
-        test.skip('theme(fontSize.xs[1].lineHeight)', async () => {
+        test('theme(fontSize.xs[1].lineHeight)', async () => {
           expect(
             await compileCss(css`
               @theme {
@@ -273,7 +273,17 @@ describe('theme function', () => {
                 line-height: theme(fontSize.xs[1].lineHeight);
               }
             `),
-          ).toMatchInlineSnapshot()
+          ).toMatchInlineSnapshot(`
+            ":root {
+              --font-size-xs: .75rem;
+              --font-size-xs--line-height: 1rem;
+            }
+
+            .text {
+              font-size: .75rem;
+              line-height: 1rem;
+            }"
+          `)
         })
       })
 
@@ -462,7 +472,7 @@ describe('theme function', () => {
         ],
         ['width.xs', '20rem'],
         ['transition.timing.function.in.out', 'cubic-bezier(.4, 0, .2, 1)'],
-        ['backgroundColors.red.500', '#ef4444'],
+        ['backgroundColor.red.500', '#ef4444'],
       ])('theme(%s) → %s', async (value, result) => {
         let defaultTheme = await fs.readFile(path.join(__dirname, '..', 'theme.css'), 'utf8')
 

--- a/packages/tailwindcss/src/functions.test.ts
+++ b/packages/tailwindcss/src/functions.test.ts
@@ -1,0 +1,546 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+import { compileCss } from './test-utils/run'
+
+const css = String.raw
+
+describe('theme function', () => {
+  describe('in declaration values', () => {
+    describe('without fallback values', () => {
+      test('theme(colors.red.500)', async () => {
+        expect(
+          await compileCss(css`
+            @theme {
+              --color-red-500: #f00;
+            }
+            .red {
+              color: theme(colors.red.500);
+            }
+          `),
+        ).toMatchInlineSnapshot(`
+          ":root {
+            --color-red-500: red;
+          }
+
+          .red {
+            color: red;
+          }"
+        `)
+      })
+
+      test("theme('colors.red.500')", async () => {
+        expect(
+          await compileCss(css`
+            @theme {
+              --color-red-500: #f00;
+            }
+            .red {
+              color: theme('colors.red.500');
+            }
+          `),
+        ).toMatchInlineSnapshot(`
+          ":root {
+            --color-red-500: red;
+          }
+
+          .red {
+            color: red;
+          }"
+        `)
+      })
+
+      test('theme(colors[red]500)', async () => {
+        expect(
+          await compileCss(css`
+            @theme {
+              --color-red-500: #f00;
+            }
+            .red {
+              color: theme(colors[red]500);
+            }
+          `),
+        ).toMatchInlineSnapshot(`
+          ":root {
+            --color-red-500: red;
+          }
+
+          .red {
+            color: red;
+          }"
+        `)
+      })
+
+      test('theme(colors[red].500)', async () => {
+        expect(
+          await compileCss(css`
+            @theme {
+              --color-red-500: #f00;
+            }
+            .red {
+              color: theme(colors[red].500);
+            }
+          `),
+        ).toMatchInlineSnapshot(`
+          ":root {
+            --color-red-500: red;
+          }
+
+          .red {
+            color: red;
+          }"
+        `)
+      })
+
+      test('theme(colors[red][500])', async () => {
+        expect(
+          await compileCss(css`
+            @theme {
+              --color-red-500: #f00;
+            }
+            .red {
+              color: theme(colors[red][500]);
+            }
+          `),
+        ).toMatchInlineSnapshot(`
+          ":root {
+            --color-red-500: red;
+          }
+
+          .red {
+            color: red;
+          }"
+        `)
+      })
+
+      test('theme(colors[red].[500])', async () => {
+        expect(
+          await compileCss(css`
+            @theme {
+              --color-red-500: #f00;
+            }
+            .red {
+              color: theme(colors[red].[500]);
+            }
+          `),
+        ).toMatchInlineSnapshot(`
+          ":root {
+            --color-red-500: red;
+          }
+
+          .red {
+            color: red;
+          }"
+        `)
+      })
+
+      test('theme(colors.red.500 / 75%)', async () => {
+        expect(
+          await compileCss(css`
+            @theme {
+              --color-red-500: #f00;
+            }
+            .red {
+              color: theme(colors.red.500 / 75%);
+            }
+          `),
+        ).toMatchInlineSnapshot(`
+          ":root {
+            --color-red-500: red;
+          }
+
+          .red {
+            color: #ff0000bf;
+          }"
+        `)
+      })
+
+      test("theme('colors.red.500 / 75%')", async () => {
+        expect(
+          await compileCss(css`
+            @theme {
+              --color-red-500: #f00;
+            }
+            .red {
+              color: theme('colors.red.500 / 75%');
+            }
+          `),
+        ).toMatchInlineSnapshot(`
+          ":root {
+            --color-red-500: red;
+          }
+
+          .red {
+            color: #ff0000bf;
+          }"
+        `)
+      })
+
+      test('theme(spacing.12)', async () => {
+        expect(
+          await compileCss(css`
+            @theme {
+              --spacing-12: 3rem;
+            }
+            .space-on-the-left {
+              margin-left: theme(spacing.12);
+            }
+          `),
+        ).toMatchInlineSnapshot(`
+          ":root {
+            --spacing-12: 3rem;
+          }
+
+          .space-on-the-left {
+            margin-left: 3rem;
+          }"
+        `)
+      })
+
+      test('theme(spacing[2.5])', async () => {
+        expect(
+          await compileCss(css`
+            @theme {
+              --spacing-2_5: 0.625rem;
+            }
+            .space-on-the-left {
+              margin-left: theme(spacing[2.5]);
+            }
+          `),
+        ).toMatchInlineSnapshot(`
+          ":root {
+            --spacing-2_5: .625rem;
+          }
+
+          .space-on-the-left {
+            margin-left: .625rem;
+          }"
+        `)
+      })
+
+      test('calc(100vh - theme(spacing[2.5]))', async () => {
+        expect(
+          await compileCss(css`
+            @theme {
+              --spacing-2_5: 0.625rem;
+            }
+            .space-on-the-left {
+              margin-left: calc(100vh - theme(spacing[2.5]));
+            }
+          `),
+        ).toMatchInlineSnapshot(`
+          ":root {
+            --spacing-2_5: .625rem;
+          }
+
+          .space-on-the-left {
+            margin-left: calc(100vh - .625rem);
+          }"
+        `)
+      })
+
+      describe('for v3 compatibility', () => {
+        test('theme(blur.DEFAULT)', async () => {
+          expect(
+            await compileCss(css`
+              @theme {
+                --blur: 8px;
+              }
+              .default-blur {
+                filter: blur(theme(blur.DEFAULT));
+              }
+            `),
+          ).toMatchInlineSnapshot(`
+          ":root {
+            --blur: 8px;
+          }
+
+          .default-blur {
+            filter: blur(8px);
+          }"
+        `)
+        })
+
+        test.skip('theme(fontSize.xs[1].lineHeight)', async () => {
+          expect(
+            await compileCss(css`
+              @theme {
+                --font-size-xs: 0.75rem;
+                --font-size-xs--line-height: 1rem;
+              }
+              .text {
+                font-size: theme(fontSize.xs);
+                line-height: theme(fontSize.xs[1].lineHeight);
+              }
+            `),
+          ).toMatchInlineSnapshot()
+        })
+      })
+
+      test('theme(colors.unknown.500)', async () =>
+        expect(() =>
+          compileCss(css`
+            .red {
+              color: theme(colors.unknown.500);
+            }
+          `),
+        ).rejects.toThrowErrorMatchingInlineSnapshot(
+          `[Error: Could not resolve value for theme function: \`theme(colors.unknown.500)\`]`,
+        ))
+    })
+
+    describe('with default values', () => {
+      test('theme(colors.red.unknown / 50%, #f00)', async () => {
+        expect(
+          await compileCss(css`
+            .red {
+              color: theme(colors.red.unknown / 50%, #f00);
+            }
+          `),
+        ).toMatchInlineSnapshot(`
+          ".red {
+            color: red;
+          }"
+        `)
+      })
+
+      test('theme(colors.red.unknown / 75%, theme(colors.red.500 / 25%))', async () => {
+        expect(
+          await compileCss(css`
+            @theme {
+              --color-red-500: #f00;
+            }
+            .red {
+              color: theme(colors.red.unknown / 75%, theme(colors.red.500 / 25%));
+            }
+          `),
+        ).toMatchInlineSnapshot(`
+          ":root {
+            --color-red-500: red;
+          }
+
+          .red {
+            color: #ff000040;
+          }"
+        `)
+      })
+
+      test('theme(fontFamily.sans, Helvetica Neue, Helvetica, sans-serif)', async () => {
+        expect(
+          await compileCss(css`
+            .fam {
+              font-family: theme(fontFamily.sans, Helvetica Neue, Helvetica, sans-serif);
+            }
+          `),
+        ).toMatchInlineSnapshot(`
+          ".fam {
+            font-family: Neue, Helvetica, sans-serif;
+          }"
+        `)
+      })
+    })
+
+    describe('recursive theme()', () => {
+      test('can references theme inside @theme', async () => {
+        expect(
+          await compileCss(css`
+            @theme {
+              --color-red-500: #f00;
+              --color-foo: theme(colors.red.500);
+            }
+            .red {
+              color: theme(colors.foo);
+            }
+          `),
+        ).toMatchInlineSnapshot(`
+          ":root {
+            --color-red-500: red;
+            --color-foo: red;
+          }
+
+          .red {
+            color: red;
+          }"
+        `)
+      })
+
+      test('can references theme inside @theme and stacking opacity', async () => {
+        expect(
+          await compileCss(css`
+            @theme {
+              --color-red-500: #f00;
+              --color-foo: theme(colors.red.500 / 50%);
+            }
+            .red {
+              color: theme(colors.foo / 50%);
+            }
+          `),
+        ).toMatchInlineSnapshot(`
+          ":root {
+            --color-red-500: red;
+            --color-foo: #ff000080;
+          }
+
+          .red {
+            color: #ff000040;
+          }"
+        `)
+      })
+    })
+
+    describe('with CSS variable syntax', () => {
+      test('theme(--color-red-500)', async () => {
+        expect(
+          await compileCss(css`
+            @theme {
+              --color-red-500: #f00;
+            }
+            .red {
+              color: theme(--color-red-500);
+            }
+          `),
+        ).toMatchInlineSnapshot(`
+          ":root {
+            --color-red-500: red;
+          }
+
+          .red {
+            color: red;
+          }"
+        `)
+      })
+      test('theme("--color-red-500")', async () => {
+        expect(
+          await compileCss(css`
+            @theme {
+              --color-red-500: #f00;
+            }
+            .red {
+              color: theme(--color-red-500);
+            }
+          `),
+        ).toMatchInlineSnapshot(`
+          ":root {
+            --color-red-500: red;
+          }
+
+          .red {
+            color: red;
+          }"
+        `)
+      })
+    })
+
+    describe('resolving --default lookups', () => {
+      test('theme(font.family)', async () => {
+        expect(
+          await compileCss(css`
+            @theme {
+              --default-font-family: Helvetica Neue, Helvetica, sans-serif;
+            }
+            .sans {
+              font-family: theme(font.family);
+            }
+          `),
+        ).toMatchInlineSnapshot(`
+          ":root {
+            --default-font-family: Helvetica Neue, Helvetica, sans-serif;
+          }
+
+          .sans {
+            font-family: Helvetica Neue, Helvetica, sans-serif;
+          }"
+        `)
+      })
+    })
+
+    describe('with default theme', () => {
+      test.each([
+        [
+          'fontFamily.sans',
+          'ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"',
+        ],
+        ['width.xs', '20rem'],
+        ['transition.timing.function.in.out', 'cubic-bezier(.4, 0, .2, 1)'],
+        ['backgroundColors.red.500', '#ef4444'],
+      ])('theme(%s) → %s', async (value, result) => {
+        let defaultTheme = await fs.readFile(path.join(__dirname, '..', 'theme.css'), 'utf8')
+
+        let compiled = await compileCss(css`
+          ${defaultTheme}
+          .custom {
+            --custom-value: theme(${value});
+          }
+        `)
+
+        let startOfCustomClass = compiled.indexOf('.custom {\n')
+        let endOfCustomClass = compiled.indexOf('}', startOfCustomClass)
+
+        let customClassRule = compiled
+          .slice(startOfCustomClass + '.custom {\n'.length, endOfCustomClass)
+          .replace('--custom-value:', '')
+          .trim()
+          .slice(0, -1)
+
+        expect(customClassRule).toBe(result)
+      })
+    })
+  })
+
+  describe('in candidates', () => {
+    test('sm:[--color:theme(colors.red[500])]', async () => {
+      expect(
+        await compileCss(
+          css`
+            @tailwind utilities;
+            @theme {
+              --breakpoint-sm: 40rem;
+              --color-red-500: #f00;
+            }
+          `,
+          ['sm:[--color:theme(colors.red[500])]'],
+        ),
+      ).toMatchInlineSnapshot(`
+        "@media (width >= 40rem) {
+          .sm\\:\\[--color\\:theme\\(colors\\.red\\[500\\]\\)\\] {
+            --color: red;
+          }
+        }
+
+        :root {
+          --breakpoint-sm: 40rem;
+          --color-red-500: red;
+        }"
+      `)
+    })
+  })
+
+  describe('in @media queries', () => {
+    test('@media (min-width: theme(breakpoint.md)) and (max-width: theme(--breakpoint-lg))', async () => {
+      expect(
+        await compileCss(css`
+          @theme {
+            --breakpoint-md: 48rem;
+            --breakpoint-lg: 64rem;
+          }
+          @media (min-width: theme(breakpoint.md)) and (max-width: theme(--breakpoint-lg)) {
+            .red {
+              color: red;
+            }
+          }
+        `),
+      ).toMatchInlineSnapshot(`
+        ":root {
+          --breakpoint-md: 48rem;
+          --breakpoint-lg: 64rem;
+        }
+
+        @media (width >= 48rem) and (width <= 64rem) {
+          .red {
+            color: red;
+          }
+        }"
+      `)
+    })
+  })
+})

--- a/packages/tailwindcss/src/functions.test.ts
+++ b/packages/tailwindcss/src/functions.test.ts
@@ -432,23 +432,23 @@ describe('theme function', () => {
     })
 
     describe('resolving --default lookups', () => {
-      test('theme(font.family)', async () => {
+      test('theme(blur.DEFAULT)', async () => {
         expect(
           await compileCss(css`
             @theme {
-              --default-font-family: Helvetica Neue, Helvetica, sans-serif;
+              --blur: 8px;
             }
-            .sans {
-              font-family: theme(font.family);
+            .blur {
+              filter: blur(theme(blur));
             }
           `),
         ).toMatchInlineSnapshot(`
           ":root {
-            --default-font-family: Helvetica Neue, Helvetica, sans-serif;
+            --blur: 8px;
           }
 
-          .sans {
-            font-family: Helvetica Neue, Helvetica, sans-serif;
+          .blur {
+            filter: blur(8px);
           }"
         `)
       })

--- a/packages/tailwindcss/src/functions.ts
+++ b/packages/tailwindcss/src/functions.ts
@@ -1,0 +1,241 @@
+import { walk, type AstNode } from './ast'
+import type { DesignSystem } from './design-system'
+import type { ThemeKey } from './theme'
+import { withAlpha } from './utilities'
+import { segment } from './utils/segment'
+import {
+  toCss as toValueCss,
+  walk as walkValues,
+  type AstNode as ValueAstNode,
+} from './value-parser/ast'
+import * as ValueParser from './value-parser/parser'
+
+export const THEME_FUNCTION_INVOCATION = 'theme('
+
+export function substituteFunctions(ast: AstNode[], designSystem: DesignSystem) {
+  walk(ast, (node) => {
+    // Find all declaration values
+    if (node.kind === 'declaration' && node.value.includes(THEME_FUNCTION_INVOCATION)) {
+      node.value = substituteFunctionsInValue(node.value, designSystem)
+      return
+    }
+
+    // Find @media rules
+    if (node.kind === 'rule') {
+      if (
+        node.selector[0] === '@' &&
+        node.selector.startsWith('@media ') &&
+        node.selector.includes(THEME_FUNCTION_INVOCATION)
+      ) {
+        node.selector = substituteFunctionsInValue(node.selector, designSystem)
+      }
+    }
+  })
+}
+
+export function substituteFunctionsInValue(value: string, designSystem: DesignSystem): string {
+  let ast = ValueParser.parse(value)
+  walkValues(ast, (node, { replaceWith }) => {
+    if (node.kind === 'function' && node.value === 'theme') {
+      if (node.nodes.length < 1) {
+        // TODO: Update wording
+        throw new Error('Expected theme() function to have at least one argument.')
+      }
+
+      let pathNode = node.nodes[0]
+      if (pathNode.kind !== 'word') {
+        // TODO: Update wording
+        throw new Error('Expected the first argument of the theme() function to be a word.')
+      }
+      let path = pathNode.value
+
+      // For the theme function arguments, we require all separators to contain comma (`,`), spaces
+      // alone should be merged into the previous word to avoid splitting in this case:
+      //
+      // theme(colors.red.500 / 75%)
+      // theme(colors.red.500 / 75%, foo, bar)
+      //
+      // We only need to do this for the first node
+      let skipUntilIndex = 1
+      for (let i = skipUntilIndex; i < node.nodes.length; i++) {
+        if (node.nodes[i].value.includes(',')) {
+          break
+        }
+        path += node.nodes[i].value
+        skipUntilIndex = i
+      }
+
+      path = eventuallyUnquote(path)
+      let fallbackValues = node.nodes.slice(skipUntilIndex + 2)
+
+      replaceWith(theme(designSystem, path, fallbackValues))
+    }
+  })
+
+  return toValueCss(ast)
+}
+
+function theme(
+  designSystem: DesignSystem,
+  path: string,
+  fallbackValues: ValueAstNode[],
+): ValueAstNode[] {
+  let inputPath = path
+  let modifier: string | null = null
+  // Extract an eventual modifier from the path. e.g.:
+  //
+  // - "colors.red.500 / 50%" -> "50%"
+  // - "foo/bar/baz/50%"      -> "50%"
+  let lastSlash = path.lastIndexOf('/')
+  if (lastSlash !== -1) {
+    modifier = path.slice(lastSlash + 1).trim()
+    path = path.slice(0, lastSlash).trim()
+  }
+
+  let resolvedValue: string | null = null
+
+  // Lookup CSS variables without attempting any normalization
+  if (path.startsWith('--')) {
+    resolvedValue = designSystem.theme.get([path as ThemeKey])
+  } else {
+    // Handle `[]` blocks as segments in addition to `.` separators.
+    // This is used to extract floating point keys like `spacing[2.5]`.
+    let segmented: string[] = []
+    for (let candidate of segment(path, '.')) {
+      if (!candidate.includes('[')) {
+        segmented.push(candidate)
+        continue
+      }
+
+      let matches = candidate.matchAll(/\[([^\]]+)\]/g)
+      let i = 0
+      for (let match of matches) {
+        // Add anything between the last match and the current match
+        if (match.index > i) {
+          segmented.push(candidate.slice(i, match.index))
+          i = match.index
+        }
+
+        segmented.push(match[1])
+        i += match[0].length
+      }
+      // Add anything after the last segment
+      if (i < candidate.length - 1) {
+        segmented.push(candidate.slice(i))
+      }
+    }
+
+    // Handle tuple resolve syntax:
+    //
+    // - fontSize.sm.1.lineHeight
+    // - fontSize.sm[1].lineHeight
+    //
+    // In V4, these are nested with a `--` separator, e.g.:
+    // ` --font-size-xs--line-height`. We can resolve those by adding an empty
+    // string part that will `.join('-')` to the two minuses.
+    for (let i = 0; i < segmented.length; i++) {
+      if (segmented[i] === '1') {
+        segmented[i] = ''
+      }
+    }
+
+    let [namespaceCandidate, ...remainder] = segmented
+    let namespaces = [
+      `--${namespaceCandidate}` as ThemeKey,
+      `--default-${namespaceCandidate}` as ThemeKey,
+    ]
+
+    // Resolve legacy namespaces to their V4 equivalent if possible.
+    // TODO: Should this warn so the user migrates to the CSS var based syntax?
+    if (Object.hasOwn(LEGACY_NAMESPACE_MAP, namespaceCandidate)) {
+      namespaces = LEGACY_NAMESPACE_MAP[namespaceCandidate]
+    }
+
+    // .DEFAULT lookups from v3 now point to either:
+    //
+    // 1. The raw key (e.g. `blur.DEFAULT` => `--blur`)
+    // 2. The `--default` prefixed key (e.g. `transitionDuration` =>
+    //    `--default-transition-duration`)
+    //
+    // 1) is handled by dropping the `DEFAULT` access and 2) is handled in the
+    // legacy namespace map.
+    if (remainder.length > 0 && remainder[remainder.length - 1] === 'DEFAULT') {
+      remainder.pop()
+    }
+
+    let candidateValue =
+      remainder.length > 0 ? remainder.map((p) => p.replace('.', '_')).join('-') : null
+
+    resolvedValue = designSystem.theme.resolveValue(candidateValue, namespaces)
+  }
+
+  if (!resolvedValue && fallbackValues.length > 0) {
+    return fallbackValues
+  }
+
+  if (!resolvedValue) {
+    // TODO: Update wording
+    throw new Error(
+      `Could not resolve value for theme function: \`theme(${path}${modifier ? ` / ${modifier}` : ''})\``,
+    )
+  }
+
+  if (modifier) {
+    resolvedValue = withAlpha(resolvedValue, modifier)
+  }
+
+  // We need to parse the value here since this can resolve with
+  // another theme() function definition in case the @theme defines it as
+  // theme()
+  return ValueParser.parse(resolvedValue)
+}
+
+function eventuallyUnquote(value: string) {
+  if (value[0] !== "'" && value[0] !== '"') return value
+
+  let unquoted = ''
+  let quoteChar = value[0]
+  for (let i = 1; i < value.length - 1; i++) {
+    let currentChar = value[i]
+    let nextChar = value[i + 1]
+
+    if (currentChar === '\\' && (nextChar === quoteChar || nextChar === '\\')) {
+      unquoted += nextChar
+      i++
+    } else {
+      unquoted += currentChar
+    }
+  }
+
+  return unquoted
+}
+
+// @see https://github.com/tailwindlabs/tailwindcss/blob/main/stubs/config.full.js
+const LEGACY_NAMESPACE_MAP: {
+  [key: string]: ThemeKey[]
+} = {
+  colors: ['--color'],
+  backgroundColors: ['--background-color', '--color'],
+  accentColor: ['--accent-color', '--color'],
+  borderColor: ['--border-color', '--color'],
+  boxShadowColor: ['--box-shadow-color', '--color'],
+  caretColor: ['--caret-color', '--color'],
+  divedColor: ['--divide-color', '--color'],
+  fill: ['--fill', '--color'],
+  // This matches the lookup in the gradientStopUtility implementation
+  gradientColorStops: ['--background-color', '--color'],
+  outlineColor: ['--outline-color', '--color'],
+  placeholderColor: ['--placeholder-color', '--color'],
+  ringColor: ['--ring-color', '--color'],
+  ringOffsetColor: ['--ring-offset-color', '--color'],
+  stroke: ['--stroke', '--color'],
+  textColor: ['--text-color', '--color'],
+  textDecorationColor: ['--text-decoration-color', '--color'],
+
+  fontFamily: ['--font-family'],
+  fontSize: ['--font-size'],
+
+  transitionDuration: ['--transition-duration', '--default-transition-duration'],
+
+  // TODO: Add many more
+}

--- a/packages/tailwindcss/src/functions.ts
+++ b/packages/tailwindcss/src/functions.ts
@@ -119,14 +119,10 @@ function cssThemeFn(
   // Since this is overkill, we instead introspect the string and try to unwrap
   // the `var()` call for now. This works because we always define a fallback
   // value that points to the raw CSS variable value.
-  if (typeof resolvedValue === 'string') {
-    if (resolvedValue.startsWith('var(')) {
-      const firstComma = resolvedValue.indexOf(',')
-      if (firstComma !== -1) {
-        resolvedValue = resolvedValue.slice(firstComma + 1, -1).trim()
-      }
-    } else {
-      resolvedValue = resolvedValue
+  if (typeof resolvedValue === 'string' && resolvedValue.startsWith('var(')) {
+    const firstComma = resolvedValue.indexOf(',')
+    if (firstComma !== -1) {
+      resolvedValue = resolvedValue.slice(firstComma + 1, -1).trim()
     }
   }
 

--- a/packages/tailwindcss/src/functions.ts
+++ b/packages/tailwindcss/src/functions.ts
@@ -103,29 +103,6 @@ function cssThemeFn(
     resolvedValue = themeValue
   }
 
-  // The plugin `theme()` function currently returns resolved values (so values
-  // that are wrapped in `var()` and the CSS variable name). This `theme()`
-  // function should, however, instead return the raw values. Raw values are
-  // necessary because they might be used in positions where `var()` is not
-  // supported like `@media (min-width: theme(--breakpoint-sm))`.
-  //
-  // Since the plugin `theme()` function operates on a materialized config
-  // object provided by plugins, the values would already be read from the CSS
-  // theme before we even get here (the config object is initialized together
-  // with the plugins). Subsequently, we can only read resolved values here
-  // unless we create a separate config object containing unresolved CSS values
-  // that is only for use with the CSS `theme()` function.
-  //
-  // Since this is overkill, we instead introspect the string and try to unwrap
-  // the `var()` call for now. This works because we always define a fallback
-  // value that points to the raw CSS variable value.
-  if (typeof resolvedValue === 'string' && resolvedValue.startsWith('var(')) {
-    const firstComma = resolvedValue.indexOf(',')
-    if (firstComma !== -1) {
-      resolvedValue = resolvedValue.slice(firstComma + 1, -1).trim()
-    }
-  }
-
   if (!resolvedValue && fallbackValues.length > 0) {
     return fallbackValues
   }

--- a/packages/tailwindcss/src/functions.ts
+++ b/packages/tailwindcss/src/functions.ts
@@ -104,17 +104,17 @@ function cssThemeFn(
   }
 
   // The plugin `theme()` function currently returns resolved values (so values
-  // that are wrapped in `var()` and the CSS variable name. The CSS theme
-  // function should instead return the raw values though, this is because it
-  // can be used in positions where `var()` is not supported like
-  // `@media (min-width: theme(--breakpoint-sm))`.
+  // that are wrapped in `var()` and the CSS variable name). This `theme()`
+  // function should, however, instead return the raw values. Raw values are
+  // necessary because they might be used in positions where `var()` is not
+  // supported like `@media (min-width: theme(--breakpoint-sm))`.
   //
-  // Since the Plugin `theme()` function operates on the resolved config object
-  // provided by plugins though, the values would already be read from the CSS
-  // theme before we even get here. Subsequently, we can only read resolved
-  // values here unless we would create a separate resolved config object
-  // containing unresolved CSS values only for use with the CSS `theme()`
-  // function.
+  // Since the plugin `theme()` function operates on a materialized config
+  // object provided by plugins, the values would already be read from the CSS
+  // theme before we even get here (the config object is initialized together
+  // with the plugins). Subsequently, we can only read resolved values here
+  // unless we create a separate config object containing unresolved CSS values
+  // that is only for use with the CSS `theme()` function.
   //
   // Since this is overkill, we instead introspect the string and try to unwrap
   // the `var()` call for now. This works because we always define a fallback

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -282,7 +282,7 @@ async function parseCss(css: string, { loadPlugin = throwOnPlugin }: CompileOpti
 
   let plugins = await Promise.all(pluginPaths.map(loadPlugin))
 
-  registerPlugins(plugins, designSystem, ast)
+  let pluginApi = registerPlugins(plugins, designSystem, ast)
 
   // Replace `@apply` rules with the actual utility classes.
   if (css.includes('@apply')) {
@@ -291,7 +291,7 @@ async function parseCss(css: string, { loadPlugin = throwOnPlugin }: CompileOpti
 
   // Replace `theme()` function calls with the actual theme variables.
   if (css.includes(THEME_FUNCTION_INVOCATION)) {
-    substituteFunctions(ast, designSystem)
+    substituteFunctions(ast, designSystem, pluginApi)
   }
 
   // Remove `@utility`, we couldn't replace it before yet because we had to
@@ -310,6 +310,7 @@ async function parseCss(css: string, { loadPlugin = throwOnPlugin }: CompileOpti
 
   return {
     designSystem,
+    pluginApi,
     ast,
     globs,
   }
@@ -322,7 +323,7 @@ export async function compile(
   globs: string[]
   build(candidates: string[]): string
 }> {
-  let { designSystem, ast, globs } = await parseCss(css, opts)
+  let { designSystem, ast, globs, pluginApi } = await parseCss(css, opts)
 
   let tailwindUtilitiesNode: Rule | null = null
 
@@ -388,7 +389,7 @@ export async function compile(
           return compiledCss
         }
 
-        substituteFunctions(newNodes, designSystem)
+        substituteFunctions(newNodes, designSystem, pluginApi)
 
         previousAstNodeCount = newNodes.length
 

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -208,7 +208,7 @@ async function parseCss(css: string, { loadPlugin = throwOnPlugin }: CompileOpti
 
       if (child.kind === 'comment') return
       if (child.kind === 'declaration' && child.property.startsWith('--')) {
-        theme.add(child.property, child.value, { isReference, isInline })
+        theme.add(child.property, child.value ?? '', { isReference, isInline })
         return
       }
 
@@ -291,7 +291,7 @@ async function parseCss(css: string, { loadPlugin = throwOnPlugin }: CompileOpti
 
   // Replace `theme()` function calls with the actual theme variables.
   if (css.includes(THEME_FUNCTION_INVOCATION)) {
-    substituteFunctions(ast, designSystem, pluginApi)
+    substituteFunctions(ast, pluginApi)
   }
 
   // Remove `@utility`, we couldn't replace it before yet because we had to
@@ -389,7 +389,7 @@ export async function compile(
           return compiledCss
         }
 
-        substituteFunctions(newNodes, designSystem, pluginApi)
+        substituteFunctions(newNodes, pluginApi)
 
         previousAstNodeCount = newNodes.length
 

--- a/packages/tailwindcss/src/plugin-api.test.ts
+++ b/packages/tailwindcss/src/plugin-api.test.ts
@@ -104,7 +104,7 @@ describe('theme', async () => {
 
     expect(compiler.build(['scrollbar-red-500', 'scrollbar-russet-700'])).toMatchInlineSnapshot(`
       ".scrollbar-red-500 {
-        scrollbar-color: var(--color-red-500, #ef4444);
+        scrollbar-color: #ef4444;
       }
       .scrollbar-russet-700 {
         scrollbar-color: #7a4724;
@@ -338,16 +338,16 @@ describe('theme', async () => {
     expect(compiler.build(['animation-spin', 'animation', 'animation2', 'animation2-twist']))
       .toMatchInlineSnapshot(`
         ".animation {
-          animation: var(--animation, pulse 1s linear infinite);
+          animation: pulse 1s linear infinite;
         }
         .animation-spin {
-          animation: var(--animation-spin, spin 1s linear infinite);
+          animation: spin 1s linear infinite;
         }
         .animation2 {
-          animation: var(--animation, pulse 1s linear infinite);
+          animation: pulse 1s linear infinite;
         }
         .animation2-twist {
-          animation: var(--animation-spin, spin 1s linear infinite);
+          animation: spin 1s linear infinite;
         }
         "
       `)
@@ -392,13 +392,13 @@ describe('theme', async () => {
     expect(compiler.build(['animation', 'animation-spin', 'animation-bounce']))
       .toMatchInlineSnapshot(`
         ".animation {
-          --animation: var(--animation, pulse 1s linear infinite);
+          --animation: pulse 1s linear infinite;
         }
         .animation-bounce {
           --animation: bounce 1s linear infinite;
         }
         .animation-spin {
-          --animation: var(--animation-spin, spin 1s linear infinite);
+          --animation: spin 1s linear infinite;
         }
         "
       `)
@@ -442,7 +442,7 @@ describe('theme', async () => {
 
     expect(compiler.build(['animation'])).toMatchInlineSnapshot(`
       ".animation {
-        --animation: var(--animation, pulse 1s linear infinite);
+        --animation: pulse 1s linear infinite;
       }
       "
     `)
@@ -480,8 +480,8 @@ describe('theme', async () => {
     })
 
     expect(fn).toHaveBeenCalledWith({
-      spin: 'var(--animation-simple-spin, spin 1s linear infinite)',
-      bounce: 'var(--animation-simple-bounce, bounce 1s linear infinite)',
+      spin: 'spin 1s linear infinite',
+      bounce: 'bounce 1s linear infinite',
     })
   })
 
@@ -739,7 +739,7 @@ describe('theme', async () => {
       loadPlugin: async () => {
         return plugin(
           ({ theme }) => {
-            // The compatability config specifies that `accentColor` spreads in `colors`
+            // The compatibility config specifies that `accentColor` spreads in `colors`
             fn(theme('accentColor.primary'))
 
             // This should even work for theme keys specified in plugin configs
@@ -756,8 +756,8 @@ describe('theme', async () => {
       },
     })
 
-    expect(fn).toHaveBeenCalledWith('var(--color-primary, red)')
-    expect(fn).toHaveBeenCalledWith('var(--color-secondary, blue)')
+    expect(fn).toHaveBeenCalledWith('red')
+    expect(fn).toHaveBeenCalledWith('blue')
   })
 
   test('nested theme key lookups work even for flattened keys', async ({ expect }) => {
@@ -783,9 +783,9 @@ describe('theme', async () => {
       },
     })
 
-    expect(fn).toHaveBeenCalledWith('var(--color-red-100, red)')
-    expect(fn).toHaveBeenCalledWith('var(--color-red-200, orangered)')
-    expect(fn).toHaveBeenCalledWith('var(--color-red-300, darkred)')
+    expect(fn).toHaveBeenCalledWith('red')
+    expect(fn).toHaveBeenCalledWith('orangered')
+    expect(fn).toHaveBeenCalledWith('darkred')
   })
 
   test('keys that do not exist return the default value (or undefined if none)', async ({

--- a/packages/tailwindcss/src/plugin-api.ts
+++ b/packages/tailwindcss/src/plugin-api.ts
@@ -347,4 +347,6 @@ export function registerPlugins(plugins: Plugin[], designSystem: DesignSystem, a
   for (let { handler } of pluginObjects) {
     handler(pluginApi)
   }
+
+  return pluginApi
 }

--- a/packages/tailwindcss/src/theme-fn.ts
+++ b/packages/tailwindcss/src/theme-fn.ts
@@ -62,7 +62,7 @@ function readFromCss(theme: Theme, path: string[]) {
   let map = new Map<string | null, ThemeValue>()
   let nested = new DefaultMap<string | null, Map<string, string>>(() => new Map())
 
-  let ns = theme.resolveNamespace(`--${themeKey}` as any)
+  let ns = theme.namespace(`--${themeKey}` as any)
 
   if (ns.size === 0) {
     return null

--- a/packages/tailwindcss/src/theme-fn.ts
+++ b/packages/tailwindcss/src/theme-fn.ts
@@ -40,6 +40,11 @@ function readFromCss(theme: Theme, path: string[]) {
   let themeKey = path
     // Escape dots used inside square brackets
     // Replace camelCase with dashes
+    .map((part, index) =>
+      index === 0 && (part.endsWith('colors') || part.endsWith('Colors'))
+        ? part.slice(0, -1)
+        : part,
+    )
     .map((part) =>
       part.replaceAll('.', '_').replace(/([a-z])([A-Z])/g, (_, a, b) => `${a}-${b.toLowerCase()}`),
     )

--- a/packages/tailwindcss/src/theme.ts
+++ b/packages/tailwindcss/src/theme.ts
@@ -137,6 +137,10 @@ export class Theme {
     for (let [key, value] of this.values) {
       if (key === namespace) {
         values.set(null, value.value)
+      } else if (key.startsWith(`${prefix}-`)) {
+        // Preserve `--` prefix for sub-variables
+        // e.g. `--font-size-sm--line-height`
+        values.set(key.slice(namespace.length), value.value)
       } else if (key.startsWith(prefix)) {
         values.set(key.slice(prefix.length), value.value)
       }
@@ -152,6 +156,10 @@ export class Theme {
     for (let [key, value] of this.values) {
       if (key === namespace) {
         values.set(null, value.isInline ? value.value : this.#var(key)!)
+      } else if (key.startsWith(`${prefix}-`)) {
+        // Preserve `--` prefix for sub-variables
+        // e.g. `--font-size-sm--line-height`
+        values.set(key.slice(namespace.length), value.value)
       } else if (key.startsWith(prefix)) {
         values.set(key.slice(prefix.length), value.isInline ? value.value : this.#var(key)!)
       }

--- a/packages/tailwindcss/src/value-parser/ast.test.ts
+++ b/packages/tailwindcss/src/value-parser/ast.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { toCss, walk, word } from './ast'
+import { parse } from './parser'
+
+describe('toCss', () => {
+  it('should pretty print calculations', () => {
+    expect(toCss(parse('calc((1 + 2) * 3)'))).toBe('calc((1 + 2) * 3)')
+  })
+
+  it('should pretty print nested function calls', () => {
+    expect(toCss(parse('theme(foo, theme(bar))'))).toBe('theme(foo, theme(bar))')
+  })
+
+  it('should pretty print media query params with functions', () => {
+    expect(toCss(parse('(min-width: 600px) and (max-width:theme(colors.red.500))'))).toBe(
+      '(min-width: 600px) and (max-width:theme(colors.red.500))',
+    )
+  })
+
+  it('preserves multiple spaces', () => {
+    expect(toCss(parse('foo(   bar  )'))).toBe('foo(   bar  )')
+  })
+})
+
+describe('walk', () => {
+  it('can be used to replace a function call', () => {
+    const ast = parse('(min-width: 600px) and (max-width: theme(lg))')
+
+    walk(ast, (node, { replaceWith }) => {
+      if (node.kind === 'function' && node.value === 'theme') {
+        replaceWith(word('64rem'))
+      }
+    })
+
+    expect(toCss(ast)).toBe('(min-width: 600px) and (max-width: 64rem)')
+  })
+})

--- a/packages/tailwindcss/src/value-parser/ast.ts
+++ b/packages/tailwindcss/src/value-parser/ast.ts
@@ -1,0 +1,104 @@
+export type WordNode = {
+  kind: 'word'
+  value: string
+}
+
+export type FunctionNode = {
+  kind: 'function'
+  value: string
+  nodes: AstNode[]
+}
+
+export type SeparatorNode = {
+  kind: 'separator'
+  value: string
+}
+
+export type AstNode = WordNode | FunctionNode | SeparatorNode
+
+export function word(value: string): WordNode {
+  return {
+    kind: 'word',
+    value,
+  }
+}
+
+export function fun(value: string, nodes: AstNode[]): FunctionNode {
+  return {
+    kind: 'function',
+    value: value,
+    nodes,
+  }
+}
+
+export function separator(value: string): SeparatorNode {
+  return {
+    kind: 'separator',
+    value,
+  }
+}
+
+export enum WalkAction {
+  /** Continue walking, which is the default */
+  Continue,
+
+  /** Skip visiting the children of this node */
+  Skip,
+
+  /** Stop the walk entirely */
+  Stop,
+}
+
+export function walk(
+  ast: AstNode[],
+  visit: (
+    node: AstNode,
+    utils: {
+      parent: AstNode | null
+      replaceWith(newNode: AstNode | AstNode[]): void
+    },
+  ) => void | WalkAction,
+  parent: AstNode | null = null,
+) {
+  for (let i = 0; i < ast.length; i++) {
+    let node = ast[i]
+    let status =
+      visit(node, {
+        parent,
+        replaceWith(newNode) {
+          ast.splice(i, 1, ...(Array.isArray(newNode) ? newNode : [newNode]))
+          // We want to visit the newly replaced node(s), which start at the
+          // current index (i). By decrementing the index here, the next loop
+          // will process this position (containing the replaced node) again.
+          i--
+        },
+      }) ?? WalkAction.Continue
+
+    // Stop the walk entirely
+    if (status === WalkAction.Stop) return
+
+    // Skip visiting the children of this node
+    if (status === WalkAction.Skip) continue
+
+    if (node.kind === 'function') {
+      walk(node.nodes, visit, node)
+    }
+  }
+}
+
+export function toCss(ast: AstNode[]) {
+  let css = ''
+  for (const node of ast) {
+    switch (node.kind) {
+      case 'word':
+      case 'separator': {
+        css += node.value
+        break
+      }
+      case 'function': {
+        css += node.value + '(' + toCss(node.nodes) + ')'
+      }
+    }
+  }
+  return css
+}

--- a/packages/tailwindcss/src/value-parser/parser.test.ts
+++ b/packages/tailwindcss/src/value-parser/parser.test.ts
@@ -1,0 +1,118 @@
+import { expect, it } from 'vitest'
+import { parse } from './parser'
+
+it('should parse a value', () => {
+  expect(parse('123px')).toEqual([{ kind: 'word', value: '123px' }])
+})
+
+it('should parse a string value', () => {
+  expect(parse("'hello world'")).toEqual([{ kind: 'word', value: "'hello world'" }])
+})
+
+it('should parse a list', () => {
+  expect(parse('hello world')).toEqual([
+    { kind: 'word', value: 'hello' },
+    { kind: 'separator', value: ' ' },
+    { kind: 'word', value: 'world' },
+  ])
+})
+
+it('should parse a string containing parentheses', () => {
+  expect(parse("'hello ( world )'")).toEqual([{ kind: 'word', value: "'hello ( world )'" }])
+})
+
+it('should parse a function with no arguments', () => {
+  expect(parse('theme()')).toEqual([{ kind: 'function', value: 'theme', nodes: [] }])
+})
+
+it('should parse a function with a single argument', () => {
+  expect(parse('theme(foo)')).toEqual([
+    { kind: 'function', value: 'theme', nodes: [{ kind: 'word', value: 'foo' }] },
+  ])
+})
+
+it('should parse a function with a single string argument', () => {
+  expect(parse("theme('foo')")).toEqual([
+    { kind: 'function', value: 'theme', nodes: [{ kind: 'word', value: "'foo'" }] },
+  ])
+})
+
+it('should parse a function with multiple arguments', () => {
+  expect(parse('theme(foo, bar)')).toEqual([
+    {
+      kind: 'function',
+      value: 'theme',
+      nodes: [
+        { kind: 'word', value: 'foo' },
+        { kind: 'separator', value: ', ' },
+        { kind: 'word', value: 'bar' },
+      ],
+    },
+  ])
+})
+
+it('should parse a function with nested arguments', () => {
+  expect(parse('theme(foo, theme(bar))')).toEqual([
+    {
+      kind: 'function',
+      value: 'theme',
+      nodes: [
+        { kind: 'word', value: 'foo' },
+        { kind: 'separator', value: ', ' },
+        { kind: 'function', value: 'theme', nodes: [{ kind: 'word', value: 'bar' }] },
+      ],
+    },
+  ])
+})
+
+it('should handle calculations', () => {
+  expect(parse('calc((1 + 2) * 3)')).toEqual([
+    {
+      kind: 'function',
+      value: 'calc',
+      nodes: [
+        {
+          kind: 'function',
+          value: '',
+          nodes: [
+            { kind: 'word', value: '1' },
+            { kind: 'separator', value: ' ' },
+            { kind: 'word', value: '+' },
+            { kind: 'separator', value: ' ' },
+            { kind: 'word', value: '2' },
+          ],
+        },
+        { kind: 'separator', value: ' ' },
+        { kind: 'word', value: '*' },
+        { kind: 'separator', value: ' ' },
+        { kind: 'word', value: '3' },
+      ],
+    },
+  ])
+})
+
+it('should handle media query params with functions', () => {
+  expect(parse('(min-width: 600px) and (max-width:theme(colors.red.500))')).toEqual([
+    {
+      kind: 'function',
+      value: '',
+      nodes: [
+        { kind: 'word', value: 'min-width' },
+        { kind: 'separator', value: ': ' },
+        { kind: 'word', value: '600px' },
+      ],
+    },
+    { kind: 'separator', value: ' ' },
+    { kind: 'word', value: 'and' },
+    { kind: 'separator', value: ' ' },
+    {
+      kind: 'function',
+      value: '',
+      nodes: [
+        { kind: 'word', value: 'max-width' },
+        { kind: 'separator', value: ':' },
+        { kind: 'function', value: 'theme', nodes: [{ kind: 'word', value: 'colors.red.500' }] },
+      ],
+    },
+  ])
+})

--- a/packages/tailwindcss/src/value-parser/parser.ts
+++ b/packages/tailwindcss/src/value-parser/parser.ts
@@ -1,0 +1,168 @@
+import { fun, separator, word, type AstNode, type FunctionNode } from './ast'
+
+const BACKSLASH = 0x5c
+const CLOSE_PAREN = 0x29
+const COLON = 0x3a
+const COMMA = 0x2c
+const DOUBLE_QUOTE = 0x22
+const OPEN_PAREN = 0x28
+const SINGLE_QUOTE = 0x27
+const SPACE = 0x20
+
+export function parse(input: string) {
+  input = input.replaceAll('\r\n', '\n')
+
+  let ast: AstNode[] = []
+
+  let stack: (FunctionNode | null)[] = []
+
+  let parent = null as FunctionNode | null
+
+  let buffer = ''
+
+  let peekChar
+
+  for (let i = 0; i < input.length; i++) {
+    let currentChar = input.charCodeAt(i)
+
+    switch (currentChar) {
+      // Space and commas are bundled into separators
+      //
+      // E.g.:
+      //
+      // ```css
+      // foo(bar, baz)
+      //        ^^
+      // ```
+      case COLON:
+      case COMMA:
+      case SPACE: {
+        // 1. Handle everything before the separator as a word
+        // Handle everything before the closing paren a word
+        if (buffer.length > 0) {
+          let node = word(buffer)
+          if (parent) {
+            parent.nodes.push(node)
+          } else {
+            ast.push(node)
+          }
+          buffer = ''
+        }
+
+        // 2. Look ahead and find the end of the separator
+        let start = i
+        let end = i + 1
+        for (; end < input.length; end++) {
+          peekChar = input.charCodeAt(end)
+          if (peekChar !== COLON && peekChar !== COMMA && peekChar !== SPACE) {
+            break
+          }
+        }
+        i = end - 1
+
+        let node = separator(input.slice(start, end))
+        if (parent) {
+          parent.nodes.push(node)
+        } else {
+          ast.push(node)
+        }
+
+        break
+      }
+
+      // Start of a string.
+      case SINGLE_QUOTE:
+      case DOUBLE_QUOTE: {
+        let start = i
+
+        // We need to ensure that the closing quote is the same as the opening
+        // quote.
+        //
+        // E.g.:
+        //
+        // ```css
+        // "This is a string with a 'quote' in it"
+        //                          ^     ^         -> These are not the end of the string.
+        // ```
+        for (let j = i + 1; j < input.length; j++) {
+          peekChar = input.charCodeAt(j)
+          // Current character is a `\` therefore the next character is escaped.
+          if (peekChar === BACKSLASH) {
+            j += 1
+          }
+
+          // End of the string.
+          else if (peekChar === currentChar) {
+            i = j
+            break
+          }
+        }
+
+        // Adjust `buffer` to include the string.
+        buffer += input.slice(start, i + 1)
+        break
+      }
+
+      // Start of a function call.
+      //
+      // E.g.:
+      //
+      // ```css
+      // foo(bar, baz)
+      //    ^
+      // ```
+      case OPEN_PAREN: {
+        let node = fun(buffer, [])
+        buffer = ''
+
+        if (parent) {
+          parent.nodes.push(node)
+        } else {
+          ast.push(node)
+        }
+        stack.push(node)
+        parent = node
+
+        break
+      }
+
+      // End of a function call.
+      //
+      // E.g.:
+      //
+      // ```css
+      // foo(bar, baz)
+      //             ^
+      // ```
+      case CLOSE_PAREN: {
+        let tail = stack.pop()
+
+        // Handle everything before the closing paren a word
+        if (buffer.length > 0) {
+          let node = word(buffer)
+          tail!.nodes.push(node)
+          buffer = ''
+        }
+
+        if (stack.length > 0) {
+          parent = stack[stack.length - 1]
+        } else {
+          parent = null
+        }
+
+        break
+      }
+
+      // Everything else will be collected in the buffer
+      default:
+        buffer += String.fromCharCode(currentChar)
+    }
+  }
+
+  // Collect the remainder as a word
+  if (buffer.length > 0) {
+    ast.push(word(buffer))
+  }
+
+  return ast
+}

--- a/packages/tailwindcss/src/value-parser/parser.ts
+++ b/packages/tailwindcss/src/value-parser/parser.ts
@@ -154,8 +154,9 @@ export function parse(input: string) {
       }
 
       // Everything else will be collected in the buffer
-      default:
+      default: {
         buffer += String.fromCharCode(currentChar)
+      }
     }
   }
 


### PR DESCRIPTION
This PR adds the CSS `theme()` function to Tailwind V4. It's intended use is to get the raw value of a theme variable. This can be handy when trying to reference theme values in places where `var()` is not supported, for example:

```css
@media (min-width: theme(--breakpoint-md)) {
  /*...*/
}
```

The CSS `theme()` function is backward compatible with Tailwind V3 which means that it can also be used with the old key path syntax, like: `theme(colors.red.500)`. The lookup for this is shared with the plugin `theme()` function and this PR adds a bunch of edge cases to validate the backward compatibility. Here are a few interesting cases that we found to be valid in Tailwind V3 and are now also valid in Tailwind V4:

```js
// First argument can be inside quotes
theme('colors.red.500') 
// Square brackets are valid separators in V3, even when chained with dots
theme(color[red].500)
// Slashes can be used for adding opacity to colors. This can also be inside quotes
theme('colors.red.500 / 75%')
// Oh yeah and there's also the tuple syntax for accessing v3 scoped variables
theme(fontSize.xs[1].lineHeight)
// themes can also define fallback values which could be theme calls again...
theme(colors.red.unknown / 75%, theme(colors.red.500 / 25%))
// ... or list of values:
theme(fontFamily.sans, 'Helvetica Neue', Helvetica, sans-serif)
// Theme function can also be used in candidate class names...
sm:[--color:theme(colors.red[500])
// ... and of course @media queries
@media (min-width: theme(breakpoint.md)) and (max-width: theme(--breakpoint-lg))
```

The way this is implemented right now is by adding a separate walk that scans all declaration values. If these values look like they could have a `theme()` function call, we will parse these values using a new `ValueParser` into a small AST that can be used to substitute function calls.