### PR TITLE
Remove unnecessary inheritance properties in .description class

### DIFF
--- a/playgrounds/nextjs/app/page.module.css
+++ b/playgrounds/nextjs/app/page.module.css
@@ -8,9 +8,6 @@
 }
 
 .description {
-  display: inherit;
-  justify-content: inherit;
-  align-items: inherit;
   font-size: 0.85rem;
   max-width: var(--max-width);
   width: 100%;
@@ -110,6 +107,7 @@
 .logo {
   position: relative;
 }
+
 /* Enable hover only on non-touch devices */
 @media (hover: hover) and (pointer: fine) {
   .card:hover {


### PR DESCRIPTION
### Summary

This PR removes the `inherit` values for `display`, `justify-content`, and `align-items` in the `.description` class. These properties were redundant since the `.description` class already has default values set fro these propert