### PR TITLE
Upgrade: Allow `corePlugins` in JS config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - _Upgrade (experimental)_: Migrate `plugins` with options to CSS ([#14700](https://github.com/tailwindlabs/tailwindcss/pull/14700))
+- _Upgrade (experimental)_: Allow JS configuration files with `corePlugins` options to be migrated to CSS ([#14742](https://github.com/tailwindlabs/tailwindcss/pull/14742))
 
 ### Fixed
 

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -63,6 +63,12 @@ export async function migrateJsConfig(
     if (themeConfig) cssConfigs.push(themeConfig)
   }
 
+  if ('corePlugins' in unresolvedConfig) {
+    info(
+      `Your configuration file contains a \`corePlugins\` property, which is no longer available in Tailwind CSS v4. This option was not migrated to CSS.`,
+    )
+  }
+
   let simplePlugins = findStaticPlugins(source)
   if (simplePlugins !== null) {
     for (let [path, options] of simplePlugins) {
@@ -214,6 +220,7 @@ function canMigrateConfig(unresolvedConfig: Config, source: string): boolean {
     'plugins',
     'presets',
     'prefix', // Prefix is handled in the dedicated prefix migrator
+    'corePlugins',
   ]
 
   if (Object.keys(unresolvedConfig).some((key) => !knownProperties.includes(key))) {

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -65,7 +65,7 @@ export async function migrateJsConfig(
 
   if ('corePlugins' in unresolvedConfig) {
     info(
-      `Your configuration file contains a \`corePlugins\` property, which is no longer available in Tailwind CSS v4. This option was not migrated to CSS.`,
+      `The \`corePlugins\` option is no longer supported as of Tailwind CSS v4.0, so it's been removed from your configuration.`,
     )
   }
 


### PR DESCRIPTION
This PR enables JS configuration files with `corePlugins` themes to be migrated. If such option is found in your config, we will warn the user and omit the option from the resulting CSS file as there is no v4 alternative. 