### PR TITLE
Resolve theme keys when migrating JS config to CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add first draft of new wide-gamut color palette ([#14693](https://github.com/tailwindlabs/tailwindcss/pull/14693))
-- _Upgrade (experimental)_: Migrate `theme(…)` calls to `var(…)` or to the modern `theme(…)` syntax ([#14664](https://github.com/tailwindlabs/tailwindcss/pull/14664), [#14695](https://github.com/tailwindlabs/tailwindcss/pull/14695))
+- _Upgrade (experimental)_: Migrate `theme(…)` calls in classes to `var(…)` or to the modern `theme(…)` syntax ([#14664](https://github.com/tailwindlabs/tailwindcss/pull/14664))
+- _Upgrade (experimental)_: Support migrating JS configurations to CSS that contain functions inside the `theme` object ([#14675](https://github.com/tailwindlabs/tailwindcss/pull/14675))
 
 ### Fixed
 
 - Ensure `theme` values defined outside of `extend` in JS configuration files overwrite all existing values for that namespace ([#14672](https://github.com/tailwindlabs/tailwindcss/pull/14672))
 - _Upgrade (experimental)_: Speed up template migrations ([#14679](https://github.com/tailwindlabs/tailwindcss/pull/14679))
 - _Upgrade (experimental)_: Don't generate invalid CSS when migrating a complex `screens` config ([#14691](https://github.com/tailwindlabs/tailwindcss/pull/14691))
-
-### Added
-
-- _Upgrade (experimental)_: Support migrating JS configurations to CSS that contain functions inside the `theme` object ([#14675](https://github.com/tailwindlabs/tailwindcss/pull/14675))
 
 ## [4.0.0-alpha.27] - 2024-10-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add first draft of new wide-gamut color palette ([#14693](https://github.com/tailwindlabs/tailwindcss/pull/14693))
-- _Upgrade (experimental)_: Migrate `theme(…)` calls in classes to `var(…)` or to the modern `theme(…)` syntax ([#14664](https://github.com/tailwindlabs/tailwindcss/pull/14664))
+- _Upgrade (experimental)_: Migrate `theme(…)` calls to `var(…)` or to the modern `theme(…)` syntax ([#14664](https://github.com/tailwindlabs/tailwindcss/pull/14664), [#14695](https://github.com/tailwindlabs/tailwindcss/pull/14695))
 - _Upgrade (experimental)_: Support migrating JS configurations to CSS that contain functions inside the `theme` object ([#14675](https://github.com/tailwindlabs/tailwindcss/pull/14675))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - _Upgrade (experimental)_: Speed up template migrations ([#14679](https://github.com/tailwindlabs/tailwindcss/pull/14679))
 - _Upgrade (experimental)_: Don't generate invalid CSS when migrating a complex `screens` config ([#14691](https://github.com/tailwindlabs/tailwindcss/pull/14691))
 
+### Added
+
+- _Upgrade (experimental)_: Support migrating JS configurations to CSS that contain functions inside the `theme` object ([#14675](https://github.com/tailwindlabs/tailwindcss/pull/14675))
+
 ## [4.0.0-alpha.27] - 2024-10-15
 
 ### Added

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -232,17 +232,17 @@ test(
       @import 'tailwindcss';
 
       @theme {
-        --color-gray-50: #fafafa;
-        --color-gray-100: #f5f5f5;
-        --color-gray-200: #e5e5e5;
-        --color-gray-300: #d4d4d4;
-        --color-gray-400: #a3a3a3;
-        --color-gray-500: #737373;
-        --color-gray-600: #525252;
-        --color-gray-700: #404040;
-        --color-gray-800: #262626;
-        --color-gray-900: #171717;
-        --color-gray-950: #0a0a0a;
+        --color-gray-50: oklch(0.985 0 none);
+        --color-gray-100: oklch(0.97 0 none);
+        --color-gray-200: oklch(0.922 0 none);
+        --color-gray-300: oklch(0.87 0 none);
+        --color-gray-400: oklch(0.708 0 none);
+        --color-gray-500: oklch(0.556 0 none);
+        --color-gray-600: oklch(0.439 0 none);
+        --color-gray-700: oklch(0.371 0 none);
+        --color-gray-800: oklch(0.269 0 none);
+        --color-gray-900: oklch(0.205 0 none);
+        --color-gray-950: oklch(0.145 0 none);
       }
       "
     `)

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -193,7 +193,7 @@ test(
 )
 
 test(
-  'does not upgrade JS config files with functions in the theme config',
+  'upgrades JS config files with functions in the theme config',
   {
     fs: {
       'package.json': json`
@@ -230,24 +230,26 @@ test(
       "
       --- src/input.css ---
       @import 'tailwindcss';
-      @config '../tailwind.config.ts';
+
+      @theme {
+        --color-gray-50: #fafafa;
+        --color-gray-100: #f5f5f5;
+        --color-gray-200: #e5e5e5;
+        --color-gray-300: #d4d4d4;
+        --color-gray-400: #a3a3a3;
+        --color-gray-500: #737373;
+        --color-gray-600: #525252;
+        --color-gray-700: #404040;
+        --color-gray-800: #262626;
+        --color-gray-900: #171717;
+        --color-gray-950: #0a0a0a;
+      }
       "
     `)
 
     expect(await fs.dumpFiles('tailwind.config.ts')).toMatchInlineSnapshot(`
       "
-      --- tailwind.config.ts ---
-      import { type Config } from 'tailwindcss'
 
-      export default {
-        theme: {
-          extend: {
-            colors: ({ colors }) => ({
-              gray: colors.neutral,
-            }),
-          },
-        },
-      } satisfies Config
       "
     `)
   },

--- a/packages/@tailwindcss-upgrade/src/index.ts
+++ b/packages/@tailwindcss-upgrade/src/index.ts
@@ -87,7 +87,7 @@ async function run() {
   // Migrate JS config
 
   info('Migrating JavaScript configuration files using the provided configuration file.')
-  let jsConfigMigration = await migrateJsConfig(config.configFilePath, base)
+  let jsConfigMigration = await migrateJsConfig(config.designSystem, config.configFilePath, base)
 
   {
     // Stylesheet migrations

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -184,7 +184,7 @@ function canMigrateConfig(unresolvedConfig: Config, source: string): boolean {
     return ['string', 'number', 'boolean', 'undefined'].includes(typeof value)
   }
 
-  // `theme` and `plugins` are handled separately and allowed to be more complex.
+  // `theme` and `plugins` are handled separately and allowed to be more complex
   let { plugins, theme, ...remainder } = unresolvedConfig
   if (!isSimpleValue(remainder)) {
     return false

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -87,10 +87,10 @@ async function migrateTheme(
     base,
     config: { ...unresolvedConfig, plugins: [], presets: undefined },
   }
-  let { resolvedConfig, resetThemeKeys } = resolveConfig(designSystem, [configToResolve])
+  let { resolvedConfig, replacedThemeKeys } = resolveConfig(designSystem, [configToResolve])
 
   let resetNamespaces = new Map<string, boolean>(
-    Array.from(resetThemeKeys.entries()).map(([key]) => [key, false]),
+    Array.from(replacedThemeKeys.entries()).map(([key]) => [key, false]),
   )
 
   let prevSectionKey = ''

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -57,12 +57,10 @@ export async function migrateJsConfig(
     sources = migrateContent(unresolvedConfig as any, base)
   }
 
-  console.error('A', Object.keys(unresolvedConfig))
   if ('theme' in unresolvedConfig) {
     let themeConfig = await migrateTheme(designSystem, unresolvedConfig, base)
     if (themeConfig) cssConfigs.push(themeConfig)
   }
-  console.error('B', Object.keys(unresolvedConfig))
 
   let simplePlugins = findStaticPlugins(source)
   if (simplePlugins !== null) {

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -185,7 +185,7 @@ function canMigrateConfig(unresolvedConfig: Config, source: string): boolean {
   }
 
   // - `theme` can contain functions that we attempt to resolve.
-  // - `plugins` are more complex, we have a special heuristics for them.
+  // - `plugins` are more complex, we have special heuristics for them.
   let { plugins, theme, ...remainder } = unresolvedConfig
   if (!isSimpleValue(remainder)) {
     return false

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -184,8 +184,7 @@ function canMigrateConfig(unresolvedConfig: Config, source: string): boolean {
     return ['string', 'number', 'boolean', 'undefined'].includes(typeof value)
   }
 
-  // - `theme` can contain functions that we attempt to resolve.
-  // - `plugins` are more complex, we have special heuristics for them.
+  // `theme` and `plugins` are handled separately and allowed to be more complex.
   let { plugins, theme, ...remainder } = unresolvedConfig
   if (!isSimpleValue(remainder)) {
     return false

--- a/packages/tailwindcss/src/compat/apply-config-to-theme.ts
+++ b/packages/tailwindcss/src/compat/apply-config-to-theme.ts
@@ -24,8 +24,8 @@ export function applyConfigToTheme(
   { theme }: ResolvedConfig,
   replacedThemeKeys: Set<string>,
 ) {
-  for (let resetThemeKey of replacedThemeKeys) {
-    let name = keyPathToCssProperty([resetThemeKey])
+  for (let replacedThemeKey of replacedThemeKeys) {
+    let name = keyPathToCssProperty([replacedThemeKey])
     if (!name) continue
 
     designSystem.theme.clearNamespace(`--${name}`, ThemeOptions.DEFAULT)


### PR DESCRIPTION
With the changes in #14672, it now becomes trivial to actually resolve the config (while still retaining the reset behavior). This means that we can now convert JS configs that use _functions_, e.g.:

```ts
import { type Config } from 'tailwindcss'

export default {
  theme: {
    extend: {
      colors: ({ colors }) => ({
        gray: colors.neutral,
      }),
    },
  },
} satisfies Config
```

This becomes:

```css
@import 'tailwindcss';

@theme {
  --color-gray-50: #fafafa;
  --color-gray-100: #f5f5f5;
  --color-gray-200: #e5e5e5;
  --color-gray-300: #d4d4d4;
  --color-gray-400: #a3a3a3;
  --color-gray-500: #737373;
  --color-gray-600: #525252;
  --color-gray-700: #404040;
  --color-gray-800: #262626;
  --color-gray-900: #171717;
  --color-gray-950: #0a0a0a;
}
```