### PR TITLE
Warn on use of plugin parameters as function

### DIFF
--- a/packages/tailwindcss/src/compat/config/resolve-config.test.ts
+++ b/packages/tailwindcss/src/compat/config/resolve-config.test.ts
@@ -172,88 +172,87 @@ test('theme keys can reference other theme keys using the theme function regardl
   })
 })
 
-test('theme keys can read from the CSS theme', () => {
-  let originalWarn = console.warn
-  try {
-    console.warn = vi.fn()
-    let theme = new Theme()
-    theme.add('--color-green', 'green')
+test('theme keys can read from the CSS theme', ({ onTestFinished }) => {
+  let warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+  onTestFinished(() => {
+    warn.mockReset()
+  })
 
-    let design = buildDesignSystem(theme)
+  let theme = new Theme()
+  theme.add('--color-green', 'green')
 
-    let config = resolveConfig(design, [
-      {
-        config: {
-          theme: {
-            colors: ({ theme }) => ({
-              // Reads from the --color-* namespace
-              ...theme('color'),
-              red: 'red',
-            }),
-            accentColor: ({ theme }) => ({
-              // Reads from the --color-* namespace through `colors`
-              ...theme('colors'),
-            }),
-            placeholderColor: ({ theme }) => ({
-              // Reads from the --color-* namespace through `colors`
-              primary: theme('colors.green'),
+  let design = buildDesignSystem(theme)
 
-              // Reads from the --color-* namespace directly
-              secondary: theme('color.green'),
-            }),
-            caretColor: ({ colors }) => ({
-              // Gives access to the colors object directly
-              primary: colors.green,
-            }),
-            transitionColor: (theme: any) => ({
-              // The parameter object is also the theme function
-              ...theme('colors'),
-            }),
-          },
-        },
-        base: '/root',
-      },
-    ])
+  let config = resolveConfig(design, [
+    {
+      config: {
+        theme: {
+          colors: ({ theme }) => ({
+            // Reads from the --color-* namespace
+            ...theme('color'),
+            red: 'red',
+          }),
+          accentColor: ({ theme }) => ({
+            // Reads from the --color-* namespace through `colors`
+            ...theme('colors'),
+          }),
+          placeholderColor: ({ theme }) => ({
+            // Reads from the --color-* namespace through `colors`
+            primary: theme('colors.green'),
 
-    expect(config).toMatchObject({
-      theme: {
-        colors: {
-          red: 'red',
-          green: 'green',
-        },
-        accentColor: {
-          red: 'red',
-          green: 'green',
-        },
-        placeholderColor: {
-          primary: 'green',
-          secondary: 'green',
-        },
-        caretColor: {
-          primary: {
-            '50': '#f0fdf4',
-            '100': '#dcfce7',
-            '200': '#bbf7d0',
-            '300': '#86efac',
-            '400': '#4ade80',
-            '500': '#22c55e',
-            '600': '#16a34a',
-            '700': '#15803d',
-            '800': '#166534',
-            '900': '#14532d',
-            '950': '#052e16',
-          },
-        },
-        transitionColor: {
-          red: 'red',
-          green: 'green',
+            // Reads from the --color-* namespace directly
+            secondary: theme('color.green'),
+          }),
+          caretColor: ({ colors }) => ({
+            // Gives access to the colors object directly
+            primary: colors.green,
+          }),
+          transitionColor: (theme: any) => ({
+            // The parameter object is also the theme function
+            ...theme('colors'),
+          }),
         },
       },
-    })
-    expect(console.warn).toHaveBeenCalledWith(
-      'Using the plugin object parameter as the theme function is deprecated. Please use the `theme` property instead.',
-    )
-  } finally {
-    console.warn = originalWarn
-  }
+      base: '/root',
+    },
+  ])
+
+  expect(config).toMatchObject({
+    theme: {
+      colors: {
+        red: 'red',
+        green: 'green',
+      },
+      accentColor: {
+        red: 'red',
+        green: 'green',
+      },
+      placeholderColor: {
+        primary: 'green',
+        secondary: 'green',
+      },
+      caretColor: {
+        primary: {
+          '50': '#f0fdf4',
+          '100': '#dcfce7',
+          '200': '#bbf7d0',
+          '300': '#86efac',
+          '400': '#4ade80',
+          '500': '#22c55e',
+          '600': '#16a34a',
+          '700': '#15803d',
+          '800': '#166534',
+          '900': '#14532d',
+          '950': '#052e16',
+        },
+      },
+      transitionColor: {
+        red: 'red',
+        green: 'green',
+      },
+    },
+  })
+  expect(warn).toHaveBeenCalledWith(
+    'Using the plugin object parameter as the theme function is deprecated. Please use the `theme` property instead.',
+  )
 })

--- a/packages/tailwindcss/src/compat/config/resolve-config.test.ts
+++ b/packages/tailwindcss/src/compat/config/resolve-config.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 import { buildDesignSystem } from '../../design-system'
 import { Theme } from '../../theme'
 import { resolveConfig } from './resolve-config'
@@ -173,78 +173,87 @@ test('theme keys can reference other theme keys using the theme function regardl
 })
 
 test('theme keys can read from the CSS theme', () => {
-  let theme = new Theme()
-  theme.add('--color-green', 'green')
+  let originalWarn = console.warn
+  try {
+    console.warn = vi.fn()
+    let theme = new Theme()
+    theme.add('--color-green', 'green')
 
-  let design = buildDesignSystem(theme)
+    let design = buildDesignSystem(theme)
 
-  let config = resolveConfig(design, [
-    {
-      config: {
-        theme: {
-          colors: ({ theme }) => ({
-            // Reads from the --color-* namespace
-            ...theme('color'),
-            red: 'red',
-          }),
-          accentColor: ({ theme }) => ({
-            // Reads from the --color-* namespace through `colors`
-            ...theme('colors'),
-          }),
-          placeholderColor: ({ theme }) => ({
-            // Reads from the --color-* namespace through `colors`
-            primary: theme('colors.green'),
+    let config = resolveConfig(design, [
+      {
+        config: {
+          theme: {
+            colors: ({ theme }) => ({
+              // Reads from the --color-* namespace
+              ...theme('color'),
+              red: 'red',
+            }),
+            accentColor: ({ theme }) => ({
+              // Reads from the --color-* namespace through `colors`
+              ...theme('colors'),
+            }),
+            placeholderColor: ({ theme }) => ({
+              // Reads from the --color-* namespace through `colors`
+              primary: theme('colors.green'),
 
-            // Reads from the --color-* namespace directly
-            secondary: theme('color.green'),
-          }),
-          caretColor: ({ colors }) => ({
-            // Gives access to the colors object directly
-            primary: colors.green,
-          }),
-          transitionColor: (theme) => ({
-            // The parameter object is also the theme function
-            ...theme('colors'),
-          }),
+              // Reads from the --color-* namespace directly
+              secondary: theme('color.green'),
+            }),
+            caretColor: ({ colors }) => ({
+              // Gives access to the colors object directly
+              primary: colors.green,
+            }),
+            transitionColor: (theme: any) => ({
+              // The parameter object is also the theme function
+              ...theme('colors'),
+            }),
+          },
+        },
+        base: '/root',
+      },
+    ])
+
+    expect(config).toMatchObject({
+      theme: {
+        colors: {
+          red: 'red',
+          green: 'green',
+        },
+        accentColor: {
+          red: 'red',
+          green: 'green',
+        },
+        placeholderColor: {
+          primary: 'green',
+          secondary: 'green',
+        },
+        caretColor: {
+          primary: {
+            '50': '#f0fdf4',
+            '100': '#dcfce7',
+            '200': '#bbf7d0',
+            '300': '#86efac',
+            '400': '#4ade80',
+            '500': '#22c55e',
+            '600': '#16a34a',
+            '700': '#15803d',
+            '800': '#166534',
+            '900': '#14532d',
+            '950': '#052e16',
+          },
+        },
+        transitionColor: {
+          red: 'red',
+          green: 'green',
         },
       },
-      base: '/root',
-    },
-  ])
-
-  expect(config).toMatchObject({
-    theme: {
-      colors: {
-        red: 'red',
-        green: 'green',
-      },
-      accentColor: {
-        red: 'red',
-        green: 'green',
-      },
-      placeholderColor: {
-        primary: 'green',
-        secondary: 'green',
-      },
-      caretColor: {
-        primary: {
-          '50': '#f0fdf4',
-          '100': '#dcfce7',
-          '200': '#bbf7d0',
-          '300': '#86efac',
-          '400': '#4ade80',
-          '500': '#22c55e',
-          '600': '#16a34a',
-          '700': '#15803d',
-          '800': '#166534',
-          '900': '#14532d',
-          '950': '#052e16',
-        },
-      },
-      transitionColor: {
-        red: 'red',
-        green: 'green',
-      },
-    },
-  })
+    })
+    expect(console.warn).toHaveBeenCalledWith(
+      'Using the plugin object parameter as the theme function is deprecated. Please use the `theme` property instead.',
+    )
+  } finally {
+    console.warn = originalWarn
+  }
 })

--- a/packages/tailwindcss/src/compat/config/resolve-config.ts
+++ b/packages/tailwindcss/src/compat/config/resolve-config.ts
@@ -116,9 +116,8 @@ export function mergeThemeExtension(
   return undefined
 }
 
-type ThemeFunction = (keypath: string, defaultValue?: any) => any
-export type PluginUtils = ThemeFunction & {
-  theme: ThemeFunction
+export type PluginUtils = {
+  theme: (keypath: string, defaultValue?: any) => any
   colors: typeof colors
 }
 
@@ -176,12 +175,25 @@ function extractConfigs(ctx: ResolutionContext, { config, base, path }: ConfigFi
   ctx.configs.push(config)
 }
 
+let didWarnAboutUsingObjectArgumentAsThemeFn = false
+
 function mergeTheme(ctx: ResolutionContext) {
   let themeFn = createThemeFn(ctx.design, () => ctx.theme, resolveValue)
-  let theme = Object.assign(themeFn, {
-    theme: themeFn,
-    colors,
-  })
+  let theme = Object.assign(
+    (path: string, defaultValue?: any) => {
+      if (!didWarnAboutUsingObjectArgumentAsThemeFn) {
+        didWarnAboutUsingObjectArgumentAsThemeFn = true
+        console.warn(
+          'Using the plugin object parameter as the theme function is deprecated. Please use the `theme` property instead.',
+        )
+      }
+      return themeFn(path, defaultValue)
+    },
+    {
+      theme: themeFn,
+      colors,
+    },
+  )
 
   function resolveValue(value: ThemeValue | null | undefined): ResolvedThemeValue {
     if (typeof value === 'function') {


### PR DESCRIPTION
Quick follow-up to #14659 base don @thecrypticace's idea:

- This behavior is no longer added to the types of the Plugin API to be consistent with v3
- When the plugin argument is used as a function, we now warn the first time