### PR TITLE
Expose timing information in debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add support for prefixes ([#14501](https://github.com/tailwindlabs/tailwindcss/pull/14501))
+- Expose timing information in debug mode ([#14553](https://github.com/tailwindlabs/tailwindcss/pull/14553))
 - _Experimental_: Add template codemods for migrating `bg-gradient-*` utilities to `bg-linear-*` ([#14537](https://github.com/tailwindlabs/tailwindcss/pull/14537]))
 - _Experimental_: Migrate `@import "tailwindcss/tailwind.css"` to `@import "tailwindcss"` ([#14514](https://github.com/tailwindlabs/tailwindcss/pull/14514))
 

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -1,12 +1,11 @@
 import watcher from '@parcel/watcher'
-import { compile } from '@tailwindcss/node'
+import { compile, env } from '@tailwindcss/node'
 import { clearRequireCache } from '@tailwindcss/node/require-cache'
 import { Scanner, type ChangedContent } from '@tailwindcss/oxide'
 import { Features, transform } from 'lightningcss'
 import { existsSync } from 'node:fs'
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import * as env from '../../../../tailwindcss/src/env'
 import type { Arg, Result } from '../../utils/args'
 import { Disposables } from '../../utils/disposables'
 import {

--- a/packages/@tailwindcss-node/src/env.ts
+++ b/packages/@tailwindcss-node/src/env.ts
@@ -1,4 +1,4 @@
-export const DEBUG = typeof process !== 'undefined' ? resolveDebug(process.env.DEBUG) : false
+export const DEBUG = resolveDebug(process.env.DEBUG)
 
 function resolveDebug(debug: typeof process.env.DEBUG) {
   if (debug === undefined) {

--- a/packages/@tailwindcss-node/src/index.cts
+++ b/packages/@tailwindcss-node/src/index.cts
@@ -1,7 +1,9 @@
 import * as Module from 'node:module'
 import { pathToFileURL } from 'node:url'
+import * as env from './env'
 export * from './compile'
 export * from './normalize-path'
+export { env }
 
 // In Bun, ESM modules will also populate `require.cache`, so the module hook is
 // not necessary.

--- a/packages/@tailwindcss-node/src/index.ts
+++ b/packages/@tailwindcss-node/src/index.ts
@@ -1,7 +1,9 @@
 import * as Module from 'node:module'
 import { pathToFileURL } from 'node:url'
+import * as env from './env'
 export * from './compile'
 export * from './normalize-path'
+export { env }
 
 // In Bun, ESM modules will also populate `require.cache`, so the module hook is
 // not necessary.

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -1,11 +1,10 @@
-import { compile } from '@tailwindcss/node'
+import { compile, env } from '@tailwindcss/node'
 import { clearRequireCache } from '@tailwindcss/node/require-cache'
 import { Scanner } from '@tailwindcss/oxide'
 import fs from 'fs'
 import { Features, transform } from 'lightningcss'
 import path from 'path'
 import postcss, { type AcceptedPlugin, type PluginCreator } from 'postcss'
-import * as env from '../../tailwindcss/src/env'
 import fixRelativePathsPlugin from './postcss-fix-relative-paths'
 
 /**

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -5,6 +5,7 @@ import fs from 'fs'
 import { Features, transform } from 'lightningcss'
 import path from 'path'
 import postcss, { type AcceptedPlugin, type PluginCreator } from 'postcss'
+import * as env from '../../tailwindcss/src/env'
 import fixRelativePathsPlugin from './postcss-fix-relative-paths'
 
 /**
@@ -61,21 +62,26 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
       {
         postcssPlugin: 'tailwindcss',
         async OnceExit(root, { result }) {
+          env.DEBUG && console.time('[@tailwindcss/postcss] Total time in @tailwindcss/postcss')
           let inputFile = result.opts.from ?? ''
           let context = cache.get(inputFile)
           let inputBasePath = path.dirname(path.resolve(inputFile))
 
           async function createCompiler() {
+            env.DEBUG && console.time('[@tailwindcss/postcss] Setup compiler')
             clearRequireCache(context.fullRebuildPaths)
 
             context.fullRebuildPaths = []
 
-            return compile(root.toString(), {
+            let compiler = compile(root.toString(), {
               base: inputBasePath,
               onDependency: (path) => {
                 context.fullRebuildPaths.push(path)
               },
             })
+
+            env.DEBUG && console.timeEnd('[@tailwindcss/postcss] Setup compiler')
+            return compiler
           }
 
           // Setup the compiler if it doesn't exist yet. This way we can
@@ -126,7 +132,9 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
             sources: context.compiler.globs,
           })
 
+          env.DEBUG && console.time('[@tailwindcss/postcss] Scan for candidates')
           let candidates = scanner.scan()
+          env.DEBUG && console.timeEnd('[@tailwindcss/postcss] Scan for candidates')
 
           // Add all found files as direct dependencies
           for (let file of scanner.files) {
@@ -154,17 +162,26 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
           if (rebuildStrategy === 'full') {
             context.compiler = await createCompiler()
           }
+
+          env.DEBUG && console.time('[@tailwindcss/postcss] Build CSS')
           css = context.compiler.build(candidates)
+          env.DEBUG && console.timeEnd('[@tailwindcss/postcss] Build CSS')
 
           // Replace CSS
           if (css !== context.css && optimize) {
+            env.DEBUG && console.time('[@tailwindcss/postcss] Optimize CSS')
             context.optimizedCss = optimizeCss(css, {
               minify: typeof optimize === 'object' ? optimize.minify : true,
             })
+            env.DEBUG && console.timeEnd('[@tailwindcss/postcss] Optimize CSS')
           }
           context.css = css
+
+          env.DEBUG && console.time('[@tailwindcss/postcss] Update PostCSS AST')
           root.removeAll()
           root.append(postcss.parse(optimize ? context.optimizedCss : context.css, result.opts))
+          env.DEBUG && console.timeEnd('[@tailwindcss/postcss] Update PostCSS AST')
+          env.DEBUG && console.timeEnd('[@tailwindcss/postcss] Total time in @tailwindcss/postcss')
         },
       },
     ],

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -1,10 +1,9 @@
-import { compile, normalizePath } from '@tailwindcss/node'
+import { compile, env, normalizePath } from '@tailwindcss/node'
 import { clearRequireCache } from '@tailwindcss/node/require-cache'
 import { Scanner } from '@tailwindcss/oxide'
 import { Features, transform } from 'lightningcss'
 import path from 'path'
 import type { Plugin, ResolvedConfig, Rollup, Update, ViteDevServer } from 'vite'
-import * as env from '../../tailwindcss/src/env'
 
 export default function tailwindcss(): Plugin[] {
   let servers: ViteDevServer[] = []

--- a/packages/tailwindcss/src/env.ts
+++ b/packages/tailwindcss/src/env.ts
@@ -1,0 +1,40 @@
+export const DEBUG = typeof process !== 'undefined' ? resolveDebug(process.env.DEBUG) : false
+
+function resolveDebug(debug: typeof process.env.DEBUG) {
+  if (debug === undefined) {
+    return false
+  }
+
+  // Environment variables are strings, so convert to boolean
+  if (debug === 'true' || debug === '1') {
+    return true
+  }
+
+  if (debug === 'false' || debug === '0') {
+    return false
+  }
+
+  // Keep the debug convention into account:
+  // DEBUG=* -> This enables all debug modes
+  // DEBUG=projectA,projectB,projectC -> This enables debug for projectA, projectB and projectC
+  // DEBUG=projectA:* -> This enables all debug modes for projectA (if you have sub-types)
+  // DEBUG=projectA,-projectB -> This enables debug for projectA and explicitly disables it for projectB
+
+  if (debug === '*') {
+    return true
+  }
+
+  let debuggers = debug.split(',').map((d) => d.split(':')[0])
+
+  // Ignoring tailwindcss
+  if (debuggers.includes('-tailwindcss')) {
+    return false
+  }
+
+  // Including tailwindcss
+  if (debuggers.includes('tailwindcss')) {
+    return true
+  }
+
+  return false
+}


### PR DESCRIPTION
This PR exposes when using the the `DEBUG` environment variable. This follows the `DEBUG` conventions where:

- `DEBUG=1`
- `DEBUG=true`
- `DEBUG=*`
- `DEBUG=tailwindcss`

Will enable the debug information, but when using:

- `DEBUG=0`
- `DEBUG=false`
- `DEBUG=-tailwindcss`

It will not.

This currently only exposes some timings related to:

1. Scanning for candidates
2. Building the CSS
3. Optimizing the CSS

We can implement a more advanced version of this where we also expose more fine grained information such as the files we scanned, the amount of candidates we found and so on. But I believe that this will be enough to start triaging performance related issues.
