### PR TITLE
Add `default` option to `@theme` to support overriding default theme values from plugins/JS config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support TypeScript for `@plugin` and `@config` files ([#14317](https://github.com/tailwindlabs/tailwindcss/pull/14317))
+- Add `default` option to `@theme` to support overriding default theme values from plugins/JS config files ([#14327](https://github.com/tailwindlabs/tailwindcss/pull/14327))
 
 ### Fixed
 
 - Ensure content globs defined in `@config` files are relative to that file ([#14314](https://github.com/tailwindlabs/tailwindcss/pull/14314))
 - Ensure CSS `theme()` functions are evaluated in media query ranges with collapsed whitespace ((#14321)[https://github.com/tailwindlabs/tailwindcss/pull/14321])
 - Fix support for Nuxt projects in the Vite plugin (requires Nuxt 3.13.1+) ([#14319](https://github.com/tailwindlabs/tailwindcss/pull/14319))
+- Ensure theme values overridden with `reference` values don't generate stale CSS variables ([#14327](https://github.com/tailwindlabs/tailwindcss/pull/14327))
 
 ## [4.0.0-alpha.21] - 2024-09-02
 

--- a/packages/tailwindcss/src/compat/apply-config-to-theme.ts
+++ b/packages/tailwindcss/src/compat/apply-config-to-theme.ts
@@ -11,6 +11,7 @@ export function applyConfigToTheme(designSystem: DesignSystem, configs: ConfigFi
     designSystem.theme.add(`--${name}`, value as any, {
       isInline: true,
       isReference: true,
+      isDefault: true,
     })
   }
 

--- a/packages/tailwindcss/src/compat/apply-config-to-theme.ts
+++ b/packages/tailwindcss/src/compat/apply-config-to-theme.ts
@@ -10,7 +10,7 @@ export function applyConfigToTheme(designSystem: DesignSystem, configs: ConfigFi
 
     designSystem.theme.add(`--${name}`, value as any, {
       isInline: true,
-      isReference: false,
+      isReference: true,
     })
   }
 

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1292,6 +1292,68 @@ describe('Parsing themes values from CSS', () => {
       }"
     `)
   })
+
+  test('plugin theme values can override CSS theme values and behave as inline reference', async () => {
+    let { build } = await compile(
+      css`
+        @theme {
+          --color-red: red;
+          --color-orange: orange;
+        }
+        @plugin "my-plugin";
+      `,
+      {
+        loadPlugin: async () => {
+          return plugin(({}) => {}, {
+            theme: {
+              extend: {
+                colors: {
+                  orange: '#f28500',
+                },
+              },
+            },
+          })
+        },
+      },
+    )
+
+    expect(optimizeCss(build([])).trim()).toMatchInlineSnapshot(`
+      ":root {
+        --color-red: red;
+      }"
+    `)
+  })
+
+  test('config theme values can override CSS theme values and behave as inline reference', async () => {
+    let { build } = await compile(
+      css`
+        @theme {
+          --color-red: red;
+          --color-orange: orange;
+        }
+        @config "./my-config.js";
+      `,
+      {
+        loadConfig: async () => {
+          return {
+            theme: {
+              extend: {
+                colors: {
+                  orange: '#f28500',
+                },
+              },
+            },
+          }
+        },
+      },
+    )
+
+    expect(optimizeCss(build([])).trim()).toMatchInlineSnapshot(`
+      ":root {
+        --color-red: red;
+      }"
+    `)
+  })
 })
 
 describe('plugins', () => {

--- a/packages/tailwindcss/src/theme.ts
+++ b/packages/tailwindcss/src/theme.ts
@@ -2,10 +2,17 @@ import { escape } from './utils/escape'
 
 export class Theme {
   constructor(
-    private values = new Map<string, { value: string; isReference: boolean; isInline: boolean }>(),
+    private values = new Map<
+      string,
+      { value: string; isReference: boolean; isInline: boolean; isDefault: boolean }
+    >(),
   ) {}
 
-  add(key: string, value: string, { isReference = false, isInline = false } = {}): void {
+  add(
+    key: string,
+    value: string,
+    { isReference = false, isInline = false, isDefault = false } = {},
+  ): void {
     if (key.endsWith('-*')) {
       if (value !== 'initial') {
         throw new Error(`Invalid theme value \`${value}\` for namespace \`${key}\``)
@@ -17,10 +24,15 @@ export class Theme {
       }
     }
 
+    if (isDefault) {
+      let existing = this.values.get(key)
+      if (existing && !existing.isDefault) return
+    }
+
     if (value === 'initial') {
       this.values.delete(key)
     } else {
-      this.values.set(key, { value, isReference, isInline })
+      this.values.set(key, { value, isReference, isInline, isDefault })
     }
   }
 

--- a/packages/tailwindcss/theme.css
+++ b/packages/tailwindcss/theme.css
@@ -1,4 +1,4 @@
-@theme {
+@theme default {
   /* Defaults */
   --default-transition-duration: 150ms;
   --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);


### PR DESCRIPTION
This PR adds a new `default` option to `@theme` to make it possible for plugins/JS config files to override default theme values, and also ensures that the final set of CSS variables we output takes into account any theme values added by plugins/JS config files.

---

Previously, if you were using the default theme but also had a JS config file that overrode any of those defaults like this:

```js
// ./tailwind.config.js
export default {
  theme: {
    extend: {
      colors: {
        red: {
          '500': 'tomato',
        },
      }
    }
  }
}
```

…then utilities like `text-red-500` would correctly use `color: tomato`, but the `--color-red-500` CSS variable would still be set to the default value:

```css
:root {
  --color-red-500: #ef4444;
}
```

This feels like a straight-up bug — if `#ef4444` is not part of your design system because you've overridden it, it shouldn't show up in your set of CSS variables anywhere.

So this PR fixes this issue by making sure we don't print the final set of CSS variables until all of your plugins and config files have had a chance to update the theme.

---

The second issue is that we realized people have different expectations about how plugin/config theme values should interact with Tailwind's _default_ theme vs. explicitly user-configured theme values.

Take this setup for instance:

```css
@import "tailwindcss";
@config "./tailwind.config.js";
```

If `tailwind.config.js` overrides `red-500` to be `tomato`, you'd expect `text-red-500` to actually be `tomato`, not the default `#ef4444` color.

But in this setup:

```css
@import "tailwindcss";
@config "./tailwind.config.js";
@theme {
  --color-red-500: #f00;
}
```

…you'd expect `text-red-500` to be `#f00`. This is despite the fact that currently in Tailwind there is no difference here — they are both just `@theme` blocks, one just happens to be coming from an imported file (`@import "tailwindcss"`).

So to resolve this ambiguity, I've added a `default` option to `@theme` for explicitly registering theme values as "defaults" that are safe to override with plugin/JS config theme values:

```css
@import "tailwindcss";
@config "./tailwind.config.js";
@theme default {
  --color-red-500: #f00;
}
```

Now `text-red-500` would be `tomato` here as per the config file.

This API is not something users are generally going to interact with — they will almost never want to use `default` explicitly. But in this PR I've updated the default theme we ship with to include `default` so that it interacts in a more intuitive way with plugins and JS config files.

---

Finally, this PR makes sure all theme values registered by plugins/configs are registered with `isReference: true` to make sure they do not end up in the final CSS at all.

This is important to make sure that the super weird shit we used to do in configs in v3 doesn't get translated into nonsense variables that pollute your output (hello typography plugin I'm looking at you).

If we don't do this, you'll end up with CSS variables like this:

```css
:root {
  --typography-sm-css-blockquote-padding-inline-start: 1.25em;
}
```

Preventing theme values registered in plugins/configs from outputting CSS values also serves the secondary purpose of nudging users to migrate to the CSS config if they do want CSS variables for their theme values.