### PR TITLE
Bring back `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.80.1"
+profile = "default"


### PR DESCRIPTION
We accidentally removed this in #14565.