### PR TITLE
Improve sorting of utilities that contain the same properties but one has more declarations than the other

### DIFF
--- a/packages/tailwindcss/src/compile.ts
+++ b/packages/tailwindcss/src/compile.ts
@@ -14,7 +14,7 @@ export function compileCandidates(
 ) {
   let nodeSorting = new Map<
     AstNode,
-    { properties: number[]; variants: bigint; candidate: string }
+    { properties: [number[], number[]]; variants: bigint; candidate: string }
   >()
   let astNodes: AstNode[] = []
   let candidates = new Map<Candidate, string>()
@@ -68,6 +68,9 @@ export function compileCandidates(
     let aSorting = nodeSorting.get(a)!
     let zSorting = nodeSorting.get(z)!
 
+    let [aProperties, aCounts] = aSorting.properties
+    let [zProperties, zCounts] = zSorting.properties
+
     // Sort by variant order first
     if (aSorting.variants - zSorting.variants !== 0n) {
       return Number(aSorting.variants - zSorting.variants)
@@ -76,21 +79,29 @@ export function compileCandidates(
     // Find the first property that is different between the two rules
     let offset = 0
     while (
-      aSorting.properties.length < offset &&
-      zSorting.properties.length < offset &&
-      aSorting.properties[offset] === zSorting.properties[offset]
+      aProperties.length < offset &&
+      zProperties.length < offset &&
+      aProperties[offset] === zProperties[offset]
     ) {
       offset += 1
     }
 
-    return (
-      // Sort by lowest property index first
-      (aSorting.properties[offset] ?? Infinity) - (zSorting.properties[offset] ?? Infinity) ||
-      // Sort by most properties first, then by least properties
-      zSorting.properties.length - aSorting.properties.length ||
-      // Sort alphabetically
-      compare(aSorting.candidate, zSorting.candidate)
-    )
+    // Sort by lowest property index first
+    let lowestPropertyDelta = (aProperties[offset] ?? Infinity) - (zProperties[offset] ?? Infinity)
+    if (lowestPropertyDelta) return lowestPropertyDelta
+
+    // Sort by most properties first, then by least properties
+    let uniquePropertyDelta = zProperties.length - aProperties.length
+    if (uniquePropertyDelta) return uniquePropertyDelta
+
+    // If both have the same unique properties, sort based on instances of those properties
+    for (let i = 0; i < aProperties.length; i++) {
+      let delta = zCounts[i] - aCounts[i]
+      if (delta) return delta
+    }
+
+    // Sort alphabetically
+    return compare(aSorting.candidate, zSorting.candidate)
   })
 
   return {
@@ -254,9 +265,9 @@ function applyImportant(ast: AstNode[]): void {
   }
 }
 
-function getPropertySort(nodes: AstNode[]) {
+function getPropertySort(nodes: AstNode[]): [number[], number[]] {
   // Determine sort order based on properties used
-  let propertySort = new Set<number>()
+  let propertySort = new Map<number, number>()
   let q: AstNode[] = nodes.slice()
 
   while (q.length > 0) {
@@ -267,13 +278,13 @@ function getPropertySort(nodes: AstNode[]) {
       if (node.property === '--tw-sort') {
         let idx = GLOBAL_PROPERTY_ORDER.indexOf(node.value)
         if (idx !== -1) {
-          propertySort.add(idx)
+          propertySort.set(idx, (propertySort.get(idx) ?? 0) + 1)
           break
         }
       }
 
       let idx = GLOBAL_PROPERTY_ORDER.indexOf(node.property)
-      if (idx !== -1) propertySort.add(idx)
+      if (idx !== -1) propertySort.set(idx, (propertySort.get(idx) ?? 0) + 1)
     } else if (node.kind === 'rule') {
       // Don't consider properties within `@at-root` when determining the sort
       // order for a rule.
@@ -285,5 +296,10 @@ function getPropertySort(nodes: AstNode[]) {
     }
   }
 
-  return Array.from(propertySort).sort((a, z) => a - z)
+  let sorted = Array.from(propertySort).sort(([a, _a], [z, _z]) => a - z)
+
+  return [
+    sorted.map(([propertySort]) => propertySort),
+    sorted.map(([, propertyCount]) => propertyCount),
+  ]
 }

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -545,7 +545,7 @@ describe('sorting', () => {
     `)
   })
 
-  it('should sort based on amount of properties', async () => {
+  it('should sort based on amount of unique properties', async () => {
     expect(await run(['text-clip', 'truncate', 'overflow-scroll'])).toMatchInlineSnapshot(`
       ".truncate {
         text-overflow: ellipsis;
@@ -559,6 +559,69 @@ describe('sorting', () => {
 
       .text-clip {
         text-overflow: clip;
+      }"
+    `)
+  })
+
+  it('should sort based on amount of each unique property', async () => {
+    expect(
+      await compileCss(
+        css`
+          @tailwind utilities;
+
+          @utility max-w-responsive {
+            @media (min-width: 640px) {
+              max-width: 640px;
+            }
+            @media (min-width: 768px) {
+              max-width: 768px;
+            }
+            @media (min-width: 1024px) {
+              max-width: 1024px;
+            }
+            @media (min-width: 1280px) {
+              max-width: 1280px;
+            }
+            @media (min-width: 1536px) {
+              max-width: 1536px;
+            }
+          }
+        `,
+        ['max-w-responsive', 'max-w-full'],
+      ),
+    ).toMatchInlineSnapshot(`
+      "@media (width >= 640px) {
+        .max-w-responsive {
+          max-width: 640px;
+        }
+      }
+
+      @media (width >= 768px) {
+        .max-w-responsive {
+          max-width: 768px;
+        }
+      }
+
+      @media (width >= 1024px) {
+        .max-w-responsive {
+          max-width: 1024px;
+        }
+      }
+
+      @media (width >= 1280px) {
+        .max-w-responsive {
+          max-width: 1280px;
+        }
+      }
+
+      @media (width >= 1536px) {
+        .max-w-responsive {
+          max-width: 1536px;
+        }
+      }
+
+      .max-w-full {
+        max-width: 100%;
       }"
     `)
   })


### PR DESCRIPTION
This PR improves our sorting algorithm to better handle situations where two utilities have the same set of unique properties but one has more total declarations than the other.

This is motivated by trying to better sort what were considered "component classes" in v3, because in v4 we're hoping to just call all of those things "utilities" and stick them in the same layer, relying on heuristic-based sorting to keep things working the same way they did for people in v3.

Say we had a custom class that was similar to the `container` class from v3:

```css
@utility max-w-responsive {
  @media (min-width: 640px) {
    max-width: 640px;
  }
  @media (min-width: 768px) {
    max-width: 768px;
  }
  @media (min-width: 1024px) {
    max-width: 1024px;
  }
  @media (min-width: 1280px) {
    max-width: 1280px;
  }
  @media (min-width: 1536px) {
    max-width: 1536px;
  }
}
```

If you use `max-w-responsive` and `max-w-md` on the same element, right now `max-w-responsive` would take precedence over `max-w-md` because they both only target the `max-width` property, so our current sorting algorithm falls back to sorting alphabetically based on the actual class name.

This PR adds one more check before alphabetical sorting, which is checking how many instances exist of each unique property in nodes being sorted.

So since `max-w-responsive` contains 5 `max-width` declarations and `max-w-md` only contains one, the sorting algorithm considers `max-w-md` to be a more "specific" utility than `max-w-responsive` and ensures that `max-w-md` takes precedence.

**I'm opening this as a draft for now because I'm still not totally sure this is necessary** — the actual `container` class in v3 looks like this:

```css
.container {
  width: 100%;
  @media (min-width: 640px) {
    max-width: 640px;
  }
  @media (min-width: 768px) {
    max-width: 768px;
  }
  @media (min-width: 1024px) {
    max-width: 1024px;
  }
  @media (min-width: 1280px) {
    max-width: 1280px;
  }
  @media (min-width: 1536px) {
    max-width: 1536px;
  }
}
```

…so it already includes two properties (notice `width` is there), which means it'll already be sorted before the `max-w-*` utilities.

I'm also a bit nervous that this unique property counting approach is flawed when looking at things that use `@supports` with fallbacks.

For example of you had a `p-safe` utility that looked like this:

```css
@utility p-safe {
  padding: auto;
  @supports (padding: env(safe-area-inset-top, 20px)) {
    padding: env(safe-area-inset-top, 20px) env(safe-area-inset-right, 20px) env(safe-area-inset-bottom, 20px) env(safe-area-inset-left, 20px);
  }
}
```

…that technically sets `padding` twice but it's not really the same as the `max-w-responsive` example because it's not trying to do more than one _thing_, it's just that it's declaring a fallback.

So I dunno, I think this is a pretty complicated one to think through and I'm kinda hoping we just don't need to think about it at all. But we already prototyped it last week, so I'm opening this as a point of discussion in case anyone has a clearer sense than me for whether we actually need to worry about this or not.