### PR TITLE
ci: speedup windows integrations tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
 
       - name: Build
         run: pnpm run build
+        env:
+          CARGO_PROFILE_RELEASE_LTO: 'off'
+          CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER: 'lld-link'
 
       - name: Lint
         run: pnpm run lint
@@ -68,6 +71,8 @@ jobs:
 
       - name: Integration Tests
         run: pnpm run test:integrations
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -4,7 +4,7 @@ import killPort from 'kill-port'
 import { exec, spawn } from 'node:child_process'
 import fs from 'node:fs/promises'
 import net from 'node:net'
-import { homedir, platform, tmpdir } from 'node:os'
+import { platform, tmpdir } from 'node:os'
 import path from 'node:path'
 import { test as defaultTest, expect } from 'vitest'
 
@@ -63,7 +63,8 @@ const ASSERTION_TIMEOUT = IS_WINDOWS ? 10000 : 5000
 
 // On Windows CI, tmpdir returns a path containing a weird RUNNER~1 folder that
 // apparently causes the vite builds to not work.
-const TMP_ROOT = process.env.CI && IS_WINDOWS ? homedir() : tmpdir()
+const TMP_ROOT =
+  process.env.CI && IS_WINDOWS ? path.dirname(process.env.GITHUB_WORKSPACE!) : tmpdir()
 
 export function test(
   name: string,


### PR DESCRIPTION
- Avoid cross-device copying in Windows CI by setting the tests dir to the same drive as the workspace.
- Disable LTO and use a faster linker for the Rust build 


Buid: ~3min -> ~2min
Integration Tests: ~8min -> ~3min20s

![](https://github.com/user-attachments/assets/e4179d73-e0a2-4422-bc1f-220bd1ae383f)

