### PR TITLE
Add a sensible default for alt texts

### DIFF
--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -380,6 +380,13 @@ video {
   height: auto;
 }
 
+/*
+1. Sensible default for alt text
+*/
+img {
+  font-style: italic; /* 1 */
+}
+
 /* Make elements with the HTML hidden attribute stay hidden by default */
 [hidden] {
   display: none;


### PR DESCRIPTION
Hey! 

In the rare cases of a broken image, when the alt text is displayed it's is styled as raw text by default. So it's unclear where the alt text starts / ends.

This PR makes the alt text italic by default, which seems like a sensible default and a slight improved which doesn't impact most users.  

<img width="1328" alt="Capture d’écran 2024-09-29 à 14 26 33" src="https://github.com/user-attachments/assets/b04b5e4c-a014-49cf-b239-cc75299b2316">
