### PR TITLE
Prepare preflight for border compatibility

### DIFF
--- a/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
@@ -514,7 +514,7 @@ exports[`\`@import 'tailwindcss'\` is replaced with the generated CSS 1`] = `
   }
 
   input:where(:not([type="button"], [type="reset"], [type="submit"])), select, textarea {
-    border: 1px solid;
+    border-width: 1px;
   }
 
   button, input:where([type="button"], [type="reset"], [type="submit"]) {

--- a/packages/tailwindcss/preflight.css
+++ b/packages/tailwindcss/preflight.css
@@ -200,7 +200,7 @@ textarea,
 input:where(:not([type='button'], [type='reset'], [type='submit'])),
 select,
 textarea {
-  border: 1px solid;
+  border-width: 1px;
 }
 
 /*


### PR DESCRIPTION
This PR prepares the `preflight.css` so that we can introduce border style compatibility in a future PR.
