### PR TITLE
Fix stacking variant order when variants inside a group are treated as equal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Support `borderRadius.*` as an alias for `--radius-*` when using dot notation inside the `theme()` function ([#14436](https://github.com/tailwindlabs/tailwindcss/pull/14436))
+### Fixed
+
+- Fix an issue with the CSS order when stacking variants. ([#14431](https://github.com/tailwindlabs/tailwindcss/pull/14431))
 
 ## [4.0.0-alpha.24] - 2024-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix an issue with the CSS order when stacking variants. ([#14431](https://github.com/tailwindlabs/tailwindcss/pull/14431))
+- Ensure individual variants from groups are always sorted earlier than stacked variants from the same groups ([#14431](https://github.com/tailwindlabs/tailwindcss/pull/14431))
 
 ## [4.0.0-alpha.24] - 2024-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Support `borderRadius.*` as an alias for `--radius-*` when using dot notation inside the `theme()` function ([#14436](https://github.com/tailwindlabs/tailwindcss/pull/14436))
-### Fixed
-
-- Fix an issue with the CSS order when stacking variants. ([#14431](https://github.com/tailwindlabs/tailwindcss/pull/14431))
 - Ensure individual variants from groups are always sorted earlier than stacked variants from the same groups ([#14431](https://github.com/tailwindlabs/tailwindcss/pull/14431))
 
 ## [4.0.0-alpha.24] - 2024-09-11

--- a/packages/tailwindcss/src/compat/plugin-api.test.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.test.ts
@@ -1404,12 +1404,12 @@ describe('matchVariant', () => {
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
-        .potato-yellow .potato-\\[yellow\\]\\:underline {
-          text-decoration-line: underline;
-        }
-
         .potato-baked .potato-\\[baked\\]\\:flex {
           display: flex;
+        }
+
+        .potato-yellow .potato-\\[yellow\\]\\:underline {
+          text-decoration-line: underline;
         }
       }"
     `)
@@ -1435,15 +1435,15 @@ describe('matchVariant', () => {
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
-        @media (potato: yellow) {
-          .potato-\\[yellow\\]\\:underline {
-            text-decoration-line: underline;
-          }
-        }
-
         @media (potato: baked) {
           .potato-\\[baked\\]\\:flex {
             display: flex;
+          }
+        }
+
+        @media (potato: yellow) {
+          .potato-\\[yellow\\]\\:underline {
+            text-decoration-line: underline;
           }
         }
       }"
@@ -1473,18 +1473,18 @@ describe('matchVariant', () => {
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
-        @media (potato: yellow) {
-          @supports (font: bold) {
-            .potato-\\[yellow\\]\\:underline:large-potato {
-              text-decoration-line: underline;
-            }
-          }
-        }
-
         @media (potato: baked) {
           @supports (font: bold) {
             .potato-\\[baked\\]\\:flex:large-potato {
               display: flex;
+            }
+          }
+        }
+
+        @media (potato: yellow) {
+          @supports (font: bold) {
+            .potato-\\[yellow\\]\\:underline:large-potato {
+              text-decoration-line: underline;
             }
           }
         }

--- a/packages/tailwindcss/src/compat/plugin-api.test.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.test.ts
@@ -1541,10 +1541,10 @@ describe('matchVariant', () => {
           return ({ matchVariant }: PluginAPI) => {
             matchVariant('alphabet', (side) => `&${side}`, {
               values: {
-                a: '[data-value="a"]',
-                b: '[data-value="b"]',
-                c: '[data-value="c"]',
-                d: '[data-value="d"]',
+                d: '[data-order="1"]',
+                a: '[data-order="2"]',
+                c: '[data-order="3"]',
+                b: '[data-order="4"]',
               },
             })
           }
@@ -1560,19 +1560,19 @@ describe('matchVariant', () => {
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
-        .alphabet-a\\:underline[data-value="a"] {
+        .alphabet-d\\:underline[data-order="1"] {
           text-decoration-line: underline;
         }
 
-        .alphabet-b\\:underline[data-value="b"] {
+        .alphabet-a\\:underline[data-order="2"] {
           text-decoration-line: underline;
         }
 
-        .alphabet-c\\:underline[data-value="c"] {
+        .alphabet-c\\:underline[data-order="3"] {
           text-decoration-line: underline;
         }
 
-        .alphabet-d\\:underline[data-value="d"] {
+        .alphabet-b\\:underline[data-order="4"] {
           text-decoration-line: underline;
         }
       }"

--- a/packages/tailwindcss/src/compat/plugin-api.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.ts
@@ -150,10 +150,10 @@ export function buildPluginApi(
             return 0
           }
 
-          if (options && typeof options.sort === 'function') {
-            let aValue = options.values?.[a.value.value] ?? a.value.value
-            let zValue = options.values?.[z.value.value] ?? z.value.value
+          let aValue = options?.values?.[a.value.value] ?? a.value.value
+          let zValue = options?.values?.[z.value.value] ?? z.value.value
 
+          if (options && typeof options.sort === 'function') {
             return options.sort(
               { value: aValue, modifier: a.modifier?.value ?? null },
               { value: zValue, modifier: z.modifier?.value ?? null },
@@ -163,6 +163,7 @@ export function buildPluginApi(
           let aOrder = defaultOptionKeys.indexOf(a.value.value)
           let zOrder = defaultOptionKeys.indexOf(z.value.value)
 
+          if (aOrder - zOrder === 0) return aValue < zValue ? -1 : 1
           return aOrder - zOrder
         },
       )

--- a/packages/tailwindcss/src/compile.ts
+++ b/packages/tailwindcss/src/compile.ts
@@ -30,10 +30,7 @@ export function compileCandidates(
     matches.set(rawCandidate, candidates)
   }
 
-  // Sort the variants
-  let variants = sortAndGroup(designSystem.getUsedVariants(), (a, z) =>
-    designSystem.variants.compare(a, z),
-  )
+  let variants = designSystem.getUsedVariantGroups()
 
   // Create the AST
   for (let [rawCandidate, candidates] of matches) {
@@ -321,30 +318,4 @@ function getPropertySort(nodes: AstNode[]) {
   }
 
   return Array.from(propertySort).sort((a, z) => a - z)
-}
-
-/**
- * Sort an array of entries into an array-of-sets. Similar entries (where the
- * sort function returns 0) are grouped together.
- *
- * Example: [a, c, b, A]
- *
- * Becomes: [Set[a, A], Set[b], Set[c]]
- */
-function sortAndGroup<T>(entries: T[], comparator: (a: T, z: T) => number): Set<T>[] {
-  let groups: Set<T>[] = []
-  let sorted = entries.sort(comparator)
-  let prevEntry: T | undefined = undefined
-
-  for (let entry of sorted) {
-    let prevSet = groups[groups.length - 1]
-    if (prevSet && prevEntry !== undefined && comparator(prevEntry, entry) === 0) {
-      prevSet.add(entry)
-    } else {
-      prevEntry = entry
-      groups.push(new Set([entry]))
-    }
-  }
-
-  return groups
 }

--- a/packages/tailwindcss/src/compile.ts
+++ b/packages/tailwindcss/src/compile.ts
@@ -30,7 +30,7 @@ export function compileCandidates(
     matches.set(rawCandidate, candidates)
   }
 
-  let variants = designSystem.getUsedVariantGroups()
+  let variantOrderMap = designSystem.getVariantOrder()
 
   // Create the AST
   for (let [rawCandidate, candidates] of matches) {
@@ -48,8 +48,9 @@ export function compileCandidates(
         // variants used.
         let variantOrder = 0n
         for (let variant of candidate.variants) {
-          let index = variants.findIndex((inner) => inner.has(variant))
-          variantOrder |= 1n << BigInt(index)
+          let order = variantOrderMap.get(variant)
+          if (order === undefined) continue
+          variantOrder |= 1n << BigInt(order)
         }
 
         nodeSorting.set(node, {

--- a/packages/tailwindcss/src/compile.ts
+++ b/packages/tailwindcss/src/compile.ts
@@ -325,41 +325,35 @@ function getPropertySort(nodes: AstNode[]) {
 
 /**
  * Sort an array of entries into an array-of-sets. Similar entries (where the
- * sort function returns 0) are grouped together. The sort function is stable.
+ * sort function returns 0) are grouped together. The sort function is stable
+ * and uses bubble-sort
  *
  * Example:
  *
- *   [1, 4, 3, 1]
+ *   [a, c, b, A]
  *
  * Becomes:
  *
  *  [
- *    Set[1, 1],
- *    Set[3],
- *    Set[4],
+ *    Set[a, A],
+ *    Set[b],
+ *    Set[c],
  *  ]
- *
- * TODO: Make this faster.
  */
 function sortAndGroup<T>(entries: T[], comparator: (a: T, z: T) => number): Set<T>[] {
   let groups: Set<T>[] = []
-  let sorted = entries.slice().sort(comparator)
+  let sorted = entries.sort(comparator)
+  let prevEntry: T | undefined = undefined
 
   for (let entry of sorted) {
-    let prevGroup = groups[groups.length - 1]
-    if (prevGroup && comparator(first(prevGroup)!, entry) === 0) {
-      prevGroup.add(entry)
+    let prevSet = groups[groups.length - 1]
+    if (prevSet && prevEntry !== undefined && comparator(prevEntry, entry) === 0) {
+      prevSet.add(entry)
     } else {
+      prevEntry = entry
       groups.push(new Set([entry]))
     }
   }
 
   return groups
-}
-
-function first<T>(set: Set<T>): T | null {
-  for (let value of set) {
-    return value
-  }
-  return null
 }

--- a/packages/tailwindcss/src/compile.ts
+++ b/packages/tailwindcss/src/compile.ts
@@ -48,9 +48,7 @@ export function compileCandidates(
         // variants used.
         let variantOrder = 0n
         for (let variant of candidate.variants) {
-          let order = variantOrderMap.get(variant)
-          if (order === undefined) continue
-          variantOrder |= 1n << BigInt(order)
+          variantOrder |= 1n << BigInt(variantOrderMap.get(variant)!)
         }
 
         nodeSorting.set(node, {

--- a/packages/tailwindcss/src/compile.ts
+++ b/packages/tailwindcss/src/compile.ts
@@ -325,20 +325,11 @@ function getPropertySort(nodes: AstNode[]) {
 
 /**
  * Sort an array of entries into an array-of-sets. Similar entries (where the
- * sort function returns 0) are grouped together. The sort function is stable
- * and uses bubble-sort
+ * sort function returns 0) are grouped together.
  *
- * Example:
+ * Example: [a, c, b, A]
  *
- *   [a, c, b, A]
- *
- * Becomes:
- *
- *  [
- *    Set[a, A],
- *    Set[b],
- *    Set[c],
- *  ]
+ * Becomes: [Set[a, A], Set[b], Set[c]]
  */
 function sortAndGroup<T>(entries: T[], comparator: (a: T, z: T) => number): Set<T>[] {
   let groups: Set<T>[] = []

--- a/packages/tailwindcss/src/compile.ts
+++ b/packages/tailwindcss/src/compile.ts
@@ -51,7 +51,7 @@ export function compileCandidates(
         // variants used.
         let variantOrder = 0n
         for (let variant of candidate.variants) {
-          let index = variants.findIndex((g) => g.findIndex((v) => v === variant) !== -1)
+          let index = variants.findIndex((inner) => inner.has(variant))
           variantOrder |= 1n << BigInt(index)
         }
 
@@ -324,7 +324,7 @@ function getPropertySort(nodes: AstNode[]) {
 }
 
 /**
- * Sort an array of entries into arrays-of-arrays. Similar entries (where the
+ * Sort an array of entries into an array-of-sets. Similar entries (where the
  * sort function returns 0) are grouped together. The sort function is stable.
  *
  * Example:
@@ -334,25 +334,32 @@ function getPropertySort(nodes: AstNode[]) {
  * Becomes:
  *
  *  [
- *   [1, 1],
- *   [3],
- *   [4],
+ *    Set[1, 1],
+ *    Set[3],
+ *    Set[4],
  *  ]
  *
  * TODO: Make this faster.
  */
-function sortAndGroup<T>(entries: T[], comparator: (a: T, z: T) => number): T[][] {
-  let groups: T[][] = []
+function sortAndGroup<T>(entries: T[], comparator: (a: T, z: T) => number): Set<T>[] {
+  let groups: Set<T>[] = []
   let sorted = entries.slice().sort(comparator)
 
   for (let entry of sorted) {
     let prevGroup = groups[groups.length - 1]
-    if (prevGroup && comparator(prevGroup[0], entry) === 0) {
-      prevGroup.push(entry)
+    if (prevGroup && comparator(first(prevGroup)!, entry) === 0) {
+      prevGroup.add(entry)
     } else {
-      groups.push([entry])
+      groups.push(new Set([entry]))
     }
   }
 
   return groups
+}
+
+function first<T>(set: Set<T>): T | null {
+  for (let value of set) {
+    return value
+  }
+  return null
 }

--- a/packages/tailwindcss/src/design-system.ts
+++ b/packages/tailwindcss/src/design-system.ts
@@ -13,7 +13,6 @@ export type DesignSystem = {
   utilities: Utilities
   variants: Variants
 
-  candidatesToCss(classes: string[]): (string | null)[]
   getClassOrder(classes: string[]): [string, bigint | null][]
   getClassList(): ClassEntry[]
   getVariants(): VariantEntry[]
@@ -24,6 +23,9 @@ export type DesignSystem = {
 
   getUsedVariants(): ReturnType<typeof parseVariant>[]
   resolveThemeValue(path: string): string | undefined
+
+  // Used by IntelliSense
+  candidatesToCss(classes: string[]): (string | null)[]
 }
 
 export function buildDesignSystem(theme: Theme): DesignSystem {

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -1676,15 +1676,11 @@ test('not', async () => {
       display: flex;
     }
 
-    .group-not-hocus\\/parent-name\\:flex:is(:where(.group\\/parent-name):not(:hover, :focus) *) {
-      display: flex;
-    }
-
     .group-not-hocus\\:flex:is(:where(.group):not(:hover, :focus) *) {
       display: flex;
     }
 
-    .group-not-\\[\\:checked\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name):not(:checked) *) {
+    .group-not-hocus\\/parent-name\\:flex:is(:where(.group\\/parent-name):not(:hover, :focus) *) {
       display: flex;
     }
 
@@ -1692,11 +1688,11 @@ test('not', async () => {
       display: flex;
     }
 
-    .peer-not-checked\\:flex:is(:where(.peer):not(:checked) ~ *) {
+    .group-not-\\[\\:checked\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name):not(:checked) *) {
       display: flex;
     }
 
-    .peer-not-hocus\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):not(:hover, :focus) ~ *) {
+    .peer-not-checked\\:flex:is(:where(.peer):not(:checked) ~ *) {
       display: flex;
     }
 
@@ -1704,11 +1700,15 @@ test('not', async () => {
       display: flex;
     }
 
-    .peer-not-\\[\\:checked\\]\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):not(:checked) ~ *) {
+    .peer-not-hocus\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):not(:hover, :focus) ~ *) {
       display: flex;
     }
 
     .peer-not-\\[\\:checked\\]\\:flex:is(:where(.peer):not(:checked) ~ *) {
+      display: flex;
+    }
+
+    .peer-not-\\[\\:checked\\]\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):not(:checked) ~ *) {
       display: flex;
     }"
   `)
@@ -1788,15 +1788,11 @@ test('has', async () => {
       ],
     ),
   ).toMatchInlineSnapshot(`
-    ".group-has-checked\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(:checked) *) {
+    ".group-has-checked\\:flex:is(:where(.group):has(:checked) *) {
       display: flex;
     }
 
-    .group-has-checked\\:flex:is(:where(.group):has(:checked) *) {
-      display: flex;
-    }
-
-    .group-has-hocus\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(:hover, :focus) *) {
+    .group-has-checked\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(:checked) *) {
       display: flex;
     }
 
@@ -1804,7 +1800,7 @@ test('has', async () => {
       display: flex;
     }
 
-    .group-has-\\[\\:checked\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(:checked) *) {
+    .group-has-hocus\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(:hover, :focus) *) {
       display: flex;
     }
 
@@ -1812,7 +1808,7 @@ test('has', async () => {
       display: flex;
     }
 
-    .group-has-\\[\\&\\>img\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(* > img) *) {
+    .group-has-\\[\\:checked\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(:checked) *) {
       display: flex;
     }
 
@@ -1820,11 +1816,11 @@ test('has', async () => {
       display: flex;
     }
 
-    .group-has-\\[\\+img\\]\\:flex:is(:where(.group):has( + img) *) {
+    .group-has-\\[\\&\\>img\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(* > img) *) {
       display: flex;
     }
 
-    .group-has-\\[\\>img\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name):has( > img) *) {
+    .group-has-\\[\\+img\\]\\:flex:is(:where(.group):has( + img) *) {
       display: flex;
     }
 
@@ -1832,11 +1828,11 @@ test('has', async () => {
       display: flex;
     }
 
-    .group-has-\\[\\~img\\]\\:flex:is(:where(.group):has( ~ img) *) {
+    .group-has-\\[\\>img\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name):has( > img) *) {
       display: flex;
     }
 
-    .peer-has-checked\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(:checked) ~ *) {
+    .group-has-\\[\\~img\\]\\:flex:is(:where(.group):has( ~ img) *) {
       display: flex;
     }
 
@@ -1844,7 +1840,7 @@ test('has', async () => {
       display: flex;
     }
 
-    .peer-has-hocus\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(:hover, :focus) ~ *) {
+    .peer-has-checked\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(:checked) ~ *) {
       display: flex;
     }
 
@@ -1852,7 +1848,7 @@ test('has', async () => {
       display: flex;
     }
 
-    .peer-has-\\[\\:checked\\]\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(:checked) ~ *) {
+    .peer-has-hocus\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(:hover, :focus) ~ *) {
       display: flex;
     }
 
@@ -1860,7 +1856,7 @@ test('has', async () => {
       display: flex;
     }
 
-    .peer-has-\\[\\&\\>img\\]\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(* > img) ~ *) {
+    .peer-has-\\[\\:checked\\]\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(:checked) ~ *) {
       display: flex;
     }
 
@@ -1868,15 +1864,19 @@ test('has', async () => {
       display: flex;
     }
 
+    .peer-has-\\[\\&\\>img\\]\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(* > img) ~ *) {
+      display: flex;
+    }
+
     .peer-has-\\[\\+img\\]\\:flex:is(:where(.peer):has( + img) ~ *) {
       display: flex;
     }
 
-    .peer-has-\\[\\>img\\]\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has( > img) ~ *) {
+    .peer-has-\\[\\>img\\]\\:flex:is(:where(.peer):has( > img) ~ *) {
       display: flex;
     }
 
-    .peer-has-\\[\\>img\\]\\:flex:is(:where(.peer):has( > img) ~ *) {
+    .peer-has-\\[\\>img\\]\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has( > img) ~ *) {
       display: flex;
     }
 
@@ -2048,19 +2048,19 @@ test('data', async () => {
       'peer-data-[foo$=bar_baz_i]/parent-name:flex',
     ]),
   ).toMatchInlineSnapshot(`
-    ".group-data-\\[disabled\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name)[data-disabled] *) {
+    ".group-data-\\[disabled\\]\\:flex:is(:where(.group)[data-disabled] *) {
       display: flex;
     }
 
-    .group-data-\\[disabled\\]\\:flex:is(:where(.group)[data-disabled] *) {
-      display: flex;
-    }
-
-    .group-data-\\[foo\\=1\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name)[data-foo="1"] *) {
+    .group-data-\\[disabled\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name)[data-disabled] *) {
       display: flex;
     }
 
     .group-data-\\[foo\\=1\\]\\:flex:is(:where(.group)[data-foo="1"] *) {
+      display: flex;
+    }
+
+    .group-data-\\[foo\\=1\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name)[data-foo="1"] *) {
       display: flex;
     }
 
@@ -2076,19 +2076,19 @@ test('data', async () => {
       display: flex;
     }
 
-    .peer-data-\\[disabled\\]\\/parent-name\\:flex:is(:where(.peer\\/parent-name)[data-disabled] ~ *) {
-      display: flex;
-    }
-
     .peer-data-\\[disabled\\]\\:flex:is(:where(.peer)[data-disabled] ~ *) {
       display: flex;
     }
 
-    .peer-data-\\[foo\\=1\\]\\/parent-name\\:flex:is(:where(.peer\\/parent-name)[data-foo="1"] ~ *) {
+    .peer-data-\\[disabled\\]\\/parent-name\\:flex:is(:where(.peer\\/parent-name)[data-disabled] ~ *) {
       display: flex;
     }
 
     .peer-data-\\[foo\\=1\\]\\:flex:is(:where(.peer)[data-foo="1"] ~ *) {
+      display: flex;
+    }
+
+    .peer-data-\\[foo\\=1\\]\\/parent-name\\:flex:is(:where(.peer\\/parent-name)[data-foo="1"] ~ *) {
       display: flex;
     }
 
@@ -2266,7 +2266,7 @@ test('nth', async () => {
   ).toEqual('')
 })
 
-test.only('container queries', async () => {
+test('container queries', async () => {
   expect(
     await compileCss(
       css`

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -1676,15 +1676,11 @@ test('not', async () => {
       display: flex;
     }
 
-    .group-not-hocus\\:flex:is(:where(.group):not(:hover, :focus) *) {
-      display: flex;
-    }
-
     .group-not-hocus\\/parent-name\\:flex:is(:where(.group\\/parent-name):not(:hover, :focus) *) {
       display: flex;
     }
 
-    .group-not-\\[\\:checked\\]\\:flex:is(:where(.group):not(:checked) *) {
+    .group-not-hocus\\:flex:is(:where(.group):not(:hover, :focus) *) {
       display: flex;
     }
 
@@ -1692,11 +1688,11 @@ test('not', async () => {
       display: flex;
     }
 
-    .peer-not-checked\\:flex:is(:where(.peer):not(:checked) ~ *) {
+    .group-not-\\[\\:checked\\]\\:flex:is(:where(.group):not(:checked) *) {
       display: flex;
     }
 
-    .peer-not-hocus\\:flex:is(:where(.peer):not(:hover, :focus) ~ *) {
+    .peer-not-checked\\:flex:is(:where(.peer):not(:checked) ~ *) {
       display: flex;
     }
 
@@ -1704,11 +1700,15 @@ test('not', async () => {
       display: flex;
     }
 
-    .peer-not-\\[\\:checked\\]\\:flex:is(:where(.peer):not(:checked) ~ *) {
+    .peer-not-hocus\\:flex:is(:where(.peer):not(:hover, :focus) ~ *) {
       display: flex;
     }
 
     .peer-not-\\[\\:checked\\]\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):not(:checked) ~ *) {
+      display: flex;
+    }
+
+    .peer-not-\\[\\:checked\\]\\:flex:is(:where(.peer):not(:checked) ~ *) {
       display: flex;
     }"
   `)
@@ -1788,15 +1788,11 @@ test('has', async () => {
       ],
     ),
   ).toMatchInlineSnapshot(`
-    ".group-has-checked\\:flex:is(:where(.group):has(:checked) *) {
+    ".group-has-checked\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(:checked) *) {
       display: flex;
     }
 
-    .group-has-checked\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(:checked) *) {
-      display: flex;
-    }
-
-    .group-has-hocus\\:flex:is(:where(.group):has(:hover, :focus) *) {
+    .group-has-checked\\:flex:is(:where(.group):has(:checked) *) {
       display: flex;
     }
 
@@ -1804,7 +1800,7 @@ test('has', async () => {
       display: flex;
     }
 
-    .group-has-\\[\\:checked\\]\\:flex:is(:where(.group):has(:checked) *) {
+    .group-has-hocus\\:flex:is(:where(.group):has(:hover, :focus) *) {
       display: flex;
     }
 
@@ -1812,7 +1808,7 @@ test('has', async () => {
       display: flex;
     }
 
-    .group-has-\\[\\&\\>img\\]\\:flex:is(:where(.group):has(* > img) *) {
+    .group-has-\\[\\:checked\\]\\:flex:is(:where(.group):has(:checked) *) {
       display: flex;
     }
 
@@ -1820,11 +1816,11 @@ test('has', async () => {
       display: flex;
     }
 
-    .group-has-\\[\\+img\\]\\:flex:is(:where(.group):has( + img) *) {
+    .group-has-\\[\\&\\>img\\]\\:flex:is(:where(.group):has(* > img) *) {
       display: flex;
     }
 
-    .group-has-\\[\\>img\\]\\:flex:is(:where(.group):has( > img) *) {
+    .group-has-\\[\\+img\\]\\:flex:is(:where(.group):has( + img) *) {
       display: flex;
     }
 
@@ -1832,11 +1828,11 @@ test('has', async () => {
       display: flex;
     }
 
-    .group-has-\\[\\~img\\]\\:flex:is(:where(.group):has( ~ img) *) {
+    .group-has-\\[\\>img\\]\\:flex:is(:where(.group):has( > img) *) {
       display: flex;
     }
 
-    .peer-has-checked\\:flex:is(:where(.peer):has(:checked) ~ *) {
+    .group-has-\\[\\~img\\]\\:flex:is(:where(.group):has( ~ img) *) {
       display: flex;
     }
 
@@ -1844,7 +1840,7 @@ test('has', async () => {
       display: flex;
     }
 
-    .peer-has-hocus\\:flex:is(:where(.peer):has(:hover, :focus) ~ *) {
+    .peer-has-checked\\:flex:is(:where(.peer):has(:checked) ~ *) {
       display: flex;
     }
 
@@ -1852,7 +1848,7 @@ test('has', async () => {
       display: flex;
     }
 
-    .peer-has-\\[\\:checked\\]\\:flex:is(:where(.peer):has(:checked) ~ *) {
+    .peer-has-hocus\\:flex:is(:where(.peer):has(:hover, :focus) ~ *) {
       display: flex;
     }
 
@@ -1860,7 +1856,7 @@ test('has', async () => {
       display: flex;
     }
 
-    .peer-has-\\[\\&\\>img\\]\\:flex:is(:where(.peer):has(* > img) ~ *) {
+    .peer-has-\\[\\:checked\\]\\:flex:is(:where(.peer):has(:checked) ~ *) {
       display: flex;
     }
 
@@ -1868,15 +1864,19 @@ test('has', async () => {
       display: flex;
     }
 
+    .peer-has-\\[\\&\\>img\\]\\:flex:is(:where(.peer):has(* > img) ~ *) {
+      display: flex;
+    }
+
     .peer-has-\\[\\+img\\]\\:flex:is(:where(.peer):has( + img) ~ *) {
       display: flex;
     }
 
-    .peer-has-\\[\\>img\\]\\:flex:is(:where(.peer):has( > img) ~ *) {
+    .peer-has-\\[\\>img\\]\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has( > img) ~ *) {
       display: flex;
     }
 
-    .peer-has-\\[\\>img\\]\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has( > img) ~ *) {
+    .peer-has-\\[\\>img\\]\\:flex:is(:where(.peer):has( > img) ~ *) {
       display: flex;
     }
 
@@ -2048,19 +2048,19 @@ test('data', async () => {
       'peer-data-[foo$=bar_baz_i]/parent-name:flex',
     ]),
   ).toMatchInlineSnapshot(`
-    ".group-data-\\[disabled\\]\\:flex:is(:where(.group)[data-disabled] *) {
+    ".group-data-\\[disabled\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name)[data-disabled] *) {
       display: flex;
     }
 
-    .group-data-\\[disabled\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name)[data-disabled] *) {
-      display: flex;
-    }
-
-    .group-data-\\[foo\\=1\\]\\:flex:is(:where(.group)[data-foo="1"] *) {
+    .group-data-\\[disabled\\]\\:flex:is(:where(.group)[data-disabled] *) {
       display: flex;
     }
 
     .group-data-\\[foo\\=1\\]\\/parent-name\\:flex:is(:where(.group\\/parent-name)[data-foo="1"] *) {
+      display: flex;
+    }
+
+    .group-data-\\[foo\\=1\\]\\:flex:is(:where(.group)[data-foo="1"] *) {
       display: flex;
     }
 
@@ -2076,19 +2076,19 @@ test('data', async () => {
       display: flex;
     }
 
-    .peer-data-\\[disabled\\]\\:flex:is(:where(.peer)[data-disabled] ~ *) {
-      display: flex;
-    }
-
     .peer-data-\\[disabled\\]\\/parent-name\\:flex:is(:where(.peer\\/parent-name)[data-disabled] ~ *) {
       display: flex;
     }
 
-    .peer-data-\\[foo\\=1\\]\\:flex:is(:where(.peer)[data-foo="1"] ~ *) {
+    .peer-data-\\[disabled\\]\\:flex:is(:where(.peer)[data-disabled] ~ *) {
       display: flex;
     }
 
     .peer-data-\\[foo\\=1\\]\\/parent-name\\:flex:is(:where(.peer\\/parent-name)[data-foo="1"] ~ *) {
+      display: flex;
+    }
+
+    .peer-data-\\[foo\\=1\\]\\:flex:is(:where(.peer)[data-foo="1"] ~ *) {
       display: flex;
     }
 
@@ -2266,7 +2266,7 @@ test('nth', async () => {
   ).toEqual('')
 })
 
-test('container queries', async () => {
+test.only('container queries', async () => {
   expect(
     await compileCss(
       css`
@@ -2297,14 +2297,14 @@ test('container queries', async () => {
       --width-lg: 1024px;
     }
 
-    @container (width < 1024px) {
-      .\\@max-lg\\:flex {
+    @container name (width < 1024px) {
+      .\\@max-lg\\/name\\:flex {
         display: flex;
       }
     }
 
-    @container name (width < 1024px) {
-      .\\@max-lg\\/name\\:flex {
+    @container (width < 1024px) {
+      .\\@max-lg\\:flex {
         display: flex;
       }
     }
@@ -2345,12 +2345,6 @@ test('container queries', async () => {
       }
     }
 
-    @container (width >= 1024px) {
-      .\\@lg\\:flex {
-        display: flex;
-      }
-    }
-
     @container name (width >= 1024px) {
       .\\@lg\\/name\\:flex {
         display: flex;
@@ -2358,13 +2352,19 @@ test('container queries', async () => {
     }
 
     @container (width >= 1024px) {
-      .\\@min-lg\\:flex {
+      .\\@lg\\:flex {
         display: flex;
       }
     }
 
     @container name (width >= 1024px) {
       .\\@min-lg\\/name\\:flex {
+        display: flex;
+      }
+    }
+
+    @container (width >= 1024px) {
+      .\\@min-lg\\:flex {
         display: flex;
       }
     }"

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -1265,6 +1265,57 @@ test('sorting stacked min-* and max-* variants', async () => {
   `)
 })
 
+test('stacked min-* and max-* variants should come after unprefixed variants', async () => {
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          /* Explicitly ordered in a strange way */
+          --breakpoint-sm: 640px;
+          --breakpoint-lg: 1024px;
+          --breakpoint-md: 768px;
+        }
+        @tailwind utilities;
+      `,
+      ['sm:flex', 'min-sm:max-lg:flex', 'md:flex', 'min-md:max-lg:flex'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root {
+      --breakpoint-sm: 640px;
+      --breakpoint-lg: 1024px;
+      --breakpoint-md: 768px;
+    }
+
+    @media (width >= 640px) {
+      .sm\\:flex {
+        display: flex;
+      }
+    }
+
+    @media (width >= 640px) {
+      @media (width < 1024px) {
+        .min-sm\\:max-lg\\:flex {
+          display: flex;
+        }
+      }
+    }
+
+    @media (width >= 768px) {
+      .md\\:flex {
+        display: flex;
+      }
+    }
+
+    @media (width >= 768px) {
+      @media (width < 1024px) {
+        .min-md\\:max-lg\\:flex {
+          display: flex;
+        }
+      }
+    }"
+  `)
+})
+
 test('min, max and unprefixed breakpoints', async () => {
   expect(
     await compileCss(

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -117,7 +117,17 @@ export class Variants {
     if (orderedByVariant !== 0) return orderedByVariant
 
     if (a.kind === 'compound' && z.kind === 'compound') {
-      return this.compare(a.variant, z.variant)
+      let order = this.compare(a.variant, z.variant)
+      if (order === 0) {
+        if (a.modifier && z.modifier) {
+          return a.modifier.value < z.modifier.value ? -1 : 1
+        } else if (a.modifier) {
+          return 1
+        } else if (z.modifier) {
+          return -1
+        }
+      }
+      return order
     }
 
     let compareFn = this.compareFns.get(aOrder)

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -121,9 +121,8 @@ export class Variants {
     }
 
     let compareFn = this.compareFns.get(aOrder)
-    if (compareFn === undefined) return 0
-
-    return compareFn(a, z) || (a.root < z.root ? -1 : 1)
+    if (compareFn === undefined) return a.root < z.root ? -1 : 1
+    return compareFn(a, z)
   }
 
   keys() {


### PR DESCRIPTION
This PR fixes an issue with the order of CSS when using stacked variants when two variants have the same order (as defined by the custom comperator function).

## The problem

Take, for example, our breakpoint variants. Those are split into `max-*` variants and a group containing all `min-*` variants as well as the unprefixed static ones (e.g. `lg`, `sm`).

We currently define a custom sort order for all breakpoints variants that will compare their order based on the resolved value provided. So if you define `--breakpoint-sm: 100px` and `--breakpoint-lg: 200px`, we first check if both breakpoints have the same unit and then we rank based on the numerical value, making `sm` appear before `lg`.

But since the `min-*` variant and the `sm` variant share the same group, this also means that `min-sm` and `sm` as well as `min-lg` and `lg` will always have the same order (which makes sense—they also have the exact same CSS they generate!)

The issue now arises when you use these together with variant stacking. So, say you want to stack the two variants `max-lg:min-sm`. We always want stacked variants to appear _after_ their non-stacked individual parts (since they are more specific). To do this right now, we generate a bitfield based on the variant order. If you have four variants like this:


| Order | Variant |
| ------------- | ------------- |
| 0  | `max-lg`  |
| 1  | `max-sm`  |
| 2  | `min-sm`  |
| 3  | `min-lg`  |


We will assign one bit for each used variant starting from the lowest bit, so for the stack `max-lg:min-sm` we will set the bitfield to `0101` and those for the individual variants would result in `0100` (for `min-sm`) and `0001` (for `max-lg`). We then convert this bitfield to a number and order based on that number. This ensures that the stack always sorts higher.

The issue now arises from the fact that the variant order also include the unprefixed variants for a breakpoint. So in our case of `lg` and `sm`, the full list would look like this:


| Order | Variant |
| ------------- | ------------- |
| 0  | `max-lg`  |
| 1  | `max-sm`  |
| 2  | `min-sm`  |
| 3  | `sm`  |
| 4  | `min-lg`  |
| 5  | `lg`  |

This logic now breaks when you start to compute a stack for something like `max-lg:min-lg` _while also using the `lg` utility:

| Stack | Bitmap | Integer Value |
| ------------- | ------------- | ------------- |
| `max-lg:min-lg` | `010001` | 17 |
| `lg` | `100000` | 18 |

As you can see here, the sole `lg` variant will now sort higher than the compound of `max-lg:min-lg`. That's not something we want!

## Proposed solution

To fix this, we need to encode the information of _same_ variant order somehow. A single array like the example above is not sufficient for this, since it will remove the information of the similar sort order. Instead, we now computed a list of nested arrays for the order lookup that will combine variants of similar values (while keeping the order the same). So from the 6 item array above, we now have the following nested array:

| Order | Variant |
| ------------- | ------------- |
| 0  | [`max-lg`]  |
| 1  | [`max-sm`]  |
| 2  | [`min-sm`, `sm`]  |
| 3  | [`min-lg`, `lg`]  |

When we use the first layer index for the bitfield, we can now see how this solves the issue:

| Stack | Bitmap | Integer Value |
| ------------- | ------------- | ------------- |
| `max-lg:min-lg` | `1001` | 9 |
| `lg` | `1000` | 8 |

That's pretty-much it! There are a few other changes in this PR that mostly handles with a small regression by this change where now, named `group` variants and unnamed `group` variants would now have the same order (something that was undefined behavior before). 