### PR TITLE
Ensure existing spaces in attribute selectors are valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - _Upgrade (experimental)_: Migrate `plugins` with options to CSS ([#14700](https://github.com/tailwindlabs/tailwindcss/pull/14700))
 
+### Fixed
+
+- Ensure existing spaces in attribute selectors are valid ([#14703](https://github.com/tailwindlabs/tailwindcss/pull/14703))
+
 ### Changed
 
 - _Upgrade (experimental)_: Don't create `@source` rules for `content` paths that are already covered by automatic source detection ([#14714](https://github.com/tailwindlabs/tailwindcss/pull/14714))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Ensure existing spaces in attribute selectors are valid ([#14703](https://github.com/tailwindlabs/tailwindcss/pull/14703))
+- Allow spaces spaces around operators in attribute selector variants ([#14703](https://github.com/tailwindlabs/tailwindcss/pull/14703))
 
 ### Changed
 

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -1985,6 +1985,7 @@ test('aria', async () => {
       'aria-checked:flex',
       'aria-[invalid=spelling]:flex',
       'aria-[valuenow=1]:flex',
+      'aria-[valuenow_=_"1"]:flex',
 
       'group-aria-[modal]:flex',
       'group-aria-checked:flex',
@@ -2059,6 +2060,10 @@ test('aria', async () => {
 
     .aria-\\[valuenow\\=1\\]\\:flex[aria-valuenow="1"] {
       display: flex;
+    }
+
+    .aria-\\[valuenow_\\=_\\"1\\"\\]\\:flex[aria-valuenow="1"] {
+      display: flex;
     }"
   `)
   expect(await run(['aria-checked/foo:flex', 'aria-[invalid=spelling]/foo:flex'])).toEqual('')
@@ -2069,6 +2074,8 @@ test('data', async () => {
     await run([
       'data-disabled:flex',
       'data-[potato=salad]:flex',
+      'data-[potato_=_"salad"]:flex',
+      'data-[potato_^=_"salad"]:flex',
       'data-[foo=1]:flex',
       'data-[foo=bar_baz]:flex',
       "data-[foo$='bar'_i]:flex",
@@ -2155,6 +2162,14 @@ test('data', async () => {
       display: flex;
     }
 
+    .data-\\[potato_\\=_\\"salad\\"\\]\\:flex[data-potato="salad"] {
+      display: flex;
+    }
+
+    .data-\\[potato_\\^\\=_\\"salad\\"\\]\\:flex[data-potato^="salad"] {
+      display: flex;
+    }
+
     .data-\\[foo\\=1\\]\\:flex[data-foo="1"] {
       display: flex;
     }
@@ -2171,7 +2186,13 @@ test('data', async () => {
       display: flex;
     }"
   `)
-  expect(await run(['data-disabled/foo:flex', 'data-[potato=salad]/foo:flex'])).toEqual('')
+  expect(
+    await run([
+      'data-[foo_^_=_"bar"]:flex', // Can't have spaces between `^` and `=`
+      'data-disabled/foo:flex',
+      'data-[potato=salad]/foo:flex',
+    ]),
+  ).toEqual('')
 })
 
 test('portrait', async () => {

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -2076,6 +2076,7 @@ test('data', async () => {
       'data-[potato=salad]:flex',
       'data-[potato_=_"salad"]:flex',
       'data-[potato_^=_"salad"]:flex',
+      'data-[potato="^_="]:flex',
       'data-[foo=1]:flex',
       'data-[foo=bar_baz]:flex',
       "data-[foo$='bar'_i]:flex",
@@ -2167,6 +2168,10 @@ test('data', async () => {
     }
 
     .data-\\[potato_\\^\\=_\\"salad\\"\\]\\:flex[data-potato^="salad"] {
+      display: flex;
+    }
+
+    .data-\\[potato\\=\\"\\^_\\=\\"\\]\\:flex[data-potato="^ ="] {
       display: flex;
     }
 

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -506,7 +506,10 @@ export function createVariants(theme: Theme): Variants {
     if (!variant.value || variant.modifier) return null
 
     if (variant.value.kind === 'arbitrary') {
-      ruleNode.nodes = [rule(`&[aria-${quoteAttributeValue(variant.value.value)}]`, ruleNode.nodes)]
+      let value = quoteAttributeValue(variant.value.value)
+      if (value === null) return null
+
+      ruleNode.nodes = [rule(`&[aria-${value}]`, ruleNode.nodes)]
     } else {
       ruleNode.nodes = [rule(`&[aria-${variant.value.value}="true"]`, ruleNode.nodes)]
     }
@@ -527,7 +530,10 @@ export function createVariants(theme: Theme): Variants {
   variants.functional('data', (ruleNode, variant) => {
     if (!variant.value || variant.modifier) return null
 
-    ruleNode.nodes = [rule(`&[data-${quoteAttributeValue(variant.value.value)}]`, ruleNode.nodes)]
+    let value = quoteAttributeValue(variant.value.value)
+    if (value === null) return null
+
+    ruleNode.nodes = [rule(`&[data-${value}]`, ruleNode.nodes)]
   })
 
   variants.functional('nth', (ruleNode, variant) => {
@@ -900,9 +906,16 @@ export function createVariants(theme: Theme): Variants {
 
 function quoteAttributeValue(value: string) {
   if (value.includes('=')) {
+    // Do not allow invalid operators in attribute values
+    if (/[*$^|~]\s+=/.test(value)) {
+      return null
+    }
+
     value = value.replace(/(=.*)/g, (_fullMatch, match) => {
+      let value = match.slice(1).trim()
+
       // If the value is already quoted, skip.
-      if (match[1] === "'" || match[1] === '"') {
+      if (value[0] === "'" || value[0] === '"') {
         return match
       }
 

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -909,7 +909,7 @@ function quoteAttributeValue(input: string) {
       return input
     }
 
-    // Handle regex flags on unescaped values
+    // Handle case sensitivity flags on unescaped values
     if (value.length > 1) {
       let trailingCharacter = value[value.length - 1]
       if (

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -901,11 +901,10 @@ export function createVariants(theme: Theme): Variants {
 function quoteAttributeValue(input: string) {
   if (input.includes('=')) {
     let [attribute, ...after] = segment(input, '=')
-    let value = after.join('=')
-    let valueTrimmed = value.trim()
+    let value = after.join('=').trim()
 
     // If the value is already quoted, skip.
-    if (valueTrimmed[0] === "'" || valueTrimmed[0] === '"') {
+    if (value[0] === "'" || value[0] === '"') {
       return input
     }
 
@@ -923,7 +922,7 @@ function quoteAttributeValue(input: string) {
       }
     }
 
-    return `${attribute}="${valueTrimmed}"`
+    return `${attribute}="${value}"`
   }
 
   return input


### PR DESCRIPTION
This PR fixes an issue where spaces in a selector generated invalid CSS.

Lightning CSS will throw those incorrect lines of CSS out, but if you are in an environment where Lightning CSS doesn't run then invalid CSS is generated.

Given this input:

```html
data-[foo_=_"true"]:flex
```

This will be generated:

```css
.data-\[foo_\=_\"true\"\]\:flex[data-foo=""true] {
  display: flex;
}
```

With this PR in place, the generated CSS will now be:

```css
.data-\[foo_\=_\"true\"\]\:flex[data-foo="true"] {
  display: flex;
}
```
