### PR TITLE
[Failing Test] - Fix multiple data attributes

### DIFF
--- a/packages/@tailwindcss-upgrade/src/template/codemods/arbitrary-value-to-bare-value.test.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/arbitrary-value-to-bare-value.test.ts
@@ -31,6 +31,7 @@ test.each([
 
   ['data-[selected]:flex', 'data-selected:flex'],
   ['data-[selected]:flex data-[selected]:flex-col', 'data-selected:flex data-selected:flex-col'],
+  ['data-[selected]:flex data-[selected]:flex-col data-[selected]:gap-2', 'data-selected:flex data-selected:flex-col data-selected:gap-2'],
   ['data-[foo=bar]:flex', 'data-[foo=bar]:flex'],
 
   ['supports-[gap]:flex', 'supports-gap:flex'],

--- a/packages/@tailwindcss-upgrade/src/template/codemods/arbitrary-value-to-bare-value.test.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/arbitrary-value-to-bare-value.test.ts
@@ -30,6 +30,7 @@ test.each([
   ['text-[1/2]', 'text-[1/2]'],
 
   ['data-[selected]:flex', 'data-selected:flex'],
+  ['data-[selected]:flex data-[selected]:flex-col', 'data-selected:flex data-selected:flex-col'],
   ['data-[foo=bar]:flex', 'data-[foo=bar]:flex'],
 
   ['supports-[gap]:flex', 'supports-gap:flex'],


### PR DESCRIPTION
<!-- Please provide all of the information requested below. We're a small team and without all of this information it's not possible for us to help and your bug report will be closed. -->

**What version of Tailwind CSS are you using?**

For example: v4.0.0-alpha.30

**What build tool (or framework if it abstracts the build tool) are you using?**

For example: "postcss": "^8.4.47",

**Describe your issue**

<img width="1828" alt="image" src="https://github.com/user-attachments/assets/d5aead10-99f6-4075-99b6-33cd91c26cd1">

The upgrade was successful, however I can see in the diffs that only the first instance of the attribute was updated, not the other ones.