### PR TITLE
Allow `anchor-size(…)` in arbitrary values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support `borderRadius.*` as an alias for `--radius-*` when using dot notation inside the `theme()` function ([#14436](https://github.com/tailwindlabs/tailwindcss/pull/14436))
 - Ensure individual variants from groups are always sorted earlier than stacked variants from the same groups ([#14431](https://github.com/tailwindlabs/tailwindcss/pull/14431))
+- Allow `anchor-size(…)` in arbitrary values ([#14394](https://github.com/tailwindlabs/tailwindcss/pull/14394))
 
 ## [4.0.0-alpha.24] - 2024-09-11
 

--- a/packages/tailwindcss/src/utils/decode-arbitrary-value.test.ts
+++ b/packages/tailwindcss/src/utils/decode-arbitrary-value.test.ts
@@ -93,6 +93,7 @@ describe('adds spaces around math operators', () => {
       'radial-gradient(calc(1+2)),radial-gradient(calc(1+2))',
       'radial-gradient(calc(1 + 2)),radial-gradient(calc(1 + 2))',
     ],
+    ['w-[calc(anchor-size(width)+8px)]', 'w-[calc(anchor-size(width) + 8px)]'],
 
     [
       '[content-start]_calc(100%-1px)_[content-end]_minmax(1rem,1fr)',

--- a/packages/tailwindcss/src/utils/decode-arbitrary-value.test.ts
+++ b/packages/tailwindcss/src/utils/decode-arbitrary-value.test.ts
@@ -94,6 +94,7 @@ describe('adds spaces around math operators', () => {
       'radial-gradient(calc(1 + 2)),radial-gradient(calc(1 + 2))',
     ],
     ['w-[calc(anchor-size(width)+8px)]', 'w-[calc(anchor-size(width) + 8px)]'],
+    ['w-[calc(anchor-size(foo(bar))+8px)]', 'w-[calc(anchor-size(foo(bar)) + 8px)]'],
 
     [
       '[content-start]_calc(100%-1px)_[content-end]_minmax(1rem,1fr)',

--- a/packages/tailwindcss/src/utils/math-operators.ts
+++ b/packages/tailwindcss/src/utils/math-operators.ts
@@ -21,6 +21,7 @@ const MATH_FUNCTIONS = [
 ]
 
 const KNOWN_DASHED_FUNCTIONS = ['anchor-size']
+const DASHED_FUNCTIONS_REGEX = new RegExp(`(${KNOWN_DASHED_FUNCTIONS.join('|')})\\(`, 'g')
 
 export function hasMathFn(input: string) {
   return input.indexOf('(') !== -1 && MATH_FUNCTIONS.some((fn) => input.includes(`${fn}(`))
@@ -39,10 +40,13 @@ export function addWhitespaceAroundMathOperators(input: string) {
 
   // Replace known functions with a placeholder
   let hasKnownFunctions = false
-  input = input.replace(new RegExp(`(${KNOWN_DASHED_FUNCTIONS.join('|')})\\(`, 'g'), (_, fn) => {
-    hasKnownFunctions = true
-    return `$${KNOWN_DASHED_FUNCTIONS.indexOf(fn)}$(`
-  })
+  if (KNOWN_DASHED_FUNCTIONS.some((fn) => input.includes(fn))) {
+    DASHED_FUNCTIONS_REGEX.lastIndex = 0
+    input = input.replace(DASHED_FUNCTIONS_REGEX, (_, fn) => {
+      hasKnownFunctions = true
+      return `$${KNOWN_DASHED_FUNCTIONS.indexOf(fn)}$(`
+    })
+  }
 
   let result = ''
   let formattable: boolean[] = []
@@ -160,7 +164,7 @@ export function addWhitespaceAroundMathOperators(input: string) {
   }
 
   if (hasKnownFunctions) {
-    return result.replace(/\$(\d+)\$/g, (_, idx) => KNOWN_DASHED_FUNCTIONS[idx])
+    return result.replace(/\$(\d+)\$/g, (fn, idx) => KNOWN_DASHED_FUNCTIONS[idx] ?? fn)
   }
 
   return result

--- a/packages/tailwindcss/src/utils/math-operators.ts
+++ b/packages/tailwindcss/src/utils/math-operators.ts
@@ -20,6 +20,8 @@ const MATH_FUNCTIONS = [
   'round',
 ]
 
+const KNOWN_DASHED_FUNCTIONS = ['anchor-size']
+
 export function hasMathFn(input: string) {
   return input.indexOf('(') !== -1 && MATH_FUNCTIONS.some((fn) => input.includes(`${fn}(`))
 }
@@ -34,6 +36,13 @@ export function addWhitespaceAroundMathOperators(input: string) {
   if (!MATH_FUNCTIONS.some((fn) => input.includes(fn))) {
     return input
   }
+
+  // Replace known functions with a placeholder
+  let hasKnownFunctions = false
+  input = input.replace(new RegExp(`(${KNOWN_DASHED_FUNCTIONS.join('|')})\\(`, 'g'), (_, fn) => {
+    hasKnownFunctions = true
+    return `$${KNOWN_DASHED_FUNCTIONS.indexOf(fn)}$(`
+  })
 
   let result = ''
   let formattable: boolean[] = []
@@ -148,6 +157,10 @@ export function addWhitespaceAroundMathOperators(input: string) {
     else {
       result += char
     }
+  }
+
+  if (hasKnownFunctions) {
+    return result.replace(/\$(\d+)\$/g, (_, idx) => KNOWN_DASHED_FUNCTIONS[idx])
   }
 
   return result

--- a/packages/tailwindcss/src/utils/math-operators.ts
+++ b/packages/tailwindcss/src/utils/math-operators.ts
@@ -1,4 +1,4 @@
-const mathFunctions = [
+const MATH_FUNCTIONS = [
   'calc',
   'min',
   'max',
@@ -21,7 +21,7 @@ const mathFunctions = [
 ]
 
 export function hasMathFn(input: string) {
-  return input.indexOf('(') !== -1 && mathFunctions.some((fn) => input.includes(`${fn}(`))
+  return input.indexOf('(') !== -1 && MATH_FUNCTIONS.some((fn) => input.includes(`${fn}(`))
 }
 
 export function addWhitespaceAroundMathOperators(input: string) {
@@ -31,7 +31,7 @@ export function addWhitespaceAroundMathOperators(input: string) {
   }
 
   // Bail early if there are no math functions in the input
-  if (!mathFunctions.some((fn) => input.includes(fn))) {
+  if (!MATH_FUNCTIONS.some((fn) => input.includes(fn))) {
     return input
   }
 
@@ -64,7 +64,7 @@ export function addWhitespaceAroundMathOperators(input: string) {
       let fn = input.slice(start, i)
 
       // This is a known math function so start formatting
-      if (mathFunctions.includes(fn)) {
+      if (MATH_FUNCTIONS.includes(fn)) {
         formattable.unshift(true)
         continue
       }


### PR DESCRIPTION
This PR fixes an issue where using `anchor-size` in arbitrary values resulted in the incorrect css.

Input: `w-[calc(anchor-size(width)+8px)]`
Output:
```css
.w-\[calc\(anchor-size\(width\)\+8px\)\] {
  width: calc(anchor - size(width) + 8px);
}
```

This PR fixes that, by generating the correct CSS:
```css
.w-\[calc\(anchor-size\(width\)\+8px\)\] {
  width: calc(anchor-size(width) + 8px);
}
```

