### PR TITLE
Integration tests: Fix Windows flake for Vite watch mode

### DIFF
--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -317,21 +317,20 @@ import {
 
         await fs.expectFileToContain(filename, [candidate`underline`, candidate`flex`])
 
-        await new Promise((resolve) => setTimeout(resolve, 1000))
-
-        // Updates are additive and cause new candidates to be added.
-        await fs.write(
-          'project-a/index.html',
-          html`
-            <head>
-              <link rel="stylesheet" href="./src/index.css" />
-            </head>
-            <body>
-              <div class="underline m-2">Hello, world!</div>
-            </body>
-          `,
-        )
         await retryAssertion(async () => {
+          // Updates are additive and cause new candidates to be added.
+          await fs.write(
+            'project-a/index.html',
+            html`
+              <head>
+                <link rel="stylesheet" href="./src/index.css" />
+              </head>
+              <body>
+                <div class="underline m-2">Hello, world!</div>
+              </body>
+            `,
+          )
+
           let files = await fs.glob('project-a/dist/**/*.css')
           expect(files).toHaveLength(1)
           let [, css] = files[0]


### PR DESCRIPTION
I noticed the Windows integration tests for Vite's `watch` mode have been flaky. Moving the file write into the retrying assertion callback seems to fix it and allows us to get rid of the arbitrary timeout (I don't remember that I ever added this in the first place 😅 ).