### PR TITLE
Improve the CLI output when nothing changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Improve the CLI output when no new classes were found ([#14351](https://github.com/tailwindlabs/tailwindcss/pull/14351))
+- Ensure there is always CLI feedback on save even when no new classes were found ([#14351](https://github.com/tailwindlabs/tailwindcss/pull/14351))
 
 ## [4.0.0-alpha.23] - 2024-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Improve the CLI output when no new classes were found ([#14351](https://github.com/tailwindlabs/tailwindcss/pull/14351))
 
 ## [4.0.0-alpha.23] - 2024-09-05
 

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -236,9 +236,13 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
           else if (rebuildStrategy === 'incremental') {
             let newCandidates = scanner.scanFiles(changedFiles)
 
-            // No candidates found which means we don't need to rebuild. This can
-            // happen if a file is detected but doesn't match any of the globs.
-            if (newCandidates.length <= 0) return
+            // No new candidates found which means we don't need to write to
+            // disk, and can return early.
+            if (newCandidates.length <= 0) {
+              let end = process.hrtime.bigint()
+              eprintln(`Done in ${formatDuration(end - start)}`)
+              return
+            }
 
             compiledCss = compiler.build(newCandidates)
           }


### PR DESCRIPTION
When we observe that no new candidates were found, then we can return early because nothing really changed. There is also no need to re-optimize (use Lightning CSS) in this case.

But this had a side effect that when no new candidates were detected, that you didn't see any output either. This feels like nothing is working from a DX perspective.

Typically you are changing things, so it's not really a problem. But the moment you use a class that already existed (e.g.: in another file) you also don't get any output because we have a shared cache.

This PR solves that by always showing the output. But it still doesn't write to disk if nothing changed.