### PR TITLE
Export `Config` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support CSS `theme()` functions inside other `@custom-media`, `@container`, and `@supports` rules ([#14358])(https://github.com/tailwindlabs/tailwindcss/pull/14358)
+- Export `Config` type from `tailwindcss` for JS config files ([#14360])(https://github.com/tailwindlabs/tailwindcss/pull/14360)
 
 ### Fixed
 

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -9,6 +9,7 @@ import { buildDesignSystem, type DesignSystem } from './design-system'
 import { registerPlugins, type CssPluginOptions, type Plugin } from './plugin-api'
 import { Theme, ThemeOptions } from './theme'
 import { segment } from './utils/segment'
+export type Config = UserConfig
 
 const IS_VALID_UTILITY_NAME = /^[a-z][a-zA-Z0-9/%._-]*$/
 


### PR DESCRIPTION
Right now the following does not work and instead produces a type error:

```
import { type Config } from 'tailwindcss'

export default {
  // … config here
} satisfies Config
```

We were not exporting a `Config` type but thankfully this already exists in the codebase so we just need to export it.

It does _not_ have all properties of an existing config as not all features have been implemented (or in some cases necessary / relevant for v4).

Notably missing are:
- `important`
- `prefix`
- `separator`
- `safelist`
- `blocklist`
- `future`
- `experimental`
- `corePlugins`

Also, explicit keys for theme are not currently specified but we should probably bring this back even if just as an auto-complete aid.