### PR TITLE
Migrate `grid-cols-[subgrid]` and `grid-rows-[subgrid]` to `grid-cols-subgrid` and `grid-rows-subgrid`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - _Upgrade (experimental)_: Install `@tailwindcss/postcss` next to `tailwindcss` ([#14830](https://github.com/tailwindlabs/tailwindcss/pull/14830))
 - _Upgrade (experimental)_: Remove whitespace around `,` separator when print arbitrary values ([#14838](https://github.com/tailwindlabs/tailwindcss/pull/14838))
 
+### Added
+
+- _Upgrade (experimental)_: Migrate `grid-cols-[subgrid]` and `grid-rows-[subgrid]` to `grid-cols-subgrid` and `grid-rows-subgrid` ([#14840](https://github.com/tailwindlabs/tailwindcss/pull/14840))
+
 ## [4.0.0-alpha.31] - 2024-10-29
 
 ### Added

--- a/packages/@tailwindcss-upgrade/src/template/codemods/arbitrary-value-to-bare-value.test.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/arbitrary-value-to-bare-value.test.ts
@@ -8,6 +8,9 @@ test.each([
   ['col-start-[7]', 'col-start-7'],
   ['flex-[2]', 'flex-2'], // `flex` is implemented as static and functional utilities
 
+  ['grid-cols-[subgrid]', 'grid-cols-subgrid'],
+  ['grid-rows-[subgrid]', 'grid-rows-subgrid'],
+
   // Only 50-200% (inclusive) are valid:
   // https://developer.mozilla.org/en-US/docs/Web/CSS/font-stretch#percentage
   ['font-stretch-[50%]', 'font-stretch-50%'],

--- a/packages/@tailwindcss-upgrade/src/template/codemods/arbitrary-value-to-bare-value.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/arbitrary-value-to-bare-value.ts
@@ -14,6 +14,21 @@ export function arbitraryValueToBareValue(
     let clone = structuredClone(candidate)
     let changed = false
 
+    // Convert [subgrid] to subgrid
+    if (
+      clone.kind === 'functional' &&
+      clone.value?.kind === 'arbitrary' &&
+      clone.value.value === 'subgrid' &&
+      (clone.root === 'grid-cols' || clone.root == 'grid-rows')
+    ) {
+      changed = true
+      clone.value = {
+        kind: 'named',
+        value: 'subgrid',
+        fraction: null,
+      }
+    }
+
     // Convert utilities that accept bare values ending in %
     if (
       clone.kind === 'functional' &&


### PR DESCRIPTION
This PR adds a migration to convert `grid-cols-[subgrid]` to `grid-cols-subgrid` and `grid-rows-[subgrid]` to `grid-rows-subgrid`.
