### PR TITLE
Add integration test for Vite CSS module support

### DIFF
--- a/integrations/cli/config.test.ts
+++ b/integrations/cli/config.test.ts
@@ -99,7 +99,7 @@ test(
       'index.html': html`
         <div class="text-primary"></div>
       `,
-      'tailwind.config.ts': js`
+      'tailwind.config.ts': ts`
         export default {
           theme: {
             extend: {

--- a/integrations/cli/config.test.ts
+++ b/integrations/cli/config.test.ts
@@ -1,4 +1,4 @@
-import { candidate, css, html, js, json, test } from '../utils'
+import { candidate, css, html, js, json, test, ts } from '../utils'
 
 test(
   'Config files (CJS)',

--- a/integrations/vite/css-modules.test.ts
+++ b/integrations/vite/css-modules.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect } from 'vitest'
 import { css, html, test, ts, txt } from '../utils'
-;['postcss', 'lightningcss'].forEach((transformer) => {
+
+for (let transformer of ['postcss', 'lightningcss']) {
   describe(transformer, () => {
     test(
       `dev mode`,
@@ -65,4 +66,4 @@ import { css, html, test, ts, txt } from '../utils'
       },
     )
   })
-})
+}

--- a/integrations/vite/css-modules.test.ts
+++ b/integrations/vite/css-modules.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect } from 'vitest'
+import { css, html, test, ts, txt } from '../utils'
+;['postcss', 'lightningcss'].forEach((transformer) => {
+  describe(transformer, () => {
+    test(
+      `dev mode`,
+      {
+        fs: {
+          'package.json': txt`
+            {
+              "type": "module",
+              "dependencies": {
+                "@tailwindcss/vite": "workspace:^",
+                "tailwindcss": "workspace:^"
+              },
+              "devDependencies": {
+                ${transformer === 'lightningcss' ? `"lightningcss": "^1.26.0",` : ''}
+                "vite": "^5.3.5"
+              }
+            }
+          `,
+          'vite.config.ts': ts`
+            import tailwindcss from '@tailwindcss/vite'
+            import { defineConfig } from 'vite'
+
+            export default defineConfig({
+              css: ${transformer === 'postcss' ? '{}' : "{ transformer: 'lightningcss' }"},
+              build: { cssMinify: false },
+              plugins: [tailwindcss()],
+            })
+          `,
+          'index.html': html`
+            <head>
+              <script type="module" src="/src/component.ts"></script>
+            </head>
+            <body>
+              <div id="root" />
+            </body>
+          `,
+          'src/component.ts': ts`
+            import { foo } from './component.module.css'
+            let root = document.getElementById('root')
+            root.className = foo
+            root.innerText = 'Hello, world!'
+          `,
+          'src/component.module.css': css`
+            @import 'tailwindcss/utilities';
+
+            .foo {
+              @apply underline;
+            }
+          `,
+        },
+      },
+      async ({ exec, fs }) => {
+        await exec(`pnpm vite build`)
+
+        let files = await fs.glob('dist/**/*.css')
+        expect(files).toHaveLength(1)
+        let [filename] = files[0]
+
+        await fs.expectFileToContain(filename, [
+          /\.[^f]*_foo[^t]*text-decoration-line: underline;/gi,
+        ])
+      },
+    )
+  })
+})

--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -10,6 +10,7 @@ import {
   retryAssertion,
   test,
   ts,
+  txt,
   yaml,
 } from '../utils'
 ;['postcss', 'lightningcss'].forEach((transformer) => {
@@ -24,7 +25,7 @@ import {
             packages:
               - project-a
           `,
-          'project-a/package.json': json`
+          'project-a/package.json': txt`
             {
               "type": "module",
               "dependencies": {
@@ -101,7 +102,7 @@ import {
             packages:
               - project-a
           `,
-          'project-a/package.json': json`
+          'project-a/package.json': txt`
             {
               "type": "module",
               "dependencies": {
@@ -109,6 +110,7 @@ import {
                 "tailwindcss": "workspace:^"
               },
               "devDependencies": {
+                ${transformer === 'lightningcss' ? `"lightningcss": "^1.26.0",` : ''}
                 "vite": "^5.3.5"
               }
             }
@@ -254,7 +256,7 @@ import {
             packages:
               - project-a
           `,
-          'project-a/package.json': json`
+          'project-a/package.json': txt`
             {
               "type": "module",
               "dependencies": {
@@ -262,6 +264,7 @@ import {
                 "tailwindcss": "workspace:^"
               },
               "devDependencies": {
+                ${transformer === 'lightningcss' ? `"lightningcss": "^1.26.0",` : ''}
                 "vite": "^5.3.5"
               }
             }

--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -13,7 +13,8 @@ import {
   txt,
   yaml,
 } from '../utils'
-;['postcss', 'lightningcss'].forEach((transformer) => {
+
+for (let transformer of ['postcss', 'lightningcss']) {
   describe(transformer, () => {
     test(
       `production build`,
@@ -385,7 +386,7 @@ import {
       },
     )
   })
-})
+}
 
 test(
   `demote Tailwind roots to regular CSS files and back to Tailwind roots while restoring all candidates`,


### PR DESCRIPTION
Wanted to make sure stuff works with CSS modules for both the postcss and the lightningcss pipeline.