### PR TITLE
Include simple config objects when extracting static plugins

### DIFF
--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -14,7 +14,7 @@ import { resolveConfig, type ConfigFile } from '../../tailwindcss/src/compat/con
 import type { ThemeConfig } from '../../tailwindcss/src/compat/config/types'
 import { darkModePlugin } from '../../tailwindcss/src/compat/dark-mode'
 import type { DesignSystem } from '../../tailwindcss/src/design-system'
-import { findStaticPlugins } from './utils/extract-static-plugins'
+import { findStaticPlugins, type StaticPluginOptions } from './utils/extract-static-plugins'
 import { info } from './utils/renderer'
 
 const __filename = fileURLToPath(import.meta.url)
@@ -46,7 +46,7 @@ export async function migrateJsConfig(
   }
 
   let sources: { base: string; pattern: string }[] = []
-  let plugins: { base: string; path: string }[] = []
+  let plugins: { base: string; path: string; options: null | StaticPluginOptions }[] = []
   let cssConfigs: string[] = []
 
   if ('darkMode' in unresolvedConfig) {
@@ -64,8 +64,8 @@ export async function migrateJsConfig(
 
   let simplePlugins = findStaticPlugins(source)
   if (simplePlugins !== null) {
-    for (let plugin of simplePlugins) {
-      plugins.push({ base, path: plugin })
+    for (let [path, options] of simplePlugins) {
+      plugins.push({ base, path, options })
     }
   }
 

--- a/packages/@tailwindcss-upgrade/src/utils/extract-static-plugins.test.ts
+++ b/packages/@tailwindcss-upgrade/src/utils/extract-static-plugins.test.ts
@@ -203,7 +203,7 @@ describe('findStaticPlugins', () => {
     expect(
       findStaticPlugins(js`
         export default {
-          plugins: [falserequire('./plugin1')]
+          plugins: [load('./plugin1')]
         }
       `),
     ).toEqual(null)

--- a/packages/@tailwindcss-upgrade/src/utils/extract-static-plugins.test.ts
+++ b/packages/@tailwindcss-upgrade/src/utils/extract-static-plugins.test.ts
@@ -9,35 +9,44 @@ describe('findStaticPlugins', () => {
     expect(
       findStaticPlugins(js`
         import plugin1 from './plugin1'
-        import * as plugin2 from './plugin2'
 
         export default {
-          plugins: [plugin1, plugin2, 'plugin3', require('./plugin4')]
+          plugins: [plugin1, 'plugin2', require('./plugin3')]
         }
     `),
-    ).toEqual(['./plugin1', './plugin2', 'plugin3', './plugin4'])
+    ).toEqual([
+      ['./plugin1', null],
+      ['plugin2', null],
+      ['./plugin3', null],
+    ])
 
     expect(
       findStaticPlugins(js`
         import plugin1 from './plugin1'
-        import * as plugin2 from './plugin2'
 
         export default {
-          plugins: [plugin1, plugin2, 'plugin3', require('./plugin4')]
+          plugins: [plugin1, 'plugin2', require('./plugin3')]
         } as any
     `),
-    ).toEqual(['./plugin1', './plugin2', 'plugin3', './plugin4'])
+    ).toEqual([
+      ['./plugin1', null],
+      ['plugin2', null],
+      ['./plugin3', null],
+    ])
 
     expect(
       findStaticPlugins(js`
         import plugin1 from './plugin1'
-        import * as plugin2 from './plugin2'
 
         export default {
-          plugins: [plugin1, plugin2, 'plugin3', require('./plugin4')]
+          plugins: [plugin1, 'plugin2', require('./plugin3')]
         } satisfies any
     `),
-    ).toEqual(['./plugin1', './plugin2', 'plugin3', './plugin4'])
+    ).toEqual([
+      ['./plugin1', null],
+      ['plugin2', null],
+      ['./plugin3', null],
+    ])
 
     expect(
       findStaticPlugins(js`
@@ -47,7 +56,11 @@ describe('findStaticPlugins', () => {
           plugins: [plugin1, 'plugin2', require('./plugin3')]
         } as any
     `),
-    ).toEqual(['./plugin1', 'plugin2', './plugin3'])
+    ).toEqual([
+      ['./plugin1', null],
+      ['plugin2', null],
+      ['./plugin3', null],
+    ])
 
     expect(
       findStaticPlugins(js`
@@ -57,7 +70,11 @@ describe('findStaticPlugins', () => {
           plugins: [plugin1, 'plugin2', require('./plugin3')]
         } satisfies any
     `),
-    ).toEqual(['./plugin1', 'plugin2', './plugin3'])
+    ).toEqual([
+      ['./plugin1', null],
+      ['plugin2', null],
+      ['./plugin3', null],
+    ])
 
     expect(
       findStaticPlugins(js`
@@ -67,68 +84,204 @@ describe('findStaticPlugins', () => {
           plugins: [plugin1, 'plugin2', require('./plugin3')]
         }
     `),
-    ).toEqual(['./plugin1', 'plugin2', './plugin3'])
+    ).toEqual([
+      ['./plugin1', null],
+      ['plugin2', null],
+      ['./plugin3', null],
+    ])
+  })
+
+  test('can extract plugin options', () => {
+    expect(
+      findStaticPlugins(js`
+        import plugin1 from './plugin1'
+        import plugin2 from './plugin2'
+
+        export default {
+          plugins: [
+            plugin1({
+              foo: 'bar',
+            }),
+            plugin2(),
+            require('./plugin3')({
+              foo: 'bar',
+            }),
+          ]
+        }
+    `),
+    ).toEqual([
+      ['./plugin1', { foo: 'bar' }],
+      ['./plugin2', null],
+      ['./plugin3', { foo: 'bar' }],
+    ])
+  })
+
+  test('can extract all supported data types', () => {
+    expect(
+      findStaticPlugins(js`
+        import plugin from 'plugin'
+
+        export default {
+          plugins: [
+            plugin({
+              'is-arr-mixed': [null, true, false, 1234567, 1.35, 'foo', 'bar', 'true'],
+              'is-arr': ['foo', 'bar'],
+              'is-null': null,
+              'is-true': true,
+              'is-false': false,
+              'is-int': 1234567,
+              'is-float': 1.35,
+              'is-sci': 1.35e-5,
+              'is-str-null': 'null',
+              'is-str-true': 'true',
+              'is-str-false': 'false',
+              'is-str-int': '1234567',
+              'is-str-float': '1.35',
+              'is-str-sci': '1.35e-5',
+            }),
+          ]
+        }
+    `),
+    ).toEqual([
+      [
+        'plugin',
+        {
+          'is-arr-mixed': [null, true, false, 1234567, 1.35, 'foo', 'bar', 'true'],
+          'is-arr': ['foo', 'bar'],
+          'is-null': null,
+          'is-true': true,
+          'is-false': false,
+          'is-int': 1234567,
+          'is-float': 1.35,
+          'is-sci': 1.35e-5,
+          'is-str-null': 'null',
+          'is-str-true': 'true',
+          'is-str-false': 'false',
+          'is-str-int': '1234567',
+          'is-str-float': '1.35',
+          'is-str-sci': '1.35e-5',
+        },
+      ],
+    ])
+  })
+
+  test('bails out on import * as import', () => {
+    expect(
+      findStaticPlugins(js`
+        import * as plugin from './plugin'
+
+        export default {
+          plugins: [plugin]
+        }
+      `),
+    ).toEqual(null)
   })
 
   test('bails out on inline plugins', () => {
     expect(
       findStaticPlugins(js`
-      import plugin1 from './plugin1'
-
-      export default {
-        plugins: [plugin1, () => {} ]
-      }
-    `),
-    ).toEqual(null)
-
-    expect(
-      findStaticPlugins(js`
-      let plugin1 = () => {}
-
-      export default {
-        plugins: [plugin1]
-      }
-    `),
-    ).toEqual(null)
-  })
-
-  test('bails out on non `require` calls', () => {
-    expect(
-      findStaticPlugins(js`
-      export default {
-        plugins: [frequire('./plugin1')]
-      }
-    `),
-    ).toEqual(null)
-  })
-
-  test('bails out on named imports for plugins', () => {
-    expect(
-      findStaticPlugins(js`
-      import {plugin1} from './plugin1'
-
-      export default {
-        plugins: [plugin1]
-      }
-    `),
-    ).toEqual(null)
-  })
-
-  test('bails for plugins with options', () => {
-    expect(
-      findStaticPlugins(js`
         import plugin1 from './plugin1'
 
         export default {
-          plugins: [plugin1({foo:'bar'})]
+          plugins: [plugin1, () => {} ]
         }
       `),
     ).toEqual(null)
 
     expect(
       findStaticPlugins(js`
+        let plugin1 = () => {}
+
         export default {
-          plugins: [require('@tailwindcss/typography')({foo:'bar'})]
+          plugins: [plugin1]
+        }
+      `),
+    ).toEqual(null)
+  })
+
+  test('bails out on non `require` calls', () => {
+    expect(
+      findStaticPlugins(js`
+        export default {
+          plugins: [falserequire('./plugin1')]
+        }
+      `),
+    ).toEqual(null)
+  })
+
+  test('bails out on named imports for plugins', () => {
+    expect(
+      findStaticPlugins(js`
+        import {plugin1} from './plugin1'
+
+        export default {
+          plugins: [plugin1]
+        }
+      `),
+    ).toEqual(null)
+  })
+
+  test('bails on invalid plugin options', () => {
+    expect(
+      findStaticPlugins(js`
+        import plugin from './plugin'
+
+        export default {
+          plugins: [
+            plugin({ foo }),
+          ]
+        }
+    `),
+    ).toEqual(null)
+
+    expect(
+      findStaticPlugins(js`
+        import plugin from './plugin'
+
+        export default {
+          plugins: [
+            plugin({ foo: { bar: 2 } }),
+          ]
+        }
+    `),
+    ).toEqual(null)
+
+    expect(
+      findStaticPlugins(js`
+        import plugin from './plugin'
+
+        export default {
+          plugins: [
+            plugin({ foo: ${'`bar${""}`'} }),
+          ]
+        }
+    `),
+    ).toEqual(null)
+
+    expect(
+      findStaticPlugins(js`
+        import plugin from './plugin'
+
+        const OPTIONS = { foo: 1 }
+
+        export default {
+          plugins: [
+            plugin(OPTIONS),
+          ]
+        }
+      `),
+    ).toEqual(null)
+
+    expect(
+      findStaticPlugins(js`
+        import plugin from './plugin'
+
+        let something = 1
+
+        export default {
+          plugins: [
+            plugin({ foo: something }),
+          ]
         }
     `),
     ).toEqual(null)
@@ -137,16 +290,16 @@ describe('findStaticPlugins', () => {
   test('returns no plugins if none are exported', () => {
     expect(
       findStaticPlugins(js`
-      export default {
-        plugins: []
-      }
-    `),
+        export default {
+          plugins: []
+        }
+      `),
     ).toEqual([])
 
     expect(
       findStaticPlugins(js`
-      export default {}
-    `),
+        export default {}
+      `),
     ).toEqual([])
   })
 })


### PR DESCRIPTION
This PR updates the `extractStaticPlugins` function to also emit options as long as these are objects containing of only `string` and `number` values.

While doing this I also cleaned up the `require('custom-plugin')` detector to use a Tree-Sitter query instead of operating on the AST.

Here are the two cases we considered:

```js
import plugin1 from 'plugin1';

export default {
  plugins: [
    plugin1({
      foo: 'bar',
      num: 19,
    }),
    require('./plugin2')({
      foo: 'bar',
      num: 19,
    }),
  ]
}
```

The test plan also contains a number of scenarios that we do not want to migrate to CSS (because we do not have a CSS API we can use for e.g. nested objects). We do support all types that we also support in the CSS API.