### PR TITLE
Allow configs to override default CSS theme values in `theme()` function provided to plugins and configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure there is always CLI feedback on save even when no new classes were found ([#14351](https://github.com/tailwindlabs/tailwindcss/pull/14351))
 - Properly resolve `theme('someKey.DEFAULT')` when all `--some-key-*` keys have a suffix ([#14354](https://github.com/tailwindlabs/tailwindcss/pull/14354))
+- Make sure tuple theme values in JS configs take precedence over `@theme default` values ([#14359](https://github.com/tailwindlabs/tailwindcss/pull/14359))
 
 ## [4.0.0-alpha.23] - 2024-09-05
 

--- a/packages/tailwindcss/src/compat/config.test.ts
+++ b/packages/tailwindcss/src/compat/config.test.ts
@@ -258,13 +258,135 @@ describe('theme callbacks', () => {
       }),
     })
     expect(compiler.build(['leading-xl'])).toMatchInlineSnapshot(`
-    ":root {
-    }
-    .leading-xl {
-      line-height: 1.75rem;
-    }
-    "
-  `)
+      ":root {
+      }
+      .leading-xl {
+        line-height: 1.75rem;
+      }
+      "
+    `)
+  })
+
+  test.only('line-heights defined in fontSize tuples in a config take precedence over `@theme default` CSS values (2)', async ({
+    expect,
+  }) => {
+    let input = css`
+      @theme default {
+        --color-slate-100: #000100;
+        --color-slate-200: #000200;
+        --color-slate-300: #000300;
+      }
+      @theme {
+        --color-slate-400: #100400;
+        --color-slate-500: #100500;
+      }
+      @tailwind utilities;
+      @config "./config.js";
+      @plugin "./plugin.js";
+    `
+
+    let compiler = await compile(input, {
+      loadConfig: async () => ({
+        theme: {
+          extend: {
+            colors: {
+              slate: {
+                200: '#200200',
+                400: '#200400',
+                600: '#200600',
+              },
+            },
+            hoverColors: ({ theme }) => theme('colors'),
+          },
+        },
+      }),
+
+      loadPlugin: async () => {
+        return plugin(({ matchUtilities, theme }) => {
+          matchUtilities(
+            {
+              'hover-bg': (value) => {
+                return {
+                  '&:hover': {
+                    backgroundColor: value,
+                  },
+                }
+              },
+            },
+            {
+              values: theme('hoverColors'),
+            },
+          )
+        })
+      },
+    })
+    expect(
+      compiler.build([
+        'bg-slate-100',
+        'bg-slate-200',
+        'bg-slate-300',
+        'bg-slate-400',
+        'bg-slate-500',
+        'bg-slate-600',
+        'hover-bg-slate-100',
+        'hover-bg-slate-200',
+        'hover-bg-slate-300',
+        'hover-bg-slate-400',
+        'hover-bg-slate-500',
+        'hover-bg-slate-600',
+      ]),
+    ).toMatchInlineSnapshot(`
+      ":root {
+        --color-slate-100: #000100;
+        --color-slate-300: #000300;
+        --color-slate-400: #100400;
+        --color-slate-500: #100500;
+      }
+      .bg-slate-100 {
+        background-color: var(--color-slate-100, #000100);
+      }
+      .bg-slate-200 {
+        background-color: #200200;
+      }
+      .bg-slate-300 {
+        background-color: var(--color-slate-300, #000300);
+      }
+      .bg-slate-400 {
+        background-color: var(--color-slate-400, #100400);
+      }
+      .bg-slate-500 {
+        background-color: var(--color-slate-500, #100500);
+      }
+      .bg-slate-600 {
+        background-color: #200600;
+      }
+      .hover-bg-slate-100 {
+        &:hover {
+          background-color: #000100;
+        }
+      }
+      .hover-bg-slate-200 {
+        &:hover {
+          background-color: #200200;
+        }
+      }
+      .hover-bg-slate-300 {
+        &:hover {
+          background-color: #000300;
+        }
+      }
+      .hover-bg-slate-400 {
+        &:hover {
+          background-color: #100400;
+        }
+      }
+      .hover-bg-slate-500 {
+        &:hover {
+          background-color: #100500;
+        }
+      }
+      "
+    `)
   })
 })
 

--- a/packages/tailwindcss/src/compat/config.test.ts
+++ b/packages/tailwindcss/src/compat/config.test.ts
@@ -267,10 +267,49 @@ describe('theme callbacks', () => {
       "
     `)
   })
+})
 
-  test('line-heights defined in fontSize tuples in a config take precedence over `@theme default` CSS values (2)', async ({
-    expect,
-  }) => {
+describe('theme overrides order', () => {
+  test('user theme > js config > default theme', async ({ expect }) => {
+    let input = css`
+      @theme default {
+        --color-red: red;
+      }
+      @theme {
+        --color-blue: blue;
+      }
+      @tailwind utilities;
+      @config "./config.js";
+    `
+
+    let compiler = await compile(input, {
+      loadConfig: async () => ({
+        theme: {
+          extend: {
+            colors: {
+              red: 'very-red',
+              blue: 'very-blue',
+            },
+          },
+        },
+      }),
+    })
+
+    expect(compiler.build(['bg-red', 'bg-blue'])).toMatchInlineSnapshot(`
+      ":root {
+        --color-blue: blue;
+      }
+      .bg-blue {
+        background-color: var(--color-blue, blue);
+      }
+      .bg-red {
+        background-color: very-red;
+      }
+      "
+    `)
+  })
+
+  test('user theme > js config > default theme (with nested object)', async ({ expect }) => {
     let input = css`
       @theme default {
         --color-slate-100: #000100;
@@ -388,47 +427,6 @@ describe('theme callbacks', () => {
         &:hover {
           background-color: #200600;
         }
-      }
-      "
-    `)
-  })
-
-  test('line-heights defined in fontSize tuples in a config take precedence over `@theme default` CSS values (3)', async ({
-    expect,
-  }) => {
-    let input = css`
-      @theme default {
-        --color-red: red;
-      }
-      @theme {
-        --color-blue: blue;
-      }
-      @tailwind utilities;
-      @config "./config.js";
-    `
-
-    let compiler = await compile(input, {
-      loadConfig: async () => ({
-        theme: {
-          extend: {
-            colors: {
-              red: 'very-red',
-              blue: 'very-blue',
-            },
-          },
-        },
-      }),
-    })
-
-    expect(compiler.build(['bg-red', 'bg-blue'])).toMatchInlineSnapshot(`
-      ":root {
-        --color-blue: blue;
-      }
-      .bg-blue {
-        background-color: var(--color-blue, blue);
-      }
-      .bg-red {
-        background-color: very-red;
       }
       "
     `)

--- a/packages/tailwindcss/src/compat/config.test.ts
+++ b/packages/tailwindcss/src/compat/config.test.ts
@@ -230,6 +230,44 @@ test('Variants in CSS overwrite variants from plugins', async ({ expect }) => {
   `)
 })
 
+describe('theme callbacks', () => {
+  test('line-heights defined in fontSize tuples in a config take precedence over `@theme default` CSS values', async ({
+    expect,
+  }) => {
+    let input = css`
+      @theme default {
+        --font-size-xl: 1.25rem;
+        --font-size-xl--line-height: 1.5rem;
+      }
+      @tailwind utilities;
+      @config "./config.js";
+    `
+
+    let compiler = await compile(input, {
+      loadConfig: async () => ({
+        theme: {
+          extend: {
+            fontSize: {
+              xl: ['1.25rem', { lineHeight: '1.75rem' }],
+            },
+            lineHeight: ({ theme }) => ({
+              xl: theme('fontSize.xl[1].lineHeight'),
+            }),
+          },
+        },
+      }),
+    })
+    expect(compiler.build(['leading-xl'])).toMatchInlineSnapshot(`
+    ":root {
+    }
+    .leading-xl {
+      line-height: 1.75rem;
+    }
+    "
+  `)
+  })
+})
+
 describe('default font family compatibility', () => {
   test('overriding `fontFamily.sans` sets `--default-font-family`', async ({ expect }) => {
     let input = css`

--- a/packages/tailwindcss/src/compat/config/deep-merge.ts
+++ b/packages/tailwindcss/src/compat/config/deep-merge.ts
@@ -10,7 +10,8 @@ export function isPlainObject<T>(value: T): value is T & Record<keyof T, unknown
 export function deepMerge<T extends object>(
   target: T,
   sources: (Partial<T> | null | undefined)[],
-  customizer: (a: any, b: any) => any,
+  customizer: (a: any, b: any, keypath: (keyof T)[]) => any,
+  parentPath: (keyof T)[] = [],
 ) {
   type Key = keyof T
   type Value = T[Key]
@@ -21,14 +22,20 @@ export function deepMerge<T extends object>(
     }
 
     for (let k of Reflect.ownKeys(source) as Key[]) {
-      let merged = customizer(target[k], source[k])
+      let currentParentPath = [...parentPath, k]
+      let merged = customizer(target[k], source[k], currentParentPath)
 
       if (merged !== undefined) {
         target[k] = merged
       } else if (!isPlainObject(target[k]) || !isPlainObject(source[k])) {
         target[k] = source[k] as Value
       } else {
-        target[k] = deepMerge({}, [target[k], source[k]], customizer) as Value
+        target[k] = deepMerge(
+          {},
+          [target[k], source[k]],
+          customizer,
+          currentParentPath as any,
+        ) as Value
       }
     }
   }

--- a/packages/tailwindcss/src/compat/flatten-color-palette.ts
+++ b/packages/tailwindcss/src/compat/flatten-color-palette.ts
@@ -1,0 +1,19 @@
+type Colors = {
+  [key: string | number]: string | Colors
+}
+
+export function flattenColorPalette(colors: Colors) {
+  let result: Record<string, string> = {}
+
+  for (let [root, children] of Object.entries(colors ?? {})) {
+    if (typeof children === 'object' && children !== null) {
+      for (let [parent, value] of Object.entries(flattenColorPalette(children))) {
+        result[`${root}${parent === 'DEFAULT' ? '' : `-${parent}`}`] = value
+      }
+    } else {
+      result[root] = children
+    }
+  }
+
+  return result
+}

--- a/packages/tailwindcss/src/compat/plugin-functions.ts
+++ b/packages/tailwindcss/src/compat/plugin-functions.ts
@@ -59,6 +59,9 @@ export function createThemeFn(
         for (let key in cssValue) {
           if (key === '__CSS_VALUES__') continue
 
+          // If the value is coming from a default source (`@theme default`),
+          // then we keep the value from the js config (which is also a
+          // default source, but wins from the built in defaults).
           if (
             configValue?.__CSS_VALUES__?.[key] & ThemeOptions.DEFAULT &&
             get(configValueCopy, key.split('-')) !== undefined
@@ -66,6 +69,7 @@ export function createThemeFn(
             continue
           }
 
+          // CSS values from `@theme` win over values from the config
           configValueCopy[key] = cssValue[key]
         }
 
@@ -195,7 +199,8 @@ function readFromCss(
     return [obj.DEFAULT as string, options.DEFAULT ?? 0] as const
   }
 
-  //
+  // Attach the CSS values to the object for later use. This object could be
+  // mutated by the user so we want to keep the original CSS values around.
   obj.__CSS_VALUES__ = options
 
   return [obj, options] as const

--- a/packages/tailwindcss/src/compat/plugin-functions.ts
+++ b/packages/tailwindcss/src/compat/plugin-functions.ts
@@ -60,8 +60,8 @@ export function createThemeFn(
           if (key === '__CSS_VALUES__') continue
 
           // If the value is coming from a default source (`@theme default`),
-          // then we keep the value from the js config (which is also a
-          // default source, but wins from the built in defaults).
+          // then we keep the value from the JS config (which is also a
+          // default source, but wins over the built-in defaults).
           if (
             configValue?.__CSS_VALUES__?.[key] & ThemeOptions.DEFAULT &&
             get(configValueCopy, key.split('-')) !== undefined

--- a/packages/tailwindcss/src/compat/plugin-functions.ts
+++ b/packages/tailwindcss/src/compat/plugin-functions.ts
@@ -211,14 +211,14 @@ function readFromCss(
   // the `DEFAULT` key from the list of possible values. If there is no
   // `DEFAULT` in the list, there is no match so return `null`.
   if (path[path.length - 1] === 'DEFAULT') {
-    return [(obj?.DEFAULT ?? null) as any, optionsObj.DEFAULT ?? 0] as const
+    return [(obj?.DEFAULT ?? null) as any, optionsObj.DEFAULT ?? ThemeOptions.NONE] as const
   }
 
   // The request looked like `theme('animation.spin')` and was turned into a
   // lookup for `--animation-spin-*` which had only one entry which means it
   // should be returned directly.
   if ('DEFAULT' in obj && Object.keys(obj).length === 1) {
-    return [obj.DEFAULT as any, optionsObj.DEFAULT ?? 0] as const
+    return [obj.DEFAULT as any, optionsObj.DEFAULT ?? ThemeOptions.NONE] as const
   }
 
   // Attach the CSS values to the object for later use. This object could be

--- a/packages/tailwindcss/src/compat/plugin-functions.ts
+++ b/packages/tailwindcss/src/compat/plugin-functions.ts
@@ -197,22 +197,9 @@ function readFromCss(
   // We have to turn the map into object-like structure for v3 compatibility
   let obj: Record<string, unknown> = {}
   let optionsObj: Record<string, number> = {}
-  let useNestedObjects = false // paths.some((path) => nestedKeys.has(path))
 
   for (let [key, value] of map) {
-    key = key ?? 'DEFAULT'
-
-    let path: string[] = []
-    let splitIndex = key.indexOf('-')
-
-    if (useNestedObjects && splitIndex !== -1) {
-      path.push(key.slice(0, splitIndex))
-      path.push(key.slice(splitIndex + 1))
-    } else {
-      path.push(key)
-    }
-
-    set(obj, path, value)
+    set(obj, [key ?? 'DEFAULT'], value)
   }
 
   for (let [key, value] of options) {

--- a/packages/tailwindcss/src/plugin-api.test.ts
+++ b/packages/tailwindcss/src/plugin-api.test.ts
@@ -524,6 +524,7 @@ describe('theme', async () => {
     })
 
     expect(fn).toHaveBeenCalledWith({
+      __CSS_VALUES__: { bounce: 2, spin: 2 },
       spin: 'spin 1s linear infinite',
       bounce: 'bounce 1s linear infinite',
     })

--- a/packages/tailwindcss/src/theme.ts
+++ b/packages/tailwindcss/src/theme.ts
@@ -69,6 +69,10 @@ export class Theme {
     return ((this.values.get(key)?.options ?? 0) & ThemeOptions.DEFAULT) === ThemeOptions.DEFAULT
   }
 
+  getOptions(key: string) {
+    return this.values.get(key)?.options ?? 0
+  }
+
   entries() {
     return this.values.entries()
   }

--- a/packages/tailwindcss/src/theme.ts
+++ b/packages/tailwindcss/src/theme.ts
@@ -66,11 +66,11 @@ export class Theme {
   }
 
   hasDefault(key: string): boolean {
-    return ((this.values.get(key)?.options ?? 0) & ThemeOptions.DEFAULT) === ThemeOptions.DEFAULT
+    return (this.getOptions(key) & ThemeOptions.DEFAULT) === ThemeOptions.DEFAULT
   }
 
   getOptions(key: string) {
-    return this.values.get(key)?.options ?? 0
+    return this.values.get(key)?.options ?? ThemeOptions.NONE
   }
 
   entries() {


### PR DESCRIPTION
Previously, given the following CSS and configuration:

```css
/* app.css */

@theme default {
  --font-size-base: 1.25rem;
  --font-size-base--line-height: 1.5rem;
}
@tailwind utilities;
@config "./config.js";
```

```js
// config.js

export default {
  theme: {
    fontSize: {
      // …
      base: ['1rem', { lineHeight: '1.75rem' }],
    },

    // …
  },
};
```

When a config or a plugin asked for the value of `theme(fontSize.base)` like so:

```js
// config.js
export default {
  theme: {
    // …

    typography: ({ theme }) => ({
      css: {
        '[class~="lead"]': {
          fontSize: theme('fontSize.base')[0],
          ...theme('fontSize.base')[1],
        },
      }
    }),
  },
};
```

We would instead pull the values from the CSS theme even through they're marked with `@theme default`. This would cause the incorrect font size and line height to be used resulting in something like this (in the case of the typography plugin with custom styles):

  ```css
  .prose [class~="lead"] {
    font-size: 1.25rem;
    line-height: 1.5rem;
  }
  ```

After this change we'll now pull the values from the appropriate place (the config in this case) and the correct font size and line height will be used:

  ```css
  .prose [class~="lead"] {
    font-size: 1rem;
    line-height: 1.75rem;
  }
  ```

This will work even when some values are overridden in the CSS theme:

  ```css
  /* app.css */
  @theme default {
    --font-size-base: 1.25rem;
    --font-size-base--line-height: 1.5rem;
  }
  @theme {
    --font-size-base: 2rem;
  }
  @tailwind utilities;
  @config "./config.js";
  ```

which would result in the following CSS:

  ```css
  .prose [class~="lead"] {
    font-size: 2rem;
    line-height: 1.75rem;
  }
  ```
