### PR TITLE
Include gradient color properties in color transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `bg-radial-*` and `bg-conic-*` utilities for radial and conic gradients ([#14467](https://github.com/tailwindlabs/tailwindcss/pull/14467))
 - Add new `shadow-initial` and `inset-shadow-initial` utilities for resetting shadow colors ([#14468](https://github.com/tailwindlabs/tailwindcss/pull/14468))
 - Add `field-sizing-*` utilities ([#14469](https://github.com/tailwindlabs/tailwindcss/pull/14469))
+- Include gradient color properties in color transitions ([#14489](https://github.com/tailwindlabs/tailwindcss/pull/14489))
 
 ### Fixed
 

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -9925,9 +9925,9 @@ test('from', async () => {
       @layer base {
         *, :before, :after, ::backdrop {
           --tw-gradient-position: initial;
-          --tw-gradient-from: #0000;
-          --tw-gradient-to: #0000;
+          --tw-gradient-from: transparent;
           --tw-gradient-via: transparent;
+          --tw-gradient-to: transparent;
           --tw-gradient-stops: initial;
           --tw-gradient-via-stops: initial;
           --tw-gradient-from-position: 0%;
@@ -9948,13 +9948,13 @@ test('from', async () => {
       initial-value: #0000;
     }
 
-    @property --tw-gradient-to {
+    @property --tw-gradient-via {
       syntax: "<color>";
       inherits: false;
       initial-value: #0000;
     }
 
-    @property --tw-gradient-via {
+    @property --tw-gradient-to {
       syntax: "<color>";
       inherits: false;
       initial-value: #0000;
@@ -10170,9 +10170,9 @@ test('via', async () => {
       @layer base {
         *, :before, :after, ::backdrop {
           --tw-gradient-position: initial;
-          --tw-gradient-from: #0000;
-          --tw-gradient-to: #0000;
+          --tw-gradient-from: transparent;
           --tw-gradient-via: transparent;
+          --tw-gradient-to: transparent;
           --tw-gradient-stops: initial;
           --tw-gradient-via-stops: initial;
           --tw-gradient-from-position: 0%;
@@ -10193,13 +10193,13 @@ test('via', async () => {
       initial-value: #0000;
     }
 
-    @property --tw-gradient-to {
+    @property --tw-gradient-via {
       syntax: "<color>";
       inherits: false;
       initial-value: #0000;
     }
 
-    @property --tw-gradient-via {
+    @property --tw-gradient-to {
       syntax: "<color>";
       inherits: false;
       initial-value: #0000;
@@ -10403,9 +10403,9 @@ test('to', async () => {
       @layer base {
         *, :before, :after, ::backdrop {
           --tw-gradient-position: initial;
-          --tw-gradient-from: #0000;
-          --tw-gradient-to: #0000;
+          --tw-gradient-from: transparent;
           --tw-gradient-via: transparent;
+          --tw-gradient-to: transparent;
           --tw-gradient-stops: initial;
           --tw-gradient-via-stops: initial;
           --tw-gradient-from-position: 0%;
@@ -10426,13 +10426,13 @@ test('to', async () => {
       initial-value: #0000;
     }
 
-    @property --tw-gradient-to {
+    @property --tw-gradient-via {
       syntax: "<color>";
       inherits: false;
       initial-value: #0000;
     }
 
-    @property --tw-gradient-via {
+    @property --tw-gradient-to {
       syntax: "<color>";
       inherits: false;
       initial-value: #0000;
@@ -12897,7 +12897,7 @@ test('transition', async () => {
     }
 
     .transition {
-      transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, -webkit-backdrop-filter, backdrop-filter;
+      transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, -webkit-backdrop-filter, backdrop-filter;
       transition-timing-function: var(--default-transition-timing-function, ease);
       transition-duration: var(--default-transition-duration, .1s);
     }
@@ -12915,7 +12915,7 @@ test('transition', async () => {
     }
 
     .transition-colors {
-      transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+      transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
       transition-timing-function: var(--default-transition-timing-function, ease);
       transition-duration: var(--default-transition-duration, .1s);
     }
@@ -12964,7 +12964,7 @@ test('transition', async () => {
     }
 
     .transition {
-      transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, -webkit-backdrop-filter, backdrop-filter;
+      transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, -webkit-backdrop-filter, backdrop-filter;
       transition-duration: .1s;
       transition-timing-function: ease;
     }
@@ -12976,7 +12976,7 @@ test('transition', async () => {
     }
 
     .transition-colors {
-      transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+      transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
       transition-duration: .1s;
       transition-timing-function: ease;
     }"

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -9925,9 +9925,9 @@ test('from', async () => {
       @layer base {
         *, :before, :after, ::backdrop {
           --tw-gradient-position: initial;
-          --tw-gradient-from: transparent;
-          --tw-gradient-via: transparent;
-          --tw-gradient-to: transparent;
+          --tw-gradient-from: #0000;
+          --tw-gradient-via: #0000;
+          --tw-gradient-to: #0000;
           --tw-gradient-stops: initial;
           --tw-gradient-via-stops: initial;
           --tw-gradient-from-position: 0%;
@@ -10170,9 +10170,9 @@ test('via', async () => {
       @layer base {
         *, :before, :after, ::backdrop {
           --tw-gradient-position: initial;
-          --tw-gradient-from: transparent;
-          --tw-gradient-via: transparent;
-          --tw-gradient-to: transparent;
+          --tw-gradient-from: #0000;
+          --tw-gradient-via: #0000;
+          --tw-gradient-to: #0000;
           --tw-gradient-stops: initial;
           --tw-gradient-via-stops: initial;
           --tw-gradient-from-position: 0%;
@@ -10403,9 +10403,9 @@ test('to', async () => {
       @layer base {
         *, :before, :after, ::backdrop {
           --tw-gradient-position: initial;
-          --tw-gradient-from: transparent;
-          --tw-gradient-via: transparent;
-          --tw-gradient-to: transparent;
+          --tw-gradient-from: #0000;
+          --tw-gradient-via: #0000;
+          --tw-gradient-to: #0000;
           --tw-gradient-stops: initial;
           --tw-gradient-via-stops: initial;
           --tw-gradient-from-position: 0%;

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -2676,8 +2676,6 @@ export function createUtilities(theme: Theme) {
   let gradientStopProperties = () => {
     return atRoot([
       property('--tw-gradient-position'),
-      property('--tw-gradient-from', '#0000', '<color>'),
-      property('--tw-gradient-to', '#0000', '<color>'),
       property('--tw-gradient-from', 'transparent', '<color>'),
       property('--tw-gradient-via', 'transparent', '<color>'),
       property('--tw-gradient-to', 'transparent', '<color>'),
@@ -3716,7 +3714,7 @@ export function createUtilities(theme: Theme) {
     staticUtility('transition-colors', [
       [
         'transition-property',
-        'color, background-color, border-color, text-decoration-color, fill, stroke',
+        'color, background-color, border-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to',
       ],
       ['transition-timing-function', defaultTimingFunction],
       ['transition-duration', defaultDuration],
@@ -3739,7 +3737,7 @@ export function createUtilities(theme: Theme) {
 
     functionalUtility('transition', {
       defaultValue:
-        'color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter',
+        'color, background-color, border-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter',
       themeKeys: ['--transition-property'],
       handle: (value) => [
         decl('transition-property', value),

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -2676,9 +2676,9 @@ export function createUtilities(theme: Theme) {
   let gradientStopProperties = () => {
     return atRoot([
       property('--tw-gradient-position'),
-      property('--tw-gradient-from', 'transparent', '<color>'),
-      property('--tw-gradient-via', 'transparent', '<color>'),
-      property('--tw-gradient-to', 'transparent', '<color>'),
+      property('--tw-gradient-from', '#0000', '<color>'),
+      property('--tw-gradient-via', '#0000', '<color>'),
+      property('--tw-gradient-to', '#0000', '<color>'),
       property('--tw-gradient-stops'),
       property('--tw-gradient-via-stops'),
       property('--tw-gradient-from-position', '0%', '<length> | <percentage>'),


### PR DESCRIPTION
This PR adds our custom gradient color properties (`--tw-gradient-from`, `--tw-gradient-via`, and `--tw-gradient-to`) to the list of color properties we transition in the `transition` and `transition-colors` utilities.

As part of this I noticed that we had duplicate `@property` declarations for these custom properties, so I've removed the duplicates.