### PR TITLE
Refactor `@media` handling

### DIFF
--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -76,7 +76,6 @@ async function parseCss(
 
   await substituteAtImports(ast, base, loadStylesheet)
 
-  // Find all `@theme` declarations
   let important: boolean | null = null
   let theme = new Theme()
   let customVariants: ((designSystem: DesignSystem) => void)[] = []
@@ -84,8 +83,10 @@ async function parseCss(
   let firstThemeRule: Rule | null = null
   let globs: { base: string; pattern: string }[] = []
 
+  // Handle at-rules
   walk(ast, (node, { parent, replaceWith, context }) => {
     if (node.kind !== 'rule') return
+    if (node.selector[0] !== '@') return
 
     // Collect custom `@utility` at-rules
     if (node.selector.startsWith('@utility ')) {
@@ -196,7 +197,7 @@ async function parseCss(
       }
     }
 
-    if (node.selector[0] === '@' && node.selector.startsWith('@media ')) {
+    if (node.selector.startsWith('@media ')) {
       let params = segment(node.selector.slice(7), ' ')
       let unknownParams: string[] = []
 


### PR DESCRIPTION
This PR is an internal refactor to improve the way we handle at-rules. Essentially we check for the `@` symbol and bail early if that's not the case.

We also improve the way `@media` is being handled by first checking for `@media`, and then handle all the params separately.

Last but not least, we also inverted the `@theme` check condition such that it is handled the same way we handle everything else.

