### PR TITLE
Allow `@plugin` and `@config` to point to TS files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support TypeScript for `@plugin` and `@config` files ([#14317](https://github.com/tailwindlabs/tailwindcss/pull/14317))
+
 ### Fixed
 
 - Ensure content globs defined in `@config` files are relative to that file ([#14314](https://github.com/tailwindlabs/tailwindcss/pull/14314))
 - Ensure CSS `theme()` functions are evaluated in media query ranges with collapsed whitespace ((#14321)[https://github.com/tailwindlabs/tailwindcss/pull/14321])
-### Added
-
-- Allow `@plugin` and `@config` to point to TypeScript files ([#14317](https://github.com/tailwindlabs/tailwindcss/pull/14317))
 
 ## [4.0.0-alpha.21] - 2024-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure content globs defined in `@config` files are relative to that file ([#14314](https://github.com/tailwindlabs/tailwindcss/pull/14314))
 - Ensure CSS `theme()` functions are evaluated in media query ranges with collapsed whitespace ((#14321)[https://github.com/tailwindlabs/tailwindcss/pull/14321])
+### Added
+
+- Allow `@plugin` and `@config` to point to TypeScript files ([#14317](https://github.com/tailwindlabs/tailwindcss/pull/14317))
 
 ## [4.0.0-alpha.21] - 2024-09-02
 

--- a/packages/@tailwindcss-node/package.json
+++ b/packages/@tailwindcss-node/package.json
@@ -38,5 +38,8 @@
   },
   "devDependencies": {
     "tailwindcss": "workspace:^"
+  },
+  "dependencies": {
+    "jiti": "^2.0.0-beta.3"
   }
 }

--- a/packages/@tailwindcss-node/src/compile.ts
+++ b/packages/@tailwindcss-node/src/compile.ts
@@ -1,3 +1,4 @@
+import { createJiti, type Jiti } from 'jiti'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { compile as _compile } from 'tailwindcss'
@@ -10,12 +11,12 @@ export async function compile(
   return await _compile(css, {
     loadPlugin: async (pluginPath) => {
       if (pluginPath[0] !== '.') {
-        return import(pluginPath).then((m) => m.default ?? m)
+        return importNativeAndJiti(pluginPath).then((m: any) => m.default ?? m)
       }
 
       let resolvedPath = path.resolve(base, pluginPath)
       let [module, moduleDependencies] = await Promise.all([
-        import(pathToFileURL(resolvedPath).href + '?id=' + Date.now()),
+        importNativeAndJiti(pathToFileURL(resolvedPath).href + '?id=' + Date.now()),
         getModuleDependencies(resolvedPath),
       ])
 
@@ -28,12 +29,12 @@ export async function compile(
 
     loadConfig: async (configPath) => {
       if (configPath[0] !== '.') {
-        return import(configPath).then((m) => m.default ?? m)
+        return importNativeAndJiti(configPath).then((m: any) => m.default ?? m)
       }
 
       let resolvedPath = path.resolve(base, configPath)
       let [module, moduleDependencies] = await Promise.all([
-        import(pathToFileURL(resolvedPath).href + '?id=' + Date.now()),
+        importNativeAndJiti(pathToFileURL(resolvedPath).href + '?id=' + Date.now()),
         getModuleDependencies(resolvedPath),
       ])
 
@@ -44,4 +45,19 @@ export async function compile(
       return module.default ?? module
     },
   })
+}
+
+let jiti: null | Jiti = null
+async function importNativeAndJiti(path: string): Promise<any> {
+  try {
+    return await import(path)
+  } catch (error) {
+    try {
+      if (!jiti) {
+        jiti = createJiti(import.meta.url)
+      }
+      return await jiti.import(path)
+    } catch {}
+    throw error
+  }
 }

--- a/packages/@tailwindcss-node/src/compile.ts
+++ b/packages/@tailwindcss-node/src/compile.ts
@@ -11,7 +11,7 @@ export async function compile(
   return await _compile(css, {
     loadPlugin: async (pluginPath) => {
       if (pluginPath[0] !== '.') {
-        return importModule(pluginPath).then((m: any) => m.default ?? m)
+        return importModule(pluginPath).then((m) => m.default ?? m)
       }
 
       let resolvedPath = path.resolve(base, pluginPath)
@@ -29,7 +29,7 @@ export async function compile(
 
     loadConfig: async (configPath) => {
       if (configPath[0] !== '.') {
-        return importModule(configPath).then((m: any) => m.default ?? m)
+        return importModule(configPath).then((m) => m.default ?? m)
       }
 
       let resolvedPath = path.resolve(base, configPath)

--- a/packages/@tailwindcss-node/src/compile.ts
+++ b/packages/@tailwindcss-node/src/compile.ts
@@ -56,9 +56,7 @@ async function importModule(path: string): Promise<any> {
     return await import(path)
   } catch (error) {
     try {
-      if (!jiti) {
-        jiti = createJiti(import.meta.url, { moduleCache: false, fsCache: false })
-      }
+      jiti ??= createJiti(import.meta.url, { moduleCache: false, fsCache: false })
       return await jiti.import(path)
     } catch {}
     throw error

--- a/packages/@tailwindcss-node/src/compile.ts
+++ b/packages/@tailwindcss-node/src/compile.ts
@@ -11,12 +11,12 @@ export async function compile(
   return await _compile(css, {
     loadPlugin: async (pluginPath) => {
       if (pluginPath[0] !== '.') {
-        return importNativeAndJiti(pluginPath).then((m: any) => m.default ?? m)
+        return importModule(pluginPath).then((m: any) => m.default ?? m)
       }
 
       let resolvedPath = path.resolve(base, pluginPath)
       let [module, moduleDependencies] = await Promise.all([
-        importNativeAndJiti(pathToFileURL(resolvedPath).href + '?id=' + Date.now()),
+        importModule(pathToFileURL(resolvedPath).href + '?id=' + Date.now()),
         getModuleDependencies(resolvedPath),
       ])
 
@@ -29,12 +29,12 @@ export async function compile(
 
     loadConfig: async (configPath) => {
       if (configPath[0] !== '.') {
-        return importNativeAndJiti(configPath).then((m: any) => m.default ?? m)
+        return importModule(configPath).then((m: any) => m.default ?? m)
       }
 
       let resolvedPath = path.resolve(base, configPath)
       let [module, moduleDependencies] = await Promise.all([
-        importNativeAndJiti(pathToFileURL(resolvedPath).href + '?id=' + Date.now()),
+        importModule(pathToFileURL(resolvedPath).href + '?id=' + Date.now()),
         getModuleDependencies(resolvedPath),
       ])
 
@@ -47,8 +47,11 @@ export async function compile(
   })
 }
 
+// Attempts to import the module using the native `import()` function. If this
+// fails, it sets up `jiti` and attempts to import this way so that `.ts` files
+// can be resolved properly.
 let jiti: null | Jiti = null
-async function importNativeAndJiti(path: string): Promise<any> {
+async function importModule(path: string): Promise<any> {
   try {
     return await import(path)
   } catch (error) {

--- a/packages/@tailwindcss-node/src/compile.ts
+++ b/packages/@tailwindcss-node/src/compile.ts
@@ -57,7 +57,7 @@ async function importModule(path: string): Promise<any> {
   } catch (error) {
     try {
       if (!jiti) {
-        jiti = createJiti(import.meta.url)
+        jiti = createJiti(import.meta.url, { moduleCache: false, fsCache: false })
       }
       return await jiti.import(path)
     } catch {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,10 @@ importers:
         version: link:../internal-postcss-fix-relative-paths
 
   packages/@tailwindcss-node:
+    dependencies:
+      jiti:
+        specifier: ^2.0.0-beta.3
+        version: 2.0.0-beta.3
     devDependencies:
       tailwindcss:
         specifier: workspace:^
@@ -2125,6 +2129,10 @@ packages:
 
   jiti@1.21.6:
     resolution: {integrity: sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==}
+    hasBin: true
+
+  jiti@2.0.0-beta.3:
+    resolution: {integrity: sha512-pmfRbVRs/7khFrSAYnSiJ8C0D5GvzkE4Ey2pAvUcJsw1ly/p+7ut27jbJrjY79BpAJQJ4gXYFtK6d1Aub+9baQ==}
     hasBin: true
 
   joycon@3.1.1:
@@ -4891,6 +4899,8 @@ snapshots:
 
   jiti@1.21.6:
     optional: true
+
+  jiti@2.0.0-beta.3: {}
 
   joycon@3.1.1: {}
 


### PR DESCRIPTION
Tailwind V3 used [jiti](https://github.com/unjs/jiti/) to allow importing of TypeScript files for the config and plugins. This PR adds the new Jiti V2 beta to our `@tailwindcss/node` and uses it if a native `import()` fails. I added a new integration test to the CLI config setup, to ensure it still works with our module cache cleanup. 