### PR TITLE
Add simple JS config migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - _Upgrade (experimental)_: Migrate v3 PostCSS setups to v4 in some cases ([#14612](https://github.com/tailwindlabs/tailwindcss/pull/14612))
 - _Upgrade (experimental)_: The upgrade tool now automatically discovers your JavaScript config ([#14597](https://github.com/tailwindlabs/tailwindcss/pull/14597))
 - _Upgrade (experimental)_: Migrate legacy classes to the v4 alternative ([#14643](https://github.com/tailwindlabs/tailwindcss/pull/14643))
+- _Upgrade (experimental)_: Fully convert simple JS configs to CSS ([#14639](https://github.com/tailwindlabs/tailwindcss/pull/14639))
 
 ### Fixed
 

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -904,6 +904,11 @@ test(
       'tailwind.config.ts': js`
         export default {
           content: ['./src/**/*.{html,js}'],
+          plugins: [
+            () => {
+              // custom stuff which is too complicated to migrate to CSS
+            },
+          ],
         }
       `,
       'src/index.html': html`
@@ -995,7 +1000,6 @@ test(
       /* Inject missing @config due to nested imports with tailwind imports */
       @import './root.4/base.css';
       @import './root.4/utilities.css';
-      @source './**/*.{html,js}';
       @source './**/*.{html,js}';
 
       --- ./src/root.5.css ---

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -973,18 +973,17 @@ test(
       --- ./src/root.1.css ---
       /* Inject missing @config */
       @import 'tailwindcss';
-      @source './**/*.{html,js}';
+      @config '../tailwind.config.ts';
 
       --- ./src/root.2.css ---
       /* Already contains @config */
       @import 'tailwindcss';
-      @source './**/*.{html,js}';
       @config "../tailwind.config.js";
 
       --- ./src/root.3.css ---
       /* Inject missing @config above first @theme */
       @import 'tailwindcss';
-      @source './**/*.{html,js}';
+      @config '../tailwind.config.ts';
 
       @variant hocus (&:hover, &:focus);
 
@@ -1000,7 +999,7 @@ test(
       /* Inject missing @config due to nested imports with tailwind imports */
       @import './root.4/base.css';
       @import './root.4/utilities.css';
-      @source './**/*.{html,js}';
+      @config '../tailwind.config.ts';
 
       --- ./src/root.5.css ---
       @import './root.5/tailwind.css';
@@ -1015,7 +1014,7 @@ test(
       --- ./src/root.5/tailwind.css ---
       /* Inject missing @config in this file, due to full import */
       @import 'tailwindcss';
-      @source '../**/*.{html,js}';
+      @config '../../tailwind.config.ts';
       "
     `)
   },

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -40,7 +40,8 @@ test(
 
       --- ./src/input.css ---
       @import 'tailwindcss';
-      @config '../tailwind.config.js';
+
+      @source './**/*.{html,js}';
       "
     `)
 
@@ -71,8 +72,9 @@ test(
         }
       `,
       'src/index.html': html`
-        <h1>🤠👋</h1>
-        <div class="!tw__flex sm:!tw__block tw__bg-gradient-to-t flex [color:red]"></div>
+        <div
+          class="!tw__flex sm:!tw__block tw__bg-gradient-to-t flex [color:red]"
+        ></div>
       `,
       'src/input.css': css`
         @tailwind base;
@@ -91,13 +93,14 @@ test(
     expect(await fs.dumpFiles('./src/**/*.{css,html}')).toMatchInlineSnapshot(`
       "
       --- ./src/index.html ---
-      <h1>🤠👋</h1>
-      <div class="tw:flex! tw:sm:block! tw:bg-linear-to-t flex tw:[color:red]"></div>
+      <div
+        class="tw:flex! tw:sm:block! tw:bg-linear-to-t flex tw:[color:red]"
+      ></div>
 
       --- ./src/input.css ---
       @import 'tailwindcss' prefix(tw);
 
-      @config '../tailwind.config.js';
+      @source './**/*.{html,js}';
 
       .btn {
         @apply tw:rounded-md! tw:px-2 tw:py-1 tw:bg-blue-500 tw:text-white;
@@ -144,8 +147,6 @@ test(
       "
       --- ./src/index.css ---
       @import 'tailwindcss';
-
-      @config '../tailwind.config.js';
 
       .a {
         @apply flex;
@@ -200,8 +201,6 @@ test(
       "
       --- ./src/index.css ---
       @import 'tailwindcss';
-
-      @config '../tailwind.config.js';
 
       @layer base {
         html {
@@ -261,8 +260,6 @@ test(
       "
       --- ./src/index.css ---
       @import 'tailwindcss';
-
-      @config '../tailwind.config.js';
 
       @utility btn {
         @apply rounded-md px-2 py-1 bg-blue-500 text-white;
@@ -631,7 +628,6 @@ test(
       --- ./src/index.css ---
       @import 'tailwindcss';
       @import './utilities.css';
-      @config '../tailwind.config.js';
 
       --- ./src/utilities.css ---
       @utility no-scrollbar {
@@ -748,7 +744,6 @@ test(
       @import './c.1.css' layer(utilities);
       @import './c.1.utilities.css';
       @import './d.1.css';
-      @config '../tailwind.config.js';
 
       --- ./src/a.1.css ---
       @import './a.1.utilities.css'
@@ -882,17 +877,14 @@ test(
       --- ./src/root.1.css ---
       @import 'tailwindcss/utilities' layer(utilities);
       @import './a.1.css' layer(utilities);
-      @config '../tailwind.config.js';
 
       --- ./src/root.2.css ---
       @import 'tailwindcss/utilities' layer(utilities);
       @import './a.1.css' layer(components);
-      @config '../tailwind.config.js';
 
       --- ./src/root.3.css ---
       @import 'tailwindcss/utilities' layer(utilities);
       @import './a.1.css' layer(utilities);
-      @config '../tailwind.config.js';
       "
     `)
   },
@@ -915,8 +907,9 @@ test(
         }
       `,
       'src/index.html': html`
-        <h1>🤠👋</h1>
-        <div class="!flex sm:!block bg-gradient-to-t bg-[--my-red]"></div>
+        <div
+          class="!flex sm:!block bg-gradient-to-t bg-[--my-red]"
+        ></div>
       `,
       'src/root.1.css': css`
         /* Inject missing @config */
@@ -968,23 +961,25 @@ test(
     expect(await fs.dumpFiles('./src/**/*.{html,css}')).toMatchInlineSnapshot(`
       "
       --- ./src/index.html ---
-      <h1>🤠👋</h1>
-      <div class="flex! sm:block! bg-linear-to-t bg-[var(--my-red)]"></div>
+      <div
+        class="flex! sm:block! bg-linear-to-t bg-[var(--my-red)]"
+      ></div>
 
       --- ./src/root.1.css ---
       /* Inject missing @config */
       @import 'tailwindcss';
-      @config '../tailwind.config.ts';
+      @source './**/*.{html,js}';
 
       --- ./src/root.2.css ---
       /* Already contains @config */
       @import 'tailwindcss';
+      @source './**/*.{html,js}';
       @config "../tailwind.config.js";
 
       --- ./src/root.3.css ---
       /* Inject missing @config above first @theme */
       @import 'tailwindcss';
-      @config '../tailwind.config.ts';
+      @source './**/*.{html,js}';
 
       @variant hocus (&:hover, &:focus);
 
@@ -1000,7 +995,8 @@ test(
       /* Inject missing @config due to nested imports with tailwind imports */
       @import './root.4/base.css';
       @import './root.4/utilities.css';
-      @config '../tailwind.config.ts';
+      @source './**/*.{html,js}';
+      @source './**/*.{html,js}';
 
       --- ./src/root.5.css ---
       @import './root.5/tailwind.css';
@@ -1015,7 +1011,7 @@ test(
       --- ./src/root.5/tailwind.css ---
       /* Inject missing @config in this file, due to full import */
       @import 'tailwindcss';
-      @config '../../tailwind.config.ts';
+      @source '../**/*.{html,js}';
       "
     `)
   },

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -59,9 +59,42 @@ test(
     },
   },
   async ({ exec, fs }) => {
-    console.log(await exec('npx @tailwindcss/upgrade'))
+    await exec('npx @tailwindcss/upgrade')
 
-    await fs.expectFileToContain('src/input.css', css` @import 'tailwindcss'; `)
-    expect(fs.read('tailwind.config.ts')).rejects.toMatchInlineSnapshot()
+    expect(await fs.dumpFiles('src/**/*.css')).toMatchInlineSnapshot(`
+      "
+      --- src/input.css ---
+      @import 'tailwindcss';
+
+      @source './**/*.{html,js}';
+
+      @variant dark (&:where(.dark, .dark *));
+
+      @theme {
+        --box-shadow-*: initial;
+        --box-shadow-sm: 0 2px 6px rgb(15 23 42 / 0.08);
+
+        --color-*: initial;
+        --color-red-500: #ef4444;
+
+        --font-size-*: initial;
+        --font-size-xs: 0.75rem;
+        --font-size-xs--line-height: 1rem;
+        --font-size-sm: 0.875rem;
+        --font-size-sm--line-height: 1.5rem;
+        --font-size-base: 1rem;
+        --font-size-base--line-height: 2rem;
+
+        --color-red-600: #dc2626;
+
+        --font-family-sans: Inter, system-ui, sans-serif;
+        --font-family-display: Cabinet Grotesk, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+
+        --border-radius-4xl: 2rem;
+      }
+      "
+    `)
+
+    expect((await fs.dumpFiles('tailwind.config.ts')).trim()).toBe('')
   },
 )

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -17,6 +17,7 @@ test(
         import defaultTheme from 'tailwindcss/defaultTheme'
 
         module.exports = {
+          darkMode: 'selector',
           content: ['./src/**/*.{html,js}'],
           theme: {
             boxShadow: {

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -1,0 +1,66 @@
+import { expect } from 'vitest'
+import { css, json, test, ts } from '../utils'
+
+test(
+  `upgrades a simple JS config file to CSS`,
+  {
+    fs: {
+      'package.json': json`
+        {
+          "dependencies": {
+            "@tailwindcss/upgrade": "workspace:^"
+          }
+        }
+      `,
+      'tailwind.config.ts': ts`
+        import { type Config } from 'tailwindcss'
+        import defaultTheme from 'tailwindcss/defaultTheme'
+
+        module.exports = {
+          content: ['./src/**/*.{html,js}'],
+          theme: {
+            boxShadow: {
+              sm: '0 2px 6px rgb(15 23 42 / 0.08)',
+            },
+            colors: {
+              red: {
+                500: '#ef4444',
+              },
+            },
+            fontSize: {
+              xs: ['0.75rem', { lineHeight: '1rem' }],
+              sm: ['0.875rem', { lineHeight: '1.5rem' }],
+              base: ['1rem', { lineHeight: '2rem' }],
+            },
+            extend: {
+              colors: {
+                red: {
+                  600: '#dc2626',
+                },
+              },
+              fontFamily: {
+                sans: 'Inter, system-ui, sans-serif',
+                display: ['Cabinet Grotesk', ...defaultTheme.fontFamily.sans],
+              },
+              borderRadius: {
+                '4xl': '2rem',
+              },
+            },
+          },
+          plugins: [],
+        } satisfies Config
+      `,
+      'src/input.css': css`
+        @tailwind base;
+        @tailwind components;
+        @tailwind utilities;
+      `,
+    },
+  },
+  async ({ exec, fs }) => {
+    console.log(await exec('npx @tailwindcss/upgrade'))
+
+    await fs.expectFileToContain('src/input.css', css` @import 'tailwindcss'; `)
+    expect(fs.read('tailwind.config.ts')).rejects.toMatchInlineSnapshot()
+  },
+)

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -25,6 +25,7 @@ test(
             },
             colors: {
               red: {
+                400: '#f87171',
                 500: 'red',
               },
             },
@@ -77,6 +78,7 @@ test(
         --box-shadow-sm: 0 2px 6px rgb(15 23 42 / 0.08);
 
         --color-*: initial;
+        --color-red-400: #f87171;
         --color-red-500: #ef4444;
         --color-red-600: #dc2626;
 

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -68,7 +68,6 @@ test(
       @import 'tailwindcss';
 
       @source './**/*.{html,js}';
-
       @source '../my-app/**/*.{html,js}';
 
       @variant dark (&:where(.dark, .dark *));

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -18,14 +18,14 @@ test(
 
         module.exports = {
           darkMode: 'selector',
-          content: ['./src/**/*.{html,js}'],
+          content: ['./src/**/*.{html,js}', './my-app/**/*.{html,js}'],
           theme: {
             boxShadow: {
               sm: '0 2px 6px rgb(15 23 42 / 0.08)',
             },
             colors: {
               red: {
-                500: '#ef4444',
+                500: 'red',
               },
             },
             fontSize: {
@@ -36,6 +36,7 @@ test(
             extend: {
               colors: {
                 red: {
+                  500: '#ef4444',
                   600: '#dc2626',
                 },
               },
@@ -68,6 +69,8 @@ test(
 
       @source './**/*.{html,js}';
 
+      @source '../my-app/**/*.{html,js}';
+
       @variant dark (&:where(.dark, .dark *));
 
       @theme {
@@ -76,6 +79,7 @@ test(
 
         --color-*: initial;
         --color-red-500: #ef4444;
+        --color-red-600: #dc2626;
 
         --font-size-*: initial;
         --font-size-xs: 0.75rem;
@@ -85,12 +89,10 @@ test(
         --font-size-base: 1rem;
         --font-size-base--line-height: 2rem;
 
-        --color-red-600: #dc2626;
-
         --font-family-sans: Inter, system-ui, sans-serif;
         --font-family-display: Cabinet Grotesk, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 
-        --border-radius-4xl: 2rem;
+        --radius-4xl: 2rem;
       }
       "
     `)

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -75,7 +75,7 @@ export function test(
 ) {
   return (only || (!process.env.CI && debug) ? defaultTest.only : defaultTest)(
     name,
-    { timeout: TEST_TIMEOUT, retry: debug || only ? 0 : 3 },
+    { timeout: TEST_TIMEOUT, retry: process.env.CI ? 2 : 0 },
     async (options) => {
       let rootDir = debug ? path.join(REPO_ROOT, '.debug') : TMP_ROOT
       await fs.mkdir(rootDir, { recursive: true })

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-config.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-config.ts
@@ -5,6 +5,8 @@ import type { JSConfigMigration } from '../migrate-js-config'
 import type { Stylesheet } from '../stylesheet'
 import { walk, WalkAction } from '../utils/walk'
 
+const ALREADY_INJECTED = new WeakMap<Stylesheet, string[]>()
+
 export function migrateConfig(
   sheet: Stylesheet,
   {
@@ -13,6 +15,15 @@ export function migrateConfig(
   }: { configFilePath: string; jsConfigMigration: JSConfigMigration },
 ): Plugin {
   function injectInto(sheet: Stylesheet) {
+    let alreadyInjected = ALREADY_INJECTED.get(sheet)
+    if (alreadyInjected && alreadyInjected.includes(configFilePath)) {
+      return
+    } else if (alreadyInjected) {
+      alreadyInjected.push(configFilePath)
+    } else {
+      ALREADY_INJECTED.set(sheet, [configFilePath])
+    }
+
     let root = sheet.root
 
     // We don't have a sheet with a file path

--- a/packages/@tailwindcss-upgrade/src/index.test.ts
+++ b/packages/@tailwindcss-upgrade/src/index.test.ts
@@ -20,6 +20,7 @@ let config = {
   userConfig: {},
   newPrefix: null,
   configFilePath: path.resolve(__dirname, './tailwind.config.js'),
+  jsConfigMigration: null,
 }
 
 function migrate(input: string, config: any) {

--- a/packages/@tailwindcss-upgrade/src/index.ts
+++ b/packages/@tailwindcss-upgrade/src/index.ts
@@ -11,6 +11,7 @@ import {
   migrate as migrateStylesheet,
   split as splitStylesheets,
 } from './migrate'
+import { migrateJsConfig } from './migrate-js-config'
 import { migratePostCSSConfig } from './migrate-postcss'
 import { Stylesheet } from './stylesheet'
 import { migrate as migrateTemplate } from './template/migrate'
@@ -79,6 +80,14 @@ async function run() {
     )
 
     success('Template migration complete.')
+  }
+
+  {
+    // Migrate JS config
+
+    info('Migrating JavaScript configuration files using the provided configuration file.')
+
+    await migrateJsConfig(config.configFilePath)
   }
 
   {

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -1,0 +1,121 @@
+import fs from 'node:fs/promises'
+import { dirname } from 'path'
+import type { Config } from 'tailwindcss'
+import { fileURLToPath } from 'url'
+import { loadModule } from '../../@tailwindcss-node/src/compile'
+import {
+  keyPathToCssProperty,
+  themeableValues,
+} from '../../tailwindcss/src/compat/apply-config-to-theme'
+import { info } from './utils/renderer'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+export async function migrateJsConfig(fullConfigPath: string): Promise<void> {
+  let [unresolvedConfig, source] = await Promise.all([
+    loadModule(fullConfigPath, __dirname, () => {}).then((result) => result.module) as Config,
+    fs.readFile(fullConfigPath, 'utf-8'),
+  ])
+
+  if (!isSimpleConfig(unresolvedConfig, source)) {
+    info(
+      'The configuration file is not a simple object. Please refer to the migration guide for how to migrate it fully to Tailwind CSS v4. For now, we will load the configuration file as-is.',
+    )
+    return
+  }
+
+  let cssConfigs: string[] = []
+
+  if ('content' in unresolvedConfig) {
+    cssConfigs.push(migrateContent(unresolvedConfig as any))
+  }
+
+  if ('theme' in unresolvedConfig) {
+    cssConfigs.push(await migrateTheme(unresolvedConfig as any))
+  }
+
+  console.log(cssConfigs.join('\n'))
+}
+
+async function migrateTheme(unresolvedConfig: Config & { theme: any }): Promise<string> {
+  let { extend: extendTheme, ...overwriteTheme } = unresolvedConfig.theme
+
+  let resetNamespaces = new Set()
+
+  let css = `@theme reference inline {\n`
+  for (let [key, value] of themeableValues(overwriteTheme)) {
+    if (typeof value !== 'string' && typeof value !== 'number') {
+      continue
+    }
+
+    if (!resetNamespaces.has(key[0])) {
+      resetNamespaces.add(key[0])
+      css += `  --${keyPathToCssProperty([key[0]])}-*: initial;\n`
+    }
+
+    css += `  --${keyPathToCssProperty(key)}: ${value};\n`
+  }
+
+  for (let [key, value] of themeableValues(extendTheme)) {
+    if (typeof value !== 'string' && typeof value !== 'number') {
+      continue
+    }
+
+    css += `  --${keyPathToCssProperty(key)}: ${value};\n`
+  }
+
+  return css + '}\n'
+}
+
+function migrateContent(unresolvedConfig: Config & { content: any }): string {
+  let css = ''
+  for (let content of unresolvedConfig.content) {
+    if (typeof content !== 'string') {
+      throw new Error('Unsupported content value: ' + content)
+    }
+
+    css += `@source  "${content}";\n`
+  }
+  return css
+}
+
+// Applies heuristics to determine if we can attempt to migrate the config
+async function isSimpleConfig(unresolvedConfig: Config, source: string): Promise<boolean> {
+  // The file may not contain any functions
+  if (source.includes('function') || source.includes(' => ')) {
+    return false
+  }
+
+  // The file may not contain non-serializable values
+  const isSimpleValue = (value: unknown): boolean => {
+    if (typeof value === 'function') return false
+    if (Array.isArray(value)) return value.every(isSimpleValue)
+    if (typeof value === 'object' && value !== null) {
+      return Object.values(value).every(isSimpleValue)
+    }
+    return ['string', 'number', 'boolean', 'undefined'].includes(typeof value)
+  }
+  if (!isSimpleValue(unresolvedConfig)) {
+    return false
+  }
+
+  // The file may only contain known-migrateable high-level properties
+  const knownProperties = ['content', 'theme', 'plugins', 'presets']
+  if (Object.keys(unresolvedConfig).some((key) => !knownProperties.includes(key))) {
+    return false
+  }
+  if (unresolvedConfig.plugins && unresolvedConfig.plugins.length > 0) {
+    return false
+  }
+  if (unresolvedConfig.presets && unresolvedConfig.presets.length > 0) {
+    return false
+  }
+
+  // The file may not contain any imports
+  if (source.includes('import') || source.includes('require')) {
+    return false
+  }
+
+  return true
+}

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -142,7 +142,7 @@ function migrateContent(
 }
 
 // Applies heuristics to determine if we can attempt to migrate the config
-async function isSimpleConfig(unresolvedConfig: Config, source: string): Promise<boolean> {
+function isSimpleConfig(unresolvedConfig: Config, source: string): boolean {
   // The file may not contain any functions
   if (source.includes('function') || source.includes(' => ')) {
     return false

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -163,7 +163,14 @@ function isSimpleConfig(unresolvedConfig: Config, source: string): boolean {
   }
 
   // The file may only contain known-migrateable top-level properties
-  let knownProperties = ['darkMode', 'content', 'theme', 'plugins', 'presets']
+  let knownProperties = [
+    'darkMode',
+    'content',
+    'theme',
+    'plugins',
+    'presets',
+    'prefix', // Prefix is handled in the dedicated prefix migrator
+  ]
   if (Object.keys(unresolvedConfig).some((key) => !knownProperties.includes(key))) {
     return false
   }

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs/promises'
 import { dirname } from 'path'
-import postcss from 'postcss'
 import type { Config } from 'tailwindcss'
 import { fileURLToPath } from 'url'
 import { loadModule } from '../../@tailwindcss-node/src/compile'
@@ -20,7 +19,7 @@ export type JSConfigMigration =
   // Could not convert the config file, need to inject it as-is in a @config directive
   null | {
     sources: { base: string; pattern: string }[]
-    css: postcss.Root
+    css: string
   }
 
 export async function migrateJsConfig(
@@ -56,7 +55,7 @@ export async function migrateJsConfig(
 
   return {
     sources,
-    css: postcss.parse(cssConfigs.join('\n')),
+    css: cssConfigs.join('\n'),
   }
 }
 
@@ -73,10 +72,7 @@ async function migrateTheme(unresolvedConfig: Config & { theme: any }): Promise<
 
     if (!resetNamespaces.has(key[0])) {
       resetNamespaces.set(key[0], false)
-      // css += `  --${keyPathToCssProperty([key[0]])}-*: initial;\n`
     }
-
-    // css += `  --${keyPathToCssProperty(key)}: ${value};\n`
   }
 
   let themeValues = deepMerge({}, [overwriteTheme, extendTheme], mergeThemeExtension)

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -149,7 +149,7 @@ function isSimpleConfig(unresolvedConfig: Config, source: string): boolean {
   }
 
   // The file may not contain non-serializable values
-  const isSimpleValue = (value: unknown): boolean => {
+  function isSimpleValue (value: unknown): boolean {
     if (typeof value === 'function') return false
     if (Array.isArray(value)) return value.every(isSimpleValue)
     if (typeof value === 'object' && value !== null) {
@@ -161,8 +161,8 @@ function isSimpleConfig(unresolvedConfig: Config, source: string): boolean {
     return false
   }
 
-  // The file may only contain known-migrateable high-level properties
-  const knownProperties = ['darkMode', 'content', 'theme', 'plugins', 'presets']
+  // The file may only contain known-migrateable top-level properties
+  let knownProperties = ['darkMode', 'content', 'theme', 'plugins', 'presets']
   if (Object.keys(unresolvedConfig).some((key) => !knownProperties.includes(key))) {
     return false
   }

--- a/packages/@tailwindcss-upgrade/src/migrate.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate.ts
@@ -5,11 +5,12 @@ import type { DesignSystem } from '../../tailwindcss/src/design-system'
 import { DefaultMap } from '../../tailwindcss/src/utils/default-map'
 import { segment } from '../../tailwindcss/src/utils/segment'
 import { migrateAtApply } from './codemods/migrate-at-apply'
-import { migrateAtConfig } from './codemods/migrate-at-config'
 import { migrateAtLayerUtilities } from './codemods/migrate-at-layer-utilities'
+import { migrateConfig } from './codemods/migrate-config'
 import { migrateMediaScreen } from './codemods/migrate-media-screen'
 import { migrateMissingLayers } from './codemods/migrate-missing-layers'
 import { migrateTailwindDirectives } from './codemods/migrate-tailwind-directives'
+import type { JSConfigMigration } from './migrate-js-config'
 import { Stylesheet, type StylesheetConnection, type StylesheetId } from './stylesheet'
 import { resolveCssId } from './utils/resolve'
 import { walk, WalkAction } from './utils/walk'
@@ -19,6 +20,7 @@ export interface MigrateOptions {
   designSystem: DesignSystem
   userConfig: Config
   configFilePath: string
+  jsConfigMigration: JSConfigMigration
 }
 
 export async function migrateContents(
@@ -37,7 +39,7 @@ export async function migrateContents(
     .use(migrateAtLayerUtilities(stylesheet))
     .use(migrateMissingLayers())
     .use(migrateTailwindDirectives(options))
-    .use(migrateAtConfig(stylesheet, options))
+    .use(migrateConfig(stylesheet, options))
     .process(stylesheet.root, { from: stylesheet.file ?? undefined })
 }
 

--- a/packages/@tailwindcss-upgrade/src/template/prepare-config.ts
+++ b/packages/@tailwindcss-upgrade/src/template/prepare-config.ts
@@ -35,8 +35,7 @@ export async function prepareConfig(
     // required so that the base for Tailwind CSS can bet inside the
     // @tailwindcss-upgrade package and we can require `tailwindcss` properly.
     let fullConfigPath = path.resolve(options.base, configPath)
-    let fullFilePath = path.resolve(__dirname)
-    let relative = path.relative(fullFilePath, fullConfigPath)
+    let relative = path.relative(__dirname, fullConfigPath)
 
     // If the path points to a file in the same directory, `path.relative` will
     // remove the leading `./` and we need to add it back in order to still

--- a/packages/tailwindcss/src/compat/apply-config-to-theme.ts
+++ b/packages/tailwindcss/src/compat/apply-config-to-theme.ts
@@ -81,7 +81,7 @@ export function applyConfigToTheme(designSystem: DesignSystem, { theme }: Resolv
   return theme
 }
 
-function themeableValues(config: ResolvedConfig['theme']): [string[], unknown][] {
+export function themeableValues(config: ResolvedConfig['theme']): [string[], unknown][] {
   let toAdd: [string[], unknown][] = []
 
   walk(config as any, [], (value, path) => {
@@ -110,7 +110,7 @@ function themeableValues(config: ResolvedConfig['theme']): [string[], unknown][]
   return toAdd
 }
 
-function keyPathToCssProperty(path: string[]) {
+export function keyPathToCssProperty(path: string[]) {
   if (path[0] === 'colors') path[0] = 'color'
   if (path[0] === 'screens') path[0] = 'breakpoint'
 

--- a/packages/tailwindcss/src/compat/apply-config-to-theme.ts
+++ b/packages/tailwindcss/src/compat/apply-config-to-theme.ts
@@ -113,6 +113,7 @@ export function themeableValues(config: ResolvedConfig['theme']): [string[], unk
 export function keyPathToCssProperty(path: string[]) {
   if (path[0] === 'colors') path[0] = 'color'
   if (path[0] === 'screens') path[0] = 'breakpoint'
+  if (path[0] === 'borderRadius') path[0] = 'radius'
 
   return (
     path

--- a/packages/tailwindcss/src/compat/config/resolve-config.ts
+++ b/packages/tailwindcss/src/compat/config/resolve-config.ts
@@ -87,7 +87,7 @@ export function resolveConfig(design: DesignSystem, files: ConfigFile[]): Resolv
   }
 }
 
-function mergeThemeExtension(
+export function mergeThemeExtension(
   themeValue: ThemeValue | ThemeValue[],
   extensionValue: ThemeValue | ThemeValue[],
 ) {

--- a/packages/tailwindcss/src/compat/dark-mode.ts
+++ b/packages/tailwindcss/src/compat/dark-mode.ts
@@ -1,7 +1,7 @@
 import type { ResolvedConfig } from './config/types'
 import type { PluginAPI } from './plugin-api'
 
-export function darkModePlugin({ addVariant, config }: PluginAPI) {
+export function darkModePlugin({ addVariant, config }: Pick<PluginAPI, 'addVariant' | 'config'>) {
   let darkMode = config('darkMode', null) as ResolvedConfig['darkMode']
   let [mode, selector = '.dark'] = Array.isArray(darkMode) ? darkMode : [darkMode]
 


### PR DESCRIPTION
This PR implements the first version of JS config file migration to CSS. It is based on the most simple config setups we are using in the Tailwind UI templates Commit, Primer, Radiant, and Studio.

The example we use in the integration test is a config that looks like this:

```js
import { type Config } from 'tailwindcss'
import defaultTheme from 'tailwindcss/defaultTheme'

module.exports = {
  darkMode: 'selector',
  content: ['./src/**/*.{html,js}'],
  theme: {
    boxShadow: {
      sm: '0 2px 6px rgb(15 23 42 / 0.08)',
    },
    colors: {
      red: {
        500: '#ef4444',
      },
    },
    fontSize: {
      xs: ['0.75rem', { lineHeight: '1rem' }],
      sm: ['0.875rem', { lineHeight: '1.5rem' }],
      base: ['1rem', { lineHeight: '2rem' }],
    },
    extend: {
      colors: {
        red: {
          600: '#dc2626',
        },
      },
      fontFamily: {
        sans: 'Inter, system-ui, sans-serif',
        display: ['Cabinet Grotesk', ...defaultTheme.fontFamily.sans],
      },
      borderRadius: {
        '4xl': '2rem',
      },
    },
  },
  plugins: [],
} satisfies Config
```

As you can see, this file only has a `darkMode` selector, custom `content` globs, a `theme` (with some theme keys being overwriting the default theme and some others extending the defaults). Note that it does not support `plugins` and/or `presets` yet.

In the case above, we will find the CSS file containing the existing `@tailwind` directives and are migrating it to the following:

```css
@import 'tailwindcss';

@source './**/*.{html,js}';

@variant dark (&:where(.dark, .dark *));

@theme {
  --box-shadow-*: initial;
  --box-shadow-sm: 0 2px 6px rgb(15 23 42 / 0.08);

  --color-*: initial;
  --color-red-500: #ef4444;

  --font-size-*: initial;
  --font-size-xs: 0.75rem;
  --font-size-xs--line-height: 1rem;
  --font-size-sm: 0.875rem;
  --font-size-sm--line-height: 1.5rem;
  --font-size-base: 1rem;
  --font-size-base--line-height: 2rem;

  --color-red-600: #dc2626;

  --font-family-sans: Inter, system-ui, sans-serif;
  --font-family-display: Cabinet Grotesk, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";

  --border-radius-4xl: 2rem;
} 
```

This replicates all features of the JS config so we can even delete the existing JS config in this case. 