### PR TITLE
CLI: Use the right `base` when loading files from `stdin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Use the right import base path when using the CLI to reading files from stdin ([#14522](https://github.com/tailwindlabs/tailwindcss/pull/14522))
 - _Experimental_: Improve codemod output, keep CSS after last Tailwind directive unlayered ([#14512](https://github.com/tailwindlabs/tailwindcss/pull/14512))
 - _Experimental_: Fix incorrect empty `layer()` at the end of `@import` at-rules when running codemods ([#14513](https://github.com/tailwindlabs/tailwindcss/pull/14513))
 - _Experimental_: Migrate `@import "tailwindcss/tailwind.css"` to `@import "tailwindcss"` ([#14514](https://github.com/tailwindlabs/tailwindcss/pull/14514))

--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -182,4 +182,29 @@ describe.each([
       ])
     },
   )
+
+  test(
+    'production build (stdin)',
+    {
+      fs: {
+        'package.json': json`
+          {
+            "dependencies": {
+              "tailwindcss": "workspace:^",
+              "@tailwindcss/cli": "workspace:^"
+            }
+          }
+        `,
+        'index.html': html`
+          <div class="underline"></div>
+        `,
+        'src/index.css': css`@import 'tailwindcss';`,
+      },
+    },
+    async ({ fs, exec }) => {
+      await exec(`${command} --input=- --output dist/out.css < src/index.css`)
+
+      await fs.expectFileToContain('dist/out.css', [candidate`underline`])
+    },
+  )
 })

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -118,8 +118,10 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
     }
   }
 
-  let inputFile = args['--input'] && args['--input'] !== '-' ? args['--input'] : process.cwd()
-  let inputBasePath = path.dirname(path.resolve(inputFile))
+  let inputBasePath =
+    args['--input'] && args['--input'] !== '-'
+      ? path.dirname(path.resolve(args['--input']))
+      : process.cwd()
   let fullRebuildPaths: string[] = []
 
   function createCompiler(css: string) {


### PR DESCRIPTION
Fixes #14521

When using the CLI to read files from `stdin` like this:

```bash
npx tailwindcss  --input=- -o bar.css < foo.css
```

We need to set the `base` path to be the current working directory (`process.cwd()`). However, `cwd()` already _is_ a directory and calling `dirname()` on it did go to the parent directory _which might not have the `tailwindcss` dependency installed.
