### PR TITLE
Try out namespace GitHub Actions workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [20]
-        runner: [nscloud-ubuntu-22.04-amd64-32x64, windows-latest, macos-14]
+        runner: [namespace-profile-default, windows-latest, macos-14]
         # Exclude windows and macos from being built on feature branches
         on-next-branch:
           - ${{ github.ref == 'refs/heads/next' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [20]
-        runner: [ubuntu-latest, windows-latest, macos-14]
+        runner: [namespace-profile-default, windows-latest, macos-14]
         # Exclude windows and macos from being built on feature branches
         on-next-branch:
           - ${{ github.ref == 'refs/heads/next' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [20]
-        runner: [namespace-profile-default, windows-latest, macos-14]
+        runner: [nscloud-ubuntu-22.04-amd64-32x64, windows-latest, macos-14]
         # Exclude windows and macos from being built on feature branches
         on-next-branch:
           - ${{ github.ref == 'refs/heads/next' }}


### PR DESCRIPTION
We're trialing [namespace.so](https://namespace.so/) for their custom GitHub Action workers. So far we're seeing an improvement of 3 minutes in our pipeline (used to take 6min 30sec and now it's 3min 30sec, an almost 50% improvement!).

We can always revert this PR, but I recommend we try it out by enabling it for our CI for the next few days.