### PR TITLE
Revert "Fix Astro integration test by pinning `zod-to-json-schema`"

### DIFF
--- a/integrations/vite/astro.test.ts
+++ b/integrations/vite/astro.test.ts
@@ -12,11 +12,6 @@ test(
             "astro": "^4.15.2",
             "@tailwindcss/vite": "workspace:^",
             "tailwindcss": "workspace:^"
-          },
-          "pnpm": {
-            "overrides": {
-              "zod-to-json-schema": "3.23.3"
-            }
           }
         }
       `,


### PR DESCRIPTION
Reverts tailwindlabs/tailwindcss#14780

The version pin is no longer needed. 🙂 

## Test Plan

CI is green again.