### PR TITLE
Migrate simple PostCSS setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support for `tailwindcss/colors.js`, `tailwindcss/defaultTheme.js`, and `tailwindcss/plugin.js` exports ([#14595](https://github.com/tailwindlabs/tailwindcss/pull/14595))
 - Support `keyframes` in JS config file themes ([#14594](https://github.com/tailwindlabs/tailwindcss/pull/14594))
-- _Experimental_: The upgrade tool now automatically discovers your JavaScript config ([#14597](https://github.com/tailwindlabs/tailwindcss/pull/14597))
-- _Experimental_: Migrate v3 PostCSS setups to v4 in some cases ([#14612](https://github.com/tailwindlabs/tailwindcss/pull/14612))
+- _Upgrade (experimental)_: Migrate v3 PostCSS setups to v4 in some cases ([#14612](https://github.com/tailwindlabs/tailwindcss/pull/14612))
 - _Upgrade (experimental)_: The upgrade tool now automatically discovers your JavaScript config ([#14597](https://github.com/tailwindlabs/tailwindcss/pull/14597))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for `tailwindcss/colors.js`, `tailwindcss/defaultTheme.js`, and `tailwindcss/plugin.js` exports ([#14595](https://github.com/tailwindlabs/tailwindcss/pull/14595))
 - Support `keyframes` in JS config file themes ([#14594](https://github.com/tailwindlabs/tailwindcss/pull/14594))
 - _Experimental_: The upgrade tool now automatically discovers your JavaScript config ([#14597](https://github.com/tailwindlabs/tailwindcss/pull/14597))
+- Support `keyframes` in JS config file themes ([14594](https://github.com/tailwindlabs/tailwindcss/pull/14594))
+- _Experimental_: Migrate v3 PostCSS setups to v4 in some cases ([#14612](https://github.com/tailwindlabs/tailwindcss/pull/14612))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for `tailwindcss/colors.js`, `tailwindcss/defaultTheme.js`, and `tailwindcss/plugin.js` exports ([#14595](https://github.com/tailwindlabs/tailwindcss/pull/14595))
 - Support `keyframes` in JS config file themes ([#14594](https://github.com/tailwindlabs/tailwindcss/pull/14594))
 - _Experimental_: The upgrade tool now automatically discovers your JavaScript config ([#14597](https://github.com/tailwindlabs/tailwindcss/pull/14597))
-- Support `keyframes` in JS config file themes ([14594](https://github.com/tailwindlabs/tailwindcss/pull/14594))
 - _Experimental_: Migrate v3 PostCSS setups to v4 in some cases ([#14612](https://github.com/tailwindlabs/tailwindcss/pull/14612))
 
 ### Fixed

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -312,7 +312,8 @@ test(
     },
   },
   async ({ fs, exec }) => {
-    console.log(await exec('npx @tailwindcss/upgrade -c tailwind.config.js'))
+    await exec('npx @tailwindcss/upgrade -c tailwind.config.js')
+
     await fs.expectFileToContain(
       'postcss.config.js',
       js`
@@ -323,10 +324,17 @@ test(
         }
       `,
     )
+    await fs.expectFileToContain('src/index.css', css` @import 'tailwindcss' prefix(tw); `)
+    await fs.expectFileToContain(
+      'src/index.html',
+      // prettier-ignore
+      js`
+        <div class="bg-[var(--my-red)]"></div>
+      `,
+    )
 
     let packageJsonContent = await fs.read('package.json')
     let packageJson = JSON.parse(packageJsonContent)
-
     expect(packageJson.dependencies).toMatchObject({
       tailwindcss: expect.stringContaining('4.0.0'),
     })

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -273,7 +273,7 @@ test(
 )
 
 test(
-  'fully migrate a simple postcss setup',
+  'migrates a simple postcss setup',
   {
     fs: {
       'package.json': json`
@@ -281,6 +281,7 @@ test(
           "dependencies": {
             "postcss": "^8",
             "postcss-cli": "^10",
+            "postcss-import": "^16",
             "autoprefixer": "^10",
             "tailwindcss": "^3",
             "@tailwindcss/upgrade": "workspace:^"
@@ -296,6 +297,8 @@ test(
       'postcss.config.js': js`
         module.exports = {
           plugins: {
+            'postcss-import': {},
+            'tailwindcss/nesting': 'postcss-nesting',
             tailwindcss: {},
             autoprefixer: {},
           },
@@ -312,7 +315,7 @@ test(
     },
   },
   async ({ fs, exec }) => {
-    await exec('npx @tailwindcss/upgrade -c tailwind.config.js')
+    await exec('npx @tailwindcss/upgrade')
 
     await fs.expectFileToContain(
       'postcss.config.js',
@@ -339,6 +342,7 @@ test(
       tailwindcss: expect.stringContaining('4.0.0'),
     })
     expect(packageJson.dependencies).not.toHaveProperty('autoprefixer')
+    expect(packageJson.dependencies).not.toHaveProperty('postcss-import')
     expect(packageJson.devDependencies).toMatchObject({
       '@tailwindcss/postcss': expect.stringContaining('4.0.0'),
     })
@@ -377,7 +381,7 @@ test(
     },
   },
   async ({ exec, fs }) => {
-    await exec('npx @tailwindcss/upgrade -c tailwind.config.js')
+    await exec('npx @tailwindcss/upgrade')
 
     await fs.expectFileToContain('src/index.html', html`
         <div class="flex"></div>
@@ -415,7 +419,7 @@ test(
     },
   },
   async ({ exec, fs }) => {
-    await exec('npx @tailwindcss/upgrade -c tailwind.config.js')
+    await exec('npx @tailwindcss/upgrade')
 
     await fs.expectFileToContain(
       'src/index.html',

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -423,6 +423,81 @@ test(
 )
 
 test(
+  'migrates a postcss setup using a json based config file',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "dependencies": {
+            "postcss": "^8",
+            "postcss-cli": "^10",
+            "postcss-import": "^16",
+            "autoprefixer": "^10",
+            "tailwindcss": "^3",
+            "@tailwindcss/upgrade": "workspace:^"
+          }
+        }
+      `,
+      '.postcssrc.json': json`
+        {
+          "plugins": {
+            "postcss-import": {},
+            "tailwindcss/nesting": "postcss-nesting",
+            "tailwindcss": {},
+            "autoprefixer": {}
+          }
+        }
+      `,
+      'tailwind.config.js': js`
+        /** @type {import('tailwindcss').Config} */
+        module.exports = {
+          content: ['./src/**/*.{html,js}'],
+        }
+      `,
+      'src/index.html': html`
+        <div class="bg-[--my-red]"></div>
+      `,
+      'src/index.css': css`
+        @tailwind base;
+        @tailwind components;
+        @tailwind utilities;
+      `,
+    },
+  },
+  async ({ fs, exec }) => {
+    console.log(await exec('npx @tailwindcss/upgrade'))
+
+    await fs.expectFileToContain('src/index.css', css`@import 'tailwindcss';`)
+    await fs.expectFileToContain(
+      'src/index.html',
+      // prettier-ignore
+      js`
+        <div class="bg-[var(--my-red)]"></div>
+      `,
+    )
+
+    let packageJsonContent = await fs.read('.postcssrc.json')
+    let packageJson = JSON.parse(packageJsonContent)
+    expect(packageJson).toMatchInlineSnapshot(`
+      {
+        "plugins": {
+          "@tailwindcss/postcss": {},
+        },
+      }
+    `)
+
+    expect(packageJson.dependencies).toMatchObject({
+      tailwindcss: expect.stringContaining('4.0.0'),
+    })
+    expect(packageJson.dependencies).not.toHaveProperty('autoprefixer')
+    expect(packageJson.dependencies).not.toHaveProperty('postcss-import')
+    expect(packageJson.devDependencies).toMatchObject({
+      '@tailwindcss/postcss': expect.stringContaining('4.0.0'),
+    })
+  },
+)
+
+test(
   `migrates prefixes even if other files have unprefixed versions of the candidate`,
   {
     fs: {

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -1,4 +1,4 @@
-import { css, html, js, json, test } from '../utils'
+import { candidate, css, html, js, json, test } from '../utils'
 
 test(
   `upgrades a v3 project to v4`,
@@ -244,6 +244,71 @@ test(
     },
   },
   async ({ fs, exec }) => {
+    await exec('npx @tailwindcss/upgrade')
+
+    await fs.expectFileToContain(
+      'src/index.css',
+      css`
+        @utility btn {
+          @apply rounded-md px-2 py-1 bg-blue-500 text-white;
+        }
+
+        @utility no-scrollbar {
+          &::-webkit-scrollbar {
+            display: none;
+          }
+          -ms-overflow-style: none;
+          scrollbar-width: none;
+        }
+      `,
+    )
+  },
+)
+
+test.only(
+  'migrate a simple postcss setup',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "dependencies": {
+            "postcss": "^8",
+            "postcss-cli": "^10",
+            "autoprefixer": "^10",
+            "tailwindcss": "^3",
+            "@tailwindcss/upgrade": "workspace:^"
+          }
+        }
+      `,
+      'tailwind.config.js': js`
+        /** @type {import('tailwindcss').Config} */
+        module.exports = {
+          content: ['./src/**/*.{html,js}'],
+        }
+      `,
+      'postcss.config.js': js`
+        module.exports = {
+          plugins: {
+            tailwindcss: {},
+            autoprefixer: {},
+          },
+        }
+      `,
+      'src/index.html': html`
+        <div class="bg-[--my-red]"></div>
+      `,
+      'src/index.css': css`
+        @tailwind base;
+        @tailwind components;
+        @tailwind utilities;
+      `,
+    },
+  },
+  async ({ fs, exec }) => {
+    // Assert that the v3 project works as expected
+    await exec('pnpm postcss src/index.css --output dist/out.css')
+    await fs.expectFileToContain('dist/out.css', [candidate`bg-[--my-red]`])
+
     await exec('npx @tailwindcss/upgrade')
 
     await fs.expectFileToContain(

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -324,7 +324,7 @@ test(
         }
       `,
     )
-    await fs.expectFileToContain('src/index.css', css` @import 'tailwindcss' prefix(tw); `)
+    await fs.expectFileToContain('src/index.css', css`@import 'tailwindcss';`)
     await fs.expectFileToContain(
       'src/index.html',
       // prettier-ignore

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -390,7 +390,7 @@ test(
     },
   },
   async ({ fs, exec }) => {
-    console.log(await exec('npx @tailwindcss/upgrade'))
+    await exec('npx @tailwindcss/upgrade')
 
     await fs.expectFileToContain('src/index.css', css`@import 'tailwindcss';`)
     await fs.expectFileToContain(
@@ -465,7 +465,7 @@ test(
     },
   },
   async ({ fs, exec }) => {
-    console.log(await exec('npx @tailwindcss/upgrade'))
+    await exec('npx @tailwindcss/upgrade')
 
     await fs.expectFileToContain('src/index.css', css`@import 'tailwindcss';`)
     await fs.expectFileToContain(
@@ -476,9 +476,9 @@ test(
       `,
     )
 
-    let packageJsonContent = await fs.read('.postcssrc.json')
-    let packageJson = JSON.parse(packageJsonContent)
-    expect(packageJson).toMatchInlineSnapshot(`
+    let jsonConfigContent = await fs.read('.postcssrc.json')
+    let jsonConfig = JSON.parse(jsonConfigContent)
+    expect(jsonConfig).toMatchInlineSnapshot(`
       {
         "plugins": {
           "@tailwindcss/postcss": {},
@@ -486,6 +486,8 @@ test(
       }
     `)
 
+    let packageJsonContent = await fs.read('package.json')
+    let packageJson = JSON.parse(packageJsonContent)
     expect(packageJson.dependencies).toMatchObject({
       tailwindcss: expect.stringContaining('4.0.0'),
     })

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -74,7 +74,7 @@ export function test(
 ) {
   return (only || (!process.env.CI && debug) ? defaultTest.only : defaultTest)(
     name,
-    { timeout: TEST_TIMEOUT },
+    { timeout: TEST_TIMEOUT, retry: 3 },
     async (options) => {
       let rootDir = debug ? path.join(REPO_ROOT, '.debug') : TMP_ROOT
       await fs.mkdir(rootDir, { recursive: true })

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -74,7 +74,7 @@ export function test(
 ) {
   return (only || (!process.env.CI && debug) ? defaultTest.only : defaultTest)(
     name,
-    { timeout: TEST_TIMEOUT, retry: debug ? 0 : 3 },
+    { timeout: TEST_TIMEOUT, retry: debug || only ? 0 : 3 },
     async (options) => {
       let rootDir = debug ? path.join(REPO_ROOT, '.debug') : TMP_ROOT
       await fs.mkdir(rootDir, { recursive: true })

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -74,7 +74,7 @@ export function test(
 ) {
   return (only || (!process.env.CI && debug) ? defaultTest.only : defaultTest)(
     name,
-    { timeout: TEST_TIMEOUT, retry: 3 },
+    { timeout: TEST_TIMEOUT },
     async (options) => {
       let rootDir = debug ? path.join(REPO_ROOT, '.debug') : TMP_ROOT
       await fs.mkdir(rootDir, { recursive: true })

--- a/packages/@tailwindcss-upgrade/src/index.ts
+++ b/packages/@tailwindcss-upgrade/src/index.ts
@@ -100,7 +100,7 @@ async function run() {
     success('Stylesheet migration complete.')
   }
 
-  if (parsedConfig) {
+  {
     // PostCSS config migration
     await migratePostCSSConfig(process.cwd())
   }

--- a/packages/@tailwindcss-upgrade/src/index.ts
+++ b/packages/@tailwindcss-upgrade/src/index.ts
@@ -4,10 +4,12 @@ import { globby } from 'globby'
 import path from 'node:path'
 import { help } from './commands/help'
 import { migrate as migrateStylesheet } from './migrate'
+import { migratePostCSSConfig } from './migrate-postcss'
 import { migrate as migrateTemplate } from './template/migrate'
 import { prepareConfig } from './template/prepare-config'
 import { args, type Arg } from './utils/args'
 import { isRepoDirty } from './utils/git'
+import { pkg } from './utils/packages'
 import { eprintln, error, header, highlight, info, success } from './utils/renderer'
 
 const options = {
@@ -97,6 +99,16 @@ async function run() {
 
     success('Stylesheet migration complete.')
   }
+
+  if (parsedConfig) {
+    // PostCSS config migration
+    await migratePostCSSConfig(process.cwd())
+  }
+
+  try {
+    // Upgrade Tailwind CSS
+    await pkg('add tailwindcss@next', process.cwd())
+  } catch {}
 
   // Figure out if we made any changes
   if (isRepoDirty()) {

--- a/packages/@tailwindcss-upgrade/src/migrate-postcss.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-postcss.ts
@@ -1,0 +1,95 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { pkg } from './utils/packages'
+import { info, success, warn } from './utils/renderer'
+
+// Migrates simple PostCSS setups. This is to cover non-dynamic config files
+// similar to the ones we have all over our docs:
+//
+// ```js
+// module.exports = {
+//  plugins: {
+//    tailwindcss: {},
+//    autoprefixer: {},
+//  }
+// }
+export async function migratePostCSSConfig(base: string) {
+  let configPath = await detectConfigPath(base)
+  if (configPath === null) {
+    // TODO: We can look for an eventual config inside package.json
+    return
+  }
+
+  info(`Attempt to upgrade the PostCSS config in file: ${configPath}`)
+
+  let isSimpleConfig = await isSimplePostCSSConfig(base, configPath)
+  if (!isSimpleConfig) {
+    warn(`The PostCSS config contains dynamic JavaScript and can not be automatically migrated.`)
+    return
+  }
+
+  let didAddPostcssClient = false
+  let didRemoveAutoprefixer = false
+
+  let fullPath = path.resolve(base, configPath)
+  let content = await fs.readFile(fullPath, 'utf-8')
+  let lines = content.split('\n')
+  let newLines: string[] = []
+  for (let line of lines) {
+    if (line.includes('tailwindcss:')) {
+      didAddPostcssClient = true
+      newLines.push(line.replace('tailwindcss:', `'@tailwindcss/postcss':`))
+    } else if (line.includes('autoprefixer:')) {
+      didRemoveAutoprefixer = true
+    } else {
+      newLines.push(line)
+    }
+  }
+  await fs.writeFile(fullPath, newLines.join('\n'))
+
+  if (didAddPostcssClient) {
+    try {
+      await pkg('add -D @tailwindcss/postcss@next', base)
+    } catch {}
+  }
+  if (didRemoveAutoprefixer) {
+    try {
+      await pkg('remove autoprefixer', base)
+    } catch {}
+  }
+
+  success(`PostCSS config in file ${configPath} has been upgraded.`)
+}
+
+const CONFIG_FILE_LOCATIONS = [
+  '.postcssrc.js',
+  '.postcssrc.mjs',
+  '.postcssrc.cjs',
+  '.postcssrc.ts',
+  '.postcssrc.mts',
+  '.postcssrc.cts',
+  'postcss.config.js',
+  'postcss.config.mjs',
+  'postcss.config.cjs',
+  'postcss.config.ts',
+  'postcss.config.mts',
+  'postcss.config.cts',
+]
+async function detectConfigPath(base: string): Promise<null | string> {
+  for (let file of CONFIG_FILE_LOCATIONS) {
+    let fullPath = path.resolve(base, file)
+    try {
+      await fs.access(fullPath)
+      return file
+    } catch {}
+  }
+  return null
+}
+
+async function isSimplePostCSSConfig(base: string, configPath: string): Promise<boolean> {
+  let fullPath = path.resolve(base, configPath)
+  let content = await fs.readFile(fullPath, 'utf-8')
+  return (
+    content.includes('tailwindcss:') && !(content.includes('require') || content.includes('import'))
+  )
+}

--- a/packages/@tailwindcss-upgrade/src/migrate-postcss.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-postcss.ts
@@ -59,7 +59,7 @@ export async function migratePostCSSConfig(base: string) {
   // Priority 3: JSON based postcss config files
   let jsonConfigPath = await detectJSONConfigPath(base)
   let jsonConfig: null | any = null
-  if (jsonConfigPath) {
+  if (!didMigrate && jsonConfigPath) {
     try {
       jsonConfig = JSON.parse(await fs.readFile(jsonConfigPath, 'utf-8'))
     } catch {}

--- a/packages/@tailwindcss-upgrade/src/utils/packages.ts
+++ b/packages/@tailwindcss-upgrade/src/utils/packages.ts
@@ -27,6 +27,9 @@ async function detectPackageManager(base: string): Promise<null | string> {
       let packageJsonContent = await fs.readFile(packageJsonPath, 'utf-8')
       let packageJson = JSON.parse(packageJsonContent)
       if (packageJson.packageManager) {
+        if (packageJson.packageManager.includes('bun')) {
+          return 'bun'
+        }
         if (packageJson.packageManager.includes('yarn')) {
           return 'yarn'
         }
@@ -40,6 +43,14 @@ async function detectPackageManager(base: string): Promise<null | string> {
     } catch {}
 
     // 2. Check for common lockfiles
+    try {
+      await fs.access(resolve(base, 'bun.lockb'))
+      return 'bun'
+    } catch {}
+    try {
+      await fs.access(resolve(base, 'bun.lock'))
+      return 'bun'
+    } catch {}
     try {
       await fs.access(resolve(base, 'pnpm-lock.yaml'))
       return 'pnpm'

--- a/packages/@tailwindcss-upgrade/src/utils/packages.ts
+++ b/packages/@tailwindcss-upgrade/src/utils/packages.ts
@@ -1,0 +1,61 @@
+import { execSync } from 'node:child_process'
+import fs from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { warn } from './renderer'
+
+let didWarnAboutPackageManager = false
+
+export async function pkg(command: string, base: string): Promise<Buffer | void> {
+  let packageManager = await detectPackageManager(base)
+  if (!packageManager) {
+    if (!didWarnAboutPackageManager) {
+      didWarnAboutPackageManager = true
+      warn('Could not detect a package manager. Please manually update `tailwindcss` to v4.')
+    }
+    return
+  }
+  return execSync(`${packageManager} ${command}`, {
+    cwd: base,
+  })
+}
+
+async function detectPackageManager(base: string): Promise<null | string> {
+  do {
+    // 1. Check package.json for a `packageManager` field
+    let packageJsonPath = resolve(base, 'package.json')
+    try {
+      let packageJsonContent = await fs.readFile(packageJsonPath, 'utf-8')
+      let packageJson = JSON.parse(packageJsonContent)
+      if (packageJson.packageManager) {
+        if (packageJson.packageManager.includes('yarn')) {
+          return 'yarn'
+        }
+        if (packageJson.packageManager.includes('pnpm')) {
+          return 'pnpm'
+        }
+        if (packageJson.packageManager.includes('npm')) {
+          return 'npm'
+        }
+      }
+    } catch {}
+
+    // 2. Check for common lockfiles
+    try {
+      await fs.access(resolve(base, 'pnpm-lock.yaml'))
+      return 'pnpm'
+    } catch {}
+
+    try {
+      await fs.access(resolve(base, 'yarn.lock'))
+      return 'yarn'
+    } catch {}
+
+    try {
+      await fs.access(resolve(base, 'package-lock.json'))
+      return 'npm'
+    } catch {}
+
+    // 3. If no lockfile is found, we might be in a monorepo
+    base = dirname(base)
+  } while (true)
+}


### PR DESCRIPTION
This PR attempts to detect simple postcss setups: These are setups that do not load dynamic modules and are based off the examples we are [recommending in our docs](https://tailwindcss.com/docs/installation/using-postcss). We detect wether a config is appropriate by having it use the object plugin config and by not requiring any other modules:

```js
module.exports = {
  plugins: {
    tailwindcss: {},
    autoprefixer: {},
  },
}
```

When we find such a config file, we will go over it line-by-line and attempt to:

- Upgrade `tailwindcss:` to `'@tailwindcss/postcss':`
- Remove `autoprefixer` if used

We then attempt to install and remove the respective npm packages based on the package manger we detect.

And since we now have logic to upgrade packages, this also makes sure to install `tailwindcss@next` at the end of a sucessful migration. 