### PR TITLE
Enable tailwindcss to run in restricted permissions environment (eg. Deno Webworker w/o read permissions)

### DIFF
--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -41,7 +41,10 @@ export function parseCandidateFiles(context, tailwindConfig) {
   files = files.map(normalizePath)
 
   // Split into included and excluded globs
-  let tasks = fastGlob.generateTasks(files)
+  let tasks = [];
+  if (files.length) {
+    tasks.push(...fastGlob.generateTasks(files))
+  }
 
   /** @type {ContentPath[]} */
   let included = []
@@ -56,14 +59,16 @@ export function parseCandidateFiles(context, tailwindConfig) {
 
   let paths = [...included, ...excluded]
 
-  // Resolve paths relative to the config file or cwd
-  paths = resolveRelativePaths(context, paths)
+  if (paths.length) {
+    // Resolve paths relative to the config file or cwd
+    paths = resolveRelativePaths(context, paths)
 
-  // Resolve symlinks if possible
-  paths = paths.flatMap(resolvePathSymlinks)
+    // Resolve symlinks if possible
+    paths = paths.flatMap(resolvePathSymlinks)
 
-  // Update cached patterns
-  paths = paths.map(resolveGlobPattern)
+    // Update cached patterns
+    paths = paths.map(resolveGlobPattern)
+  }
 
   return paths
 }
@@ -264,7 +269,10 @@ function resolveChangedFiles(candidateFiles, fileModifiedMap) {
 
   let changedFiles = new Set()
   env.DEBUG && console.time('Finding changed files')
-  let files = fastGlob.sync(paths, { absolute: true })
+  let files = [];
+  if (paths.length) {
+    files.push(...fastGlob.sync(paths, { absolute: true }))
+  }
   for (let file of files) {
     checkBroadPattern(file)
 


### PR DESCRIPTION

This PR is a suggestion implementation for solving #14299 .

#### Description:
I have identified a potential improvement for TailwindCSS that would enhance its compatibility with environments that have limited read permissions, such as Cloudflare Workers or Deno WebWorkers / Deno Deploy with limited read / write permissions.

#### Problem:
When running TailwindCSS in environments where read access to the file system is restricted (e.g., serverless functions, WebWorkers), the dependency on fast-glob for resolving file paths can cause issues. Specifically, fast-glob requires read access to the instance's current directory (via process.cwd()), which is not necessary for use cases where the Tailwind config is passed directly into PostCSS, and the HTML containing Tailwind CSS utilities is provided in-memory as the raw property in content.files.

#### Proposed Solution:
A simple solution (about 10 lines of code) could be implemented to check if the length of the paths to be verified is greater than zero. If paths are present, the regular logic using fast-glob would proceed. If not, we can skip the fast-glob call, allowing TailwindCSS to function in environments with restricted read permissions.

#### Benefits:
This change would enable dynamic CSS generation in restricted serverless environments, making TailwindCSS more versatile and opening up new use cases, such as running on platforms like Cloudflare Workers or Deno WebWorkers without the need for read access.

#### Reproduction URL

Clone the repo: https://github.com/vfssantos/tailwind-edge-test/tree/main
As we're using Deno in that repo, make sure you have Deno installed locally
Run the project as instructed. You'll be prompted for permissions. You can deny all of them and would still work, except for the --read for cwd command (which is used by fast-glob).

**Expected Behavior ** : TailwindCSS should allow dynamic CSS generation without requiring file system read access when the paths to be checked are empty.

**Proposed Changes Behavior**: With the simple proposed changes in this PR, the repo in **Reproduction URL** works seamlessly.

If the maintainers agree, I'd be happy to change this PR to comply with any other requirement.