### PR TITLE
fix: Update preflight.css

### DIFF
--- a/src/css/preflight.css
+++ b/src/css/preflight.css
@@ -18,6 +18,14 @@
 }
 
 /*
+1. Support for both light and dark color schemes
+*/
+
+:root {
+  color-scheme: light dark;
+}
+
+/*
 1. Use a consistent sensible line-height in all browsers.
 2. Prevent adjustments of font size after orientation changes in iOS.
 3. Use a more readable tab size.


### PR DESCRIPTION
Add support for both light and dark color schemes.
https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme#declaring_color_scheme_preferences

This fixes a bug where dark mode is not respected on some built-in html elements.

Issue found when using the ```<input type="date" />```, the icon would not change color based on selected theme.

Before fix:
![image](https://github.com/user-attachments/assets/474838ff-1626-4b03-94a8-8837150ec5f2)


After fix:
![image](https://github.com/user-attachments/assets/8a9c2dcf-7c31-42ea-9b88-41f949fc3d64)
