### PR TITLE
Migrate utilities in CSS files imported into layers

### DIFF
--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -32,15 +32,15 @@ test(
   async ({ exec, fs }) => {
     await exec('npx @tailwindcss/upgrade')
 
-    await fs.expectFileToContain(
-      'src/index.html',
-      html`
-        <h1>🤠👋</h1>
-        <div class="flex! sm:block! bg-linear-to-t bg-[var(--my-red)]"></div>
-      `,
-    )
+    expect(await fs.dumpFiles('./src/**/*.{css,html}')).toMatchInlineSnapshot(`
+      "
+      --- ./src/index.html ---
+      <h1>🤠👋</h1>
+      <div class="flex! sm:block! bg-linear-to-t bg-[var(--my-red)]"></div>
 
-    await fs.expectFileToContain('src/input.css', css`@import 'tailwindcss';`)
+      --- ./src/input.css ---
+      @import 'tailwindcss';"
+    `)
 
     let packageJsonContent = await fs.read('package.json')
     let packageJson = JSON.parse(packageJsonContent)
@@ -86,23 +86,19 @@ test(
   async ({ exec, fs }) => {
     await exec('npx @tailwindcss/upgrade')
 
-    await fs.expectFileToContain(
-      'src/index.html',
-      html`
-        <h1>🤠👋</h1>
-        <div class="tw:flex! tw:sm:block! tw:bg-linear-to-t flex tw:[color:red]"></div>
-      `,
-    )
+    expect(await fs.dumpFiles('./src/**/*.{css,html}')).toMatchInlineSnapshot(`
+      "
+      --- ./src/index.html ---
+      <h1>🤠👋</h1>
+      <div class="tw:flex! tw:sm:block! tw:bg-linear-to-t flex tw:[color:red]"></div>
 
-    await fs.expectFileToContain('src/input.css', css` @import 'tailwindcss' prefix(tw); `)
-    await fs.expectFileToContain(
-      'src/input.css',
-      css`
-        .btn {
-          @apply tw:rounded-md! tw:px-2 tw:py-1 tw:bg-blue-500 tw:text-white;
-        }
-      `,
-    )
+      --- ./src/input.css ---
+      @import 'tailwindcss' prefix(tw);
+
+      .btn {
+        @apply tw:rounded-md! tw:px-2 tw:py-1 tw:bg-blue-500 tw:text-white;
+      }"
+    `)
   },
 )
 
@@ -139,22 +135,23 @@ test(
   async ({ fs, exec }) => {
     await exec('npx @tailwindcss/upgrade')
 
-    await fs.expectFileToContain(
-      'src/index.css',
-      css`
-        .a {
-          @apply flex;
-        }
+    expect(await fs.dumpFiles('./src/**/*.css')).toMatchInlineSnapshot(`
+      "
+      --- ./src/index.css ---
+      @import 'tailwindcss';
 
-        .b {
-          @apply flex!;
-        }
+      .a {
+        @apply flex;
+      }
 
-        .c {
-          @apply flex! flex-col! items-center!;
-        }
-      `,
-    )
+      .b {
+        @apply flex!;
+      }
+
+      .c {
+        @apply flex! flex-col! items-center!;
+      }"
+    `)
   },
 )
 
@@ -191,27 +188,23 @@ test(
   async ({ fs, exec }) => {
     await exec('npx @tailwindcss/upgrade')
 
-    await fs.expectFileToContain('src/index.css', css`@import 'tailwindcss';`)
-    await fs.expectFileToContain(
-      'src/index.css',
-      css`
-        @layer base {
-          html {
-            color: #333;
-          }
+    expect(await fs.dumpFiles('./src/**/*.css')).toMatchInlineSnapshot(`
+      "
+      --- ./src/index.css ---
+      @import 'tailwindcss';
+
+      @layer base {
+        html {
+          color: #333;
         }
-      `,
-    )
-    await fs.expectFileToContain(
-      'src/index.css',
-      css`
-        @layer components {
-          .btn {
-            color: red;
-          }
+      }
+
+      @layer components {
+        .btn {
+          color: red;
         }
-      `,
-    )
+      }"
+    `)
   },
 )
 
@@ -253,22 +246,23 @@ test(
   async ({ fs, exec }) => {
     await exec('npx @tailwindcss/upgrade')
 
-    await fs.expectFileToContain(
-      'src/index.css',
-      css`
-        @utility btn {
-          @apply rounded-md px-2 py-1 bg-blue-500 text-white;
-        }
+    expect(await fs.dumpFiles('./src/**/*.css')).toMatchInlineSnapshot(`
+      "
+      --- ./src/index.css ---
+      @import 'tailwindcss';
 
-        @utility no-scrollbar {
-          &::-webkit-scrollbar {
-            display: none;
-          }
-          -ms-overflow-style: none;
-          scrollbar-width: none;
+      @utility btn {
+        @apply rounded-md px-2 py-1 bg-blue-500 text-white;
+      }
+
+      @utility no-scrollbar {
+        &::-webkit-scrollbar {
+          display: none;
         }
-      `,
-    )
+        -ms-overflow-style: none;
+        scrollbar-width: none;
+      }"
+    `)
   },
 )
 
@@ -533,12 +527,14 @@ test(
   async ({ exec, fs }) => {
     await exec('npx @tailwindcss/upgrade')
 
-    await fs.expectFileToContain('src/index.html', html`
-        <div class="flex"></div>
-      `)
-    await fs.expectFileToContain('src/other.html', html`
-        <div class="tw:flex"></div>
-      `)
+    expect(await fs.dumpFiles('./src/**/*.html')).toMatchInlineSnapshot(`
+      "
+      --- ./src/index.html ---
+      <div class="flex"></div>
+
+      --- ./src/other.html ---
+      <div class="tw:flex"></div>"
+    `)
   },
 )
 
@@ -571,18 +567,13 @@ test(
   async ({ exec, fs }) => {
     await exec('npx @tailwindcss/upgrade')
 
-    await fs.expectFileToContain(
-      'src/index.html',
-      html`
-        <div class="tw:bg-linear-to-t"></div>
-      `,
-    )
+    expect(await fs.dumpFiles('./src/**/*.html')).toMatchInlineSnapshot(`
+      "
+      --- ./src/index.html ---
+      <div class="tw:bg-linear-to-t"></div>
 
-    await fs.expectFileToContain(
-      'src/other.html',
-      html`
-        <div class="bg-gradient-to-t"></div>
-      `,
-    )
+      --- ./src/other.html ---
+      <div class="bg-gradient-to-t"></div>"
+    `)
   },
 )

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -114,7 +114,7 @@ export function test(
                   if (execOptions.ignoreStdErr !== true) console.error(stderr)
                   reject(error)
                 } else {
-                  resolve(stdout.toString())
+                  resolve(stdout.toString() + '\n\n' + stderr.toString())
                 }
               },
             )

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-at-layer-utilities.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-at-layer-utilities.test.ts
@@ -1,16 +1,21 @@
 import dedent from 'dedent'
 import postcss from 'postcss'
 import { describe, expect, it } from 'vitest'
+import { Stylesheet } from '../stylesheet'
 import { formatNodes } from './format-nodes'
 import { migrateAtLayerUtilities } from './migrate-at-layer-utilities'
 
 const css = dedent
 
-function migrate(input: string) {
+async function migrate(data: string) {
+  let stylesheet: Stylesheet
+
+  stylesheet = await Stylesheet.fromString(data)
+
   return postcss()
     .use(migrateAtLayerUtilities())
     .use(formatNodes())
-    .process(input, { from: expect.getState().testPath })
+    .process(stylesheet.root!, { from: expect.getState().testPath })
     .then((result) => result.css)
 }
 

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-at-layer-utilities.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-at-layer-utilities.test.ts
@@ -7,13 +7,32 @@ import { migrateAtLayerUtilities } from './migrate-at-layer-utilities'
 
 const css = dedent
 
-async function migrate(data: string) {
+async function migrate(
+  data:
+    | string
+    | {
+        root: postcss.Root
+        layers?: string[]
+      },
+) {
   let stylesheet: Stylesheet
 
-  stylesheet = await Stylesheet.fromString(data)
+  if (typeof data === 'string') {
+    stylesheet = await Stylesheet.fromString(data)
+  } else {
+    stylesheet = await Stylesheet.fromRoot(data.root)
+
+    if (data.layers) {
+      let meta = { layers: data.layers }
+      let parent = await Stylesheet.fromString('.placeholder {}')
+
+      stylesheet.parents.add({ item: parent, meta })
+      parent.children.add({ item: stylesheet, meta })
+    }
+  }
 
   return postcss()
-    .use(migrateAtLayerUtilities())
+    .use(migrateAtLayerUtilities(stylesheet))
     .use(formatNodes())
     .process(stylesheet.root!, { from: expect.getState().testPath })
     .then((result) => result.css)
@@ -824,4 +843,214 @@ it('should not lose attribute selectors', async () => {
       }
     }"
   `)
+})
+
+describe('layered stylesheets', () => {
+  it('should transform classes to utilities inside a layered stylesheet (utilities)', async () => {
+    expect(
+      await migrate({
+        root: postcss.parse(css`
+          /* Utility #1 */
+          .foo {
+            /* Declarations: */
+            color: red;
+          }
+        `),
+        layers: ['utilities'],
+      }),
+    ).toMatchInlineSnapshot(`
+      "@utility foo {
+        /* Utility #1 */
+        /* Declarations: */
+        color: red;
+      }"
+    `)
+  })
+
+  it('should transform classes to utilities inside a layered stylesheet (components)', async () => {
+    expect(
+      await migrate({
+        root: postcss.parse(css`
+          /* Utility #1 */
+          .foo {
+            /* Declarations: */
+            color: red;
+          }
+        `),
+        layers: ['components'],
+      }),
+    ).toMatchInlineSnapshot(`
+      "@utility foo {
+        /* Utility #1 */
+        /* Declarations: */
+        color: red;
+      }"
+    `)
+  })
+
+  it('should NOT transform classes to utilities inside a non-utility, layered stylesheet', async () => {
+    expect(
+      await migrate({
+        root: postcss.parse(css`
+          /* Utility #1 */
+          .foo {
+            /* Declarations: */
+            color: red;
+          }
+        `),
+        layers: ['foo'],
+      }),
+    ).toMatchInlineSnapshot(`
+      "/* Utility #1 */
+      .foo {
+        /* Declarations: */
+        color: red;
+      }"
+    `)
+  })
+
+  it('should handle non-classes in utility-layered stylesheets', async () => {
+    expect(
+      await migrate({
+        root: postcss.parse(css`
+          /* Utility #1 */
+          .foo {
+            /* Declarations: */
+            color: red;
+          }
+          #main {
+            color: red;
+          }
+        `),
+        layers: ['utilities'],
+      }),
+    ).toMatchInlineSnapshot(`
+      "
+      #main {
+        color: red;
+      }
+
+      @utility foo {
+        /* Utility #1 */
+        /* Declarations: */
+        color: red;
+      }"
+    `)
+  })
+
+  it('should handle non-classes in utility-layered stylesheets', async () => {
+    expect(
+      await migrate({
+        root: postcss.parse(css`
+          @layer utilities {
+            @layer utilities {
+              /* Utility #1 */
+              .foo {
+                /* Declarations: */
+                color: red;
+              }
+            }
+
+            /* Utility #2 */
+            .bar {
+              /* Declarations: */
+              color: red;
+            }
+
+            #main {
+              color: red;
+            }
+          }
+
+          /* Utility #3 */
+          .baz {
+            /* Declarations: */
+            color: red;
+          }
+
+          #secondary {
+            color: red;
+          }
+        `),
+        layers: ['utilities'],
+      }),
+    ).toMatchInlineSnapshot(`
+      "@layer utilities {
+
+        #main {
+          color: red;
+        }
+      }
+
+      #secondary {
+        color: red;
+      }
+
+      @utility foo {
+        @layer utilities {
+          @layer utilities {
+            /* Utility #1 */
+            /* Declarations: */
+            color: red;
+          }
+        }
+      }
+
+      @utility bar {
+        @layer utilities {
+          /* Utility #2 */
+          /* Declarations: */
+          color: red;
+        }
+      }
+
+      @utility baz {
+        /* Utility #3 */
+        /* Declarations: */
+        color: red;
+      }"
+    `)
+  })
+
+  it('imports are preserved in layered stylesheets', async () => {
+    expect(
+      await migrate({
+        root: postcss.parse(css`
+          @import 'thing';
+
+          .foo {
+            color: red;
+          }
+        `),
+        layers: ['utilities'],
+      }),
+    ).toMatchInlineSnapshot(`
+      "@import 'thing';
+
+      @utility foo {
+        color: red;
+      }"
+    `)
+  })
+
+  it('charset is preserved in layered stylesheets', async () => {
+    expect(
+      await migrate({
+        root: postcss.parse(css`
+          @charset "utf-8";
+
+          .foo {
+            color: red;
+          }
+        `),
+        layers: ['utilities'],
+      }),
+    ).toMatchInlineSnapshot(`
+      "@charset "utf-8";
+
+      @utility foo {
+        color: red;
+      }"
+    `)
+  })
 })

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-at-layer-utilities.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-at-layer-utilities.ts
@@ -186,7 +186,7 @@ export function migrateAtLayerUtilities(): Plugin {
 
       // Mark the node as pretty so that it gets formatted by Prettier later.
       clone.raws.tailwind_pretty = true
-      clone.raws.before += '\n\n'
+      clone.raws.before = `${clone.raws.before ?? ''}\n\n`
     }
 
     // Cleanup

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-at-layer-utilities.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-at-layer-utilities.ts
@@ -1,9 +1,10 @@
 import { type AtRule, type Comment, type Plugin, type Rule } from 'postcss'
 import SelectorParser from 'postcss-selector-parser'
 import { segment } from '../../../tailwindcss/src/utils/segment'
+import { Stylesheet } from '../stylesheet'
 import { walk, WalkAction, walkDepth } from '../utils/walk'
 
-export function migrateAtLayerUtilities(): Plugin {
+export function migrateAtLayerUtilities(stylesheet: Stylesheet): Plugin {
   function migrate(atRule: AtRule) {
     // Only migrate `@layer utilities` and `@layer components`.
     if (atRule.params !== 'utilities' && atRule.params !== 'components') return
@@ -86,6 +87,12 @@ export function migrateAtLayerUtilities(): Plugin {
       clones.push(clone)
 
       walk(clone, (node) => {
+        if (node.type === 'atrule') {
+          if (!node.nodes || node.nodes?.length === 0) {
+            node.remove()
+          }
+        }
+
         if (node.type !== 'rule') return
 
         // Fan out each utility into its own rule.
@@ -259,7 +266,16 @@ export function migrateAtLayerUtilities(): Plugin {
 
   return {
     postcssPlugin: '@tailwindcss/upgrade/migrate-at-layer-utilities',
-    OnceExit: (root) => {
+    OnceExit: (root, { atRule }) => {
+      let layers = stylesheet.layers()
+      let isUtilityStylesheet = layers.has('utilities') || layers.has('components')
+
+      if (isUtilityStylesheet) {
+        let rule = atRule({ name: 'layer', params: 'utilities' })
+        rule.append(root.nodes)
+        root.append(rule)
+      }
+
       // Migrate `@layer utilities` and `@layer components` into `@utility`.
       // Using this instead of the visitor API in case we want to use
       // postcss-nesting in the future.
@@ -280,6 +296,17 @@ export function migrateAtLayerUtilities(): Plugin {
               utilities.set(child.params, child)
             }
           }
+        })
+      }
+
+      // If the stylesheet is inside a layered import then we can remove the top-level layer directive we added
+      if (isUtilityStylesheet) {
+        root.each((node) => {
+          if (node.type !== 'atrule') return
+          if (node.name !== 'layer') return
+          if (node.params !== 'utilities') return
+
+          node.replaceWith(node.nodes ?? [])
         })
       }
     },

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-missing-layers.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-missing-layers.ts
@@ -110,7 +110,7 @@ export function migrateMissingLayers(): Plugin {
       let target = nodes[0]
       let layerNode = new AtRule({
         name: 'layer',
-        params: layerName || firstLayerName || '',
+        params: targetLayerName,
         nodes: nodes.map((node) => {
           // Keep the target node as-is, because we will be replacing that one
           // with the new layer node.

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-missing-layers.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-missing-layers.ts
@@ -71,6 +71,7 @@ export function migrateMissingLayers(): Plugin {
         if (node.name === 'import') {
           if (lastLayer !== '' && !node.params.includes('layer(')) {
             node.params += ` layer(${lastLayer})`
+            node.raws.tailwind_injected_layer = true
           }
 
           if (bucket.length > 0) {

--- a/packages/@tailwindcss-upgrade/src/index.ts
+++ b/packages/@tailwindcss-upgrade/src/index.ts
@@ -6,7 +6,7 @@ import path from 'node:path'
 import postcss from 'postcss'
 import { formatNodes } from './codemods/format-nodes'
 import { help } from './commands/help'
-import { migrate as migrateStylesheet } from './migrate'
+import { analyze as analyzeStylesheets, migrate as migrateStylesheet } from './migrate'
 import { migratePostCSSConfig } from './migrate-postcss'
 import { Stylesheet } from './stylesheet'
 import { migrate as migrateTemplate } from './template/migrate'
@@ -111,6 +111,13 @@ async function run() {
     let stylesheets = loadResults
       .filter((result) => result.status === 'fulfilled')
       .map((result) => result.value)
+
+    // Analyze the stylesheets
+    try {
+      await analyzeStylesheets(stylesheets)
+    } catch (e: unknown) {
+      error(`${e}`)
+    }
 
     // Migrate each file
     let migrateResults = await Promise.allSettled(

--- a/packages/@tailwindcss-upgrade/src/index.ts
+++ b/packages/@tailwindcss-upgrade/src/index.ts
@@ -6,7 +6,11 @@ import path from 'node:path'
 import postcss from 'postcss'
 import { formatNodes } from './codemods/format-nodes'
 import { help } from './commands/help'
-import { analyze as analyzeStylesheets, migrate as migrateStylesheet } from './migrate'
+import {
+  analyze as analyzeStylesheets,
+  migrate as migrateStylesheet,
+  split as splitStylesheets,
+} from './migrate'
 import { migratePostCSSConfig } from './migrate-postcss'
 import { Stylesheet } from './stylesheet'
 import { migrate as migrateTemplate } from './template/migrate'
@@ -128,6 +132,13 @@ async function run() {
       if (result.status === 'rejected') {
         error(`${result.reason}`)
       }
+    }
+
+    // Split up stylesheets (as needed)
+    try {
+      await splitStylesheets(stylesheets)
+    } catch (e: unknown) {
+      error(`${e}`)
     }
 
     // Format nodes

--- a/packages/@tailwindcss-upgrade/src/migrate.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate.ts
@@ -1,14 +1,12 @@
-import fs from 'node:fs/promises'
-import path from 'node:path'
 import postcss from 'postcss'
 import type { Config } from 'tailwindcss'
 import type { DesignSystem } from '../../tailwindcss/src/design-system'
-import { formatNodes } from './codemods/format-nodes'
 import { migrateAtApply } from './codemods/migrate-at-apply'
 import { migrateAtLayerUtilities } from './codemods/migrate-at-layer-utilities'
 import { migrateMediaScreen } from './codemods/migrate-media-screen'
 import { migrateMissingLayers } from './codemods/migrate-missing-layers'
 import { migrateTailwindDirectives } from './codemods/migrate-tailwind-directives'
+import { Stylesheet } from './stylesheet'
 
 export interface MigrateOptions {
   newPrefix: string | null
@@ -16,21 +14,29 @@ export interface MigrateOptions {
   userConfig: Config
 }
 
-export async function migrateContents(contents: string, options: MigrateOptions, file?: string) {
+export async function migrateContents(
+  stylesheet: Stylesheet | string,
+  options: MigrateOptions,
+  file?: string,
+) {
+  if (typeof stylesheet === 'string') {
+    stylesheet = await Stylesheet.fromString(stylesheet)
+    stylesheet.file = file ?? null
+  }
+
   return postcss()
     .use(migrateAtApply(options))
     .use(migrateMediaScreen(options))
     .use(migrateAtLayerUtilities())
     .use(migrateMissingLayers())
     .use(migrateTailwindDirectives(options))
-    .use(formatNodes())
-    .process(contents, { from: file })
-    .then((result) => result.css)
+    .process(stylesheet.root, { from: stylesheet.file ?? undefined })
 }
 
-export async function migrate(file: string, options: MigrateOptions) {
-  let fullPath = path.resolve(process.cwd(), file)
-  let contents = await fs.readFile(fullPath, 'utf-8')
+export async function migrate(stylesheet: Stylesheet, options: MigrateOptions) {
+  if (!stylesheet.file) {
+    throw new Error('Cannot migrate a stylesheet without a file path')
+  }
 
-  await fs.writeFile(fullPath, await migrateContents(contents, options, fullPath))
+  await migrateContents(stylesheet, options)
 }

--- a/packages/@tailwindcss-upgrade/src/migrate.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate.ts
@@ -2,14 +2,16 @@ import path from 'node:path'
 import postcss from 'postcss'
 import type { Config } from 'tailwindcss'
 import type { DesignSystem } from '../../tailwindcss/src/design-system'
+import { DefaultMap } from '../../tailwindcss/src/utils/default-map'
 import { segment } from '../../tailwindcss/src/utils/segment'
 import { migrateAtApply } from './codemods/migrate-at-apply'
 import { migrateAtLayerUtilities } from './codemods/migrate-at-layer-utilities'
 import { migrateMediaScreen } from './codemods/migrate-media-screen'
 import { migrateMissingLayers } from './codemods/migrate-missing-layers'
 import { migrateTailwindDirectives } from './codemods/migrate-tailwind-directives'
-import { Stylesheet } from './stylesheet'
+import { Stylesheet, type StylesheetId } from './stylesheet'
 import { resolveCssId } from './utils/resolve'
+import { walk, WalkAction } from './utils/walk'
 
 export interface MigrateOptions {
   newPrefix: string | null
@@ -88,6 +90,10 @@ export async function analyze(stylesheets: Stylesheet[]) {
           // that we don't want to modify
           if (!stylesheet) return
 
+          // Mark the import node with the ID of the stylesheet it points to
+          // We will use these later to build lookup tables and modify the AST
+          node.raws.tailwind_destination_sheet_id = stylesheet.id
+
           let parent = node.source?.input.file
             ? stylesheetsByFile.get(node.source.input.file)
             : undefined
@@ -117,4 +123,234 @@ export async function analyze(stylesheets: Stylesheet[]) {
 
     await processor.process(sheet.root, { from: sheet.file })
   }
+}
+
+export async function split(stylesheets: Stylesheet[]) {
+  let stylesheetsById = new Map<StylesheetId, Stylesheet>()
+  let stylesheetsByFile = new Map<string, Stylesheet>()
+
+  for (let sheet of stylesheets) {
+    stylesheetsById.set(sheet.id, sheet)
+
+    if (sheet.file) {
+      stylesheetsByFile.set(sheet.file, sheet)
+    }
+  }
+
+  // Keep track of sheets that contain `@utillity` rules
+  let containsUtilities = new Set<Stylesheet>()
+
+  for (let sheet of stylesheets) {
+    let layers = sheet.layers()
+    let isLayered = layers.has('utilities') || layers.has('components')
+    if (!isLayered) continue
+
+    walk(sheet.root, (node) => {
+      if (node.type !== 'atrule') return
+      if (node.name !== 'utility') return
+
+      containsUtilities.add(sheet)
+
+      return WalkAction.Stop
+    })
+  }
+
+  // Split every imported stylesheet into two parts
+  let utilitySheets = new Map<Stylesheet, Stylesheet>()
+
+  for (let sheet of stylesheets) {
+    // Ignore stylesheets that were not imported
+    if (!sheet.file) continue
+    if (sheet.parents.size === 0) continue
+
+    // Skip stylesheets that don't have utilities
+    // and don't have any children that have utilities
+    if (!containsUtilities.has(sheet)) {
+      if (!Array.from(sheet.descendants()).some((child) => containsUtilities.has(child))) {
+        continue
+      }
+    }
+
+    let utilities = postcss.root({
+      raws: {
+        tailwind_pretty: true,
+      },
+    })
+
+    walk(sheet.root, (node) => {
+      if (node.type !== 'atrule') return
+      if (node.name !== 'utility') return
+
+      // `append` will move this node from the original sheet
+      // to the new utilities sheet
+      utilities.append(node)
+
+      return WalkAction.Skip
+    })
+
+    let newFileName = sheet.file.replace(/\.css$/, '.utilities.css')
+
+    let counter = 0
+
+    // If we already have a utility sheet with this name, we need to rename it
+    while (stylesheetsByFile.has(newFileName)) {
+      counter += 1
+      newFileName = sheet.file.replace(/\.css$/, `.utilities.${counter}.css`)
+    }
+
+    let utilitySheet = await Stylesheet.fromRoot(utilities, newFileName)
+
+    utilitySheet.extension = counter > 0 ? `.utilities.${counter}.css` : `.utilities.css`
+
+    utilitySheets.set(sheet, utilitySheet)
+    stylesheetsById.set(utilitySheet.id, utilitySheet)
+  }
+
+  // Make sure the utility sheets are linked to one another
+  for (let [normalSheet, utilitySheet] of utilitySheets) {
+    for (let parent of normalSheet.parents) {
+      let utilityParent = utilitySheets.get(parent.item)
+      if (!utilityParent) continue
+      utilitySheet.parents.add({
+        item: utilityParent,
+        meta: parent.meta,
+      })
+    }
+
+    for (let child of normalSheet.children) {
+      let utilityChild = utilitySheets.get(child.item)
+      if (!utilityChild) continue
+      utilitySheet.children.add({
+        item: utilityChild,
+        meta: child.meta,
+      })
+    }
+  }
+
+  for (let sheet of stylesheets) {
+    let utilitySheet = utilitySheets.get(sheet)
+    let utilityImports: Set<postcss.AtRule> = new Set()
+
+    for (let node of sheet.importRules) {
+      let sheetId = node.raws.tailwind_destination_sheet_id as StylesheetId | undefined
+
+      // This import rule does not point to a stylesheet
+      // which likely means it points to `node_modules`
+      if (!sheetId) continue
+
+      let originalDestination = stylesheetsById.get(sheetId)
+
+      // This import points to a stylesheet that no longer exists which likely
+      // means it was removed by the optimizer this will be cleaned up later
+      if (!originalDestination) continue
+
+      let utilityDestination = utilitySheets.get(originalDestination)
+
+      // A utility sheet doesn't exist for this import so it doesn't need
+      // to be processed
+      if (!utilityDestination) continue
+
+      let match = node.params.match(/(['"])(.*)\1/)
+      if (!match) return
+
+      let quote = match[1]
+      let id = match[2]
+
+      let newFile = id.replace(/\.css$/, utilityDestination.extension!)
+
+      // The import will just point to the new file without any media queries,
+      // layers, or other conditions because `@utility` MUST be top-level.
+      let newImport = node.clone({
+        params: `${quote}${newFile}${quote}`,
+        raws: {
+          after: '\n\n',
+          tailwind_original_params: `${quote}${id}${quote}`,
+          tailwind_destination_sheet_id: utilityDestination.id,
+        },
+      })
+
+      if (utilitySheet) {
+        // If this import is intended to go into the utility sheet
+        // we'll collect it into a list to add later. If we don't'
+        // we'll end up adding them in reverse order.
+        utilityImports.add(newImport)
+      } else {
+        // This import will go immediately after the original import
+        node.after(newImport)
+      }
+    }
+
+    // Add imports to the top of the utility sheet if necessary
+    if (utilitySheet && utilityImports.size > 0) {
+      utilitySheet.root.prepend(Array.from(utilityImports))
+    }
+  }
+
+  // Tracks the at rules that import a given stylesheet
+  let importNodes = new DefaultMap<Stylesheet, Set<postcss.AtRule>>(() => new Set())
+
+  for (let sheet of stylesheetsById.values()) {
+    for (let node of sheet.importRules) {
+      let sheetId = node.raws.tailwind_destination_sheet_id as StylesheetId | undefined
+
+      // This import rule does not point to a stylesheet
+      if (!sheetId) continue
+
+      let destination = stylesheetsById.get(sheetId)
+
+      // This import rule does not point to a stylesheet that exists
+      // We'll remove it later
+      if (!destination) continue
+
+      importNodes.get(destination).add(node)
+    }
+  }
+
+  // At this point we've created many `{name}.utilities.css` files.
+  // If the original file _becomes_ empty after splitting that means that
+  // dedicated utility file is not required and we can move the utilities
+  // back to the original file.
+  //
+  // This could be done in one step but separating them makes it easier to
+  // reason about since the stylesheets are in a consistent state before we
+  // perform any cleanup tasks.
+  let list: Stylesheet[] = []
+
+  for (let sheet of stylesheets.slice()) {
+    for (let child of sheet.descendants()) {
+      list.push(child)
+    }
+
+    list.push(sheet)
+  }
+
+  for (let sheet of list) {
+    let utilitySheet = utilitySheets.get(sheet)
+
+    // This sheet was not split so there's nothing to do
+    if (!utilitySheet) continue
+
+    // This sheet did not become empty
+    if (!sheet.isEmpty) continue
+
+    // We have a sheet that became empty after splitting
+    // 1. Replace the sheet with it's utility sheet content
+    sheet.root = utilitySheet.root
+
+    // 2. Rewrite imports in parent sheets to point to the original sheet
+    // Ideally this wouldn't need to be _undone_ but instead only done once at the end
+    for (let node of importNodes.get(utilitySheet)) {
+      node.params = node.raws.tailwind_original_params as any
+    }
+
+    // 3. Remove the original import from the non-utility sheet
+    for (let node of importNodes.get(sheet)) {
+      node.remove()
+    }
+
+    // 3. Mark the utility sheet for removal
+    utilitySheets.delete(sheet)
+  }
+
+  stylesheets.push(...utilitySheets.values())
 }

--- a/packages/@tailwindcss-upgrade/src/stylesheet.ts
+++ b/packages/@tailwindcss-upgrade/src/stylesheet.ts
@@ -1,0 +1,51 @@
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import * as util from 'node:util'
+import * as postcss from 'postcss'
+
+export type StylesheetId = string
+
+export class Stylesheet {
+  /**
+   * The PostCSS AST that represents this stylesheet.
+   */
+  root: postcss.Root
+
+  /**
+   * The path to the file that this stylesheet was loaded from.
+   *
+   * If this stylesheet was not loaded from a file this will be `null`.
+   */
+  file: string | null = null
+
+  static async load(filepath: string) {
+    filepath = path.resolve(process.cwd(), filepath)
+
+    let css = await fs.readFile(filepath, 'utf-8')
+    let root = postcss.parse(css, { from: filepath })
+
+    return new Stylesheet(root, filepath)
+  }
+
+  static async fromString(css: string) {
+    let root = postcss.parse(css)
+
+    return new Stylesheet(root)
+  }
+
+  static async fromRoot(root: postcss.Root, file?: string) {
+    return new Stylesheet(root, file)
+  }
+
+  constructor(root: postcss.Root, file?: string) {
+    this.root = root
+    this.file = file ?? null
+  }
+
+  [util.inspect.custom]() {
+    return {
+      ...this,
+      root: this.root.toString(),
+    }
+  }
+}

--- a/packages/@tailwindcss-upgrade/src/stylesheet.ts
+++ b/packages/@tailwindcss-upgrade/src/stylesheet.ts
@@ -42,6 +42,11 @@ export class Stylesheet {
    */
   children = new Set<StylesheetConnection>()
 
+  /**
+   * Whether or not this stylesheet can be migrated
+   */
+  extension: string | null = null
+
   static async load(filepath: string) {
     filepath = path.resolve(process.cwd(), filepath)
 
@@ -65,6 +70,24 @@ export class Stylesheet {
     this.id = Math.random().toString(36).slice(2)
     this.root = root
     this.file = file ?? null
+
+    if (file) {
+      this.extension = path.extname(file)
+    }
+  }
+
+  get importRules() {
+    let imports = new Set<postcss.AtRule>()
+
+    this.root.walkAtRules('import', (rule) => {
+      imports.add(rule)
+    })
+
+    return imports
+  }
+
+  get isEmpty() {
+    return this.root.toString().trim() === ''
   }
 
   *ancestors() {


### PR DESCRIPTION
When a stylesheet is imported with `@import “…” layer(utilities)` that means that all classes in that stylesheet and any of its imported stylesheets become candidates for `@utility` conversion.

Doing this correctly requires us to place `@utility` rules into separate stylesheets (usually) and replicate the import tree without layers as `@utility` MUST be root-level. If a file consists of only utilities we won't create a separate file for it and instead place the `@utility` rules in the same stylesheet.

Been doing a LOT of pairing with @RobinMalfait on this one but I think this is finally ready to be looked at