### PR TITLE
Ensure auto complete suggestions work when using `matchUtilities`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure the CSS `theme()` function resolves to the right value in some compatibility situations ([#14614](https://github.com/tailwindlabs/tailwindcss/pull/14614))
 - Fix issue that could cause the CLI to crash when files are deleted while watching ([#14616](https://github.com/tailwindlabs/tailwindcss/pull/14616))
 - Ensure custom variants using the JS API have access to modifiers ([#14637](https://github.com/tailwindlabs/tailwindcss/pull/14637))
+- Ensure auto complete suggestions work when using `matchUtilities` ([#14589](https://github.com/tailwindlabs/tailwindcss/pull/14589))
 - _Upgrade (experimental)_: Ensure CSS before a layer stays unlayered when running codemods ([#14596](https://github.com/tailwindlabs/tailwindcss/pull/14596))
 - _Upgrade (experimental)_: Resolve issues where some prefixed candidates were not properly migrated ([#14600](https://github.com/tailwindlabs/tailwindcss/pull/14600))
 

--- a/packages/tailwindcss/src/compat/plugin-api.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.ts
@@ -341,6 +341,32 @@ export function buildPluginApi(
         designSystem.utilities.functional(name, compileFn, {
           types,
         })
+
+        designSystem.utilities.suggest(name, () => {
+          let values = options?.values ?? {}
+          let valueKeys = new Set<string | null>(Object.keys(values))
+
+          // The `__BARE_VALUE__` key is a special key used to ensure bare values
+          // work even with legacy configs and plugins
+          valueKeys.delete('__BARE_VALUE__')
+
+          // The `DEFAULT` key is represented as `null` in the utility API
+          if (valueKeys.has('DEFAULT')) {
+            valueKeys.delete('DEFAULT')
+            valueKeys.add(null)
+          }
+
+          let modifiers = options?.modifiers ?? {}
+          let modifierKeys = modifiers === 'any' ? [] : Object.keys(modifiers)
+
+          return [
+            {
+              supportsNegative: options?.supportsNegativeValues ?? false,
+              values: Array.from(valueKeys),
+              modifiers: modifierKeys,
+            },
+          ]
+        })
       }
     },
 


### PR DESCRIPTION
Discovered `matchUtilities(…)` wasn't populating intellisense on v4 when working on Tailwind Play earlier today. This PR fixes this so plugins using matchUtilities also have intellisense suggestions.