### PR TITLE
fix: avoid `require` not exists

### DIFF
--- a/packages/@tailwindcss-node/src/require-cache.cts
+++ b/packages/@tailwindcss-node/src/require-cache.cts
@@ -1,4 +1,8 @@
 export function clearRequireCache(files: string[]) {
+  if (!(typeof require === 'function' && require.cache)) {
+    return
+  }
+
   for (let key of files) {
     delete require.cache[key]
   }


### PR DESCRIPTION
avoiding the absence of `require.cache` in some runtime environments