### PR TITLE
Remove .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-CHANGELOG.md merge=union


### PR DESCRIPTION
I added the `.gitattributes` a while back because I thought it would help us make it simpler when rebasing changes to the `CHANGELOG.md` file. However, I don't think this is actually true. Now, instead of a merge conflict, the rebase just ends up duplicating a lot of lines which we only see when we review the PR on GitHub later which is really annoying.

So, for now, let's remove it again. Ideally we can have a better merge strategy here (or potentially other tools).