### PR TITLE
Evaluate theme functions in plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure content globs defined in `@config` files are relative to that file ([#14314](https://github.com/tailwindlabs/tailwindcss/pull/14314))
 - Ensure CSS `theme()` functions are evaluated in media query ranges with collapsed whitespace ((#14321)[https://github.com/tailwindlabs/tailwindcss/pull/14321])
 - Fix support for Nuxt projects in the Vite plugin (requires Nuxt 3.13.1+) ([#14319](https://github.com/tailwindlabs/tailwindcss/pull/14319))
+- Evaluate theme functions in plugins and JS config files ([#14326](https://github.com/tailwindlabs/tailwindcss/pull/14326))
 
 ## [4.0.0-alpha.21] - 2024-09-02
 

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -376,7 +376,7 @@ async function parseCss(
   // could register new rules that include functions, and JS config files could
   // also contain functions or plugins that use functions so we need to evaluate
   // functions if either of those are present.
-  if (css.includes(THEME_FUNCTION_INVOCATION) || plugins.length > 0 || configs.length > 0) {
+  if (plugins.length > 0 || configs.length > 0 || css.includes(THEME_FUNCTION_INVOCATION)) {
     substituteFunctions(ast, pluginApi)
   }
 


### PR DESCRIPTION
This PR fixes a bug where CSS `theme()` functions were not evaluated when present in rules added by plugins, using either `@plugin` or registering a plugin in a JS config file.

For example, prior to this PR the `theme()` functions in this plugin would make it into the final CSS without being evaluated:

```js
// ./my-plugin.js
export default plugin(({ addBase }) => {
  addBase({
    '.my-rule': {
      background: 'theme(colors.primary)',
      color: 'theme(colors.secondary)',
    },
  })
})
```