### PR TITLE
Pin rust toolchain to work around Windows regression

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.80.1"
+profile = "default"


### PR DESCRIPTION
This PR works around a current regression in the Rust toolchain that caused our Windows workers to start failing with:

```
    Finished `test` profile [unoptimized + debuginfo] target(s) in 32.63s
     Running unittests src\lib.rs (target\debug\deps\tailwind_oxide-ce6a5d43a3798437.exe)
Load Node-API [napi_get_last_error_info] from host runtime failed: GetProcAddress failed
fatal runtime error: thread::set_current should only be called once per thread
Load Node-API [napi_get_uv_event_loop] from host runtime failed: GetProcAddress failed
Load Node-API [napi_fatal_exception] from host runtime failed: GetProcAddress failed
Load Node-API [napi_create_threadsafe_function] from host runtime failed: GetProcAddress failed
error: test failed, to rerun pass `-p tailwind-oxide --lib`
```

The workaround is to pin the rust toolchain version so that the regression isn't applied when we build on Windows in test mode.