### PR TITLE
Don't crash when encountering a candidate that is only the prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Prevent a crash when encountering a candidate that matches the configured prefix ([#14593](https://github.com/tailwindlabs/tailwindcss/pull/14593))
 
 ## [4.0.0-alpha.26] - 2024-10-03
 

--- a/packages/tailwindcss/src/candidate.ts
+++ b/packages/tailwindcss/src/candidate.ts
@@ -230,6 +230,7 @@ export function* parseCandidate(input: string, designSystem: DesignSystem): Iter
   // all utilities must start with that variant which we will then remove from
   // the variant list so no other part of the codebase has to know about it.
   if (designSystem.theme.prefix) {
+    if (rawVariants.length < 2) return null
     if (rawVariants[0] !== designSystem.theme.prefix) return null
 
     rawVariants.shift()

--- a/packages/tailwindcss/src/prefix.test.ts
+++ b/packages/tailwindcss/src/prefix.test.ts
@@ -333,3 +333,14 @@ test('a prefix must be letters only', async () => {
     `[Error: The prefix "__" is invalid. Prefixes must be lowercase ASCII letters (a-z) only.]`,
   )
 })
+
+test('does not crash on sole prefix', async () => {
+  let input = css`
+    @theme reference prefix(tw);
+    @tailwind utilities;
+  `
+
+  let compiler = await compile(input)
+
+  expect(compiler.build(['tw', 'tw:', 'tw: '])).toBe('')
+})


### PR DESCRIPTION
If you have a prefix in your project (like `prefix(potato)`) and one of your template files contains `potato`, Tailwind currently crashes. We need to assert that Candidates require at least a "base" part. 