### PR TITLE
Remove `theme(inline)` option from CSS API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove default `--spacing-*` scale in favor of `--spacing` multiplier ([#14857](https://github.com/tailwindlabs/tailwindcss/pull/14857))
 - Remove `var(…)` fallbacks from theme values in utilities ([#14881](https://github.com/tailwindlabs/tailwindcss/pull/14881))
 - Remove static `font-weight` utilities and add `--font-weight-*` values to the default theme ([#14883](https://github.com/tailwindlabs/tailwindcss/pull/14883))
+- Remove `theme(inline)` option from CSS API ([#14894](https://github.com/tailwindlabs/tailwindcss/pull/14894))
 
 ## [4.0.0-alpha.31] - 2024-10-29
 

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-import.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-import.test.ts
@@ -1,22 +1,13 @@
-import { __unstable__loadDesignSystem } from '@tailwindcss/node'
 import dedent from 'dedent'
 import postcss from 'postcss'
 import { expect, it } from 'vitest'
-import type { UserConfig } from '../../../tailwindcss/src/compat/config/types'
 import { migrateImport } from './migrate-import'
 
 const css = dedent
 
-async function migrate(input: string, userConfig: UserConfig = {}) {
+async function migrate(input: string) {
   return postcss()
-    .use(
-      migrateImport({
-        designSystem: await __unstable__loadDesignSystem(`@import 'tailwindcss';`, {
-          base: __dirname,
-        }),
-        userConfig,
-      }),
-    )
+    .use(migrateImport())
     .process(input, { from: expect.getState().testPath })
     .then((result) => result.css)
 }

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-import.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-import.test.ts
@@ -44,11 +44,6 @@ it('prints relative file imports as relative paths', async () => {
       @import './fixtures/test.css' layer(utilities);
       @import './fixtures/test' layer(utilities);
 
-      @import 'fixtures/test' theme(inline);
-      @import 'fixtures/test.css' theme(inline);
-      @import './fixtures/test.css' theme(inline);
-      @import './fixtures/test' theme(inline);
-
       @import 'fixtures/test' layer(utilities) supports(display: grid) screen and (min-width: 600px);
       @import 'fixtures/test.css' layer(utilities) supports(display: grid) screen and
         (min-width: 600px);
@@ -81,11 +76,6 @@ it('prints relative file imports as relative paths', async () => {
     @import './fixtures/test.css' layer(utilities);
     @import './fixtures/test.css' layer(utilities);
     @import './fixtures/test.css' layer(utilities);
-
-    @import './fixtures/test.css' theme(inline);
-    @import './fixtures/test.css' theme(inline);
-    @import './fixtures/test.css' theme(inline);
-    @import './fixtures/test.css' theme(inline);
 
     @import './fixtures/test.css' layer(utilities) supports(display: grid) screen and (min-width: 600px);
     @import './fixtures/test.css' layer(utilities) supports(display: grid) screen and

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1349,138 +1349,6 @@ describe('Parsing themes values from CSS', () => {
     )
   })
 
-  test('theme values added as `inline` are not wrapped in `var(…)` when used as utility values', async () => {
-    expect(
-      await compileCss(
-        css`
-          @theme inline {
-            --color-tomato: #e10c04;
-            --color-potato: #ac855b;
-            --color-primary: var(--primary);
-          }
-
-          @tailwind utilities;
-        `,
-        ['bg-tomato', 'bg-potato', 'bg-primary'],
-      ),
-    ).toMatchInlineSnapshot(`
-      ":root {
-        --color-tomato: #e10c04;
-        --color-potato: #ac855b;
-        --color-primary: var(--primary);
-      }
-
-      .bg-potato {
-        background-color: #ac855b;
-      }
-
-      .bg-primary {
-        background-color: var(--primary);
-      }
-
-      .bg-tomato {
-        background-color: #e10c04;
-      }"
-    `)
-  })
-
-  test('wrapping `@theme` with `@media theme(inline)` behaves like `@theme inline` to support `@import` statements', async () => {
-    expect(
-      await compileCss(
-        css`
-          @media theme(inline) {
-            @theme {
-              --color-tomato: #e10c04;
-              --color-potato: #ac855b;
-              --color-primary: var(--primary);
-            }
-          }
-
-          @tailwind utilities;
-        `,
-        ['bg-tomato', 'bg-potato', 'bg-primary'],
-      ),
-    ).toMatchInlineSnapshot(`
-      ":root {
-        --color-tomato: #e10c04;
-        --color-potato: #ac855b;
-        --color-primary: var(--primary);
-      }
-
-      .bg-potato {
-        background-color: #ac855b;
-      }
-
-      .bg-primary {
-        background-color: var(--primary);
-      }
-
-      .bg-tomato {
-        background-color: #e10c04;
-      }"
-    `)
-  })
-
-  test('`inline` and `reference` can be used together', async () => {
-    expect(
-      await compileCss(
-        css`
-          @theme reference inline {
-            --color-tomato: #e10c04;
-            --color-potato: #ac855b;
-            --color-primary: var(--primary);
-          }
-
-          @tailwind utilities;
-        `,
-        ['bg-tomato', 'bg-potato', 'bg-primary'],
-      ),
-    ).toMatchInlineSnapshot(`
-      ".bg-potato {
-        background-color: #ac855b;
-      }
-
-      .bg-primary {
-        background-color: var(--primary);
-      }
-
-      .bg-tomato {
-        background-color: #e10c04;
-      }"
-    `)
-  })
-
-  test('`inline` and `reference` can be used together in `media(…)`', async () => {
-    expect(
-      await compileCss(
-        css`
-          @media theme(reference inline) {
-            @theme {
-              --color-tomato: #e10c04;
-              --color-potato: #ac855b;
-              --color-primary: var(--primary);
-            }
-          }
-
-          @tailwind utilities;
-        `,
-        ['bg-tomato', 'bg-potato', 'bg-primary'],
-      ),
-    ).toMatchInlineSnapshot(`
-      ".bg-potato {
-        background-color: #ac855b;
-      }
-
-      .bg-primary {
-        background-color: var(--primary);
-      }
-
-      .bg-tomato {
-        background-color: #e10c04;
-      }"
-    `)
-  })
-
   test('`default` theme values can be overridden by regular theme values`', async () => {
     expect(
       await compileCss(
@@ -1507,29 +1375,6 @@ describe('Parsing themes values from CSS', () => {
     `)
   })
 
-  test('`default` and `inline` can be used together', async () => {
-    expect(
-      await compileCss(
-        css`
-          @theme default inline {
-            --color-potato: #efb46b;
-          }
-
-          @tailwind utilities;
-        `,
-        ['bg-potato'],
-      ),
-    ).toMatchInlineSnapshot(`
-      ":root {
-        --color-potato: #efb46b;
-      }
-
-      .bg-potato {
-        background-color: #efb46b;
-      }"
-    `)
-  })
-
   test('`default` and `reference` can be used together', async () => {
     expect(
       await compileCss(
@@ -1545,25 +1390,6 @@ describe('Parsing themes values from CSS', () => {
     ).toMatchInlineSnapshot(`
       ".bg-potato {
         background-color: var(--color-potato);
-      }"
-    `)
-  })
-
-  test('`default`, `inline`, and `reference` can be used together', async () => {
-    expect(
-      await compileCss(
-        css`
-          @theme default reference inline {
-            --color-potato: #efb46b;
-          }
-
-          @tailwind utilities;
-        `,
-        ['bg-potato'],
-      ),
-    ).toMatchInlineSnapshot(`
-      ".bg-potato {
-        background-color: #efb46b;
       }"
     `)
   })

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -56,8 +56,6 @@ function parseThemeOptions(params: string) {
   for (let option of segment(params, ' ')) {
     if (option === 'reference') {
       options |= ThemeOptions.REFERENCE
-    } else if (option === 'inline') {
-      options |= ThemeOptions.INLINE
     } else if (option === 'default') {
       options |= ThemeOptions.DEFAULT
     } else if (option.startsWith('prefix(') && option.endsWith(')')) {

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -13638,7 +13638,7 @@ test('transition', async () => {
   expect(
     await compileCss(
       css`
-        @theme inline {
+        @theme {
           --default-transition-timing-function: ease;
           --default-transition-duration: 100ms;
         }
@@ -13654,20 +13654,20 @@ test('transition', async () => {
 
     .transition {
       transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, -webkit-backdrop-filter, -webkit-backdrop-filter, backdrop-filter;
-      transition-timing-function: var(--tw-ease, ease);
-      transition-duration: var(--tw-duration, .1s);
+      transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+      transition-duration: var(--tw-duration, var(--default-transition-duration));
     }
 
     .transition-all {
       transition-property: all;
-      transition-timing-function: var(--tw-ease, ease);
-      transition-duration: var(--tw-duration, .1s);
+      transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+      transition-duration: var(--tw-duration, var(--default-transition-duration));
     }
 
     .transition-colors {
       transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
-      transition-timing-function: var(--tw-ease, ease);
-      transition-duration: var(--tw-duration, .1s);
+      transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+      transition-duration: var(--tw-duration, var(--default-transition-duration));
     }"
   `)
 


### PR DESCRIPTION
This PR removes the `theme(inline)` option for now. We might re-introduce this in the future but for now we get rid of it to ensure there are fewer knobs to turn.

We still have the `inline` option internally because it is used in the v3 compat layer.
