### PR TITLE
Only run Ubuntu tests on feature branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,14 @@ jobs:
       matrix:
         node-version: [20]
         runner: [ubuntu-latest, windows-latest, macos-14]
+        # Exclude windows and macos from being built on feature branches
+        main:
+          - ${{ contains(github.ref, 'next') }}
+        exclude:
+          - main: false
+            runner: windows-latest
+          - main: false
+            runner: macos-14
 
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ jobs:
         node-version: [20]
         runner: [ubuntu-latest, windows-latest, macos-14]
         # Exclude windows and macos from being built on feature branches
-        on-next-branch: ${{ github.ref == 'refs/heads/next' }}
+        on-next-branch:
+          - ${{ github.ref == 'refs/heads/next' }}
         exclude:
           - on-next-branch: false
             runner: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         node-version: [20]
         runner: [ubuntu-latest, windows-latest, macos-14]
         # Exclude windows and macos from being built on feature branches
-        on-next-branch: [${{ github.ref == 'refs/heads/next' }}]
+        on-next-branch: ${{ github.ref == 'refs/heads/next' }}
         exclude:
           - on-next-branch: false
             runner: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,10 @@ jobs:
 
       - name: Run Playwright tests
         run: npm run test:ui
+
+      - name: Notify Discord
+        if: failure() && github.ref == 'refs/heads/next'
+        uses: discord-actions/message@v2
+        with:
+          webhookUrl: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          message: 'Oh noes! A build on `next` failed!'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,7 @@ jobs:
         node-version: [20]
         runner: [ubuntu-latest, windows-latest, macos-14]
         # Exclude windows and macos from being built on feature branches
-        on-next-branch:
-          - ${{ github.ref == 'refs/heads/next' }}
+        on-next-branch: ${{ github.ref == 'refs/heads/next' }}
         exclude:
           - on-next-branch: false
             runner: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         node-version: [20]
         runner: [ubuntu-latest, windows-latest, macos-14]
         # Exclude windows and macos from being built on feature branches
-        on-next-branch: ${{ github.ref == 'refs/heads/next' }}
+        on-next-branch: [${{ github.ref == 'refs/heads/next' }}]
         exclude:
           - on-next-branch: false
             runner: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
         node-version: [20]
         runner: [ubuntu-latest, windows-latest, macos-14]
         # Exclude windows and macos from being built on feature branches
-        main:
-          - ${{ contains(github.ref, 'next') }}
+        on-next-branch:
+          - ${{ github.ref == 'refs/heads/next' }}
         exclude:
-          - main: false
+          - on-next-branch: false
             runner: windows-latest
-          - main: false
+          - on-next-branch: false
             runner: macos-14
 
     runs-on: ${{ matrix.runner }}

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -74,7 +74,7 @@ export function test(
 ) {
   return (only || (!process.env.CI && debug) ? defaultTest.only : defaultTest)(
     name,
-    { timeout: TEST_TIMEOUT },
+    { timeout: TEST_TIMEOUT, retry: 3 },
     async (options) => {
       let rootDir = debug ? path.join(REPO_ROOT, '.debug') : TMP_ROOT
       await fs.mkdir(rootDir, { recursive: true })


### PR DESCRIPTION
This PR changes it so that only the Ubuntu runner starts when doing a pull request. On a successfull `next` merge, all runners shoould start.

Furthermore this increases the retry count for integration test to 3. This is mainly so that rare Windows flakes we still see won't become noise when we enabled the Discord notification.