### PR TITLE
Ensure `--inset-ring=*` and `--inset-shadow-*` variables are ignored by `inset-*` utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Detect classes in new files when using `@tailwindcss/postcss` ([#14829](https://github.com/tailwindlabs/tailwindcss/pull/14829))
 - Fix crash when using `@source` containing `..` ([#14831](https://github.com/tailwindlabs/tailwindcss/pull/14831))
 - Ensure instances of the same variant with different values are always sorted deterministically (e.g. `data-focus:flex` and `data-active:flex`) ([#14835](https://github.com/tailwindlabs/tailwindcss/pull/14835))
+- Ensure `--inset-ring=*` and `--inset-shadow-*` variables are ignored by `inset-*` utilities ([#14855](https://github.com/tailwindlabs/tailwindcss/pull/14855))
 - _Upgrade (experimental)_: Install `@tailwindcss/postcss` next to `tailwindcss` ([#14830](https://github.com/tailwindlabs/tailwindcss/pull/14830))
 - _Upgrade (experimental)_: Remove whitespace around `,` separator when print arbitrary values ([#14838](https://github.com/tailwindlabs/tailwindcss/pull/14838))
 

--- a/packages/tailwindcss/src/intellisense.test.ts
+++ b/packages/tailwindcss/src/intellisense.test.ts
@@ -22,6 +22,7 @@ function loadDesignSystem() {
   theme.add('--perspective-normal', '500px')
   theme.add('--opacity-background', '0.3')
   theme.add('--drop-shadow-sm', '0 1px 1px rgb(0 0 0 / 0.05)')
+  theme.add('--inset-shadow-sm', 'inset 0 1px 1px rgb(0 0 0 / 0.05)')
   return buildDesignSystem(theme)
 }
 

--- a/packages/tailwindcss/src/intellisense.test.ts
+++ b/packages/tailwindcss/src/intellisense.test.ts
@@ -23,6 +23,7 @@ function loadDesignSystem() {
   theme.add('--opacity-background', '0.3')
   theme.add('--drop-shadow-sm', '0 1px 1px rgb(0 0 0 / 0.05)')
   theme.add('--inset-shadow-sm', 'inset 0 1px 1px rgb(0 0 0 / 0.05)')
+  theme.add('--inset-ring-big', '100px')
   return buildDesignSystem(theme)
 }
 

--- a/packages/tailwindcss/src/theme.ts
+++ b/packages/tailwindcss/src/theme.ts
@@ -8,6 +8,12 @@ export const enum ThemeOptions {
   DEFAULT = 1 << 2,
 }
 
+function isIgnoredThemeKey(themeKey: ThemeKey, ignoredThemeKeys: ThemeKey[]) {
+  return ignoredThemeKeys.some(
+    (ignoredThemeKey) => themeKey === ignoredThemeKey || themeKey.startsWith(`${ignoredThemeKey}-`),
+  )
+}
+
 export class Theme {
   public prefix: string | null = null
 
@@ -53,7 +59,7 @@ export class Theme {
       for (let key of this.values.keys()) {
         if (!key.startsWith(namespace)) continue
 
-        if (ignoredThemeKeys.some((ignoredThemeKey) => key.startsWith(ignoredThemeKey))) {
+        if (isIgnoredThemeKey(key as ThemeKey, ignoredThemeKeys)) {
           continue
         }
 
@@ -122,12 +128,11 @@ export class Theme {
   ): string | null {
     for (let key of themeKeys) {
       let themeKey =
-        candidateValue !== null ? escape(`${key}-${candidateValue.replaceAll('.', '_')}`) : key
+        candidateValue !== null
+          ? (escape(`${key}-${candidateValue.replaceAll('.', '_')}`) as ThemeKey)
+          : key
 
-      if (
-        this.values.has(themeKey) &&
-        !ignoredThemeKeys.some((ignoredThemeKey) => themeKey.startsWith(ignoredThemeKey))
-      ) {
+      if (this.values.has(themeKey) && !isIgnoredThemeKey(themeKey, ignoredThemeKeys)) {
         return themeKey
       }
     }

--- a/packages/tailwindcss/src/theme.ts
+++ b/packages/tailwindcss/src/theme.ts
@@ -182,8 +182,9 @@ export class Theme {
     candidateValue: string,
     themeKeys: ThemeKey[],
     nestedKeys: `--${string}`[] = [],
+    ignoredThemeKeys: ThemeKey[] = [],
   ): [string, Record<string, string>] | null {
-    let themeKey = this.#resolveKey(candidateValue, themeKeys)
+    let themeKey = this.#resolveKey(candidateValue, themeKeys, ignoredThemeKeys)
 
     if (!themeKey) return null
 

--- a/packages/tailwindcss/src/theme.ts
+++ b/packages/tailwindcss/src/theme.ts
@@ -132,9 +132,10 @@ export class Theme {
           ? (escape(`${key}-${candidateValue.replaceAll('.', '_')}`) as ThemeKey)
           : key
 
-      if (this.values.has(themeKey) && !isIgnoredThemeKey(themeKey, ignoredThemeKeys)) {
-        return themeKey
-      }
+      if (!this.values.has(themeKey)) continue
+      if (isIgnoredThemeKey(themeKey, ignoredThemeKeys)) continue
+
+      return themeKey
     }
 
     return null

--- a/packages/tailwindcss/src/theme.ts
+++ b/packages/tailwindcss/src/theme.ts
@@ -59,11 +59,9 @@ export class Theme {
       for (let key of this.values.keys()) {
         if (!key.startsWith(namespace)) continue
 
-        if (isIgnoredThemeKey(key as ThemeKey, ignoredThemeKeys)) {
-          continue
-        }
+        if (key.indexOf('--', 2) !== -1) continue
 
-        if (key.indexOf('--', 2) !== -1) {
+        if (isIgnoredThemeKey(key as ThemeKey, ignoredThemeKeys)) {
           continue
         }
 

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -301,15 +301,11 @@ test('inset-x', async () => {
       css`
         @theme {
           --spacing-4: 1rem;
-          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
-          --inset-ring-thick: 100px;
           --inset-ringo-starr: 1940px;
         }
         @tailwind utilities;
       `,
       [
-        'inset-x-shadow-sm',
-        'inset-x-ring-thick',
         'inset-x-ringo-starr',
         'inset-x-auto',
         'inset-x-full',
@@ -323,8 +319,6 @@ test('inset-x', async () => {
   ).toMatchInlineSnapshot(`
     ":root {
       --spacing-4: 1rem;
-      --inset-shadow-sm: inset 0 1px 1px #0000000d;
-      --inset-ring-thick: 100px;
       --inset-ringo-starr: 1940px;
     }
 
@@ -361,20 +355,32 @@ test('inset-x', async () => {
     }"
   `)
   expect(
-    await run([
-      'inset-x',
-      'inset-x--1',
-      'inset-x--1/2',
-      'inset-x--1/-2',
-      'inset-x-1/-2',
-      'inset-x-auto/foo',
-      'inset-x-full/foo',
-      '-inset-x-full/foo',
-      'inset-x-3/4/foo',
-      'inset-x-4/foo',
-      '-inset-x-4/foo',
-      'inset-x-[4px]/foo',
-    ]),
+    await compileCss(
+      css`
+        @theme reference {
+          --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px #0000000d;
+          --inset-ring-thick: 100px;
+        }
+        @tailwind utilities;
+      `,
+      [
+        'inset-x-shadow-sm',
+        'inset-x-ring-thick',
+        'inset-x',
+        'inset-x--1',
+        'inset-x--1/2',
+        'inset-x--1/-2',
+        'inset-x-1/-2',
+        'inset-x-auto/foo',
+        'inset-x-full/foo',
+        '-inset-x-full/foo',
+        'inset-x-3/4/foo',
+        'inset-x-4/foo',
+        '-inset-x-4/foo',
+        'inset-x-[4px]/foo',
+      ],
+    ),
   ).toEqual('')
 })
 
@@ -384,15 +390,11 @@ test('inset-y', async () => {
       css`
         @theme {
           --spacing-4: 1rem;
-          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
-          --inset-ring-thick: 100px;
           --inset-ringo-starr: 1940px;
         }
         @tailwind utilities;
       `,
       [
-        'inset-y-shadow-sm',
-        'inset-y-ring-thick',
         'inset-y-ringo-starr',
         'inset-y-auto',
         'inset-y-full',
@@ -406,8 +408,6 @@ test('inset-y', async () => {
   ).toMatchInlineSnapshot(`
     ":root {
       --spacing-4: 1rem;
-      --inset-shadow-sm: inset 0 1px 1px #0000000d;
-      --inset-ring-thick: 100px;
       --inset-ringo-starr: 1940px;
     }
 
@@ -444,20 +444,32 @@ test('inset-y', async () => {
     }"
   `)
   expect(
-    await run([
-      'inset-y',
-      'inset-y--1',
-      'inset-y--1/2',
-      'inset-y--1/-2',
-      'inset-1/-2',
-      'inset-y-auto/foo',
-      'inset-y-full/foo',
-      '-inset-y-full/foo',
-      'inset-y-3/4/foo',
-      'inset-y-4/foo',
-      '-inset-y-4/foo',
-      'inset-y-[4px]/foo',
-    ]),
+    await compileCss(
+      css`
+        @theme reference {
+          --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+          --inset-ring-thick: 100px;
+        }
+        @tailwind utilities;
+      `,
+      [
+        'inset-y-shadow-sm',
+        'inset-y-ring-thick',
+        'inset-y',
+        'inset-y--1',
+        'inset-y--1/2',
+        'inset-y--1/-2',
+        'inset-1/-2',
+        'inset-y-auto/foo',
+        'inset-y-full/foo',
+        '-inset-y-full/foo',
+        'inset-y-3/4/foo',
+        'inset-y-4/foo',
+        '-inset-y-4/foo',
+        'inset-y-[4px]/foo',
+      ],
+    ),
   ).toEqual('')
 })
 
@@ -467,15 +479,11 @@ test('start', async () => {
       css`
         @theme {
           --spacing-4: 1rem;
-          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
-          --inset-ring-thick: 100px;
           --inset-ringo-starr: 1940px;
         }
         @tailwind utilities;
       `,
       [
-        'start-shadow-sm',
-        'start-ring-thick',
         'start-ringo-starr',
         'start-auto',
         '-start-full',
@@ -489,8 +497,6 @@ test('start', async () => {
   ).toMatchInlineSnapshot(`
     ":root {
       --spacing-4: 1rem;
-      --inset-shadow-sm: inset 0 1px 1px #0000000d;
-      --inset-ring-thick: 100px;
       --inset-ringo-starr: 1940px;
     }
 
@@ -527,20 +533,32 @@ test('start', async () => {
     }"
   `)
   expect(
-    await run([
-      'start',
-      'start--1',
-      'start--1/2',
-      'start--1/-2',
-      'start-1/-2',
-      'start-auto/foo',
-      '-start-full/foo',
-      'start-full/foo',
-      'start-3/4/foo',
-      'start-4/foo',
-      '-start-4/foo',
-      'start-[4px]/foo',
-    ]),
+    await compileCss(
+      css`
+        @theme reference {
+          --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+          --inset-ring-thick: 100px;
+        }
+        @tailwind utilities;
+      `,
+      [
+        'start-shadow-sm',
+        'start-ring-thick',
+        'start',
+        'start--1',
+        'start--1/2',
+        'start--1/-2',
+        'start-1/-2',
+        'start-auto/foo',
+        '-start-full/foo',
+        'start-full/foo',
+        'start-3/4/foo',
+        'start-4/foo',
+        '-start-4/foo',
+        'start-[4px]/foo',
+      ],
+    ),
   ).toEqual('')
 })
 
@@ -550,15 +568,11 @@ test('end', async () => {
       css`
         @theme {
           --spacing-4: 1rem;
-          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
-          --inset-ring-thick: 100px;
           --inset-ringo-starr: 1940px;
         }
         @tailwind utilities;
       `,
       [
-        'end-shadow-sm',
-        'end-ring-thick',
         'end-ringo-starr',
         'end-auto',
         '-end-full',
@@ -572,8 +586,6 @@ test('end', async () => {
   ).toMatchInlineSnapshot(`
     ":root {
       --spacing-4: 1rem;
-      --inset-shadow-sm: inset 0 1px 1px #0000000d;
-      --inset-ring-thick: 100px;
       --inset-ringo-starr: 1940px;
     }
 
@@ -610,20 +622,32 @@ test('end', async () => {
     }"
   `)
   expect(
-    await run([
-      'end',
-      'end--1',
-      'end--1/2',
-      'end--1/-2',
-      'end-1/-2',
-      'end-auto/foo',
-      '-end-full/foo',
-      'end-full/foo',
-      'end-3/4/foo',
-      'end-4/foo',
-      '-end-4/foo',
-      'end-[4px]/foo',
-    ]),
+    await compileCss(
+      css`
+        @theme reference {
+          --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+          --inset-ring-thick: 100px;
+        }
+        @tailwind utilities;
+      `,
+      [
+        'end-shadow-sm',
+        'end-ring-thick',
+        'end',
+        'end--1',
+        'end--1/2',
+        'end--1/-2',
+        'end-1/-2',
+        'end-auto/foo',
+        '-end-full/foo',
+        'end-full/foo',
+        'end-3/4/foo',
+        'end-4/foo',
+        '-end-4/foo',
+        'end-[4px]/foo',
+      ],
+    ),
   ).toEqual('')
 })
 
@@ -633,16 +657,12 @@ test('top', async () => {
       css`
         @theme {
           --spacing-4: 1rem;
-          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
-          --inset-ring-thick: 100px;
           --inset-ringo-starr: 1940px;
         }
         @tailwind utilities;
       `,
 
       [
-        'top-shadow-sm',
-        'top-ring-thick',
         'top-ringo-starr',
         'top-auto',
         '-top-full',
@@ -656,8 +676,6 @@ test('top', async () => {
   ).toMatchInlineSnapshot(`
     ":root {
       --spacing-4: 1rem;
-      --inset-shadow-sm: inset 0 1px 1px #0000000d;
-      --inset-ring-thick: 100px;
       --inset-ringo-starr: 1940px;
     }
 
@@ -694,20 +712,32 @@ test('top', async () => {
     }"
   `)
   expect(
-    await run([
-      'top',
-      'top--1',
-      'top--1/2',
-      'top--1/-2',
-      'top-1/-2',
-      'top-auto/foo',
-      '-top-full/foo',
-      'top-full/foo',
-      'top-3/4/foo',
-      'top-4/foo',
-      '-top-4/foo',
-      'top-[4px]/foo',
-    ]),
+    await compileCss(
+      css`
+        @theme reference {
+          --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+          --inset-ring-thick: 100px;
+        }
+        @tailwind utilities;
+      `,
+      [
+        'top-shadow-sm',
+        'top-ring-thick',
+        'top',
+        'top--1',
+        'top--1/2',
+        'top--1/-2',
+        'top-1/-2',
+        'top-auto/foo',
+        '-top-full/foo',
+        'top-full/foo',
+        'top-3/4/foo',
+        'top-4/foo',
+        '-top-4/foo',
+        'top-[4px]/foo',
+      ],
+    ),
   ).toEqual('')
 })
 
@@ -717,15 +747,11 @@ test('right', async () => {
       css`
         @theme {
           --spacing-4: 1rem;
-          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
-          --inset-ring-thick: 100px;
           --inset-ringo-starr: 1940px;
         }
         @tailwind utilities;
       `,
       [
-        'right-shadow-sm',
-        'right-ring-thick',
         'right-ringo-starr',
         'right-auto',
         '-right-full',
@@ -739,8 +765,6 @@ test('right', async () => {
   ).toMatchInlineSnapshot(`
     ":root {
       --spacing-4: 1rem;
-      --inset-shadow-sm: inset 0 1px 1px #0000000d;
-      --inset-ring-thick: 100px;
       --inset-ringo-starr: 1940px;
     }
 
@@ -777,20 +801,32 @@ test('right', async () => {
     }"
   `)
   expect(
-    await run([
-      'right',
-      'right--1',
-      'right--1/2',
-      'right--1/-2',
-      'right-1/-2',
-      'right-auto/foo',
-      '-right-full/foo',
-      'right-full/foo',
-      'right-3/4/foo',
-      'right-4/foo',
-      '-right-4/foo',
-      'right-[4px]/foo',
-    ]),
+    await compileCss(
+      css`
+        @theme reference {
+          --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+          --inset-ring-thick: 100px;
+        }
+        @tailwind utilities;
+      `,
+      [
+        'right-shadow-sm',
+        'right-ring-thick',
+        'right',
+        'right--1',
+        'right--1/2',
+        'right--1/-2',
+        'right-1/-2',
+        'right-auto/foo',
+        '-right-full/foo',
+        'right-full/foo',
+        'right-3/4/foo',
+        'right-4/foo',
+        '-right-4/foo',
+        'right-[4px]/foo',
+      ],
+    ),
   ).toEqual('')
 })
 
@@ -800,15 +836,11 @@ test('bottom', async () => {
       css`
         @theme {
           --spacing-4: 1rem;
-          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
-          --inset-ring-thick: 100px;
           --inset-ringo-starr: 1940px;
         }
         @tailwind utilities;
       `,
       [
-        'bottom-shadow-sm',
-        'bottom-ring-thick',
         'bottom-ringo-starr',
         'bottom-auto',
         '-bottom-full',
@@ -822,8 +854,6 @@ test('bottom', async () => {
   ).toMatchInlineSnapshot(`
     ":root {
       --spacing-4: 1rem;
-      --inset-shadow-sm: inset 0 1px 1px #0000000d;
-      --inset-ring-thick: 100px;
       --inset-ringo-starr: 1940px;
     }
 
@@ -860,20 +890,32 @@ test('bottom', async () => {
     }"
   `)
   expect(
-    await run([
-      'bottom',
-      'bottom--1',
-      'bottom--1/2',
-      'bottom--1/-2',
-      'bottom-1/-2',
-      'bottom-auto/foo',
-      '-bottom-full/foo',
-      'bottom-full/foo',
-      'bottom-3/4/foo',
-      'bottom-4/foo',
-      '-bottom-4/foo',
-      'bottom-[4px]/foo',
-    ]),
+    await compileCss(
+      css`
+        @theme reference {
+          --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+          --inset-ring-thick: 100px;
+        }
+        @tailwind utilities;
+      `,
+      [
+        'bottom-shadow-sm',
+        'bottom-ring-thick',
+        'bottom',
+        'bottom--1',
+        'bottom--1/2',
+        'bottom--1/-2',
+        'bottom-1/-2',
+        'bottom-auto/foo',
+        '-bottom-full/foo',
+        'bottom-full/foo',
+        'bottom-3/4/foo',
+        'bottom-4/foo',
+        '-bottom-4/foo',
+        'bottom-[4px]/foo',
+      ],
+    ),
   ).toEqual('')
 })
 
@@ -883,15 +925,11 @@ test('left', async () => {
       css`
         @theme {
           --spacing-4: 1rem;
-          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
-          --inset-ring-thick: 100px;
           --inset-ringo-starr: 1940px;
         }
         @tailwind utilities;
       `,
       [
-        'left-shadow-sm',
-        'left-ring-thick',
         'left-ringo-starr',
         'left-auto',
         '-left-full',
@@ -905,8 +943,6 @@ test('left', async () => {
   ).toMatchInlineSnapshot(`
     ":root {
       --spacing-4: 1rem;
-      --inset-shadow-sm: inset 0 1px 1px #0000000d;
-      --inset-ring-thick: 100px;
       --inset-ringo-starr: 1940px;
     }
 
@@ -943,20 +979,32 @@ test('left', async () => {
     }"
   `)
   expect(
-    await run([
-      'left',
-      'left--1',
-      'left--1/2',
-      'left--1/-2',
-      'left-1/-2',
-      'left-auto/foo',
-      '-left-full/foo',
-      'left-full/foo',
-      'left-3/4/foo',
-      'left-4/foo',
-      '-left-4/foo',
-      'left-[4px]/foo',
-    ]),
+    await compileCss(
+      css`
+        @theme reference {
+          --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+          --inset-ring-thick: 100px;
+        }
+        @tailwind utilities;
+      `,
+      [
+        'left-shadow-sm',
+        'left-ring-thick',
+        'left',
+        'left--1',
+        'left--1/2',
+        'left--1/-2',
+        'left-1/-2',
+        'left-auto/foo',
+        '-left-full/foo',
+        'left-full/foo',
+        'left-3/4/foo',
+        'left-4/foo',
+        '-left-4/foo',
+        'left-[4px]/foo',
+      ],
+    ),
   ).toEqual('')
 })
 

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -127,11 +127,17 @@ test('inset', async () => {
       css`
         @theme {
           --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+          --inset-ring-thick: 100px;
+          --inset-ringo-starr: 1940px;
         }
         @tailwind utilities;
       `,
       [
         'inset-auto',
+        'inset-shadow-sm',
+        'inset-ring-thick',
+        'inset-ringo-starr',
         '-inset-full',
         'inset-full',
         'inset-3/4',
@@ -143,6 +149,9 @@ test('inset', async () => {
   ).toMatchInlineSnapshot(`
     ":root {
       --spacing-4: 1rem;
+      --inset-shadow-sm: inset 0 1px 1px #0000000d;
+      --inset-ring-thick: 100px;
+      --inset-ringo-starr: 1940px;
     }
 
     .-inset-4 {
@@ -171,6 +180,101 @@ test('inset', async () => {
 
     .inset-full {
       inset: 100%;
+    }
+
+    .inset-ringo-starr {
+      inset: var(--inset-ringo-starr, 1940px);
+    }
+
+    .inset-shadow-sm {
+      --tw-inset-shadow: inset 0 1px 1px var(--tw-inset-shadow-color, #0000000d);
+      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+
+    @supports (-moz-orient: inline) {
+      @layer base {
+        *, :before, :after, ::backdrop {
+          --tw-shadow: 0 0 #0000;
+          --tw-shadow-color: initial;
+          --tw-inset-shadow: 0 0 #0000;
+          --tw-inset-shadow-color: initial;
+          --tw-ring-color: initial;
+          --tw-ring-shadow: 0 0 #0000;
+          --tw-inset-ring-color: initial;
+          --tw-inset-ring-shadow: 0 0 #0000;
+          --tw-ring-inset: initial;
+          --tw-ring-offset-width: 0px;
+          --tw-ring-offset-color: #fff;
+          --tw-ring-offset-shadow: 0 0 #0000;
+        }
+      }
+    }
+
+    @property --tw-shadow {
+      syntax: "*";
+      inherits: false;
+      initial-value: 0 0 #0000;
+    }
+
+    @property --tw-shadow-color {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-inset-shadow {
+      syntax: "*";
+      inherits: false;
+      initial-value: 0 0 #0000;
+    }
+
+    @property --tw-inset-shadow-color {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-ring-color {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-ring-shadow {
+      syntax: "*";
+      inherits: false;
+      initial-value: 0 0 #0000;
+    }
+
+    @property --tw-inset-ring-color {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-inset-ring-shadow {
+      syntax: "*";
+      inherits: false;
+      initial-value: 0 0 #0000;
+    }
+
+    @property --tw-ring-inset {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-ring-offset-width {
+      syntax: "<length>";
+      inherits: false;
+      initial-value: 0;
+    }
+
+    @property --tw-ring-offset-color {
+      syntax: "*";
+      inherits: false;
+      initial-value: #fff;
+    }
+
+    @property --tw-ring-offset-shadow {
+      syntax: "*";
+      inherits: false;
+      initial-value: 0 0 #0000;
     }"
   `)
   expect(
@@ -197,10 +301,16 @@ test('inset-x', async () => {
       css`
         @theme {
           --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+          --inset-ring-thick: 100px;
+          --inset-ringo-starr: 1940px;
         }
         @tailwind utilities;
       `,
       [
+        'inset-x-shadow-sm',
+        'inset-x-ring-thick',
+        'inset-x-ringo-starr',
         'inset-x-auto',
         'inset-x-full',
         '-inset-x-full',
@@ -213,6 +323,9 @@ test('inset-x', async () => {
   ).toMatchInlineSnapshot(`
     ":root {
       --spacing-4: 1rem;
+      --inset-shadow-sm: inset 0 1px 1px #0000000d;
+      --inset-ring-thick: 100px;
+      --inset-ringo-starr: 1940px;
     }
 
     .-inset-x-4 {
@@ -241,6 +354,10 @@ test('inset-x', async () => {
 
     .inset-x-full {
       inset-inline: 100%;
+    }
+
+    .inset-x-ringo-starr {
+      inset-inline: var(--inset-ringo-starr, 1940px);
     }"
   `)
   expect(
@@ -267,10 +384,16 @@ test('inset-y', async () => {
       css`
         @theme {
           --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+          --inset-ring-thick: 100px;
+          --inset-ringo-starr: 1940px;
         }
         @tailwind utilities;
       `,
       [
+        'inset-y-shadow-sm',
+        'inset-y-ring-thick',
+        'inset-y-ringo-starr',
         'inset-y-auto',
         'inset-y-full',
         '-inset-y-full',
@@ -283,6 +406,9 @@ test('inset-y', async () => {
   ).toMatchInlineSnapshot(`
     ":root {
       --spacing-4: 1rem;
+      --inset-shadow-sm: inset 0 1px 1px #0000000d;
+      --inset-ring-thick: 100px;
+      --inset-ringo-starr: 1940px;
     }
 
     .-inset-y-4 {
@@ -311,6 +437,10 @@ test('inset-y', async () => {
 
     .inset-y-full {
       inset-block: 100%;
+    }
+
+    .inset-y-ringo-starr {
+      inset-block: var(--inset-ringo-starr, 1940px);
     }"
   `)
   expect(
@@ -337,10 +467,16 @@ test('start', async () => {
       css`
         @theme {
           --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+          --inset-ring-thick: 100px;
+          --inset-ringo-starr: 1940px;
         }
         @tailwind utilities;
       `,
       [
+        'start-shadow-sm',
+        'start-ring-thick',
+        'start-ringo-starr',
         'start-auto',
         '-start-full',
         'start-full',
@@ -353,6 +489,9 @@ test('start', async () => {
   ).toMatchInlineSnapshot(`
     ":root {
       --spacing-4: 1rem;
+      --inset-shadow-sm: inset 0 1px 1px #0000000d;
+      --inset-ring-thick: 100px;
+      --inset-ringo-starr: 1940px;
     }
 
     .-start-4 {
@@ -381,6 +520,10 @@ test('start', async () => {
 
     .start-full {
       inset-inline-start: 100%;
+    }
+
+    .start-ringo-starr {
+      inset-inline-start: var(--inset-ringo-starr, 1940px);
     }"
   `)
   expect(
@@ -407,14 +550,31 @@ test('end', async () => {
       css`
         @theme {
           --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+          --inset-ring-thick: 100px;
+          --inset-ringo-starr: 1940px;
         }
         @tailwind utilities;
       `,
-      ['end-auto', '-end-full', 'end-full', 'end-3/4', 'end-4', '-end-4', 'end-[4px]'],
+      [
+        'end-shadow-sm',
+        'end-ring-thick',
+        'end-ringo-starr',
+        'end-auto',
+        '-end-full',
+        'end-full',
+        'end-3/4',
+        'end-4',
+        '-end-4',
+        'end-[4px]',
+      ],
     ),
   ).toMatchInlineSnapshot(`
     ":root {
       --spacing-4: 1rem;
+      --inset-shadow-sm: inset 0 1px 1px #0000000d;
+      --inset-ring-thick: 100px;
+      --inset-ringo-starr: 1940px;
     }
 
     .-end-4 {
@@ -443,6 +603,10 @@ test('end', async () => {
 
     .end-full {
       inset-inline-end: 100%;
+    }
+
+    .end-ringo-starr {
+      inset-inline-end: var(--inset-ringo-starr, 1940px);
     }"
   `)
   expect(
@@ -469,15 +633,32 @@ test('top', async () => {
       css`
         @theme {
           --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+          --inset-ring-thick: 100px;
+          --inset-ringo-starr: 1940px;
         }
         @tailwind utilities;
       `,
 
-      ['top-auto', '-top-full', 'top-full', 'top-3/4', 'top-4', '-top-4', 'top-[4px]'],
+      [
+        'top-shadow-sm',
+        'top-ring-thick',
+        'top-ringo-starr',
+        'top-auto',
+        '-top-full',
+        'top-full',
+        'top-3/4',
+        'top-4',
+        '-top-4',
+        'top-[4px]',
+      ],
     ),
   ).toMatchInlineSnapshot(`
     ":root {
       --spacing-4: 1rem;
+      --inset-shadow-sm: inset 0 1px 1px #0000000d;
+      --inset-ring-thick: 100px;
+      --inset-ringo-starr: 1940px;
     }
 
     .-top-4 {
@@ -506,6 +687,10 @@ test('top', async () => {
 
     .top-full {
       top: 100%;
+    }
+
+    .top-ringo-starr {
+      top: var(--inset-ringo-starr, 1940px);
     }"
   `)
   expect(
@@ -532,10 +717,16 @@ test('right', async () => {
       css`
         @theme {
           --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+          --inset-ring-thick: 100px;
+          --inset-ringo-starr: 1940px;
         }
         @tailwind utilities;
       `,
       [
+        'right-shadow-sm',
+        'right-ring-thick',
+        'right-ringo-starr',
         'right-auto',
         '-right-full',
         'right-full',
@@ -548,6 +739,9 @@ test('right', async () => {
   ).toMatchInlineSnapshot(`
     ":root {
       --spacing-4: 1rem;
+      --inset-shadow-sm: inset 0 1px 1px #0000000d;
+      --inset-ring-thick: 100px;
+      --inset-ringo-starr: 1940px;
     }
 
     .-right-4 {
@@ -576,6 +770,10 @@ test('right', async () => {
 
     .right-full {
       right: 100%;
+    }
+
+    .right-ringo-starr {
+      right: var(--inset-ringo-starr, 1940px);
     }"
   `)
   expect(
@@ -602,10 +800,16 @@ test('bottom', async () => {
       css`
         @theme {
           --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+          --inset-ring-thick: 100px;
+          --inset-ringo-starr: 1940px;
         }
         @tailwind utilities;
       `,
       [
+        'bottom-shadow-sm',
+        'bottom-ring-thick',
+        'bottom-ringo-starr',
         'bottom-auto',
         '-bottom-full',
         'bottom-full',
@@ -618,6 +822,9 @@ test('bottom', async () => {
   ).toMatchInlineSnapshot(`
     ":root {
       --spacing-4: 1rem;
+      --inset-shadow-sm: inset 0 1px 1px #0000000d;
+      --inset-ring-thick: 100px;
+      --inset-ringo-starr: 1940px;
     }
 
     .-bottom-4 {
@@ -646,6 +853,10 @@ test('bottom', async () => {
 
     .bottom-full {
       bottom: 100%;
+    }
+
+    .bottom-ringo-starr {
+      bottom: var(--inset-ringo-starr, 1940px);
     }"
   `)
   expect(
@@ -672,14 +883,31 @@ test('left', async () => {
       css`
         @theme {
           --spacing-4: 1rem;
+          --inset-shadow-sm: inset 0 1px 1px rgb(0 0 0 / 0.05);
+          --inset-ring-thick: 100px;
+          --inset-ringo-starr: 1940px;
         }
         @tailwind utilities;
       `,
-      ['left-auto', '-left-full', 'left-full', 'left-3/4', 'left-4', '-left-4', 'left-[4px]'],
+      [
+        'left-shadow-sm',
+        'left-ring-thick',
+        'left-ringo-starr',
+        'left-auto',
+        '-left-full',
+        'left-full',
+        'left-3/4',
+        'left-4',
+        '-left-4',
+        'left-[4px]',
+      ],
     ),
   ).toMatchInlineSnapshot(`
     ":root {
       --spacing-4: 1rem;
+      --inset-shadow-sm: inset 0 1px 1px #0000000d;
+      --inset-ring-thick: 100px;
+      --inset-ringo-starr: 1940px;
     }
 
     .-left-4 {
@@ -708,6 +936,10 @@ test('left', async () => {
 
     .left-full {
       left: 100%;
+    }
+
+    .left-ringo-starr {
+      left: var(--inset-ringo-starr, 1940px);
     }"
   `)
   expect(

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -23,6 +23,7 @@ type SuggestionDefinition =
       values?: string[]
       modifiers?: string[]
       valueThemeKeys?: ThemeKey[]
+      ignoredThemeKeys?: ThemeKey[]
       modifierThemeKeys?: ThemeKey[]
       hasDefaultValue?: boolean
     }
@@ -203,8 +204,8 @@ export function createUtilities(theme: Theme) {
    * Register list of suggestions for a class
    */
   function suggest(classRoot: string, defns: () => SuggestionDefinition[]) {
-    function* resolve(themeKeys: ThemeKey[]) {
-      for (let value of theme.keysInNamespaces(themeKeys)) {
+    function* resolve(themeKeys: ThemeKey[], ignoredThemeKeys: ThemeKey[] = []) {
+      for (let value of theme.keysInNamespaces(themeKeys, ignoredThemeKeys)) {
         yield value.replaceAll('_', '.')
       }
     }
@@ -220,7 +221,7 @@ export function createUtilities(theme: Theme) {
 
         let values: (string | null)[] = [
           ...(defn.values ?? []),
-          ...resolve(defn.valueThemeKeys ?? []),
+          ...resolve(defn.valueThemeKeys ?? [], defn.ignoredThemeKeys),
         ]
         let modifiers = [...(defn.modifiers ?? []), ...resolve(defn.modifierThemeKeys ?? [])]
 
@@ -252,6 +253,7 @@ export function createUtilities(theme: Theme) {
     supportsNegative?: boolean
     supportsFractions?: boolean
     themeKeys?: ThemeKey[]
+    ignoredThemeKeys?: ThemeKey[]
     defaultValue?: string | null
     handleBareValue?: (value: NamedUtilityValue) => string | null
     handle: (value: string) => AstNode[] | undefined
@@ -285,6 +287,7 @@ export function createUtilities(theme: Theme) {
         value = theme.resolve(
           candidate.value.fraction ?? candidate.value.value,
           desc.themeKeys ?? [],
+          desc.ignoredThemeKeys,
         )
 
         // Automatically handle things like `w-1/2` without requiring `1/2` to
@@ -314,6 +317,7 @@ export function createUtilities(theme: Theme) {
       {
         supportsNegative: desc.supportsNegative,
         valueThemeKeys: desc.themeKeys ?? [],
+        ignoredThemeKeys: desc.ignoredThemeKeys ?? [],
         hasDefaultValue: desc.defaultValue !== undefined && desc.defaultValue !== null,
       },
     ])

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -447,6 +447,7 @@ export function createUtilities(theme: Theme) {
     supportsNegative: true,
     supportsFractions: true,
     themeKeys: ['--inset', '--spacing'],
+    ignoredThemeKeys: ['--inset-ring', '--inset-shadow'],
     handle: (value) => [decl('inset-inline', value)],
   })
 
@@ -459,6 +460,7 @@ export function createUtilities(theme: Theme) {
     supportsNegative: true,
     supportsFractions: true,
     themeKeys: ['--inset', '--spacing'],
+    ignoredThemeKeys: ['--inset-ring', '--inset-shadow'],
     handle: (value) => [decl('inset-block', value)],
   })
 
@@ -471,6 +473,7 @@ export function createUtilities(theme: Theme) {
     supportsNegative: true,
     supportsFractions: true,
     themeKeys: ['--inset', '--spacing'],
+    ignoredThemeKeys: ['--inset-ring', '--inset-shadow'],
     handle: (value) => [decl('inset-inline-start', value)],
   })
 
@@ -483,6 +486,7 @@ export function createUtilities(theme: Theme) {
     supportsNegative: true,
     supportsFractions: true,
     themeKeys: ['--inset', '--spacing'],
+    ignoredThemeKeys: ['--inset-ring', '--inset-shadow'],
     handle: (value) => [decl('inset-inline-end', value)],
   })
 
@@ -495,6 +499,7 @@ export function createUtilities(theme: Theme) {
     supportsNegative: true,
     supportsFractions: true,
     themeKeys: ['--inset', '--spacing'],
+    ignoredThemeKeys: ['--inset-ring', '--inset-shadow'],
     handle: (value) => [decl('top', value)],
   })
 
@@ -507,6 +512,7 @@ export function createUtilities(theme: Theme) {
     supportsNegative: true,
     supportsFractions: true,
     themeKeys: ['--inset', '--spacing'],
+    ignoredThemeKeys: ['--inset-ring', '--inset-shadow'],
     handle: (value) => [decl('right', value)],
   })
 
@@ -519,6 +525,7 @@ export function createUtilities(theme: Theme) {
     supportsNegative: true,
     supportsFractions: true,
     themeKeys: ['--inset', '--spacing'],
+    ignoredThemeKeys: ['--inset-ring', '--inset-shadow'],
     handle: (value) => [decl('bottom', value)],
   })
 
@@ -531,6 +538,7 @@ export function createUtilities(theme: Theme) {
     supportsNegative: true,
     supportsFractions: true,
     themeKeys: ['--inset', '--spacing'],
+    ignoredThemeKeys: ['--inset-ring', '--inset-shadow'],
     handle: (value) => [decl('left', value)],
   })
 


### PR DESCRIPTION
This PR fixes a issue where utilities like `inset-x-*`, `left-*`, `top-*`, etc. mistakenly pull values from the `--inset-ring-*` and `--inset-shadow-*` theme namespaces.

For example, the class `left-shadow-sm` currently generates this CSS:

```css
.left-shadow-sm {
  left: var(
    --inset-shadow-sm,
    inset 0 1px 1px rgb(0 0 0 / 0.05)
  );
}
```

This happens because the `--inset-ring-*` and `--inset-shadow-*` namespaces collide with the `--inset-*` namespace.

We were already handling this manually for just the `inset-*` utilities but didn't realize we needed to handle it for every related utility, so this PR fixes that.

This also fixes an issue where IntelliSense would suggest classes like `inset-x-shadow-sm` when they shouldn't actually exist.

To do this we've created this new concept of `ignoredThemeKeys` in the relevant APIs to make sure these are filtered out at the source.