### PR TITLE
Use official FxHash crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,12 +51,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
-
-[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,15 +195,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
 
 [[package]]
 name = "glob-match"
@@ -528,6 +513,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+
+[[package]]
 name = "rustix"
 version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,12 +614,12 @@ dependencies = [
  "bstr",
  "crossbeam",
  "dunce",
- "fxhash",
  "glob-match",
  "globwalk",
  "ignore",
  "log",
  "rayon",
+ "rustc-hash",
  "tempfile",
  "tracing",
  "tracing-subscriber",

--- a/crates/oxide/Cargo.toml
+++ b/crates/oxide/Cargo.toml
@@ -8,7 +8,7 @@ bstr = "1.0.1"
 globwalk = "0.8.1"
 log = "0.4"
 rayon = "1.5.3"
-fxhash = "0.2.1"
+fxhash = { package = "rustc-hash", version = "2.0.0" }
 crossbeam = "0.8.2"
 tracing = { version = "0.1.37", features = [] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }


### PR DESCRIPTION
`fxhash` is an old (and abandoned?) crate that simply extracts the fxhash implementation from rustc. These days, rustc has an official fxhash crate, that is actively maintained by the rust-lang organization.

In practice this does not really matter, aside from the new crate having one less dependency (`byteorder`), but I think it's generally a good idea to use something straight from the rust team.