### PR TITLE
Refactor some screen compatibility code

### DIFF
--- a/packages/tailwindcss/src/compat/config/resolve-config.ts
+++ b/packages/tailwindcss/src/compat/config/resolve-config.ts
@@ -203,4 +203,19 @@ function mergeTheme(ctx: ResolutionContext) {
   for (let key in ctx.theme) {
     ctx.theme[key] = resolveValue(ctx.theme[key])
   }
+
+  // Turn {min: '123px'} into '123px' in screens
+  if (ctx.theme.screens && typeof ctx.theme.screens === 'object') {
+    for (let key of Object.keys(ctx.theme.screens)) {
+      let screen = ctx.theme.screens[key]
+      if (!screen) continue
+      if (typeof screen !== 'object') continue
+
+      if ('raw' in screen) continue
+      if ('max' in screen) continue
+      if (!('min' in screen)) continue
+
+      ctx.theme.screens[key] = screen.min
+    }
+  }
 }

--- a/packages/tailwindcss/src/compat/screens-config.test.ts
+++ b/packages/tailwindcss/src/compat/screens-config.test.ts
@@ -457,7 +457,7 @@ describe('complex screen configs', () => {
               md: [
                 //
                 { min: '668px', max: '767px' },
-                { min: '868px' },
+                '868px',
               ],
               lg: { min: '868px' },
               xl: { min: '1024px', max: '1279px' },
@@ -468,15 +468,14 @@ describe('complex screen configs', () => {
       }),
     })
 
-    expect(
-      compiler.build(['min-sm:flex', 'min-md:flex', 'min-lg:flex', 'min-xl:flex', 'min-tall:flex']),
-    ).toBe('')
+    expect(compiler.build(['min-sm:flex', 'min-md:flex', 'min-xl:flex', 'min-tall:flex'])).toBe('')
 
     expect(
       compiler.build([
         'sm:flex',
         'md:flex',
         'lg:flex',
+        'min-lg:flex',
         'xl:flex',
         'tall:flex',
 
@@ -485,22 +484,27 @@ describe('complex screen configs', () => {
       ]),
     ).toMatchInlineSnapshot(`
       ".lg\\:flex {
-        @media (min-width: 868px) {
+        @media (width >= 868px) {
+          display: flex;
+        }
+      }
+      .min-lg\\:flex {
+        @media (width >= 868px) {
           display: flex;
         }
       }
       .sm\\:flex {
-        @media (max-width: 639px) {
+        @media (639px >= width) {
           display: flex;
         }
       }
       .md\\:flex {
-        @media (min-width: 668px and max-width: 767px), (min-width: 868px) {
+        @media (767px >= width >= 668px), (width >= 868px) {
           display: flex;
         }
       }
       .xl\\:flex {
-        @media (min-width: 1024px and max-width: 1279px) {
+        @media (1279px >= width >= 1024px) {
           display: flex;
         }
       }

--- a/packages/tailwindcss/src/css-functions.ts
+++ b/packages/tailwindcss/src/css-functions.ts
@@ -19,9 +19,13 @@ export function substituteFunctions(ast: AstNode[], resolveThemeValue: ResolveTh
       if (
         node.selector[0] === '@' &&
         (node.selector.startsWith('@media ') ||
+          node.selector.startsWith('@media(') ||
           node.selector.startsWith('@custom-media ') ||
+          node.selector.startsWith('@custom-media(') ||
           node.selector.startsWith('@container ') ||
-          node.selector.startsWith('@supports ')) &&
+          node.selector.startsWith('@container(') ||
+          node.selector.startsWith('@supports ') ||
+          node.selector.startsWith('@supports(')) &&
         node.selector.includes(THEME_FUNCTION_INVOCATION)
       ) {
         node.selector = substituteFunctionsInValue(node.selector, resolveThemeValue)


### PR DESCRIPTION
This adds support for the `screen(…)` CSS function which can be used to build the media queries for a given breakpoint:

Input:

```css
@theme {
  --breakpoint-sm: 640px;
}

@media screen(sm) {
  .foo {
    color: red;
  }
}
```

output:
  
```css
@media (width >= 640px) {
  .foo {
    color: red;
  }
}
```

We also support more advanced `screens` configurations from configuration files (mainly for backwards) compat:
```ts
export default {
  theme: {
    screens: {
      sm: '640px',
      md: { min: '768px' },
      lg: { min: '1024px', max: '1280px' },
      sidebar: [
        { min: '640px', max: '768px' },
        { min: '1024px' },
      ],
    }
  }
}
```

```css
@media screen(sm) {
  .foo {
    color: red;
  }
}

@media screen(md) {
  .foo {
    color: blue;
  }
}

@media screen(lg) {
  .foo {
    color: green;
  }
}

@media screen(sidebar) {
  .foo {
    color: yellow;
  }
}
```

Output:

```css
@media (width >= 640px) {
  .foo {
    color: red;
  }
}

@media (width >= 768px) {
  .foo {
    color: blue;
  }
}

@media (1280px >= width >= 1024px) {
  .foo {
    color: green;
  }
}

@media (768px >= width >= 640px), (width >= 1024px) {
  .foo {
    color: yellow;
  }
}
```