### PR TITLE
Generate CSS after Vite handles imports during prod builds

### DIFF
--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -28,6 +28,7 @@ interface ExecOptions {
 }
 
 interface TestConfig {
+  todo?: boolean
   fs: {
     [filePath: string]: string | Uint8Array
   }
@@ -74,6 +75,10 @@ export function test(
   testCallback: TestCallback,
   { only = false, debug = false }: TestFlags = {},
 ) {
+  if (config.todo) {
+    return defaultTest.todo(name)
+  }
+
   return (only || (!process.env.CI && debug) ? defaultTest.only : defaultTest)(
     name,
     { timeout: TEST_TIMEOUT, retry: process.env.CI ? 2 : 0 },

--- a/integrations/vite/url-rewriting.test.ts
+++ b/integrations/vite/url-rewriting.test.ts
@@ -1,68 +1,76 @@
-import { expect } from 'vitest'
-import { binary, css, html, json, test, ts } from '../utils'
+import { describe, expect } from 'vitest'
+import { binary, css, html, test, ts, txt } from '../utils'
 
 const SIMPLE_IMAGE = `iVBORw0KGgoAAAANSUhEUgAAADAAAAAlAQAAAAAsYlcCAAAACklEQVR4AWMYBQABAwABRUEDtQAAAABJRU5ErkJggg==`
 
-test(
-  'can rewrite urls in production builds',
-  {
-    fs: {
-      'package.json': json`
-        {
-          "type": "module",
-          "dependencies": {
-            "tailwindcss": "workspace:^"
-          },
-          "devDependencies": {
-            "@tailwindcss/vite": "workspace:^",
-            "vite": "^5.3.5"
-          }
-        }
-      `,
-      'vite.config.ts': ts`
-        import { defineConfig } from 'vite'
-        import tailwindcss from '@tailwindcss/vite'
+for (let transformer of ['postcss', 'lightningcss']) {
+  describe(transformer, () => {
+    test(
+      'can rewrite urls in production builds',
+      {
+        todo: transformer === 'lightningcss',
+        fs: {
+          'package.json': txt`
+            {
+              "type": "module",
+              "dependencies": {
+                "tailwindcss": "workspace:^"
+              },
+              "devDependencies": {
+                ${transformer === 'lightningcss' ? `"lightningcss": "^1.26.0",` : ''}
+                "@tailwindcss/vite": "workspace:^",
+                "vite": "^5.3.5"
+              }
+            }
+          `,
+          'vite.config.ts': ts`
+            import tailwindcss from '@tailwindcss/vite'
+            import { defineConfig } from 'vite'
 
-        export default defineConfig({
-          plugins: [tailwindcss()],
-        })
-      `,
-      'index.html': html`
-        <!doctype html>
-        <html>
-          <head>
-            <link rel="stylesheet" href="./src/app.css" />
-          </head>
-          <body>
-            <div id="app"></div>
-            <script type="module" src="./src/main.ts"></script>
-          </body>
-        </html>
-      `,
-      'src/main.ts': ts``,
-      'src/app.css': css`
-        @import './dir-1/bar.css';
-        @import './dir-1/dir-2/baz.css';
-      `,
-      'src/dir-1/bar.css': css`
-        .bar {
-          background-image: url('../../resources/image.png');
-        }
-      `,
-      'src/dir-1/dir-2/baz.css': css`
-        .baz {
-          background-image: url('../../../resources/image.png');
-        }
-      `,
-      'resources/image.png': binary(SIMPLE_IMAGE),
-    },
-  },
-  async ({ fs, exec }) => {
-    await exec('pnpm vite build')
+            export default defineConfig({
+              plugins: [tailwindcss()],
+              build: { cssMinify: false },
+              css: ${transformer === 'postcss' ? '{}' : "{ transformer: 'lightningcss' }"},
+            })
+          `,
+          'index.html': html`
+            <!doctype html>
+            <html>
+              <head>
+                <link rel="stylesheet" href="./src/app.css" />
+              </head>
+              <body>
+                <div id="app"></div>
+                <script type="module" src="./src/main.ts"></script>
+              </body>
+            </html>
+          `,
+          'src/main.ts': ts``,
+          'src/app.css': css`
+            @import './dir-1/bar.css';
+            @import './dir-1/dir-2/baz.css';
+          `,
+          'src/dir-1/bar.css': css`
+            .bar {
+              background-image: url('../../resources/image.png');
+            }
+          `,
+          'src/dir-1/dir-2/baz.css': css`
+            .baz {
+              background-image: url('../../../resources/image.png');
+            }
+          `,
+          'resources/image.png': binary(SIMPLE_IMAGE),
+        },
+      },
+      async ({ fs, exec }) => {
+        await exec('pnpm vite build')
 
-    let files = await fs.glob('dist/**/*.css')
-    expect(files).toHaveLength(1)
+        let files = await fs.glob('dist/**/*.css')
+        expect(files).toHaveLength(1)
 
-    await fs.expectFileToContain(files[0][0], [SIMPLE_IMAGE])
-  },
-)
+        await fs.expectFileToContain(files[0][0], [SIMPLE_IMAGE])
+      },
+    )
+  })
+}

--- a/integrations/vite/url-rewriting.test.ts
+++ b/integrations/vite/url-rewriting.test.ts
@@ -1,0 +1,68 @@
+import { expect } from 'vitest'
+import { binary, css, html, json, test, ts } from '../utils'
+
+const SIMPLE_IMAGE = `iVBORw0KGgoAAAANSUhEUgAAADAAAAAlAQAAAAAsYlcCAAAACklEQVR4AWMYBQABAwABRUEDtQAAAABJRU5ErkJggg==`
+
+test(
+  'can rewrite urls in production builds',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "type": "module",
+          "dependencies": {
+            "tailwindcss": "workspace:^"
+          },
+          "devDependencies": {
+            "@tailwindcss/vite": "workspace:^",
+            "vite": "^5.3.5"
+          }
+        }
+      `,
+      'vite.config.ts': ts`
+        import { defineConfig } from 'vite'
+        import tailwindcss from '@tailwindcss/vite'
+
+        export default defineConfig({
+          plugins: [tailwindcss()],
+        })
+      `,
+      'index.html': html`
+        <!doctype html>
+        <html>
+          <head>
+            <link rel="stylesheet" href="./src/app.css" />
+          </head>
+          <body>
+            <div id="app"></div>
+            <script type="module" src="./src/main.ts"></script>
+          </body>
+        </html>
+      `,
+      'src/main.ts': ts``,
+      'src/app.css': css`
+        @import './dir-1/bar.css';
+        @import './dir-1/dir-2/baz.css';
+      `,
+      'src/dir-1/bar.css': css`
+        .bar {
+          background-image: url('../../resources/image.png');
+        }
+      `,
+      'src/dir-1/dir-2/baz.css': css`
+        .baz {
+          background-image: url('../../../resources/image.png');
+        }
+      `,
+      'resources/image.png': binary(SIMPLE_IMAGE),
+    },
+  },
+  async ({ fs, exec }) => {
+    await exec('pnpm vite build')
+
+    let files = await fs.glob('dist/**/*.css')
+    expect(files).toHaveLength(1)
+
+    await fs.expectFileToContain(files[0][0], [SIMPLE_IMAGE])
+  },
+)

--- a/integrations/vite/vue.test.ts
+++ b/integrations/vite/vue.test.ts
@@ -51,9 +51,15 @@ test(
             @apply text-red-500;
           }
         </style>
-
+        <style scoped>
+          @import 'tailwindcss/utilities';
+          @import 'tailwindcss/theme' theme(reference);
+          :deep(.bar) {
+            color: red;
+          }
+        </style>
         <template>
-          <div class="underline foo">Hello Vue!</div>
+          <div class="underline foo bar">Hello Vue!</div>
         </template>
       `,
     },
@@ -65,5 +71,7 @@ test(
     expect(files).toHaveLength(1)
 
     await fs.expectFileToContain(files[0][0], [candidate`underline`, candidate`foo`])
+
+    await fs.expectFileNotToContain(files[0][0], [':deep(.bar)'])
   },
 )

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -209,7 +209,22 @@ export default function tailwindcss(): Plugin[] {
       // Step 2 (full build): Generate CSS
       name: '@tailwindcss/vite:generate:build',
       apply: 'build',
-      enforce: 'pre',
+
+      // NOTE:
+      // We used to use `enforce: 'pre'` here because Tailwind CSS can handle
+      // imports itself. However, this caused two problems:
+      //
+      // - Relative asset URL rewriting for was not happening so things like
+      // `background-image: url(../image.png)` could break if done in an
+      // imported CSS file.
+      //
+      // - Processing of Vue scoped style blocks didn't happen at the right time
+      // which caused `:deep(…)` to end up in the generated CSS rather than
+      // appropriately handled by Vue.
+      //
+      // This does mean that Tailwind is no longer handling the imports itself
+      // which is not ideal but it's a reasonable tradeoff until we can resolve
+      // both of these issues with Tailwind's own import handling.
 
       async transform(src, id) {
         if (!isPotentialCssRootFile(id)) return


### PR DESCRIPTION
When we started handling `@import` ourselves in #14446 we inadvertently broke Vite's URL asset url rewriting inside of some imported CSS files. 

For example, given the following files:
```css
/* ./main.css */
@import "./dir/imported.css";

/* ./dir/imported.css */
.foo {
  background: url(../image.png);
}

/* ./image.png */
/* … */
```

We'd flatten the import CSS and you'd end up with the following:
```css
/* main.css */
.foo {
  background: url(../image.png);
}

/* ./image.png */
/* … */
```

And, as you can see, `../image.png` does not exist relative to the "final" CSS. It should've been rewritten to `./image.png` but was not. Letting Vite handle the imports will rewrite these urls properly — which is what this PR does. It achieves this by running our CSS generation when typtical Vite plugins do rather than before (via `enforce: 'pre'`).

Additionally, because we were running the generation step early, Vue had not handled `:deep(…)` selectors in `<style scoped>` blocks yet and we were caching the unprocessed CSS. This is also fixed by this PR.

Ideally both of these things would be fixable by changing how we handle imports but that will require additional APIs so this is a reasonable stopgap measure until we can do that.

Fixes #14839
