### PR TITLE
Inject `@config "..."` when a `tailwind.config.{js,ts,...}` is detected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         on-next-branch:
           - ${{ github.ref == 'refs/heads/next' }}
         exclude:
-          - on-next-branch: false
+          - on-next-branch: true
             runner: windows-latest
           - on-next-branch: false
             runner: macos-14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         on-next-branch:
           - ${{ github.ref == 'refs/heads/next' }}
         exclude:
-          - on-next-branch: true
+          - on-next-branch: false
             runner: windows-latest
           - on-next-branch: false
             runner: macos-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - _Upgrade (experimental)_: Ensure CSS before a layer stays unlayered when running codemods ([#14596](https://github.com/tailwindlabs/tailwindcss/pull/14596))
 - _Upgrade (experimental)_: Resolve issues where some prefixed candidates were not properly migrated ([#14600](https://github.com/tailwindlabs/tailwindcss/pull/14600))
 - _Upgrade (experimental)_: Migrate `@media screen(…)` when running codemods ([#14603](https://github.com/tailwindlabs/tailwindcss/pull/14603))
+- _Upgrade (experimental)_: Inject `@config "…"` when a `tailwind.config.{js,ts,…}` is detected ([#14635](https://github.com/tailwindlabs/tailwindcss/pull/14635))
 
 ## [4.0.0-alpha.26] - 2024-10-03
 

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -39,7 +39,8 @@ test(
       <div class="flex! sm:block! bg-linear-to-t bg-[var(--my-red)]"></div>
 
       --- ./src/input.css ---
-      @import 'tailwindcss';"
+      @import 'tailwindcss';
+      @config "../tailwind.config.js";"
     `)
 
     let packageJsonContent = await fs.read('package.json')
@@ -95,6 +96,8 @@ test(
       --- ./src/input.css ---
       @import 'tailwindcss' prefix(tw);
 
+      @config "../tailwind.config.js";
+
       .btn {
         @apply tw:rounded-md! tw:px-2 tw:py-1 tw:bg-blue-500 tw:text-white;
       }"
@@ -139,6 +142,8 @@ test(
       "
       --- ./src/index.css ---
       @import 'tailwindcss';
+
+      @config "../tailwind.config.js";
 
       .a {
         @apply flex;
@@ -192,6 +197,8 @@ test(
       "
       --- ./src/index.css ---
       @import 'tailwindcss';
+
+      @config "../tailwind.config.js";
 
       @layer base {
         html {
@@ -250,6 +257,8 @@ test(
       "
       --- ./src/index.css ---
       @import 'tailwindcss';
+
+      @config "../tailwind.config.js";
 
       @utility btn {
         @apply rounded-md px-2 py-1 bg-blue-500 text-white;
@@ -615,6 +624,7 @@ test(
       --- ./src/index.css ---
       @import 'tailwindcss';
       @import './utilities.css';
+      @config "../tailwind.config.js";
 
       --- ./src/utilities.css ---
       @utility no-scrollbar {
@@ -730,6 +740,7 @@ test(
       @import './c.1.css' layer(utilities);
       @import './c.1.utilities.css';
       @import './d.1.css';
+      @config "../tailwind.config.js";
 
       --- ./src/a.1.css ---
       @import './a.1.utilities.css'
@@ -862,14 +873,64 @@ test(
       --- ./src/root.1.css ---
       @import 'tailwindcss/utilities' layer(utilities);
       @import './a.1.css' layer(utilities);
+      @config "../tailwind.config.js";
 
       --- ./src/root.2.css ---
       @import 'tailwindcss/utilities' layer(utilities);
       @import './a.1.css' layer(components);
+      @config "../tailwind.config.js";
 
       --- ./src/root.3.css ---
       @import 'tailwindcss/utilities' layer(utilities);
-      @import './a.1.css' layer(utilities);"
+      @import './a.1.css' layer(utilities);
+      @config "../tailwind.config.js";"
+    `)
+  },
+)
+
+test(
+  'injecting `@config` when a tailwind.config.{js,ts,…} is detected',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "dependencies": {
+            "@tailwindcss/upgrade": "workspace:^"
+          }
+        }
+      `,
+      'tailwind.config.ts': js`
+        export default {
+          content: ['./src/**/*.{html,js}'],
+        }
+      `,
+      'src/index.html': html`
+        <h1>🤠👋</h1>
+        <div class="!flex sm:!block bg-gradient-to-t bg-[--my-red]"></div>
+      `,
+      'src/input.css': css`
+        @tailwind base;
+        @tailwind components;
+        @tailwind utilities;
+      `,
+    },
+  },
+  async ({ exec, fs }) => {
+    await exec('npx @tailwindcss/upgrade --force')
+
+    await fs.expectFileToContain(
+      'src/index.html',
+      html`
+        <h1>🤠👋</h1>
+        <div class="flex! sm:block! bg-linear-to-t bg-[var(--my-red)]"></div>
+      `,
+    )
+
+    expect(await fs.dumpFiles('./src/**/*.css')).toMatchInlineSnapshot(`
+      "
+      --- ./src/input.css ---
+      @import 'tailwindcss';
+      @config "../tailwind.config.ts";"
     `)
   },
 )

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -974,10 +974,9 @@ test(
       --- ./src/root.3.css ---
       /* Inject missing @config above first @theme */
       @import 'tailwindcss';
+      @config "../tailwind.config.ts";
 
       @variant hocus (&:hover, &:focus);
-
-      @config "../tailwind.config.ts";
 
       @theme {
         --color-red-500: #f00;

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -908,11 +908,42 @@ test(
         <h1>🤠👋</h1>
         <div class="!flex sm:!block bg-gradient-to-t bg-[--my-red]"></div>
       `,
-      'src/input.css': css`
+      'src/root.1.css': css`
+        /* Inject missing @config */
         @tailwind base;
         @tailwind components;
         @tailwind utilities;
       `,
+      'src/root.2.css': css`
+        /* Already contains @config */
+        @tailwind base;
+        @tailwind components;
+        @tailwind utilities;
+        @config "../tailwind.config.js";
+      `,
+      'src/root.3.css': css`
+        /* Inject missing @config above first @theme */
+        @tailwind base;
+        @tailwind components;
+        @tailwind utilities;
+
+        @variant hocus (&:hover, &:focus);
+
+        @theme {
+          --color-red-500: #f00;
+        }
+
+        @theme {
+          --color-blue-500: #00f;
+        }
+      `,
+      'src/root.4.css': css`
+        /* Inject missing @config due to nested imports with tailwind imports */
+        @import './root.4/base.css';
+        @import './root.4/utilities.css';
+      `,
+      'src/root.4/base.css': css`@import 'tailwindcss/base';`,
+      'src/root.4/utilities.css': css`@import 'tailwindcss/utilities';`,
     },
   },
   async ({ exec, fs }) => {
@@ -924,9 +955,43 @@ test(
       <h1>🤠👋</h1>
       <div class="flex! sm:block! bg-linear-to-t bg-[var(--my-red)]"></div>
 
-      --- ./src/input.css ---
+      --- ./src/root.1.css ---
+      /* Inject missing @config */
       @import 'tailwindcss';
-      @config "../tailwind.config.ts";"
+      @config "../tailwind.config.ts";
+
+      --- ./src/root.2.css ---
+      /* Already contains @config */
+      @import 'tailwindcss';
+      @config "../tailwind.config.js";
+
+      --- ./src/root.3.css ---
+      /* Inject missing @config above first @theme */
+      @import 'tailwindcss';
+
+      @variant hocus (&:hover, &:focus);
+
+      @config "../tailwind.config.ts";
+
+      @theme {
+        --color-red-500: #f00;
+      }
+
+      @theme {
+        --color-blue-500: #00f;
+      }
+
+      --- ./src/root.4.css ---
+      /* Inject missing @config due to nested imports with tailwind imports */
+      @import './root.4/base.css';
+      @import './root.4/utilities.css';
+
+      --- ./src/root.4/base.css ---
+      @import 'tailwindcss/theme' layer(theme);
+      @import 'tailwindcss/preflight' layer(base);
+
+      --- ./src/root.4/utilities.css ---
+      @import 'tailwindcss/utilities' layer(utilities);"
     `)
   },
 )

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -944,6 +944,12 @@ test(
       `,
       'src/root.4/base.css': css`@import 'tailwindcss/base';`,
       'src/root.4/utilities.css': css`@import 'tailwindcss/utilities';`,
+
+      'src/root.5.css': css`@import './root.5/tailwind.css';`,
+      'src/root.5/tailwind.css': css`
+        /* Inject missing @config in this file, due to full import */
+        @import 'tailwindcss';
+      `,
     },
   },
   async ({ exec, fs }) => {
@@ -987,12 +993,20 @@ test(
       @import './root.4/utilities.css';
       @config "../tailwind.config.ts";
 
+      --- ./src/root.5.css ---
+      @import './root.5/tailwind.css';
+
       --- ./src/root.4/base.css ---
       @import 'tailwindcss/theme' layer(theme);
       @import 'tailwindcss/preflight' layer(base);
 
       --- ./src/root.4/utilities.css ---
-      @import 'tailwindcss/utilities' layer(utilities);"
+      @import 'tailwindcss/utilities' layer(utilities);
+
+      --- ./src/root.5/tailwind.css ---
+      /* Inject missing @config in this file, due to full import */
+      @import 'tailwindcss';
+      @config "../../tailwind.config.ts";"
     `)
   },
 )

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -40,7 +40,8 @@ test(
 
       --- ./src/input.css ---
       @import 'tailwindcss';
-      @config "../tailwind.config.js";"
+      @config "../tailwind.config.js";
+      "
     `)
 
     let packageJsonContent = await fs.read('package.json')
@@ -100,7 +101,8 @@ test(
 
       .btn {
         @apply tw:rounded-md! tw:px-2 tw:py-1 tw:bg-blue-500 tw:text-white;
-      }"
+      }
+      "
     `)
   },
 )
@@ -155,7 +157,8 @@ test(
 
       .c {
         @apply flex! flex-col! items-center!;
-      }"
+      }
+      "
     `)
   },
 )
@@ -210,7 +213,8 @@ test(
         .btn {
           color: red;
         }
-      }"
+      }
+      "
     `)
   },
 )
@@ -270,7 +274,8 @@ test(
         }
         -ms-overflow-style: none;
         scrollbar-width: none;
-      }"
+      }
+      "
     `)
   },
 )
@@ -542,7 +547,8 @@ test(
       <div class="flex"></div>
 
       --- ./src/other.html ---
-      <div class="tw:flex"></div>"
+      <div class="tw:flex"></div>
+      "
     `)
   },
 )
@@ -582,7 +588,8 @@ test(
       <div class="tw:bg-linear-to-t"></div>
 
       --- ./src/other.html ---
-      <div class="bg-gradient-to-t"></div>"
+      <div class="bg-gradient-to-t"></div>
+      "
     `)
   },
 )
@@ -633,7 +640,8 @@ test(
         }
         -ms-overflow-style: none;
         scrollbar-width: none;
-      }"
+      }
+      "
     `)
   },
 )
@@ -815,7 +823,8 @@ test(
       --- ./src/d.4.css ---
       @utility from-a-4 {
         color: blue;
-      }"
+      }
+      "
     `)
   },
 )
@@ -883,7 +892,8 @@ test(
       --- ./src/root.3.css ---
       @import 'tailwindcss/utilities' layer(utilities);
       @import './a.1.css' layer(utilities);
-      @config "../tailwind.config.js";"
+      @config "../tailwind.config.js";
+      "
     `)
   },
 )
@@ -1005,7 +1015,8 @@ test(
       --- ./src/root.5/tailwind.css ---
       /* Inject missing @config in this file, due to full import */
       @import 'tailwindcss';
-      @config "../../tailwind.config.ts";"
+      @config "../../tailwind.config.ts";
+      "
     `)
   },
 )

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -985,6 +985,7 @@ test(
       /* Inject missing @config due to nested imports with tailwind imports */
       @import './root.4/base.css';
       @import './root.4/utilities.css';
+      @config "../tailwind.config.ts";
 
       --- ./src/root.4/base.css ---
       @import 'tailwindcss/theme' layer(theme);

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -918,16 +918,12 @@ test(
   async ({ exec, fs }) => {
     await exec('npx @tailwindcss/upgrade --force')
 
-    await fs.expectFileToContain(
-      'src/index.html',
-      html`
-        <h1>🤠👋</h1>
-        <div class="flex! sm:block! bg-linear-to-t bg-[var(--my-red)]"></div>
-      `,
-    )
-
-    expect(await fs.dumpFiles('./src/**/*.css')).toMatchInlineSnapshot(`
+    expect(await fs.dumpFiles('./src/**/*.{html,css}')).toMatchInlineSnapshot(`
       "
+      --- ./src/index.html ---
+      <h1>🤠👋</h1>
+      <div class="flex! sm:block! bg-linear-to-t bg-[var(--my-red)]"></div>
+
       --- ./src/input.css ---
       @import 'tailwindcss';
       @config "../tailwind.config.ts";"

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -330,7 +330,8 @@ export function test(
                 return a[0].localeCompare(z[0])
               })
               .map(([file, content]) => `--- ${file} ---\n${content || '<EMPTY>'}`)
-              .join('\n\n')}`
+              .join('\n\n')
+              .trim()}\n`
           },
           async expectFileToContain(filePath, contents) {
             return retryAssertion(async () => {

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-at-config.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-at-config.ts
@@ -37,18 +37,12 @@ export function migrateAtConfig(
     relative = normalizePath(relative)
 
     // Inject the `@config` in a sensible place
-    // 1. Above the first `@theme`
-    // 2. Below the last `@import`
-    // 3. At the top of the file
+    // 1. Below the last `@import`
+    // 2. At the top of the file
     let locationNode = null as AtRule | null
-    let firstThemeNode = null as AtRule | null
 
     walk(root, (node) => {
-      if (node.type === 'atrule' && node.name === 'theme' && firstThemeNode === null) {
-        firstThemeNode = node
-        locationNode = node
-        return WalkAction.Skip
-      } else if (node.type === 'atrule' && node.name === 'import') {
+      if (node.type === 'atrule' && node.name === 'import') {
         locationNode = node
       }
 
@@ -61,8 +55,6 @@ export function migrateAtConfig(
       root.prepend(configNode)
     } else if (locationNode.name === 'import') {
       locationNode.after(configNode)
-    } else if (locationNode.name === 'theme') {
-      locationNode.before(configNode)
     }
   }
 

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-at-config.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-at-config.ts
@@ -18,7 +18,6 @@ export function migrateAtConfig(
     if (hasConfig) return
 
     // We don't have a sheet with a file path
-    // TODO: Why? Tests?
     if (!sheet.file) return
 
     // Should this sheet have an `@config`?
@@ -39,7 +38,7 @@ export function migrateAtConfig(
     let sheetPath = sheet.file
     let configPath = configFilePath
 
-    let relativePath = path.relative(path.dirname(sheetPath), configPath)
+    let relativePath = path.relative(path.dirname(sheetPath), configPath).replaceAll('\\', '/')
     if (relativePath[0] !== '.') {
       relativePath = `./${relativePath}`
     }

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-at-config.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-at-config.ts
@@ -1,0 +1,73 @@
+import path from 'node:path'
+import { AtRule, type Plugin, type Root } from 'postcss'
+import type { Stylesheet } from '../stylesheet'
+import { walk, WalkAction } from '../utils/walk'
+
+export function migrateAtConfig(
+  sheet: Stylesheet,
+  { configFilePath }: { configFilePath: string },
+): Plugin {
+  function migrate(root: Root) {
+    let hasConfig = false
+    root.walkAtRules('config', () => {
+      hasConfig = true
+      return false
+    })
+
+    // We already have a `@config`
+    if (hasConfig) return
+
+    // We don't have a sheet with a file path
+    // TODO: Why? Tests?
+    if (!sheet.file) return
+
+    // Should this sheet have an `@config`?
+    // 1. It should be a root CSS file
+    if (sheet.parents.size > 0) return
+
+    // 2. It should include a `@import "tailwindcss"`
+    let hasTailwindImport = false
+    root.walkAtRules('import', (node) => {
+      if (node.params.includes('tailwindcss')) {
+        hasTailwindImport = true
+        return false
+      }
+    })
+    if (!hasTailwindImport) return
+
+    // Figure out the path to the config file
+    let sheetPath = sheet.file
+    let configPath = configFilePath
+
+    let relativePath = path.relative(path.dirname(sheetPath), configPath)
+    if (relativePath[0] !== '.') {
+      relativePath = `./${relativePath}`
+    }
+
+    // Inject the `@config` in a sensible place
+    let locationNode = null as AtRule | null
+
+    walk(root, (node) => {
+      if (node.type === 'atrule' && (node.name === 'import' || node.name === 'theme')) {
+        locationNode = node
+      }
+
+      return WalkAction.Skip
+    })
+
+    let configNode = new AtRule({ name: 'config', params: `"${relativePath}"` })
+
+    if (!locationNode) {
+      root.prepend(configNode)
+    } else if (locationNode.name === 'import') {
+      locationNode.after(configNode)
+    } else if (locationNode.name === 'theme') {
+      locationNode.before(configNode)
+    }
+  }
+
+  return {
+    postcssPlugin: '@tailwindcss/upgrade/migrate-at-config',
+    OnceExit: migrate,
+  }
+}

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-missing-layers.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-missing-layers.ts
@@ -10,7 +10,13 @@ export function migrateMissingLayers(): Plugin {
     root.each((node) => {
       if (node.type === 'atrule') {
         // Known Tailwind directives that should not be inside a layer.
-        if (node.name === 'theme' || node.name === 'utility') {
+        if (
+          node.name === 'config' ||
+          node.name === 'source' ||
+          node.name === 'theme' ||
+          node.name === 'utility' ||
+          node.name === 'variant'
+        ) {
           if (bucket.length > 0) {
             buckets.push([lastLayer, bucket.splice(0)])
           }

--- a/packages/@tailwindcss-upgrade/src/index.test.ts
+++ b/packages/@tailwindcss-upgrade/src/index.test.ts
@@ -1,5 +1,6 @@
 import { __unstable__loadDesignSystem } from '@tailwindcss/node'
 import dedent from 'dedent'
+import path from 'node:path'
 import postcss from 'postcss'
 import { expect, it } from 'vitest'
 import { formatNodes } from './codemods/format-nodes'
@@ -13,7 +14,13 @@ let designSystem = await __unstable__loadDesignSystem(
   `,
   { base: __dirname },
 )
-let config = { designSystem, userConfig: {}, newPrefix: null }
+
+let config = {
+  designSystem,
+  userConfig: {},
+  newPrefix: null,
+  configFilePath: path.resolve(__dirname, './tailwind.config.js'),
+}
 
 function migrate(input: string, config: any) {
   return migrateContents(input, config, expect.getState().testPath)
@@ -87,6 +94,8 @@ it('should migrate a stylesheet', async () => {
   ).toMatchInlineSnapshot(`
     "@import 'tailwindcss';
 
+    @config "./tailwind.config.js";
+
     @layer base {
       html {
         overflow: hidden;
@@ -138,7 +147,8 @@ it('should migrate a stylesheet (with imports)', async () => {
     "@import 'tailwindcss';
     @import './my-base.css' layer(base);
     @import './my-components.css' layer(components);
-    @import './my-utilities.css' layer(utilities);"
+    @import './my-utilities.css' layer(utilities);
+    @config "./tailwind.config.js";"
   `)
 })
 
@@ -163,6 +173,7 @@ it('should migrate a stylesheet (with preceding rules that should be wrapped in 
     @layer foo, bar, baz;
     /**! My license comment */
     @import 'tailwindcss';
+    @config "./tailwind.config.js";
     @layer base {
       html {
         color: red;

--- a/packages/@tailwindcss-upgrade/src/migrate.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate.ts
@@ -5,6 +5,7 @@ import type { DesignSystem } from '../../tailwindcss/src/design-system'
 import { DefaultMap } from '../../tailwindcss/src/utils/default-map'
 import { segment } from '../../tailwindcss/src/utils/segment'
 import { migrateAtApply } from './codemods/migrate-at-apply'
+import { migrateAtConfig } from './codemods/migrate-at-config'
 import { migrateAtLayerUtilities } from './codemods/migrate-at-layer-utilities'
 import { migrateMediaScreen } from './codemods/migrate-media-screen'
 import { migrateMissingLayers } from './codemods/migrate-missing-layers'
@@ -17,6 +18,7 @@ export interface MigrateOptions {
   newPrefix: string | null
   designSystem: DesignSystem
   userConfig: Config
+  configFilePath: string
 }
 
 export async function migrateContents(
@@ -35,6 +37,7 @@ export async function migrateContents(
     .use(migrateAtLayerUtilities(stylesheet))
     .use(migrateMissingLayers())
     .use(migrateTailwindDirectives(options))
+    .use(migrateAtConfig(stylesheet, options))
     .process(stylesheet.root, { from: stylesheet.file ?? undefined })
 }
 

--- a/packages/@tailwindcss-upgrade/src/template/prepare-config.ts
+++ b/packages/@tailwindcss-upgrade/src/template/prepare-config.ts
@@ -22,6 +22,7 @@ export async function prepareConfig(
   designSystem: DesignSystem
   globs: { base: string; pattern: string }[]
   userConfig: Config
+  configFilePath: string
 
   newPrefix: string | null
 }> {
@@ -57,7 +58,13 @@ export async function prepareConfig(
       __unstable__loadDesignSystem(input, { base: __dirname }),
     ])
 
-    return { designSystem, globs: compiler.globs, userConfig, newPrefix }
+    return {
+      designSystem,
+      globs: compiler.globs,
+      userConfig,
+      newPrefix,
+      configFilePath: fullConfigPath,
+    }
   } catch (e: any) {
     error('Could not load the configuration file: ' + e.message)
     process.exit(1)


### PR DESCRIPTION
This PR injects a `@config "…"` in the CSS file if a JS based config has been found.

We will try to inject the `@config` in a sensible place:
1. Above the very first `@theme`
2. If that doesn't work, below the last `@import`
3. If that doesn't work, at the top of the file (as a last resort)

