### PR TITLE
Split CI to run jobs in parallel

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -1,0 +1,59 @@
+name: 'Build'
+description: 'Runs the main build step'
+inputs:
+  node-version:
+    description: 'Version of node to use'
+    required: true
+  os:
+    description: 'Host OS'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/checkout@v4
+    - uses: pnpm/action-setup@v4
+
+    - name: Use Node.js ${{ inputs.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: 'pnpm'
+
+    # Cargo already skips downloading dependencies if they already exist
+    - name: Cache cargo
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ inputs.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Cache turbo build
+      uses: actions/cache@v4
+      with:
+        path: .turbo
+        key: ${{ inputs.os }}-turbo-${{ github.sha }}
+        restore-keys: |
+          ${{ inputs.os }}-turbo-
+
+    # Cache the `oxide` Rust build
+    - name: Cache oxide build
+      uses: actions/cache@v4
+      with:
+        path: |
+          ./target/
+          ./crates/node/*.node
+          ./crates/node/index.js
+          ./crates/node/index.d.ts
+        key: ${{ inputs.os }}-oxide-${{ hashFiles('./crates/**/*') }}
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install
+
+    - name: Build
+      shell: bash
+      run: pnpm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,28 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20]
+        # Only lint on linux to avoid \r\n line ending errors
+        runner: [ubuntu-latest]
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        uses: ./.github/actions/build
+        with:
+          os: ${{ runner.os }}
+          node-version: ${{ matrix.node-version }}
+
+      - name: Lint
+        run: pnpm run lint
+        if: matrix.runner == 'ubuntu-latest'
+
   tests:
     strategy:
       fail-fast: false
@@ -21,53 +43,56 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-
-      # Cargo already skips downloading dependencies if they already exist
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      # Cache the `oxide` Rust build
-      - name: Cache oxide build
-        uses: actions/cache@v4
-        with:
-          path: |
-            ./target/
-            ./crates/node/*.node
-            ./crates/node/index.js
-            ./crates/node/index.d.ts
-          key: ${{ runner.os }}-oxide-${{ hashFiles('./crates/**/*') }}
-
-      - name: Install dependencies
-        run: pnpm install
 
       - name: Build
-        run: pnpm run build
-
-      - name: Lint
-        run: pnpm run lint
-        # Only lint on linux to avoid \r\n line ending errors
-        if: matrix.runner == 'ubuntu-latest'
+        uses: ./.github/actions/build
+        with:
+          os: ${{ runner.os }}
+          node-version: ${{ matrix.node-version }}
 
       - name: Test
         run: pnpm run test
 
+  integration-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20]
+        runner: [ubuntu-latest, windows-latest, macos-14]
+
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        uses: ./.github/actions/build
+        with:
+          os: ${{ runner.os }}
+          node-version: ${{ matrix.node-version }}
+
       - name: Integration Tests
         run: pnpm run test:integrations
+
+  e2e-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20]
+        runner: [ubuntu-latest, windows-latest, macos-14]
+
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        uses: ./.github/actions/build
+        with:
+          os: ${{ runner.os }}
+          node-version: ${{ matrix.node-version }}
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps


### PR DESCRIPTION
I shaved some minutes from the CI (_In the scenario of caches being hit_, the most common?) by splitting various test types into their own jobs, to run them in parallel.
So it's as fast as its slowest job (Windows integration tests), rather than unrelated tests waiting on others.

I guess the DX improves too, to more quickly visualise failing tests on the job list (instead of needing to open a job to look for the failing step).

Before:

![image](https://github.com/user-attachments/assets/23217397-710e-40e0-a4f7-e4e690836990)

After (sometimes 6min, not sure why the large variance):

![image](https://github.com/user-attachments/assets/44452dca-42e7-4c57-a363-0365bf0c5525)


(Edit: apologies, I created duplicate PRs because it seems I can't force push and reopen https://github.com/tailwindlabs/tailwindcss/pull/14460)