### PR TITLE
Handle new `source(…)`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bexpand"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "045d7d9db8390cf2c59f39f3bd138f1962ef616b096d1b9f5651c7acba19e5a7"
+dependencies = [
+ "itertools",
+ "nom",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +194,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,7 +221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -231,6 +250,12 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "napi"
@@ -287,6 +312,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "427802e8ec3a734331fec1035594a210ce1ff4dc5bc1950530920ab717964ea3"
 dependencies = [
  "libloading",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -485,6 +520,7 @@ dependencies = [
 name = "tailwindcss-oxide"
 version = "0.1.0"
 dependencies = [
+ "bexpand",
  "bstr",
  "crossbeam",
  "dunce",
@@ -649,7 +685,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -658,22 +694,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -682,21 +703,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -706,21 +721,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -736,21 +739,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -760,21 +751,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -20,13 +20,6 @@ pub struct ChangedContent {
 
 #[derive(Debug, Clone)]
 #[napi(object)]
-pub struct DetectSources {
-  /// Base path to start scanning from
-  pub base: String,
-}
-
-#[derive(Debug, Clone)]
-#[napi(object)]
 pub struct GlobEntry {
   /// Base path of the glob
   pub base: String,
@@ -62,20 +55,11 @@ impl From<tailwindcss_oxide::GlobEntry> for GlobEntry {
   }
 }
 
-impl From<DetectSources> for tailwindcss_oxide::scanner::detect_sources::DetectSources {
-  fn from(detect_sources: DetectSources) -> Self {
-    Self::new(detect_sources.base.into())
-  }
-}
-
 // ---
 
 #[derive(Debug, Clone)]
 #[napi(object)]
 pub struct ScannerOptions {
-  /// Automatically detect sources in the base path
-  pub detect_sources: Option<DetectSources>,
-
   /// Glob sources
   pub sources: Option<Vec<GlobEntry>>,
 }
@@ -102,7 +86,6 @@ impl Scanner {
   pub fn new(opts: ScannerOptions) -> Self {
     Self {
       scanner: tailwindcss_oxide::Scanner::new(
-        opts.detect_sources.map(Into::into),
         opts
           .sources
           .map(|x| x.into_iter().map(Into::into).collect()),

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -128,7 +128,7 @@ impl Scanner {
     input: ChangedContent,
   ) -> Vec<CandidateWithPosition> {
     let content = input.content.unwrap_or_else(|| {
-      std::fs::read_to_string(&input.file.unwrap()).expect("Failed to read file")
+      std::fs::read_to_string(input.file.unwrap()).expect("Failed to read file")
     });
 
     let input = ChangedContent {

--- a/crates/node/src/utf16.rs
+++ b/crates/node/src/utf16.rs
@@ -31,20 +31,18 @@ impl<'a> IndexConverter<'a> {
     // will only ever be incremented up to the length of the input string.
     //
     // This eliminates a "potential" panic that cannot actually happen
-    let slice = unsafe {
-      self.input.get_unchecked(self.curr_utf8..)
-    };
+    let slice = unsafe { self.input.get_unchecked(self.curr_utf8..) };
 
     for c in slice.chars() {
       if self.curr_utf8 >= pos {
-        break
+        break;
       }
 
       self.curr_utf8 += c.len_utf8();
       self.curr_utf16 += c.len_utf16();
     }
 
-    return self.curr_utf16 as i64;
+    self.curr_utf16 as i64
   }
 }
 
@@ -66,19 +64,16 @@ mod test {
       (4, 4),
       (5, 5),
       (6, 6),
-
       // inside the 🔥
       (7, 8),
       (8, 8),
       (9, 8),
       (10, 8),
-
       // inside the 🥳
       (11, 10),
       (12, 10),
       (13, 10),
       (14, 10),
-
       // <space>world!
       (15, 11),
       (16, 12),
@@ -87,7 +82,6 @@ mod test {
       (19, 15),
       (20, 16),
       (21, 17),
-
       // Past the end should return the last utf-16 character index
       (22, 17),
       (100, 17),

--- a/crates/oxide/Cargo.toml
+++ b/crates/oxide/Cargo.toml
@@ -16,6 +16,7 @@ walkdir = "2.5.0"
 ignore = "0.4.23"
 glob-match = "0.2.1"
 dunce = "1.0.5"
+bexpand = "1.2.0"
 
 [dev-dependencies]
 tempfile = "3.13.0"

--- a/crates/oxide/src/lib.rs
+++ b/crates/oxide/src/lib.rs
@@ -229,10 +229,10 @@ impl Scanner {
 
                 expression
                     .into_iter()
-                    .filter_map(|expanded_pattern| expanded_pattern.map(|x| x.into()).ok())
+                    .filter_map(Result::ok)
                     .map(move |pattern| GlobEntry {
                         base: source.base.clone(),
-                        pattern,
+                        pattern: pattern.into(),
                     })
                     .collect::<Vec<_>>()
             })

--- a/crates/oxide/src/lib.rs
+++ b/crates/oxide/src/lib.rs
@@ -231,20 +231,22 @@ impl Scanner {
                 }
 
                 let path = PathBuf::from(&source.base).join(&source.pattern);
-                if let Some(folder_name) = path.file_name() {
-                    // Contains a file extension, e.g.: `foo.html`, therefore we don't want to
-                    // detect sources here.
-                    if folder_name.to_str().unwrap().contains(".") {
-                        continue;
-                    }
+                let Some(folder_name) = path.file_name() else {
+                    continue;
+                };
 
-                    // Promote to auto source detection
-                    let detect_sources = DetectSources::new(path.clone());
-
-                    let (files, globs) = detect_sources.detect();
-                    self.files.extend(files);
-                    self.globs.extend(globs);
+                // Contains a file extension, e.g.: `foo.html`, therefore we don't want to
+                // detect sources here.
+                if folder_name.to_str().unwrap().contains(".") {
+                    continue;
                 }
+
+                // Promote to auto source detection
+                let detect_sources = DetectSources::new(path.clone());
+
+                let (files, globs) = detect_sources.detect();
+                self.files.extend(files);
+                self.globs.extend(globs);
             }
         }
     }

--- a/crates/oxide/tests/scanner.rs
+++ b/crates/oxide/tests/scanner.rs
@@ -69,7 +69,11 @@ mod scanner {
         paths = paths
             .into_iter()
             .map(|x| {
-                let parent_dir = format!("{}{}", &base.to_string(), path::MAIN_SEPARATOR);
+                let parent_dir = format!(
+                    "{}{}",
+                    fs::canonicalize(&base).unwrap().display(),
+                    path::MAIN_SEPARATOR
+                );
                 x.replace(&parent_dir, "")
                     // Normalize paths to use unix style separators
                     .replace('\\', "/")

--- a/crates/oxide/tests/scanner.rs
+++ b/crates/oxide/tests/scanner.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 mod scanner {
-    use scanner::detect_sources::DetectSources;
     use std::process::Command;
     use std::{fs, path};
 
@@ -35,18 +34,20 @@ mod scanner {
         let base = format!("{}", dir.display());
 
         // Resolve all content paths for the (temporary) current working directory
-        let mut scanner = Scanner::new(
-            Some(DetectSources::new(base.clone().into())),
-            Some(
-                globs
-                    .iter()
-                    .map(|x| GlobEntry {
-                        base: base.clone(),
-                        pattern: x.to_string(),
-                    })
-                    .collect(),
-            ),
-        );
+        let mut sources: Vec<GlobEntry> = globs
+            .iter()
+            .map(|x| GlobEntry {
+                base: base.clone(),
+                pattern: x.to_string(),
+            })
+            .collect();
+
+        sources.push(GlobEntry {
+            base: base.clone(),
+            pattern: "**/*".to_string(),
+        });
+
+        let mut scanner = Scanner::new(Some(sources));
 
         let candidates = scanner.scan();
 

--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -365,11 +365,9 @@ test(
     },
   },
   async ({ fs, exec, root }) => {
-    console.log(
-      await exec('pnpm tailwindcss --input src/index.css --output dist/out.css', {
-        cwd: path.join(root, 'project-a'),
-      }),
-    )
+    await exec('pnpm tailwindcss --input src/index.css --output dist/out.css', {
+      cwd: path.join(root, 'project-a'),
+    })
 
     expect(await fs.dumpFiles('./project-a/dist/*.css')).toMatchInlineSnapshot(`
       "

--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -285,18 +285,33 @@ describe.only('@source', () => {
           /*   {my-lib-1,my-lib-2}: expand */
           /*   *.html: only look for .html */
           @source '../node_modules/{my-lib-1,my-lib-2}/src/**/*.html';
-          @source './logo.{jpg,png}'; /* Don't worry about it */
+
+          /* We typically ignore these extensions, but now include them explicitly */
+          @source './logo.{jpg,png}';
+
+          /* Project C should apply auto source detection */
+          @source '../../project-c';
         `,
+
+        // Project A is the current folder, but we explicitly configured
+        // `source(project-b)`, therefore project-a should not be included in
+        // the output.
         'project-a/src/index.html': html`
           <div
             class="content-['SHOULD-NOT-EXIST-IN-OUTPUT'] content-['project-a/src/index.html']"
           ></div>
         `,
+
+        // Project A explicitly includes an extension we usually ignore,
+        // therefore it should be included in the output.
         'project-a/src/logo.jpg': html`
           <div
             class="content-['project-a/src/logo.jpg']"
           ></div>
         `,
+
+        // Project A explicitly includes node_modules/{my-lib-1,my-lib-2},
+        // therefore these files should be included in the output.
         'project-a/node_modules/my-lib-1/src/index.html': html`
           <div
             class="content-['project-a/node_modules/my-lib-1/src/index.html']"
@@ -307,22 +322,55 @@ describe.only('@source', () => {
             class="content-['project-a/node_modules/my-lib-2/src/index.html']"
           ></div>
         `,
+
+        // Project B is the configured `source(…)`, therefore auto source
+        // detection should include known extensions and folders in the output.
         'project-b/src/index.html': html`
           <div
             class="content-['project-b/src/index.html']"
           ></div>
         `,
+
+        // Project B is the configured `source(…)`, therefore auto source
+        // detection should apply and node_modules should not be included in the
+        // output.
         'project-b/node_modules/my-lib-3/src/index.html': html`
           <div
             class="content-['SHOULD-NOT-EXIST-IN-OUTPUT'] content-['project-b/node_modules/my-lib-3/src/index.html']"
           ></div>
         `,
+
+        // Project C should apply auto source detection, therefore known
+        // extensions and folders should be included in the output.
+        'project-c/src/index.html': html`
+          <div
+            class="content-['project-c/src/index.html']"
+          ></div>
+        `,
+
+        // Project C should apply auto source detection, therefore known ignored
+        // extensions should not be included in the output.
+        'project-c/src/logo.jpg': html`
+          <div
+            class="content-['SHOULD-NOT-EXIST-IN-OUTPUT'] content-['project-c/src/logo.jpg']"
+          ></div>
+        `,
+
+        // Project C should apply auto source detection, therefore node_modules
+        // should not be included in the output.
+        'project-c/node_modules/my-lib-1/src/index.html': html`
+          <div
+            class="content-['SHOULD-NOT-EXIST-IN-OUTPUT'] content-['project-c/node_modules/my-lib-1/src/index.html']"
+          ></div>
+        `,
       },
     },
     async ({ fs, exec, root }) => {
-      await exec('pnpm tailwindcss --input src/index.css --output dist/out.css', {
-        cwd: path.join(root, 'project-a'),
-      })
+      console.log(
+        await exec('pnpm tailwindcss --input src/index.css --output dist/out.css', {
+          cwd: path.join(root, 'project-a'),
+        }),
+      )
 
       expect(await fs.dumpFiles('./project-a/dist/*.css')).toMatchInlineSnapshot(`
         "
@@ -342,6 +390,10 @@ describe.only('@source', () => {
           }
           .content-\\[\\'project-b\\/src\\/index\\.html\\'\\] {
             --tw-content: 'project-b/src/index.html';
+            content: var(--tw-content);
+          }
+          .content-\\[\\'project-c\\/src\\/index\\.html\\'\\] {
+            --tw-content: 'project-c/src/index.html';
             content: var(--tw-content);
           }
         }

--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -375,27 +375,25 @@ describe.only('@source', () => {
       expect(await fs.dumpFiles('./project-a/dist/*.css')).toMatchInlineSnapshot(`
         "
         --- ./project-a/dist/out.css ---
-        @tailwind utilities source('../../project-b') {
-          .content-\\[\\'project-a\\/node_modules\\/my-lib-1\\/src\\/index\\.html\\'\\] {
-            --tw-content: 'project-a/node modules/my-lib-1/src/index.html';
-            content: var(--tw-content);
-          }
-          .content-\\[\\'project-a\\/node_modules\\/my-lib-2\\/src\\/index\\.html\\'\\] {
-            --tw-content: 'project-a/node modules/my-lib-2/src/index.html';
-            content: var(--tw-content);
-          }
-          .content-\\[\\'project-a\\/src\\/logo\\.jpg\\'\\] {
-            --tw-content: 'project-a/src/logo.jpg';
-            content: var(--tw-content);
-          }
-          .content-\\[\\'project-b\\/src\\/index\\.html\\'\\] {
-            --tw-content: 'project-b/src/index.html';
-            content: var(--tw-content);
-          }
-          .content-\\[\\'project-c\\/src\\/index\\.html\\'\\] {
-            --tw-content: 'project-c/src/index.html';
-            content: var(--tw-content);
-          }
+        .content-\\[\\'project-a\\/node_modules\\/my-lib-1\\/src\\/index\\.html\\'\\] {
+          --tw-content: 'project-a/node modules/my-lib-1/src/index.html';
+          content: var(--tw-content);
+        }
+        .content-\\[\\'project-a\\/node_modules\\/my-lib-2\\/src\\/index\\.html\\'\\] {
+          --tw-content: 'project-a/node modules/my-lib-2/src/index.html';
+          content: var(--tw-content);
+        }
+        .content-\\[\\'project-a\\/src\\/logo\\.jpg\\'\\] {
+          --tw-content: 'project-a/src/logo.jpg';
+          content: var(--tw-content);
+        }
+        .content-\\[\\'project-b\\/src\\/index\\.html\\'\\] {
+          --tw-content: 'project-b/src/index.html';
+          content: var(--tw-content);
+        }
+        .content-\\[\\'project-c\\/src\\/index\\.html\\'\\] {
+          --tw-content: 'project-c/src/index.html';
+          content: var(--tw-content);
         }
         @supports (-moz-orient: inline) {
           @layer base {

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -303,7 +303,11 @@ export function test(
             return Promise.all(
               files.map(async (file) => {
                 let content = await fs.readFile(path.join(root, file), 'utf8')
-                return [file, content]
+                return [
+                  file,
+                  // Drop license comment
+                  content.replace(/[\s\n]*\/\*! tailwindcss .*? \*\/[\s\n]*/g, ''),
+                ]
               }),
             )
           },

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -150,7 +150,7 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
       }
 
       // Use the specified root
-      return [{ base: compiler.root.base, pattern: compiler.root.pattern }]
+      return [compiler.root]
     })().concat(compiler.globs)
 
     let scanner = new Scanner({ sources })

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -150,7 +150,7 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
       }
 
       // Use the specified root
-      return [{ base: path.resolve(compiler.root.base, compiler.root.pattern), pattern: '**/*' }]
+      return [{ base: compiler.root.base, pattern: compiler.root.pattern }]
     })().concat(compiler.globs)
 
     let scanner = new Scanner({ sources })

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -138,22 +138,22 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
       },
     })
 
-    let detectSources = (() => {
+    let sources = (() => {
       // Disable auto source detection
       if (compiler.root === 'none') {
-        return undefined
+        return []
       }
 
       // No root specified, use the base directory
       if (compiler.root === null) {
-        return { base }
+        return [{ base, pattern: '**/*' }]
       }
 
       // Use the specified root
-      return { base: path.resolve(compiler.root.base, compiler.root.pattern) }
-    })()
+      return [{ base: path.resolve(compiler.root.base, compiler.root.pattern), pattern: '**/*' }]
+    })().concat(compiler.globs)
 
-    let scanner = new Scanner({ detectSources, sources: compiler.globs })
+    let scanner = new Scanner({ sources })
     env.DEBUG && console.timeEnd('[@tailwindcss/cli] Setup compiler')
 
     return [compiler, scanner] as const

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -136,8 +136,7 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
           if (context.scanner === null || rebuildStrategy === 'full') {
             // Look for candidates used to generate the CSS
             context.scanner = new Scanner({
-              detectSources: { base },
-              sources: context.compiler.globs,
+              sources: [{ base, pattern: '**/*' }].concat(context.compiler.globs),
             })
           }
 

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -134,10 +134,23 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
           }
 
           if (context.scanner === null || rebuildStrategy === 'full') {
+            let sources = (() => {
+              // Disable auto source detection
+              if (context.compiler.root === 'none') {
+                return []
+              }
+
+              // No root specified, use the base directory
+              if (context.compiler.root === null) {
+                return [{ base, pattern: '**/*' }]
+              }
+
+              // Use the specified root
+              return [context.compiler.root]
+            })().concat(context.compiler.globs)
+
             // Look for candidates used to generate the CSS
-            context.scanner = new Scanner({
-              sources: [{ base, pattern: '**/*' }].concat(context.compiler.globs),
-            })
+            context.scanner = new Scanner({ sources })
           }
 
           env.DEBUG && console.time('[@tailwindcss/postcss] Scan for candidates')

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -285,7 +285,7 @@ function keyframesToCss(keyframes: Record<string, unknown>): string {
 }
 
 function autodetectedSourceFiles(base: string) {
-  let scanner = new Scanner({ detectSources: { base } })
+  let scanner = new Scanner({ sources: [{ base, pattern: '**/*' }] })
   scanner.scan()
   return scanner.files
 }

--- a/packages/@tailwindcss-upgrade/tsconfig.json
+++ b/packages/@tailwindcss-upgrade/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "allowSyntheticDefaultImports":true
-  }
+    "allowSyntheticDefaultImports": true,
+  },
 }

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -396,6 +396,9 @@ class Root {
           return []
         }
 
+        // TODO: In a follow up PR we want this filter this against the module graph.
+        this.includeCandidatesFromModuleGraph = false
+
         // Use the specified root
         return [this.compiler.root]
       })().concat(this.compiler.globs)

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -393,6 +393,8 @@ class Root {
 
         // No root specified, use the module graph
         if (this.compiler.root === null) {
+          this.includeCandidatesFromModuleGraph = true
+
           return []
         }
 

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -399,7 +399,7 @@ class Root {
         }
 
         // TODO: In a follow up PR we want this filter this against the module graph.
-        this.includeCandidatesFromModuleGraph = false
+        this.includeCandidatesFromModuleGraph = true
 
         // Use the specified root
         return [this.compiler.root]

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -185,7 +185,10 @@ export function toCss(ast: AstNode[]) {
 
     // Rule
     if (node.kind === 'rule') {
-      if (node.selector === '@tailwind utilities') {
+      if (
+        node.selector === '@tailwind utilities' ||
+        node.selector.startsWith('@tailwind utilities ')
+      ) {
         for (let child of node.nodes) {
           css += stringify(child, depth)
         }

--- a/packages/tailwindcss/src/at-import.ts
+++ b/packages/tailwindcss/src/at-import.ts
@@ -44,8 +44,12 @@ export async function substituteAtImports(
             let ast = CSS.parse(loaded.content)
             await substituteAtImports(ast, loaded.base, loadStylesheet, recurseCount + 1)
 
-            contextNode.nodes = buildImportNodes(ast, layer, media, supports)
-            contextNode.context.base = loaded.base
+            contextNode.nodes = buildImportNodes(
+              [context({ base: loaded.base }, ast)],
+              layer,
+              media,
+              supports,
+            )
           })(),
         )
 

--- a/packages/tailwindcss/src/candidate.bench.ts
+++ b/packages/tailwindcss/src/candidate.bench.ts
@@ -8,7 +8,7 @@ import { Theme } from './theme'
 const root = process.env.FOLDER || process.cwd()
 
 // Auto content detection
-const scanner = new Scanner({ detectSources: { base: root } })
+const scanner = new Scanner({ sources: [{ base: root, pattern: '**/*' }] })
 
 const candidates = scanner.scan()
 const designSystem = buildDesignSystem(new Theme())

--- a/packages/tailwindcss/src/index.bench.ts
+++ b/packages/tailwindcss/src/index.bench.ts
@@ -7,7 +7,7 @@ const root = process.env.FOLDER || process.cwd()
 const css = String.raw
 
 bench('compile', async () => {
-  let scanner = new Scanner({ detectSources: { base: root } })
+  let scanner = new Scanner({ sources: [{ base: root, pattern: '**/*' }] })
   let candidates = scanner.scan()
 
   let { build } = await compile(css`

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -3,7 +3,7 @@ import { substituteAtApply } from './apply'
 import {
   atRoot,
   comment,
-  context,
+  context as contextNode,
   decl,
   rule,
   toCss,
@@ -73,21 +73,63 @@ async function parseCss(
     loadStylesheet = throwOnLoadStylesheet,
   }: CompileOptions = {},
 ) {
-  let ast = [context({ base }, CSS.parse(css))] as AstNode[]
+  let ast = [contextNode({ base }, CSS.parse(css))] as AstNode[]
 
   await substituteAtImports(ast, base, loadStylesheet)
 
-  let important: boolean | null = null
+  let important = null as boolean | null
   let theme = new Theme()
   let customVariants: ((designSystem: DesignSystem) => void)[] = []
   let customUtilities: ((designSystem: DesignSystem) => void)[] = []
-  let firstThemeRule: Rule | null = null
+  let firstThemeRule = null as Rule | null
+  let utilitiesNode = null as Rule | null
   let globs: { base: string; pattern: string }[] = []
+  let root:
+    | null // Unknown root
+    | 'none' // Explicitly no root specified via `source(none)`
+    // Specified via `source(…)`, relative to the `base`
+    | { base: string; pattern: string } = null
 
   // Handle at-rules
   walk(ast, (node, { parent, replaceWith, context }) => {
     if (node.kind !== 'rule') return
     if (node.selector[0] !== '@') return
+
+    // Find `@tailwind utilities` so that we can later replace it with the
+    // actual generated utility class CSS.
+    if (
+      utilitiesNode === null &&
+      (node.selector === '@tailwind utilities' || node.selector.startsWith('@tailwind utilities '))
+    ) {
+      let params = segment(node.selector.slice(20).trim(), ' ')
+      for (let param of params) {
+        if (param.startsWith('source(')) {
+          let path = param.slice(7, -1)
+
+          // Keyword: `source(none)`
+          if (path === 'none') {
+            root = path
+            continue
+          }
+
+          // Explicit path: `source('…')`
+          if (
+            (path[0] === '"' && path[path.length - 1] !== '"') ||
+            (path[0] === "'" && path[path.length - 1] !== "'") ||
+            (path[0] !== "'" && path[0] !== '"')
+          ) {
+            throw new Error('`source(…)` paths must be quoted.')
+          }
+
+          root = {
+            base: context.sourceBase ?? context.base,
+            pattern: path.slice(1, -1),
+          }
+        }
+      }
+
+      utilitiesNode = node
+    }
 
     // Collect custom `@utility` at-rules
     if (node.selector.startsWith('@utility ')) {
@@ -232,12 +274,26 @@ async function parseCss(
       let unknownParams: string[] = []
 
       for (let param of params) {
+        // Handle `@media source(…)`
+        if (param.startsWith('source(')) {
+          let path = param.slice(7, -1)
+
+          walk(node.nodes, (child, { replaceWith }) => {
+            if (child.kind !== 'rule') return
+            if (child.selector === '@tailwind utilities') {
+              child.selector += ` source(${path})`
+              replaceWith([contextNode({ sourceBase: context.base }, [child])])
+              return WalkAction.Stop
+            }
+          })
+        }
+
         // Handle `@media theme(…)`
         //
         // We support `@import "tailwindcss/theme" theme(reference)` as a way to
         // import an external theme file as a reference, which becomes `@media
         // theme(reference) { … }` when the `@import` is processed.
-        if (param.startsWith('theme(')) {
+        else if (param.startsWith('theme(')) {
           let themeParams = param.slice(6, -1)
 
           walk(node.nodes, (child) => {
@@ -419,6 +475,8 @@ async function parseCss(
     designSystem,
     ast,
     globs,
+    root,
+    utilitiesNode,
   }
 }
 
@@ -427,24 +485,13 @@ export async function compile(
   opts: CompileOptions = {},
 ): Promise<{
   globs: { base: string; pattern: string }[]
+  root:
+    | null // Unknown root
+    | 'none' // Explicitly no root specified via `source(none)`
+    | { base: string; pattern: string } // Specified via `source(…)`, relative to the `base`
   build(candidates: string[]): string
 }> {
-  let { designSystem, ast, globs } = await parseCss(css, opts)
-
-  let tailwindUtilitiesNode: Rule | null = null
-
-  // Find `@tailwind utilities` so that we can later replace it with the actual
-  // generated utility class CSS.
-  walk(ast, (node) => {
-    if (node.kind === 'rule' && node.selector === '@tailwind utilities') {
-      tailwindUtilitiesNode = node
-
-      // Stop walking after finding `@tailwind utilities` to avoid walking all
-      // of the generated CSS. This means `@tailwind utilities` can only appear
-      // once per file but that's the intended usage at this point in time.
-      return WalkAction.Stop
-    }
-  })
+  let { designSystem, ast, globs, root, utilitiesNode } = await parseCss(css, opts)
 
   if (process.env.NODE_ENV !== 'test') {
     ast.unshift(comment(`! tailwindcss v${version} | MIT License | https://tailwindcss.com `))
@@ -464,6 +511,7 @@ export async function compile(
 
   return {
     globs,
+    root,
     build(newRawCandidates: string[]) {
       let didChange = false
 
@@ -482,7 +530,7 @@ export async function compile(
         return compiledCss
       }
 
-      if (tailwindUtilitiesNode) {
+      if (utilitiesNode) {
         let newNodes = compileCandidates(allValidCandidates, designSystem, {
           onInvalidCandidate,
         }).astNodes
@@ -496,7 +544,7 @@ export async function compile(
 
         previousAstNodeCount = newNodes.length
 
-        tailwindUtilitiesNode.nodes = newNodes
+        utilitiesNode.nodes = newNodes
         compiledCss = toCss(ast)
       }
 

--- a/turbo.json
+++ b/turbo.json
@@ -3,14 +3,8 @@
   "ui": "tui",
   "tasks": {
     "@tailwindcss/oxide#build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "outputs": [
-        "./index.d.ts",
-        "./index.js",
-        "./*.node"
-      ],
+      "dependsOn": ["^build"],
+      "outputs": ["./index.d.ts", "./index.js", "./*.node"],
       "inputs": [
         "./src/**/*",
         "./build.rs",
@@ -23,14 +17,8 @@
       ]
     },
     "@tailwindcss/oxide#dev": {
-      "dependsOn": [
-        "^dev"
-      ],
-      "outputs": [
-        "./index.d.ts",
-        "./index.js",
-        "./*.node"
-      ],
+      "dependsOn": ["^dev"],
+      "outputs": ["./index.d.ts", "./index.js", "./*.node"],
       "inputs": [
         "./src/**/*",
         "./build.rs",
@@ -45,12 +33,8 @@
       "persistent": true
     },
     "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "outputs": [
-        "dist/**"
-      ]
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
     },
     "lint": {},
     "dev": {
@@ -60,7 +44,5 @@
   },
   // If rustup is installed outside of the default ~/.rustup directory, we need
   // to pass the path through to the individual rust tasks.
-  "globalPassThroughEnv": [
-    "RUSTUP_HOME"
-  ]
+  "globalPassThroughEnv": ["RUSTUP_HOME"]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -3,29 +3,41 @@
   "ui": "tui",
   "tasks": {
     "@tailwindcss/oxide#build": {
-      "dependsOn": ["^build"],
-      "outputs": ["./index.d.ts", "./index.js", "./*.node"],
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "./index.d.ts",
+        "./index.js",
+        "./*.node"
+      ],
       "inputs": [
         "./src/**/*",
         "./build.rs",
         "./package.json",
         "./Cargo.toml",
-        "../core/src/**/*",
-        "../core/Cargo.toml",
+        "../oxide/src/**/*",
+        "../oxide/Cargo.toml",
         "../Cargo.toml",
         "../package.json"
       ]
     },
     "@tailwindcss/oxide#dev": {
-      "dependsOn": ["^dev"],
-      "outputs": ["./index.d.ts", "./index.js", "./*.node"],
+      "dependsOn": [
+        "^dev"
+      ],
+      "outputs": [
+        "./index.d.ts",
+        "./index.js",
+        "./*.node"
+      ],
       "inputs": [
         "./src/**/*",
         "./build.rs",
         "./package.json",
         "./Cargo.toml",
-        "../core/src/**/*",
-        "../core/Cargo.toml",
+        "../oxide/src/**/*",
+        "../oxide/Cargo.toml",
         "../Cargo.toml",
         "../package.json"
       ],
@@ -33,8 +45,12 @@
       "persistent": true
     },
     "build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "dist/**"
+      ]
     },
     "lint": {},
     "dev": {
@@ -44,5 +60,7 @@
   },
   // If rustup is installed outside of the default ~/.rustup directory, we need
   // to pass the path through to the individual rust tasks.
-  "globalPassThroughEnv": ["RUSTUP_HOME"]
+  "globalPassThroughEnv": [
+    "RUSTUP_HOME"
+  ]
 }


### PR DESCRIPTION
This PR introduces a new `source(…)` argument and improves on the existing `@source`. The goal of this PR is to make the automatic source detection configurable, let's dig in.

By default, we will perform automatic source detection starting at the current working directory. Auto source detection will find plain text files (no binaries, images, ...) and will ignore git-ignored files.

If you want to start from a different directory, you can use the new `source(…)` next to the `@import "tailwindcss/utilities" layer(utilities) source(…)`.

E.g.:

```css
/* ./src/styles/index.css */
@import 'tailwindcss/utilities' layer(utilities) source('../../');
```

Most people won't split their source files, and will just use the simple `@import "tailwindcss";`, because of this reason, you can use `source(…)` on the import as well:

E.g.:

```css
/* ./src/styles/index.css */
@import 'tailwindcss' source('../../');
```

Sometimes, you want to rely on auto source detection, but also want to look in another directory for source files. In this case, yuo can use the `@source` directive:

```css
/* ./src/index.css */
@import 'tailwindcss';

/* Look for `blade.php` files in `../resources/views` */
@source '../resources/views/**/*.blade.php';
```

However, you don't need to specify the extension, instead you can just point the directory and all the same automatic source detection rules will apply.

```css
/* ./src/index.css */
@import 'tailwindcss';

@source '../resources/views';
```

If, for whatever reason, you want to disable the default source detection feature entirely, and only want to rely on very specific glob patterns you define, then you can disable it via `source(none)`.

```css
/* Completely disable the default auto source detection */
@import 'tailwindcss' source(none);

/* Only look at .blade.php files, nothing else  */
@source "../resources/views/**/*.blade.php";
```

Note: even with `source(none)`, if your `@source` points to a directory, then auto source detection will still be performed in that directory. If you don't want that, then you can simply add explicit files in the globs as seen in the previous example.

```css
/* Completely disable the default auto source detection */
@import 'tailwindcss' source(none);

/* Run auto source detection in `../resources/views` */
@source "../resources/views";
```
