### PR TITLE
Fix Nuxt integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure content globs defined in `@config` files are relative to that file ([#14314](https://github.com/tailwindlabs/tailwindcss/pull/14314))
 - Ensure CSS `theme()` functions are evaluated in media query ranges with collapsed whitespace ((#14321)[https://github.com/tailwindlabs/tailwindcss/pull/14321])
+- Fix support for Nuxt projects in the Vite plugin (requires Nuxt 3.13.1+) ([#14319](https://github.com/tailwindlabs/tailwindcss/pull/14319))
 
 ## [4.0.0-alpha.21] - 2024-09-02
 

--- a/integrations/vite/nuxt.test.ts
+++ b/integrations/vite/nuxt.test.ts
@@ -1,0 +1,64 @@
+import { expect } from 'vitest'
+import { candidate, css, fetchStyles, html, json, retryAssertion, test, ts } from '../utils'
+
+test(
+  'dev mode',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "type": "module",
+          "dependencies": {
+            "@tailwindcss/vite": "workspace:^",
+            "nuxt": "^3.13.1",
+            "tailwindcss": "workspace:^",
+            "vue": "latest"
+          }
+        }
+      `,
+      'nuxt.config.ts': ts`
+        import tailwindcss from '@tailwindcss/vite'
+
+        // https://nuxt.com/docs/api/configuration/nuxt-config
+        export default defineNuxtConfig({
+          vite: {
+            plugins: [tailwindcss()],
+          },
+
+          css: ['~/assets/css/main.css'],
+          devtools: { enabled: true },
+          compatibilityDate: '2024-08-30',
+        })
+      `,
+      'app.vue': html`
+        <template>
+          <div class="underline">Hello world!</div>
+        </template>
+      `,
+      'assets/css/main.css': css`@import 'tailwindcss';`,
+    },
+  },
+  async ({ fs, spawn, getFreePort }) => {
+    let port = await getFreePort()
+    await spawn(`pnpm nuxt dev --port ${port}`)
+
+    await retryAssertion(async () => {
+      let css = await fetchStyles(port)
+      expect(css).toContain(candidate`underline`)
+    })
+
+    await fs.write(
+      'app.vue',
+      html`
+        <template>
+          <div class="underline font-bold">Hello world!</div>
+        </template>
+      `,
+    )
+    await retryAssertion(async () => {
+      let css = await fetchStyles(port)
+      expect(css).toContain(candidate`underline`)
+      expect(css).toContain(candidate`font-bold`)
+    })
+  },
+)

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -192,9 +192,7 @@ export default function tailwindcss(): Plugin[] {
           // The reason why we can not rely on the invalidation here is that the
           // users would otherwise see a flicker in the styles as the CSS might
           // be loaded with an invalid set of candidates first.
-          for (let server of servers) {
-            await server.waitForRequestsIdle(id)
-          }
+          await Promise.all(servers.map((server) => server.waitForRequestsIdle(id)))
         }
 
         let generated = await root.generate(src, (file) => this.addWatchFile(file))


### PR DESCRIPTION
We noticed that Nuxt projects were not working with the tailwindcss project. The issue was traced down to the fact that Nuxt starts multiple Vite dev servers and calling the experimental `waitForRequestsIdle()` on one of the test servers would never resolve.

This was fixed upstream and is part of the latest Vite/Nuxt release: https://github.com/vitejs/vite/issues/17980.

We still need to handle the fact that Vite can spawn multiple dev servers. This is necessary because when we invalidate all roots, we need to find that module inside all of the spawned servers. If we only look at the _last server_ (what we have done before), we would not find the module and thus could not invalidate it.