### PR TITLE
Support plugin options in CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add new standalone builds of Tailwind CSS v4 ([#14270](https://github.com/tailwindlabs/tailwindcss/pull/14270))
 - Support JavaScript configuration files using `@config` ([#14239](https://github.com/tailwindlabs/tailwindcss/pull/14239))
-- Add support for `@config` to load V3 JavaScript config files ([#14239](https://github.com/tailwindlabs/tailwindcss/pull/14239))
 - Support plugin options in CSS ([#14264](https://github.com/tailwindlabs/tailwindcss/pull/14264))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add new standalone builds of Tailwind CSS v4 ([#14270](https://github.com/tailwindlabs/tailwindcss/pull/14270))
 - Support JavaScript configuration files using `@config` ([#14239](https://github.com/tailwindlabs/tailwindcss/pull/14239))
-- Support plugin options in CSS ([#14264](https://github.com/tailwindlabs/tailwindcss/pull/14264))
+- Support plugin options in `@plugin` in CSS ([#14264](https://github.com/tailwindlabs/tailwindcss/pull/14264))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add new standalone builds of Tailwind CSS v4 ([#14270](https://github.com/tailwindlabs/tailwindcss/pull/14270))
 - Support JavaScript configuration files using `@config` ([#14239](https://github.com/tailwindlabs/tailwindcss/pull/14239))
+- Add support for `@config` to load V3 JavaScript config files ([#14239](https://github.com/tailwindlabs/tailwindcss/pull/14239))
+- Support plugin options in CSS ([#14264](https://github.com/tailwindlabs/tailwindcss/pull/14264))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add new standalone builds of Tailwind CSS v4 ([#14270](https://github.com/tailwindlabs/tailwindcss/pull/14270))
 - Support JavaScript configuration files using `@config` ([#14239](https://github.com/tailwindlabs/tailwindcss/pull/14239))
-- Support plugin options in `@plugin` in CSS ([#14264](https://github.com/tailwindlabs/tailwindcss/pull/14264))
+- Support plugin options in `@plugin` ([#14264](https://github.com/tailwindlabs/tailwindcss/pull/14264))
 
 ### Fixed
 

--- a/integrations/cli/plugins.test.ts
+++ b/integrations/cli/plugins.test.ts
@@ -78,6 +78,51 @@ test(
 )
 
 test(
+  'builds the `@tailwindcss/forms` plugin utilities (with options)',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "dependencies": {
+            "@tailwindcss/forms": "^0.5.7",
+            "tailwindcss": "workspace:^",
+            "@tailwindcss/cli": "workspace:^"
+          }
+        }
+      `,
+      'index.html': html`
+        <input type="text" class="form-input" />
+        <textarea class="form-textarea"></textarea>
+      `,
+      'src/index.css': css`
+        @import 'tailwindcss';
+        @plugin '@tailwindcss/forms' {
+          strategy: base;
+        }
+      `,
+    },
+  },
+  async ({ fs, exec }) => {
+    await exec('pnpm tailwindcss --input src/index.css --output dist/out.css')
+
+    await fs.expectFileToContain('dist/out.css', [
+      //
+      `::-webkit-date-and-time-value`,
+      `[type='checkbox']:indeterminate`,
+    ])
+
+    // No classes are included even though they are used in the HTML
+    // because the `base` strategy is used
+    await fs.expectFileNotToContain('dist/out.css', [
+      //
+      candidate`form-input`,
+      candidate`form-textarea`,
+      candidate`form-radio`,
+    ])
+  },
+)
+
+test(
   'builds the `tailwindcss-animate` plugin utilities',
   {
     fs: {

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1319,7 +1319,7 @@ describe('plugins', () => {
     let { build } = await compile(
       css`
         @tailwind utilities;
-        @plugin {
+        @plugin "my-plugin" {
           color: red;
         }
       `,
@@ -1357,13 +1357,19 @@ describe('plugins', () => {
     await compile(
       css`
         @tailwind utilities;
-        @plugin {
+        @plugin "my-plugin" {
           is-null: null;
           is-true: true;
           is-false: false;
           is-int: 1234567;
           is-float: 1.35;
           is-sci: 1.35e-5;
+          is-str-null: 'null';
+          is-str-true: 'true';
+          is-str-false: 'false';
+          is-str-int: '1234567';
+          is-str-float: '1.35';
+          is-str-sci: '1.35e-5';
         }
       `,
       {
@@ -1376,6 +1382,12 @@ describe('plugins', () => {
               'is-int': 1234567,
               'is-float': 1.35,
               'is-sci': 1.35e-5,
+              'is-str-null': 'null',
+              'is-str-true': 'true',
+              'is-str-false': 'false',
+              'is-str-int': '1234567',
+              'is-str-float': '1.35',
+              'is-str-sci': '1.35e-5',
             })
 
             return () => {}
@@ -1389,7 +1401,7 @@ describe('plugins', () => {
     expect(
       compile(
         css`
-          @plugin {
+          @plugin "my-plugin" {
             color: red;
             sizes {
               sm: 1rem;
@@ -1412,7 +1424,17 @@ describe('plugins', () => {
         },
       ),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: \`@plugin\` can only contain declarations.]`,
+      `
+      [Error: Unexpected \`@plugin\` option:
+
+      sizes {
+        sm: 1rem;
+        md: 2rem;
+      }
+
+
+      Plugins can only contain a flat list of declarations.]
+    `,
     )
   })
 
@@ -1454,7 +1476,11 @@ describe('plugins', () => {
         },
       ),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: Arrays are not supported in \`@plugin\` options.]`,
+      `
+      [Error: Unexpected \`@plugin\` option: Value of declaration \`--color: [ 'red', 'green', 'blue'];\` is not supported.
+
+      It looks like you want to pass an array to plugin options. This is not supported in CSS.]
+    `,
     )
   })
 
@@ -1475,7 +1501,15 @@ describe('plugins', () => {
         },
       ),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: Objects are not supported in \`@plugin\` options.]`,
+      `
+      [Error: Unexpected \`@plugin\` option: Value of declaration \`--color: {
+                    red: 100;
+                    green: 200;
+                    blue: 300;
+                  };\` is not supported.
+
+      It looks like you want to pass an object to plugin options. This is not supported in CSS.]
+    `,
     )
   })
 

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1295,6 +1295,38 @@ describe('Parsing themes values from CSS', () => {
 })
 
 describe('plugins', () => {
+  test('@plugin need a path', () =>
+    expect(
+      compile(
+        css`
+          @plugin;
+        `,
+        {
+          loadPlugin: async () => {
+            return ({ addVariant }: PluginAPI) => {
+              addVariant('hocus', '&:hover, &:focus')
+            }
+          },
+        },
+      ),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: \`@plugin\` must have a path.]`))
+
+  test('@plugin can not have an empty path', () =>
+    expect(
+      compile(
+        css`
+          @plugin '';
+        `,
+        {
+          loadPlugin: async () => {
+            return ({ addVariant }: PluginAPI) => {
+              addVariant('hocus', '&:hover, &:focus')
+            }
+          },
+        },
+      ),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: \`@plugin\` must have a path.]`))
+
   test('@plugin cannot be nested.', () =>
     expect(
       compile(

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1474,7 +1474,9 @@ describe('plugins', () => {
           loadPlugin: async () => plugin(() => {}),
         },
       ),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: Objects are not supported in \`@plugin\` options.]`)
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: Objects are not supported in \`@plugin\` options.]`,
+    )
   })
 
   test('addVariant with string selector', async () => {

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1383,7 +1383,7 @@ describe('plugins', () => {
     `)
   })
 
-  test('@plugin options can specify null, booleans, or numbers', async () => {
+  test('@plugin options can be null, booleans, string, numbers, or arrays including those types', async () => {
     expect.hasAssertions()
 
     await compile(

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1345,7 +1345,7 @@ describe('plugins', () => {
       ),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: \`@plugin\` cannot be nested.]`))
 
-  test('@plugin can provide options', async () => {
+  test('@plugin can accept options', async () => {
     expect.hasAssertions()
 
     let { build } = await compile(

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1469,7 +1469,7 @@ describe('plugins', () => {
       }
 
 
-      Plugins can only contain a flat list of declarations.]
+      \`@plugin\` options must be a flat list of declarations.]
     `,
     )
   })

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1512,11 +1512,7 @@ describe('plugins', () => {
         },
       ),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `
-      [Error: Unexpected \`@plugin\` option: Value of declaration \`--color: [ 'red', 'green', 'blue'];\` is not supported.
-
-      It looks like you want to pass an array to plugin options. This is not supported in CSS.]
-    `,
+      `[Error: The plugin "my-plugin" does not accept options]`,
     )
   })
 
@@ -1544,7 +1540,7 @@ describe('plugins', () => {
                     blue: 300;
                   };\` is not supported.
 
-      It looks like you want to pass an object to plugin options. This is not supported in CSS.]
+      Using an object as a plugin option is currently only supported in JavaScript configuration files.]
     `,
     )
   })

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1402,6 +1402,8 @@ describe('plugins', () => {
           is-str-int: '1234567';
           is-str-float: '1.35';
           is-str-sci: '1.35e-5';
+          is-arr: foo, bar;
+          is-arr-mixed: null, true, false, 1234567, 1.35, foo, 'bar', 'true';
         }
       `,
       {
@@ -1420,6 +1422,8 @@ describe('plugins', () => {
               'is-str-int': '1234567',
               'is-str-float': '1.35',
               'is-str-sci': '1.35e-5',
+              'is-arr': ['foo', 'bar'],
+              'is-arr-mixed': [null, true, false, 1234567, 1.35, 'foo', 'bar', 'true'],
             })
 
             return () => {}

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -86,6 +86,8 @@ async function parseCss(
         let value: CssPluginOptions[keyof CssPluginOptions] = decl.value
 
         let parts = segment(value, ',').map((part) => {
+          part = part.trim()
+
           if (part === 'null') {
             return null
           } else if (part === 'true') {
@@ -110,7 +112,7 @@ async function parseCss(
             )
           }
 
-          return value
+          return part
         })
 
         options[decl.property] = parts.length === 1 ? parts[0] : parts

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -101,14 +101,9 @@ async function parseCss(
             (part[0] === "'" && part[part.length - 1] === "'")
           ) {
             return part.slice(1, -1)
-          } else if (
-            (part[0] === '[' && part[part.length - 1] === ']') ||
-            (part[0] === '{' && part[part.length - 1] === '}')
-          ) {
+          } else if (part[0] === '{' && part[part.length - 1] === '}') {
             throw new Error(
-              `Unexpected \`@plugin\` option: Value of declaration \`${toCss([decl]).trim()}\` is not supported.\n\nIt looks like you want to pass an ${
-                part[0] === '[' ? 'array' : 'object'
-              } to plugin options. This is not supported in CSS.`,
+              `Unexpected \`@plugin\` option: Value of declaration \`${toCss([decl]).trim()}\` is not supported.\n\nUsing an object as a plugin option is currently only supported in JavaScript configuration files.`,
             )
           }
 

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -75,7 +75,7 @@ async function parseCss(
       for (let decl of node.nodes ?? []) {
         if (decl.kind !== 'declaration') {
           throw new Error(
-            `Unexpected \`@plugin\` option:\n\n${toCss([decl])}\n\nPlugins can only contain a flat list of declarations.`,
+            `Unexpected \`@plugin\` option:\n\n${toCss([decl])}\n\n\`@plugin\` options must be a flat list of declarations.`,
           )
         }
 

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -85,31 +85,35 @@ async function parseCss(
         // These are the same primitive values supported by JSON
         let value: CssPluginOptions[keyof CssPluginOptions] = decl.value
 
-        if (value === 'null') {
-          value = null
-        } else if (value === 'true') {
-          value = true
-        } else if (value === 'false') {
-          value = false
-        } else if (!Number.isNaN(Number(value))) {
-          value = Number(value)
-        } else if (
-          (value[0] === '"' && value[value.length - 1] === '"') ||
-          (value[0] === "'" && value[value.length - 1] === "'")
-        ) {
-          value = value.slice(1, -1)
-        } else if (
-          (value[0] === '[' && value[value.length - 1] === ']') ||
-          (value[0] === '{' && value[value.length - 1] === '}')
-        ) {
-          throw new Error(
-            `Unexpected \`@plugin\` option: Value of declaration \`${toCss([decl]).trim()}\` is not supported.\n\nIt looks like you want to pass an ${
-              value[0] === '[' ? 'array' : 'object'
-            } to plugin options. This is not supported in CSS.`,
-          )
-        }
+        let parts = segment(value, ',').map((part) => {
+          if (part === 'null') {
+            return null
+          } else if (part === 'true') {
+            return true
+          } else if (part === 'false') {
+            return false
+          } else if (!Number.isNaN(Number(part))) {
+            return Number(part)
+          } else if (
+            (part[0] === '"' && part[part.length - 1] === '"') ||
+            (part[0] === "'" && part[part.length - 1] === "'")
+          ) {
+            return part.slice(1, -1)
+          } else if (
+            (part[0] === '[' && part[part.length - 1] === ']') ||
+            (part[0] === '{' && part[part.length - 1] === '}')
+          ) {
+            throw new Error(
+              `Unexpected \`@plugin\` option: Value of declaration \`${toCss([decl]).trim()}\` is not supported.\n\nIt looks like you want to pass an ${
+                part[0] === '[' ? 'array' : 'object'
+              } to plugin options. This is not supported in CSS.`,
+            )
+          }
 
-        options[decl.property] = value
+          return value
+        })
+
+        options[decl.property] = parts.length === 1 ? parts[0] : parts
       }
 
       pluginPaths.push([pluginPath, Object.keys(options).length > 0 ? options : null])

--- a/packages/tailwindcss/src/plugin-api.ts
+++ b/packages/tailwindcss/src/plugin-api.ts
@@ -346,7 +346,8 @@ function objectToAst(rules: CssInJs | CssInJs[]): AstNode[] {
   return ast
 }
 
-export type CssPluginOptions = Record<string, string | number | boolean | null>
+type Primitive = string | number | boolean | null
+export type CssPluginOptions = Record<string, Primitive | Primitive[]>
 
 interface PluginDetail {
   path: string


### PR DESCRIPTION
Builds on #14239 — that PR needs to be merged first.

This PR allows plugins defined with `plugin.withOptions` to receive options in CSS when using `@plugin` as long as the options are simple key/value pairs.

For example, the following is now valid and will include the forms plugin with only the base styles enabled:

```css
@plugin "@tailwindcss/forms" {
  strategy: base;
}
```

We handle `null`, `true`, `false`, and numeric values as expected and will convert them to their JavaScript equivalents. Comma separated values are turned into arrays. All other values are converted to strings.

For example, in the following plugin definition, the options that are passed to the plugin will be the correct types:
- `debug` will be the boolean value `true`
- `threshold` will be the number `0.5`
- `message` will be the string `"Hello world"`
- `features` will be the array `["base", "responsive"]`

```css
@plugin "my-plugin" {
  debug: false;
  threshold: 0.5;
  message: Hello world;
  features: base, responsive;
}
```

If you need to pass a number or boolean value as a string, you can do so by wrapping the value in quotes:

```css
@plugin "my-plugin" {
  debug: "false";
  threshold: "0.5";
  message: "Hello world";
}
```

When duplicate options are encountered the last value wins:

```css
@plugin "my-plugin" {
  message: Hello world;
  message: Hello plugin; /* this will be the value of `message` */
}
```

It's important to note that this feature is **only available for plugins defined with `plugin.withOptions`**. If you try to pass options to a plugin that doesn't support them, you'll get an error message when building:

```css
@plugin "my-plugin" {
  debug: false;
  threshold: 0.5;
}

/* Error: The plugin "my-plugin" does not accept options */
```

Additionally, if you try to pass in more complex values like objects or selectors you'll get an error message:

```css
@plugin "my-plugin" {
  color: { red: 100; green: 200; blue: 300 };
}

/* Error: Objects are not supported in `@plugin` options. */
```

```css
@plugin "my-plugin" {
  .some-selector > * {
    primary: "blue";
    secondary: "green";
  }
}

/* Error: `@plugin` can only contain declarations. */
```
