### PR TITLE
Fix parsing `url(…)` with special characters such as `;` or `{}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix crash when using `@source` containing `..` ([#14831](https://github.com/tailwindlabs/tailwindcss/pull/14831))
 - Ensure instances of the same variant with different values are always sorted deterministically (e.g. `data-focus:flex` and `data-active:flex`) ([#14835](https://github.com/tailwindlabs/tailwindcss/pull/14835))
 - Ensure `--inset-ring=*` and `--inset-shadow-*` variables are ignored by `inset-*` utilities ([#14855](https://github.com/tailwindlabs/tailwindcss/pull/14855))
-- Fix parsing `url(…)` with special characters such as `;` or `{}` ([#14879](https://github.com/tailwindlabs/tailwindcss/pull/14879))
+- Ensure `url(…)` containing special characters such as `;` or `{}` end up in one declaration ([#14879](https://github.com/tailwindlabs/tailwindcss/pull/14879))
 - _Upgrade (experimental)_: Install `@tailwindcss/postcss` next to `tailwindcss` ([#14830](https://github.com/tailwindlabs/tailwindcss/pull/14830))
 - _Upgrade (experimental)_: Remove whitespace around `,` separator when print arbitrary values ([#14838](https://github.com/tailwindlabs/tailwindcss/pull/14838))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix crash when using `@source` containing `..` ([#14831](https://github.com/tailwindlabs/tailwindcss/pull/14831))
 - Ensure instances of the same variant with different values are always sorted deterministically (e.g. `data-focus:flex` and `data-active:flex`) ([#14835](https://github.com/tailwindlabs/tailwindcss/pull/14835))
 - Ensure `--inset-ring=*` and `--inset-shadow-*` variables are ignored by `inset-*` utilities ([#14855](https://github.com/tailwindlabs/tailwindcss/pull/14855))
+- Fix parsing `url(…)` with special characters such as `;` or `{}` ([#14879](https://github.com/tailwindlabs/tailwindcss/pull/14879))
 - _Upgrade (experimental)_: Install `@tailwindcss/postcss` next to `tailwindcss` ([#14830](https://github.com/tailwindlabs/tailwindcss/pull/14830))
 - _Upgrade (experimental)_: Remove whitespace around `,` separator when print arbitrary values ([#14838](https://github.com/tailwindlabs/tailwindcss/pull/14838))
 

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -331,7 +331,10 @@ export function parse(input: string) {
     // }
     // ```
     //
-    else if (currentChar === SEMICOLON) {
+    else if (
+      currentChar === SEMICOLON &&
+      (closingBracketStack.length === 0 || !closingBracketStack.includes(')'))
+    ) {
       let declaration = parseDeclaration(buffer)
       if (parent) {
         parent.nodes.push(declaration)
@@ -343,7 +346,10 @@ export function parse(input: string) {
     }
 
     // Start of a block.
-    else if (currentChar === OPEN_CURLY) {
+    else if (
+      currentChar === OPEN_CURLY &&
+      (closingBracketStack.length === 0 || !closingBracketStack.includes(')'))
+    ) {
       closingBracketStack += '}'
 
       // At this point `buffer` should resemble a selector or an at-rule.
@@ -368,7 +374,10 @@ export function parse(input: string) {
     }
 
     // End of a block.
-    else if (currentChar === CLOSE_CURLY) {
+    else if (
+      currentChar === CLOSE_CURLY &&
+      (closingBracketStack.length === 0 || !closingBracketStack.includes(')'))
+    ) {
       if (closingBracketStack === '') {
         throw new Error('Missing opening {')
       }
@@ -454,6 +463,24 @@ export function parse(input: string) {
       // Reset the state for the next node.
       buffer = ''
       node = null
+    }
+
+    //
+    else if (currentChar === OPEN_CURLY) {
+      closingBracketStack += '}'
+      buffer += '{'
+    } else if (currentChar === OPEN_PAREN) {
+      closingBracketStack += ')'
+      buffer += '('
+    } else if (currentChar === CLOSE_CURLY || currentChar === CLOSE_PAREN) {
+      if (
+        closingBracketStack.length > 0 &&
+        input[i] === closingBracketStack[closingBracketStack.length - 1]
+      ) {
+        closingBracketStack = closingBracketStack.slice(0, -1)
+      }
+
+      buffer += String.fromCharCode(currentChar)
     }
 
     // Any other character is part of the current node.

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -42,7 +42,6 @@ export function parse(input: string) {
 
   let buffer = ''
   let closingBracketStack = ''
-  let parenStack = 0
 
   let peekChar
 
@@ -332,7 +331,10 @@ export function parse(input: string) {
     // }
     // ```
     //
-    else if (currentChar === SEMICOLON && parenStack <= 0) {
+    else if (
+      currentChar === SEMICOLON &&
+      closingBracketStack[closingBracketStack.length - 1] !== ')'
+    ) {
       let declaration = parseDeclaration(buffer)
       if (parent) {
         parent.nodes.push(declaration)
@@ -344,7 +346,10 @@ export function parse(input: string) {
     }
 
     // Start of a block.
-    else if (currentChar === OPEN_CURLY && parenStack <= 0) {
+    else if (
+      currentChar === OPEN_CURLY &&
+      closingBracketStack[closingBracketStack.length - 1] !== ')'
+    ) {
       closingBracketStack += '}'
 
       // At this point `buffer` should resemble a selector or an at-rule.
@@ -369,7 +374,10 @@ export function parse(input: string) {
     }
 
     // End of a block.
-    else if (currentChar === CLOSE_CURLY && parenStack <= 0) {
+    else if (
+      currentChar === CLOSE_CURLY &&
+      closingBracketStack[closingBracketStack.length - 1] !== ')'
+    ) {
       if (closingBracketStack === '') {
         throw new Error('Missing opening {')
       }
@@ -459,17 +467,17 @@ export function parse(input: string) {
 
     // `(`
     else if (currentChar === OPEN_PAREN) {
-      parenStack += 1
+      closingBracketStack += ')'
       buffer += '('
     }
 
     // `)`
     else if (currentChar === CLOSE_PAREN) {
-      if (parenStack <= 0) {
+      if (closingBracketStack[closingBracketStack.length - 1] !== ')') {
         throw new Error('Missing opening (')
       }
 
-      parenStack -= 1
+      closingBracketStack = closingBracketStack.slice(0, -1)
       buffer += ')'
     }
 


### PR DESCRIPTION
This PR fixes an issue where some special characters (with an actual meaning CSS) were used inside of the `url(…)` function, would result in incorrectly parsed CSS.

For example, when we encounter a `{`, then we would start a new "block" for nesting purposes. If we encounter an `}`, then the block would end. If we encounter a `;`, then that would be the end of a declaration.

All of that is true, unless we are in a `url(…)` function. In that case, we should ignore all of those characters and treat them as part of the URL.

This is only an issue because:

1. We are allowed to use these characters in URLs.
2. We can write an url inside `url(…)` without quotes. With quotes, this would not be an issue. 
