### PR TITLE
Fix Astro integration test by pinning `zod-to-json-schema`

### DIFF
--- a/integrations/vite/astro.test.ts
+++ b/integrations/vite/astro.test.ts
@@ -12,6 +12,11 @@ test(
             "astro": "^4.15.2",
             "@tailwindcss/vite": "workspace:^",
             "tailwindcss": "workspace:^"
+          },
+          "pnpm": {
+            "overrides": {
+              "zod-to-json-schema": "3.23.3"
+            }
           }
         }
       `,


### PR DESCRIPTION
A regression in one of the dependencies of `astro` has broken our integration tests. An upstream issue already exists and is tracked as https://github.com/StefanTerdell/zod-to-json-schema/issues/151.

This PR pins `zod-to-json-schema` to unblock the issue.

## Test Plan

1. I made sure that `pnpm test:integrations astro` fails locally as well
2. After the change, it passes again:
    ![Screenshot 2024-10-24 at 17.16.27.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/0Y77ilPI2WoJfMLFiAEw/3a35eca7-8d31-41e0-b961-c1fd1ed55ba6.png)

