### PR TITLE
Change line height of the `lg` font size to `1.625rem`

### DIFF
--- a/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
@@ -356,7 +356,7 @@ exports[`\`@import 'tailwindcss'\` is replaced with the generated CSS 1`] = `
     --font-size-base: 1rem;
     --font-size-base--line-height: 1.5rem;
     --font-size-lg: 1.125rem;
-    --font-size-lg--line-height: 1.75rem;
+    --font-size-lg--line-height: 1.625rem;
     --font-size-xl: 1.25rem;
     --font-size-xl--line-height: 1.75rem;
     --font-size-2xl: 1.5rem;

--- a/packages/tailwindcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/tailwindcss/src/__snapshots__/index.test.ts.snap
@@ -355,7 +355,7 @@ exports[`compiling CSS > \`@tailwind utilities\` is replaced by utilities using 
   --font-size-base: 1rem;
   --font-size-base--line-height: 1.5rem;
   --font-size-lg: 1.125rem;
-  --font-size-lg--line-height: 1.75rem;
+  --font-size-lg--line-height: 1.625rem;
   --font-size-xl: 1.25rem;
   --font-size-xl--line-height: 1.75rem;
   --font-size-2xl: 1.5rem;

--- a/packages/tailwindcss/theme.css
+++ b/packages/tailwindcss/theme.css
@@ -379,7 +379,7 @@
   --font-size-base: 1rem;
   --font-size-base--line-height: 1.5rem;
   --font-size-lg: 1.125rem;
-  --font-size-lg--line-height: 1.75rem;
+  --font-size-lg--line-height: 1.625rem;
   --font-size-xl: 1.25rem;
   --font-size-xl--line-height: 1.75rem;
   --font-size-2xl: 1.5rem;


### PR DESCRIPTION
The default line height of the `lg` font size looks a bit large compared to the rest of the line heights. You can see this in these demo's (third paragraph):

| https://play.tailwindcss.com/0B3D7HVsj0 | https://play.tailwindcss.com/rZkSJPczKR |
| - | - |
| ![PixelSnap 2024-08-20 at 11 06 02 AM@2x](https://github.com/user-attachments/assets/2a68418d-5a01-4123-ad52-652321266184) | ![PixelSnap 2024-08-20 at 11 05 24 AM@2x](https://github.com/user-attachments/assets/35f8a9d0-c946-48de-af17-8c69b2c911ea) |

Also, if you plot the values of the relative line heights, you see the gap between `lg` and `xl` (blue dots 4&5):

![Relative line-height](https://github.com/user-attachments/assets/a09dd782-12b4-4db5-a22e-023179918309)

This is a breaking change, so I changed this in `v4`.
