### PR TITLE
Fix config types for boxShadow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Bump versions for security vulnerabilities ([#14697](https://github.com/tailwindlabs/tailwindcss/pull/14697))
-- Fix `boxShadow` configuration TS types ([#14856](https://github.com/tailwindlabs/tailwindcss/pull/14856))
+- Ensure the TypeScript types for the `boxShadow` theme configuration allows arrays ([#14856](https://github.com/tailwindlabs/tailwindcss/pull/14856))
 
 ## [3.4.14] - 2024-10-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Bump versions for security vulnerabilities ([#14697](https://github.com/tailwindlabs/tailwindcss/pull/14697))
+- Fix `boxShadow` configuration TS types ([#14856](https://github.com/tailwindlabs/tailwindcss/pull/14856))
 
 ## [3.4.14] - 2024-10-15
 

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -207,7 +207,7 @@ export interface ThemeConfig {
   caretColor: ThemeConfig['colors']
   accentColor: ThemeConfig['colors']
   opacity: ResolvableTo<KeyValuePair>
-  boxShadow: ResolvableTo<KeyValuePair>
+  boxShadow: ResolvableTo<KeyValuePair<string, string | string[]>>
   boxShadowColor: ThemeConfig['colors']
   outlineWidth: ResolvableTo<KeyValuePair>
   outlineOffset: ResolvableTo<KeyValuePair>


### PR DESCRIPTION
`boxShadow` accepts multiple shadows just like `dropShadow` does. This patch fixes the TS typings to reflect that.

See demo showing that multiple shadows are supported (complete with it incorrectly complaining that the config is bad) here: https://play.tailwindcss.com/VHqWbbEIrz?file=config