### PR TITLE
Add server API

### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for tasks
+const tasks = [
+  {
+    id: 1,
+    description: 'Complete monthly financial report'
+  },
+  {
+    id: 2,
+    description: 'Plan team building activity'
+  },
+  {
+    id: 3,
+    description: 'Update project documentation'
+  }
+];
+
+app.get('/search', (req, res) => {
+  // Retrieve the query parameter
+  const query = req.query.query?.toLowerCase() || '';
+
+  // Filter tasks based on the query
+  const filteredTasks = tasks.filter(task => task.description.toLowerCase().includes(query));
+
+  // Sort the filtered tasks alphabetically by description
+  const sortedTasks = filteredTasks.sort((a, b) => a.description.localeCompare(b.description));
+
+  res.json(sortedTasks);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
# Add Express server with task search functionality

This pull request introduces a new Express server with a `/search` endpoint for task management. The server includes:

- A basic Express setup listening on port 3000
- A mock dataset of tasks with IDs and descriptions
- A `/search` endpoint that:
  - Accepts a query parameter for filtering tasks
  - Filters tasks based on the provided query
  - Sorts the filtered tasks alphabetically by description
  - Returns the sorted and filtered tasks as JSON

This addition provides a foundation for a task management API, allowing for easy integration with front-end applications.