### PR TITLE
Don’t crash when scanning candidate matching the prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Don’t crash when scanning a candidate equal to the configured prefix ([#14588](https://github.com/tailwindlabs/tailwindcss/pull/14588))
 
 ## [4.0.0-alpha.26] - 2024-10-03
 

--- a/packages/tailwindcss/src/candidate.ts
+++ b/packages/tailwindcss/src/candidate.ts
@@ -229,7 +229,8 @@ export function* parseCandidate(input: string, designSystem: DesignSystem): Iter
   // A prefix is a special variant used to prefix all utilities. When present,
   // all utilities must start with that variant which we will then remove from
   // the variant list so no other part of the codebase has to know about it.
-  if (designSystem.theme.prefix && rawVariants.length > 1) {
+  if (designSystem.theme.prefix) {
+    if (rawVariants.length === 1) return null
     if (rawVariants[0] !== designSystem.theme.prefix) return null
 
     rawVariants.shift()

--- a/packages/tailwindcss/src/candidate.ts
+++ b/packages/tailwindcss/src/candidate.ts
@@ -229,7 +229,7 @@ export function* parseCandidate(input: string, designSystem: DesignSystem): Iter
   // A prefix is a special variant used to prefix all utilities. When present,
   // all utilities must start with that variant which we will then remove from
   // the variant list so no other part of the codebase has to know about it.
-  if (designSystem.theme.prefix) {
+  if (designSystem.theme.prefix && rawVariants.length > 1) {
     if (rawVariants[0] !== designSystem.theme.prefix) return null
 
     rawVariants.shift()

--- a/packages/tailwindcss/src/prefix.test.ts
+++ b/packages/tailwindcss/src/prefix.test.ts
@@ -333,3 +333,19 @@ test('a prefix must be letters only', async () => {
     `[Error: The prefix "__" is invalid. Prefixes must be lowercase ASCII letters (a-z) only.]`,
   )
 })
+
+test('a candidate matching the prefix does not crash', async () => {
+  let input = css`
+    @theme reference prefix(tomato);
+    @tailwind utilities;
+  `
+
+  let compiler = await compile(input)
+
+  expect(compiler.build(['tomato', 'tomato:flex'])).toMatchInlineSnapshot(`
+    ".tomato\\:flex {
+      display: flex;
+    }
+    "
+  `)
+})


### PR DESCRIPTION
When a prefix is set in a stylesheet and we found a candidate that is equal to the prefix we would crash:
```css
@import "tailwindcss" prefix(tomato);
```

```js
console.log("tomato")
```

This PR fixes this case by ensuring that we have something that looks like a variant before considering a prefix.