### PR TITLE
Support complex compound variants in `group-*`, `peer-*`, `has-*`, and `not-*`

### DIFF
--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -128,6 +128,41 @@ export function walk(
   }
 }
 
+// This is a depth-first traversal of the AST
+export function walkDepth(
+  ast: AstNode[],
+  visit: (
+    node: AstNode,
+    utils: {
+      parent: AstNode | null
+      path: AstNode[]
+      replaceWith(newNode: AstNode[]): void
+    },
+  ) => void,
+  parent: AstNode | null = null,
+  parentPath: AstNode[] = [],
+) {
+  for (let i = 0; i < ast.length; i++) {
+    let node = ast[i]
+    let path = [node, ...parentPath]
+
+    if (node.kind === 'rule') {
+      walkDepth(node.nodes, visit, node, path)
+    }
+
+    visit(node, {
+      parent,
+      path,
+      replaceWith(newNode) {
+        ast.splice(i, 1, ...newNode)
+
+        // Skip over the newly inserted nodes (being depth-first it doesn't make sense to visit them)
+        i += newNode.length - 1
+      },
+    })
+  }
+}
+
 export function toCss(ast: AstNode[]) {
   let atRoots: string = ''
   let seenAtProperties = new Set<string>()

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -136,23 +136,30 @@ export function walkDepth(
     utils: {
       parent: AstNode | null
       path: AstNode[]
+      context: Record<string, string>
       replaceWith(newNode: AstNode[]): void
     },
   ) => void,
   parent: AstNode | null = null,
   parentPath: AstNode[] = [],
+  context: Record<string, string> = {},
 ) {
   for (let i = 0; i < ast.length; i++) {
     let node = ast[i]
     let path = [node, ...parentPath]
 
     if (node.kind === 'rule') {
-      walkDepth(node.nodes, visit, node, path)
+      walkDepth(node.nodes, visit, node, path, context)
+    } else if (node.kind === 'context') {
+      walkDepth(node.nodes, visit, node, path, { ...context, ...node.context })
+
+      // NOTE: we _do_ want to visit individual context nodes in `walkDepth`
     }
 
     visit(node, {
       parent,
       path,
+      context,
       replaceWith(newNode) {
         ast.splice(i, 1, ...newNode)
 

--- a/packages/tailwindcss/src/compat/plugin-api.test.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.test.ts
@@ -1282,10 +1282,6 @@ describe('addVariant', () => {
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
-        .group-hocus\\:flex:is(:where(.group):hover *), .group-hocus\\:flex:is(:where(.group):focus *) {
-          display: flex;
-        }
-
         .hocus\\:underline:hover, .hocus\\:underline:focus {
           text-decoration-line: underline;
         }
@@ -1319,10 +1315,6 @@ describe('addVariant', () => {
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
-        .group-hocus\\:flex:is(:where(.group):hover *), .group-hocus\\:flex:is(:where(.group):focus *) {
-          display: flex;
-        }
-
         .hocus\\:underline:hover, .hocus\\:underline:focus {
           text-decoration-line: underline;
         }
@@ -1359,12 +1351,12 @@ describe('addVariant', () => {
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
         @media (hover: hover) {
-          .group-hocus\\:flex:is(:where(.group):hover *) {
+          .group-hocus\\:flex:is(:where(.group) *):hover {
             display: flex;
           }
         }
 
-        .group-hocus\\:flex:is(:where(.group):focus *) {
+        .group-hocus\\:flex:is(:where(.group) *):is(:where(.group):focus *) {
           display: flex;
         }
 

--- a/packages/tailwindcss/src/compat/plugin-api.test.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.test.ts
@@ -1247,7 +1247,7 @@ describe('addVariant', () => {
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
-        .group-hocus\\:flex:is(:is(:where(.group):hover, :where(.group):focus) *) {
+        .group-hocus\\:flex:is(:where(.group):hover *), .group-hocus\\:flex:is(:where(.group):focus *) {
           display: flex;
         }
 
@@ -1282,6 +1282,10 @@ describe('addVariant', () => {
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
+        .group-hocus\\:flex:is(:where(.group):hover *), .group-hocus\\:flex:is(:where(.group):focus *) {
+          display: flex;
+        }
+
         .hocus\\:underline:hover, .hocus\\:underline:focus {
           text-decoration-line: underline;
         }
@@ -1315,6 +1319,10 @@ describe('addVariant', () => {
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
+        .group-hocus\\:flex:is(:where(.group):hover *), .group-hocus\\:flex:is(:where(.group):focus *) {
+          display: flex;
+        }
+
         .hocus\\:underline:hover, .hocus\\:underline:focus {
           text-decoration-line: underline;
         }
@@ -1351,12 +1359,12 @@ describe('addVariant', () => {
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
         @media (hover: hover) {
-          .group-hocus\\:flex:is(:where(.group) *):hover {
+          .group-hocus\\:flex:is(:where(.group):hover *) {
             display: flex;
           }
         }
 
-        .group-hocus\\:flex:is(:where(.group) *):is(:where(.group):focus *) {
+        .group-hocus\\:flex:is(:where(.group):focus *) {
           display: flex;
         }
 

--- a/packages/tailwindcss/src/compile.ts
+++ b/packages/tailwindcss/src/compile.ts
@@ -210,6 +210,14 @@ export function applyVariant(
     let result = applyVariant(isolatedNode, variant.variant, variants, depth + 1)
     if (result === null) return null
 
+    // Wrap in a single `&` rule so :not(…) can have the entire list of
+    // selectors / nodes from the "root"
+    //
+    // TODO: Rework this because it's not a great solution
+    if (isolatedNode.nodes.length > 1) {
+      isolatedNode.nodes = [rule('&', isolatedNode.nodes)]
+    }
+
     for (let child of isolatedNode.nodes) {
       // Only some variants wrap children in rules. For example, the `force`
       // variant is a noop on the AST. And the `has` variant modifies the

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1859,7 +1859,7 @@ describe('plugins', () => {
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
-        .group-hocus\\:flex:is(:is(:where(.group):hover, :where(.group):focus) *) {
+        .group-hocus\\:flex:is(:where(.group):hover *), .group-hocus\\:flex:is(:where(.group):focus *) {
           display: flex;
         }
 
@@ -1892,6 +1892,10 @@ describe('plugins', () => {
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
+        .group-hocus\\:flex:is(:where(.group):hover *), .group-hocus\\:flex:is(:where(.group):focus *) {
+          display: flex;
+        }
+
         .hocus\\:underline:hover, .hocus\\:underline:focus {
           text-decoration-line: underline;
         }
@@ -1923,6 +1927,10 @@ describe('plugins', () => {
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
+        .group-hocus\\:flex:is(:where(.group):hover *), .group-hocus\\:flex:is(:where(.group):focus *) {
+          display: flex;
+        }
+
         .hocus\\:underline:hover, .hocus\\:underline:focus {
           text-decoration-line: underline;
         }
@@ -1957,12 +1965,12 @@ describe('plugins', () => {
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
         @media (hover: hover) {
-          .group-hocus\\:flex:is(:where(.group) *):hover {
+          .group-hocus\\:flex:is(:where(.group):hover *) {
             display: flex;
           }
         }
 
-        .group-hocus\\:flex:is(:where(.group) *):is(:where(.group):focus *) {
+        .group-hocus\\:flex:is(:where(.group):focus *) {
           display: flex;
         }
 
@@ -2147,6 +2155,10 @@ describe('@variant', () => {
 
       expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
         "@layer utilities {
+          .group-hocus\\:flex:is(:where(.group):hover *), .group-hocus\\:flex:is(:where(.group):focus *) {
+            display: flex;
+          }
+
           .hocus\\:underline:hover, .hocus\\:underline:focus {
             text-decoration-line: underline;
           }
@@ -2223,7 +2235,7 @@ describe('@variant', () => {
 
       expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
         "@layer utilities {
-          .group-hocus\\:underline:is(:is(:where(.group):hover, :where(.group):focus) *) {
+          .group-hocus\\:underline:is(:where(.group):hover *), .group-hocus\\:underline:is(:where(.group):focus *) {
             text-decoration-line: underline;
           }
 
@@ -2254,6 +2266,10 @@ describe('@variant', () => {
 
       expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
         "@layer utilities {
+          .group-hocus\\:underline:is(:where(.group):hover *), .group-hocus\\:underline:is(:where(.group):focus *) {
+            text-decoration-line: underline;
+          }
+
           .hocus\\:underline:hover, .hocus\\:underline:focus {
             text-decoration-line: underline;
           }
@@ -2346,6 +2362,16 @@ describe('@variant', () => {
 
       expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
         "@layer utilities {
+          @media (hover: hover) {
+            .group-hocus\\:underline:is(:where(.group):hover *) {
+              text-decoration-line: underline;
+            }
+          }
+
+          .group-hocus\\:underline:is(:where(.group):focus *) {
+            text-decoration-line: underline;
+          }
+
           @media (hover: hover) {
             .hocus\\:underline:hover {
               text-decoration-line: underline;

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -2598,6 +2598,12 @@ describe('@variant', () => {
       ),
     ).toMatchInlineSnapshot(`
       "@layer utilities {
+        @media not foo {
+          .not-foo\\:flex {
+            display: flex;
+          }
+        }
+
         @media foo {
           .foo\\:flex {
             display: flex;

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1892,10 +1892,6 @@ describe('plugins', () => {
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
-        .group-hocus\\:flex:is(:where(.group):hover *), .group-hocus\\:flex:is(:where(.group):focus *) {
-          display: flex;
-        }
-
         .hocus\\:underline:hover, .hocus\\:underline:focus {
           text-decoration-line: underline;
         }
@@ -1927,10 +1923,6 @@ describe('plugins', () => {
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
-        .group-hocus\\:flex:is(:where(.group):hover *), .group-hocus\\:flex:is(:where(.group):focus *) {
-          display: flex;
-        }
-
         .hocus\\:underline:hover, .hocus\\:underline:focus {
           text-decoration-line: underline;
         }
@@ -1965,12 +1957,12 @@ describe('plugins', () => {
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
         @media (hover: hover) {
-          .group-hocus\\:flex:is(:where(.group):hover *) {
+          .group-hocus\\:flex:is(:where(.group) *):hover {
             display: flex;
           }
         }
 
-        .group-hocus\\:flex:is(:where(.group):focus *) {
+        .group-hocus\\:flex:is(:where(.group) *):is(:where(.group):focus *) {
           display: flex;
         }
 
@@ -2155,10 +2147,6 @@ describe('@variant', () => {
 
       expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
         "@layer utilities {
-          .group-hocus\\:flex:is(:where(.group):hover *), .group-hocus\\:flex:is(:where(.group):focus *) {
-            display: flex;
-          }
-
           .hocus\\:underline:hover, .hocus\\:underline:focus {
             text-decoration-line: underline;
           }
@@ -2266,10 +2254,6 @@ describe('@variant', () => {
 
       expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
         "@layer utilities {
-          .group-hocus\\:underline:is(:where(.group):hover *), .group-hocus\\:underline:is(:where(.group):focus *) {
-            text-decoration-line: underline;
-          }
-
           .hocus\\:underline:hover, .hocus\\:underline:focus {
             text-decoration-line: underline;
           }
@@ -2362,16 +2346,6 @@ describe('@variant', () => {
 
       expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
         "@layer utilities {
-          @media (hover: hover) {
-            .group-hocus\\:underline:is(:where(.group):hover *) {
-              text-decoration-line: underline;
-            }
-          }
-
-          .group-hocus\\:underline:is(:where(.group):focus *) {
-            text-decoration-line: underline;
-          }
-
           @media (hover: hover) {
             .hocus\\:underline:hover {
               text-decoration-line: underline;

--- a/packages/tailwindcss/src/intellisense.test.ts
+++ b/packages/tailwindcss/src/intellisense.test.ts
@@ -72,9 +72,9 @@ test('getVariants compound', () => {
   ]
 
   expect(list).toEqual([
-    ['&:is(:where(.group):hover *)'],
-    ['&:is(:where(.group\\/sidebar):hover *)'],
-    ['&:is(:where(.group):is(:where(.group):hover *) *)'],
+    ['@media (hover: hover) { &:is(:where(.group):hover *) { & } }'],
+    ['@media (hover: hover) { &:is(:where(.group\\/sidebar):hover *) { & } }'],
+    ['@media (hover: hover) { &:is(:where(.group):is(:where(.group):hover *) *) { & } }'],
     [],
     [],
   ])

--- a/packages/tailwindcss/src/selectors/expr.ts
+++ b/packages/tailwindcss/src/selectors/expr.ts
@@ -14,45 +14,55 @@ export type Expr<T = any> = {
   nodes: Expr<T>[]
 }
 
-// This is a standin for a node that has been removed
+/**
+ * A placeholder for a node that has been removed from the expression graph
+ */
 export function none(): Expr<any> {
   return { kind: 'none', value: null, nodes: [] }
 }
 
+/**
+ * Creates an AND relationship between the given nodes
+ */
 export function and<T>(nodes: Expr<T>[]): Expr<T> {
   return { kind: 'and', value: null, nodes }
 }
 
+/**
+ * Creates an OR relationship between the given nodes
+ */
 export function or<T>(nodes: Expr<T>[]): Expr<T> {
   return { kind: 'or', value: null, nodes }
 }
 
+/**
+ * Creates a NOT relationship with the given node
+ */
 export function not<T>(node: Expr<T>): Expr<T> {
   return { kind: 'not', value: null, nodes: [node] }
 }
 
+/**
+ * Represents a "literal" value in the expression graph.
+ * This is essential an opaque variable that stands in for some value.
+ */
 export function lit<T>(value: T): Expr<T> {
   return { kind: 'lit', value, nodes: [] }
 }
 
-export type Visitor = (e: Expr) => Expr
-
-export function visit(e: Expr, w: Visitor, depth: number = 0): Expr {
-  e = w(e)
-
-  for (let i = 0; i < e.nodes.length; i++) {
-    e.nodes[i] = visit(e.nodes[i], w, depth + 1)
-  }
-
-  return e
+export type Visitor = {
+  Enter?: (e: Expr) => Expr
+  Exit?: (e: Expr) => Expr
 }
 
-export function visitDepth(e: Expr, w: Visitor, depth: number = 0): Expr {
+export function visit(e: Expr, w: Visitor): Expr {
+  e = w.Enter?.(e) ?? e
+
   for (let i = 0; i < e.nodes.length; i++) {
-    e.nodes[i] = visitDepth(e.nodes[i], w, depth + 1)
+    e.nodes[i] = visit(e.nodes[i], w)
   }
 
-  e = w(e)
+  e = w.Exit?.(e) ?? e
 
   return e
 }

--- a/packages/tailwindcss/src/selectors/expr.ts
+++ b/packages/tailwindcss/src/selectors/expr.ts
@@ -1,0 +1,58 @@
+/**
+ * A logical expression represented as a nested object graph
+ *
+ * The possible nodes are:
+ * - lit: A literal
+ * - not: A negation
+ * - and: A conjunction
+ * - or: A disjunction
+ * - none: A placeholder for a node that has been removed from the graph
+ */
+export type Expr<T = any> = {
+  kind: 'lit' | 'not' | 'and' | 'or' | 'none'
+  value: T | null
+  nodes: Expr<T>[]
+}
+
+// This is a standin for a node that has been removed
+export function none(): Expr<any> {
+  return { kind: 'none', value: null, nodes: [] }
+}
+
+export function and<T>(nodes: Expr<T>[]): Expr<T> {
+  return { kind: 'and', value: null, nodes }
+}
+
+export function or<T>(nodes: Expr<T>[]): Expr<T> {
+  return { kind: 'or', value: null, nodes }
+}
+
+export function not<T>(node: Expr<T>): Expr<T> {
+  return { kind: 'not', value: null, nodes: [node] }
+}
+
+export function lit<T>(value: T): Expr<T> {
+  return { kind: 'lit', value, nodes: [] }
+}
+
+export type Visitor = (e: Expr) => Expr
+
+export function visit(e: Expr, w: Visitor, depth: number = 0): Expr {
+  e = w(e)
+
+  for (let i = 0; i < e.nodes.length; i++) {
+    e.nodes[i] = visit(e.nodes[i], w, depth + 1)
+  }
+
+  return e
+}
+
+export function visitDepth(e: Expr, w: Visitor, depth: number = 0): Expr {
+  for (let i = 0; i < e.nodes.length; i++) {
+    e.nodes[i] = visitDepth(e.nodes[i], w, depth + 1)
+  }
+
+  e = w(e)
+
+  return e
+}

--- a/packages/tailwindcss/src/selectors/negate.test.ts
+++ b/packages/tailwindcss/src/selectors/negate.test.ts
@@ -152,7 +152,7 @@ test('Negation of complex graphs mixing at rules and style rules', () => {
     @media (min-width: 500px) {
       &:hover:focus,
       &:visited {
-        @container sidebar {
+        @container sidebar (width < 500px) {
           &:active {
           }
         }
@@ -168,7 +168,7 @@ test('Negation of complex graphs mixing at rules and style rules', () => {
         /* … */
       }
     }
-    @container sidebar {
+    @container sidebar not (width < 500px) {
       @media not (orientation: landscape) {
         /* … */
       }
@@ -180,4 +180,15 @@ test('Negation of complex graphs mixing at rules and style rules', () => {
     }
     "
   `)
+})
+
+test('Negation of at-rules that cant be', () => {
+  expect(() =>
+    negate(css`
+      @media (min-width: 500px) {
+        @layer components {
+        }
+      }
+    `),
+  ).toThrowErrorMatchingInlineSnapshot(`[Error: Unable to negate rule: @layer components]`)
 })

--- a/packages/tailwindcss/src/selectors/negate.test.ts
+++ b/packages/tailwindcss/src/selectors/negate.test.ts
@@ -1,0 +1,183 @@
+import { expect, test } from 'vitest'
+import { comment, toCss, walkDepth } from '../ast'
+import { parse } from '../css-parser'
+import { negateRules } from './negate'
+
+const css = String.raw
+
+function negate(input: string) {
+  let ast = parse(input)
+  let negated = negateRules(ast)
+
+  walkDepth(negated, (node) => {
+    if (node.kind !== 'rule') return
+    if (node.nodes.length > 0) return
+
+    node.nodes.push(comment(' … '))
+  })
+
+  return negated
+}
+
+test('Negation of a simple style rules', () => {
+  let ast = negate(css`
+    &:hover,
+    &:focus {
+    }
+  `)
+
+  expect(toCss(ast)).toMatchInlineSnapshot(`
+    "&:not(*:hover, *:focus) {
+      /* … */
+    }
+    "
+  `)
+})
+
+test('Negation of simple nested style rules', () => {
+  let ast = negate(css`
+    &:hover {
+      &:focus {
+      }
+    }
+  `)
+
+  expect(toCss(ast)).toMatchInlineSnapshot(`
+    "&:not(*:hover:focus) {
+      /* … */
+    }
+    "
+  `)
+})
+
+test('Negation of nested style rules containing multiple selectors', () => {
+  let ast = negate(css`
+    &:hover,
+    &:focus {
+      &:visited,
+      &:active {
+      }
+    }
+  `)
+
+  expect(toCss(ast)).toMatchInlineSnapshot(`
+    "&:not(:is(*:hover, *:focus):visited, :is(*:hover, *:focus):active) {
+      /* … */
+    }
+    "
+  `)
+})
+
+test('Negation of complex nested style rules', () => {
+  let ast = negate(css`
+    &:hover {
+      &:focus {
+        &:active {
+        }
+
+        &[data-whatever] {
+        }
+      }
+
+      &[data-foo] {
+      }
+    }
+
+    &:visited {
+    }
+  `)
+
+  expect(toCss(ast)).toMatchInlineSnapshot(`
+    "&:not(*:hover:focus:active):not(*:hover:focus[data-whatever]):not(*:hover[data-foo]):not(*:visited) {
+      /* … */
+    }
+    "
+  `)
+})
+
+test('Negation of simple media queries', () => {
+  let ast = negate(css`
+    @media (min-width: 500px) {
+    }
+  `)
+
+  expect(toCss(ast)).toMatchInlineSnapshot(`
+    "@media not (min-width: 500px) {
+      /* … */
+    }
+    "
+  `)
+})
+
+test('Negation of nested at rules', () => {
+  let ast = negate(css`
+    @media (min-width: 500px) {
+      @media (orientation: portrait) {
+      }
+    }
+  `)
+
+  expect(toCss(ast)).toMatchInlineSnapshot(`
+    "@media not (orientation: portrait) {
+      /* … */
+    }
+    @media not (min-width: 500px) {
+      /* … */
+    }
+    "
+  `)
+})
+
+test('Negation of at rules wrapping selectors', () => {
+  let ast = negate(css`
+    @media (hover: hover) {
+      &:hover {
+      }
+    }
+  `)
+
+  expect(toCss(ast)).toMatchInlineSnapshot(`
+    "&:not(*:hover) {
+      /* … */
+    }
+    @media not (hover: hover) {
+      /* … */
+    }
+    "
+  `)
+})
+
+test('Negation of complex graphs mixing at rules and style rules', () => {
+  let ast = negate(css`
+    @media (min-width: 500px) {
+      &:hover:focus,
+      &:visited {
+        @container sidebar {
+          &:active {
+          }
+        }
+      }
+    }
+    @media (orientation: landscape) {
+    }
+  `)
+
+  expect(toCss(ast)).toMatchInlineSnapshot(`
+    "@media not (orientation: landscape) {
+      &:not(:is(*:hover:focus,  *:visited):active) {
+        /* … */
+      }
+    }
+    @container sidebar {
+      @media not (orientation: landscape) {
+        /* … */
+      }
+    }
+    @media not (min-width: 500px) {
+      @media not (orientation: landscape) {
+        /* … */
+      }
+    }
+    "
+  `)
+})

--- a/packages/tailwindcss/src/selectors/negate.ts
+++ b/packages/tailwindcss/src/selectors/negate.ts
@@ -1,0 +1,87 @@
+import type { AstNode } from '../ast'
+import { rule, walkDepth } from '../ast'
+import { DefaultMap } from '../utils/default-map'
+import { segment } from '../utils/segment'
+import { and, lit, not, or, type Expr } from './expr'
+import { flattenNesting } from './nesting'
+import { toDNF } from './rewriting'
+
+export function negateRules(ast: AstNode[]): AstNode[] {
+  // 1. Flatten any nesting
+  // 2. Isolate rules such that no siblings are present except at the root
+  let flattened = flattenNesting(structuredClone(ast))
+
+  // 3. Convert the AST into an expression graph
+  // 4. Negate the graph
+  let graph = not(toGraph(flattened))
+
+  // 5. Convert the graph to Disjunctive Normal Form (DNF)
+  graph = toDNF(graph)
+
+  // 6. Convert the graph back into a structured AST
+  // The current graph looks like this
+  // (A && B && …) || (D && E && …) || …
+
+  // Each conjunction represents one set of nested rules
+  // Each disjunction represents a separate set of rules
+  let newAst: AstNode[] = []
+
+  for (let expr of graph.nodes) {
+    let current: AstNode | null = null
+
+    for (let child of expr.nodes.reverse()) {
+      let selector = child.kind === 'not' ? invertSelector(child.nodes[0].value!) : child.value!
+
+      current = rule(selector, current ? [current] : [])
+    }
+
+    if (current) {
+      newAst.push(current)
+    }
+  }
+
+  return flattenNesting(newAst)
+}
+
+function invertSelector(selector: string): string {
+  if (selector[0] === '@') {
+    return selector
+      .replace('@media', '@media not')
+      .replace('@supports', '@supports not')
+      .replace('@document', '@document not')
+  }
+
+  let selectors = segment(selector, ',').map((part) => {
+    part = part.trim()
+
+    if (part.startsWith(':is(') && part.endsWith(')')) {
+      part = part.slice(4, -1)
+    }
+
+    part = part.replaceAll('&', '*')
+
+    return part
+  })
+
+  return `&:not(${selectors.join(', ')})`
+}
+
+function toGraph(ast: AstNode[]): Expr<string> {
+  let current = 1
+  let table = new DefaultMap<string, number>(() => current++)
+  let graph = or([])
+
+  walkDepth(ast, (node, { path }) => {
+    // Ignore non-rules
+    if (node.kind !== 'rule') return
+
+    // Only consider leaf nodes
+    if (node.nodes.length > 0) return
+
+    let rules = path.filter((node) => node.kind === 'rule')
+
+    graph.nodes.push(and(rules.map((rule) => lit(rule.selector))))
+  })
+
+  return graph as Expr<string>
+}

--- a/packages/tailwindcss/src/selectors/nesting.test.ts
+++ b/packages/tailwindcss/src/selectors/nesting.test.ts
@@ -50,8 +50,10 @@ test('parse', () => {
       }
     }
     @layer thing {
-      .a .b .d {
-        color: green;
+      @supports (color: green) {
+        .a .b .d {
+          color: green;
+        }
       }
     }
     .a .e {
@@ -126,10 +128,10 @@ test('parse', () => {
     }
   `)
   expect(toCss(flattenNesting(ast))).toMatchInlineSnapshot(`
-    ":is(.a, .b) {
+    ".a, .b {
       color: red;
     }
-    :is(:is(:is(:is(.a, .b) .c, :is(.a, .b) .d) .e, :is(:is(.a, .b) .c, :is(.a, .b) .d) .f) .g, :is(:is(:is(.a, .b) .c, :is(.a, .b) .d) .e, :is(:is(.a, .b) .c, :is(.a, .b) .d) .f) .h) {
+    :is(:is(:is(.a, .b) .c, :is(.a, .b) .d) .e, :is(:is(.a, .b) .c, :is(.a, .b) .d) .f) .g, :is(:is(:is(.a, .b) .c, :is(.a, .b) .d) .e, :is(:is(.a, .b) .c, :is(.a, .b) .d) .f) .h {
       color: green;
     }
     "
@@ -160,10 +162,10 @@ test('flat variant', () => {
   `)
 
   expect(toCss(flattenNesting(ast))).toMatchInlineSnapshot(`
-    "&:hover:focus:hover:focus:active {
+    "&:hover:focus:active {
       @slot;
     }
-    &:hover:focus:hover:focus[data-whatever] {
+    &:hover:focus[data-whatever] {
       @slot;
     }
     &:hover[data-foo] {

--- a/packages/tailwindcss/src/selectors/nesting.test.ts
+++ b/packages/tailwindcss/src/selectors/nesting.test.ts
@@ -1,0 +1,137 @@
+import { expect, test } from 'vitest'
+import { toCss } from '../ast'
+import { parse } from '../css-parser'
+import { flattenNesting } from './nesting'
+
+const css = String.raw
+
+test('parse', () => {
+  let ast = parse(css`
+    .a {
+      color: red;
+      @layer thing {
+        .b {
+          color: orange;
+          @media (min-width: 600px) {
+            .c {
+              color: yellow;
+            }
+          }
+          .d {
+            @supports (color: green) {
+              color: green;
+            }
+          }
+          color: blue;
+        }
+      }
+      .e {
+        color: indigo;
+      }
+      color: violet;
+    }
+  `)
+  expect(toCss(flattenNesting(ast))).toMatchInlineSnapshot(`
+    ".a {
+      color: red;
+      color: violet;
+    }
+    @layer thing {
+      .a .b {
+        color: orange;
+        color: blue;
+      }
+    }
+    @layer thing {
+      @media (min-width: 600px) {
+        .a .b .c {
+          color: yellow;
+        }
+      }
+    }
+    @layer thing {
+      .a .b .d {
+        color: green;
+      }
+    }
+    .a .e {
+      color: indigo;
+    }
+    "
+  `)
+})
+
+test('parse', () => {
+  let ast = parse(css`
+    .a {
+      color: red;
+      .b {
+        color: orange;
+        color: blue;
+      }
+      .b {
+        .c {
+          color: yellow;
+        }
+      }
+      .b {
+        .d {
+          color: green;
+        }
+      }
+      .e {
+        color: indigo;
+      }
+      color: violet;
+    }
+  `)
+  expect(toCss(flattenNesting(ast))).toMatchInlineSnapshot(`
+    ".a {
+      color: red;
+      color: violet;
+    }
+    .a .b {
+      color: orange;
+      color: blue;
+    }
+    .a .b .c {
+      color: yellow;
+    }
+    .a .b .d {
+      color: green;
+    }
+    .a .e {
+      color: indigo;
+    }
+    "
+  `)
+})
+
+test('parse', () => {
+  let ast = parse(css`
+    .a,
+    .b {
+      color: red;
+
+      .c,
+      .d {
+        .e,
+        .f {
+          .g,
+          .h {
+            color: green;
+          }
+        }
+      }
+    }
+  `)
+  expect(toCss(flattenNesting(ast))).toMatchInlineSnapshot(`
+    ":is(.a, .b) {
+      color: red;
+    }
+    :is(:is(:is(:is(.a, .b) .c, :is(.a, .b) .d) .e, :is(:is(.a, .b) .c, :is(.a, .b) .d) .f) .g, :is(:is(:is(.a, .b) .c, :is(.a, .b) .d) .e, :is(:is(.a, .b) .c, :is(.a, .b) .d) .f) .h) {
+      color: green;
+    }
+    "
+  `)
+})

--- a/packages/tailwindcss/src/selectors/nesting.test.ts
+++ b/packages/tailwindcss/src/selectors/nesting.test.ts
@@ -34,12 +34,10 @@ test('parse', () => {
   expect(toCss(flattenNesting(ast))).toMatchInlineSnapshot(`
     ".a {
       color: red;
-      color: violet;
     }
     @layer thing {
       .a .b {
         color: orange;
-        color: blue;
       }
     }
     @layer thing {
@@ -56,8 +54,16 @@ test('parse', () => {
         }
       }
     }
+    @layer thing {
+      .a .b {
+        color: blue;
+      }
+    }
     .a .e {
       color: indigo;
+    }
+    .a {
+      color: violet;
     }
     "
   `)
@@ -90,7 +96,6 @@ test('parse', () => {
   expect(toCss(flattenNesting(ast))).toMatchInlineSnapshot(`
     ".a {
       color: red;
-      color: violet;
     }
     .a .b {
       color: orange;
@@ -104,6 +109,9 @@ test('parse', () => {
     }
     .a .e {
       color: indigo;
+    }
+    .a {
+      color: violet;
     }
     "
   `)

--- a/packages/tailwindcss/src/selectors/nesting.test.ts
+++ b/packages/tailwindcss/src/selectors/nesting.test.ts
@@ -135,3 +135,43 @@ test('parse', () => {
     "
   `)
 })
+
+test.only('flat variant', () => {
+  let ast = parse(css`
+    &:hover {
+      &:focus {
+        &:active {
+          @slot;
+        }
+
+        &[data-whatever] {
+          @slot;
+        }
+      }
+
+      &[data-foo] {
+        @slot;
+      }
+    }
+
+    &:visited {
+      @slot;
+    }
+  `)
+
+  expect(toCss(flattenNesting(ast))).toMatchInlineSnapshot(`
+    "&:hover:focus:hover:focus:active {
+      @slot;
+    }
+    &:hover:focus:hover:focus[data-whatever] {
+      @slot;
+    }
+    &:hover[data-foo] {
+      @slot;
+    }
+    &:visited {
+      @slot;
+    }
+    "
+  `)
+})

--- a/packages/tailwindcss/src/selectors/nesting.test.ts
+++ b/packages/tailwindcss/src/selectors/nesting.test.ts
@@ -136,7 +136,7 @@ test('parse', () => {
   `)
 })
 
-test.only('flat variant', () => {
+test('flat variant', () => {
   let ast = parse(css`
     &:hover {
       &:focus {

--- a/packages/tailwindcss/src/selectors/nesting.ts
+++ b/packages/tailwindcss/src/selectors/nesting.ts
@@ -1,4 +1,4 @@
-import { walk, walkDepth, type AstNode, type Rule } from '../ast'
+import { rule, walk, walkDepth, type AstNode, type Rule } from '../ast'
 import { segment } from '../utils/segment'
 
 let nestableAtRules = [
@@ -29,8 +29,6 @@ export function flattenNesting(ast: AstNode[]) {
     if (node.kind !== 'rule') return
 
     // Step 1: Add implicit `&` to all nested selectors
-    // This is done early to help reduce memory usage of repeated selectors
-    // https://www.w3.org/TR/css-nesting-1/#example-31845edf
     if (parent && !node.selector.startsWith('@')) {
       let selectors = segment(node.selector, ',')
 
@@ -52,14 +50,8 @@ export function flattenNesting(ast: AstNode[]) {
       node.selector = selectors.join(', ')
     }
 
-    // Step 2: Wrap selector lists in `:is()` when there are multiple selectors
-    if (!node.selector.startsWith('@')) {
-      node.selector =
-        segment(node.selector, ',').length > 1 ? `:is(${node.selector})` : node.selector
-    }
-
-    // Step 3: Split rules from declarations
-    // This will simplify the tree-flattening in the next step
+    // Step 2: Split rules from declarations
+    // This will simplify the tree-flattening later
     let rules: Rule[] = []
     let other: AstNode[] = []
 
@@ -74,61 +66,58 @@ export function flattenNesting(ast: AstNode[]) {
     // We need at least two nested
     if (rules.length === 0) return
 
-    // There's exactly one nested rule so there's nothing for us to do
-    if (rules.length === 1 && other.length === 0) return
-
-    // 1. Replace the children in the current node with just the declarations
     let replacements: AstNode[] = []
 
+    // Add declarations in a separate rule node
     if (other.length > 0) {
-      node.nodes = other
-      replacements.push(node)
+      replacements.push(rule(node.selector, other))
     }
 
-    // 2. Insert the nested rules as siblings after the current node
-    // while also wrapping each rule in a copy of the current rule
-    for (let rule of rules) {
-      let clone = structuredClone(node)
-      clone.nodes = [rule]
-      replacements.push(clone)
+    // Add each nested rule in a separate rule node
+    for (let r of rules) {
+      replacements.push(rule(node.selector, [r]))
     }
 
     replaceWith(replacements)
   })
 
-  // Step 2: De-nest rules by:
-  // - Moving at rules up one level
-  // - Merging selectors with `&` in them
+  // Step 2: Merge selectors of style rules
+  // This technically produces invalid intermediate CSS but that gets flattened
+  // out in the next step
+  walkDepth(ast, (node, { path }) => {
+    if (node.kind !== 'rule') return
+    if (node.selector.startsWith('@')) return
+
+    for (let ancestor of path.slice(1)) {
+      if (ancestor.kind !== 'rule') continue
+      if (ancestor.selector.startsWith('@')) continue
+
+      let parentSelector =
+        segment(ancestor.selector, ',').length > 1 ? `:is(${ancestor.selector})` : ancestor.selector
+
+      node.selector = node.selector.replaceAll('&', parentSelector)
+    }
+  })
+
+  // Step 3: Flatten nested style rules
   walk(ast, (node, { replaceWith }) => {
     if (node.kind !== 'rule') return
-    if (node.nodes.length === 0) return
-    if (node.selector.startsWith('@')) return
+    if (node.selector[0] === '@') return
+    if (node.nodes.length !== 1) return
+
+    let child = node.nodes[0]
 
     // At this point it's guaranteed that a rule has either
     // multiple declarations in it _or_ a single rule
     // We want to skip if there's only declarations
-    if (node.nodes[0].kind === 'declaration') return
-
-    let child = node.nodes[0]
     if (child.kind !== 'rule') return
+
     if (child.selector[0] === '@') {
-      let isNestable = nestableAtRules.some((atRule) => child.selector.startsWith(atRule))
+      let isNestable = nestableAtRules.some((atRule) => (child as Rule).selector.startsWith(atRule))
       if (!isNestable) return
 
-      node.nodes = child.nodes
-
-      // this is an at-rule inside of a style rule
-      let cloned = structuredClone(child)
-      cloned.nodes = [node]
-
-      replaceWith(cloned)
-
-      return
+      child = rule(child.selector, [rule(node.selector, child.nodes)])
     }
-
-    child.selector = segment(child.selector, ',')
-      .map((s) => s.replaceAll('&', node.selector))
-      .join(',')
 
     replaceWith(child)
   })

--- a/packages/tailwindcss/src/selectors/nesting.ts
+++ b/packages/tailwindcss/src/selectors/nesting.ts
@@ -13,11 +13,11 @@ let nestableAtRules = [
 export function flattenNesting(ast: AstNode[]) {
   // Step 1: Sorting and selector preparation
   //
-  // - Declarations must be sorted before nested rules:
-  // https://www.w3.org/TR/css-nesting-1/#mixing
-  //
   // - Selectors have their implicit `&` inserted to make selector manipulation
   // simpler in future steps.
+  //
+  // - Declarations must be sorted before nested rules:
+  // https://www.w3.org/TR/css-nesting-1/#mixing
   //
   // - Rules are split into multiple groups such that each group has either
   // a list of declarations OR at most one rule inside. This means the split

--- a/packages/tailwindcss/src/selectors/nesting.ts
+++ b/packages/tailwindcss/src/selectors/nesting.ts
@@ -1,0 +1,137 @@
+import { walk, walkDepth, type AstNode, type Rule } from '../ast'
+import { segment } from '../utils/segment'
+
+let nestableAtRules = [
+  '@container',
+  '@supports',
+  '@media',
+  '@layer',
+  '@starting-style',
+  '@document',
+]
+
+export function flattenNesting(ast: AstNode[]) {
+  // Step 1: Sorting and selector preparation
+  //
+  // - Declarations must be sorted before nested rules:
+  // https://www.w3.org/TR/css-nesting-1/#mixing
+  //
+  // - Selectors have their implicit `&` inserted to make selector manipulation
+  // simpler in future steps.
+  //
+  // - Rules are split into multiple groups such that each group has either
+  // a list of declarations OR at most one rule inside. This means the split
+  // is done all the way to the root of the AST.
+  //
+  // We traverse from the inside out to ensure that AST modifications are
+  // minimized and easier to reason about.
+  walkDepth(ast, (node, { parent, replaceWith }) => {
+    if (node.kind !== 'rule') return
+
+    // Step 1: Add implicit `&` to all nested selectors
+    // This is done early to help reduce memory usage of repeated selectors
+    // https://www.w3.org/TR/css-nesting-1/#example-31845edf
+    if (parent && !node.selector.startsWith('@')) {
+      let selectors = segment(node.selector, ',')
+
+      for (let i = 0; i < selectors.length; i++) {
+        let selector = selectors[i].trim()
+
+        // Selectors that are relative *always* need to be prefixed with `&`
+        // As do selectors that do not contain `&`
+        if (
+          selector.startsWith('+') ||
+          selector.startsWith('~') ||
+          selector.startsWith('>') ||
+          !selector.includes('&')
+        ) {
+          selectors[i] = `& ${selector}`
+        }
+      }
+
+      node.selector = selectors.join(', ')
+    }
+
+    // Step 2: Wrap selector lists in `:is()` when there are multiple selectors
+    if (!node.selector.startsWith('@')) {
+      node.selector =
+        segment(node.selector, ',').length > 1 ? `:is(${node.selector})` : node.selector
+    }
+
+    // Step 3: Split rules from declarations
+    // This will simplify the tree-flattening in the next step
+    let rules: Rule[] = []
+    let other: AstNode[] = []
+
+    for (let child of node.nodes) {
+      if (child.kind !== 'rule') {
+        other.push(child)
+      } else {
+        rules.push(child)
+      }
+    }
+
+    // We need at least two nested
+    if (rules.length === 0) return
+
+    // There's exactly one nested rule so there's nothing for us to do
+    if (rules.length === 1 && other.length === 0) return
+
+    // 1. Replace the children in the current node with just the declarations
+    let replacements: AstNode[] = []
+
+    if (other.length > 0) {
+      node.nodes = other
+      replacements.push(node)
+    }
+
+    // 2. Insert the nested rules as siblings after the current node
+    // while also wrapping each rule in a copy of the current rule
+    for (let rule of rules) {
+      let clone = structuredClone(node)
+      clone.nodes = [rule]
+      replacements.push(clone)
+    }
+
+    replaceWith(replacements)
+  })
+
+  // Step 2: De-nest rules by:
+  // - Moving at rules up one level
+  // - Merging selectors with `&` in them
+  walk(ast, (node, { replaceWith }) => {
+    if (node.kind !== 'rule') return
+    if (node.nodes.length === 0) return
+    if (node.selector.startsWith('@')) return
+
+    // At this point it's guaranteed that a rule has either
+    // multiple declarations in it _or_ a single rule
+    // We want to skip if there's only declarations
+    if (node.nodes[0].kind === 'declaration') return
+
+    let child = node.nodes[0]
+    if (child.kind !== 'rule') return
+    if (child.selector[0] === '@') {
+      let isNestable = nestableAtRules.some((atRule) => child.selector.startsWith(atRule))
+      if (!isNestable) return
+
+      node.nodes = child.nodes
+
+      // this is an at-rule inside of a style rule
+      let cloned = structuredClone(child)
+      cloned.nodes = [node]
+
+      replaceWith(cloned)
+
+      return
+    }
+
+    child.selector = segment(child.selector, ',')
+      .map((s) => s.replaceAll('&', node.selector))
+      .join(',')
+
+    replaceWith(child)
+  })
+
+  return ast
+}

--- a/packages/tailwindcss/src/selectors/rewriting.test.ts
+++ b/packages/tailwindcss/src/selectors/rewriting.test.ts
@@ -1,16 +1,16 @@
 import { expect, test } from 'vitest'
-import { and, lit, not, or, visitDepth } from './expr'
+import { and, lit, not, or, visit } from './expr'
 import { flatten, toDNF } from './rewriting'
 
 test('De Morgan: !(A || B)', () => {
   let expr = toDNF(not(or([lit(1), lit(2)])))
-  expr = visitDepth(expr, flatten)
+  expr = visit(expr, { Exit: flatten })
   expect(expr).toEqual(and([not(lit(1)), not(lit(2))]))
 })
 
 test('De Morgan: !(A && B)', () => {
   let expr = toDNF(not(and([lit(1), lit(2)])))
-  expr = visitDepth(expr, flatten)
+  expr = visit(expr, { Exit: flatten })
   expect(expr).toEqual(or([not(lit(1)), not(lit(2))]))
 })
 

--- a/packages/tailwindcss/src/selectors/rewriting.test.ts
+++ b/packages/tailwindcss/src/selectors/rewriting.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from 'vitest'
+import { and, lit, not, or, visitDepth } from './expr'
+import { flatten, toDNF } from './rewriting'
+
+test('De Morgan: !(A || B)', () => {
+  let expr = toDNF(not(or([lit(1), lit(2)])))
+  expr = visitDepth(expr, flatten)
+  expect(expr).toEqual(and([not(lit(1)), not(lit(2))]))
+})
+
+test('De Morgan: !(A && B)', () => {
+  let expr = toDNF(not(and([lit(1), lit(2)])))
+  expr = visitDepth(expr, flatten)
+  expect(expr).toEqual(or([not(lit(1)), not(lit(2))]))
+})
+
+test('Disjunctive Normal Form', () => {
+  // (A || B) && (C || D) && (E || F)
+  let expr = and([
+    //
+    or([lit(1), lit(2)]),
+    or([lit(3), lit(4)]),
+    or([lit(5), lit(6)]),
+  ])
+
+  expr = toDNF(expr)
+
+  expect(expr).toEqual(
+    // A && C && E ||
+    // A && C && F ||
+    // A && D && E ||
+    // A && D && F ||
+    // B && C && E ||
+    // B && C && F ||
+    // B && D && E ||
+    // B && D && F
+    or([
+      //
+      and([lit(1), lit(3), lit(5)]),
+      and([lit(1), lit(3), lit(6)]),
+
+      and([lit(1), lit(4), lit(5)]),
+      and([lit(1), lit(4), lit(6)]),
+
+      and([lit(2), lit(3), lit(5)]),
+      and([lit(2), lit(3), lit(6)]),
+
+      and([lit(2), lit(4), lit(5)]),
+      and([lit(2), lit(4), lit(6)]),
+    ]),
+  )
+})

--- a/packages/tailwindcss/src/selectors/rewriting.ts
+++ b/packages/tailwindcss/src/selectors/rewriting.ts
@@ -1,0 +1,429 @@
+import { and, none, not, or, visit, visitDepth, type Expr } from './expr'
+
+export function toDNF(expr: Expr): Expr {
+  // Convert the expression to Negation Normal Form (NNF)
+  expr = visit(expr, deMorgan)
+  expr = visitDepth(expr, flatten)
+
+  // Convert the expression to Disjunctive Normal Form (DNF)
+  expr = visitDepth(expr, dnf)
+  expr = visitDepth(expr, flatten)
+  expr = visitDepth(expr, dedupe)
+  expr = normalizeDNF(expr)
+  expr = visitDepth(expr, eliminateSupersets)
+
+  return expr
+}
+
+/**
+ * Flatten the expression tree by removing redundant NOT and AND/OR nodes
+ */
+export function flatten(e: Expr) {
+  if (e.kind === 'not') {
+    let child = e.nodes[0]
+
+    if (child.kind === 'not') {
+      return child.nodes[0]
+    }
+  } else if (e.kind === 'and' || e.kind === 'or') {
+    e.nodes = e.nodes.flatMap((child) => {
+      if (child.kind === e.kind) {
+        return child.nodes
+      }
+
+      return child
+    })
+
+    if (e.nodes.length === 1) {
+      return e.nodes[0]
+    }
+  }
+
+  return e
+}
+
+/**
+ * Apply one iteration of De Morgan's law to the expression
+ *
+ * To apply this to an entire tree you must use a breadth-first visitor
+ */
+function deMorgan(e: Expr): Expr {
+  if (e.kind === 'not') {
+    let child = e.nodes[0]
+
+    // We can re-assign the node because its still logically correct to do so
+    if (child.kind === 'or') {
+      e.kind = 'and'
+      e.nodes = child.nodes.map((node) => not(node))
+    } else if (child.kind === 'and') {
+      e.kind = 'or'
+      e.nodes = child.nodes.map((node) => not(node))
+    }
+  }
+
+  return e
+}
+
+function normalizeDNF(e: Expr): Expr {
+  if (e.kind === 'lit' || e.kind === 'not') {
+    return or([and([e])])
+  } else if (e.kind === 'and') {
+    return or([e])
+  } else if (e.kind === 'or') {
+    for (let i = 0; i < e.nodes.length; i++) {
+      let child = e.nodes[i]
+
+      if (child.kind === 'lit' || child.kind === 'not') {
+        e.nodes[i] = and([child])
+      }
+    }
+  }
+
+  return e
+}
+
+function dedupe(e: Expr): Expr {
+  for (let i = 0; i < e.nodes.length; i++) {
+    for (let j = i + 1; j < e.nodes.length; j++) {
+      if (areNodesEqual(e.nodes[i], e.nodes[j])) {
+        e.nodes[j] = none()
+      }
+    }
+  }
+
+  return clean(e)
+}
+
+// DNF Convert an expression to disjunctive normal form
+function dnf(e: Expr): Expr {
+  // Since we always first convert to NNF
+  // These forms are trivial terms
+  if (e.kind === 'lit' || e.kind === 'not') return e
+
+  // By this point children have already been converted to DNF
+  if (e.kind === 'or') return e
+
+  // Create a matrix of clauses
+  // We have to take the following:
+  // (A₀ || A₁ || … || Aₙ) && (B₀ || B₁ || … || Bₙ) && … && (N₀ || N₁ || … || Nₙ)
+
+  // And convert it to a 3D matrix
+  // (A₀ && B₀ && … && Nₙ) || (A₁ && B₀ && … && Nₙ) || … || (Aₙ && B₀ && … && Nₙ) ||
+  // (A₀ && B₁ && … && Nₙ) || (A₁ && B₁ && … && Nₙ) || … || (Aₙ && B₁ && … && Nₙ) ||
+  // …
+  // (A₀ && Bₙ && … && Nₙ) || (A₁ && Bₙ && … && Nₙ) || … || (Aₙ && Bₙ && … && Nₙ)
+
+  // a: Generate a 2D list of clauses
+  let lists = clausesIn(e)
+
+  // b: Generate a 2D list of combinations
+  let combos = combinations(lists)
+
+  // c: Re-construct the matrix into expression nodes
+  let clauses: Expr[] = []
+
+  for (let i = 0; i < combos.length; i++) {
+    clauses[i] = and(combos[i])
+  }
+
+  // d: Switch this node to OR with the appropriate clauses
+  // Node switching is appropriate because this is logically-equivalent for the whole AST
+  e.kind = 'or'
+  e.nodes = clauses
+
+  return e
+}
+
+/**
+ * Generate a 2D list of clauses considering only AND and ORs
+ */
+function clausesIn(e: Expr): Expr[][] {
+  return e.nodes.map((child) => {
+    if (child.kind === 'lit' || child.kind === 'not') {
+      return [child]
+    } else if (child.kind === 'and' || child.kind === 'or') {
+      return child.nodes
+    } else if (child.kind === 'none') {
+      return []
+    }
+
+    return []
+  })
+}
+
+function combinations(lists: Expr[][]): Expr[][] {
+  if (lists.length == 0) return []
+
+  let pos: number[] = []
+  let indexes: number[] = []
+  let iters = 1n
+
+  for (let idx = 0; idx < lists.length; idx++) {
+    let len = lists[idx].length
+    pos[idx] = 0
+    indexes[idx] = len - 1
+
+    iters *= BigInt(len)
+  }
+
+  // Check if the number of combinations can be represented as a 64-bit int
+  let u64Max = 2n ** 64n - 1n
+
+  if (iters > u64Max) {
+    let diff = iters - u64Max
+
+    throw new Error(
+      `Number of combinations cannot be represented as a 64-bit int. Overflowed by ${diff} (total: ${iters})`,
+    )
+  }
+
+  let iterations = Number(iters)
+
+  // One of the lists is empty…
+  if (iterations == 0) {
+    return []
+  }
+
+  let lastListIndex = lists.length - 1
+  let lastListLastIndex = indexes[lastListIndex]
+
+  let blocks: Expr[][] = []
+
+  for (let i = 0; i < iterations; ++i) {
+    let block: Expr[] = []
+
+    // Get the cusrrent combination
+    for (let j = 0; j < lists.length; j++) {
+      block.push(lists[j][pos[j]])
+    }
+
+    blocks.push(block)
+
+    // Move to the next combination
+    // when no wrapping is needed
+    if (pos[lastListIndex] != lastListLastIndex) {
+      pos[lastListIndex]++
+      continue
+    }
+
+    // Move to the next combination by
+    // wrapping around from len() to 0
+    for (let j = lastListIndex; j >= 0; j--) {
+      // 1. Increment the position of the furthest list that has not hit the end
+      if (pos[j] != indexes[j]) {
+        pos[j]++
+        break
+      }
+
+      // 2. Reset positions for lists that have hit the end
+      pos[j] = 0
+    }
+  }
+
+  return blocks
+}
+
+// Determine if two nodes are semantically- and structurally-equivalent even if they don't share pointers
+function areNodesEqual(a: Expr, z: Expr): boolean {
+  if (a === z) {
+    return true
+  }
+
+  if (a.kind !== z.kind) {
+    return false
+  }
+
+  if (a.nodes.length !== z.nodes.length) {
+    return false
+  }
+
+  if (a.value !== z.value) {
+    return false
+  }
+
+  for (let index = 0; index < a.nodes.length; index++) {
+    if (!areNodesEqual(a.nodes[index], z.nodes[index])) {
+      return false
+    }
+  }
+
+  return true
+}
+
+function countIntersections(a: Expr, z: Expr): number {
+  let n = 0
+
+  for (let i = 0; i < a.nodes.length; i++) {
+    for (let j = 0; j < z.nodes.length; j++) {
+      if (areNodesEqual(a.nodes[i], z.nodes[j])) {
+        n++
+      }
+    }
+  }
+
+  return n
+}
+
+/**
+ * Cleanup an expression to ensure that:
+ * - All `none` placeholder nodes are removed
+ * - All empty ANDs, ORs, and NOTs are removed
+ */
+function clean(e: Expr): Expr {
+  if (e.kind === 'not') {
+    // The node that is negated has disappeared this is no longer valid
+    if (e.nodes.length === 0) {
+      return none()
+    }
+
+    if (e.nodes[0].kind === 'none') {
+      return none()
+    }
+  } else if (e.kind === 'and' || e.kind === 'or') {
+    e.nodes = e.nodes.flatMap((node) => {
+      if (node.kind === 'none') {
+        return []
+      }
+
+      return node
+    })
+
+    // If therea re no nodes left the AND / OR goes away too
+    if (e.nodes.length == 0) {
+      return none()
+    }
+  }
+
+  return e
+}
+
+/**
+ * Eliminates supersets from the expression tree
+ *
+ * Given the expressions:
+ * - `(A || B) && (A || B || C) && (A || C)`
+ * - `(A && B) || (A && B && C) || (A && C)`
+ *
+ * We want to produce:
+ * - `(A || B) && (A || C)`
+ * - `(A && B) || (A && C)`
+ *
+ * The reason for this is that AND short-circuits logic on false values, and
+ * OR short-circuits logic on true values.
+ *
+ * In the first case, if `A || B` is true then `A || B || C` MUST be true.
+ * Likewise, if `A || B` is false then `A || B || C` won't be checked.
+ *
+ * In the second case, if `A && B` is false then `A && B && C` MUST be false.
+ * Likewise, if `A && B` is true then `A && B && C` won't be checked.
+ *
+ * More specifically: the simplified expressions have identical truth tables.
+ *
+ * The algorithm works by walking the list of ANDs/ORs and removing any that are
+ * supersets of the examined expression.
+ *
+ * We walk two pointers along the set of expressions and compare them. The
+ * algorithmic complexity of this technically `O(n^2)` but the actual search
+ * space is a bit smaller: O((n^2 - n)/2) because the search space contracts as
+ * the list of expressions is walked.
+ *
+ * So for 8 disjunctions the search space is 28 checks versus 64
+ * So for 80 disjunctions the search space is 3160 checks versus 6400
+ *
+ * Example 1:
+ * Step 1:
+ *        ↓1          ↓2
+ * Check: (A || B) && (A || B || C) && (A || C)
+ * Result: ↓2 is a superset of ↓1. So remove ↓2.
+ *
+ *        ↓1          ↓2
+ * Check: (A || B) && (A || C)
+ * Result: ↓2 is not superset of ↓1. So do nothing
+ *
+ *        ↓1                   ↓2
+ * Check: (A || B) && (A || C)
+ * Result: ↓2 is at the end. Advance ↓1 and reset ↓2 to one past ↓1.
+ *
+ *                    ↓1       ↓2
+ * Check: (A || B) && (A || C)
+ * Result: ↓2 is at the end. Advance ↓1 and reset ↓2 to one past ↓1.
+ *
+ *                             ↓1↓2
+ * Check: (A || B) && (A || C)
+ * Result: ↓1 is at the end. We're done.
+ *
+ * Example 2:
+ * Step 1:
+ *        ↓1               ↓2
+ * Check: (A || B || C) && (A || B) && (A || C)
+ * Result: ↓1 is a superset of ↓2. So remove ↓1.
+ *
+ *        ↓1          ↓2
+ * Check: (A || B) && (A || C)
+ * Result: ↓2 is not superset of ↓1. So do nothing
+ *
+ *        ↓1                   ↓2
+ * Check: (A || B) && (A || C)
+ * Result: ↓2 is at the end. Advance ↓1 and reset ↓2 to one past ↓1.
+ *
+ *                    ↓1       ↓2
+ * Check: (A || B) && (A || C)
+ * Result: ↓2 is at the end. Advance ↓1 and reset ↓2 to one past ↓1.
+ *
+ *                             ↓1↓2
+ * Check: (A || B) && (A || C)
+ * Result: ↓1 is at the end. We're done.
+ */
+function eliminateSupersets(e: Expr): Expr {
+  if (e.kind === 'and') {
+    return eliminateSupersetsImpl(e, 'and', 'or')
+  } else if (e.kind === 'or') {
+    return eliminateSupersetsImpl(e, 'or', 'and')
+  }
+
+  return e
+}
+
+function eliminateSupersetsImpl(e: Expr, outerType: Expr['kind'], innerType: Expr['kind']): Expr {
+  let endIndex = e.nodes.length - 1
+
+  for (let i = 0; i < endIndex; i++) {
+    let one = e.nodes[i]
+
+    if (!one) continue
+
+    // Skip if we're not looking at the right type of expression
+    if (one.kind != innerType) continue
+
+    let oneSize = one.nodes.length
+
+    // The second pointer is reset and traverses a shrinking subset of the
+    // elements from the next position `i+1` to `endIndex`
+    for (let j = i + 1; j <= endIndex; j++) {
+      let two = e.nodes[j]
+
+      if (!two) continue
+
+      // Skip if we're not looking at the right type of expression
+      if (two.kind != innerType) continue
+
+      let twoSize = two.nodes.length
+
+      // Count the intersections between $one and $two
+      let intersections = countIntersections(one, two)
+
+      if (intersections == oneSize) {
+        // two is superset of one, so remove two
+        e.nodes[j] = none()
+      } else if (intersections == twoSize) {
+        // one is superset of two, so remove one
+        e.nodes[i] = none()
+
+        // go to the next `one` group since we removed the current one group
+        break
+      }
+    }
+  }
+
+  return clean(e)
+}

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -792,12 +792,20 @@ test('group-*', async () => {
             @slot;
           }
         }
+        @variant nested-selectors {
+          &:hover {
+            &:focus {
+              @slot;
+            }
+          }
+        }
         @tailwind utilities;
       `,
       [
         'group-hover:flex',
         'group-focus:flex',
         'group-hocus:flex',
+        'group-nested-selectors:flex',
 
         'group-hover:group-focus:flex',
         'group-focus:group-hover:flex',
@@ -828,6 +836,10 @@ test('group-*', async () => {
 
     .group-hocus\\:flex:is(:is(:where(.group):hover, :where(.group):focus) *) {
       display: flex;
+    }
+
+    .group-nested-selectors\\:flex:is(:where(.group):hover:focus *) {
+      display: flex;
     }"
   `)
 
@@ -835,16 +847,9 @@ test('group-*', async () => {
     await compileCss(
       css`
         @variant custom-at-rule (@media foo);
-        @variant nested-selectors {
-          &:hover {
-            &:focus {
-              @slot;
-            }
-          }
-        }
         @tailwind utilities;
       `,
-      ['group-custom-at-rule:flex', 'group-nested-selectors:flex'],
+      ['group-custom-at-rule:flex'],
     ),
   ).toEqual('')
 })
@@ -912,6 +917,7 @@ test('peer-*', async () => {
         'peer-hover:flex',
         'peer-focus:flex',
         'peer-hocus:flex',
+        'peer-nested-selectors:flex',
         'peer-hover:peer-focus:flex',
         'peer-focus:peer-hover:flex',
       ],
@@ -948,16 +954,9 @@ test('peer-*', async () => {
     await compileCss(
       css`
         @variant custom-at-rule (@media foo);
-        @variant nested-selectors {
-          &:hover {
-            &:focus {
-              @slot;
-            }
-          }
-        }
         @tailwind utilities;
       `,
-      ['peer-custom-at-rule:flex', 'peer-nested-selectors:flex'],
+      ['peer-custom-at-rule:flex'],
     ),
   ).toEqual('')
 })
@@ -1804,6 +1803,26 @@ test('has', async () => {
             @slot;
           }
         }
+        @variant nested-selectors {
+          &:hover {
+            &:focus {
+              @slot;
+            }
+          }
+        }
+        @variant complex-selectors {
+          &:hover,
+          &[data-hovered] {
+            &:focus {
+              @slot;
+            }
+
+            &:active,
+            &[data-active] {
+              @slot;
+            }
+          }
+        }
         @tailwind utilities;
       `,
       [
@@ -1814,6 +1833,8 @@ test('has', async () => {
         'has-[~img]:flex',
         'has-[&>img]:flex',
         'has-hocus:flex',
+        'has-nested-selectors:flex',
+        'has-complex-selectors:flex',
 
         'group-has-[:checked]:flex',
         'group-has-[:checked]/parent-name:flex',
@@ -1827,6 +1848,10 @@ test('has', async () => {
         'group-has-[&>img]/parent-name:flex',
         'group-has-hocus:flex',
         'group-has-hocus/parent-name:flex',
+        'group-has-nested-selectors:flex',
+        'group-has-nested-selectors/parent-name:flex',
+        'group-has-complex-selectors/parent-name:flex',
+        'group-has-complex-selectors/parent-name:flex',
 
         'peer-has-[:checked]:flex',
         'peer-has-[:checked]/sibling-name:flex',
@@ -1840,6 +1865,10 @@ test('has', async () => {
         'peer-has-[&>img]/sibling-name:flex',
         'peer-has-hocus:flex',
         'peer-has-hocus/sibling-name:flex',
+        'peer-has-nested-selectors:flex',
+        'peer-has-nested-selectors/sibling-name:flex',
+        'peer-has-complex-selectors/sibling-name:flex',
+        'peer-has-complex-selectors/sibling-name:flex',
       ],
     ),
   ).toMatchInlineSnapshot(`
@@ -1856,6 +1885,18 @@ test('has', async () => {
     }
 
     .group-has-hocus\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(:hover, :focus) *) {
+      display: flex;
+    }
+
+    .group-has-nested-selectors\\:flex:is(:where(.group):has(:hover:focus) *) {
+      display: flex;
+    }
+
+    .group-has-nested-selectors\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(:hover:focus) *) {
+      display: flex;
+    }
+
+    .group-has-complex-selectors\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(:is(:hover, [data-hovered]):focus) *), .group-has-complex-selectors\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(:is(:hover, [data-hovered]):active, :is(:hover, [data-hovered])[data-active]) *) {
       display: flex;
     }
 
@@ -1907,6 +1948,18 @@ test('has', async () => {
       display: flex;
     }
 
+    .peer-has-nested-selectors\\:flex:is(:where(.peer):has(:hover:focus) ~ *) {
+      display: flex;
+    }
+
+    .peer-has-nested-selectors\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(:hover:focus) ~ *) {
+      display: flex;
+    }
+
+    .peer-has-complex-selectors\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(:is(:hover, [data-hovered]):focus) ~ *), .peer-has-complex-selectors\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(:is(:hover, [data-hovered]):active, :is(:hover, [data-hovered])[data-active]) ~ *) {
+      display: flex;
+    }
+
     .peer-has-\\[\\:checked\\]\\:flex:is(:where(.peer):has(:checked) ~ *) {
       display: flex;
     }
@@ -1947,6 +2000,14 @@ test('has', async () => {
       display: flex;
     }
 
+    .has-nested-selectors\\:flex:has(:hover:focus) {
+      display: flex;
+    }
+
+    .has-complex-selectors\\:flex:has(:is(:hover, [data-hovered]):focus), .has-complex-selectors\\:flex:has(:is(:hover, [data-hovered]):active, :is(:hover, [data-hovered])[data-active]) {
+      display: flex;
+    }
+
     .has-\\[\\:checked\\]\\:flex:has(:checked) {
       display: flex;
     }
@@ -1972,21 +2033,9 @@ test('has', async () => {
     await compileCss(
       css`
         @variant custom-at-rule (@media foo);
-        @variant nested-selectors {
-          &:hover {
-            &:focus {
-              @slot;
-            }
-          }
-        }
         @tailwind utilities;
       `,
-      [
-        'has-[:checked]/foo:flex',
-        'has-[@media_print]:flex',
-        'has-custom-at-rule:flex',
-        'has-nested-selectors:flex',
-      ],
+      ['has-[:checked]/foo:flex', 'has-[@media_print]:flex', 'has-custom-at-rule:flex'],
     ),
   ).toEqual('')
 })
@@ -2869,7 +2918,7 @@ test('variant order', async () => {
   `)
 })
 
-test.only('not selector inversion creation thing', async () => {
+test('not selector inversion creation thing', async () => {
   let input = css`
     @variant omg {
       &:hover {
@@ -2896,7 +2945,7 @@ test.only('not selector inversion creation thing', async () => {
   `
 
   expect(await compileCss(input, ['omg:flex', 'not-omg:flex'])).toMatchInlineSnapshot(`
-    ".not-omg\\:flex:not(:hover:hover:focus:hover:focus:active, :hover:hover:focus:hover:focus[data-whatever], :hover:hover[data-foo], :visited) {
+    ".not-omg\\:flex:not(:hover:focus:active, :hover:focus[data-whatever], :hover[data-foo], :visited) {
       display: flex;
     }
 

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -2868,3 +2868,48 @@ test('variant order', async () => {
     }"
   `)
 })
+
+test.only('not selector inversion creation thing', async () => {
+  let input = css`
+    @variant omg {
+      &:hover {
+        &:focus {
+          &:active {
+            @slot;
+          }
+
+          &[data-whatever] {
+            @slot;
+          }
+        }
+
+        &[data-foo] {
+          @slot;
+        }
+      }
+
+      &:visited {
+        @slot;
+      }
+    }
+    @tailwind utilities;
+  `
+
+  expect(await compileCss(input, ['omg:flex', 'not-omg:flex'])).toMatchInlineSnapshot(`
+    ".not-omg\\:flex:not(:hover:focus:hover:focus:active, :hover:focus:hover:focus[data-whatever], :hover[data-foo]), .not-omg\\:flex:not(:visited) {
+      display: flex;
+    }
+
+    .omg\\:flex:hover:focus:active, .omg\\:flex:hover:focus[data-whatever] {
+      display: flex;
+    }
+
+    .omg\\:flex:hover[data-foo] {
+      display: flex;
+    }
+
+    .omg\\:flex:visited {
+      display: flex;
+    }"
+  `)
+})

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -1754,13 +1754,31 @@ test('not', async () => {
             }
           }
         }
+
+        @variant custom-media-rule (@media foo);
+        @variant custom-supports-rule (@supports foo);
+        @variant custom-container-rule (@container foo);
+        @variant nested-at-rules {
+          @media print {
+            &:hover {
+              @slot;
+            }
+          }
+        }
+
         @tailwind utilities;
       `,
       [
         'not-[:checked]:flex',
+        'not-hover:flex',
         'not-hocus:flex',
         'not-nested-selectors:flex',
         'not-complex-selectors:flex',
+
+        'not-print:flex',
+        'not-[@media_print]:flex',
+        'not-custom-at-rule:flex',
+        'not-nested-at-rules:flex',
 
         'group-not-[:checked]:flex',
         'group-not-[:checked]/parent-name:flex',
@@ -1786,7 +1804,17 @@ test('not', async () => {
       ],
     ),
   ).toMatchInlineSnapshot(`
-    ".not-hocus\\:flex:not(:hover, :focus) {
+    ".not-hover\\:flex:not(:hover) {
+      display: flex;
+    }
+
+    @media not (hover: hover) {
+      .not-hover\\:flex {
+        display: flex;
+      }
+    }
+
+    .not-hocus\\:flex:not(:hover, :focus) {
       display: flex;
     }
 
@@ -1794,12 +1822,28 @@ test('not', async () => {
       display: flex;
     }
 
-    .not-complex-selectors\\:flex:not(:is(:hover, [data-hovered]):focus, :is(:hover, [data-hovered]):active, :is(:hover, [data-hovered])[data-active]) {
+    .not-complex-selectors\\:flex:not(:is(:hover, [data-hovered]):focus):not(:is(:hover, [data-hovered]):active, :is(:hover, [data-hovered])[data-active]) {
       display: flex;
+    }
+
+    .not-nested-at-rules\\:flex:not(:hover) {
+      display: flex;
+    }
+
+    @media not print {
+      .not-nested-at-rules\\:flex {
+        display: flex;
+      }
     }
 
     .not-\\[\\:checked\\]\\:flex:not(:checked) {
       display: flex;
+    }
+
+    @media not print {
+      .not-\\[\\@media_print\\]\\:flex {
+        display: flex;
+      }
     }
 
     .group-not-checked\\:flex:is(:where(.group):not(:checked) *) {
@@ -1822,11 +1866,11 @@ test('not', async () => {
       display: flex;
     }
 
-    .group-not-complex-selectors\\:flex:is(:where(.group):not(:is(:hover, [data-hovered]):focus, :is(:hover, [data-hovered]):active, :is(:hover, [data-hovered])[data-active]) *) {
+    .group-not-complex-selectors\\:flex:is(:where(.group):not(:is(:hover, [data-hovered]):focus):not(:is(:hover, [data-hovered]):active, :is(:hover, [data-hovered])[data-active]) *) {
       display: flex;
     }
 
-    .group-not-complex-selectors\\/parent-name\\:flex:is(:where(.group\\/parent-name):not(:is(:hover, [data-hovered]):focus, :is(:hover, [data-hovered]):active, :is(:hover, [data-hovered])[data-active]) *) {
+    .group-not-complex-selectors\\/parent-name\\:flex:is(:where(.group\\/parent-name):not(:is(:hover, [data-hovered]):focus):not(:is(:hover, [data-hovered]):active, :is(:hover, [data-hovered])[data-active]) *) {
       display: flex;
     }
 
@@ -1858,11 +1902,11 @@ test('not', async () => {
       display: flex;
     }
 
-    .peer-not-complex-selectors\\:flex:is(:where(.peer):not(:is(:hover, [data-hovered]):focus, :is(:hover, [data-hovered]):active, :is(:hover, [data-hovered])[data-active]) ~ *) {
+    .peer-not-complex-selectors\\:flex:is(:where(.peer):not(:is(:hover, [data-hovered]):focus):not(:is(:hover, [data-hovered]):active, :is(:hover, [data-hovered])[data-active]) ~ *) {
       display: flex;
     }
 
-    .peer-not-complex-selectors\\/parent-name\\:flex:is(:where(.peer\\/parent-name):not(:is(:hover, [data-hovered]):focus, :is(:hover, [data-hovered]):active, :is(:hover, [data-hovered])[data-active]) ~ *) {
+    .peer-not-complex-selectors\\/parent-name\\:flex:is(:where(.peer\\/parent-name):not(:is(:hover, [data-hovered]):focus):not(:is(:hover, [data-hovered]):active, :is(:hover, [data-hovered])[data-active]) ~ *) {
       display: flex;
     }
 
@@ -1878,24 +1922,14 @@ test('not', async () => {
   expect(
     await compileCss(
       css`
-        @variant custom-at-rule (@media foo);
-        @variant nested-at-rules {
-          &:hover {
-            @media print {
-              @slot;
-            }
-          }
-        }
         @tailwind utilities;
       `,
       [
+        //
         'not-[>img]:flex',
         'not-[+img]:flex',
         'not-[~img]:flex',
         'not-[:checked]/foo:flex',
-        'not-[@media_print]:flex',
-        'not-custom-at-rule:flex',
-        'not-nested-at-rules:flex',
       ],
     ),
   ).toEqual('')
@@ -3049,11 +3083,12 @@ test('not selector inversion creation thing', async () => {
         @slot;
       }
     }
+
     @tailwind utilities;
   `
 
   expect(await compileCss(input, ['omg:flex', 'not-omg:flex'])).toMatchInlineSnapshot(`
-    ".not-omg\\:flex:not(:hover:focus:active, :hover:focus[data-whatever], :hover[data-foo], :visited) {
+    ".not-omg\\:flex:not(:hover:focus:active):not(:hover:focus[data-whatever]):not(:hover[data-foo]):not(:visited) {
       display: flex;
     }
 

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -1687,11 +1687,19 @@ test('not', async () => {
             @slot;
           }
         }
+        @variant nested-selectors {
+          &:hover {
+            &:focus {
+              @slot;
+            }
+          }
+        }
         @tailwind utilities;
       `,
       [
         'not-[:checked]:flex',
         'not-hocus:flex',
+        'not-nested-selectors:flex',
 
         'group-not-[:checked]:flex',
         'group-not-[:checked]/parent-name:flex',
@@ -1708,6 +1716,10 @@ test('not', async () => {
     ),
   ).toMatchInlineSnapshot(`
     ".not-hocus\\:flex:not(:hover, :focus) {
+      display: flex;
+    }
+
+    .not-nested-selectors\\:flex:not(:hover:focus) {
       display: flex;
     }
 
@@ -1760,9 +1772,9 @@ test('not', async () => {
     await compileCss(
       css`
         @variant custom-at-rule (@media foo);
-        @variant nested-selectors {
+        @variant nested-at-rules {
           &:hover {
-            &:focus {
+            @media print {
               @slot;
             }
           }
@@ -1776,7 +1788,7 @@ test('not', async () => {
         'not-[:checked]/foo:flex',
         'not-[@media_print]:flex',
         'not-custom-at-rule:flex',
-        'not-nested-selectors:flex',
+        'not-nested-at-rules:flex',
       ],
     ),
   ).toEqual('')

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -799,6 +799,19 @@ test('group-*', async () => {
             }
           }
         }
+        @variant complex-selectors {
+          &:hover,
+          &[data-hovered] {
+            &:focus {
+              @slot;
+            }
+
+            &:active,
+            &[data-active] {
+              @slot;
+            }
+          }
+        }
         @tailwind utilities;
       `,
       [
@@ -806,6 +819,7 @@ test('group-*', async () => {
         'group-focus:flex',
         'group-hocus:flex',
         'group-nested-selectors:flex',
+        'group-complex-selectors:flex',
 
         'group-hover:group-focus:flex',
         'group-focus:group-hover:flex',
@@ -834,11 +848,15 @@ test('group-*', async () => {
       }
     }
 
-    .group-hocus\\:flex:is(:is(:where(.group):hover, :where(.group):focus) *) {
+    .group-hocus\\:flex:is(:where(.group):hover *), .group-hocus\\:flex:is(:where(.group):focus *) {
       display: flex;
     }
 
     .group-nested-selectors\\:flex:is(:where(.group):hover:focus *) {
+      display: flex;
+    }
+
+    .group-complex-selectors\\:flex:is(:is(:where(.group):hover, :where(.group)[data-hovered]):focus *), .group-complex-selectors\\:flex:is(:is(:where(.group):hover, :where(.group)[data-hovered]):active *), .group-complex-selectors\\:flex:is(:is(:where(.group):hover, :where(.group)[data-hovered])[data-active] *) {
       display: flex;
     }"
   `)
@@ -911,6 +929,26 @@ test('peer-*', async () => {
             @slot;
           }
         }
+        @variant nested-selectors {
+          &:hover {
+            &:focus {
+              @slot;
+            }
+          }
+        }
+        @variant complex-selectors {
+          &:hover,
+          &[data-hovered] {
+            &:focus {
+              @slot;
+            }
+
+            &:active,
+            &[data-active] {
+              @slot;
+            }
+          }
+        }
         @tailwind utilities;
       `,
       [
@@ -918,6 +956,8 @@ test('peer-*', async () => {
         'peer-focus:flex',
         'peer-hocus:flex',
         'peer-nested-selectors:flex',
+        'peer-complex-selectors:flex',
+
         'peer-hover:peer-focus:flex',
         'peer-focus:peer-hover:flex',
       ],
@@ -945,7 +985,15 @@ test('peer-*', async () => {
       }
     }
 
-    .peer-hocus\\:flex:is(:is(:where(.peer):hover, :where(.peer):focus) ~ *) {
+    .peer-hocus\\:flex:is(:where(.peer):hover ~ *), .peer-hocus\\:flex:is(:where(.peer):focus ~ *) {
+      display: flex;
+    }
+
+    .peer-nested-selectors\\:flex:is(:where(.peer):hover:focus ~ *) {
+      display: flex;
+    }
+
+    .peer-complex-selectors\\:flex:is(:is(:where(.peer):hover, :where(.peer)[data-hovered]):focus ~ *), .peer-complex-selectors\\:flex:is(:is(:where(.peer):hover, :where(.peer)[data-hovered]):active ~ *), .peer-complex-selectors\\:flex:is(:is(:where(.peer):hover, :where(.peer)[data-hovered])[data-active] ~ *) {
       display: flex;
     }"
   `)
@@ -1693,12 +1741,26 @@ test('not', async () => {
             }
           }
         }
+        @variant complex-selectors {
+          &:hover,
+          &[data-hovered] {
+            &:focus {
+              @slot;
+            }
+
+            &:active,
+            &[data-active] {
+              @slot;
+            }
+          }
+        }
         @tailwind utilities;
       `,
       [
         'not-[:checked]:flex',
         'not-hocus:flex',
         'not-nested-selectors:flex',
+        'not-complex-selectors:flex',
 
         'group-not-[:checked]:flex',
         'group-not-[:checked]/parent-name:flex',
@@ -1706,11 +1768,21 @@ test('not', async () => {
         'group-not-hocus:flex',
         'group-not-hocus/parent-name:flex',
 
+        'group-not-nested-selectors:flex',
+        'group-not-nested-selectors/parent-name:flex',
+        'group-not-complex-selectors:flex',
+        'group-not-complex-selectors/parent-name:flex',
+
         'peer-not-[:checked]:flex',
         'peer-not-[:checked]/sibling-name:flex',
         'peer-not-checked:flex',
         'peer-not-hocus:flex',
         'peer-not-hocus/sibling-name:flex',
+
+        'peer-not-nested-selectors:flex',
+        'peer-not-nested-selectors/parent-name:flex',
+        'peer-not-complex-selectors:flex',
+        'peer-not-complex-selectors/parent-name:flex',
       ],
     ),
   ).toMatchInlineSnapshot(`
@@ -1719,6 +1791,10 @@ test('not', async () => {
     }
 
     .not-nested-selectors\\:flex:not(:hover:focus) {
+      display: flex;
+    }
+
+    .not-complex-selectors\\:flex:not(:is(:hover, [data-hovered]):focus, :is(:hover, [data-hovered]):active, :is(:hover, [data-hovered])[data-active]) {
       display: flex;
     }
 
@@ -1735,6 +1811,22 @@ test('not', async () => {
     }
 
     .group-not-hocus\\/parent-name\\:flex:is(:where(.group\\/parent-name):not(:hover, :focus) *) {
+      display: flex;
+    }
+
+    .group-not-nested-selectors\\:flex:is(:where(.group):not(:hover:focus) *) {
+      display: flex;
+    }
+
+    .group-not-nested-selectors\\/parent-name\\:flex:is(:where(.group\\/parent-name):not(:hover:focus) *) {
+      display: flex;
+    }
+
+    .group-not-complex-selectors\\:flex:is(:where(.group):not(:is(:hover, [data-hovered]):focus, :is(:hover, [data-hovered]):active, :is(:hover, [data-hovered])[data-active]) *) {
+      display: flex;
+    }
+
+    .group-not-complex-selectors\\/parent-name\\:flex:is(:where(.group\\/parent-name):not(:is(:hover, [data-hovered]):focus, :is(:hover, [data-hovered]):active, :is(:hover, [data-hovered])[data-active]) *) {
       display: flex;
     }
 
@@ -1755,6 +1847,22 @@ test('not', async () => {
     }
 
     .peer-not-hocus\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):not(:hover, :focus) ~ *) {
+      display: flex;
+    }
+
+    .peer-not-nested-selectors\\:flex:is(:where(.peer):not(:hover:focus) ~ *) {
+      display: flex;
+    }
+
+    .peer-not-nested-selectors\\/parent-name\\:flex:is(:where(.peer\\/parent-name):not(:hover:focus) ~ *) {
+      display: flex;
+    }
+
+    .peer-not-complex-selectors\\:flex:is(:where(.peer):not(:is(:hover, [data-hovered]):focus, :is(:hover, [data-hovered]):active, :is(:hover, [data-hovered])[data-active]) ~ *) {
+      display: flex;
+    }
+
+    .peer-not-complex-selectors\\/parent-name\\:flex:is(:where(.peer\\/parent-name):not(:is(:hover, [data-hovered]):focus, :is(:hover, [data-hovered]):active, :is(:hover, [data-hovered])[data-active]) ~ *) {
       display: flex;
     }
 
@@ -1880,11 +1988,11 @@ test('has', async () => {
       display: flex;
     }
 
-    .group-has-hocus\\:flex:is(:where(.group):has(:hover, :focus) *) {
+    .group-has-hocus\\:flex:is(:where(.group):has(:hover) *), .group-has-hocus\\:flex:is(:where(.group):has(:focus) *) {
       display: flex;
     }
 
-    .group-has-hocus\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(:hover, :focus) *) {
+    .group-has-hocus\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(:hover) *), .group-has-hocus\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(:focus) *) {
       display: flex;
     }
 
@@ -1896,7 +2004,7 @@ test('has', async () => {
       display: flex;
     }
 
-    .group-has-complex-selectors\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(:is(:hover, [data-hovered]):focus) *), .group-has-complex-selectors\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(:is(:hover, [data-hovered]):active, :is(:hover, [data-hovered])[data-active]) *) {
+    .group-has-complex-selectors\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(:is(:hover, [data-hovered]):focus) *), .group-has-complex-selectors\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(:is(:hover, [data-hovered]):active) *), .group-has-complex-selectors\\/parent-name\\:flex:is(:where(.group\\/parent-name):has(:is(:hover, [data-hovered])[data-active]) *) {
       display: flex;
     }
 
@@ -1940,11 +2048,11 @@ test('has', async () => {
       display: flex;
     }
 
-    .peer-has-hocus\\:flex:is(:where(.peer):has(:hover, :focus) ~ *) {
+    .peer-has-hocus\\:flex:is(:where(.peer):has(:hover) ~ *), .peer-has-hocus\\:flex:is(:where(.peer):has(:focus) ~ *) {
       display: flex;
     }
 
-    .peer-has-hocus\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(:hover, :focus) ~ *) {
+    .peer-has-hocus\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(:hover) ~ *), .peer-has-hocus\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(:focus) ~ *) {
       display: flex;
     }
 
@@ -1956,7 +2064,7 @@ test('has', async () => {
       display: flex;
     }
 
-    .peer-has-complex-selectors\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(:is(:hover, [data-hovered]):focus) ~ *), .peer-has-complex-selectors\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(:is(:hover, [data-hovered]):active, :is(:hover, [data-hovered])[data-active]) ~ *) {
+    .peer-has-complex-selectors\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(:is(:hover, [data-hovered]):focus) ~ *), .peer-has-complex-selectors\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(:is(:hover, [data-hovered]):active) ~ *), .peer-has-complex-selectors\\/sibling-name\\:flex:is(:where(.peer\\/sibling-name):has(:is(:hover, [data-hovered])[data-active]) ~ *) {
       display: flex;
     }
 
@@ -1996,7 +2104,7 @@ test('has', async () => {
       display: flex;
     }
 
-    .has-hocus\\:flex:has(:hover, :focus) {
+    .has-hocus\\:flex:has(:hover), .has-hocus\\:flex:has(:focus) {
       display: flex;
     }
 
@@ -2004,7 +2112,7 @@ test('has', async () => {
       display: flex;
     }
 
-    .has-complex-selectors\\:flex:has(:is(:hover, [data-hovered]):focus), .has-complex-selectors\\:flex:has(:is(:hover, [data-hovered]):active, :is(:hover, [data-hovered])[data-active]) {
+    .has-complex-selectors\\:flex:has(:is(:hover, [data-hovered]):focus), .has-complex-selectors\\:flex:has(:is(:hover, [data-hovered]):active), .has-complex-selectors\\:flex:has(:is(:hover, [data-hovered])[data-active]) {
       display: flex;
     }
 

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -2896,7 +2896,7 @@ test.only('not selector inversion creation thing', async () => {
   `
 
   expect(await compileCss(input, ['omg:flex', 'not-omg:flex'])).toMatchInlineSnapshot(`
-    ".not-omg\\:flex:not(:hover:focus:hover:focus:active, :hover:focus:hover:focus[data-whatever], :hover[data-foo]), .not-omg\\:flex:not(:visited) {
+    ".not-omg\\:flex:not(:hover:hover:focus:hover:focus:active, :hover:hover:focus:hover:focus[data-whatever], :hover:hover[data-foo], :visited) {
       display: flex;
     }
 

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -244,7 +244,9 @@ export function createVariants(theme: Theme): Variants {
   // ```
   //
   // Further, for a variant using multiple at-rules as an OR we would have to
-  // combine them like so:
+  // combine them.
+  //
+  // For example, given the following:
   //
   // ```css
   // @media (hover: hover), (any-hover: fine) {
@@ -267,11 +269,11 @@ export function createVariants(theme: Theme): Variants {
   // @media not (hover: hover) {
   //   @media not (any-hover: fine) {
   //     /* declarations */
-  //    }
+  //   }
   // }
   //
   // &:not(:hover) {
-  //  /* declarations */
+  //   /* declarations */
   // }
   // ```
   //

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -233,6 +233,8 @@ export function createVariants(theme: Theme): Variants {
       selector = selector.slice(4, -1)
     }
 
+    console.log({ selector })
+
     ruleNode.selector = `&:not(${selector})`
     ruleNode.nodes = []
   })


### PR DESCRIPTION
This PR adds support for more complex variant definitions when using the four compound variants: `group-*`, `peer-*`, `has-*`, and `not-*`. Before this PR these variants were limited in what compound variants they supported — often limited to single rules with single selectors.

Now, all of these variants support (nearly) the full range of all variant definitions.

Examples TBD — opening to get some eyes on stuff

TODOs:
- [ ] Bail when there's an at rule that is not invertible