### PR TITLE
Make `config()` path arg optional in v4 plugin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Make `config()` path argument optional in v4 plugin API for backwards compat ([#14799](https://github.com/tailwindlabs/tailwindcss/pull/14799))
+- Support calling `config()` with no arguments in plugin API ([#14799](https://github.com/tailwindlabs/tailwindcss/pull/14799))
 
 ## [4.0.0-alpha.30] - 2024-10-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Make `config()` path argument optional in v4 plugin API for backwards compat ([#14799](https://github.com/tailwindlabs/tailwindcss/pull/14799))
 
 ## [4.0.0-alpha.30] - 2024-10-24
 

--- a/packages/tailwindcss/src/compat/config/resolve-config.ts
+++ b/packages/tailwindcss/src/compat/config/resolve-config.ts
@@ -29,6 +29,7 @@ interface ResolutionContext {
 
 let minimal: ResolvedConfig = {
   blocklist: [],
+  future: {},
   prefix: '',
   important: false,
   darkMode: null,

--- a/packages/tailwindcss/src/compat/config/types.ts
+++ b/packages/tailwindcss/src/compat/config/types.ts
@@ -96,3 +96,12 @@ export interface UserConfig {
 export interface ResolvedConfig {
   important: boolean | string
 }
+
+// `future` key support
+export interface UserConfig {
+  future: 'all' | Record<string, boolean>
+}
+
+export interface ResolvedConfig {
+  future: Record<string, boolean>
+}

--- a/packages/tailwindcss/src/compat/config/types.ts
+++ b/packages/tailwindcss/src/compat/config/types.ts
@@ -99,7 +99,7 @@ export interface ResolvedConfig {
 
 // `future` key support
 export interface UserConfig {
-  future: 'all' | Record<string, boolean>
+  future?: 'all' | Record<string, boolean>
 }
 
 export interface ResolvedConfig {

--- a/packages/tailwindcss/src/compat/plugin-api.test.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.test.ts
@@ -3793,6 +3793,33 @@ describe('prefix()', () => {
 })
 
 describe('config()', () => {
+  test('can return the resolved config when passed no arguments', async () => {
+    let fn = vi.fn()
+    await compile(
+      css`
+        @plugin "my-plugin";
+      `,
+      {
+        async loadModule(id, base) {
+          return {
+            base,
+            module: ({ config }: PluginAPI) => {
+              fn(config())
+            },
+          }
+        },
+      },
+    )
+
+    expect(fn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        theme: expect.objectContaining({
+          spacing: expect.any(Object),
+        }),
+      }),
+    )
+  })
+
   test('can return part of the config', async () => {
     let fn = vi.fn()
     await compile(

--- a/packages/tailwindcss/src/compat/plugin-api.test.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.test.ts
@@ -3791,3 +3791,51 @@ describe('prefix()', () => {
     expect(fn).toHaveBeenCalledWith('btn')
   })
 })
+
+describe('config()', () => {
+  test('can return part of the config', async () => {
+    let fn = vi.fn()
+    await compile(
+      css`
+        @plugin "my-plugin";
+      `,
+      {
+        async loadModule(id, base) {
+          return {
+            base,
+            module: ({ config }: PluginAPI) => {
+              fn(config('theme'))
+            },
+          }
+        },
+      },
+    )
+
+    expect(fn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spacing: expect.any(Object),
+      }),
+    )
+  })
+
+  test('falls back to default value if requested path does not exist', async () => {
+    let fn = vi.fn()
+    await compile(
+      css`
+        @plugin "my-plugin";
+      `,
+      {
+        async loadModule(id, base) {
+          return {
+            base,
+            module: ({ config }: PluginAPI) => {
+              fn(config('somekey', 'defaultvalue'))
+            },
+          }
+        },
+      },
+    )
+
+    expect(fn).toHaveBeenCalledWith('defaultvalue')
+  })
+})

--- a/packages/tailwindcss/src/compat/plugin-api.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.ts
@@ -71,7 +71,7 @@ export type PluginAPI = {
   ): void
 
   theme(path: string, defaultValue?: any): any
-  config(path: string, defaultValue?: any): any
+  config(path?: string, defaultValue?: any): any
   prefix(className: string): string
 }
 
@@ -398,6 +398,8 @@ export function buildPluginApi(
 
     config(path, defaultValue) {
       let obj: Record<any, any> = resolvedConfig
+
+      if (!path) return obj
 
       let keypath = toKeyPath(path)
 


### PR DESCRIPTION
Fixes #14797

The `config()` function in v3 had an optional `path` argument and when it wasn't provided it returned the resolved config directly so we need to do the same here.

I've also added a `future` key to the config objects / types.

cc @adamwathan any objection to adding this or do you think we can get by without it?