### PR TITLE
Migrate `flex-grow` -> `grow` and `flex-shrink` -> `shrink`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Allow spaces spaces around operators in attribute selector variants ([#14703](https://github.com/tailwindlabs/tailwindcss/pull/14703))
+- _Upgrade (experimental)_: Migrate `flex-grow` to `grow` and `flex-shrink` to `shrink` ([#14721](https://github.com/tailwindlabs/tailwindcss/pull/14721))
 
 ### Changed
 

--- a/packages/@tailwindcss-upgrade/src/template/codemods/simple-legacy-classes.test.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/simple-legacy-classes.test.ts
@@ -5,7 +5,9 @@ import { simpleLegacyClasses } from './simple-legacy-classes'
 test.each([
   ['overflow-clip', 'text-clip'],
   ['overflow-ellipsis', 'text-ellipsis'],
+  ['flex-grow', 'grow'],
   ['flex-grow-0', 'grow-0'],
+  ['flex-shrink', 'shrink'],
   ['flex-shrink-0', 'shrink-0'],
   ['decoration-clone', 'box-decoration-clone'],
   ['decoration-slice', 'box-decoration-slice'],

--- a/packages/@tailwindcss-upgrade/src/template/codemods/simple-legacy-classes.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/simple-legacy-classes.ts
@@ -7,7 +7,9 @@ import { printCandidate } from '../candidates'
 const LEGACY_CLASS_MAP = {
   'overflow-clip': 'text-clip',
   'overflow-ellipsis': 'text-ellipsis',
+  'flex-grow': 'grow',
   'flex-grow-0': 'grow-0',
+  'flex-shrink': 'shrink',
   'flex-shrink-0': 'shrink-0',
   'decoration-clone': 'box-decoration-clone',
   'decoration-slice': 'box-decoration-slice',


### PR DESCRIPTION
This PR adds missing legacy migrations for migrating `flex-grow` to `grow` and `flex-shrink` to `shrink`.

We already migrated `flex-grow-0` to `grow-0` and `flex-shrink-0` to `shrink-0`, but forgot about these cases.
