### PR TITLE
Don't assert on mangled CSS names

### DIFF
--- a/integrations/vite/css-modules.test.ts
+++ b/integrations/vite/css-modules.test.ts
@@ -60,9 +60,7 @@ for (let transformer of ['postcss', 'lightningcss']) {
         expect(files).toHaveLength(1)
         let [filename] = files[0]
 
-        await fs.expectFileToContain(filename, [
-          /\.[^f]*_foo[^t]*text-decoration-line: underline;/gi,
-        ])
+        await fs.expectFileToContain(filename, [/text-decoration-line: underline;/gi])
       },
     )
   })


### PR DESCRIPTION
This PR fixes an issue with the regex rule I oh-so-carefully constructed that would fail the regex when the _randomness_ part contains a `t` 😶‍🌫️.