### PR TITLE
Don't generate CSS for less specific utilities when a more specific utility matches

### DIFF
--- a/packages/tailwindcss/src/candidate.test.ts
+++ b/packages/tailwindcss/src/candidate.test.ts
@@ -1,4 +1,4 @@
-import { expect, it } from 'vitest'
+import { expect, it, test } from 'vitest'
 import { buildDesignSystem } from './design-system'
 import { Theme } from './theme'
 import { Utilities } from './utilities'
@@ -1279,6 +1279,31 @@ it('should parse a variant containing an arbitrary string with unbalanced parens
             },
           },
         ],
+      },
+    ]
+  `)
+})
+
+test('more specific roots take precedence over less specific roots', () => {
+  let utilities = new Utilities()
+  utilities.functional('foo', () => [])
+  utilities.functional('foo-bar', () => [])
+
+  expect(run('foo-bar-2', { utilities })).toMatchInlineSnapshot(`
+    [
+      {
+        "important": false,
+        "kind": "functional",
+        "modifier": null,
+        "negative": false,
+        "raw": "foo-bar-2",
+        "root": "foo-bar",
+        "value": {
+          "fraction": null,
+          "kind": "named",
+          "value": "2",
+        },
+        "variants": [],
       },
     ]
   `)

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -14144,14 +14144,6 @@ test('inset-shadow', async () => {
     }
 
     .inset-shadow {
-      inset: var(--inset-shadow, inset 0 2px 4px #0000000d);
-    }
-
-    .inset-shadow-sm {
-      inset: var(--inset-shadow-sm, inset 0 1px 1px #0000000d);
-    }
-
-    .inset-shadow {
       --tw-inset-shadow: inset 0 2px 4px #0000000d;
       --tw-inset-shadow-colored: inset 0 2px 4px var(--tw-inset-shadow-color);
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);


### PR DESCRIPTION
Resolves #14440.

This PR fixes an issue where registering a custom `inset-shadow-*` utility value in your theme like this:

```css
@theme {
  --inset-shadow-potato: inset 0px 2px 6px #7a4724;
}
```

…mistakenly generates both an `inset-shadow-*` and `inset-*` utility with that value:

```css
.inset-shadow-potato {
  inset: inset 0px 2px 6px #7a4724;
}

.inset-shadow-potato {
  box-shadow: inset 0px 2px 6px #7a4724;
}
```

We do this by making sure that when parsing a candidate name like `inset-shadow-potato`, we stop trying to find less specific matches as soon as we find any match. So once `inset-shadow` matches as a root with `potato` as a value, we don't try to match `inset` as a root with `shadow-potato` as a value.

This reverts _some_ of the things we changed in https://github.com/tailwindlabs/tailwindcss/pull/14231 ~~that we can't for the life of us remember why we changed 🧠~~

Remembered why we didn't want to do this — if we only accept the most specific match it's possible for someone to completely override a core utility without really doing it on purpose.

For example, say for some cursed reason someone wants to change the color of all bold text by doing this:

```css
@utility font-bold {
  color: red;
}
```

That will actually _remove_ the `font-weight: bold` declaration from that utility in this case, because we don't explicitly register `font-bold`. We register `font` and handle `bold` as a value, so the user-defined `font-bold` will match as more specific, and our handler for `font-*` with `bold` as a value will never run.

No one should ever do this, but it does expose this other weird thing where we could refactor internals to use a static utility for a previously functional utility (or vice versa) and change the behavior of user-land code which just doesn't feel right.

Replacing this PR with #14447.