### PR TITLE
Upgrade: Add `--shadow-inner` theme variable when `shadow-inner` class is used

### DIFF
--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -116,9 +116,9 @@ test(
       @import 'tailwindcss';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -134,12 +134,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -223,9 +223,9 @@ test(
       @import 'tailwindcss' prefix(tw);
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -241,12 +241,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -303,9 +303,9 @@ test(
       @import 'tailwindcss';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -321,12 +321,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -391,9 +391,9 @@ test(
       @import 'tailwindcss';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -409,12 +409,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -484,9 +484,9 @@ test(
       @import 'tailwindcss';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -502,12 +502,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -985,9 +985,9 @@ test(
       @import './utilities.css';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -1003,12 +1003,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1425,9 +1425,9 @@ test(
       @config '../tailwind.config.ts';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -1443,12 +1443,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1465,9 +1465,9 @@ test(
       @config "../tailwind.config.ts";
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -1483,12 +1483,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1515,9 +1515,9 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -1533,12 +1533,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1563,9 +1563,9 @@ test(
       @import 'tailwindcss/preflight' layer(base);
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -1581,12 +1581,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1606,9 +1606,9 @@ test(
       @config '../../tailwind.config.ts';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -1624,12 +1624,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1679,9 +1679,9 @@ test(
       @import './styles/components.css' layer(components);
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -1697,12 +1697,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -262,9 +262,9 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -280,12 +280,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -386,9 +386,9 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -404,12 +404,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -483,9 +483,9 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -501,12 +501,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -572,9 +572,9 @@ test(
       @config '../tailwind.config.ts';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -590,12 +590,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -665,9 +665,9 @@ test(
       @config '../tailwind.config.ts';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -683,12 +683,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -754,9 +754,9 @@ test(
       @config '../tailwind.config.ts';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -772,12 +772,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -881,9 +881,9 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -899,12 +899,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -922,9 +922,9 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -940,12 +940,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1014,9 +1014,9 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -1032,12 +1032,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1089,9 +1089,9 @@ describe('border compatibility', () => {
         @import 'tailwindcss';
 
         /*
-          The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-          so we've added these compatibility styles to make sure everything still
-          looks the same as it did with Tailwind CSS v3.
+          The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+          we've added these compatibility styles to make sure everything still looks the
+          same as it did with Tailwind CSS v3.
 
           If we ever want to remove these styles, we need to add an explicit border
           color utility to any element that depends on these defaults.
@@ -1107,12 +1107,12 @@ describe('border compatibility', () => {
         }
 
         /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've
-          added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
+          Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+          these compatibility styles to make sure everything still looks the same as it
+          did with Tailwind CSS v3.
 
-          If we ever want to remove these styles, we need to add \`border-0\` to
-          any form elements that shouldn't have a border.
+          If we ever want to remove these styles, we need to add \`border-0\` to any form
+          elements that shouldn't have a border.
         */
         @layer base {
           input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1166,9 +1166,9 @@ describe('border compatibility', () => {
         @import 'tailwindcss';
 
         /*
-          The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-          so we've added these compatibility styles to make sure everything still
-          looks the same as it did with Tailwind CSS v3.
+          The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+          we've added these compatibility styles to make sure everything still looks the
+          same as it did with Tailwind CSS v3.
 
           If we ever want to remove these styles, we need to add an explicit border
           color utility to any element that depends on these defaults.
@@ -1184,12 +1184,12 @@ describe('border compatibility', () => {
         }
 
         /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've
-          added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
+          Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+          these compatibility styles to make sure everything still looks the same as it
+          did with Tailwind CSS v3.
 
-          If we ever want to remove these styles, we need to add \`border-0\` to
-          any form elements that shouldn't have a border.
+          If we ever want to remove these styles, we need to add \`border-0\` to any form
+          elements that shouldn't have a border.
         */
         @layer base {
           input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1243,12 +1243,12 @@ describe('border compatibility', () => {
         @import 'tailwindcss';
 
         /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've
-          added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
+          Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+          these compatibility styles to make sure everything still looks the same as it
+          did with Tailwind CSS v3.
 
-          If we ever want to remove these styles, we need to add \`border-0\` to
-          any form elements that shouldn't have a border.
+          If we ever want to remove these styles, we need to add \`border-0\` to any form
+          elements that shouldn't have a border.
         */
         @layer base {
           input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1300,9 +1300,9 @@ describe('border compatibility', () => {
         @import 'tailwindcss';
 
         /*
-          The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-          so we've added these compatibility styles to make sure everything still
-          looks the same as it did with Tailwind CSS v3.
+          The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+          we've added these compatibility styles to make sure everything still looks the
+          same as it did with Tailwind CSS v3.
 
           If we ever want to remove these styles, we need to add an explicit border
           color utility to any element that depends on these defaults.
@@ -1318,12 +1318,12 @@ describe('border compatibility', () => {
         }
 
         /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've
-          added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
+          Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+          these compatibility styles to make sure everything still looks the same as it
+          did with Tailwind CSS v3.
 
-          If we ever want to remove these styles, we need to add \`border-0\` to
-          any form elements that shouldn't have a border.
+          If we ever want to remove these styles, we need to add \`border-0\` to any form
+          elements that shouldn't have a border.
         */
         @layer base {
           input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1384,9 +1384,9 @@ describe('border compatibility', () => {
         @import 'tailwindcss/preflight' layer(base);
 
         /*
-          The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-          so we've added these compatibility styles to make sure everything still
-          looks the same as it did with Tailwind CSS v3.
+          The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+          we've added these compatibility styles to make sure everything still looks the
+          same as it did with Tailwind CSS v3.
 
           If we ever want to remove these styles, we need to add an explicit border
           color utility to any element that depends on these defaults.
@@ -1402,12 +1402,12 @@ describe('border compatibility', () => {
         }
 
         /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've
-          added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
+          Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+          these compatibility styles to make sure everything still looks the same as it
+          did with Tailwind CSS v3.
 
-          If we ever want to remove these styles, we need to add \`border-0\` to
-          any form elements that shouldn't have a border.
+          If we ever want to remove these styles, we need to add \`border-0\` to any form
+          elements that shouldn't have a border.
         */
         @layer base {
           input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1692,3 +1692,91 @@ describe('border compatibility', () => {
     },
   )
 })
+
+test(
+  'adds a --shadow-inner theme variable if the shadow-inner class is used',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "dependencies": {
+            "@tailwindcss/upgrade": "workspace:^"
+          }
+        }
+      `,
+      'tailwind.config.ts': ts`
+        import { type Config } from 'tailwindcss'
+
+        export default {
+          content: ['./src/**/*.html'],
+        } satisfies Config
+      `,
+      'src/input.css': css`
+        @tailwind base;
+        @tailwind components;
+        @tailwind utilities;
+      `,
+      'src/index.html': css`
+        <div class="shadow-inner"></div>
+      `,
+    },
+  },
+  async ({ exec, fs }) => {
+    await exec('npx @tailwindcss/upgrade')
+
+    expect(await fs.dumpFiles('src/**/*.{css,html}')).toMatchInlineSnapshot(`
+      "
+      --- src/index.html ---
+      <div class="shadow-inner"></div>
+
+      --- src/input.css ---
+      @import 'tailwindcss';
+
+      @theme {
+        /*
+          The \`shadow-inner\` class existed in Tailwind CSS v3 but doesn't exist by
+          default in v4.
+
+          If we ever want to remove this, we need to update our use of \`shadow-inner\`
+          to \`inset-shadow-sm\` instead.
+        */
+        --shadow-inner: inset 0 2px 4px 0 rgb(0 0 0 / 0.05);
+      }
+
+      /*
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
+
+        If we ever want to remove these styles, we need to add an explicit border
+        color utility to any element that depends on these defaults.
+      */
+      @layer base {
+        *,
+        ::after,
+        ::before,
+        ::backdrop,
+        ::file-selector-button {
+          border-color: var(--color-gray-200, currentColor);
+        }
+      }
+
+      /*
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
+
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
+      */
+      @layer base {
+        input:where(:not([type='button'], [type='reset'], [type='submit'])),
+        select,
+        textarea {
+          border-width: 0;
+        }
+      }
+      "
+    `)
+  },
+)

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -262,9 +262,9 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -280,12 +280,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -386,9 +386,9 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -404,12 +404,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -483,9 +483,9 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -501,12 +501,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -572,9 +572,9 @@ test(
       @config '../tailwind.config.ts';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -590,12 +590,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -665,9 +665,9 @@ test(
       @config '../tailwind.config.ts';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -683,12 +683,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -754,9 +754,9 @@ test(
       @config '../tailwind.config.ts';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -772,12 +772,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -881,9 +881,9 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -899,12 +899,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -922,9 +922,9 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -940,12 +940,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1014,9 +1014,9 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -1032,12 +1032,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1089,9 +1089,9 @@ describe('border compatibility', () => {
         @import 'tailwindcss';
 
         /*
-          The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-          so we've added these compatibility styles to make sure everything still
-          looks the same as it did with Tailwind CSS v3.
+          The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+          we've added these compatibility styles to make sure everything still looks the
+          same as it did with Tailwind CSS v3.
 
           If we ever want to remove these styles, we need to add an explicit border
           color utility to any element that depends on these defaults.
@@ -1107,12 +1107,12 @@ describe('border compatibility', () => {
         }
 
         /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've
-          added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
+          Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+          these compatibility styles to make sure everything still looks the same as it
+          did with Tailwind CSS v3.
 
-          If we ever want to remove these styles, we need to add \`border-0\` to
-          any form elements that shouldn't have a border.
+          If we ever want to remove these styles, we need to add \`border-0\` to any form
+          elements that shouldn't have a border.
         */
         @layer base {
           input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1166,9 +1166,9 @@ describe('border compatibility', () => {
         @import 'tailwindcss';
 
         /*
-          The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-          so we've added these compatibility styles to make sure everything still
-          looks the same as it did with Tailwind CSS v3.
+          The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+          we've added these compatibility styles to make sure everything still looks the
+          same as it did with Tailwind CSS v3.
 
           If we ever want to remove these styles, we need to add an explicit border
           color utility to any element that depends on these defaults.
@@ -1184,12 +1184,12 @@ describe('border compatibility', () => {
         }
 
         /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've
-          added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
+          Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+          these compatibility styles to make sure everything still looks the same as it
+          did with Tailwind CSS v3.
 
-          If we ever want to remove these styles, we need to add \`border-0\` to
-          any form elements that shouldn't have a border.
+          If we ever want to remove these styles, we need to add \`border-0\` to any form
+          elements that shouldn't have a border.
         */
         @layer base {
           input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1243,12 +1243,12 @@ describe('border compatibility', () => {
         @import 'tailwindcss';
 
         /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've
-          added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
+          Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+          these compatibility styles to make sure everything still looks the same as it
+          did with Tailwind CSS v3.
 
-          If we ever want to remove these styles, we need to add \`border-0\` to
-          any form elements that shouldn't have a border.
+          If we ever want to remove these styles, we need to add \`border-0\` to any form
+          elements that shouldn't have a border.
         */
         @layer base {
           input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1300,9 +1300,9 @@ describe('border compatibility', () => {
         @import 'tailwindcss';
 
         /*
-          The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-          so we've added these compatibility styles to make sure everything still
-          looks the same as it did with Tailwind CSS v3.
+          The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+          we've added these compatibility styles to make sure everything still looks the
+          same as it did with Tailwind CSS v3.
 
           If we ever want to remove these styles, we need to add an explicit border
           color utility to any element that depends on these defaults.
@@ -1318,12 +1318,12 @@ describe('border compatibility', () => {
         }
 
         /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've
-          added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
+          Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+          these compatibility styles to make sure everything still looks the same as it
+          did with Tailwind CSS v3.
 
-          If we ever want to remove these styles, we need to add \`border-0\` to
-          any form elements that shouldn't have a border.
+          If we ever want to remove these styles, we need to add \`border-0\` to any form
+          elements that shouldn't have a border.
         */
         @layer base {
           input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1384,9 +1384,9 @@ describe('border compatibility', () => {
         @import 'tailwindcss/preflight' layer(base);
 
         /*
-          The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-          so we've added these compatibility styles to make sure everything still
-          looks the same as it did with Tailwind CSS v3.
+          The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+          we've added these compatibility styles to make sure everything still looks the
+          same as it did with Tailwind CSS v3.
 
           If we ever want to remove these styles, we need to add an explicit border
           color utility to any element that depends on these defaults.
@@ -1402,12 +1402,12 @@ describe('border compatibility', () => {
         }
 
         /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've
-          added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
+          Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+          these compatibility styles to make sure everything still looks the same as it
+          did with Tailwind CSS v3.
 
-          If we ever want to remove these styles, we need to add \`border-0\` to
-          any form elements that shouldn't have a border.
+          If we ever want to remove these styles, we need to add \`border-0\` to any form
+          elements that shouldn't have a border.
         */
         @layer base {
           input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1517,9 +1517,9 @@ describe('border compatibility', () => {
         }
 
         /*
-          The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-          so we've added these compatibility styles to make sure everything still
-          looks the same as it did with Tailwind CSS v3.
+          The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+          we've added these compatibility styles to make sure everything still looks the
+          same as it did with Tailwind CSS v3.
 
           If we ever want to remove these styles, we need to add an explicit border
           color utility to any element that depends on these defaults.
@@ -1535,12 +1535,12 @@ describe('border compatibility', () => {
         }
 
         /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've
-          added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
+          Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+          these compatibility styles to make sure everything still looks the same as it
+          did with Tailwind CSS v3.
 
-          If we ever want to remove these styles, we need to add \`border-0\` to
-          any form elements that shouldn't have a border.
+          If we ever want to remove these styles, we need to add \`border-0\` to any form
+          elements that shouldn't have a border.
         */
         @layer base {
           input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1646,9 +1646,9 @@ describe('border compatibility', () => {
         }
 
         /*
-          The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-          so we've added these compatibility styles to make sure everything still
-          looks the same as it did with Tailwind CSS v3.
+          The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+          we've added these compatibility styles to make sure everything still looks the
+          same as it did with Tailwind CSS v3.
 
           If we ever want to remove these styles, we need to add an explicit border
           color utility to any element that depends on these defaults.
@@ -1664,12 +1664,12 @@ describe('border compatibility', () => {
         }
 
         /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've
-          added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
+          Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+          these compatibility styles to make sure everything still looks the same as it
+          did with Tailwind CSS v3.
 
-          If we ever want to remove these styles, we need to add \`border-0\` to
-          any form elements that shouldn't have a border.
+          If we ever want to remove these styles, we need to add \`border-0\` to any form
+          elements that shouldn't have a border.
         */
         @layer base {
           input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1732,10 +1732,21 @@ test(
       --- src/input.css ---
       @import 'tailwindcss';
 
+      @theme {
+        /*
+          The \`shadow-inner\` class existed in Tailwind CSS v3 but doesn't exist by
+          default in v4.
+
+          If we ever want to remove this, we need to update our use of \`shadow-inner\`
+          to \`inset-shadow-sm\` instead.
+        */
+        --shadow-inner: inset 0 2px 4px 0 rgb(0 0 0 / 0.05);
+      }
+
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-        so we've added these compatibility styles to make sure everything still
-        looks the same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+        we've added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -1751,12 +1762,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+        these compatibility styles to make sure everything still looks the same as it
+        did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to any form
+        elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -262,9 +262,9 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
-        we've added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        so we've added these compatibility styles to make sure everything still
+        looks the same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -280,12 +280,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
-        these compatibility styles to make sure everything still looks the same as it
-        did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've
+        added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to any form
-        elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to
+        any form elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -386,9 +386,9 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
-        we've added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        so we've added these compatibility styles to make sure everything still
+        looks the same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -404,12 +404,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
-        these compatibility styles to make sure everything still looks the same as it
-        did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've
+        added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to any form
-        elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to
+        any form elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -483,9 +483,9 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
-        we've added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        so we've added these compatibility styles to make sure everything still
+        looks the same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -501,12 +501,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
-        these compatibility styles to make sure everything still looks the same as it
-        did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've
+        added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to any form
-        elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to
+        any form elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -572,9 +572,9 @@ test(
       @config '../tailwind.config.ts';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
-        we've added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        so we've added these compatibility styles to make sure everything still
+        looks the same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -590,12 +590,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
-        these compatibility styles to make sure everything still looks the same as it
-        did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've
+        added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to any form
-        elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to
+        any form elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -665,9 +665,9 @@ test(
       @config '../tailwind.config.ts';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
-        we've added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        so we've added these compatibility styles to make sure everything still
+        looks the same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -683,12 +683,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
-        these compatibility styles to make sure everything still looks the same as it
-        did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've
+        added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to any form
-        elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to
+        any form elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -754,9 +754,9 @@ test(
       @config '../tailwind.config.ts';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
-        we've added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        so we've added these compatibility styles to make sure everything still
+        looks the same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -772,12 +772,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
-        these compatibility styles to make sure everything still looks the same as it
-        did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've
+        added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to any form
-        elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to
+        any form elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -881,9 +881,9 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
-        we've added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        so we've added these compatibility styles to make sure everything still
+        looks the same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -899,12 +899,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
-        these compatibility styles to make sure everything still looks the same as it
-        did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've
+        added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to any form
-        elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to
+        any form elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -922,9 +922,9 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
-        we've added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        so we've added these compatibility styles to make sure everything still
+        looks the same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -940,12 +940,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
-        these compatibility styles to make sure everything still looks the same as it
-        did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've
+        added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to any form
-        elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to
+        any form elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1014,9 +1014,9 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
-        we've added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        so we've added these compatibility styles to make sure everything still
+        looks the same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -1032,12 +1032,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
-        these compatibility styles to make sure everything still looks the same as it
-        did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've
+        added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to any form
-        elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to
+        any form elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1089,9 +1089,9 @@ describe('border compatibility', () => {
         @import 'tailwindcss';
 
         /*
-          The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
-          we've added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
+          The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+          so we've added these compatibility styles to make sure everything still
+          looks the same as it did with Tailwind CSS v3.
 
           If we ever want to remove these styles, we need to add an explicit border
           color utility to any element that depends on these defaults.
@@ -1107,12 +1107,12 @@ describe('border compatibility', () => {
         }
 
         /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've added
-          these compatibility styles to make sure everything still looks the same as it
-          did with Tailwind CSS v3.
+          Form elements have a 1px border by default in Tailwind CSS v4, so we've
+          added these compatibility styles to make sure everything still looks the
+          same as it did with Tailwind CSS v3.
 
-          If we ever want to remove these styles, we need to add \`border-0\` to any form
-          elements that shouldn't have a border.
+          If we ever want to remove these styles, we need to add \`border-0\` to
+          any form elements that shouldn't have a border.
         */
         @layer base {
           input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1166,9 +1166,9 @@ describe('border compatibility', () => {
         @import 'tailwindcss';
 
         /*
-          The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
-          we've added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
+          The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+          so we've added these compatibility styles to make sure everything still
+          looks the same as it did with Tailwind CSS v3.
 
           If we ever want to remove these styles, we need to add an explicit border
           color utility to any element that depends on these defaults.
@@ -1184,12 +1184,12 @@ describe('border compatibility', () => {
         }
 
         /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've added
-          these compatibility styles to make sure everything still looks the same as it
-          did with Tailwind CSS v3.
+          Form elements have a 1px border by default in Tailwind CSS v4, so we've
+          added these compatibility styles to make sure everything still looks the
+          same as it did with Tailwind CSS v3.
 
-          If we ever want to remove these styles, we need to add \`border-0\` to any form
-          elements that shouldn't have a border.
+          If we ever want to remove these styles, we need to add \`border-0\` to
+          any form elements that shouldn't have a border.
         */
         @layer base {
           input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1243,12 +1243,12 @@ describe('border compatibility', () => {
         @import 'tailwindcss';
 
         /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've added
-          these compatibility styles to make sure everything still looks the same as it
-          did with Tailwind CSS v3.
+          Form elements have a 1px border by default in Tailwind CSS v4, so we've
+          added these compatibility styles to make sure everything still looks the
+          same as it did with Tailwind CSS v3.
 
-          If we ever want to remove these styles, we need to add \`border-0\` to any form
-          elements that shouldn't have a border.
+          If we ever want to remove these styles, we need to add \`border-0\` to
+          any form elements that shouldn't have a border.
         */
         @layer base {
           input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1300,9 +1300,9 @@ describe('border compatibility', () => {
         @import 'tailwindcss';
 
         /*
-          The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
-          we've added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
+          The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+          so we've added these compatibility styles to make sure everything still
+          looks the same as it did with Tailwind CSS v3.
 
           If we ever want to remove these styles, we need to add an explicit border
           color utility to any element that depends on these defaults.
@@ -1318,12 +1318,12 @@ describe('border compatibility', () => {
         }
 
         /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've added
-          these compatibility styles to make sure everything still looks the same as it
-          did with Tailwind CSS v3.
+          Form elements have a 1px border by default in Tailwind CSS v4, so we've
+          added these compatibility styles to make sure everything still looks the
+          same as it did with Tailwind CSS v3.
 
-          If we ever want to remove these styles, we need to add \`border-0\` to any form
-          elements that shouldn't have a border.
+          If we ever want to remove these styles, we need to add \`border-0\` to
+          any form elements that shouldn't have a border.
         */
         @layer base {
           input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1384,9 +1384,9 @@ describe('border compatibility', () => {
         @import 'tailwindcss/preflight' layer(base);
 
         /*
-          The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
-          we've added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
+          The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+          so we've added these compatibility styles to make sure everything still
+          looks the same as it did with Tailwind CSS v3.
 
           If we ever want to remove these styles, we need to add an explicit border
           color utility to any element that depends on these defaults.
@@ -1402,12 +1402,12 @@ describe('border compatibility', () => {
         }
 
         /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've added
-          these compatibility styles to make sure everything still looks the same as it
-          did with Tailwind CSS v3.
+          Form elements have a 1px border by default in Tailwind CSS v4, so we've
+          added these compatibility styles to make sure everything still looks the
+          same as it did with Tailwind CSS v3.
 
-          If we ever want to remove these styles, we need to add \`border-0\` to any form
-          elements that shouldn't have a border.
+          If we ever want to remove these styles, we need to add \`border-0\` to
+          any form elements that shouldn't have a border.
         */
         @layer base {
           input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -1732,21 +1732,10 @@ test(
       --- src/input.css ---
       @import 'tailwindcss';
 
-      @theme {
-        /*
-          The \`shadow-inner\` class existed in Tailwind CSS v3 but doesn't exist by
-          default in v4.
-
-          If we ever want to remove this, we need to update our use of \`shadow-inner\`
-          to \`inset-shadow-sm\` instead.
-        */
-        --shadow-inner: inset 0 2px 4px 0 rgb(0 0 0 / 0.05);
-      }
-
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
-        we've added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        so we've added these compatibility styles to make sure everything still
+        looks the same as it did with Tailwind CSS v3.
 
         If we ever want to remove these styles, we need to add an explicit border
         color utility to any element that depends on these defaults.
@@ -1762,12 +1751,12 @@ test(
       }
 
       /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've added
-        these compatibility styles to make sure everything still looks the same as it
-        did with Tailwind CSS v3.
+        Form elements have a 1px border by default in Tailwind CSS v4, so we've
+        added these compatibility styles to make sure everything still looks the
+        same as it did with Tailwind CSS v3.
 
-        If we ever want to remove these styles, we need to add \`border-0\` to any form
-        elements that shouldn't have a border.
+        If we ever want to remove these styles, we need to add \`border-0\` to
+        any form elements that shouldn't have a border.
       */
       @layer base {
         input:where(:not([type='button'], [type='reset'], [type='submit'])),

--- a/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
@@ -286,7 +286,6 @@ exports[`\`@import 'tailwindcss'\` is replaced with the generated CSS 1`] = `
     --shadow-lg: 0 10px 15px -3px #0000001a, 0 4px 6px -4px #0000001a;
     --shadow-xl: 0 20px 25px -5px #0000001a, 0 8px 10px -6px #0000001a;
     --shadow-2xl: 0 25px 50px -12px #00000040;
-    --shadow-inner: inset 0 2px 4px 0 #0000000d;
     --inset-shadow-2xs: inset 0 1px #0000000d;
     --inset-shadow-xs: inset 0 1px 1px #0000000d;
     --inset-shadow-sm: inset 0 2px 4px #0000000d;

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-border-compatibility.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-border-compatibility.test.ts
@@ -33,9 +33,9 @@ it("should add compatibility CSS after the `@import 'tailwindcss'`", async () =>
     "@import 'tailwindcss';
 
     /*
-      The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-      so we've added these compatibility styles to make sure everything still
-      looks the same as it did with Tailwind CSS v3.
+      The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+      we've added these compatibility styles to make sure everything still looks the
+      same as it did with Tailwind CSS v3.
 
       If we ever want to remove these styles, we need to add an explicit border
       color utility to any element that depends on these defaults.
@@ -51,12 +51,12 @@ it("should add compatibility CSS after the `@import 'tailwindcss'`", async () =>
     }
 
     /*
-      Form elements have a 1px border by default in Tailwind CSS v4, so we've
-      added these compatibility styles to make sure everything still looks the
-      same as it did with Tailwind CSS v3.
+      Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+      these compatibility styles to make sure everything still looks the same as it
+      did with Tailwind CSS v3.
 
-      If we ever want to remove these styles, we need to add \`border-0\` to
-      any form elements that shouldn't have a border.
+      If we ever want to remove these styles, we need to add \`border-0\` to any form
+      elements that shouldn't have a border.
     */
     @layer base {
       input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -81,9 +81,9 @@ it('should add the compatibility CSS after the last `@import`', async () => {
     @import './bar.css';
 
     /*
-      The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-      so we've added these compatibility styles to make sure everything still
-      looks the same as it did with Tailwind CSS v3.
+      The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+      we've added these compatibility styles to make sure everything still looks the
+      same as it did with Tailwind CSS v3.
 
       If we ever want to remove these styles, we need to add an explicit border
       color utility to any element that depends on these defaults.
@@ -99,12 +99,12 @@ it('should add the compatibility CSS after the last `@import`', async () => {
     }
 
     /*
-      Form elements have a 1px border by default in Tailwind CSS v4, so we've
-      added these compatibility styles to make sure everything still looks the
-      same as it did with Tailwind CSS v3.
+      Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+      these compatibility styles to make sure everything still looks the same as it
+      did with Tailwind CSS v3.
 
-      If we ever want to remove these styles, we need to add \`border-0\` to
-      any form elements that shouldn't have a border.
+      If we ever want to remove these styles, we need to add \`border-0\` to any form
+      elements that shouldn't have a border.
     */
     @layer base {
       input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -143,9 +143,9 @@ it('should add the compatibility CSS after the last import, even if a body-less 
     @import './bar.css';
 
     /*
-      The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-      so we've added these compatibility styles to make sure everything still
-      looks the same as it did with Tailwind CSS v3.
+      The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+      we've added these compatibility styles to make sure everything still looks the
+      same as it did with Tailwind CSS v3.
 
       If we ever want to remove these styles, we need to add an explicit border
       color utility to any element that depends on these defaults.
@@ -161,12 +161,12 @@ it('should add the compatibility CSS after the last import, even if a body-less 
     }
 
     /*
-      Form elements have a 1px border by default in Tailwind CSS v4, so we've
-      added these compatibility styles to make sure everything still looks the
-      same as it did with Tailwind CSS v3.
+      Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+      these compatibility styles to make sure everything still looks the same as it
+      did with Tailwind CSS v3.
 
-      If we ever want to remove these styles, we need to add \`border-0\` to
-      any form elements that shouldn't have a border.
+      If we ever want to remove these styles, we need to add \`border-0\` to any form
+      elements that shouldn't have a border.
     */
     @layer base {
       input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -205,9 +205,9 @@ it('should add the compatibility CSS before the first `@layer base` (if the "tai
     }
 
     /*
-      The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-      so we've added these compatibility styles to make sure everything still
-      looks the same as it did with Tailwind CSS v3.
+      The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+      we've added these compatibility styles to make sure everything still looks the
+      same as it did with Tailwind CSS v3.
 
       If we ever want to remove these styles, we need to add an explicit border
       color utility to any element that depends on these defaults.
@@ -223,12 +223,12 @@ it('should add the compatibility CSS before the first `@layer base` (if the "tai
     }
 
     /*
-      Form elements have a 1px border by default in Tailwind CSS v4, so we've
-      added these compatibility styles to make sure everything still looks the
-      same as it did with Tailwind CSS v3.
+      Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+      these compatibility styles to make sure everything still looks the same as it
+      did with Tailwind CSS v3.
 
-      If we ever want to remove these styles, we need to add \`border-0\` to
-      any form elements that shouldn't have a border.
+      If we ever want to remove these styles, we need to add \`border-0\` to any form
+      elements that shouldn't have a border.
     */
     @layer base {
       input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -279,9 +279,9 @@ it('should add the compatibility CSS before the first `@layer base` (if the "tai
     }
 
     /*
-      The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-      so we've added these compatibility styles to make sure everything still
-      looks the same as it did with Tailwind CSS v3.
+      The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+      we've added these compatibility styles to make sure everything still looks the
+      same as it did with Tailwind CSS v3.
 
       If we ever want to remove these styles, we need to add an explicit border
       color utility to any element that depends on these defaults.
@@ -297,12 +297,12 @@ it('should add the compatibility CSS before the first `@layer base` (if the "tai
     }
 
     /*
-      Form elements have a 1px border by default in Tailwind CSS v4, so we've
-      added these compatibility styles to make sure everything still looks the
-      same as it did with Tailwind CSS v3.
+      Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+      these compatibility styles to make sure everything still looks the same as it
+      did with Tailwind CSS v3.
 
-      If we ever want to remove these styles, we need to add \`border-0\` to
-      any form elements that shouldn't have a border.
+      If we ever want to remove these styles, we need to add \`border-0\` to any form
+      elements that shouldn't have a border.
     */
     @layer base {
       input:where(:not([type='button'], [type='reset'], [type='submit'])),

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-border-compatibility.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-border-compatibility.ts
@@ -12,9 +12,9 @@ const DEFAULT_BORDER_COLOR = 'currentColor'
 const css = dedent
 const BORDER_COLOR_COMPATIBILITY_CSS = css`
   /*
-    The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-    so we've added these compatibility styles to make sure everything still
-    looks the same as it did with Tailwind CSS v3.
+    The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+    we've added these compatibility styles to make sure everything still looks the
+    same as it did with Tailwind CSS v3.
 
     If we ever want to remove these styles, we need to add an explicit border
     color utility to any element that depends on these defaults.
@@ -32,12 +32,12 @@ const BORDER_COLOR_COMPATIBILITY_CSS = css`
 
 const BORDER_WIDTH_COMPATIBILITY_CSS = css`
   /*
-    Form elements have a 1px border by default in Tailwind CSS v4, so we've
-    added these compatibility styles to make sure everything still looks the
-    same as it did with Tailwind CSS v3.
+    Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+    these compatibility styles to make sure everything still looks the same as it
+    did with Tailwind CSS v3.
 
-    If we ever want to remove these styles, we need to add \`border-0\` to
-    any form elements that shouldn't have a border.
+    If we ever want to remove these styles, we need to add \`border-0\` to any form
+    elements that shouldn't have a border.
   */
   @layer base {
     input:where(:not([type='button'], [type='reset'], [type='submit'])),

--- a/packages/@tailwindcss-upgrade/src/index.test.ts
+++ b/packages/@tailwindcss-upgrade/src/index.test.ts
@@ -97,9 +97,9 @@ it('should migrate a stylesheet', async () => {
     "@import 'tailwindcss';
 
     /*
-      The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-      so we've added these compatibility styles to make sure everything still
-      looks the same as it did with Tailwind CSS v3.
+      The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+      we've added these compatibility styles to make sure everything still looks the
+      same as it did with Tailwind CSS v3.
 
       If we ever want to remove these styles, we need to add an explicit border
       color utility to any element that depends on these defaults.
@@ -115,12 +115,12 @@ it('should migrate a stylesheet', async () => {
     }
 
     /*
-      Form elements have a 1px border by default in Tailwind CSS v4, so we've
-      added these compatibility styles to make sure everything still looks the
-      same as it did with Tailwind CSS v3.
+      Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+      these compatibility styles to make sure everything still looks the same as it
+      did with Tailwind CSS v3.
 
-      If we ever want to remove these styles, we need to add \`border-0\` to
-      any form elements that shouldn't have a border.
+      If we ever want to remove these styles, we need to add \`border-0\` to any form
+      elements that shouldn't have a border.
     */
     @layer base {
       input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -184,9 +184,9 @@ it('should migrate a stylesheet (with imports)', async () => {
     @import './my-utilities.css' layer(utilities);
 
     /*
-      The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-      so we've added these compatibility styles to make sure everything still
-      looks the same as it did with Tailwind CSS v3.
+      The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+      we've added these compatibility styles to make sure everything still looks the
+      same as it did with Tailwind CSS v3.
 
       If we ever want to remove these styles, we need to add an explicit border
       color utility to any element that depends on these defaults.
@@ -202,12 +202,12 @@ it('should migrate a stylesheet (with imports)', async () => {
     }
 
     /*
-      Form elements have a 1px border by default in Tailwind CSS v4, so we've
-      added these compatibility styles to make sure everything still looks the
-      same as it did with Tailwind CSS v3.
+      Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+      these compatibility styles to make sure everything still looks the same as it
+      did with Tailwind CSS v3.
 
-      If we ever want to remove these styles, we need to add \`border-0\` to
-      any form elements that shouldn't have a border.
+      If we ever want to remove these styles, we need to add \`border-0\` to any form
+      elements that shouldn't have a border.
     */
     @layer base {
       input:where(:not([type='button'], [type='reset'], [type='submit'])),
@@ -242,9 +242,9 @@ it('should migrate a stylesheet (with preceding rules that should be wrapped in 
     @import 'tailwindcss';
 
     /*
-      The default border color has changed to \`currentColor\` in Tailwind CSS v4,
-      so we've added these compatibility styles to make sure everything still
-      looks the same as it did with Tailwind CSS v3.
+      The default border color has changed to \`currentColor\` in Tailwind CSS v4, so
+      we've added these compatibility styles to make sure everything still looks the
+      same as it did with Tailwind CSS v3.
 
       If we ever want to remove these styles, we need to add an explicit border
       color utility to any element that depends on these defaults.
@@ -260,12 +260,12 @@ it('should migrate a stylesheet (with preceding rules that should be wrapped in 
     }
 
     /*
-      Form elements have a 1px border by default in Tailwind CSS v4, so we've
-      added these compatibility styles to make sure everything still looks the
-      same as it did with Tailwind CSS v3.
+      Form elements have a 1px border by default in Tailwind CSS v4, so we've added
+      these compatibility styles to make sure everything still looks the same as it
+      did with Tailwind CSS v3.
 
-      If we ever want to remove these styles, we need to add \`border-0\` to
-      any form elements that shouldn't have a border.
+      If we ever want to remove these styles, we need to add \`border-0\` to any form
+      elements that shouldn't have a border.
     */
     @layer base {
       input:where(:not([type='button'], [type='reset'], [type='submit'])),

--- a/packages/@tailwindcss-upgrade/src/template/migrate.ts
+++ b/packages/@tailwindcss-upgrade/src/template/migrate.ts
@@ -1,8 +1,5 @@
-import fs from 'node:fs/promises'
-import path, { extname } from 'node:path'
 import type { Config } from 'tailwindcss'
 import type { DesignSystem } from '../../../tailwindcss/src/design-system'
-import { extractRawCandidates } from './candidates'
 import { arbitraryValueToBareValue } from './codemods/arbitrary-value-to-bare-value'
 import { automaticVarInjection } from './codemods/automatic-var-injection'
 import { bgGradient } from './codemods/bg-gradient'
@@ -54,14 +51,12 @@ export function migrateCandidate(
   return rawCandidate
 }
 
-export default async function migrateContents(
+export async function migrateContents(
+  candidates: { rawCandidate: string; start: number; end: number }[],
   designSystem: DesignSystem,
   userConfig: Config,
   contents: string,
-  extension: string,
 ): Promise<string> {
-  let candidates = await extractRawCandidates(contents, extension)
-
   let changes: StringChange[] = []
 
   for (let { rawCandidate, start, end } of candidates) {
@@ -83,14 +78,4 @@ export default async function migrateContents(
   }
 
   return spliceChangesIntoString(contents, changes)
-}
-
-export async function migrate(designSystem: DesignSystem, userConfig: Config, file: string) {
-  let fullPath = path.isAbsolute(file) ? file : path.resolve(process.cwd(), file)
-  let contents = await fs.readFile(fullPath, 'utf-8')
-
-  await fs.writeFile(
-    fullPath,
-    await migrateContents(designSystem, userConfig, contents, extname(file)),
-  )
 }

--- a/packages/tailwindcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/tailwindcss/src/__snapshots__/index.test.ts.snap
@@ -285,7 +285,6 @@ exports[`compiling CSS > \`@tailwind utilities\` is replaced by utilities using 
   --shadow-lg: 0 10px 15px -3px #0000001a, 0 4px 6px -4px #0000001a;
   --shadow-xl: 0 20px 25px -5px #0000001a, 0 8px 10px -6px #0000001a;
   --shadow-2xl: 0 25px 50px -12px #00000040;
-  --shadow-inner: inset 0 2px 4px 0 #0000000d;
   --inset-shadow-2xs: inset 0 1px #0000000d;
   --inset-shadow-xs: inset 0 1px 1px #0000000d;
   --inset-shadow-sm: inset 0 2px 4px #0000000d;

--- a/packages/tailwindcss/theme.css
+++ b/packages/tailwindcss/theme.css
@@ -317,7 +317,6 @@
   --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
   --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
   --shadow-2xl: 0 25px 50px -12px rgb(0 0 0 / 0.25);
-  --shadow-inner: inset 0 2px 4px 0 rgb(0 0 0 / 0.05);
 
   /* Inset shadows */
   --inset-shadow-2xs: inset 0 1px rgb(0 0 0 / 0.05);


### PR DESCRIPTION
We are dropping the default `--shadow-inner` theme variable from Tailwind CSS v4 in favor of the `inset-shadow` utilities. We can't however, easily codemod usages from `shadow-inner` to `insert-shadow-sm` because of how this utility interacts with shadow colors. E.g.:


```diff
- <div class="shadow-inner shadow-red-500">
+ <div class="inset-shadow-sm inset-shadow-red-500">
```

Since we can't do codemods on connected candidates right now, we instead backfill support for `shadow-inner` if it is used in one of your templates files. This is as simple as adding the following CSS theme variable:

```css
@theme {
  --shadow-inner: inset 0 2px 4px 0 rgb(0 0 0 / 0.05);
}
```

## Test plan

Added an integration test for a setup using `shadow-inner` in its templates.