### PR TITLE
Install `@tailwindcss/postcss` next to `tailwindcss`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Detect classes in new files when using `@tailwindcss/postcss` ([#14829](https://github.com/tailwindlabs/tailwindcss/pull/14829))
+- _Upgrade (experimental)_: Install `@tailwindcss/postcss` next to `tailwindcss` ([#14830](https://github.com/tailwindlabs/tailwindcss/pull/14830))
 
 ## [4.0.0-alpha.31] - 2024-10-29
 

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -598,7 +598,7 @@ test(
 )
 
 test(
-  '`@tailwindcss/postcss` should be installed in dev dependencies when `tailwindcss` exists in dev dependencies',
+  '`@tailwindcss/postcss` should be installed in devDependencies when `tailwindcss` exists in dev dependencies',
   {
     fs: {
       'package.json': json`

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -544,6 +544,100 @@ test(
     })
     expect(packageJson.dependencies).not.toHaveProperty('autoprefixer')
     expect(packageJson.dependencies).not.toHaveProperty('postcss-import')
+    expect(packageJson.dependencies).toMatchObject({
+      '@tailwindcss/postcss': expect.stringContaining('4.0.0'),
+    })
+  },
+)
+
+test(
+  '`@tailwindcss/postcss` should be installed in dependencies when `tailwindcss` exists in dependencies',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "dependencies": {
+            "postcss": "^8",
+            "tailwindcss": "^3",
+            "@tailwindcss/upgrade": "workspace:^"
+          }
+        }
+      `,
+      'tailwind.config.js': js`
+        /** @type {import('tailwindcss').Config} */
+        module.exports = {
+          content: ['./src/**/*.{html,js}'],
+        }
+      `,
+      'postcss.config.js': js`
+        module.exports = {
+          plugins: {
+            tailwindcss: {},
+          },
+        }
+      `,
+      'src/index.html': html`
+        <div class="bg-[--my-red]"></div>
+      `,
+      'src/index.css': css`
+        @tailwind base;
+        @tailwind components;
+        @tailwind utilities;
+      `,
+    },
+  },
+  async ({ fs, exec }) => {
+    await exec('npx @tailwindcss/upgrade')
+
+    let packageJsonContent = await fs.read('package.json')
+    let packageJson = JSON.parse(packageJsonContent)
+    expect(packageJson.dependencies).toMatchObject({
+      '@tailwindcss/postcss': expect.stringContaining('4.0.0'),
+    })
+  },
+)
+
+test(
+  '`@tailwindcss/postcss` should be installed in dev dependencies when `tailwindcss` exists in dev dependencies',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "devDependencies": {
+            "postcss": "^8",
+            "tailwindcss": "^3",
+            "@tailwindcss/upgrade": "workspace:^"
+          }
+        }
+      `,
+      'tailwind.config.js': js`
+        /** @type {import('tailwindcss').Config} */
+        module.exports = {
+          content: ['./src/**/*.{html,js}'],
+        }
+      `,
+      'postcss.config.js': js`
+        module.exports = {
+          plugins: {
+            tailwindcss: {},
+          },
+        }
+      `,
+      'src/index.html': html`
+        <div class="bg-[--my-red]"></div>
+      `,
+      'src/index.css': css`
+        @tailwind base;
+        @tailwind components;
+        @tailwind utilities;
+      `,
+    },
+  },
+  async ({ fs, exec }) => {
+    await exec('npx @tailwindcss/upgrade')
+
+    let packageJsonContent = await fs.read('package.json')
+    let packageJson = JSON.parse(packageJsonContent)
     expect(packageJson.devDependencies).toMatchObject({
       '@tailwindcss/postcss': expect.stringContaining('4.0.0'),
     })
@@ -617,7 +711,7 @@ test(
     })
     expect(packageJson.dependencies).not.toHaveProperty('autoprefixer')
     expect(packageJson.dependencies).not.toHaveProperty('postcss-import')
-    expect(packageJson.devDependencies).toMatchObject({
+    expect(packageJson.dependencies).toMatchObject({
       '@tailwindcss/postcss': expect.stringContaining('4.0.0'),
     })
   },
@@ -694,7 +788,7 @@ test(
     })
     expect(packageJson.dependencies).not.toHaveProperty('autoprefixer')
     expect(packageJson.dependencies).not.toHaveProperty('postcss-import')
-    expect(packageJson.devDependencies).toMatchObject({
+    expect(packageJson.dependencies).toMatchObject({
       '@tailwindcss/postcss': expect.stringContaining('4.0.0'),
     })
   },

--- a/packages/@tailwindcss-upgrade/src/index.ts
+++ b/packages/@tailwindcss-upgrade/src/index.ts
@@ -199,7 +199,7 @@ async function run() {
 
   try {
     // Upgrade Tailwind CSS
-    await pkg('add tailwindcss@next', base)
+    await pkg(base).add(['tailwindcss@next'])
   } catch {}
 
   // Remove the JS config if it was fully migrated

--- a/packages/@tailwindcss-upgrade/src/migrate-postcss.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-postcss.ts
@@ -84,7 +84,7 @@ export async function migratePostCSSConfig(base: string) {
 
   if (didAddPostcssClient) {
     try {
-      await pkg('add -D @tailwindcss/postcss@next', base)
+      await pkg(base).add(['@tailwindcss/postcss@next'], 'devDependencies')
     } catch {}
   }
   if (didRemoveAutoprefixer || didRemovePostCSSImport) {
@@ -92,10 +92,8 @@ export async function migratePostCSSConfig(base: string) {
       let packagesToRemove = [
         didRemoveAutoprefixer ? 'autoprefixer' : null,
         didRemovePostCSSImport ? 'postcss-import' : null,
-      ]
-        .filter(Boolean)
-        .join(' ')
-      await pkg(`remove ${packagesToRemove}`, base)
+      ].filter(Boolean) as string[]
+      await pkg(base).remove(packagesToRemove)
     } catch {}
   }
 

--- a/packages/@tailwindcss-upgrade/src/migrate-postcss.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-postcss.ts
@@ -83,9 +83,17 @@ export async function migratePostCSSConfig(base: string) {
   }
 
   if (didAddPostcssClient) {
-    try {
-      await pkg(base).add(['@tailwindcss/postcss@next'], 'devDependencies')
-    } catch {}
+    let location = Object.hasOwn(packageJson?.dependencies ?? {}, 'tailwindcss')
+      ? ('dependencies' as const)
+      : Object.hasOwn(packageJson?.devDependencies ?? {}, 'tailwindcss')
+        ? ('devDependencies' as const)
+        : null
+
+    if (location !== null) {
+      try {
+        await pkg(base).add(['@tailwindcss/postcss@next'], location)
+      } catch {}
+    }
   }
   if (didRemoveAutoprefixer || didRemovePostCSSImport) {
     try {

--- a/packages/@tailwindcss-upgrade/src/migrate-prettier.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-prettier.ts
@@ -8,7 +8,7 @@ export async function migratePrettierPlugin(base: string) {
   try {
     let packageJson = await fs.readFile(packageJsonPath, 'utf-8')
     if (packageJson.includes('prettier-plugin-tailwindcss')) {
-      await pkg('add prettier-plugin-tailwindcss@latest', base)
+      await pkg(base).add(['prettier-plugin-tailwindcss@latest'])
       success(`Prettier plugin migrated to latest version.`)
     }
   } catch {}

--- a/packages/@tailwindcss-upgrade/src/utils/packages.ts
+++ b/packages/@tailwindcss-upgrade/src/utils/packages.ts
@@ -121,7 +121,7 @@ let packageManagers = new DefaultMap((base) => {
 })
 
 let didWarnAboutPackageManager = false
-async function detectPackageManager(base: string): Promise<PackageManager> {
+let packageManagerForBase = new DefaultMap(async (base) => {
   do {
     // 1. Check package.json for a `packageManager` field
     let packageJsonPath = resolve(base, 'package.json')
@@ -182,4 +182,4 @@ async function detectPackageManager(base: string): Promise<PackageManager> {
       return Promise.reject('No package manager detected')
     }
   } while (true)
-}
+})

--- a/packages/@tailwindcss-upgrade/src/utils/packages.ts
+++ b/packages/@tailwindcss-upgrade/src/utils/packages.ts
@@ -7,6 +7,19 @@ import { warn } from './renderer'
 
 const exec = promisify(execCb)
 
+export function pkg(base: string) {
+  return {
+    async add(packages: string[], location: 'dependencies' | 'devDependencies' = 'dependencies') {
+      let packageManager = await packageManagerForBase.get(base)
+      return packageManager.add(packages, location)
+    },
+    async remove(packages: string[]) {
+      let packageManager = await packageManagerForBase.get(base)
+      return packageManager.remove(packages)
+    },
+  }
+}
+
 class PackageManager {
   constructor(private base: string) {}
 
@@ -106,19 +119,6 @@ let packageManagers = new DefaultMap((base) => {
     }
   })
 })
-
-export function pkg(base: string) {
-  return {
-    async add(packages: string[], location: 'dependencies' | 'devDependencies' = 'dependencies') {
-      let packageManager = await detectPackageManager(base)
-      return packageManager.add(packages, location)
-    },
-    async remove(packages: string[]) {
-      let packageManager = await detectPackageManager(base)
-      return packageManager.remove(packages)
-    },
-  }
-}
 
 let didWarnAboutPackageManager = false
 async function detectPackageManager(base: string): Promise<PackageManager> {


### PR DESCRIPTION
This PR improves the PostCSS migrations to make sure that we install `@tailwindcss/postcss` in the same bucket as `tailwindcss`.

If `tailwindcss` exists in the `dependencies` bucket, we install `@tailwindcss/postcss` in the same bucket. If `tailwindcss` exists in the `devDependencies` bucket, we install `@tailwindcss/postcss` in the same bucket.

This also contains an internal refactor that normalizes the package manager to make sure we can install a package to the correct bucket depending on the package manager.
