### PR TITLE
Pretty print `!important` in declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support for `tailwindcss/colors.js`, `tailwindcss/defaultTheme.js`, and `tailwindcss/plugin.js` exports ([#14595](https://github.com/tailwindlabs/tailwindcss/pull/14595))
 - Support `keyframes` in JS config file themes ([14594](https://github.com/tailwindlabs/tailwindcss/pull/14594))
+- Pretty print `!important` in declarations ([#14611](https://github.com/tailwindlabs/tailwindcss/pull/14611))
 
 ### Fixed
 

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -206,7 +206,7 @@ export function toCss(ast: AstNode[]) {
 
     // Declaration
     else if (node.property !== '--tw-sort' && node.value !== undefined && node.value !== null) {
-      css += `${indent}${node.property}: ${node.value}${node.important ? '!important' : ''};\n`
+      css += `${indent}${node.property}: ${node.value}${node.important ? ' !important' : ''};\n`
     }
 
     return css

--- a/packages/tailwindcss/src/compat/config.test.ts
+++ b/packages/tailwindcss/src/compat/config.test.ts
@@ -1428,15 +1428,15 @@ test('important: true', async () => {
 
   expect(compiler.build(['underline', 'hover:line-through', 'custom'])).toMatchInlineSnapshot(`
     ".custom {
-      color: red!important;
+      color: red !important;
     }
     .underline {
-      text-decoration-line: underline!important;
+      text-decoration-line: underline !important;
     }
     .hover\\:line-through {
       &:hover {
         @media (hover: hover) {
-          text-decoration-line: line-through!important;
+          text-decoration-line: line-through !important;
         }
       }
     }

--- a/packages/tailwindcss/src/important.test.ts
+++ b/packages/tailwindcss/src/important.test.ts
@@ -45,12 +45,12 @@ test('Utilities can be marked with important', async () => {
 
   expect(compiler.build(['underline', 'hover:line-through'])).toMatchInlineSnapshot(`
     ".underline {
-      text-decoration-line: underline!important;
+      text-decoration-line: underline !important;
     }
     .hover\\:line-through {
       &:hover {
         @media (hover: hover) {
-          text-decoration-line: line-through!important;
+          text-decoration-line: line-through !important;
         }
       }
     }
@@ -74,12 +74,12 @@ test('Utilities can be wrapped with a selector and marked as important', async (
   expect(compiler.build(['underline', 'hover:line-through'])).toMatchInlineSnapshot(`
     "#app {
       .underline {
-        text-decoration-line: underline!important;
+        text-decoration-line: underline !important;
       }
       .hover\\:line-through {
         &:hover {
           @media (hover: hover) {
-            text-decoration-line: line-through!important;
+            text-decoration-line: line-through !important;
           }
         }
       }

--- a/packages/tailwindcss/src/intellisense.test.ts
+++ b/packages/tailwindcss/src/intellisense.test.ts
@@ -160,13 +160,13 @@ test('Utilities, when marked as important, show as important in intellisense', a
   expect(design.candidatesToCss(['underline', 'hover:line-through'])).toMatchInlineSnapshot(`
     [
       ".underline {
-      text-decoration-line: underline!important;
+      text-decoration-line: underline !important;
     }
     ",
       ".hover\\:line-through {
       &:hover {
         @media (hover: hover) {
-          text-decoration-line: line-through!important;
+          text-decoration-line: line-through !important;
         }
       }
     }


### PR DESCRIPTION
This PR is a very small improvement. We started pretty printing the generated CSS (proper indentation) a while ago, so that we can use the output as-is for intellisense (on hover).

The other day I noticed that when you use `!important` that we attach it directly to the declaration. Not the end of the world, but this PR injects a little space to make sure that the `!important` is separated from the value which makes it a little easier to read and looks more like what you would write by hand.

Before:
```css
.flex\! {
  display: flex!important;
}
```

After:
```css
.flex\! {
  display: flex !important;
}
```
