### PR TITLE
Ensure `layer(…)` on `@import` is only removed when `@utility` is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - _Upgrade (experimental)_: Ensure `@import` statements for relative CSS files are actually migrated to use relative path syntax ([#14769](https://github.com/tailwindlabs/tailwindcss/pull/14769))
 - _Upgrade (experimental)_: Only generate Preflight compatibility styles when Preflight is used ([#14773](https://github.com/tailwindlabs/tailwindcss/pull/14773))
 - _Upgrade (experimental)_: Don't escape underscores when printing theme values migrated to CSS variables in arbitrary values (e.g. `m-[var(--spacing-1_5)]` instead of `m-[var(--spacing-1\_5)]`) ([#14778](https://github.com/tailwindlabs/tailwindcss/pull/14778))
+- _Upgrade (experimental)_: Ensure `layer(…)` on `@import` is correct ([#14783](https://github.com/tailwindlabs/tailwindcss/pull/14783))
 
 ## [4.0.0-alpha.29] - 2024-10-23
 
@@ -490,3 +491,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move the CLI into a separate `@tailwindcss/cli` package ([#13095](https://github.com/tailwindlabs/tailwindcss/pull/13095))
 
 ## [4.0.0-alpha.1] - 2024-03-06
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `not-*` versions of all builtin media query and supports variants ([#14743](https://github.com/tailwindlabs/tailwindcss/pull/14743))
 - Improved support for custom variants with `group-*`, `peer-*`, `has-*`, and `not-*` ([#14743](https://github.com/tailwindlabs/tailwindcss/pull/14743))
 
-### Changed
-
-- Don't convert underscores in the first argument to `var()` and `theme()` to spaces ([#14776](https://github.com/tailwindlabs/tailwindcss/pull/14776), [#14781](https://github.com/tailwindlabs/tailwindcss/pull/14781))
-
 ### Fixed
 
 - Ensure individual logical property utilities are sorted later than left/right pair utilities ([#14777](https://github.com/tailwindlabs/tailwindcss/pull/14777))
@@ -26,7 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - _Upgrade (experimental)_: Ensure `@import` statements for relative CSS files are actually migrated to use relative path syntax ([#14769](https://github.com/tailwindlabs/tailwindcss/pull/14769))
 - _Upgrade (experimental)_: Only generate Preflight compatibility styles when Preflight is used ([#14773](https://github.com/tailwindlabs/tailwindcss/pull/14773))
 - _Upgrade (experimental)_: Don't escape underscores when printing theme values migrated to CSS variables in arbitrary values (e.g. `m-[var(--spacing-1_5)]` instead of `m-[var(--spacing-1\_5)]`) ([#14778](https://github.com/tailwindlabs/tailwindcss/pull/14778))
-- _Upgrade (experimental)_: Ensure `layer(…)` on `@import` is correct ([#14783](https://github.com/tailwindlabs/tailwindcss/pull/14783))
+- _Upgrade (experimental)_: Ensure `layer(…)` on `@import` is only removed when `@utility` is present ([#14783](https://github.com/tailwindlabs/tailwindcss/pull/14783))
+
+### Changed
+
+- Don't convert underscores in the first argument to `var()` and `theme()` to spaces ([#14776](https://github.com/tailwindlabs/tailwindcss/pull/14776), [#14781](https://github.com/tailwindlabs/tailwindcss/pull/14781))
 
 ## [4.0.0-alpha.29] - 2024-10-23
 
@@ -491,4 +491,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move the CLI into a separate `@tailwindcss/cli` package ([#13095](https://github.com/tailwindlabs/tailwindcss/pull/13095))
 
 ## [4.0.0-alpha.1] - 2024-03-06
-

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-missing-layers.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-missing-layers.test.ts
@@ -22,6 +22,22 @@ it('should not migrate already migrated `@import` at-rules', async () => {
   ).toMatchInlineSnapshot(`"@import 'tailwindcss';"`)
 })
 
+it('should add missing `layer(…)` to imported files', async () => {
+  expect(
+    await migrate(css`
+      @import 'tailwindcss/utilities'; /* Expected no layer */
+      @import './foo.css'; /* Expected layer(utilities) */
+      @import './bar.css'; /* Expected layer(utilities) */
+      @import 'tailwindcss/components'; /* Expected no layer */
+    `),
+  ).toMatchInlineSnapshot(`
+    "@import 'tailwindcss/utilities'; /* Expected no layer */
+    @import './foo.css' layer(utilities); /* Expected layer(utilities) */
+    @import './bar.css' layer(utilities); /* Expected layer(utilities) */
+    @import 'tailwindcss/components'; /* Expected no layer */"
+  `)
+})
+
 it('should not migrate anything if no `@tailwind` directives (or imports) are found', async () => {
   expect(
     await migrate(css`

--- a/packages/@tailwindcss-upgrade/src/stylesheet.ts
+++ b/packages/@tailwindcss-upgrade/src/stylesheet.ts
@@ -219,6 +219,29 @@ export class Stylesheet {
     return { convertiblePaths, nonConvertiblePaths }
   }
 
+  containsRule(cb: (rule: postcss.AnyNode) => boolean) {
+    let contains = false
+
+    this.root.walk((rule) => {
+      if (cb(rule)) {
+        contains = true
+        return false
+      }
+    })
+
+    if (contains) {
+      return true
+    }
+
+    for (let child of this.children) {
+      if (child.item.containsRule(cb)) {
+        return true
+      }
+    }
+
+    return false
+  }
+
   [util.inspect.custom]() {
     return {
       ...this,


### PR DESCRIPTION
This PR fixes an issue where `layer(…)` next to imports were removed where they shouldn't have been removed.

The issue exists if _any_ of the `@import` nodes in a file contains `@utility`, if that's the case then we removed the `layer(…)` next to _all_ `@import` nodes.

Before we were checking if the current sheet contained `@utility` or in any of its children (sub-`@import` nodes).

This fixes that by looping over the `@import` nodes in the current sheet, and looking for the `@utility` in the associated/imported file. This way we update each node individually.

Test plan:
---

Added a dedicated integration test to make sure all codemods together result in the correct result. Input:
https://github.com/tailwindlabs/tailwindcss/blob/96e890837809487fecdd713695294cb9961cc1d6/integrations/upgrade/index.test.ts#L2076-L2108

Output:
https://github.com/tailwindlabs/tailwindcss/blob/96e890837809487fecdd713695294cb9961cc1d6/integrations/upgrade/index.test.ts#L2116-L2126