### PR TITLE
`content` rules from the JS config that are also covered by the automatic source detection should not be migrated to CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- _Upgrade (experimental)_: `content` rules from the JS configuration that are also covered by the automatic source detection are no longer migrated to CSS ([#14714](https://github.com/tailwindlabs/tailwindcss/pull/14714))
+- _Upgrade (experimental)_: Don't create `@source` rules for `content` paths that are already covered by automatic source detection ([#14714](https://github.com/tailwindlabs/tailwindcss/pull/14714))
 
 ## [4.0.0-alpha.28] - 2024-10-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - _Upgrade (experimental)_: Migrate `plugins` with options to CSS ([#14700](https://github.com/tailwindlabs/tailwindcss/pull/14700))
 
+### Changed
+
+- _Upgrade (experimental)_: `content` rules from the JS configuration that are also covered by the automatic source detection are no longer migrated to CSS ([#14714](https://github.com/tailwindlabs/tailwindcss/pull/14714))
+
 ## [4.0.0-alpha.28] - 2024-10-17
 
 ### Added

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -40,8 +40,6 @@ test(
 
       --- ./src/input.css ---
       @import 'tailwindcss';
-
-      @source './**/*.{html,js}';
       "
     `)
 
@@ -99,8 +97,6 @@ test(
 
       --- ./src/input.css ---
       @import 'tailwindcss' prefix(tw);
-
-      @source './**/*.{html,js}';
 
       .btn {
         @apply tw:rounded-md! tw:px-2 tw:py-1 tw:bg-blue-500 tw:text-white;

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'vitest'
-import { css, json, test, ts } from '../utils'
+import { css, html, json, test, ts } from '../utils'
 
 test(
   `upgrade JS config files with flat theme values, darkMode, and content fields`,
@@ -18,7 +18,7 @@ test(
 
         module.exports = {
           darkMode: 'selector',
-          content: ['./src/**/*.{html,js}', './my-app/**/*.{html,js}'],
+          content: ['./src/**/*.{html,js}', './node_modules/my-external-lib/**/*.{html}'],
           theme: {
             boxShadow: {
               sm: '0 2px 6px rgb(15 23 42 / 0.08)',
@@ -72,6 +72,11 @@ test(
         @tailwind components;
         @tailwind utilities;
       `,
+      'node_modules/my-external-lib/src/template.html': html`
+        <div class="text-red-500">
+          Hello world!
+        </div>
+      `,
     },
   },
   async ({ exec, fs }) => {
@@ -82,8 +87,7 @@ test(
       --- src/input.css ---
       @import 'tailwindcss';
 
-      @source './**/*.{html,js}';
-      @source '../my-app/**/*.{html,js}';
+      @source '../node_modules/my-external-lib/**/*.{html}';
 
       @variant dark (&:where(.dark, .dark *));
 


### PR DESCRIPTION
This PR changes the migration of `content` rules in the JS config to CSS codemods.

When a `content` rule is processed which matches files that are _also matched by the automatic content discovery in v4_, we do not need to emit CSS for that rule. 

Take, for example this v3 configuration file:

```ts
import { type Config } from 'tailwindcss'

module.exports = {
  content: [
    './src/**/*.{html,js}', 
    './node_modules/my-external-lib/**/*.{html}'
  ],
} satisfies Config
```

Provided the base directories match up, the first rule will also be covered by the automatic content discovery in v4 and thus we only need to convert the second rule to CSS:

```css
@import "tailwindcss";
@source '../node_modules/my-external-lib/**/*.{html}';
```