### PR TITLE
Add `*.js` export variants for compat files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for `tailwindcss/colors.js`, `tailwindcss/defaultTheme.js`, and `tailwindcss/plugin.js` exports ([#14595](https://github.com/tailwindlabs/tailwindcss/pull/14595))
+
 ### Fixed
 
 - Don’t crash when scanning a candidate equal to the configured prefix ([#14588](https://github.com/tailwindlabs/tailwindcss/pull/14588))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add support for `tailwindcss/colors.js`, `tailwindcss/defaultTheme.js`, and `tailwindcss/plugin.js` exports ([#14595](https://github.com/tailwindlabs/tailwindcss/pull/14595))
-
-### Added
-
 - Support `keyframes` in JS config file themes ([14594](https://github.com/tailwindlabs/tailwindcss/pull/14594))
 
 ### Fixed

--- a/packages/tailwindcss/package.json
+++ b/packages/tailwindcss/package.json
@@ -71,11 +71,23 @@
         "require": "./dist/plugin.js",
         "import": "./dist/plugin.mjs"
       },
+      "./plugin.js": {
+        "require": "./dist/plugin.js",
+        "import": "./dist/plugin.mjs"
+      },
       "./defaultTheme": {
         "require": "./dist/default-theme.js",
         "import": "./dist/default-theme.mjs"
       },
+      "./defaultTheme.js": {
+        "require": "./dist/default-theme.js",
+        "import": "./dist/default-theme.mjs"
+      },
       "./colors": {
+        "require": "./dist/colors.js",
+        "import": "./dist/colors.mjs"
+      },
+      "./colors.js": {
         "require": "./dist/colors.js",
         "import": "./dist/colors.mjs"
       },

--- a/packages/tailwindcss/package.json
+++ b/packages/tailwindcss/package.json
@@ -27,11 +27,23 @@
       "require": "./src/compat/colors.cts",
       "import": "./src/compat/colors.ts"
     },
+    "./colors.js": {
+      "require": "./src/compat/colors.cts",
+      "import": "./src/compat/colors.ts"
+    },
     "./defaultTheme": {
       "require": "./src/compat/default-theme.cts",
       "import": "./src/compat/default-theme.ts"
     },
+    "./defaultTheme.js": {
+      "require": "./src/compat/default-theme.cts",
+      "import": "./src/compat/default-theme.ts"
+    },
     "./plugin": {
+      "require": "./src/plugin.cts",
+      "import": "./src/plugin.ts"
+    },
+    "./plugin.js": {
       "require": "./src/plugin.cts",
       "import": "./src/plugin.ts"
     },


### PR DESCRIPTION
In v3 it was possible to import `*.js` variants of compat files, e.g. `tailwindcss/plugin.js` in addition to `tailwindcss/plugin`. We need to properly map the exports to support this.