### PR TITLE
Internal refactor, introduce `AtRule`

### DIFF
--- a/packages/@tailwindcss-upgrade/src/template/codemods/variant-order.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/variant-order.ts
@@ -57,7 +57,7 @@ function isAtRuleVariant(designSystem: DesignSystem, variant: Variant) {
     return true
   }
   let stack = getAppliedNodeStack(designSystem, variant)
-  return stack.every((node) => node.kind === 'rule' && node.selector[0] === '@')
+  return stack.every((node) => node.kind === 'at-rule')
 }
 
 function isCombinatorVariant(designSystem: DesignSystem, variant: Variant) {
@@ -65,8 +65,6 @@ function isCombinatorVariant(designSystem: DesignSystem, variant: Variant) {
   return stack.some(
     (node) =>
       node.kind === 'rule' &&
-      // Ignore at-rules as they are hoisted
-      node.selector[0] !== '@' &&
       // Combinators include any of the following characters
       (node.selector.includes(' ') ||
         node.selector.includes('>') ||

--- a/packages/@tailwindcss-upgrade/src/template/codemods/variant-order.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/variant-order.ts
@@ -64,7 +64,7 @@ function isCombinatorVariant(designSystem: DesignSystem, variant: Variant) {
   let stack = getAppliedNodeStack(designSystem, variant)
   return stack.some(
     (node) =>
-      node.kind === 'style-rule' &&
+      node.kind === 'rule' &&
       // Combinators include any of the following characters
       (node.selector.includes(' ') ||
         node.selector.includes('>') ||
@@ -77,7 +77,7 @@ function isEndOfSelectorPseudoElement(designSystem: DesignSystem, variant: Varia
   let stack = getAppliedNodeStack(designSystem, variant)
   return stack.some(
     (node) =>
-      node.kind === 'style-rule' &&
+      node.kind === 'rule' &&
       (node.selector.includes('::after') ||
         node.selector.includes('::backdrop') ||
         node.selector.includes('::before') ||
@@ -105,7 +105,7 @@ function getAppliedNodeStack(designSystem: DesignSystem, variant: Variant): AstN
 
   walk(ast, (node) => {
     // Ignore the variant root class
-    if (node.kind === 'style-rule' && node.selector === '.candidate') {
+    if (node.kind === 'rule' && node.selector === '.candidate') {
       return
     }
     // Ignore the dummy declaration

--- a/packages/@tailwindcss-upgrade/src/template/codemods/variant-order.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/variant-order.ts
@@ -64,7 +64,7 @@ function isCombinatorVariant(designSystem: DesignSystem, variant: Variant) {
   let stack = getAppliedNodeStack(designSystem, variant)
   return stack.some(
     (node) =>
-      node.kind === 'rule' &&
+      node.kind === 'style-rule' &&
       // Combinators include any of the following characters
       (node.selector.includes(' ') ||
         node.selector.includes('>') ||
@@ -77,7 +77,7 @@ function isEndOfSelectorPseudoElement(designSystem: DesignSystem, variant: Varia
   let stack = getAppliedNodeStack(designSystem, variant)
   return stack.some(
     (node) =>
-      node.kind === 'rule' &&
+      node.kind === 'style-rule' &&
       (node.selector.includes('::after') ||
         node.selector.includes('::backdrop') ||
         node.selector.includes('::before') ||
@@ -105,7 +105,7 @@ function getAppliedNodeStack(designSystem: DesignSystem, variant: Variant): AstN
 
   walk(ast, (node) => {
     // Ignore the variant root class
-    if (node.kind === 'rule' && node.selector === '.candidate') {
+    if (node.kind === 'style-rule' && node.selector === '.candidate') {
       return
     }
     // Ignore the dummy declaration

--- a/packages/@tailwindcss-upgrade/tsconfig.json
+++ b/packages/@tailwindcss-upgrade/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "allowSyntheticDefaultImports":true
-  }
+    "allowSyntheticDefaultImports": true,
+  },
 }

--- a/packages/tailwindcss/src/apply.ts
+++ b/packages/tailwindcss/src/apply.ts
@@ -8,16 +8,16 @@ export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
     if (node.kind !== 'at-rule') return
 
     // Do not allow `@apply` rules inside `@keyframes` rules.
-    if (node.name === 'keyframes') {
+    if (node.name === '@keyframes') {
       walk(node.nodes, (child) => {
-        if (child.kind === 'at-rule' && child.name === 'apply') {
+        if (child.kind === 'at-rule' && child.name === '@apply') {
           throw new Error(`You cannot use \`@apply\` inside \`@keyframes\`.`)
         }
       })
       return WalkAction.Skip
     }
 
-    if (node.name !== 'apply') return
+    if (node.name !== '@apply') return
 
     let candidates = node.params.split(/\s+/g)
 

--- a/packages/tailwindcss/src/apply.ts
+++ b/packages/tailwindcss/src/apply.ts
@@ -36,7 +36,7 @@ export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
       // don't want the wrapping selector.
       let newNodes: AstNode[] = []
       for (let candidateNode of candidateAst) {
-        if (candidateNode.kind === 'style-rule') {
+        if (candidateNode.kind === 'rule') {
           for (let child of candidateNode.nodes) {
             newNodes.push(child)
           }
@@ -58,7 +58,7 @@ export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
           let selector = `.${escape(candidate)}`
 
           for (let rule of candidateAst) {
-            if (rule.kind !== 'style-rule') continue
+            if (rule.kind !== 'rule') continue
             if (rule.selector !== selector) continue
 
             walk(rule.nodes, (child) => {

--- a/packages/tailwindcss/src/apply.ts
+++ b/packages/tailwindcss/src/apply.ts
@@ -36,7 +36,7 @@ export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
       // don't want the wrapping selector.
       let newNodes: AstNode[] = []
       for (let candidateNode of candidateAst) {
-        if (candidateNode.kind === 'rule') {
+        if (candidateNode.kind === 'style-rule') {
           for (let child of candidateNode.nodes) {
             newNodes.push(child)
           }
@@ -58,7 +58,7 @@ export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
           let selector = `.${escape(candidate)}`
 
           for (let rule of candidateAst) {
-            if (rule.kind !== 'rule') continue
+            if (rule.kind !== 'style-rule') continue
             if (rule.selector !== selector) continue
 
             walk(rule.nodes, (child) => {

--- a/packages/tailwindcss/src/ast.test.ts
+++ b/packages/tailwindcss/src/ast.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from 'vitest'
-import { context, decl, rule, toCss, walk } from './ast'
+import { context, decl, styleRule, toCss, walk } from './ast'
 import * as CSS from './css-parser'
 
 it('should pretty print an AST', () => {
@@ -16,13 +16,13 @@ it('should pretty print an AST', () => {
 
 it('allows the placement of context nodes', () => {
   const ast = [
-    rule('.foo', [decl('color', 'red')]),
+    styleRule('.foo', [decl('color', 'red')]),
     context({ context: 'a' }, [
-      rule('.bar', [
+      styleRule('.bar', [
         decl('color', 'blue'),
         context({ context: 'b' }, [
           //
-          rule('.baz', [decl('color', 'green')]),
+          styleRule('.baz', [decl('color', 'green')]),
         ]),
       ]),
     ]),

--- a/packages/tailwindcss/src/ast.test.ts
+++ b/packages/tailwindcss/src/ast.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from 'vitest'
-import { context, decl, styleRule, toCss, walk } from './ast'
+import { context, decl, rule, toCss, walk } from './ast'
 import * as CSS from './css-parser'
 
 it('should pretty print an AST', () => {
@@ -16,13 +16,13 @@ it('should pretty print an AST', () => {
 
 it('allows the placement of context nodes', () => {
   const ast = [
-    styleRule('.foo', [decl('color', 'red')]),
+    rule('.foo', [decl('color', 'red')]),
     context({ context: 'a' }, [
-      styleRule('.bar', [
+      rule('.bar', [
         decl('color', 'blue'),
         context({ context: 'b' }, [
           //
-          styleRule('.baz', [decl('color', 'green')]),
+          rule('.baz', [decl('color', 'green')]),
         ]),
       ]),
     ]),

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -1,5 +1,7 @@
 import { parseAtRule } from './css-parser'
 
+const AT_SIGN = 0x40
+
 export type StyleRule = {
   kind: 'rule'
   selector: string
@@ -57,7 +59,7 @@ export function atRule(name: string, params: string = '', nodes: AstNode[] = [])
 }
 
 export function rule(selector: string, nodes: AstNode[] = []): StyleRule | AtRule {
-  if (selector[0] === '@') {
+  if (selector.charCodeAt(0) === AT_SIGN) {
     return parseAtRule(selector, nodes)
   }
 

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -1,5 +1,5 @@
-export type Rule = {
-  kind: 'rule'
+export type StyleRule = {
+  kind: 'style-rule'
   selector: string
   nodes: AstNode[]
 }
@@ -34,11 +34,11 @@ export type AtRoot = {
   nodes: AstNode[]
 }
 
-export type AstNode = Rule | AtRule | Declaration | Comment | Context | AtRoot
+export type AstNode = StyleRule | AtRule | Declaration | Comment | Context | AtRoot
 
-export function rule(selector: string, nodes: AstNode[] = []): Rule {
+export function styleRule(selector: string, nodes: AstNode[] = []): StyleRule {
   return {
-    kind: 'rule',
+    kind: 'style-rule',
     selector,
     nodes,
   }
@@ -142,7 +142,7 @@ export function walk(
     // Skip visiting the children of this node
     if (status === WalkAction.Skip) continue
 
-    if (node.kind === 'rule' || node.kind === 'at-rule') {
+    if (node.kind === 'style-rule' || node.kind === 'at-rule') {
       walk(node.nodes, visit, path, context)
     }
   }
@@ -168,7 +168,7 @@ export function walkDepth(
     let path = [...parentPath, node]
     let parent = parentPath.at(-1) ?? null
 
-    if (node.kind === 'rule' || node.kind === 'at-rule') {
+    if (node.kind === 'style-rule' || node.kind === 'at-rule') {
       walkDepth(node.nodes, visit, path, context)
     } else if (node.kind === 'context') {
       walkDepth(node.nodes, visit, parentPath, { ...context, ...node.context })
@@ -200,7 +200,7 @@ export function toCss(ast: AstNode[]) {
     let indent = '  '.repeat(depth)
 
     // Rule
-    if (node.kind === 'rule') {
+    if (node.kind === 'style-rule') {
       css += `${indent}${node.selector} {\n`
       for (let child of node.nodes) {
         css += stringify(child, depth + 1)
@@ -307,11 +307,11 @@ export function toCss(ast: AstNode[]) {
   let fallbackAst = []
 
   if (propertyFallbacksRoot.length) {
-    fallbackAst.push(rule(':root', propertyFallbacksRoot))
+    fallbackAst.push(styleRule(':root', propertyFallbacksRoot))
   }
 
   if (propertyFallbacksUniversal.length) {
-    fallbackAst.push(rule('*, ::before, ::after, ::backdrop', propertyFallbacksUniversal))
+    fallbackAst.push(styleRule('*, ::before, ::after, ::backdrop', propertyFallbacksUniversal))
   }
 
   let fallback = ''

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -223,7 +223,7 @@ export function toCss(ast: AstNode[]) {
 
     // AtRule
     else if (node.kind === 'at-rule') {
-      if (node.name === 'tailwind' && node.params === 'utilities') {
+      if (node.name === '@tailwind' && node.params === 'utilities') {
         for (let child of node.nodes) {
           css += stringify(child, depth)
         }
@@ -238,11 +238,11 @@ export function toCss(ast: AstNode[]) {
       // @layer base, components, utilities;
       // ```
       else if (node.nodes.length === 0) {
-        return `${indent}@${node.name} ${node.params};\n`
+        return `${indent}${node.name} ${node.params};\n`
       }
 
       //
-      else if (node.name === 'property' && depth === 0) {
+      else if (node.name === '@property' && depth === 0) {
         // Don't output duplicate `@property` rules
         if (seenAtProperties.has(node.params)) {
           return ''
@@ -273,7 +273,7 @@ export function toCss(ast: AstNode[]) {
         seenAtProperties.add(node.params)
       }
 
-      css += `${indent}@${node.name}${node.params ? ` ${node.params} ` : ' '}{\n`
+      css += `${indent}${node.name}${node.params ? ` ${node.params} ` : ' '}{\n`
       for (let child of node.nodes) {
         css += stringify(child, depth + 1)
       }
@@ -331,7 +331,7 @@ export function toCss(ast: AstNode[]) {
 
   if (fallbackAst.length) {
     fallback = stringify(
-      atRule('supports', '(-moz-orient: inline)', [atRule('layer', 'base', fallbackAst)]),
+      atRule('@supports', '(-moz-orient: inline)', [atRule('@layer', 'base', fallbackAst)]),
     )
   }
 

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -318,11 +318,11 @@ export function toCss(ast: AstNode[]) {
   let fallbackAst = []
 
   if (propertyFallbacksRoot.length) {
-    fallbackAst.push(styleRule(':root', propertyFallbacksRoot))
+    fallbackAst.push(rule(':root', propertyFallbacksRoot))
   }
 
   if (propertyFallbacksUniversal.length) {
-    fallbackAst.push(styleRule('*, ::before, ::after, ::backdrop', propertyFallbacksUniversal))
+    fallbackAst.push(rule('*, ::before, ::after, ::backdrop', propertyFallbacksUniversal))
   }
 
   let fallback = ''

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -1,7 +1,7 @@
 import { parseAtRule } from './css-parser'
 
 export type StyleRule = {
-  kind: 'style-rule'
+  kind: 'rule'
   selector: string
   nodes: AstNode[]
 }
@@ -41,7 +41,7 @@ export type AstNode = StyleRule | AtRule | Declaration | Comment | Context | AtR
 
 export function styleRule(selector: string, nodes: AstNode[] = []): StyleRule {
   return {
-    kind: 'style-rule',
+    kind: 'rule',
     selector,
     nodes,
   }
@@ -153,7 +153,7 @@ export function walk(
     // Skip visiting the children of this node
     if (status === WalkAction.Skip) continue
 
-    if (node.kind === 'style-rule' || node.kind === 'at-rule') {
+    if (node.kind === 'rule' || node.kind === 'at-rule') {
       walk(node.nodes, visit, path, context)
     }
   }
@@ -179,7 +179,7 @@ export function walkDepth(
     let path = [...parentPath, node]
     let parent = parentPath.at(-1) ?? null
 
-    if (node.kind === 'style-rule' || node.kind === 'at-rule') {
+    if (node.kind === 'rule' || node.kind === 'at-rule') {
       walkDepth(node.nodes, visit, path, context)
     } else if (node.kind === 'context') {
       walkDepth(node.nodes, visit, parentPath, { ...context, ...node.context })
@@ -211,7 +211,7 @@ export function toCss(ast: AstNode[]) {
     let indent = '  '.repeat(depth)
 
     // Rule
-    if (node.kind === 'style-rule') {
+    if (node.kind === 'rule') {
       css += `${indent}${node.selector} {\n`
       for (let child of node.nodes) {
         css += stringify(child, depth + 1)

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -1,3 +1,5 @@
+import { parseAtRule } from './css-parser'
+
 export type StyleRule = {
   kind: 'style-rule'
   selector: string
@@ -34,6 +36,7 @@ export type AtRoot = {
   nodes: AstNode[]
 }
 
+export type Rule = StyleRule | AtRule
 export type AstNode = StyleRule | AtRule | Declaration | Comment | Context | AtRoot
 
 export function styleRule(selector: string, nodes: AstNode[] = []): StyleRule {
@@ -51,6 +54,14 @@ export function atRule(name: string, params: string = '', nodes: AstNode[] = [])
     params,
     nodes,
   }
+}
+
+export function rule(selector: string, nodes: AstNode[] = []): StyleRule | AtRule {
+  if (selector[0] === '@') {
+    return parseAtRule(selector, nodes)
+  }
+
+  return styleRule(selector, nodes)
 }
 
 export function decl(property: string, value: string | undefined): Declaration {

--- a/packages/tailwindcss/src/at-import.ts
+++ b/packages/tailwindcss/src/at-import.ts
@@ -13,7 +13,7 @@ export async function substituteAtImports(
   let promises: Promise<void>[] = []
 
   walk(ast, (node, { replaceWith }) => {
-    if (node.kind === 'at-rule' && node.name === 'import') {
+    if (node.kind === 'at-rule' && node.name === '@import') {
       try {
         let { uri, layer, media, supports } = parseImportParams(ValueParser.parse(node.params))
 
@@ -126,15 +126,15 @@ function buildImportNodes(
   let root = importedAst
 
   if (layer !== null) {
-    root = [atRule('layer', layer, root)]
+    root = [atRule('@layer', layer, root)]
   }
 
   if (media !== null) {
-    root = [atRule('media', media, root)]
+    root = [atRule('@media', media, root)]
   }
 
   if (supports !== null) {
-    root = [atRule('supports', supports[0] === '(' ? supports : `(${supports})`, root)]
+    root = [atRule('@supports', supports[0] === '(' ? supports : `(${supports})`, root)]
   }
 
   return root

--- a/packages/tailwindcss/src/compat/apply-compat-hooks.ts
+++ b/packages/tailwindcss/src/compat/apply-compat-hooks.ts
@@ -1,4 +1,4 @@
-import { rule, toCss, walk, WalkAction, type AstNode } from '../ast'
+import { styleRule, toCss, walk, WalkAction, type AstNode } from '../ast'
 import type { DesignSystem } from '../design-system'
 import { segment } from '../utils/segment'
 import { applyConfigToTheme } from './apply-config-to-theme'
@@ -272,11 +272,11 @@ function upgradeToFullPluginSupport({
       if (node.name !== 'tailwind' || node.params !== 'utilities') return
 
       // The AST node was already manually wrapped so there's nothing to do
-      if (parent?.kind === 'rule' && parent.selector === wrappingSelector) {
+      if (parent?.kind === 'style-rule' && parent.selector === wrappingSelector) {
         return WalkAction.Stop
       }
 
-      replaceWith(rule(wrappingSelector, [node]))
+      replaceWith(styleRule(wrappingSelector, [node]))
 
       return WalkAction.Stop
     })

--- a/packages/tailwindcss/src/compat/apply-compat-hooks.ts
+++ b/packages/tailwindcss/src/compat/apply-compat-hooks.ts
@@ -37,7 +37,7 @@ export async function applyCompatibilityHooks({
     if (node.kind !== 'at-rule') return
 
     // Collect paths from `@plugin` at-rules
-    if (node.name === 'plugin') {
+    if (node.name === '@plugin') {
       if (parent !== null) {
         throw new Error('`@plugin` cannot be nested.')
       }
@@ -100,7 +100,7 @@ export async function applyCompatibilityHooks({
     }
 
     // Collect paths from `@config` at-rules
-    if (node.name === 'config') {
+    if (node.name === '@config') {
       if (node.nodes.length > 0) {
         throw new Error('`@config` cannot have a body.')
       }
@@ -269,7 +269,7 @@ function upgradeToFullPluginSupport({
 
     walk(ast, (node, { replaceWith, parent }) => {
       if (node.kind !== 'at-rule') return
-      if (node.name !== 'tailwind' || node.params !== 'utilities') return
+      if (node.name !== '@tailwind' || node.params !== 'utilities') return
 
       // The AST node was already manually wrapped so there's nothing to do
       if (parent?.kind === 'rule' && parent.selector === wrappingSelector) {

--- a/packages/tailwindcss/src/compat/apply-compat-hooks.ts
+++ b/packages/tailwindcss/src/compat/apply-compat-hooks.ts
@@ -1,4 +1,4 @@
-import { styleRule, toCss, walk, WalkAction, type AstNode } from '../ast'
+import { rule, toCss, walk, WalkAction, type AstNode } from '../ast'
 import type { DesignSystem } from '../design-system'
 import { segment } from '../utils/segment'
 import { applyConfigToTheme } from './apply-config-to-theme'
@@ -276,7 +276,7 @@ function upgradeToFullPluginSupport({
         return WalkAction.Stop
       }
 
-      replaceWith(styleRule(wrappingSelector, [node]))
+      replaceWith(rule(wrappingSelector, [node]))
 
       return WalkAction.Stop
     })

--- a/packages/tailwindcss/src/compat/apply-compat-hooks.ts
+++ b/packages/tailwindcss/src/compat/apply-compat-hooks.ts
@@ -272,7 +272,7 @@ function upgradeToFullPluginSupport({
       if (node.name !== 'tailwind' || node.params !== 'utilities') return
 
       // The AST node was already manually wrapped so there's nothing to do
-      if (parent?.kind === 'style-rule' && parent.selector === wrappingSelector) {
+      if (parent?.kind === 'rule' && parent.selector === wrappingSelector) {
         return WalkAction.Stop
       }
 

--- a/packages/tailwindcss/src/compat/apply-compat-hooks.ts
+++ b/packages/tailwindcss/src/compat/apply-compat-hooks.ts
@@ -1,4 +1,4 @@
-import { rule, toCss, walk, WalkAction, type AstNode } from '../ast'
+import { styleRule, toCss, walk, WalkAction, type AstNode } from '../ast'
 import type { DesignSystem } from '../design-system'
 import { segment } from '../utils/segment'
 import { applyConfigToTheme } from './apply-config-to-theme'
@@ -276,7 +276,7 @@ function upgradeToFullPluginSupport({
         return WalkAction.Stop
       }
 
-      replaceWith(rule(wrappingSelector, [node]))
+      replaceWith(styleRule(wrappingSelector, [node]))
 
       return WalkAction.Stop
     })

--- a/packages/tailwindcss/src/compat/apply-keyframes-to-theme.test.ts
+++ b/packages/tailwindcss/src/compat/apply-keyframes-to-theme.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { atRule, decl, styleRule, toCss } from '../ast'
+import { atRule, decl, rule, toCss } from '../ast'
 import { buildDesignSystem } from '../design-system'
 import { Theme } from '../theme'
 import { applyKeyframesToTheme } from './apply-keyframes-to-theme'
@@ -59,14 +59,14 @@ test('will append to the default keyframes with new keyframes', () => {
 
   theme.addKeyframes(
     atRule('keyframes', 'slide-in', [
-      styleRule('from', [decl('opacity', 'translateX(0%)')]),
-      styleRule('to', [decl('opacity', 'translateX(100%)')]),
+      rule('from', [decl('opacity', 'translateX(0%)')]),
+      rule('to', [decl('opacity', 'translateX(100%)')]),
     ]),
   )
   theme.addKeyframes(
     atRule('keyframes', 'slide-out', [
-      styleRule('from', [decl('opacity', 'translateX(100%)')]),
-      styleRule('to', [decl('opacity', 'translateX(0%)')]),
+      rule('from', [decl('opacity', 'translateX(100%)')]),
+      rule('to', [decl('opacity', 'translateX(0%)')]),
     ]),
   )
 

--- a/packages/tailwindcss/src/compat/apply-keyframes-to-theme.test.ts
+++ b/packages/tailwindcss/src/compat/apply-keyframes-to-theme.test.ts
@@ -58,13 +58,13 @@ test('will append to the default keyframes with new keyframes', () => {
   let design = buildDesignSystem(theme)
 
   theme.addKeyframes(
-    atRule('keyframes', 'slide-in', [
+    atRule('@keyframes', 'slide-in', [
       styleRule('from', [decl('opacity', 'translateX(0%)')]),
       styleRule('to', [decl('opacity', 'translateX(100%)')]),
     ]),
   )
   theme.addKeyframes(
-    atRule('keyframes', 'slide-out', [
+    atRule('@keyframes', 'slide-out', [
       styleRule('from', [decl('opacity', 'translateX(100%)')]),
       styleRule('to', [decl('opacity', 'translateX(0%)')]),
     ]),

--- a/packages/tailwindcss/src/compat/apply-keyframes-to-theme.test.ts
+++ b/packages/tailwindcss/src/compat/apply-keyframes-to-theme.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { decl, rule, toCss } from '../ast'
+import { atRule, decl, rule, toCss } from '../ast'
 import { buildDesignSystem } from '../design-system'
 import { Theme } from '../theme'
 import { applyKeyframesToTheme } from './apply-keyframes-to-theme'
@@ -58,13 +58,13 @@ test('will append to the default keyframes with new keyframes', () => {
   let design = buildDesignSystem(theme)
 
   theme.addKeyframes(
-    rule('@keyframes slide-in', [
+    atRule('keyframes', 'slide-in', [
       rule('from', [decl('opacity', 'translateX(0%)')]),
       rule('to', [decl('opacity', 'translateX(100%)')]),
     ]),
   )
   theme.addKeyframes(
-    rule('@keyframes slide-out', [
+    atRule('keyframes', 'slide-out', [
       rule('from', [decl('opacity', 'translateX(100%)')]),
       rule('to', [decl('opacity', 'translateX(0%)')]),
     ]),

--- a/packages/tailwindcss/src/compat/apply-keyframes-to-theme.test.ts
+++ b/packages/tailwindcss/src/compat/apply-keyframes-to-theme.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { atRule, decl, rule, toCss } from '../ast'
+import { atRule, decl, styleRule, toCss } from '../ast'
 import { buildDesignSystem } from '../design-system'
 import { Theme } from '../theme'
 import { applyKeyframesToTheme } from './apply-keyframes-to-theme'
@@ -59,14 +59,14 @@ test('will append to the default keyframes with new keyframes', () => {
 
   theme.addKeyframes(
     atRule('keyframes', 'slide-in', [
-      rule('from', [decl('opacity', 'translateX(0%)')]),
-      rule('to', [decl('opacity', 'translateX(100%)')]),
+      styleRule('from', [decl('opacity', 'translateX(0%)')]),
+      styleRule('to', [decl('opacity', 'translateX(100%)')]),
     ]),
   )
   theme.addKeyframes(
     atRule('keyframes', 'slide-out', [
-      rule('from', [decl('opacity', 'translateX(100%)')]),
-      rule('to', [decl('opacity', 'translateX(0%)')]),
+      styleRule('from', [decl('opacity', 'translateX(100%)')]),
+      styleRule('to', [decl('opacity', 'translateX(0%)')]),
     ]),
   )
 

--- a/packages/tailwindcss/src/compat/apply-keyframes-to-theme.ts
+++ b/packages/tailwindcss/src/compat/apply-keyframes-to-theme.ts
@@ -1,4 +1,4 @@
-import { rule, type Rule } from '../ast'
+import { styleRule, type StyleRule } from '../ast'
 import type { DesignSystem } from '../design-system'
 import type { ResolvedConfig } from './config/types'
 import { objectToAst } from './plugin-api'
@@ -13,11 +13,11 @@ export function applyKeyframesToTheme(
   }
 }
 
-export function keyframesToRules(resolvedConfig: Pick<ResolvedConfig, 'theme'>): Rule[] {
-  let rules: Rule[] = []
+export function keyframesToRules(resolvedConfig: Pick<ResolvedConfig, 'theme'>): StyleRule[] {
+  let rules: StyleRule[] = []
   if ('keyframes' in resolvedConfig.theme) {
     for (let [name, keyframe] of Object.entries(resolvedConfig.theme.keyframes)) {
-      rules.push(rule(`@keyframes ${name}`, objectToAst(keyframe as any)))
+      rules.push(styleRule(`@keyframes ${name}`, objectToAst(keyframe as any)))
     }
   }
   return rules

--- a/packages/tailwindcss/src/compat/apply-keyframes-to-theme.ts
+++ b/packages/tailwindcss/src/compat/apply-keyframes-to-theme.ts
@@ -17,7 +17,7 @@ export function keyframesToRules(resolvedConfig: Pick<ResolvedConfig, 'theme'>):
   let rules: AtRule[] = []
   if ('keyframes' in resolvedConfig.theme) {
     for (let [name, keyframe] of Object.entries(resolvedConfig.theme.keyframes)) {
-      rules.push(atRule('keyframes', name, objectToAst(keyframe as any)))
+      rules.push(atRule('@keyframes', name, objectToAst(keyframe as any)))
     }
   }
   return rules

--- a/packages/tailwindcss/src/compat/apply-keyframes-to-theme.ts
+++ b/packages/tailwindcss/src/compat/apply-keyframes-to-theme.ts
@@ -1,4 +1,4 @@
-import { styleRule, type StyleRule } from '../ast'
+import { atRule, type AtRule } from '../ast'
 import type { DesignSystem } from '../design-system'
 import type { ResolvedConfig } from './config/types'
 import { objectToAst } from './plugin-api'
@@ -13,11 +13,11 @@ export function applyKeyframesToTheme(
   }
 }
 
-export function keyframesToRules(resolvedConfig: Pick<ResolvedConfig, 'theme'>): StyleRule[] {
-  let rules: StyleRule[] = []
+export function keyframesToRules(resolvedConfig: Pick<ResolvedConfig, 'theme'>): AtRule[] {
+  let rules: AtRule[] = []
   if ('keyframes' in resolvedConfig.theme) {
     for (let [name, keyframe] of Object.entries(resolvedConfig.theme.keyframes)) {
-      rules.push(styleRule(`@keyframes ${name}`, objectToAst(keyframe as any)))
+      rules.push(atRule('keyframes', name, objectToAst(keyframe as any)))
     }
   }
   return rules

--- a/packages/tailwindcss/src/compat/plugin-api.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.ts
@@ -1,5 +1,5 @@
 import { substituteAtApply } from '../apply'
-import { decl, rule, type AstNode } from '../ast'
+import { atRule, decl, rule, type AstNode } from '../ast'
 import type { Candidate, CandidateModifier, NamedUtilityValue } from '../candidate'
 import { substituteFunctions } from '../css-functions'
 import * as CSS from '../css-parser'
@@ -86,7 +86,7 @@ export function buildPluginApi(
     addBase(css) {
       let baseNodes = objectToAst(css)
       substituteFunctions(baseNodes, api.theme)
-      ast.push(rule('@layer base', baseNodes))
+      ast.push(atRule('layer', 'base', baseNodes))
     },
 
     addVariant(name, variant) {
@@ -210,7 +210,7 @@ export function buildPluginApi(
 
       for (let [name, css] of Object.entries(utils)) {
         if (name.startsWith('@keyframes ')) {
-          ast.push(rule(name, objectToAst(css)))
+          ast.push(CSS.parseAtRule(name, objectToAst(css)))
           continue
         }
 
@@ -434,7 +434,11 @@ export function objectToAst(rules: CssInJs | CssInJs[]): AstNode[] {
   for (let [name, value] of entries) {
     if (typeof value !== 'object') {
       if (!name.startsWith('--') && value === '@slot') {
-        ast.push(rule(name, [rule('@slot', [])]))
+        if (name[0] === '@') {
+          ast.push(CSS.parseAtRule(name, [atRule('slot')]))
+        } else {
+          ast.push(rule(name, [atRule('slot')]))
+        }
       } else {
         // Convert camelCase to kebab-case:
         // https://github.com/postcss/postcss-js/blob/b3db658b932b42f6ac14ca0b1d50f50c4569805b/parser.js#L30-L35
@@ -447,11 +451,19 @@ export function objectToAst(rules: CssInJs | CssInJs[]): AstNode[] {
         if (typeof item === 'string') {
           ast.push(decl(name, item))
         } else {
-          ast.push(rule(name, objectToAst(item)))
+          if (name[0] === '@') {
+            ast.push(CSS.parseAtRule(name, objectToAst(item)))
+          } else {
+            ast.push(rule(name, objectToAst(item)))
+          }
         }
       }
     } else if (value !== null) {
-      ast.push(rule(name, objectToAst(value)))
+      if (name[0] === '@') {
+        ast.push(CSS.parseAtRule(name, objectToAst(value)))
+      } else {
+        ast.push(rule(name, objectToAst(value)))
+      }
     }
   }
 

--- a/packages/tailwindcss/src/compat/plugin-api.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.ts
@@ -1,5 +1,5 @@
 import { substituteAtApply } from '../apply'
-import { atRule, decl, rule, type AstNode } from '../ast'
+import { atRule, decl, styleRule, type AstNode } from '../ast'
 import type { Candidate, CandidateModifier, NamedUtilityValue } from '../candidate'
 import { substituteFunctions } from '../css-functions'
 import * as CSS from '../css-parser'
@@ -437,7 +437,7 @@ export function objectToAst(rules: CssInJs | CssInJs[]): AstNode[] {
         if (name[0] === '@') {
           ast.push(CSS.parseAtRule(name, [atRule('slot')]))
         } else {
-          ast.push(rule(name, [atRule('slot')]))
+          ast.push(styleRule(name, [atRule('slot')]))
         }
       } else {
         // Convert camelCase to kebab-case:
@@ -454,7 +454,7 @@ export function objectToAst(rules: CssInJs | CssInJs[]): AstNode[] {
           if (name[0] === '@') {
             ast.push(CSS.parseAtRule(name, objectToAst(item)))
           } else {
-            ast.push(rule(name, objectToAst(item)))
+            ast.push(styleRule(name, objectToAst(item)))
           }
         }
       }
@@ -462,7 +462,7 @@ export function objectToAst(rules: CssInJs | CssInJs[]): AstNode[] {
       if (name[0] === '@') {
         ast.push(CSS.parseAtRule(name, objectToAst(value)))
       } else {
-        ast.push(rule(name, objectToAst(value)))
+        ast.push(styleRule(name, objectToAst(value)))
       }
     }
   }
@@ -479,7 +479,7 @@ function parseVariantValue(resolved: string | string[], nodes: AstNode[]): AstNo
       substituteAtSlot(ast, nodes)
       return ast
     } else {
-      return rule(r, nodes)
+      return styleRule(r, nodes)
     }
   })
 }

--- a/packages/tailwindcss/src/compat/plugin-api.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.ts
@@ -1,5 +1,5 @@
 import { substituteAtApply } from '../apply'
-import { atRule, decl, rule, styleRule, type AstNode } from '../ast'
+import { atRule, decl, rule, type AstNode } from '../ast'
 import type { Candidate, CandidateModifier, NamedUtilityValue } from '../candidate'
 import { substituteFunctions } from '../css-functions'
 import * as CSS from '../css-parser'
@@ -467,7 +467,7 @@ function parseVariantValue(resolved: string | string[], nodes: AstNode[]): AstNo
       substituteAtSlot(ast, nodes)
       return ast
     } else {
-      return styleRule(r, nodes)
+      return rule(r, nodes)
     }
   })
 }

--- a/packages/tailwindcss/src/compat/plugin-api.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.ts
@@ -86,7 +86,7 @@ export function buildPluginApi(
     addBase(css) {
       let baseNodes = objectToAst(css)
       substituteFunctions(baseNodes, api.theme)
-      ast.push(atRule('layer', 'base', baseNodes))
+      ast.push(atRule('@layer', 'base', baseNodes))
     },
 
     addVariant(name, variant) {
@@ -434,7 +434,7 @@ export function objectToAst(rules: CssInJs | CssInJs[]): AstNode[] {
   for (let [name, value] of entries) {
     if (typeof value !== 'object') {
       if (!name.startsWith('--') && value === '@slot') {
-        ast.push(rule(name, [atRule('slot')]))
+        ast.push(rule(name, [atRule('@slot')]))
       } else {
         // Convert camelCase to kebab-case:
         // https://github.com/postcss/postcss-js/blob/b3db658b932b42f6ac14ca0b1d50f50c4569805b/parser.js#L30-L35

--- a/packages/tailwindcss/src/compat/plugin-api.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.ts
@@ -1,5 +1,5 @@
 import { substituteAtApply } from '../apply'
-import { atRule, decl, styleRule, type AstNode } from '../ast'
+import { atRule, decl, rule, styleRule, type AstNode } from '../ast'
 import type { Candidate, CandidateModifier, NamedUtilityValue } from '../candidate'
 import { substituteFunctions } from '../css-functions'
 import * as CSS from '../css-parser'
@@ -210,7 +210,7 @@ export function buildPluginApi(
 
       for (let [name, css] of Object.entries(utils)) {
         if (name.startsWith('@keyframes ')) {
-          ast.push(CSS.parseAtRule(name, objectToAst(css)))
+          ast.push(rule(name, objectToAst(css)))
           continue
         }
 
@@ -434,11 +434,7 @@ export function objectToAst(rules: CssInJs | CssInJs[]): AstNode[] {
   for (let [name, value] of entries) {
     if (typeof value !== 'object') {
       if (!name.startsWith('--') && value === '@slot') {
-        if (name[0] === '@') {
-          ast.push(CSS.parseAtRule(name, [atRule('slot')]))
-        } else {
-          ast.push(styleRule(name, [atRule('slot')]))
-        }
+        ast.push(rule(name, [atRule('slot')]))
       } else {
         // Convert camelCase to kebab-case:
         // https://github.com/postcss/postcss-js/blob/b3db658b932b42f6ac14ca0b1d50f50c4569805b/parser.js#L30-L35
@@ -451,19 +447,11 @@ export function objectToAst(rules: CssInJs | CssInJs[]): AstNode[] {
         if (typeof item === 'string') {
           ast.push(decl(name, item))
         } else {
-          if (name[0] === '@') {
-            ast.push(CSS.parseAtRule(name, objectToAst(item)))
-          } else {
-            ast.push(styleRule(name, objectToAst(item)))
-          }
+          ast.push(rule(name, objectToAst(item)))
         }
       }
     } else if (value !== null) {
-      if (name[0] === '@') {
-        ast.push(CSS.parseAtRule(name, objectToAst(value)))
-      } else {
-        ast.push(styleRule(name, objectToAst(value)))
-      }
+      ast.push(rule(name, objectToAst(value)))
     }
   }
 

--- a/packages/tailwindcss/src/compat/screens-config.ts
+++ b/packages/tailwindcss/src/compat/screens-config.ts
@@ -45,7 +45,7 @@ export function registerScreensConfig(userConfig: ResolvedConfig, designSystem: 
       designSystem.variants.static(
         name,
         (ruleNode) => {
-          ruleNode.nodes = [atRule('media', query, ruleNode.nodes)]
+          ruleNode.nodes = [atRule('@media', query, ruleNode.nodes)]
         },
         { order },
       )

--- a/packages/tailwindcss/src/compat/screens-config.ts
+++ b/packages/tailwindcss/src/compat/screens-config.ts
@@ -1,4 +1,4 @@
-import { rule } from '../ast'
+import { styleRule } from '../ast'
 import type { DesignSystem } from '../design-system'
 import type { ResolvedConfig } from './config/types'
 
@@ -45,7 +45,7 @@ export function registerScreensConfig(userConfig: ResolvedConfig, designSystem: 
       designSystem.variants.static(
         name,
         (ruleNode) => {
-          ruleNode.nodes = [rule(`@media ${query}`, ruleNode.nodes)]
+          ruleNode.nodes = [styleRule(`@media ${query}`, ruleNode.nodes)]
         },
         { order },
       )

--- a/packages/tailwindcss/src/compat/screens-config.ts
+++ b/packages/tailwindcss/src/compat/screens-config.ts
@@ -1,4 +1,4 @@
-import { styleRule } from '../ast'
+import { rule } from '../ast'
 import type { DesignSystem } from '../design-system'
 import type { ResolvedConfig } from './config/types'
 
@@ -45,7 +45,7 @@ export function registerScreensConfig(userConfig: ResolvedConfig, designSystem: 
       designSystem.variants.static(
         name,
         (ruleNode) => {
-          ruleNode.nodes = [styleRule(`@media ${query}`, ruleNode.nodes)]
+          ruleNode.nodes = [rule(`@media ${query}`, ruleNode.nodes)]
         },
         { order },
       )

--- a/packages/tailwindcss/src/compat/screens-config.ts
+++ b/packages/tailwindcss/src/compat/screens-config.ts
@@ -1,4 +1,4 @@
-import { rule } from '../ast'
+import { atRule } from '../ast'
 import type { DesignSystem } from '../design-system'
 import type { ResolvedConfig } from './config/types'
 
@@ -45,7 +45,7 @@ export function registerScreensConfig(userConfig: ResolvedConfig, designSystem: 
       designSystem.variants.static(
         name,
         (ruleNode) => {
-          ruleNode.nodes = [rule(`@media ${query}`, ruleNode.nodes)]
+          ruleNode.nodes = [atRule('media', query, ruleNode.nodes)]
         },
         { order },
       )

--- a/packages/tailwindcss/src/compile.ts
+++ b/packages/tailwindcss/src/compile.ts
@@ -214,7 +214,7 @@ export function applyVariant(
     // To solve this, we provide an isolated placeholder node to the variant.
     // The variant can now apply its logic to the isolated node without
     // affecting the original node.
-    let isolatedNode = atRule('slot')
+    let isolatedNode = atRule('@slot')
 
     let result = applyVariant(isolatedNode, variant.variant, variants, depth + 1)
     if (result === null) return null

--- a/packages/tailwindcss/src/compile.ts
+++ b/packages/tailwindcss/src/compile.ts
@@ -1,7 +1,15 @@
-import { atRule, decl, styleRule, walk, WalkAction, type AstNode, type AtRule, type StyleRule } from './ast'
+import {
+  atRule,
+  decl,
+  rule,
+  walk,
+  WalkAction,
+  type AstNode,
+  type Rule,
+  type StyleRule,
+} from './ast'
 import { type Candidate, type Variant } from './candidate'
 import { substituteFunctions } from './css-functions'
-import { parseAtRule } from './css-parser'
 import { type DesignSystem } from './design-system'
 import GLOBAL_PROPERTY_ORDER from './property-order'
 import { asColor, type Utility } from './utilities'
@@ -170,7 +178,7 @@ export function compileAstNodes(candidate: Candidate, designSystem: DesignSystem
 }
 
 export function applyVariant(
-  node: AtRule | StyleRule,
+  node: Rule,
   variant: Variant,
   variants: Variants,
   depth: number = 0,
@@ -182,11 +190,7 @@ export function applyVariant(
     // E.g. `[>img]:flex` is not valid, but `has-[>img]:flex` is
     if (variant.relative && depth === 0) return null
 
-    if (variant.selector[0] === '@') {
-      node.nodes = [parseAtRule(variant.selector, node.nodes)]
-    } else {
-      node.nodes = [styleRule(variant.selector, node.nodes)]
-    }
+    node.nodes = [rule(variant.selector, node.nodes)]
     return
   }
 

--- a/packages/tailwindcss/src/compile.ts
+++ b/packages/tailwindcss/src/compile.ts
@@ -154,7 +154,7 @@ export function compileAstNodes(candidate: Candidate, designSystem: DesignSystem
     }
 
     let node: StyleRule = {
-      kind: 'style-rule',
+      kind: 'rule',
       selector,
       nodes,
     }
@@ -227,7 +227,7 @@ export function applyVariant(
       // This means `child` may be a declaration and we don't want to apply the
       // variant to it. This also means the entire variant as a whole is not
       // applicable to the rule and should generate nothing.
-      if (child.kind !== 'style-rule' && child.kind !== 'at-rule') return null
+      if (child.kind !== 'rule' && child.kind !== 'at-rule') return null
 
       let result = applyFn(child, variant)
       if (result === null) return null
@@ -236,7 +236,7 @@ export function applyVariant(
     // Replace the placeholder node with the actual node
     {
       walk(isolatedNode.nodes, (child) => {
-        if ((child.kind === 'style-rule' || child.kind === 'at-rule') && child.nodes.length <= 0) {
+        if ((child.kind === 'rule' || child.kind === 'at-rule') && child.nodes.length <= 0) {
           child.nodes = node.nodes
           return WalkAction.Skip
         }
@@ -310,7 +310,7 @@ function applyImportant(ast: AstNode[]): void {
 
     if (node.kind === 'declaration') {
       node.important = true
-    } else if (node.kind === 'style-rule' || node.kind === 'at-rule') {
+    } else if (node.kind === 'rule' || node.kind === 'at-rule') {
       applyImportant(node.nodes)
     }
   }
@@ -336,7 +336,7 @@ function getPropertySort(nodes: AstNode[]) {
 
       let idx = GLOBAL_PROPERTY_ORDER.indexOf(node.property)
       if (idx !== -1) propertySort.add(idx)
-    } else if (node.kind === 'style-rule' || node.kind === 'at-rule') {
+    } else if (node.kind === 'rule' || node.kind === 'at-rule') {
       for (let child of node.nodes) {
         q.push(child)
       }

--- a/packages/tailwindcss/src/compile.ts
+++ b/packages/tailwindcss/src/compile.ts
@@ -1,6 +1,7 @@
-import { decl, rule, walk, WalkAction, type AstNode, type Rule } from './ast'
+import { atRule, decl, rule, walk, WalkAction, type AstNode, type AtRule, type Rule } from './ast'
 import { type Candidate, type Variant } from './candidate'
 import { substituteFunctions } from './css-functions'
+import { parseAtRule } from './css-parser'
 import { type DesignSystem } from './design-system'
 import GLOBAL_PROPERTY_ORDER from './property-order'
 import { asColor, type Utility } from './utilities'
@@ -169,7 +170,7 @@ export function compileAstNodes(candidate: Candidate, designSystem: DesignSystem
 }
 
 export function applyVariant(
-  node: Rule,
+  node: AtRule | Rule,
   variant: Variant,
   variants: Variants,
   depth: number = 0,
@@ -181,7 +182,11 @@ export function applyVariant(
     // E.g. `[>img]:flex` is not valid, but `has-[>img]:flex` is
     if (variant.relative && depth === 0) return null
 
-    node.nodes = [rule(variant.selector, node.nodes)]
+    if (variant.selector[0] === '@') {
+      node.nodes = [parseAtRule(variant.selector, node.nodes)]
+    } else {
+      node.nodes = [rule(variant.selector, node.nodes)]
+    }
     return
   }
 
@@ -205,7 +210,7 @@ export function applyVariant(
     // To solve this, we provide an isolated placeholder node to the variant.
     // The variant can now apply its logic to the isolated node without
     // affecting the original node.
-    let isolatedNode = rule('@slot', [])
+    let isolatedNode = atRule('slot')
 
     let result = applyVariant(isolatedNode, variant.variant, variants, depth + 1)
     if (result === null) return null
@@ -218,16 +223,16 @@ export function applyVariant(
       // This means `child` may be a declaration and we don't want to apply the
       // variant to it. This also means the entire variant as a whole is not
       // applicable to the rule and should generate nothing.
-      if (child.kind !== 'rule') return null
+      if (child.kind !== 'rule' && child.kind !== 'at-rule') return null
 
-      let result = applyFn(child as Rule, variant)
+      let result = applyFn(child, variant)
       if (result === null) return null
     }
 
     // Replace the placeholder node with the actual node
     {
       walk(isolatedNode.nodes, (child) => {
-        if (child.kind === 'rule' && child.nodes.length <= 0) {
+        if ((child.kind === 'rule' || child.kind === 'at-rule') && child.nodes.length <= 0) {
           child.nodes = node.nodes
           return WalkAction.Skip
         }
@@ -301,7 +306,7 @@ function applyImportant(ast: AstNode[]): void {
 
     if (node.kind === 'declaration') {
       node.important = true
-    } else if (node.kind === 'rule') {
+    } else if (node.kind === 'rule' || node.kind === 'at-rule') {
       applyImportant(node.nodes)
     }
   }
@@ -327,7 +332,7 @@ function getPropertySort(nodes: AstNode[]) {
 
       let idx = GLOBAL_PROPERTY_ORDER.indexOf(node.property)
       if (idx !== -1) propertySort.add(idx)
-    } else if (node.kind === 'rule') {
+    } else if (node.kind === 'rule' || node.kind === 'at-rule') {
       for (let child of node.nodes) {
         q.push(child)
       }

--- a/packages/tailwindcss/src/css-functions.ts
+++ b/packages/tailwindcss/src/css-functions.ts
@@ -17,10 +17,10 @@ export function substituteFunctions(ast: AstNode[], resolveThemeValue: ResolveTh
     // Find at-rules rules
     if (node.kind === 'at-rule') {
       if (
-        (node.name === 'media' ||
-          node.name === 'custom-media' ||
-          node.name === 'container' ||
-          node.name === 'supports') &&
+        (node.name === '@media' ||
+          node.name === '@custom-media' ||
+          node.name === '@container' ||
+          node.name === '@supports') &&
         node.params.includes(THEME_FUNCTION_INVOCATION)
       ) {
         node.params = substituteFunctionsInValue(node.params, resolveThemeValue)

--- a/packages/tailwindcss/src/css-functions.ts
+++ b/packages/tailwindcss/src/css-functions.ts
@@ -15,20 +15,15 @@ export function substituteFunctions(ast: AstNode[], resolveThemeValue: ResolveTh
     }
 
     // Find at-rules rules
-    if (node.kind === 'rule') {
+    if (node.kind === 'at-rule') {
       if (
-        node.selector[0] === '@' &&
-        (node.selector.startsWith('@media ') ||
-          node.selector.startsWith('@media(') ||
-          node.selector.startsWith('@custom-media ') ||
-          node.selector.startsWith('@custom-media(') ||
-          node.selector.startsWith('@container ') ||
-          node.selector.startsWith('@container(') ||
-          node.selector.startsWith('@supports ') ||
-          node.selector.startsWith('@supports(')) &&
-        node.selector.includes(THEME_FUNCTION_INVOCATION)
+        (node.name === 'media' ||
+          node.name === 'custom-media' ||
+          node.name === 'container' ||
+          node.name === 'supports') &&
+        node.params.includes(THEME_FUNCTION_INVOCATION)
       ) {
-        node.selector = substituteFunctionsInValue(node.selector, resolveThemeValue)
+        node.params = substituteFunctionsInValue(node.params, resolveThemeValue)
       }
     }
   })

--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -34,7 +34,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'style-rule',
+          kind: 'rule',
           selector: '.foo',
           nodes: [],
         },
@@ -63,12 +63,12 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
           }
         `),
       ).toEqual([
-        { kind: 'style-rule', selector: '.foo.baz', nodes: [] },
-        { kind: 'style-rule', selector: '.foo.qux', nodes: [] },
-        { kind: 'style-rule', selector: '.foo .qux', nodes: [] },
-        { kind: 'style-rule', selector: '.foo .baz', nodes: [] },
-        { kind: 'style-rule', selector: '.foo .baz', nodes: [] },
-        { kind: 'style-rule', selector: '.foo .baz', nodes: [] },
+        { kind: 'rule', selector: '.foo.baz', nodes: [] },
+        { kind: 'rule', selector: '.foo.qux', nodes: [] },
+        { kind: 'rule', selector: '.foo .qux', nodes: [] },
+        { kind: 'rule', selector: '.foo .baz', nodes: [] },
+        { kind: 'rule', selector: '.foo .baz', nodes: [] },
+        { kind: 'rule', selector: '.foo .baz', nodes: [] },
       ])
     })
 
@@ -112,12 +112,12 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         { kind: 'comment', value: '! License #2.5 ' },
         { kind: 'comment', value: '! License #3 ' },
         {
-          kind: 'style-rule',
+          kind: 'rule',
           selector: '.foo',
           nodes: [{ kind: 'declaration', property: 'color', value: 'red', important: false }],
         },
         {
-          kind: 'style-rule',
+          kind: 'rule',
           selector: '.bar',
           nodes: [{ kind: 'declaration', property: 'color', value: 'blue', important: false }],
         },
@@ -133,7 +133,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'style-rule',
+          kind: 'rule',
           selector: '.dark p',
           nodes: [
             {
@@ -256,7 +256,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
       it('should parse a minified custom property', () => {
         expect(parse(':root{--foo:bar;}')).toEqual([
           {
-            kind: 'style-rule',
+            kind: 'rule',
             selector: ':root',
             nodes: [
               {
@@ -273,7 +273,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
       it('should parse a minified custom property with no semicolon ', () => {
         expect(parse(':root{--foo:bar}')).toEqual([
           {
-            kind: 'style-rule',
+            kind: 'rule',
             selector: ':root',
             nodes: [
               {
@@ -466,7 +466,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         { kind: 'declaration', property: 'color', value: 'red', important: false },
         { kind: 'declaration', property: 'font-weight', value: 'bold', important: false },
         {
-          kind: 'style-rule',
+          kind: 'rule',
           selector: '.foo',
           nodes: [
             {
@@ -492,7 +492,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'style-rule',
+          kind: 'rule',
           selector: '.foo',
           nodes: [
             {
@@ -514,7 +514,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
           .foo {
           }
         `),
-      ).toEqual([{ kind: 'style-rule', selector: '.foo', nodes: [] }])
+      ).toEqual([{ kind: 'rule', selector: '.foo', nodes: [] }])
     })
 
     it('should parse selectors with escaped characters', () => {
@@ -526,8 +526,8 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
           }
         `),
       ).toEqual([
-        { kind: 'style-rule', selector: '.hover\\:foo:hover', nodes: [] },
-        { kind: 'style-rule', selector: '.\\32 xl\\:foo', nodes: [] },
+        { kind: 'rule', selector: '.hover\\:foo:hover', nodes: [] },
+        { kind: 'rule', selector: '.\\32 xl\\:foo', nodes: [] },
       ])
     })
 
@@ -538,7 +538,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
           .bar {
           }
         `),
-      ).toEqual([{ kind: 'style-rule', selector: '.foo, .bar', nodes: [] }])
+      ).toEqual([{ kind: 'rule', selector: '.foo, .bar', nodes: [] }])
     })
 
     it('should parse multiple declarations inside of a selector', () => {
@@ -551,7 +551,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'style-rule',
+          kind: 'rule',
           selector: '.foo',
           nodes: [
             { kind: 'declaration', property: 'color', value: 'red', important: false },
@@ -571,7 +571,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'style-rule',
+          kind: 'rule',
           selector: '.foo',
           nodes: [
             { kind: 'declaration', property: 'color', value: 'red', important: false },
@@ -591,7 +591,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'style-rule',
+          kind: 'rule',
           selector: '.foo',
           nodes: [
             { kind: 'declaration', property: 'color', value: 'red', important: false },
@@ -604,7 +604,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
     it('should parse a multi-line selector', () => {
       expect(parse(['.foo,', '.bar,', '.baz', '{', 'color:red;', '}'].join('\n'))).toEqual([
         {
-          kind: 'style-rule',
+          kind: 'rule',
           selector: '.foo, .bar, .baz',
           nodes: [{ kind: 'declaration', property: 'color', value: 'red', important: false }],
         },
@@ -616,7 +616,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         parse(['.foo,', '.bar,', '.baz\t\n \n .qux', '{', 'color:red;', '}'].join('\n')),
       ).toEqual([
         {
-          kind: 'style-rule',
+          kind: 'rule',
           selector: '.foo, .bar, .baz .qux',
           nodes: [{ kind: 'declaration', property: 'color', value: 'red', important: false }],
         },
@@ -677,7 +677,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
           nodes: [{ kind: 'at-rule', name: 'charset', params: '"UTF-8"', nodes: [] }],
         },
         {
-          kind: 'style-rule',
+          kind: 'rule',
           selector: '.foo',
           nodes: [
             { kind: 'at-rule', name: 'apply', params: 'font-bold hover:text-red-500', nodes: [] },
@@ -720,7 +720,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
           params: '(width >= 600px)',
           nodes: [
             {
-              kind: 'style-rule',
+              kind: 'rule',
               selector: '.foo',
               nodes: [
                 { kind: 'declaration', property: 'color', value: 'red', important: false },
@@ -760,7 +760,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'style-rule',
+          kind: 'rule',
           nodes: [
             {
               kind: 'at-rule',
@@ -790,15 +790,15 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'style-rule',
+          kind: 'rule',
           selector: '.foo',
           nodes: [
             {
-              kind: 'style-rule',
+              kind: 'rule',
               selector: '.bar',
               nodes: [
                 {
-                  kind: 'style-rule',
+                  kind: 'rule',
                   selector: '.baz',
                   nodes: [
                     { kind: 'declaration', property: 'color', value: 'red', important: false },
@@ -824,12 +824,12 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'style-rule',
+          kind: 'rule',
           selector: '.foo',
           nodes: [
             { kind: 'declaration', property: 'color', value: 'red', important: false },
             {
-              kind: 'style-rule',
+              kind: 'rule',
               selector: '&:hover',
               nodes: [{ kind: 'declaration', property: 'color', value: 'blue', important: false }],
             },
@@ -853,16 +853,16 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'style-rule',
+          kind: 'rule',
           selector: '.foo',
           nodes: [
             {
-              kind: 'style-rule',
+              kind: 'rule',
               selector: '.bar',
               nodes: [{ kind: 'declaration', property: 'color', value: 'red', important: false }],
             },
             {
-              kind: 'style-rule',
+              kind: 'rule',
               selector: '.baz',
               nodes: [{ kind: 'declaration', property: 'color', value: 'blue', important: false }],
             },
@@ -893,7 +893,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'style-rule',
+          kind: 'rule',
           selector: '.foo',
           nodes: [
             { kind: 'declaration', property: 'font-weight', value: 'bold', important: false },
@@ -904,13 +904,13 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
               important: false,
             },
             {
-              kind: 'style-rule',
+              kind: 'rule',
               selector: '.bar',
               nodes: [{ kind: 'declaration', property: 'color', value: 'red', important: false }],
             },
             { kind: 'declaration', property: '--in-between', value: '1', important: false },
             {
-              kind: 'style-rule',
+              kind: 'rule',
               selector: '.baz',
               nodes: [{ kind: 'declaration', property: 'color', value: 'blue', important: false }],
             },
@@ -944,7 +944,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         parse('.foo{color:red;@media(width>=600px){.bar{color:blue;font-weight:bold}}}'),
       ).toEqual([
         {
-          kind: 'style-rule',
+          kind: 'rule',
           selector: '.foo',
           nodes: [
             { kind: 'declaration', property: 'color', value: 'red', important: false },
@@ -954,7 +954,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
               params: '(width>=600px)',
               nodes: [
                 {
-                  kind: 'style-rule',
+                  kind: 'rule',
                   selector: '.bar',
                   nodes: [
                     { kind: 'declaration', property: 'color', value: 'blue', important: false },
@@ -982,7 +982,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'style-rule',
+          kind: 'rule',
           selector: '.foo:has(.bar )',
           nodes: [{ kind: 'declaration', property: 'color', value: 'red', important: false }],
         },

--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -630,7 +630,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         parse(css`
           @charset "UTF-8";
         `),
-      ).toEqual([{ kind: 'rule', selector: '@charset "UTF-8"', nodes: [] }])
+      ).toEqual([{ kind: 'at-rule', name: 'charset', params: '"UTF-8"', nodes: [] }])
     })
 
     it('should parse an at-rule without a block or semicolon', () => {
@@ -638,7 +638,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         parse(`
           @tailwind utilities
         `),
-      ).toEqual([{ kind: 'rule', selector: '@tailwind utilities', nodes: [] }])
+      ).toEqual([{ kind: 'at-rule', name: 'tailwind', params: 'utilities', nodes: [] }])
     })
 
     it("should parse an at-rule without a block or semicolon when it's the last rule in a block", () => {
@@ -650,9 +650,10 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'rule',
-          selector: '@layer utilities',
-          nodes: [{ kind: 'rule', selector: '@tailwind utilities', nodes: [] }],
+          kind: 'at-rule',
+          name: 'layer',
+          params: 'utilities',
+          nodes: [{ kind: 'at-rule', name: 'tailwind', params: 'utilities', nodes: [] }],
         },
       ])
     })
@@ -670,14 +671,17 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'rule',
-          selector: '@layer utilities',
-          nodes: [{ kind: 'rule', selector: '@charset "UTF-8"', nodes: [] }],
+          kind: 'at-rule',
+          name: 'layer',
+          params: 'utilities',
+          nodes: [{ kind: 'at-rule', name: 'charset', params: '"UTF-8"', nodes: [] }],
         },
         {
           kind: 'rule',
           selector: '.foo',
-          nodes: [{ kind: 'rule', selector: '@apply font-bold hover:text-red-500', nodes: [] }],
+          nodes: [
+            { kind: 'at-rule', name: 'apply', params: 'font-bold hover:text-red-500', nodes: [] },
+          ],
         },
       ])
     })
@@ -689,8 +693,8 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
           @tailwind base;
         `),
       ).toEqual([
-        { kind: 'rule', selector: '@tailwind', nodes: [] },
-        { kind: 'rule', selector: '@tailwind base', nodes: [] },
+        { kind: 'at-rule', name: 'tailwind', params: '', nodes: [] },
+        { kind: 'at-rule', name: 'tailwind', params: 'base', nodes: [] },
       ])
     })
 
@@ -711,8 +715,9 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'rule',
-          selector: '@media (width >= 600px)',
+          kind: 'at-rule',
+          name: 'media',
+          params: '(width >= 600px)',
           nodes: [
             {
               kind: 'rule',
@@ -720,15 +725,17 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
               nodes: [
                 { kind: 'declaration', property: 'color', value: 'red', important: false },
                 {
-                  kind: 'rule',
-                  selector: '@media (width >= 800px)',
+                  kind: 'at-rule',
+                  name: 'media',
+                  params: '(width >= 800px)',
                   nodes: [
                     { kind: 'declaration', property: 'color', value: 'blue', important: false },
                   ],
                 },
                 {
-                  kind: 'rule',
-                  selector: '@media (width >= 1000px)',
+                  kind: 'at-rule',
+                  name: 'media',
+                  params: '(width >= 1000px)',
                   nodes: [
                     { kind: 'declaration', property: 'color', value: 'green', important: false },
                   ],
@@ -756,10 +763,11 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
           kind: 'rule',
           nodes: [
             {
-              kind: 'rule',
+              kind: 'at-rule',
+              name: 'apply',
+              params:
+                'hover:text-red-100 sm:hover:text-red-200 md:hover:text-red-300 lg:hover:text-red-400 xl:hover:text-red-500',
               nodes: [],
-              selector:
-                '@apply hover:text-red-100 sm:hover:text-red-200 md:hover:text-red-300 lg:hover:text-red-400 xl:hover:text-red-500',
             },
           ],
           selector: '.foo',
@@ -923,8 +931,9 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'rule',
-          selector: '@custom \\{',
+          kind: 'at-rule',
+          name: 'custom',
+          params: '\\{',
           nodes: [{ kind: 'declaration', property: 'foo', value: 'bar', important: false }],
         },
       ])
@@ -940,8 +949,9 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
           nodes: [
             { kind: 'declaration', property: 'color', value: 'red', important: false },
             {
-              kind: 'rule',
-              selector: '@media(width>=600px)',
+              kind: 'at-rule',
+              name: 'media',
+              params: '(width>=600px)',
               nodes: [
                 {
                   kind: 'rule',

--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -630,7 +630,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         parse(css`
           @charset "UTF-8";
         `),
-      ).toEqual([{ kind: 'at-rule', name: 'charset', params: '"UTF-8"', nodes: [] }])
+      ).toEqual([{ kind: 'at-rule', name: '@charset', params: '"UTF-8"', nodes: [] }])
     })
 
     it('should parse an at-rule without a block or semicolon', () => {
@@ -638,7 +638,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         parse(`
           @tailwind utilities
         `),
-      ).toEqual([{ kind: 'at-rule', name: 'tailwind', params: 'utilities', nodes: [] }])
+      ).toEqual([{ kind: 'at-rule', name: '@tailwind', params: 'utilities', nodes: [] }])
     })
 
     it("should parse an at-rule without a block or semicolon when it's the last rule in a block", () => {
@@ -651,9 +651,9 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
       ).toEqual([
         {
           kind: 'at-rule',
-          name: 'layer',
+          name: '@layer',
           params: 'utilities',
-          nodes: [{ kind: 'at-rule', name: 'tailwind', params: 'utilities', nodes: [] }],
+          nodes: [{ kind: 'at-rule', name: '@tailwind', params: 'utilities', nodes: [] }],
         },
       ])
     })
@@ -672,15 +672,15 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
       ).toEqual([
         {
           kind: 'at-rule',
-          name: 'layer',
+          name: '@layer',
           params: 'utilities',
-          nodes: [{ kind: 'at-rule', name: 'charset', params: '"UTF-8"', nodes: [] }],
+          nodes: [{ kind: 'at-rule', name: '@charset', params: '"UTF-8"', nodes: [] }],
         },
         {
           kind: 'rule',
           selector: '.foo',
           nodes: [
-            { kind: 'at-rule', name: 'apply', params: 'font-bold hover:text-red-500', nodes: [] },
+            { kind: 'at-rule', name: '@apply', params: 'font-bold hover:text-red-500', nodes: [] },
           ],
         },
       ])
@@ -693,8 +693,8 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
           @tailwind base;
         `),
       ).toEqual([
-        { kind: 'at-rule', name: 'tailwind', params: '', nodes: [] },
-        { kind: 'at-rule', name: 'tailwind', params: 'base', nodes: [] },
+        { kind: 'at-rule', name: '@tailwind', params: '', nodes: [] },
+        { kind: 'at-rule', name: '@tailwind', params: 'base', nodes: [] },
       ])
     })
 
@@ -716,7 +716,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
       ).toEqual([
         {
           kind: 'at-rule',
-          name: 'media',
+          name: '@media',
           params: '(width >= 600px)',
           nodes: [
             {
@@ -726,7 +726,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
                 { kind: 'declaration', property: 'color', value: 'red', important: false },
                 {
                   kind: 'at-rule',
-                  name: 'media',
+                  name: '@media',
                   params: '(width >= 800px)',
                   nodes: [
                     { kind: 'declaration', property: 'color', value: 'blue', important: false },
@@ -734,7 +734,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
                 },
                 {
                   kind: 'at-rule',
-                  name: 'media',
+                  name: '@media',
                   params: '(width >= 1000px)',
                   nodes: [
                     { kind: 'declaration', property: 'color', value: 'green', important: false },
@@ -764,7 +764,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
           nodes: [
             {
               kind: 'at-rule',
-              name: 'apply',
+              name: '@apply',
               params:
                 'hover:text-red-100 sm:hover:text-red-200 md:hover:text-red-300 lg:hover:text-red-400 xl:hover:text-red-500',
               nodes: [],
@@ -932,7 +932,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
       ).toEqual([
         {
           kind: 'at-rule',
-          name: 'custom',
+          name: '@custom',
           params: '\\{',
           nodes: [{ kind: 'declaration', property: 'foo', value: 'bar', important: false }],
         },
@@ -950,7 +950,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
             { kind: 'declaration', property: 'color', value: 'red', important: false },
             {
               kind: 'at-rule',
-              name: 'media',
+              name: '@media',
               params: '(width>=600px)',
               nodes: [
                 {

--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -34,7 +34,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'rule',
+          kind: 'style-rule',
           selector: '.foo',
           nodes: [],
         },
@@ -63,12 +63,12 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
           }
         `),
       ).toEqual([
-        { kind: 'rule', selector: '.foo.baz', nodes: [] },
-        { kind: 'rule', selector: '.foo.qux', nodes: [] },
-        { kind: 'rule', selector: '.foo .qux', nodes: [] },
-        { kind: 'rule', selector: '.foo .baz', nodes: [] },
-        { kind: 'rule', selector: '.foo .baz', nodes: [] },
-        { kind: 'rule', selector: '.foo .baz', nodes: [] },
+        { kind: 'style-rule', selector: '.foo.baz', nodes: [] },
+        { kind: 'style-rule', selector: '.foo.qux', nodes: [] },
+        { kind: 'style-rule', selector: '.foo .qux', nodes: [] },
+        { kind: 'style-rule', selector: '.foo .baz', nodes: [] },
+        { kind: 'style-rule', selector: '.foo .baz', nodes: [] },
+        { kind: 'style-rule', selector: '.foo .baz', nodes: [] },
       ])
     })
 
@@ -112,12 +112,12 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         { kind: 'comment', value: '! License #2.5 ' },
         { kind: 'comment', value: '! License #3 ' },
         {
-          kind: 'rule',
+          kind: 'style-rule',
           selector: '.foo',
           nodes: [{ kind: 'declaration', property: 'color', value: 'red', important: false }],
         },
         {
-          kind: 'rule',
+          kind: 'style-rule',
           selector: '.bar',
           nodes: [{ kind: 'declaration', property: 'color', value: 'blue', important: false }],
         },
@@ -133,7 +133,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'rule',
+          kind: 'style-rule',
           selector: '.dark p',
           nodes: [
             {
@@ -256,7 +256,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
       it('should parse a minified custom property', () => {
         expect(parse(':root{--foo:bar;}')).toEqual([
           {
-            kind: 'rule',
+            kind: 'style-rule',
             selector: ':root',
             nodes: [
               {
@@ -273,7 +273,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
       it('should parse a minified custom property with no semicolon ', () => {
         expect(parse(':root{--foo:bar}')).toEqual([
           {
-            kind: 'rule',
+            kind: 'style-rule',
             selector: ':root',
             nodes: [
               {
@@ -466,7 +466,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         { kind: 'declaration', property: 'color', value: 'red', important: false },
         { kind: 'declaration', property: 'font-weight', value: 'bold', important: false },
         {
-          kind: 'rule',
+          kind: 'style-rule',
           selector: '.foo',
           nodes: [
             {
@@ -492,7 +492,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'rule',
+          kind: 'style-rule',
           selector: '.foo',
           nodes: [
             {
@@ -514,7 +514,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
           .foo {
           }
         `),
-      ).toEqual([{ kind: 'rule', selector: '.foo', nodes: [] }])
+      ).toEqual([{ kind: 'style-rule', selector: '.foo', nodes: [] }])
     })
 
     it('should parse selectors with escaped characters', () => {
@@ -526,8 +526,8 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
           }
         `),
       ).toEqual([
-        { kind: 'rule', selector: '.hover\\:foo:hover', nodes: [] },
-        { kind: 'rule', selector: '.\\32 xl\\:foo', nodes: [] },
+        { kind: 'style-rule', selector: '.hover\\:foo:hover', nodes: [] },
+        { kind: 'style-rule', selector: '.\\32 xl\\:foo', nodes: [] },
       ])
     })
 
@@ -538,7 +538,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
           .bar {
           }
         `),
-      ).toEqual([{ kind: 'rule', selector: '.foo, .bar', nodes: [] }])
+      ).toEqual([{ kind: 'style-rule', selector: '.foo, .bar', nodes: [] }])
     })
 
     it('should parse multiple declarations inside of a selector', () => {
@@ -551,7 +551,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'rule',
+          kind: 'style-rule',
           selector: '.foo',
           nodes: [
             { kind: 'declaration', property: 'color', value: 'red', important: false },
@@ -571,7 +571,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'rule',
+          kind: 'style-rule',
           selector: '.foo',
           nodes: [
             { kind: 'declaration', property: 'color', value: 'red', important: false },
@@ -591,7 +591,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'rule',
+          kind: 'style-rule',
           selector: '.foo',
           nodes: [
             { kind: 'declaration', property: 'color', value: 'red', important: false },
@@ -604,7 +604,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
     it('should parse a multi-line selector', () => {
       expect(parse(['.foo,', '.bar,', '.baz', '{', 'color:red;', '}'].join('\n'))).toEqual([
         {
-          kind: 'rule',
+          kind: 'style-rule',
           selector: '.foo, .bar, .baz',
           nodes: [{ kind: 'declaration', property: 'color', value: 'red', important: false }],
         },
@@ -616,7 +616,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         parse(['.foo,', '.bar,', '.baz\t\n \n .qux', '{', 'color:red;', '}'].join('\n')),
       ).toEqual([
         {
-          kind: 'rule',
+          kind: 'style-rule',
           selector: '.foo, .bar, .baz .qux',
           nodes: [{ kind: 'declaration', property: 'color', value: 'red', important: false }],
         },
@@ -677,7 +677,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
           nodes: [{ kind: 'at-rule', name: 'charset', params: '"UTF-8"', nodes: [] }],
         },
         {
-          kind: 'rule',
+          kind: 'style-rule',
           selector: '.foo',
           nodes: [
             { kind: 'at-rule', name: 'apply', params: 'font-bold hover:text-red-500', nodes: [] },
@@ -720,7 +720,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
           params: '(width >= 600px)',
           nodes: [
             {
-              kind: 'rule',
+              kind: 'style-rule',
               selector: '.foo',
               nodes: [
                 { kind: 'declaration', property: 'color', value: 'red', important: false },
@@ -760,7 +760,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'rule',
+          kind: 'style-rule',
           nodes: [
             {
               kind: 'at-rule',
@@ -790,15 +790,15 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'rule',
+          kind: 'style-rule',
           selector: '.foo',
           nodes: [
             {
-              kind: 'rule',
+              kind: 'style-rule',
               selector: '.bar',
               nodes: [
                 {
-                  kind: 'rule',
+                  kind: 'style-rule',
                   selector: '.baz',
                   nodes: [
                     { kind: 'declaration', property: 'color', value: 'red', important: false },
@@ -824,12 +824,12 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'rule',
+          kind: 'style-rule',
           selector: '.foo',
           nodes: [
             { kind: 'declaration', property: 'color', value: 'red', important: false },
             {
-              kind: 'rule',
+              kind: 'style-rule',
               selector: '&:hover',
               nodes: [{ kind: 'declaration', property: 'color', value: 'blue', important: false }],
             },
@@ -853,16 +853,16 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'rule',
+          kind: 'style-rule',
           selector: '.foo',
           nodes: [
             {
-              kind: 'rule',
+              kind: 'style-rule',
               selector: '.bar',
               nodes: [{ kind: 'declaration', property: 'color', value: 'red', important: false }],
             },
             {
-              kind: 'rule',
+              kind: 'style-rule',
               selector: '.baz',
               nodes: [{ kind: 'declaration', property: 'color', value: 'blue', important: false }],
             },
@@ -893,7 +893,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'rule',
+          kind: 'style-rule',
           selector: '.foo',
           nodes: [
             { kind: 'declaration', property: 'font-weight', value: 'bold', important: false },
@@ -904,13 +904,13 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
               important: false,
             },
             {
-              kind: 'rule',
+              kind: 'style-rule',
               selector: '.bar',
               nodes: [{ kind: 'declaration', property: 'color', value: 'red', important: false }],
             },
             { kind: 'declaration', property: '--in-between', value: '1', important: false },
             {
-              kind: 'rule',
+              kind: 'style-rule',
               selector: '.baz',
               nodes: [{ kind: 'declaration', property: 'color', value: 'blue', important: false }],
             },
@@ -944,7 +944,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         parse('.foo{color:red;@media(width>=600px){.bar{color:blue;font-weight:bold}}}'),
       ).toEqual([
         {
-          kind: 'rule',
+          kind: 'style-rule',
           selector: '.foo',
           nodes: [
             { kind: 'declaration', property: 'color', value: 'red', important: false },
@@ -954,7 +954,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
               params: '(width>=600px)',
               nodes: [
                 {
-                  kind: 'rule',
+                  kind: 'style-rule',
                   selector: '.bar',
                   nodes: [
                     { kind: 'declaration', property: 'color', value: 'blue', important: false },
@@ -982,7 +982,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `),
       ).toEqual([
         {
-          kind: 'rule',
+          kind: 'style-rule',
           selector: '.foo:has(.bar )',
           nodes: [{ kind: 'declaration', property: 'color', value: 'red', important: false }],
         },

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -496,7 +496,7 @@ export function parse(input: string) {
 }
 
 export function parseAtRule(buffer: string, nodes: AstNode[] = []): AtRule {
-  for (let i = 0; i < buffer.length; i++) {
+  for (let i = 6 /* '@page'.length + 1 */; i < buffer.length; i++) {
     let currentChar = buffer.charCodeAt(i)
     if (currentChar === SPACE || currentChar === OPEN_PAREN) {
       let name = buffer.slice(1, i).trim()

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -480,7 +480,7 @@ export function parse(input: string) {
   // When we are done parsing then everything should be balanced. If we still
   // have a leftover `parent`, then it means that we have an unterminated block.
   if (closingBracketStack.length > 0 && parent) {
-    if (parent.kind === 'style-rule') {
+    if (parent.kind === 'rule') {
       throw new Error(`Missing closing } at ${parent.selector}`)
     }
     if (parent.kind === 'at-rule') {

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -484,7 +484,7 @@ export function parse(input: string) {
       throw new Error(`Missing closing } at ${parent.selector}`)
     }
     if (parent.kind === 'at-rule') {
-      throw new Error(`Missing closing } at @${parent.name} ${parent.params}`)
+      throw new Error(`Missing closing } at ${parent.name} ${parent.params}`)
     }
   }
 
@@ -516,13 +516,13 @@ export function parseAtRule(buffer: string, nodes: AstNode[] = []): AtRule {
   for (let i = 5 /* '@page'.length */; i < buffer.length; i++) {
     let currentChar = buffer.charCodeAt(i)
     if (currentChar === SPACE || currentChar === OPEN_PAREN) {
-      let name = buffer.slice(1, i).trim()
+      let name = buffer.slice(0, i).trim()
       let params = buffer.slice(i).trim()
       return atRule(name, params, nodes)
     }
   }
 
-  return atRule(buffer.slice(1).trim(), '', nodes)
+  return atRule(buffer.trim(), '', nodes)
 }
 
 function parseDeclaration(buffer: string, colonIdx: number = buffer.indexOf(':')): Declaration {

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -496,7 +496,7 @@ export function parse(input: string) {
 }
 
 export function parseAtRule(buffer: string, nodes: AstNode[] = []): AtRule {
-  for (let i = 6 /* '@page'.length + 1 */; i < buffer.length; i++) {
+  for (let i = 2 /* '@x'.length */; i < buffer.length; i++) {
     let currentChar = buffer.charCodeAt(i)
     if (currentChar === SPACE || currentChar === OPEN_PAREN) {
       let name = buffer.slice(1, i).trim()

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -496,12 +496,16 @@ export function parse(input: string) {
 }
 
 export function parseAtRule(buffer: string, nodes: AstNode[] = []): AtRule {
-  let splitIdx = buffer.search(/[\s(]/g)
-  if (splitIdx === -1) return atRule(buffer.slice(1).trim(), '', nodes)
+  for (let i = 0; i < buffer.length; i++) {
+    let currentChar = buffer.charCodeAt(i)
+    if (currentChar === SPACE || currentChar === OPEN_PAREN) {
+      let name = buffer.slice(1, i).trim()
+      let params = buffer.slice(i).trim()
+      return atRule(name, params, nodes)
+    }
+  }
 
-  let name = buffer.slice(1, splitIdx).trim()
-  let params = buffer.slice(splitIdx).trim()
-  return atRule(name, params, nodes)
+  return atRule(buffer.slice(1).trim(), '', nodes)
 }
 
 function parseDeclaration(buffer: string, colonIdx: number = buffer.indexOf(':')): Declaration {

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -496,7 +496,24 @@ export function parse(input: string) {
 }
 
 export function parseAtRule(buffer: string, nodes: AstNode[] = []): AtRule {
-  for (let i = 2 /* '@x'.length */; i < buffer.length; i++) {
+  // Assumption: The smallest at-rule in CSS right now is `@page`, this means
+  //             that we can always skip the first 5 characters and start at the
+  //             sixth (at index 5).
+  //
+  // There is a chance someone is using a shorter at-rule, in that case we have
+  // to adjust this number back to 2, e.g.: `@x`.
+  //
+  // This issue can only occur if somebody does the following things:
+  //
+  // 1. Uses a shorter at-rule than `@page`
+  // 2. Disables Lightning CSS from `@tailwindcss/postcss` (because Lightning
+  //    CSS doesn't handle custom at-rules properly right now)
+  // 3. Sandwiches the `@tailwindcss/postcss` plugin between two other plugins
+  //    that can handle the shorter at-rule
+  //
+  // Let's use the more common case as the default and we can adjust this
+  // behavior if necessary.
+  for (let i = 5 /* '@page'.length */; i < buffer.length; i++) {
     let currentChar = buffer.charCodeAt(i)
     if (currentChar === SPACE || currentChar === OPEN_PAREN) {
       let name = buffer.slice(1, i).trim()

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -1,12 +1,12 @@
 import {
   atRule,
   comment,
-  rule,
+  styleRule,
   type AstNode,
   type AtRule,
   type Comment,
   type Declaration,
-  type Rule,
+  type StyleRule,
 } from './ast'
 
 const BACKSLASH = 0x5c
@@ -35,9 +35,9 @@ export function parse(input: string) {
   let ast: AstNode[] = []
   let licenseComments: Comment[] = []
 
-  let stack: (Rule | AtRule | null)[] = []
+  let stack: (StyleRule | AtRule | null)[] = []
 
-  let parent = null as (Rule | AtRule) | null
+  let parent = null as (StyleRule | AtRule) | null
   let node = null as AstNode | null
 
   let buffer = ''
@@ -350,7 +350,7 @@ export function parse(input: string) {
       if (buffer.charCodeAt(0) === AT_SIGN) {
         node = parseAtRule(buffer)
       } else {
-        node = rule(buffer.trim(), [])
+        node = styleRule(buffer.trim(), [])
       }
 
       // Attach the rule to the parent in case it's nested.
@@ -484,7 +484,7 @@ export function parse(input: string) {
   // When we are done parsing then everything should be balanced. If we still
   // have a leftover `parent`, then it means that we have an unterminated block.
   if (closingBracketStack.length > 0 && parent) {
-    if (parent.kind === 'rule') {
+    if (parent.kind === 'style-rule') {
       throw new Error(`Missing closing } at ${parent.selector}`)
     }
     if (parent.kind === 'at-rule') {

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -1,12 +1,12 @@
 import {
   atRule,
   comment,
-  styleRule,
+  rule,
   type AstNode,
   type AtRule,
   type Comment,
   type Declaration,
-  type StyleRule,
+  type Rule,
 } from './ast'
 
 const BACKSLASH = 0x5c
@@ -35,9 +35,9 @@ export function parse(input: string) {
   let ast: AstNode[] = []
   let licenseComments: Comment[] = []
 
-  let stack: (StyleRule | AtRule | null)[] = []
+  let stack: (Rule | null)[] = []
 
-  let parent = null as (StyleRule | AtRule) | null
+  let parent = null as Rule | null
   let node = null as AstNode | null
 
   let buffer = ''
@@ -347,11 +347,7 @@ export function parse(input: string) {
       closingBracketStack += '}'
 
       // At this point `buffer` should resemble a selector or an at-rule.
-      if (buffer.charCodeAt(0) === AT_SIGN) {
-        node = parseAtRule(buffer)
-      } else {
-        node = styleRule(buffer.trim(), [])
-      }
+      node = rule(buffer.trim())
 
       // Attach the rule to the parent in case it's nested.
       if (parent) {
@@ -502,6 +498,7 @@ export function parse(input: string) {
 export function parseAtRule(buffer: string, nodes: AstNode[] = []): AtRule {
   let splitIdx = buffer.search(/[\s(]/g)
   if (splitIdx === -1) return atRule(buffer.slice(1).trim(), '', nodes)
+
   let name = buffer.slice(1, splitIdx).trim()
   let params = buffer.slice(splitIdx).trim()
   return atRule(name, params, nodes)

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -92,7 +92,7 @@ async function parseCss(
     if (node.kind !== 'at-rule') return
 
     // Collect custom `@utility` at-rules
-    if (node.name === 'utility') {
+    if (node.name === '@utility') {
       if (parent !== null) {
         throw new Error('`@utility` cannot be nested.')
       }
@@ -122,7 +122,7 @@ async function parseCss(
     }
 
     // Collect paths from `@source` at-rules
-    if (node.name === 'source') {
+    if (node.name === '@source') {
       if (node.nodes.length > 0) {
         throw new Error('`@source` cannot have a body.')
       }
@@ -145,7 +145,7 @@ async function parseCss(
     }
 
     // Register custom variants from `@variant` at-rules
-    if (node.name === 'variant') {
+    if (node.name === '@variant') {
       if (parent !== null) {
         throw new Error('`@variant` cannot be nested.')
       }
@@ -229,7 +229,7 @@ async function parseCss(
       }
     }
 
-    if (node.name === 'media') {
+    if (node.name === '@media') {
       let params = segment(node.params, ' ')
       let unknownParams: string[] = []
 
@@ -248,7 +248,7 @@ async function parseCss(
                 'Files imported with `@import "…" theme(…)` must only contain `@theme` blocks.',
               )
             }
-            if (child.name === 'theme') {
+            if (child.name === '@theme') {
               child.params += ' ' + themeParams
               return WalkAction.Skip
             }
@@ -264,7 +264,7 @@ async function parseCss(
 
           walk(node.nodes, (child) => {
             if (child.kind !== 'at-rule') return
-            if (child.name === 'theme') {
+            if (child.name === '@theme') {
               child.params += ` prefix(${prefix})`
               return WalkAction.Skip
             }
@@ -292,7 +292,7 @@ async function parseCss(
     }
 
     // Handle `@theme`
-    if (node.name === 'theme') {
+    if (node.name === '@theme') {
       let [themeOptions, themePrefix] = parseThemeOptions(node.params)
 
       if (themePrefix) {
@@ -309,7 +309,7 @@ async function parseCss(
       walk(node.nodes, (child, { replaceWith }) => {
         // Collect `@keyframes` rules to re-insert with theme variables later,
         // since the `@theme` rule itself will be removed.
-        if (child.kind === 'at-rule' && child.name === 'keyframes') {
+        if (child.kind === 'at-rule' && child.name === '@keyframes') {
           theme.addKeyframes(child)
           replaceWith([])
           return WalkAction.Skip
@@ -404,7 +404,7 @@ async function parseCss(
   walk(ast, (node, { replaceWith }) => {
     if (node.kind !== 'at-rule') return
 
-    if (node.name === 'utility') {
+    if (node.name === '@utility') {
       replaceWith([])
     }
 
@@ -434,7 +434,7 @@ export async function compile(
   // Find `@tailwind utilities` so that we can later replace it with the actual
   // generated utility class CSS.
   walk(ast, (node) => {
-    if (node.kind === 'at-rule' && node.name === 'tailwind' && node.params === 'utilities') {
+    if (node.kind === 'at-rule' && node.name === '@tailwind' && node.params === 'utilities') {
       tailwindUtilitiesNode = node
 
       // Stop walking after finding `@tailwind utilities` to avoid walking all

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -388,12 +388,7 @@ async function parseCss(
 
         // Wrap `@keyframes` in `AtRoot` so they are hoisted out of `:root` when
         // printing.
-        nodes.push(
-          Object.assign(
-            keyframesRule,
-            atRoot([atRule(keyframesRule.name, keyframesRule.params, keyframesRule.nodes)]),
-          ),
-        )
+        nodes.push(atRoot([keyframesRule]))
       }
     }
     firstThemeRule.nodes = nodes

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -7,6 +7,7 @@ import {
   context,
   decl,
   rule,
+  styleRule,
   toCss,
   walk,
   WalkAction,
@@ -186,7 +187,7 @@ async function parseCss(
               let nodes: AstNode[] = []
 
               if (styleRuleSelectors.length > 0) {
-                nodes.push(rule(styleRuleSelectors.join(', '), r.nodes))
+                nodes.push(styleRule(styleRuleSelectors.join(', '), r.nodes))
               }
 
               for (let selector of atRuleParams) {
@@ -333,7 +334,7 @@ async function parseCss(
       // Keep a reference to the first `@theme` rule to update with the full
       // theme later, and delete any other `@theme` rules.
       if (!firstThemeRule && !(themeOptions & ThemeOptions.REFERENCE)) {
-        firstThemeRule = rule(':root', node.nodes) as StyleRule
+        firstThemeRule = styleRule(':root', node.nodes)
         replaceWith([firstThemeRule])
       } else {
         replaceWith([])

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -7,7 +7,6 @@ import {
   context,
   decl,
   rule,
-  styleRule,
   toCss,
   walk,
   WalkAction,
@@ -187,7 +186,7 @@ async function parseCss(
               let nodes: AstNode[] = []
 
               if (styleRuleSelectors.length > 0) {
-                nodes.push(styleRule(styleRuleSelectors.join(', '), r.nodes))
+                nodes.push(rule(styleRuleSelectors.join(', '), r.nodes))
               }
 
               for (let selector of atRuleParams) {
@@ -334,7 +333,7 @@ async function parseCss(
       // Keep a reference to the first `@theme` rule to update with the full
       // theme later, and delete any other `@theme` rules.
       if (!firstThemeRule && !(themeOptions & ThemeOptions.REFERENCE)) {
-        firstThemeRule = styleRule(':root', node.nodes)
+        firstThemeRule = rule(':root', node.nodes) as StyleRule
         replaceWith([firstThemeRule])
       } else {
         replaceWith([])

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -6,6 +6,7 @@ import {
   comment,
   context,
   decl,
+  rule,
   styleRule,
   toCss,
   walk,
@@ -190,7 +191,7 @@ async function parseCss(
               }
 
               for (let selector of atRuleParams) {
-                nodes.push(CSS.parseAtRule(selector, r.nodes))
+                nodes.push(rule(selector, r.nodes))
               }
 
               r.nodes = nodes

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -6,13 +6,13 @@ import {
   comment,
   context,
   decl,
-  rule,
+  styleRule,
   toCss,
   walk,
   WalkAction,
   type AstNode,
   type AtRule,
-  type Rule,
+  type StyleRule,
 } from './ast'
 import { substituteAtImports } from './at-import'
 import { applyCompatibilityHooks } from './compat/apply-compat-hooks'
@@ -83,7 +83,7 @@ async function parseCss(
   let theme = new Theme()
   let customVariants: ((designSystem: DesignSystem) => void)[] = []
   let customUtilities: ((designSystem: DesignSystem) => void)[] = []
-  let firstThemeRule = null as Rule | null
+  let firstThemeRule = null as StyleRule | null
   let globs: { base: string; pattern: string }[] = []
 
   // Handle at-rules
@@ -186,7 +186,7 @@ async function parseCss(
               let nodes: AstNode[] = []
 
               if (styleRuleSelectors.length > 0) {
-                nodes.push(rule(styleRuleSelectors.join(', '), r.nodes))
+                nodes.push(styleRule(styleRuleSelectors.join(', '), r.nodes))
               }
 
               for (let selector of atRuleParams) {
@@ -333,7 +333,7 @@ async function parseCss(
       // Keep a reference to the first `@theme` rule to update with the full
       // theme later, and delete any other `@theme` rules.
       if (!firstThemeRule && !(themeOptions & ThemeOptions.REFERENCE)) {
-        firstThemeRule = rule(':root', node.nodes)
+        firstThemeRule = styleRule(':root', node.nodes)
         replaceWith([firstThemeRule])
       } else {
         replaceWith([])

--- a/packages/tailwindcss/src/intellisense.ts
+++ b/packages/tailwindcss/src/intellisense.ts
@@ -1,4 +1,4 @@
-import { styleRule, walkDepth } from './ast'
+import { rule, walkDepth } from './ast'
 import { applyVariant } from './compile'
 import type { DesignSystem } from './design-system'
 
@@ -69,7 +69,7 @@ export function getVariants(design: DesignSystem) {
       if (!variant) return []
 
       // Apply the variant to a placeholder rule
-      let node = styleRule('.__placeholder__', [])
+      let node = rule('.__placeholder__', [])
 
       // If the rule produces no nodes it means the variant does not apply
       if (applyVariant(node, variant, design.variants) === null) {

--- a/packages/tailwindcss/src/intellisense.ts
+++ b/packages/tailwindcss/src/intellisense.ts
@@ -82,7 +82,7 @@ export function getVariants(design: DesignSystem) {
       // Produce v3-style selector strings in the face of nested rules
       // this is more visible for things like group-*, not-*, etc…
       walkDepth(node.nodes, (node, { path }) => {
-        if (node.kind !== 'style-rule' && node.kind !== 'at-rule') return
+        if (node.kind !== 'rule' && node.kind !== 'at-rule') return
         if (node.nodes.length > 0) return
 
         // Sort at-rules before style rules
@@ -98,7 +98,7 @@ export function getVariants(design: DesignSystem) {
 
         // A list of the selectors / at rules encountered to get to this point
         let group = path.flatMap((node) => {
-          if (node.kind === 'style-rule') {
+          if (node.kind === 'rule') {
             return node.selector === '&' ? [] : [node.selector]
           }
 

--- a/packages/tailwindcss/src/intellisense.ts
+++ b/packages/tailwindcss/src/intellisense.ts
@@ -1,4 +1,4 @@
-import { rule, walkDepth } from './ast'
+import { styleRule, walkDepth } from './ast'
 import { applyVariant } from './compile'
 import type { DesignSystem } from './design-system'
 
@@ -69,7 +69,7 @@ export function getVariants(design: DesignSystem) {
       if (!variant) return []
 
       // Apply the variant to a placeholder rule
-      let node = rule('.__placeholder__', [])
+      let node = styleRule('.__placeholder__', [])
 
       // If the rule produces no nodes it means the variant does not apply
       if (applyVariant(node, variant, design.variants) === null) {
@@ -82,7 +82,7 @@ export function getVariants(design: DesignSystem) {
       // Produce v3-style selector strings in the face of nested rules
       // this is more visible for things like group-*, not-*, etc…
       walkDepth(node.nodes, (node, { path }) => {
-        if (node.kind !== 'rule' && node.kind !== 'at-rule') return
+        if (node.kind !== 'style-rule' && node.kind !== 'at-rule') return
         if (node.nodes.length > 0) return
 
         // Sort at-rules before style rules
@@ -98,7 +98,7 @@ export function getVariants(design: DesignSystem) {
 
         // A list of the selectors / at rules encountered to get to this point
         let group = path.flatMap((node) => {
-          if (node.kind === 'rule') {
+          if (node.kind === 'style-rule') {
             return node.selector === '&' ? [] : [node.selector]
           }
 

--- a/packages/tailwindcss/src/intellisense.ts
+++ b/packages/tailwindcss/src/intellisense.ts
@@ -82,16 +82,13 @@ export function getVariants(design: DesignSystem) {
       // Produce v3-style selector strings in the face of nested rules
       // this is more visible for things like group-*, not-*, etc…
       walkDepth(node.nodes, (node, { path }) => {
-        if (node.kind !== 'rule') return
+        if (node.kind !== 'rule' && node.kind !== 'at-rule') return
         if (node.nodes.length > 0) return
 
         // Sort at-rules before style rules
         path.sort((a, b) => {
-          // This won't actually happen, but it's here to make TypeScript happy
-          if (a.kind !== 'rule' || b.kind !== 'rule') return 0
-
-          let aIsAtRule = a.selector[0] === '@'
-          let bIsAtRule = b.selector[0] === '@'
+          let aIsAtRule = a.kind === 'at-rule'
+          let bIsAtRule = b.kind === 'at-rule'
 
           if (aIsAtRule && !bIsAtRule) return -1
           if (!aIsAtRule && bIsAtRule) return 1
@@ -101,8 +98,15 @@ export function getVariants(design: DesignSystem) {
 
         // A list of the selectors / at rules encountered to get to this point
         let group = path.flatMap((node) => {
-          if (node.kind !== 'rule') return []
-          return node.selector === '&' ? [] : [node.selector]
+          if (node.kind === 'rule') {
+            return node.selector === '&' ? [] : [node.selector]
+          }
+
+          if (node.kind === 'at-rule') {
+            return [`@${node.name} ${node.params}`]
+          }
+
+          return []
         })
 
         // Build a v3-style nested selector

--- a/packages/tailwindcss/src/intellisense.ts
+++ b/packages/tailwindcss/src/intellisense.ts
@@ -103,7 +103,7 @@ export function getVariants(design: DesignSystem) {
           }
 
           if (node.kind === 'at-rule') {
-            return [`@${node.name} ${node.params}`]
+            return [`${node.name} ${node.params}`]
           }
 
           return []

--- a/packages/tailwindcss/src/intellisense.ts
+++ b/packages/tailwindcss/src/intellisense.ts
@@ -1,4 +1,4 @@
-import { rule, walkDepth } from './ast'
+import { styleRule, walkDepth } from './ast'
 import { applyVariant } from './compile'
 import type { DesignSystem } from './design-system'
 
@@ -69,7 +69,7 @@ export function getVariants(design: DesignSystem) {
       if (!variant) return []
 
       // Apply the variant to a placeholder rule
-      let node = rule('.__placeholder__', [])
+      let node = styleRule('.__placeholder__', [])
 
       // If the rule produces no nodes it means the variant does not apply
       if (applyVariant(node, variant, design.variants) === null) {

--- a/packages/tailwindcss/src/theme.ts
+++ b/packages/tailwindcss/src/theme.ts
@@ -1,4 +1,4 @@
-import type { Rule } from './ast'
+import type { AtRule } from './ast'
 import { escape } from './utils/escape'
 
 export const enum ThemeOptions {
@@ -13,7 +13,7 @@ export class Theme {
 
   constructor(
     private values = new Map<string, { value: string; options: ThemeOptions }>(),
-    private keyframes = new Set<Rule>([]),
+    private keyframes = new Set<AtRule>([]),
   ) {}
 
   add(key: string, value: string, options = ThemeOptions.NONE): void {
@@ -204,7 +204,7 @@ export class Theme {
     return values
   }
 
-  addKeyframes(value: Rule): void {
+  addKeyframes(value: AtRule): void {
     this.keyframes.add(value)
   }
 

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -1,4 +1,4 @@
-import { atRoot, decl, rule, type AstNode } from './ast'
+import { atRoot, atRule, decl, rule, type AstNode } from './ast'
 import type { Candidate, CandidateModifier, NamedUtilityValue } from './candidate'
 import type { Theme, ThemeKey } from './theme'
 import { DefaultMap } from './utils/default-map'
@@ -85,7 +85,7 @@ export class Utilities {
 }
 
 function property(ident: string, initialValue?: string, syntax?: string) {
-  return rule(`@property ${ident}`, [
+  return atRule('property', ident, [
     decl('syntax', syntax ? `"${syntax}"` : `"*"`),
     decl('inherits', 'false'),
 

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -19,13 +19,13 @@ interface SuggestionGroup {
 type SuggestionDefinition =
   | string
   | {
-    supportsNegative?: boolean
-    values?: string[]
-    modifiers?: string[]
-    valueThemeKeys?: ThemeKey[]
-    modifierThemeKeys?: ThemeKey[]
-    hasDefaultValue?: boolean
-  }
+      supportsNegative?: boolean
+      values?: string[]
+      modifiers?: string[]
+      valueThemeKeys?: ThemeKey[]
+      modifierThemeKeys?: ThemeKey[]
+      hasDefaultValue?: boolean
+    }
 
 export type UtilityOptions = {
   types: string[]

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -1,4 +1,4 @@
-import { atRoot, atRule, decl, rule, type AstNode } from './ast'
+import { atRoot, atRule, decl, styleRule, type AstNode } from './ast'
 import type { Candidate, CandidateModifier, NamedUtilityValue } from './candidate'
 import type { Theme, ThemeKey } from './theme'
 import { DefaultMap } from './utils/default-map'
@@ -19,13 +19,13 @@ interface SuggestionGroup {
 type SuggestionDefinition =
   | string
   | {
-      supportsNegative?: boolean
-      values?: string[]
-      modifiers?: string[]
-      valueThemeKeys?: ThemeKey[]
-      modifierThemeKeys?: ThemeKey[]
-      hasDefaultValue?: boolean
-    }
+    supportsNegative?: boolean
+    values?: string[]
+    modifiers?: string[]
+    valueThemeKeys?: ThemeKey[]
+    modifierThemeKeys?: ThemeKey[]
+    hasDefaultValue?: boolean
+  }
 
 export type UtilityOptions = {
   types: string[]
@@ -2024,7 +2024,7 @@ export function createUtilities(theme: Theme) {
     handle: (value) => [
       atRoot([property('--tw-space-x-reverse', '0', '<number>')]),
 
-      rule(':where(& > :not(:last-child))', [
+      styleRule(':where(& > :not(:last-child))', [
         decl('--tw-sort', 'row-gap'),
         decl('margin-inline-start', `calc(${value} * var(--tw-space-x-reverse))`),
         decl('margin-inline-end', `calc(${value} * calc(1 - var(--tw-space-x-reverse)))`),
@@ -2038,7 +2038,7 @@ export function createUtilities(theme: Theme) {
     handle: (value) => [
       atRoot([property('--tw-space-y-reverse', '0', '<number>')]),
 
-      rule(':where(& > :not(:last-child))', [
+      styleRule(':where(& > :not(:last-child))', [
         decl('--tw-sort', 'column-gap'),
         decl('margin-block-start', `calc(${value} * var(--tw-space-y-reverse))`),
         decl('margin-block-end', `calc(${value} * calc(1 - var(--tw-space-y-reverse)))`),
@@ -2049,7 +2049,7 @@ export function createUtilities(theme: Theme) {
   staticUtility('space-x-reverse', [
     () => atRoot([property('--tw-space-x-reverse', '0', '<number>')]),
     () =>
-      rule(':where(& > :not(:last-child))', [
+      styleRule(':where(& > :not(:last-child))', [
         decl('--tw-sort', 'row-gap'),
         decl('--tw-space-x-reverse', '1'),
       ]),
@@ -2058,7 +2058,7 @@ export function createUtilities(theme: Theme) {
   staticUtility('space-y-reverse', [
     () => atRoot([property('--tw-space-y-reverse', '0', '<number>')]),
     () =>
-      rule(':where(& > :not(:last-child))', [
+      styleRule(':where(& > :not(:last-child))', [
         decl('--tw-sort', 'column-gap'),
         decl('--tw-space-y-reverse', '1'),
       ]),
@@ -2078,7 +2078,7 @@ export function createUtilities(theme: Theme) {
   colorUtility('divide', {
     themeKeys: ['--divide-color', '--color'],
     handle: (value) => [
-      rule(':where(& > :not(:last-child))', [
+      styleRule(':where(& > :not(:last-child))', [
         decl('--tw-sort', 'divide-color'),
         decl('border-color', value),
       ]),
@@ -2386,7 +2386,7 @@ export function createUtilities(theme: Theme) {
       handle: (value) => [
         atRoot([property('--tw-divide-x-reverse', '0', '<number>')]),
 
-        rule(':where(& > :not(:last-child))', [
+        styleRule(':where(& > :not(:last-child))', [
           decl('--tw-sort', 'divide-x-width'),
           borderProperties(),
           decl('border-inline-style', 'var(--tw-border-style)'),
@@ -2406,7 +2406,7 @@ export function createUtilities(theme: Theme) {
       handle: (value) => [
         atRoot([property('--tw-divide-y-reverse', '0', '<number>')]),
 
-        rule(':where(& > :not(:last-child))', [
+        styleRule(':where(& > :not(:last-child))', [
           decl('--tw-sort', 'divide-y-width'),
           borderProperties(),
           decl('border-bottom-style', 'var(--tw-border-style)'),
@@ -2435,18 +2435,18 @@ export function createUtilities(theme: Theme) {
 
     staticUtility('divide-x-reverse', [
       () => atRoot([property('--tw-divide-x-reverse', '0', '<number>')]),
-      () => rule(':where(& > :not(:last-child))', [decl('--tw-divide-x-reverse', '1')]),
+      () => styleRule(':where(& > :not(:last-child))', [decl('--tw-divide-x-reverse', '1')]),
     ])
 
     staticUtility('divide-y-reverse', [
       () => atRoot([property('--tw-divide-y-reverse', '0', '<number>')]),
-      () => rule(':where(& > :not(:last-child))', [decl('--tw-divide-y-reverse', '1')]),
+      () => styleRule(':where(& > :not(:last-child))', [decl('--tw-divide-y-reverse', '1')]),
     ])
 
     for (let value of ['solid', 'dashed', 'dotted', 'double', 'none']) {
       staticUtility(`divide-${value}`, [
         () =>
-          rule(':where(& > :not(:last-child))', [
+          styleRule(':where(& > :not(:last-child))', [
             decl('--tw-sort', 'divide-style'),
             decl('--tw-border-style', value),
             decl('border-style', value),
@@ -3150,7 +3150,7 @@ export function createUtilities(theme: Theme) {
   colorUtility('placeholder', {
     themeKeys: ['--background-color', '--color'],
     handle: (value) => [
-      rule('&::placeholder', [decl('--tw-sort', 'placeholder-color'), decl('color', value)]),
+      styleRule('&::placeholder', [decl('--tw-sort', 'placeholder-color'), decl('color', value)]),
     ],
   })
 

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -85,7 +85,7 @@ export class Utilities {
 }
 
 function property(ident: string, initialValue?: string, syntax?: string) {
-  return atRule('property', ident, [
+  return atRule('@property', ident, [
     decl('syntax', syntax ? `"${syntax}"` : `"*"`),
     decl('inherits', 'false'),
 

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -1,4 +1,4 @@
-import { atRoot, atRule, decl, styleRule, type AstNode } from './ast'
+import { atRoot, atRule, decl, rule, type AstNode } from './ast'
 import type { Candidate, CandidateModifier, NamedUtilityValue } from './candidate'
 import type { Theme, ThemeKey } from './theme'
 import { DefaultMap } from './utils/default-map'
@@ -2024,7 +2024,7 @@ export function createUtilities(theme: Theme) {
     handle: (value) => [
       atRoot([property('--tw-space-x-reverse', '0', '<number>')]),
 
-      styleRule(':where(& > :not(:last-child))', [
+      rule(':where(& > :not(:last-child))', [
         decl('--tw-sort', 'row-gap'),
         decl('margin-inline-start', `calc(${value} * var(--tw-space-x-reverse))`),
         decl('margin-inline-end', `calc(${value} * calc(1 - var(--tw-space-x-reverse)))`),
@@ -2038,7 +2038,7 @@ export function createUtilities(theme: Theme) {
     handle: (value) => [
       atRoot([property('--tw-space-y-reverse', '0', '<number>')]),
 
-      styleRule(':where(& > :not(:last-child))', [
+      rule(':where(& > :not(:last-child))', [
         decl('--tw-sort', 'column-gap'),
         decl('margin-block-start', `calc(${value} * var(--tw-space-y-reverse))`),
         decl('margin-block-end', `calc(${value} * calc(1 - var(--tw-space-y-reverse)))`),
@@ -2049,7 +2049,7 @@ export function createUtilities(theme: Theme) {
   staticUtility('space-x-reverse', [
     () => atRoot([property('--tw-space-x-reverse', '0', '<number>')]),
     () =>
-      styleRule(':where(& > :not(:last-child))', [
+      rule(':where(& > :not(:last-child))', [
         decl('--tw-sort', 'row-gap'),
         decl('--tw-space-x-reverse', '1'),
       ]),
@@ -2058,7 +2058,7 @@ export function createUtilities(theme: Theme) {
   staticUtility('space-y-reverse', [
     () => atRoot([property('--tw-space-y-reverse', '0', '<number>')]),
     () =>
-      styleRule(':where(& > :not(:last-child))', [
+      rule(':where(& > :not(:last-child))', [
         decl('--tw-sort', 'column-gap'),
         decl('--tw-space-y-reverse', '1'),
       ]),
@@ -2078,7 +2078,7 @@ export function createUtilities(theme: Theme) {
   colorUtility('divide', {
     themeKeys: ['--divide-color', '--color'],
     handle: (value) => [
-      styleRule(':where(& > :not(:last-child))', [
+      rule(':where(& > :not(:last-child))', [
         decl('--tw-sort', 'divide-color'),
         decl('border-color', value),
       ]),
@@ -2386,7 +2386,7 @@ export function createUtilities(theme: Theme) {
       handle: (value) => [
         atRoot([property('--tw-divide-x-reverse', '0', '<number>')]),
 
-        styleRule(':where(& > :not(:last-child))', [
+        rule(':where(& > :not(:last-child))', [
           decl('--tw-sort', 'divide-x-width'),
           borderProperties(),
           decl('border-inline-style', 'var(--tw-border-style)'),
@@ -2406,7 +2406,7 @@ export function createUtilities(theme: Theme) {
       handle: (value) => [
         atRoot([property('--tw-divide-y-reverse', '0', '<number>')]),
 
-        styleRule(':where(& > :not(:last-child))', [
+        rule(':where(& > :not(:last-child))', [
           decl('--tw-sort', 'divide-y-width'),
           borderProperties(),
           decl('border-bottom-style', 'var(--tw-border-style)'),
@@ -2435,18 +2435,18 @@ export function createUtilities(theme: Theme) {
 
     staticUtility('divide-x-reverse', [
       () => atRoot([property('--tw-divide-x-reverse', '0', '<number>')]),
-      () => styleRule(':where(& > :not(:last-child))', [decl('--tw-divide-x-reverse', '1')]),
+      () => rule(':where(& > :not(:last-child))', [decl('--tw-divide-x-reverse', '1')]),
     ])
 
     staticUtility('divide-y-reverse', [
       () => atRoot([property('--tw-divide-y-reverse', '0', '<number>')]),
-      () => styleRule(':where(& > :not(:last-child))', [decl('--tw-divide-y-reverse', '1')]),
+      () => rule(':where(& > :not(:last-child))', [decl('--tw-divide-y-reverse', '1')]),
     ])
 
     for (let value of ['solid', 'dashed', 'dotted', 'double', 'none']) {
       staticUtility(`divide-${value}`, [
         () =>
-          styleRule(':where(& > :not(:last-child))', [
+          rule(':where(& > :not(:last-child))', [
             decl('--tw-sort', 'divide-style'),
             decl('--tw-border-style', value),
             decl('border-style', value),
@@ -3150,7 +3150,7 @@ export function createUtilities(theme: Theme) {
   colorUtility('placeholder', {
     themeKeys: ['--background-color', '--color'],
     handle: (value) => [
-      styleRule('&::placeholder', [decl('--tw-sort', 'placeholder-color'), decl('color', value)]),
+      rule('&::placeholder', [decl('--tw-sort', 'placeholder-color'), decl('color', value)]),
     ],
   })
 

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -1,4 +1,4 @@
-import { atRoot, atRule, decl, rule, type AstNode } from './ast'
+import { atRoot, atRule, decl, styleRule, type AstNode } from './ast'
 import type { Candidate, CandidateModifier, NamedUtilityValue } from './candidate'
 import type { Theme, ThemeKey } from './theme'
 import { DefaultMap } from './utils/default-map'
@@ -2024,7 +2024,7 @@ export function createUtilities(theme: Theme) {
     handle: (value) => [
       atRoot([property('--tw-space-x-reverse', '0', '<number>')]),
 
-      rule(':where(& > :not(:last-child))', [
+      styleRule(':where(& > :not(:last-child))', [
         decl('--tw-sort', 'row-gap'),
         decl('margin-inline-start', `calc(${value} * var(--tw-space-x-reverse))`),
         decl('margin-inline-end', `calc(${value} * calc(1 - var(--tw-space-x-reverse)))`),
@@ -2038,7 +2038,7 @@ export function createUtilities(theme: Theme) {
     handle: (value) => [
       atRoot([property('--tw-space-y-reverse', '0', '<number>')]),
 
-      rule(':where(& > :not(:last-child))', [
+      styleRule(':where(& > :not(:last-child))', [
         decl('--tw-sort', 'column-gap'),
         decl('margin-block-start', `calc(${value} * var(--tw-space-y-reverse))`),
         decl('margin-block-end', `calc(${value} * calc(1 - var(--tw-space-y-reverse)))`),
@@ -2049,7 +2049,7 @@ export function createUtilities(theme: Theme) {
   staticUtility('space-x-reverse', [
     () => atRoot([property('--tw-space-x-reverse', '0', '<number>')]),
     () =>
-      rule(':where(& > :not(:last-child))', [
+      styleRule(':where(& > :not(:last-child))', [
         decl('--tw-sort', 'row-gap'),
         decl('--tw-space-x-reverse', '1'),
       ]),
@@ -2058,7 +2058,7 @@ export function createUtilities(theme: Theme) {
   staticUtility('space-y-reverse', [
     () => atRoot([property('--tw-space-y-reverse', '0', '<number>')]),
     () =>
-      rule(':where(& > :not(:last-child))', [
+      styleRule(':where(& > :not(:last-child))', [
         decl('--tw-sort', 'column-gap'),
         decl('--tw-space-y-reverse', '1'),
       ]),
@@ -2078,7 +2078,7 @@ export function createUtilities(theme: Theme) {
   colorUtility('divide', {
     themeKeys: ['--divide-color', '--color'],
     handle: (value) => [
-      rule(':where(& > :not(:last-child))', [
+      styleRule(':where(& > :not(:last-child))', [
         decl('--tw-sort', 'divide-color'),
         decl('border-color', value),
       ]),
@@ -2386,7 +2386,7 @@ export function createUtilities(theme: Theme) {
       handle: (value) => [
         atRoot([property('--tw-divide-x-reverse', '0', '<number>')]),
 
-        rule(':where(& > :not(:last-child))', [
+        styleRule(':where(& > :not(:last-child))', [
           decl('--tw-sort', 'divide-x-width'),
           borderProperties(),
           decl('border-inline-style', 'var(--tw-border-style)'),
@@ -2406,7 +2406,7 @@ export function createUtilities(theme: Theme) {
       handle: (value) => [
         atRoot([property('--tw-divide-y-reverse', '0', '<number>')]),
 
-        rule(':where(& > :not(:last-child))', [
+        styleRule(':where(& > :not(:last-child))', [
           decl('--tw-sort', 'divide-y-width'),
           borderProperties(),
           decl('border-bottom-style', 'var(--tw-border-style)'),
@@ -2435,18 +2435,18 @@ export function createUtilities(theme: Theme) {
 
     staticUtility('divide-x-reverse', [
       () => atRoot([property('--tw-divide-x-reverse', '0', '<number>')]),
-      () => rule(':where(& > :not(:last-child))', [decl('--tw-divide-x-reverse', '1')]),
+      () => styleRule(':where(& > :not(:last-child))', [decl('--tw-divide-x-reverse', '1')]),
     ])
 
     staticUtility('divide-y-reverse', [
       () => atRoot([property('--tw-divide-y-reverse', '0', '<number>')]),
-      () => rule(':where(& > :not(:last-child))', [decl('--tw-divide-y-reverse', '1')]),
+      () => styleRule(':where(& > :not(:last-child))', [decl('--tw-divide-y-reverse', '1')]),
     ])
 
     for (let value of ['solid', 'dashed', 'dotted', 'double', 'none']) {
       staticUtility(`divide-${value}`, [
         () =>
-          rule(':where(& > :not(:last-child))', [
+          styleRule(':where(& > :not(:last-child))', [
             decl('--tw-sort', 'divide-style'),
             decl('--tw-border-style', value),
             decl('border-style', value),
@@ -3150,7 +3150,7 @@ export function createUtilities(theme: Theme) {
   colorUtility('placeholder', {
     themeKeys: ['--background-color', '--color'],
     handle: (value) => [
-      rule('&::placeholder', [decl('--tw-sort', 'placeholder-color'), decl('color', value)]),
+      styleRule('&::placeholder', [decl('--tw-sort', 'placeholder-color'), decl('color', value)]),
     ],
   })
 

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -81,7 +81,7 @@ export class Variants {
     let selectors: string[] = []
 
     walk(ast, (node) => {
-      if (node.kind === 'style-rule') {
+      if (node.kind === 'rule') {
         selectors.push(node.selector)
       } else if (node.kind === 'at-rule' && node.name !== 'slot') {
         selectors.push(`@${node.name} ${node.params}`)
@@ -415,7 +415,7 @@ export function createVariants(theme: Theme): Variants {
     let didApply = false
 
     walk([ruleNode], (node, { path }) => {
-      if (node.kind !== 'style-rule' && node.kind !== 'at-rule') return WalkAction.Continue
+      if (node.kind !== 'rule' && node.kind !== 'at-rule') return WalkAction.Continue
       if (node.nodes.length > 0) return WalkAction.Continue
 
       // Throw out any candidates with variants using nested style rules
@@ -425,7 +425,7 @@ export function createVariants(theme: Theme): Variants {
       for (let parent of path) {
         if (parent.kind === 'at-rule') {
           atRules.push(parent)
-        } else if (parent.kind === 'style-rule') {
+        } else if (parent.kind === 'rule') {
           styleRules.push(parent)
         }
       }
@@ -464,11 +464,7 @@ export function createVariants(theme: Theme): Variants {
     })
 
     // TODO: Tweak group, peer, has to ignore intermediate `&` selectors (maybe?)
-    if (
-      ruleNode.kind === 'style-rule' &&
-      ruleNode.selector === '&' &&
-      ruleNode.nodes.length === 1
-    ) {
+    if (ruleNode.kind === 'rule' && ruleNode.selector === '&' && ruleNode.nodes.length === 1) {
       Object.assign(ruleNode, ruleNode.nodes[0])
     }
 
@@ -495,11 +491,11 @@ export function createVariants(theme: Theme): Variants {
     let didApply = false
 
     walk([ruleNode], (node, { path }) => {
-      if (node.kind !== 'style-rule') return WalkAction.Continue
+      if (node.kind !== 'rule') return WalkAction.Continue
 
       // Throw out any candidates with variants using nested style rules
       for (let parent of path.slice(0, -1)) {
-        if (parent.kind !== 'style-rule') continue
+        if (parent.kind !== 'rule') continue
 
         didApply = false
         return WalkAction.Stop
@@ -547,11 +543,11 @@ export function createVariants(theme: Theme): Variants {
     let didApply = false
 
     walk([ruleNode], (node, { path }) => {
-      if (node.kind !== 'style-rule') return WalkAction.Continue
+      if (node.kind !== 'rule') return WalkAction.Continue
 
       // Throw out any candidates with variants using nested style rules
       for (let parent of path.slice(0, -1)) {
-        if (parent.kind !== 'style-rule') continue
+        if (parent.kind !== 'rule') continue
 
         didApply = false
         return WalkAction.Stop
@@ -688,11 +684,11 @@ export function createVariants(theme: Theme): Variants {
     let didApply = false
 
     walk([ruleNode], (node, { path }) => {
-      if (node.kind !== 'style-rule') return WalkAction.Continue
+      if (node.kind !== 'rule') return WalkAction.Continue
 
       // Throw out any candidates with variants using nested style rules
       for (let parent of path.slice(0, -1)) {
-        if (parent.kind !== 'style-rule') continue
+        if (parent.kind !== 'rule') continue
 
         didApply = false
         return WalkAction.Stop

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -83,8 +83,8 @@ export class Variants {
     walk(ast, (node) => {
       if (node.kind === 'rule') {
         selectors.push(node.selector)
-      } else if (node.kind === 'at-rule' && node.name !== 'slot') {
-        selectors.push(`@${node.name} ${node.params}`)
+      } else if (node.kind === 'at-rule' && node.name !== '@slot') {
+        selectors.push(`${node.name} ${node.params}`)
       }
     })
 
@@ -347,7 +347,7 @@ export function createVariants(theme: Theme): Variants {
         return parts.slice(1).join(' ')
       }
 
-      if (ruleName === 'container') {
+      if (ruleName === '@container') {
         // @container {query}
         if (parts[0][0] === '(') {
           return `not ${condition}`
@@ -368,7 +368,7 @@ export function createVariants(theme: Theme): Variants {
     })
   }
 
-  let conditionalRules = ['media', 'supports', 'container']
+  let conditionalRules = ['@media', '@supports', '@container']
 
   function negateAtRule(rule: AtRule) {
     for (let ruleName of conditionalRules) {
@@ -597,7 +597,7 @@ export function createVariants(theme: Theme): Variants {
   {
     function contentProperties() {
       return atRoot([
-        atRule('property', '--tw-content', [
+        atRule('@property', '--tw-content', [
           decl('syntax', '"*"'),
           decl('initial-value', '""'),
           decl('inherits', 'false'),
@@ -668,7 +668,7 @@ export function createVariants(theme: Theme): Variants {
   // Interactive
   staticVariant('focus-within', ['&:focus-within'])
   variants.static('hover', (r) => {
-    r.nodes = [styleRule('&:hover', [atRule('media', '(hover: hover)', r.nodes)])]
+    r.nodes = [styleRule('&:hover', [atRule('@media', '(hover: hover)', r.nodes)])]
   })
   staticVariant('focus', ['&:focus'])
   staticVariant('focus-visible', ['&:focus-visible'])
@@ -796,7 +796,7 @@ export function createVariants(theme: Theme): Variants {
         // `(condition1) or (condition2)` is supported.
         let query = value.replace(/\b(and|or|not)\b/g, ' $1 ')
 
-        ruleNode.nodes = [atRule('supports', query, ruleNode.nodes)]
+        ruleNode.nodes = [atRule('@supports', query, ruleNode.nodes)]
         return
       }
 
@@ -822,7 +822,7 @@ export function createVariants(theme: Theme): Variants {
         value = `(${value})`
       }
 
-      ruleNode.nodes = [atRule('supports', value, ruleNode.nodes)]
+      ruleNode.nodes = [atRule('@supports', value, ruleNode.nodes)]
     },
     { compounds: Compounds.AtRules },
   )
@@ -941,7 +941,7 @@ export function createVariants(theme: Theme): Variants {
               let value = resolvedBreakpoints.get(variant)
               if (value === null) return null
 
-              ruleNode.nodes = [atRule('media', `(width < ${value})`, ruleNode.nodes)]
+              ruleNode.nodes = [atRule('@media', `(width < ${value})`, ruleNode.nodes)]
             },
             { compounds: Compounds.AtRules },
           )
@@ -963,7 +963,7 @@ export function createVariants(theme: Theme): Variants {
             variants.static(
               key,
               (ruleNode) => {
-                ruleNode.nodes = [atRule('media', `(width >= ${value})`, ruleNode.nodes)]
+                ruleNode.nodes = [atRule('@media', `(width >= ${value})`, ruleNode.nodes)]
               },
               { compounds: Compounds.AtRules },
             )
@@ -976,7 +976,7 @@ export function createVariants(theme: Theme): Variants {
               let value = resolvedBreakpoints.get(variant)
               if (value === null) return null
 
-              ruleNode.nodes = [atRule('media', `(width >= ${value})`, ruleNode.nodes)]
+              ruleNode.nodes = [atRule('@media', `(width >= ${value})`, ruleNode.nodes)]
             },
             { compounds: Compounds.AtRules },
           )
@@ -1029,7 +1029,7 @@ export function createVariants(theme: Theme): Variants {
 
               ruleNode.nodes = [
                 atRule(
-                  'container',
+                  '@container',
                   variant.modifier
                     ? `${variant.modifier.value} (width < ${value})`
                     : `(width < ${value})`,
@@ -1058,7 +1058,7 @@ export function createVariants(theme: Theme): Variants {
 
               ruleNode.nodes = [
                 atRule(
-                  'container',
+                  '@container',
                   variant.modifier
                     ? `${variant.modifier.value} (width >= ${value})`
                     : `(width >= ${value})`,
@@ -1076,7 +1076,7 @@ export function createVariants(theme: Theme): Variants {
 
               ruleNode.nodes = [
                 atRule(
-                  'container',
+                  '@container',
                   variant.modifier
                     ? `${variant.modifier.value} (width >= ${value})`
                     : `(width >= ${value})`,
@@ -1147,12 +1147,12 @@ function quoteAttributeValue(input: string) {
 export function substituteAtSlot(ast: AstNode[], nodes: AstNode[]) {
   walk(ast, (node, { replaceWith }) => {
     // Replace `@slot` with rule nodes
-    if (node.kind === 'at-rule' && node.name === 'slot') {
+    if (node.kind === 'at-rule' && node.name === '@slot') {
       replaceWith(nodes)
     }
 
     // Wrap `@keyframes` and `@property` in `AtRoot` nodes
-    else if (node.kind === 'at-rule' && (node.name === 'keyframes' || node.name === 'property')) {
+    else if (node.kind === 'at-rule' && (node.name === '@keyframes' || node.name === '@property')) {
       Object.assign(node, atRoot([atRule(node.name, node.params, node.nodes)]))
       return WalkAction.Skip
     }

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -4,7 +4,6 @@ import {
   atRule,
   decl,
   rule,
-  styleRule,
   walk,
   type AstNode,
   type AtRule,
@@ -442,7 +441,7 @@ export function createVariants(theme: Theme): Variants {
           return WalkAction.Stop
         }
 
-        rules.push(styleRule(selector, []))
+        rules.push(rule(selector, []))
       }
 
       for (let node of atRules) {
@@ -455,7 +454,7 @@ export function createVariants(theme: Theme): Variants {
         rules.push(negatedAtRule)
       }
 
-      Object.assign(ruleNode, styleRule('&', rules))
+      Object.assign(ruleNode, rule('&', rules))
 
       // Track that the variant was actually applied
       didApply = true
@@ -608,7 +607,7 @@ export function createVariants(theme: Theme): Variants {
       'before',
       (v) => {
         v.nodes = [
-          styleRule('&::before', [
+          rule('&::before', [
             contentProperties(),
             decl('content', 'var(--tw-content)'),
             ...v.nodes,
@@ -622,11 +621,7 @@ export function createVariants(theme: Theme): Variants {
       'after',
       (v) => {
         v.nodes = [
-          styleRule('&::after', [
-            contentProperties(),
-            decl('content', 'var(--tw-content)'),
-            ...v.nodes,
-          ]),
+          rule('&::after', [contentProperties(), decl('content', 'var(--tw-content)'), ...v.nodes]),
         ]
       },
       { compounds: Compounds.Never },
@@ -668,7 +663,7 @@ export function createVariants(theme: Theme): Variants {
   // Interactive
   staticVariant('focus-within', ['&:focus-within'])
   variants.static('hover', (r) => {
-    r.nodes = [styleRule('&:hover', [atRule('media', '(hover: hover)', r.nodes)])]
+    r.nodes = [rule('&:hover', [atRule('media', '(hover: hover)', r.nodes)])]
   })
   staticVariant('focus', ['&:focus'])
   staticVariant('focus-visible', ['&:focus-visible'])
@@ -717,11 +712,9 @@ export function createVariants(theme: Theme): Variants {
     if (!variant.value || variant.modifier) return null
 
     if (variant.value.kind === 'arbitrary') {
-      ruleNode.nodes = [
-        styleRule(`&[aria-${quoteAttributeValue(variant.value.value)}]`, ruleNode.nodes),
-      ]
+      ruleNode.nodes = [rule(`&[aria-${quoteAttributeValue(variant.value.value)}]`, ruleNode.nodes)]
     } else {
-      ruleNode.nodes = [styleRule(`&[aria-${variant.value.value}="true"]`, ruleNode.nodes)]
+      ruleNode.nodes = [rule(`&[aria-${variant.value.value}="true"]`, ruleNode.nodes)]
     }
   })
 
@@ -740,9 +733,7 @@ export function createVariants(theme: Theme): Variants {
   variants.functional('data', (ruleNode, variant) => {
     if (!variant.value || variant.modifier) return null
 
-    ruleNode.nodes = [
-      styleRule(`&[data-${quoteAttributeValue(variant.value.value)}]`, ruleNode.nodes),
-    ]
+    ruleNode.nodes = [rule(`&[data-${quoteAttributeValue(variant.value.value)}]`, ruleNode.nodes)]
   })
 
   variants.functional('nth', (ruleNode, variant) => {
@@ -751,7 +742,7 @@ export function createVariants(theme: Theme): Variants {
     // Only numeric bare values are allowed
     if (variant.value.kind === 'named' && !isPositiveInteger(variant.value.value)) return null
 
-    ruleNode.nodes = [styleRule(`&:nth-child(${variant.value.value})`, ruleNode.nodes)]
+    ruleNode.nodes = [rule(`&:nth-child(${variant.value.value})`, ruleNode.nodes)]
   })
 
   variants.functional('nth-last', (ruleNode, variant) => {
@@ -760,7 +751,7 @@ export function createVariants(theme: Theme): Variants {
     // Only numeric bare values are allowed
     if (variant.value.kind === 'named' && !isPositiveInteger(variant.value.value)) return null
 
-    ruleNode.nodes = [styleRule(`&:nth-last-child(${variant.value.value})`, ruleNode.nodes)]
+    ruleNode.nodes = [rule(`&:nth-last-child(${variant.value.value})`, ruleNode.nodes)]
   })
 
   variants.functional('nth-of-type', (ruleNode, variant) => {
@@ -769,7 +760,7 @@ export function createVariants(theme: Theme): Variants {
     // Only numeric bare values are allowed
     if (variant.value.kind === 'named' && !isPositiveInteger(variant.value.value)) return null
 
-    ruleNode.nodes = [styleRule(`&:nth-of-type(${variant.value.value})`, ruleNode.nodes)]
+    ruleNode.nodes = [rule(`&:nth-of-type(${variant.value.value})`, ruleNode.nodes)]
   })
 
   variants.functional('nth-last-of-type', (ruleNode, variant) => {
@@ -778,7 +769,7 @@ export function createVariants(theme: Theme): Variants {
     // Only numeric bare values are allowed
     if (variant.value.kind === 'named' && !isPositiveInteger(variant.value.value)) return null
 
-    ruleNode.nodes = [styleRule(`&:nth-last-of-type(${variant.value.value})`, ruleNode.nodes)]
+    ruleNode.nodes = [rule(`&:nth-last-of-type(${variant.value.value})`, ruleNode.nodes)]
   })
 
   variants.functional(

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -4,6 +4,7 @@ import {
   atRule,
   decl,
   rule,
+  styleRule,
   walk,
   type AstNode,
   type AtRule,
@@ -441,7 +442,7 @@ export function createVariants(theme: Theme): Variants {
           return WalkAction.Stop
         }
 
-        rules.push(rule(selector, []))
+        rules.push(styleRule(selector, []))
       }
 
       for (let node of atRules) {
@@ -454,7 +455,7 @@ export function createVariants(theme: Theme): Variants {
         rules.push(negatedAtRule)
       }
 
-      Object.assign(ruleNode, rule('&', rules))
+      Object.assign(ruleNode, styleRule('&', rules))
 
       // Track that the variant was actually applied
       didApply = true
@@ -607,7 +608,7 @@ export function createVariants(theme: Theme): Variants {
       'before',
       (v) => {
         v.nodes = [
-          rule('&::before', [
+          styleRule('&::before', [
             contentProperties(),
             decl('content', 'var(--tw-content)'),
             ...v.nodes,
@@ -621,7 +622,11 @@ export function createVariants(theme: Theme): Variants {
       'after',
       (v) => {
         v.nodes = [
-          rule('&::after', [contentProperties(), decl('content', 'var(--tw-content)'), ...v.nodes]),
+          styleRule('&::after', [
+            contentProperties(),
+            decl('content', 'var(--tw-content)'),
+            ...v.nodes,
+          ]),
         ]
       },
       { compounds: Compounds.Never },
@@ -663,7 +668,7 @@ export function createVariants(theme: Theme): Variants {
   // Interactive
   staticVariant('focus-within', ['&:focus-within'])
   variants.static('hover', (r) => {
-    r.nodes = [rule('&:hover', [atRule('media', '(hover: hover)', r.nodes)])]
+    r.nodes = [styleRule('&:hover', [atRule('media', '(hover: hover)', r.nodes)])]
   })
   staticVariant('focus', ['&:focus'])
   staticVariant('focus-visible', ['&:focus-visible'])
@@ -712,9 +717,11 @@ export function createVariants(theme: Theme): Variants {
     if (!variant.value || variant.modifier) return null
 
     if (variant.value.kind === 'arbitrary') {
-      ruleNode.nodes = [rule(`&[aria-${quoteAttributeValue(variant.value.value)}]`, ruleNode.nodes)]
+      ruleNode.nodes = [
+        styleRule(`&[aria-${quoteAttributeValue(variant.value.value)}]`, ruleNode.nodes),
+      ]
     } else {
-      ruleNode.nodes = [rule(`&[aria-${variant.value.value}="true"]`, ruleNode.nodes)]
+      ruleNode.nodes = [styleRule(`&[aria-${variant.value.value}="true"]`, ruleNode.nodes)]
     }
   })
 
@@ -733,7 +740,9 @@ export function createVariants(theme: Theme): Variants {
   variants.functional('data', (ruleNode, variant) => {
     if (!variant.value || variant.modifier) return null
 
-    ruleNode.nodes = [rule(`&[data-${quoteAttributeValue(variant.value.value)}]`, ruleNode.nodes)]
+    ruleNode.nodes = [
+      styleRule(`&[data-${quoteAttributeValue(variant.value.value)}]`, ruleNode.nodes),
+    ]
   })
 
   variants.functional('nth', (ruleNode, variant) => {
@@ -742,7 +751,7 @@ export function createVariants(theme: Theme): Variants {
     // Only numeric bare values are allowed
     if (variant.value.kind === 'named' && !isPositiveInteger(variant.value.value)) return null
 
-    ruleNode.nodes = [rule(`&:nth-child(${variant.value.value})`, ruleNode.nodes)]
+    ruleNode.nodes = [styleRule(`&:nth-child(${variant.value.value})`, ruleNode.nodes)]
   })
 
   variants.functional('nth-last', (ruleNode, variant) => {
@@ -751,7 +760,7 @@ export function createVariants(theme: Theme): Variants {
     // Only numeric bare values are allowed
     if (variant.value.kind === 'named' && !isPositiveInteger(variant.value.value)) return null
 
-    ruleNode.nodes = [rule(`&:nth-last-child(${variant.value.value})`, ruleNode.nodes)]
+    ruleNode.nodes = [styleRule(`&:nth-last-child(${variant.value.value})`, ruleNode.nodes)]
   })
 
   variants.functional('nth-of-type', (ruleNode, variant) => {
@@ -760,7 +769,7 @@ export function createVariants(theme: Theme): Variants {
     // Only numeric bare values are allowed
     if (variant.value.kind === 'named' && !isPositiveInteger(variant.value.value)) return null
 
-    ruleNode.nodes = [rule(`&:nth-of-type(${variant.value.value})`, ruleNode.nodes)]
+    ruleNode.nodes = [styleRule(`&:nth-of-type(${variant.value.value})`, ruleNode.nodes)]
   })
 
   variants.functional('nth-last-of-type', (ruleNode, variant) => {
@@ -769,7 +778,7 @@ export function createVariants(theme: Theme): Variants {
     // Only numeric bare values are allowed
     if (variant.value.kind === 'named' && !isPositiveInteger(variant.value.value)) return null
 
-    ruleNode.nodes = [rule(`&:nth-last-of-type(${variant.value.value})`, ruleNode.nodes)]
+    ruleNode.nodes = [styleRule(`&:nth-last-of-type(${variant.value.value})`, ruleNode.nodes)]
   })
 
   variants.functional(

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -156,8 +156,8 @@ export class Variants {
         ? this.variants.get(child)
         : child.kind === 'arbitrary'
           ? // This isn't strictly necessary but it'll allow us to bail quickly
-          // when parsing candidates
-          { compounds: compoundsForSelectors([child.selector]) }
+            // when parsing candidates
+            { compounds: compoundsForSelectors([child.selector]) }
           : this.variants.get(child.root)
 
     // One of the variants don't exist
@@ -331,7 +331,7 @@ export function createVariants(theme: Theme): Variants {
     )
   }
 
-  variants.static('force', () => { }, { compounds: Compounds.Never })
+  variants.static('force', () => {}, { compounds: Compounds.Never })
   staticVariant('*', [':where(& > *)'], { compounds: Compounds.Never })
 
   function negateConditions(ruleName: string, conditions: string[]) {
@@ -464,7 +464,11 @@ export function createVariants(theme: Theme): Variants {
     })
 
     // TODO: Tweak group, peer, has to ignore intermediate `&` selectors (maybe?)
-    if (ruleNode.kind === 'style-rule' && ruleNode.selector === '&' && ruleNode.nodes.length === 1) {
+    if (
+      ruleNode.kind === 'style-rule' &&
+      ruleNode.selector === '&' &&
+      ruleNode.nodes.length === 1
+    ) {
       Object.assign(ruleNode, ruleNode.nodes[0])
     }
 
@@ -622,7 +626,11 @@ export function createVariants(theme: Theme): Variants {
       'after',
       (v) => {
         v.nodes = [
-          styleRule('&::after', [contentProperties(), decl('content', 'var(--tw-content)'), ...v.nodes]),
+          styleRule('&::after', [
+            contentProperties(),
+            decl('content', 'var(--tw-content)'),
+            ...v.nodes,
+          ]),
         ]
       },
       { compounds: Compounds.Never },
@@ -713,7 +721,9 @@ export function createVariants(theme: Theme): Variants {
     if (!variant.value || variant.modifier) return null
 
     if (variant.value.kind === 'arbitrary') {
-      ruleNode.nodes = [styleRule(`&[aria-${quoteAttributeValue(variant.value.value)}]`, ruleNode.nodes)]
+      ruleNode.nodes = [
+        styleRule(`&[aria-${quoteAttributeValue(variant.value.value)}]`, ruleNode.nodes),
+      ]
     } else {
       ruleNode.nodes = [styleRule(`&[aria-${variant.value.value}="true"]`, ruleNode.nodes)]
     }
@@ -734,7 +744,9 @@ export function createVariants(theme: Theme): Variants {
   variants.functional('data', (ruleNode, variant) => {
     if (!variant.value || variant.modifier) return null
 
-    ruleNode.nodes = [styleRule(`&[data-${quoteAttributeValue(variant.value.value)}]`, ruleNode.nodes)]
+    ruleNode.nodes = [
+      styleRule(`&[data-${quoteAttributeValue(variant.value.value)}]`, ruleNode.nodes),
+    ]
   })
 
   variants.functional('nth', (ruleNode, variant) => {
@@ -853,16 +865,16 @@ export function createVariants(theme: Theme): Variants {
       let aBucket =
         aIsCssFunction === -1
           ? // No CSS function found, bucket by unit instead
-          aValue.replace(/[\d.]+/g, '')
+            aValue.replace(/[\d.]+/g, '')
           : // CSS function found, bucket by function name
-          aValue.slice(0, aIsCssFunction)
+            aValue.slice(0, aIsCssFunction)
 
       let zBucket =
         zIsCssFunction === -1
           ? // No CSS function found, bucket by unit
-          zValue.replace(/[\d.]+/g, '')
+            zValue.replace(/[\d.]+/g, '')
           : // CSS function found, bucket by function name
-          zValue.slice(0, zIsCssFunction)
+            zValue.slice(0, zIsCssFunction)
 
       let order =
         // Compare by bucket name

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -3,21 +3,22 @@ import {
   atRoot,
   atRule,
   decl,
+  rule,
   styleRule,
   walk,
   type AstNode,
   type AtRule,
+  type Rule,
   type StyleRule,
 } from './ast'
 import { type Variant } from './candidate'
-import { parseAtRule } from './css-parser'
 import type { Theme } from './theme'
 import { DefaultMap } from './utils/default-map'
 import { isPositiveInteger } from './utils/infer-data-type'
 import { segment } from './utils/segment'
 
 type VariantFn<T extends Variant['kind']> = (
-  rule: AtRule | StyleRule,
+  rule: Rule,
   variant: Extract<Variant, { kind: T }>,
 ) => null | void
 
@@ -324,13 +325,7 @@ export function createVariants(theme: Theme): Variants {
     variants.static(
       name,
       (r) => {
-        r.nodes = selectors.map((selector) => {
-          if (selector[0] === '@') {
-            return parseAtRule(selector, r.nodes)
-          } else {
-            return styleRule(selector, r.nodes)
-          }
-        })
+        r.nodes = selectors.map((selector) => rule(selector, r.nodes))
       },
       { compounds },
     )
@@ -438,7 +433,7 @@ export function createVariants(theme: Theme): Variants {
       if (atRules.length > 1) return WalkAction.Stop
       if (styleRules.length > 1) return WalkAction.Stop
 
-      let rules: (StyleRule | AtRule)[] = []
+      let rules: Rule[] = []
 
       for (let node of styleRules) {
         let selector = negateSelector(node.selector)


### PR DESCRIPTION
This PR introduces an internal refactor where we introduce the `AtRule` CSS Node in our AST.

The motivation for this is that in a lot of places we need to differentiate between a `Rule` and an `AtRule`. We often do this with code that looks like this:

```ts
rule.selector[0] === '@' && rule.selector.startsWith('@media')
```

Another issue we have is that we often need to check for `'@media '` including the space, because we don't want to match `@mediafoobar` if somebody has this in their CSS. Alternatively, if you CSS is minified then it could be that you have a rule that looks like `@media(width>=100px)`, in this case we _also_ have to check for `@media(`.

Here is a snippet of code that we have in our codebase:

```ts
// Find at-rules rules
if (node.kind === 'rule') {
  if (
    node.selector[0] === '@' &&
    (node.selector.startsWith('@media ') ||
      node.selector.startsWith('@media(') ||
      node.selector.startsWith('@custom-media ') ||
      node.selector.startsWith('@custom-media(') ||
      node.selector.startsWith('@container ') ||
      node.selector.startsWith('@container(') ||
      node.selector.startsWith('@supports ') ||
      node.selector.startsWith('@supports(')) &&
    node.selector.includes(THEME_FUNCTION_INVOCATION)
  ) {
    node.selector = substituteFunctionsInValue(node.selector, resolveThemeValue)
  }
}
```

Which will now be replaced with a much simpler version:
```ts
// Find at-rules rules
if (node.kind === 'at-rule') {
  if (
    (node.name === '@media' ||
      node.name === '@custom-media' ||
      node.name === '@container' ||
      node.name === '@supports') &&
    node.params.includes(THEME_FUNCTION_INVOCATION)
  ) {
    node.params = substituteFunctionsInValue(node.params, resolveThemeValue)
  }
}
```

Checking for all the cases from the first snippet is not the end of the world, but it is error prone. It's easy to miss a case.

A direct comparison is also faster than comparing via the `startsWith(…)` function.

---

Note: this is only a refactor without changing other code _unless_ it was required to make the tests pass. The tests themselves are all passing and none of them changed (because the behavior should be the same).
The one exception is the tests where we check the parsed AST, which now includes `at-rule` nodes instead of `rule` nodes when we have an at-rule.
