### PR TITLE
Don't set `display: none` on elements that use `hidden="until-found"`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Don't set `display: none` on elements that use `hidden="until-found"` ([#14625](https://github.com/tailwindlabs/tailwindcss/pull/14625))
 
 ## [3.4.13] - 2024-09-23
 

--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -381,6 +381,6 @@ video {
 }
 
 /* Make elements with the HTML hidden attribute stay hidden by default */
-[hidden] {
+[hidden]:where(:not([hidden="until-found"])) {
   display: none;
 }


### PR DESCRIPTION
Fixes an issue reported by the React Aria Components team here:

https://github.com/adobe/react-spectrum/issues/7160

Basically `hidden="until-found"` behaves very differently than `hidden` and doesn't actually use `display: none`, so we don't want to apply the behavior we apply for the regular `hidden` attribute.
