### PR TITLE
Add ability to parse SCSS syntax

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ crates/node/index.d.ts
 crates/node/index.js
 .next
 .fingerprint
+__snapshots__/

--- a/packages/tailwindcss/src/__snapshots__/kitchen-sink.scss
+++ b/packages/tailwindcss/src/__snapshots__/kitchen-sink.scss
@@ -1,0 +1,22 @@
+@mixin prefix($property, $value, $prefixes) {
+  @each $prefix in $prefixes {
+    -#{$prefix}-#{$property}: $value;
+  }
+  #{$property}: $value;
+}
+.gray {
+  @include prefix(filter, grayscale(50%), moz webkit);
+}
+%toolbelt {
+  box-sizing: border-box;
+  border-top: 1px rgba(#000, 0.12) solid;
+  padding: 16px 0;
+  width: 100%;
+  &:hover {
+    border: 2px rgba(#000, 0.5) solid;
+  }
+}
+.action-buttons {
+  @extend %toolbelt;
+  color: #4285f4;
+}

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -416,15 +416,7 @@ export function parse(input: string) {
 
           // Attach the declaration to the parent.
           if (parent) {
-            let importantIdx = buffer.indexOf('!important', colonIdx + 1)
-            parent.nodes.push({
-              kind: 'declaration',
-              property: buffer.slice(0, colonIdx).trim(),
-              value: buffer
-                .slice(colonIdx + 1, importantIdx === -1 ? buffer.length : importantIdx)
-                .trim(),
-              important: importantIdx !== -1,
-            } satisfies Declaration)
+            parent.nodes.push(parseDeclaration(buffer, colonIdx))
           }
         }
       }

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -55,7 +55,7 @@ export function parse(input: string) {
       i += 1
     }
 
-    // Parse scss one-line comments.
+    // Parse SCSS one-line comments.
     //
     // E.g.:
     //
@@ -80,7 +80,7 @@ export function parse(input: string) {
       }
     }
 
-    // Parse scss-like hash interpolation.
+    // Parse SCSS-like hash interpolation.
     //
     // E.g.:
     // ```css


### PR DESCRIPTION
This PR adds support for parsing SCSS syntax. This will help with codemods.

Note: this does not "run" or "execute" SCSS code, it only parses it. If you are using SCSS and any of its features that aren't native to CSS (e.g.: $variables, mixins, functions, …), you will need to use a SCSS compiler to transform the SCSS.

Note: while this parse CSS comments and SCSS single-line comments, they are not in the AST yet. This will be a a separate PR for when we need it.

