### PR TITLE
Bare values: Disallow zeros in decimal places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - _Experimental_: Ensure we don't lose selectors when running codemods ([#14518](https://github.com/tailwindlabs/tailwindcss/pull/14518))
 - _Experimental_: inject `@import` in a more expected location when running codemods ([#14536](https://github.com/tailwindlabs/tailwindcss/pull/14536))
 
+### Changed
+
+- Disallow bare values with decimal places ([#14562](https://github.com/tailwindlabs/tailwindcss/pull/14562))
+
 ## [4.0.0-alpha.25] - 2024-09-24
 
 ### Added

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -10044,6 +10044,8 @@ test('from', async () => {
   expect(
     await run([
       'from',
+      'from-25.%',
+      'from-25.0%',
       'from-123',
       'from--123',
       'from--5%',

--- a/packages/tailwindcss/src/utils/infer-data-type.ts
+++ b/packages/tailwindcss/src/utils/infer-data-type.ts
@@ -326,5 +326,5 @@ function isVector(value: string) {
  */
 export function isPositiveInteger(value: any) {
   let num = Number(value)
-  return Number.isInteger(num) && num >= 0
+  return Number.isInteger(num) && num >= 0 && String(num) === String(value)
 }


### PR DESCRIPTION
I noticed some more unexpected values being passed through as _bare values_: Decimal places with zero. 

These should not generate CSS but currently does:

- `from-25.%`
- `from-25.0%`
- `from-25.00%`
- etc.

