### PR TITLE
Fix rebuilds when editing imported CSS files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use the right import base path when using the CLI to reading files from stdin ([#14522](https://github.com/tailwindlabs/tailwindcss/pull/14522))
 - Ensure that `@utility` is top-level and cannot be nested ([#14525](https://github.com/tailwindlabs/tailwindcss/pull/14525))
+- Editing imported CSS files should trigger a rebuild ([#14561](https://github.com/tailwindlabs/tailwindcss/pull/14561))
 - _Experimental_: Improve codemod output, keep CSS after last Tailwind directive unlayered ([#14512](https://github.com/tailwindlabs/tailwindcss/pull/14512))
 - _Experimental_: Fix incorrect empty `layer()` at the end of `@import` at-rules when running codemods ([#14513](https://github.com/tailwindlabs/tailwindcss/pull/14513))
 - _Experimental_: Do not wrap comment nodes in `@layer` when running codemods ([#14517](https://github.com/tailwindlabs/tailwindcss/pull/14517))

--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -112,7 +112,7 @@ describe.each([
         `,
         'project-a/index.html': html`
           <div
-            class="underline 2xl:font-bold hocus:underline inverted:flex"
+            class="underline 2xl:font-bold hocus:underline inverted:flex text-primary"
           ></div>
         `,
         'project-a/plugin.js': js`
@@ -128,9 +128,16 @@ describe.each([
         `,
         'project-a/src/index.css': css`
           @import 'tailwindcss/utilities';
+          @import './custom-theme.css';
           @config '../tailwind.config.js';
           @source '../../project-b/src/**/*.html';
           @plugin '../plugin.js';
+        `,
+        'project-a/src/custom-theme.css': css`
+          /* Will be overwritten later */
+          @theme {
+            --color-primary: black;
+          }
         `,
         'project-a/src/index.js': js`
           const className = "content-['project-a/src/index.js']"
@@ -157,6 +164,11 @@ describe.each([
         candidate`content-['project-b/src/index.js']`,
         candidate`inverted:flex`,
         candidate`hocus:underline`,
+        css`
+          .text-primary {
+            color: var(--color-primary, black);
+          }
+        `,
       ])
 
       await fs.write(
@@ -179,6 +191,24 @@ describe.each([
       )
       await fs.expectFileToContain('project-a/dist/out.css', [
         candidate`[.changed_&]:content-['project-b/src/index.js']`,
+      ])
+
+      await fs.write(
+        'project-a/src/custom-theme.css',
+        css`
+          /* Overriding the primary color */
+          @theme {
+            --color-primary: red;
+          }
+        `,
+      )
+
+      await fs.expectFileToContain('project-a/dist/out.css', [
+        css`
+          .text-primary {
+            color: var(--color-primary, red);
+          }
+        `,
       ])
     },
   )

--- a/packages/@tailwindcss-node/src/compile.ts
+++ b/packages/@tailwindcss-node/src/compile.ts
@@ -74,6 +74,8 @@ async function loadStylesheet(id: string, base: string, onDependency: (path: str
   let resolvedPath = await resolveCssId(id, base)
   if (!resolvedPath) throw new Error(`Could not resolve '${id}' from '${base}'`)
 
+  onDependency(resolvedPath)
+
   if (typeof globalThis.__tw_readFile === 'function') {
     let file = await globalThis.__tw_readFile(resolvedPath, 'utf-8')
     if (file) {


### PR DESCRIPTION
This PR fixes an issue where importing other CSS files, then changing those CSS files didn't trigger a rebuild. This PR fixes that by making sure that the imported CSS files are properly watched.

This PR also adds some integration tests for `@tailwindcss/postcss`, `@tailwindcss/vite` and `@tailwindcss/cli` to make sure this works as expected.
