### PR TITLE
Don't wrap relative selectors in arbitrary variants with `:is(…)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for `addBase` plugins using the `@plugin` directive ([#14172](https://github.com/tailwindlabs/tailwindcss/pull/14172))
 - Add support for the `tailwindcss/plugin` export ([#14173](https://github.com/tailwindlabs/tailwindcss/pull/14173))
 
+### Fixed
+
+- Don't wrap relative selectors in arbitrary variants with `:is(…)` ([#14203](https://github.com/tailwindlabs/tailwindcss/pull/14203))
+
 ## [4.0.0-alpha.19] - 2024-08-09
 
 ### Added

--- a/packages/tailwindcss/src/candidate.test.ts
+++ b/packages/tailwindcss/src/candidate.test.ts
@@ -93,7 +93,6 @@ it('should parse a simple utility with a variant', () => {
       "root": "flex",
       "variants": [
         {
-          "compounded": false,
           "compounds": true,
           "kind": "static",
           "root": "hover",
@@ -119,13 +118,11 @@ it('should parse a simple utility with stacked variants', () => {
       "root": "flex",
       "variants": [
         {
-          "compounded": false,
           "compounds": true,
           "kind": "static",
           "root": "hover",
         },
         {
-          "compounded": false,
           "compounds": true,
           "kind": "static",
           "root": "focus",
@@ -147,7 +144,6 @@ it('should parse a simple utility with an arbitrary variant', () => {
       "root": "flex",
       "variants": [
         {
-          "compounded": false,
           "compounds": true,
           "kind": "arbitrary",
           "relative": false,
@@ -173,7 +169,6 @@ it('should parse a simple utility with a parameterized variant', () => {
       "root": "flex",
       "variants": [
         {
-          "compounded": false,
           "compounds": true,
           "kind": "functional",
           "modifier": null,
@@ -203,7 +198,6 @@ it('should parse compound variants with an arbitrary value as an arbitrary varia
       "root": "flex",
       "variants": [
         {
-          "compounded": false,
           "compounds": true,
           "kind": "compound",
           "modifier": {
@@ -212,7 +206,6 @@ it('should parse compound variants with an arbitrary value as an arbitrary varia
           },
           "root": "group",
           "variant": {
-            "compounded": true,
             "compounds": true,
             "kind": "arbitrary",
             "relative": false,
@@ -241,7 +234,6 @@ it('should parse a simple utility with a parameterized variant and a modifier', 
         "root": "flex",
         "variants": [
           {
-            "compounded": false,
             "compounds": true,
             "kind": "compound",
             "modifier": {
@@ -250,7 +242,6 @@ it('should parse a simple utility with a parameterized variant and a modifier', 
             },
             "root": "group",
             "variant": {
-              "compounded": true,
               "compounds": true,
               "kind": "functional",
               "modifier": null,
@@ -283,7 +274,6 @@ it('should parse compound group with itself group-group-*', () => {
         "root": "flex",
         "variants": [
           {
-            "compounded": false,
             "compounds": true,
             "kind": "compound",
             "modifier": {
@@ -292,19 +282,16 @@ it('should parse compound group with itself group-group-*', () => {
             },
             "root": "group",
             "variant": {
-              "compounded": true,
               "compounds": true,
               "kind": "compound",
               "modifier": null,
               "root": "group",
               "variant": {
-                "compounded": true,
                 "compounds": true,
                 "kind": "compound",
                 "modifier": null,
                 "root": "group",
                 "variant": {
-                  "compounded": true,
                   "compounds": true,
                   "kind": "static",
                   "root": "hover",
@@ -329,7 +316,6 @@ it('should parse a simple utility with an arbitrary media variant', () => {
       "root": "flex",
       "variants": [
         {
-          "compounded": false,
           "compounds": true,
           "kind": "arbitrary",
           "relative": false,
@@ -444,7 +430,6 @@ it('should parse a utility with a modifier and a variant', () => {
       },
       "variants": [
         {
-          "compounded": false,
           "compounds": true,
           "kind": "static",
           "root": "hover",
@@ -840,7 +825,6 @@ it('should parse a static variant starting with @', () => {
       "root": "flex",
       "variants": [
         {
-          "compounded": false,
           "compounds": true,
           "kind": "static",
           "root": "@lg",
@@ -865,7 +849,6 @@ it('should parse a functional variant with a modifier', () => {
       "root": "flex",
       "variants": [
         {
-          "compounded": false,
           "compounds": true,
           "kind": "functional",
           "modifier": {
@@ -898,7 +881,6 @@ it('should parse a functional variant starting with @', () => {
       "root": "flex",
       "variants": [
         {
-          "compounded": false,
           "compounds": true,
           "kind": "functional",
           "modifier": null,
@@ -928,7 +910,6 @@ it('should parse a functional variant starting with @ and a modifier', () => {
       "root": "flex",
       "variants": [
         {
-          "compounded": false,
           "compounds": true,
           "kind": "functional",
           "modifier": {
@@ -1075,7 +1056,6 @@ it('should parse arbitrary properties with a variant', () => {
       "value": "red",
       "variants": [
         {
-          "compounded": false,
           "compounds": true,
           "kind": "static",
           "root": "hover",
@@ -1099,13 +1079,11 @@ it('should parse arbitrary properties with stacked variants', () => {
       "value": "red",
       "variants": [
         {
-          "compounded": false,
           "compounds": true,
           "kind": "static",
           "root": "hover",
         },
         {
-          "compounded": false,
           "compounds": true,
           "kind": "static",
           "root": "focus",
@@ -1125,14 +1103,12 @@ it('should parse arbitrary properties that are important and using stacked arbit
       "value": "red",
       "variants": [
         {
-          "compounded": false,
           "compounds": true,
           "kind": "arbitrary",
           "relative": false,
           "selector": "& p",
         },
         {
-          "compounded": false,
           "compounds": true,
           "kind": "arbitrary",
           "relative": false,
@@ -1168,7 +1144,6 @@ it('should parse a variant containing an arbitrary string with unbalanced parens
       "root": "flex",
       "variants": [
         {
-          "compounded": false,
           "compounds": true,
           "kind": "functional",
           "modifier": null,

--- a/packages/tailwindcss/src/candidate.test.ts
+++ b/packages/tailwindcss/src/candidate.test.ts
@@ -93,6 +93,7 @@ it('should parse a simple utility with a variant', () => {
       "root": "flex",
       "variants": [
         {
+          "compounded": false,
           "compounds": true,
           "kind": "static",
           "root": "hover",
@@ -118,11 +119,13 @@ it('should parse a simple utility with stacked variants', () => {
       "root": "flex",
       "variants": [
         {
+          "compounded": false,
           "compounds": true,
           "kind": "static",
           "root": "hover",
         },
         {
+          "compounded": false,
           "compounds": true,
           "kind": "static",
           "root": "focus",
@@ -144,8 +147,10 @@ it('should parse a simple utility with an arbitrary variant', () => {
       "root": "flex",
       "variants": [
         {
+          "compounded": false,
           "compounds": true,
           "kind": "arbitrary",
+          "relative": false,
           "selector": "& p",
         },
       ],
@@ -168,6 +173,7 @@ it('should parse a simple utility with a parameterized variant', () => {
       "root": "flex",
       "variants": [
         {
+          "compounded": false,
           "compounds": true,
           "kind": "functional",
           "modifier": null,
@@ -197,6 +203,7 @@ it('should parse compound variants with an arbitrary value as an arbitrary varia
       "root": "flex",
       "variants": [
         {
+          "compounded": false,
           "compounds": true,
           "kind": "compound",
           "modifier": {
@@ -205,8 +212,10 @@ it('should parse compound variants with an arbitrary value as an arbitrary varia
           },
           "root": "group",
           "variant": {
+            "compounded": true,
             "compounds": true,
             "kind": "arbitrary",
+            "relative": false,
             "selector": "& p",
           },
         },
@@ -232,6 +241,7 @@ it('should parse a simple utility with a parameterized variant and a modifier', 
         "root": "flex",
         "variants": [
           {
+            "compounded": false,
             "compounds": true,
             "kind": "compound",
             "modifier": {
@@ -240,6 +250,7 @@ it('should parse a simple utility with a parameterized variant and a modifier', 
             },
             "root": "group",
             "variant": {
+              "compounded": true,
               "compounds": true,
               "kind": "functional",
               "modifier": null,
@@ -272,6 +283,7 @@ it('should parse compound group with itself group-group-*', () => {
         "root": "flex",
         "variants": [
           {
+            "compounded": false,
             "compounds": true,
             "kind": "compound",
             "modifier": {
@@ -280,16 +292,19 @@ it('should parse compound group with itself group-group-*', () => {
             },
             "root": "group",
             "variant": {
+              "compounded": true,
               "compounds": true,
               "kind": "compound",
               "modifier": null,
               "root": "group",
               "variant": {
+                "compounded": true,
                 "compounds": true,
                 "kind": "compound",
                 "modifier": null,
                 "root": "group",
                 "variant": {
+                  "compounded": true,
                   "compounds": true,
                   "kind": "static",
                   "root": "hover",
@@ -314,8 +329,10 @@ it('should parse a simple utility with an arbitrary media variant', () => {
       "root": "flex",
       "variants": [
         {
+          "compounded": false,
           "compounds": true,
           "kind": "arbitrary",
+          "relative": false,
           "selector": "@media(width>=123px)",
         },
       ],
@@ -427,6 +444,7 @@ it('should parse a utility with a modifier and a variant', () => {
       },
       "variants": [
         {
+          "compounded": false,
           "compounds": true,
           "kind": "static",
           "root": "hover",
@@ -822,6 +840,7 @@ it('should parse a static variant starting with @', () => {
       "root": "flex",
       "variants": [
         {
+          "compounded": false,
           "compounds": true,
           "kind": "static",
           "root": "@lg",
@@ -846,6 +865,7 @@ it('should parse a functional variant with a modifier', () => {
       "root": "flex",
       "variants": [
         {
+          "compounded": false,
           "compounds": true,
           "kind": "functional",
           "modifier": {
@@ -878,6 +898,7 @@ it('should parse a functional variant starting with @', () => {
       "root": "flex",
       "variants": [
         {
+          "compounded": false,
           "compounds": true,
           "kind": "functional",
           "modifier": null,
@@ -907,6 +928,7 @@ it('should parse a functional variant starting with @ and a modifier', () => {
       "root": "flex",
       "variants": [
         {
+          "compounded": false,
           "compounds": true,
           "kind": "functional",
           "modifier": {
@@ -1053,6 +1075,7 @@ it('should parse arbitrary properties with a variant', () => {
       "value": "red",
       "variants": [
         {
+          "compounded": false,
           "compounds": true,
           "kind": "static",
           "root": "hover",
@@ -1076,11 +1099,13 @@ it('should parse arbitrary properties with stacked variants', () => {
       "value": "red",
       "variants": [
         {
+          "compounded": false,
           "compounds": true,
           "kind": "static",
           "root": "hover",
         },
         {
+          "compounded": false,
           "compounds": true,
           "kind": "static",
           "root": "focus",
@@ -1100,13 +1125,17 @@ it('should parse arbitrary properties that are important and using stacked arbit
       "value": "red",
       "variants": [
         {
+          "compounded": false,
           "compounds": true,
           "kind": "arbitrary",
+          "relative": false,
           "selector": "& p",
         },
         {
+          "compounded": false,
           "compounds": true,
           "kind": "arbitrary",
+          "relative": false,
           "selector": "@media(width>=123px)",
         },
       ],
@@ -1139,6 +1168,7 @@ it('should parse a variant containing an arbitrary string with unbalanced parens
       "root": "flex",
       "variants": [
         {
+          "compounded": false,
           "compounds": true,
           "kind": "functional",
           "modifier": null,

--- a/packages/tailwindcss/src/candidate.ts
+++ b/packages/tailwindcss/src/candidate.ts
@@ -522,7 +522,7 @@ export function parseVariant(variant: string, designSystem: DesignSystem): Varia
     // E.g.:
     //
     // - `[p]:flex`
-    if (selector[0] !== '@' && !selector.includes('&') && !relative) {
+    if (!relative && selector[0] !== '@' && !selector.includes('&')) {
       selector = `&:is(${selector})`
     }
 

--- a/packages/tailwindcss/src/candidate.ts
+++ b/packages/tailwindcss/src/candidate.ts
@@ -102,9 +102,6 @@ export type Variant =
       // If true, it can be applied as a child of a compound variant
       compounds: boolean
 
-      // Whether or not this variant is part of a compound variant
-      compounded: boolean
-
       // Whether or not the selector is a relative selector
       // @see https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#relative_selector
       relative: boolean
@@ -121,9 +118,6 @@ export type Variant =
 
       // If true, it can be applied as a child of a compound variant
       compounds: boolean
-
-      // Whether or not this variant is part of a compound variant
-      compounded: boolean
     }
 
   /**
@@ -146,9 +140,6 @@ export type Variant =
 
       // If true, it can be applied as a child of a compound variant
       compounds: boolean
-
-      // Whether or not this variant is part of a compound variant
-      compounded: boolean
     }
 
   /**
@@ -168,9 +159,6 @@ export type Variant =
 
       // If true, it can be applied as a child of a compound variant
       compounds: boolean
-
-      // Whether or not this variant is part of a compound variant
-      compounded: boolean
     }
 
 export type Candidate =
@@ -542,7 +530,6 @@ export function parseVariant(variant: string, designSystem: DesignSystem): Varia
       kind: 'arbitrary',
       selector,
       compounds: true,
-      compounded: false,
       relative,
     }
   }
@@ -581,7 +568,6 @@ export function parseVariant(variant: string, designSystem: DesignSystem): Varia
           kind: 'static',
           root,
           compounds: designSystem.variants.compounds(root),
-          compounded: false,
         }
       }
 
@@ -598,7 +584,6 @@ export function parseVariant(variant: string, designSystem: DesignSystem): Varia
               value: decodeArbitraryValue(value.slice(1, -1)),
             },
             compounds: designSystem.variants.compounds(root),
-            compounded: false,
           }
         }
 
@@ -608,7 +593,6 @@ export function parseVariant(variant: string, designSystem: DesignSystem): Varia
           modifier: modifier === null ? null : parseModifier(modifier),
           value: { kind: 'named', value },
           compounds: designSystem.variants.compounds(root),
-          compounded: false,
         }
       }
 
@@ -623,9 +607,8 @@ export function parseVariant(variant: string, designSystem: DesignSystem): Varia
           kind: 'compound',
           root,
           modifier: modifier === null ? null : { kind: 'named', value: modifier },
-          variant: { ...subVariant, compounded: true },
+          variant: subVariant,
           compounds: designSystem.variants.compounds(root),
-          compounded: false,
         }
       }
     }

--- a/packages/tailwindcss/src/compile.ts
+++ b/packages/tailwindcss/src/compile.ts
@@ -134,13 +134,18 @@ export function compileAstNodes(rawCandidate: string, designSystem: DesignSystem
   }
 }
 
-export function applyVariant(node: Rule, variant: Variant, variants: Variants): null | void {
+export function applyVariant(
+  node: Rule,
+  variant: Variant,
+  variants: Variants,
+  depth: number = 0,
+): null | void {
   if (variant.kind === 'arbitrary') {
     // Relative selectors are not valid as an entire arbitrary variant, only as
     // an arbitrary variant that is part of another compound variant.
     //
     // E.g. `[>img]:flex` is not valid, but `has-[>img]:flex` is
-    if (variant.relative && !variant.compounded) return null
+    if (variant.relative && depth === 0) return null
 
     node.nodes = [rule(variant.selector, node.nodes)]
     return
@@ -168,7 +173,7 @@ export function applyVariant(node: Rule, variant: Variant, variants: Variants): 
     // affecting the original node.
     let isolatedNode = rule('@slot', [])
 
-    let result = applyVariant(isolatedNode, variant.variant, variants)
+    let result = applyVariant(isolatedNode, variant.variant, variants, depth + 1)
     if (result === null) return null
 
     for (let child of isolatedNode.nodes) {

--- a/packages/tailwindcss/src/compile.ts
+++ b/packages/tailwindcss/src/compile.ts
@@ -136,6 +136,12 @@ export function compileAstNodes(rawCandidate: string, designSystem: DesignSystem
 
 export function applyVariant(node: Rule, variant: Variant, variants: Variants): null | void {
   if (variant.kind === 'arbitrary') {
+    // Relative selectors are not valid as an entire arbitrary variant, only as
+    // an arbitrary variant that is part of another compound variant.
+    //
+    // E.g. `[>img]:flex` is not valid, but `has-[>img]:flex` is
+    if (variant.relative && !variant.compounded) return null
+
     node.nodes = [rule(variant.selector, node.nodes)]
     return
   }

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -382,7 +382,7 @@ describe('arbitrary variants', () => {
   })
 
   it('discards arbitrary variants using relative selectors', async () => {
-    expect(await run(['[>img]:flex'])).toBe('')
+    expect(await run(['[>img]:flex', '[+img]:flex', '[~img]:flex'])).toBe('')
   })
 })
 

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -380,6 +380,10 @@ describe('arbitrary variants', () => {
       }"
     `)
   })
+
+  it('discards arbitrary variants using relative selectors', async () => {
+    expect(await run(['[>img]:flex'])).toBe('')
+  })
 })
 
 describe('variant stacking', () => {

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -759,7 +759,7 @@ test('group-[...]', async () => {
       css`
         @tailwind utilities;
       `,
-      ['group-[@media_foo]:flex'],
+      ['group-[@media_foo]:flex', 'group-[>img]:flex'],
     ),
   ).toEqual('')
 })
@@ -861,7 +861,7 @@ test('peer-[...]', async () => {
       css`
         @tailwind utilities;
       `,
-      ['peer-[@media_foo]:flex'],
+      ['peer-[@media_foo]:flex', 'peer-[>img]'],
     ),
   ).toEqual('')
 })
@@ -1690,24 +1690,41 @@ test('has', async () => {
         @tailwind utilities;
       `,
       [
+        'has-checked:flex',
         'has-[:checked]:flex',
+        'has-[>img]:flex',
+        'has-[&>img]:flex',
         'has-hocus:flex',
 
         'group-has-[:checked]:flex',
         'group-has-[:checked]/parent-name:flex',
         'group-has-checked:flex',
+        'group-has-checked/parent-name:flex',
+        'group-has-[>img]:flex',
+        'group-has-[>img]/parent-name:flex',
+        'group-has-[&>img]:flex',
+        'group-has-[&>img]/parent-name:flex',
         'group-has-hocus:flex',
         'group-has-hocus/parent-name:flex',
 
         'peer-has-[:checked]:flex',
         'peer-has-[:checked]/sibling-name:flex',
         'peer-has-checked:flex',
+        'peer-has-checked/sibling-name:flex',
+        'peer-has-[>img]:flex',
+        'peer-has-[>img]/sibling-name:flex',
+        'peer-has-[&>img]:flex',
+        'peer-has-[&>img]/sibling-name:flex',
         'peer-has-hocus:flex',
         'peer-has-hocus/sibling-name:flex',
       ],
     ),
   ).toMatchInlineSnapshot(`
     ".group-has-checked\\:flex:is(:where(.group):has(:checked) *) {
+      display: flex;
+    }
+
+    .group-has-checked\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(:checked) *) {
       display: flex;
     }
 
@@ -1727,7 +1744,27 @@ test('has', async () => {
       display: flex;
     }
 
+    .group-has-\\[\\&\\>img\\]\\:flex:is(:where(.group):has(* > img) *) {
+      display: flex;
+    }
+
+    .group-has-\\[\\&\\>img\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(* > img) *) {
+      display: flex;
+    }
+
+    .group-has-\\[\\>img\\]\\:flex:is(:where(.group):has( > img) *) {
+      display: flex;
+    }
+
+    .group-has-\\[\\>img\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name):has( > img) *) {
+      display: flex;
+    }
+
     .peer-has-checked\\:flex:is(:where(.peer):has(:checked) ~ *) {
+      display: flex;
+    }
+
+    .peer-has-checked\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(:checked) ~ *) {
       display: flex;
     }
 
@@ -1747,11 +1784,39 @@ test('has', async () => {
       display: flex;
     }
 
+    .peer-has-\\[\\&\\>img\\]\\:flex:is(:where(.peer):has(* > img) ~ *) {
+      display: flex;
+    }
+
+    .peer-has-\\[\\&\\>img\\]\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(* > img) ~ *) {
+      display: flex;
+    }
+
+    .peer-has-\\[\\>img\\]\\:flex:is(:where(.peer):has( > img) ~ *) {
+      display: flex;
+    }
+
+    .peer-has-\\[\\>img\\]\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has( > img) ~ *) {
+      display: flex;
+    }
+
+    .has-checked\\:flex:has(:checked) {
+      display: flex;
+    }
+
     .has-hocus\\:flex:has(:hover, :focus) {
       display: flex;
     }
 
     .has-\\[\\:checked\\]\\:flex:has(:checked) {
+      display: flex;
+    }
+
+    .has-\\[\\&\\>img\\]\\:flex:has(* > img) {
+      display: flex;
+    }
+
+    .has-\\[\\>img\\]\\:flex:has( > img) {
       display: flex;
     }"
   `)

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -1669,6 +1669,8 @@ test('not', async () => {
       `,
       [
         'not-[>img]:flex',
+        'not-[+img]:flex',
+        'not-[~img]:flex',
         'not-[:checked]/foo:flex',
         'not-[@media_print]:flex',
         'not-custom-at-rule:flex',
@@ -1694,6 +1696,8 @@ test('has', async () => {
         'has-checked:flex',
         'has-[:checked]:flex',
         'has-[>img]:flex',
+        'has-[+img]:flex',
+        'has-[~img]:flex',
         'has-[&>img]:flex',
         'has-hocus:flex',
 
@@ -1703,6 +1707,8 @@ test('has', async () => {
         'group-has-checked/parent-name:flex',
         'group-has-[>img]:flex',
         'group-has-[>img]/parent-name:flex',
+        'group-has-[+img]:flex',
+        'group-has-[~img]:flex',
         'group-has-[&>img]:flex',
         'group-has-[&>img]/parent-name:flex',
         'group-has-hocus:flex',
@@ -1714,6 +1720,8 @@ test('has', async () => {
         'peer-has-checked/sibling-name:flex',
         'peer-has-[>img]:flex',
         'peer-has-[>img]/sibling-name:flex',
+        'peer-has-[+img]:flex',
+        'peer-has-[~img]:flex',
         'peer-has-[&>img]:flex',
         'peer-has-[&>img]/sibling-name:flex',
         'peer-has-hocus:flex',
@@ -1753,11 +1761,19 @@ test('has', async () => {
       display: flex;
     }
 
+    .group-has-\\[\\+img\\]\\:flex:is(:where(.group):has( + img) *) {
+      display: flex;
+    }
+
     .group-has-\\[\\>img\\]\\:flex:is(:where(.group):has( > img) *) {
       display: flex;
     }
 
     .group-has-\\[\\>img\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name):has( > img) *) {
+      display: flex;
+    }
+
+    .group-has-\\[\\~img\\]\\:flex:is(:where(.group):has( ~ img) *) {
       display: flex;
     }
 
@@ -1793,11 +1809,19 @@ test('has', async () => {
       display: flex;
     }
 
+    .peer-has-\\[\\+img\\]\\:flex:is(:where(.peer):has( + img) ~ *) {
+      display: flex;
+    }
+
     .peer-has-\\[\\>img\\]\\:flex:is(:where(.peer):has( > img) ~ *) {
       display: flex;
     }
 
     .peer-has-\\[\\>img\\]\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has( > img) ~ *) {
+      display: flex;
+    }
+
+    .peer-has-\\[\\~img\\]\\:flex:is(:where(.peer):has( ~ img) ~ *) {
       display: flex;
     }
 
@@ -1817,7 +1841,15 @@ test('has', async () => {
       display: flex;
     }
 
+    .has-\\[\\+img\\]\\:flex:has( + img) {
+      display: flex;
+    }
+
     .has-\\[\\>img\\]\\:flex:has( > img) {
+      display: flex;
+    }
+
+    .has-\\[\\~img\\]\\:flex:has( ~ img) {
       display: flex;
     }"
   `)

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -861,7 +861,7 @@ test('peer-[...]', async () => {
       css`
         @tailwind utilities;
       `,
-      ['peer-[@media_foo]:flex', 'peer-[>img]'],
+      ['peer-[@media_foo]:flex', 'peer-[>img]:flex'],
     ),
   ).toEqual('')
 })
@@ -1668,6 +1668,7 @@ test('not', async () => {
         @tailwind utilities;
       `,
       [
+        'not-[>img]:flex',
         'not-[:checked]/foo:flex',
         'not-[@media_print]:flex',
         'not-custom-at-rule:flex',

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -242,6 +242,8 @@ export function createVariants(theme: Theme): Variants {
   })
 
   variants.compound('group', (ruleNode, variant) => {
+    if (variant.variant.kind === 'arbitrary' && variant.variant.relative) return null
+
     // Name the group by appending the modifier to `group` class itself if
     // present.
     let groupSelector = variant.modifier

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -204,6 +204,8 @@ export function createVariants(theme: Theme): Variants {
   staticVariant('*', [':where(& > *)'], { compounds: false })
 
   variants.compound('not', (ruleNode, variant) => {
+    if (variant.variant.kind === 'arbitrary' && variant.variant.relative) return null
+
     if (variant.modifier) return null
 
     let didApply = false
@@ -303,6 +305,8 @@ export function createVariants(theme: Theme): Variants {
   })
 
   variants.compound('peer', (ruleNode, variant) => {
+    if (variant.variant.kind === 'arbitrary' && variant.variant.relative) return null
+
     // Name the peer by appending the modifier to `peer` class itself if
     // present.
     let peerSelector = variant.modifier


### PR DESCRIPTION
Prior to this PR, we weren't accounting for the fact that `:has(…)` supports [relative selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_selectors/Selector_structure#relative_selector), which are sort of like partial selectors that can start with a combinator like `>`, `+`, or `~`.

Before, a class like `has-[>img]:flex` would generate this:

```css
.has-\[\>img\]\:flex:has(*:is(> img)) {
  display: flex;
}
```

This was incorrect because `*:is(> img)` isn't even valid CSS at all, so the rule would do nothing.

After this change, we generate this instead:

```css
.has-\[\>img\]\:flex:has(> img) {
  display: flex;
}
```

This PR also ensures that relative selectors are recognized as invalid in places where they are not supported, so classes like `group-[>img]:flex` for example will produce nothing now instead of invalid CSS.

This is mostly a simple change but it did involve storing some additional information in the variant AST.

Fixes #14202.