### PR TITLE
Don't set `display: none` on elements that use `hidden="until-found"`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure there's always a space before `!important` when stringifying CSS ([#14611](https://github.com/tailwindlabs/tailwindcss/pull/14611))
 - _Upgrade (experimental)_: Ensure CSS before a layer stays unlayered when running codemods ([#14596](https://github.com/tailwindlabs/tailwindcss/pull/14596))
 - _Upgrade (experimental)_: Resolve issues where some prefixed candidates were not properly migrated ([#14600](https://github.com/tailwindlabs/tailwindcss/pull/14600))
+- Don't set `display: none` on elements that use `hidden="until-found"` ([#14631](https://github.com/tailwindlabs/tailwindcss/pull/14631))
 
 ## [4.0.0-alpha.26] - 2024-10-03
 

--- a/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
@@ -576,7 +576,7 @@ exports[`\`@import 'tailwindcss'\` is replaced with the generated CSS 1`] = `
     height: auto;
   }
 
-  [hidden] {
+  [hidden]:where(:not([hidden="until-found"])) {
     display: none !important;
   }
 }

--- a/packages/tailwindcss/preflight.css
+++ b/packages/tailwindcss/preflight.css
@@ -321,6 +321,6 @@ video {
   Make elements with the HTML hidden attribute stay hidden by default.
 */
 
-[hidden] {
+[hidden]:where(:not([hidden='until-found'])) {
   display: none !important;
 }


### PR DESCRIPTION
Fixes an issue reported by the React Aria Components team here:

https://github.com/adobe/react-spectrum/issues/7160

Basically `hidden="until-found"` behaves very differently than `hidden` and doesn't actually use `display: none`, so we don't want to apply the behavior we apply for the regular `hidden` attribute.

