### PR TITLE
`@apply` is not allowed inside `@keyframes`

### DIFF
--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -148,6 +148,20 @@ describe('arbitrary properties', () => {
 })
 
 describe('@apply', () => {
+  it('@apply in @keyframes is not allowed', () => {
+    return expect(() =>
+      compileCss(css`
+        @keyframes foo {
+          0% {
+            @apply bg-red-500;
+          }
+        }
+      `),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: You cannot use \`@apply\` inside \`@keyframes\`.]`,
+    )
+  })
+
   it('should replace @apply with the correct result', async () => {
     expect(
       await compileCss(css`


### PR DESCRIPTION
This PR makes sure that you cannot use `@apply` inside `@keyframes`. 

While some utilities can be used in `@keyframes`, the moment you introduce a variant, that's not going to work anymore because they need to operate on selectors which `@keyframes` don't have.

This PR now removes all usages of `@apply` in `@keyframes`.
