### PR TITLE
Fix new file detection in PostCSS plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
         on-next-branch:
           - ${{ github.ref == 'refs/heads/next' }}
         exclude:
-          - on-next-branch: false
+          - on-next-branch: true
             runner: windows-latest
-          - on-next-branch: false
+          - on-next-branch: true
             runner: macos-14
 
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
         on-next-branch:
           - ${{ github.ref == 'refs/heads/next' }}
         exclude:
-          - on-next-branch: true
+          - on-next-branch: false
             runner: windows-latest
-          - on-next-branch: true
+          - on-next-branch: false
             runner: macos-14
 
     runs-on: ${{ matrix.runner }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Detect classes in new files when using `@tailwindcss/postcss` ([#14829](https://github.com/tailwindlabs/tailwindcss/pull/14829))
 
 ## [4.0.0-alpha.31] - 2024-10-29
 

--- a/crates/oxide/src/lib.rs
+++ b/crates/oxide/src/lib.rs
@@ -223,11 +223,17 @@ impl Scanner {
 
         // Check all directories to see if they were modified
         for path in &self.dirs {
+            dbg!(&path);
+
             let current_time = fs::metadata(path)
                 .and_then(|m| m.modified())
                 .unwrap_or(SystemTime::now());
 
+            dbg!(&current_time);
+
             let previous_time = self.mtimes.insert(path.clone(), current_time);
+
+            dbg!(&previous_time);
 
             let should_scan = match previous_time {
                 // Time has changed, so we need to re-scan the file
@@ -240,6 +246,8 @@ impl Scanner {
                 None => true,
             };
 
+            dbg!(&should_scan);
+
             if should_scan {
                 modified_dirs.push(path.clone());
             }
@@ -248,6 +256,8 @@ impl Scanner {
         // Scan all modified directories for their immediate files
         let mut known = FxHashSet::from_iter(self.files.iter().chain(self.dirs.iter()).cloned());
 
+        dbg!(&self.dirs, &modified_dirs, &known);
+
         while !modified_dirs.is_empty() {
             let new_entries = modified_dirs
                 .iter()
@@ -255,6 +265,8 @@ impl Scanner {
                 .map(|entry| entry.path().to_owned())
                 .filter(|path| !known.contains(path))
                 .collect::<Vec<_>>();
+
+            dbg!(&new_entries);
 
             modified_dirs.clear();
 
@@ -268,6 +280,8 @@ impl Scanner {
 
                     // Recursively scan the new directory for files
                     modified_dirs.push(path);
+                } else {
+                    eprintln!("Ignoring non-file/directory: {:?}", path);
                 }
             }
         }

--- a/crates/oxide/src/lib.rs
+++ b/crates/oxide/src/lib.rs
@@ -223,17 +223,11 @@ impl Scanner {
 
         // Check all directories to see if they were modified
         for path in &self.dirs {
-            dbg!(&path);
-
             let current_time = fs::metadata(path)
                 .and_then(|m| m.modified())
                 .unwrap_or(SystemTime::now());
 
-            dbg!(&current_time);
-
             let previous_time = self.mtimes.insert(path.clone(), current_time);
-
-            dbg!(&previous_time);
 
             let should_scan = match previous_time {
                 // Time has changed, so we need to re-scan the file
@@ -246,8 +240,6 @@ impl Scanner {
                 None => true,
             };
 
-            dbg!(&should_scan);
-
             if should_scan {
                 modified_dirs.push(path.clone());
             }
@@ -256,8 +248,6 @@ impl Scanner {
         // Scan all modified directories for their immediate files
         let mut known = FxHashSet::from_iter(self.files.iter().chain(self.dirs.iter()).cloned());
 
-        dbg!(&self.dirs, &modified_dirs, &known);
-
         while !modified_dirs.is_empty() {
             let new_entries = modified_dirs
                 .iter()
@@ -265,8 +255,6 @@ impl Scanner {
                 .map(|entry| entry.path().to_owned())
                 .filter(|path| !known.contains(path))
                 .collect::<Vec<_>>();
-
-            dbg!(&new_entries);
 
             modified_dirs.clear();
 
@@ -280,8 +268,6 @@ impl Scanner {
 
                     // Recursively scan the new directory for files
                     modified_dirs.push(path);
-                } else {
-                    eprintln!("Ignoring non-file/directory: {:?}", path);
                 }
             }
         }

--- a/crates/oxide/src/scanner/detect_sources.rs
+++ b/crates/oxide/src/scanner/detect_sources.rs
@@ -27,11 +27,11 @@ impl DetectSources {
         Self { base }
     }
 
-    pub fn detect(&self) -> (Vec<PathBuf>, Vec<GlobEntry>) {
+    pub fn detect(&self) -> (Vec<PathBuf>, Vec<GlobEntry>, Vec<PathBuf>) {
         let (files, dirs) = self.resolve_files();
         let globs = self.resolve_globs(&dirs);
 
-        (files, globs)
+        (files, globs, dirs)
     }
 
     fn resolve_files(&self) -> (Vec<PathBuf>, Vec<PathBuf>) {

--- a/crates/oxide/tests/scanner.rs
+++ b/crates/oxide/tests/scanner.rs
@@ -405,6 +405,9 @@ mod scanner {
             ]
         );
 
+        // We have to sleep because it might run too fast (seriously) and the
+        // mtimes of the directories end up being the same as the last time we
+        // checked them
         sleep(Duration::from_millis(100));
 
         // Create files
@@ -427,6 +430,11 @@ mod scanner {
                 "content-['project-b/new.html']".to_owned(),
             ]
         );
+
+        // We have to sleep because it might run too fast (seriously) and the
+        // mtimes of the directories end up being the same as the last time we
+        // checked them
+        sleep(Duration::from_millis(100));
 
         // Create folders
         create_files_in(
@@ -456,6 +464,11 @@ mod scanner {
                 "content-['project-b/sub1/sub2/index.html']".to_owned(),
             ]
         );
+
+        // We have to sleep because it might run too fast (seriously) and the
+        // mtimes of the directories end up being the same as the last time we
+        // checked them
+        sleep(Duration::from_millis(100));
 
         // Create folders
         create_files_in(

--- a/crates/oxide/tests/scanner.rs
+++ b/crates/oxide/tests/scanner.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod scanner {
     use std::process::Command;
+    use std::thread::sleep;
+    use std::time::Duration;
     use std::{fs, path};
 
     use tailwindcss_oxide::*;
@@ -402,6 +404,8 @@ mod scanner {
                 "content-['project-b/index.html']".to_owned(),
             ]
         );
+
+        sleep(Duration::from_millis(100));
 
         // Create files
         create_files_in(

--- a/integrations/postcss/index.test.ts
+++ b/integrations/postcss/index.test.ts
@@ -947,32 +947,42 @@ test(
     ])
 
     // Creating new files in the "root" of auto source detected folders
-    // await fs.write(
-    //   'project-b/new-file.html',
-    //   html`<div class="[.created_&]:content-['project-b/new-file.html']"></div>`,
-    // )
-    // await fs.write(
-    //   'project-b/new-folder/new-file.html',
-    //   html`<div class="[.created_&]:content-['project-b/new-folder/new-file.html']"></div>`,
-    // )
-    // await fs.write(
-    //   'project-c/new-file.html',
-    //   html`<div class="[.created_&]:content-['project-c/new-file.html']"></div>`,
-    // )
-    // await fs.write(
-    //   'project-c/new-folder/new-file.html',
-    //   html`<div class="[.created_&]:content-['project-c/new-folder/new-file.html']"></div>`,
-    // )
+    // We need to create the files and *then* update them because postcss-cli
+    // does not pick up new files — only changes to existing files.
+    await fs.create([
+      'project-b/new-file.html',
+      'project-b/new-folder/new-file.html',
+      'project-c/new-file.html',
+      'project-c/new-folder/new-file.html',
+    ])
 
-    // await fs.write('project-a/src/index.css', await fs.read('project-a/src/index.css'))
-    // await new Promise((resolve) => setTimeout(resolve, 1000))
+    // If we don't wait writes will be coalesced into a "add" event which
+    // isn't picked up by postcss-cli.
+    await new Promise((resolve) => setTimeout(resolve, 100))
 
-    // await fs.expectFileToContain('./project-a/dist/out.css', [
-    //   candidate`[.created_&]:content-['project-b/new-file.html']`,
-    //   candidate`[.created_&]:content-['project-b/new-folder/new-file.html']`,
-    //   candidate`[.created_&]:content-['project-c/new-file.html']`,
-    //   candidate`[.created_&]:content-['project-c/new-folder/new-file.html']`,
-    // ])
+    await fs.write(
+      'project-b/new-file.html',
+      html`<div class="[.created_&]:content-['project-b/new-file.html']"></div>`,
+    )
+    await fs.write(
+      'project-b/new-folder/new-file.html',
+      html`<div class="[.created_&]:content-['project-b/new-folder/new-file.html']"></div>`,
+    )
+    await fs.write(
+      'project-c/new-file.html',
+      html`<div class="[.created_&]:content-['project-c/new-file.html']"></div>`,
+    )
+    await fs.write(
+      'project-c/new-folder/new-file.html',
+      html`<div class="[.created_&]:content-['project-c/new-folder/new-file.html']"></div>`,
+    )
+
+    await fs.expectFileToContain('./project-a/dist/out.css', [
+      candidate`[.created_&]:content-['project-b/new-file.html']`,
+      candidate`[.created_&]:content-['project-b/new-folder/new-file.html']`,
+      candidate`[.created_&]:content-['project-c/new-file.html']`,
+      candidate`[.created_&]:content-['project-c/new-folder/new-file.html']`,
+    ])
   },
 )
 

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -302,9 +302,6 @@ export function test(
 
               let dir = path.dirname(full)
               await fs.mkdir(dir, { recursive: true })
-
-              // Create the file _then_ write to it which is necessary because
-              // postcss-cli doesn't listen for new files just updates to them
               await fs.writeFile(full, '')
             }
           },

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -39,6 +39,7 @@ interface TestContext {
   getFreePort(): Promise<number>
   fs: {
     write(filePath: string, content: string): Promise<void>
+    create(filePaths: string[]): Promise<void>
     read(filePath: string): Promise<string>
     glob(pattern: string): Promise<[string, string][]>
     dumpFiles(pattern: string): Promise<string>
@@ -294,6 +295,20 @@ export function test(
             await fs.mkdir(dir, { recursive: true })
             await fs.writeFile(full, content)
           },
+
+          async create(filenames: string[]): Promise<void> {
+            for (let filename of filenames) {
+              let full = path.join(root, filename)
+
+              let dir = path.dirname(full)
+              await fs.mkdir(dir, { recursive: true })
+
+              // Create the file _then_ write to it which is necessary because
+              // postcss-cli doesn't listen for new files just updates to them
+              await fs.writeFile(full, '')
+            }
+          },
+
           async read(filePath: string) {
             let content = await fs.readFile(path.resolve(root, filePath), 'utf8')
 


### PR DESCRIPTION
We broke this at some point — probably when we tried to optimize rebuilds in PostCSS by not performing a full auto-source detection scan.

This PR addresses this problem by:
1. Storing a list of found directories
2. Comparing their mod times on every scan
3. If the mod time has changed we scan the directory for new files which we then store and scan