### PR TITLE
Add binary extensions found in macOS traces

### DIFF
--- a/crates/oxide/src/scanner/fixtures/binary-extensions.txt
+++ b/crates/oxide/src/scanner/fixtures/binary-extensions.txt
@@ -152,6 +152,7 @@ pdf
 pea
 pgm
 pic
+plist
 png
 pnm
 pot

--- a/crates/oxide/src/scanner/fixtures/binary-extensions.txt
+++ b/crates/oxide/src/scanner/fixtures/binary-extensions.txt
@@ -135,6 +135,7 @@ npx
 numbers
 nupkg
 o
+oa
 odp
 ods
 odt
@@ -200,9 +201,11 @@ sqlite
 sqlite3
 sqlite3
 stl
+storedata
 sub
 suo
 swf
+symbolsarchive
 tar
 tbz
 tbz2


### PR DESCRIPTION
While we were doing some tracing for Rust memory issues, we noticed that the builds became slower and slower. Turns out we did store the macOS `.trace` dirs within the auto content directory of the Tailwind CSS instance we were profiling and that _some of the files were massive binary files that we were now scanning_.

Here's the anatomy of a single trace:


```
[ 320]  .
├── [497K]  form.template
├── [5.1K]  open.creq
├── [ 261]  UI_state_metadata.bin
├── [ 160]  corespace
│   ├── [1.2K]  MANIFEST.plist
│   ├── [  96]  currentRun
│   │   └── [  96]  core
│   │       └── [ 128]  uniquing
│   │           ├── [ 128]  arrayUniquer
│   │           │   ├── [10.0K]  integeruniquer.data
│   │           │   └── [   0]  integeruniquer.index
│   │           └── [ 128]  typedArrayUniquer
│   │               ├── [10.0K]  integeruniquer.data
│   │               └── [   0]  integeruniquer.index
│   └── [  96]  run1
│       └── [ 192]  core
│           ├── [ 224]  uniquing
│           │   ├── [6.5K]  EngineeringTypes.etypes
│           │   ├── [3.5K]  strings
│           │   ├── [ 344]  TOC
│           │   ├── [ 128]  arrayUniquer
│           │   │   ├── [1.1K]  integeruniquer.data
│           │   │   └── [  96]  integeruniquer.index
│           │   └── [ 128]  typedArrayUniquer
│           │       ├── [1.0K]  integeruniquer.data
│           │       └── [  28]  integeruniquer.index
│           ├── [ 192]  stores
│           │   ├── [ 224]  indexed-store-0
│           │   │   ├── [1.6K]  bulkstore
│           │   │   ├── [1.2K]  spindex.0
│           │   │   ├── [1.1K]  bulkstore_descriptor
│           │   │   ├── [ 433]  spec.plist
│           │   │   └── [ 188]  schema.xml
│           │   ├── [ 224]  indexed-store-1
│           │   │   ├── [7.5K]  bulkstore
│           │   │   ├── [7.0K]  spindex.0
│           │   │   ├── [1.6K]  bulkstore_descriptor
│           │   │   ├── [ 522]  spec.plist
│           │   │   └── [ 352]  schema.xml
│           │   ├── [ 224]  indexed-store-2
│           │   │   ├── [ 17K]  bulkstore
│           │   │   ├── [7.2K]  spindex.0
│           │   │   ├── [2.0K]  bulkstore_descriptor
│           │   │   ├── [ 532]  spec.plist
│           │   │   └── [ 412]  schema.xml
│           │   └── [ 192]  indexed-store-3
│           │       ├── [1.8K]  bulkstore_descriptor
│           │       ├── [ 426]  spec.plist
│           │       ├── [ 399]  schema.xml
│           │       └── [  50]  bulkstore
│           ├── [  96]  core-config
│           │   └── [2.0K]  exposedTableInfo.plist
│           └── [  96]  table-manager
│               └── [1.6K]  tables.plist
├── [ 128]  Trace1.run
│   ├── [966M]  event_data_52237.oa
│   └── [ 52K]  RunIssues.storedata
├── [ 128]  instrument_data
│   ├── [  96]  EF4DC038-8A17-421A-8050-39DD0980C06F
│   │   └── [  96]  run_data
│   │       └── [ 17K]  1.run.zip
│   └── [  96]  F9F2B147-A042-43F0-A791-EA6D63C7C1E8
│       └── [  96]  run_data
│           └── [2.2K]  1.run.zip
├── [ 128]  symbols
│   ├── [ 608]  stores
│   │   ├── [453K]  D14A8304-5F09-385D-9AA6-1B0C815B6356.symbolsarchive
│   │   ├── [ 36K]  4E9DB999-EFF4-3C83-B4E8-E1914D2C331E.symbolsarchive
│   │   ├── [3.7K]  B5D897DF-D536-3668-BBAD-A17119439EF0.symbolsarchive
│   │   ├── [3.1K]  57FFCB9D-A6C9-3E9A-AA82-40F192626527.symbolsarchive
│   │   ├── [2.9K]  69AA9AB7-C5DE-3CAE-BF1A-384F9F36A3E0.symbolsarchive
│   │   ├── [2.8K]  F453C5AE-3568-3AAA-AAA0-D2FDFBB9BC7A.symbolsarchive
│   │   ├── [2.6K]  62D27203-665F-3AA7-8BE9-7E3C3A847353.symbolsarchive
│   │   ├── [2.4K]  9896C713-054D-377D-88B4-45E1DE3FB6C5.symbolsarchive
│   │   ├── [2.1K]  249D8F21-72A2-3A80-ADC1-7BEAF24B5B58.symbolsarchive
│   │   ├── [2.1K]  FA954AC0-FCC5-3711-800B-432011ACD89E.symbolsarchive
│   │   ├── [2.0K]  E7ED11EE-AFB0-3B96-90A8-F1835726B9B8.symbolsarchive
│   │   ├── [1.3K]  5B476F9B-DF8B-356A-8582-615D4AD08504.symbolsarchive
│   │   ├── [1.3K]  6102110F-7ED8-34C2-95D3-C5ACCB41497E.symbolsarchive
│   │   ├── [1.1K]  EC86EDBF-30B9-3BF8-A358-C8D51805B016.symbolsarchive
│   │   ├── [1.0K]  6740FF57-8D20-3FC7-97F5-B2AFB6E5F48A.symbolsarchive
│   │   ├── [ 963]  9A72FD37-D827-3D6D-B6F4-422621E36C94.symbolsarchive
│   │   └── [ 948]  67A46592-439B-36DA-8A08-A7CD777A43A8.symbolsarchive
│   └── [ 290]  MANIFEST.plist
└── [  96]  shared_data
    └── [  96]  1.run
        └── [ 14M]  533F36D4-2C90-4030-95CA-74077F2E26D7.zip

29 directories, 59 files
```

Note that the biggest binary file is a `.oa` but I've also added `.storedata` and `.symbolsarchive` as binary extensions to this PR.