### PR TITLE
Adjust CSS resolver heuristics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure color opacity modifiers work with OKLCH colors ([#14741](https://github.com/tailwindlabs/tailwindcss/pull/14741))
 - Ensure changes to the input CSS file result in a full rebuild ([#14744](https://github.com/tailwindlabs/tailwindcss/pull/14744))
 - Add `postcss` as a dependency of `@tailwindcss/postcss` ([#14750](https://github.com/tailwindlabs/tailwindcss/pull/14750))
+- Ensure CSS imports for files without a file extension still prefer files relative to input file ([#14752](https://github.com/tailwindlabs/tailwindcss/pull/14752))
 - _Upgrade (experimental)_: Migrate `flex-grow` to `grow` and `flex-shrink` to `shrink` ([#14721](https://github.com/tailwindlabs/tailwindcss/pull/14721))
 - _Upgrade (experimental)_: Minify arbitrary values when printing candidates ([#14720](https://github.com/tailwindlabs/tailwindcss/pull/14720))
 - _Upgrade (experimental)_: Ensure legacy theme values ending in `1` (like `theme(spacing.1)`) are correctly migrated to custom properties ([#14724](https://github.com/tailwindlabs/tailwindcss/pull/14724))

--- a/packages/@tailwindcss-node/src/compile.ts
+++ b/packages/@tailwindcss-node/src/compile.ts
@@ -2,7 +2,7 @@ import EnhancedResolve from 'enhanced-resolve'
 import { createJiti, type Jiti } from 'jiti'
 import fs from 'node:fs'
 import fsPromises from 'node:fs/promises'
-import path, { dirname, extname } from 'node:path'
+import path, { dirname } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import {
   __unstable__loadDesignSystem as ___unstable__loadDesignSystem,
@@ -123,9 +123,10 @@ async function resolveCssId(id: string, base: string): Promise<string | false | 
   // CSS imports that do not have a dir prefix are considered relative. Since
   // the resolver does not account for this, we need to do a first pass with an
   // assumed relative import by prefixing `./${path}`. We don't have to do this
-  // when the path starts with a `.` or when the path has no extension (at which
-  // case it's likely an npm package and not a relative stylesheet).
-  let skipRelativeCheck = extname(id) === '' || id.startsWith('.')
+  // when the path starts with a `.`. We also special case the default
+  // `tailwindcss` imports, since we know those will resolve from an npm module.
+  let skipRelativeCheck =
+    id.startsWith('.') || id === 'tailwindcss' || id.startsWith('tailwindcss/')
 
   if (!skipRelativeCheck) {
     try {


### PR DESCRIPTION
When we implemented the CSS import resolution system, we found out a nasty detail about CSS imports in that files without a relative path prefix would still be relative to the source file. E.g.:

```css
@import 'foo.css';
```

Should first look for the file `foo.css` in the same directory. To make this cost as cheap as possible, we limited this by a heuristics to only apply the auto-relative imports for files with a file extension.

Naturally, while testing v4 on more templates, we found that it's common for people to omit the file extension when loading css file. The above could also be written as such:

```css
@import 'foo';
```

So we are lifting the heuristics for better interop with the ecosystem. Note that we still look for specific imports (`tailwindcss` and `tailwindcss/*`) where we do not do the additional lookup since this is a module level import we expect most users to be adding in their app.