### PR TITLE
Remove input borders by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `--line-height-*` variables to `--leading-*` ([#14925](https://github.com/tailwindlabs/tailwindcss/pull/14925))
 - Revert specificity of `*` variant to match v3 behavior ([#14920](https://github.com/tailwindlabs/tailwindcss/pull/14920))
 - Replace `outline-none` with `outline-hidden`, add new simplified `outline-none` utility ([#14926](https://github.com/tailwindlabs/tailwindcss/pull/14926))
+- Revert adding borders by default to form inputs ([#14929](https://github.com/tailwindlabs/tailwindcss/pull/14929))
 
 ## [4.0.0-alpha.31] - 2024-10-29
 

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -133,22 +133,6 @@ test(
         }
       }
 
-      /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
-
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
-      */
-      @layer base {
-        input:where(:not([type='button'], [type='reset'], [type='submit'])),
-        select,
-        textarea {
-          border-width: 0;
-        }
-      }
-
       @utility foo {
         color: red;
       }
@@ -240,22 +224,6 @@ test(
         }
       }
 
-      /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
-
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
-      */
-      @layer base {
-        input:where(:not([type='button'], [type='reset'], [type='submit'])),
-        select,
-        textarea {
-          border-width: 0;
-        }
-      }
-
       .btn {
         @apply tw:rounded-md! tw:px-2 tw:py-1 tw:bg-blue-500 tw:text-white;
       }
@@ -317,22 +285,6 @@ test(
         ::backdrop,
         ::file-selector-button {
           border-color: var(--color-gray-200, currentColor);
-        }
-      }
-
-      /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
-
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
-      */
-      @layer base {
-        input:where(:not([type='button'], [type='reset'], [type='submit'])),
-        select,
-        textarea {
-          border-width: 0;
         }
       }
 
@@ -405,22 +357,6 @@ test(
         ::backdrop,
         ::file-selector-button {
           border-color: var(--color-gray-200, currentColor);
-        }
-      }
-
-      /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
-
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
-      */
-      @layer base {
-        input:where(:not([type='button'], [type='reset'], [type='submit'])),
-        select,
-        textarea {
-          border-width: 0;
         }
       }
 
@@ -498,22 +434,6 @@ test(
         ::backdrop,
         ::file-selector-button {
           border-color: var(--color-gray-200, currentColor);
-        }
-      }
-
-      /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
-
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
-      */
-      @layer base {
-        input:where(:not([type='button'], [type='reset'], [type='submit'])),
-        select,
-        textarea {
-          border-width: 0;
         }
       }
 
@@ -1002,22 +922,6 @@ test(
         }
       }
 
-      /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
-
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
-      */
-      @layer base {
-        input:where(:not([type='button'], [type='reset'], [type='submit'])),
-        select,
-        textarea {
-          border-width: 0;
-        }
-      }
-
       --- ./src/utilities.css ---
       @utility no-scrollbar {
         &::-webkit-scrollbar {
@@ -1442,22 +1346,6 @@ test(
         }
       }
 
-      /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
-
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
-      */
-      @layer base {
-        input:where(:not([type='button'], [type='reset'], [type='submit'])),
-        select,
-        textarea {
-          border-width: 0;
-        }
-      }
-
       --- ./src/root.2.css ---
       /* Already contains @config */
       @import 'tailwindcss';
@@ -1479,22 +1367,6 @@ test(
         ::backdrop,
         ::file-selector-button {
           border-color: var(--color-gray-200, currentColor);
-        }
-      }
-
-      /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
-
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
-      */
-      @layer base {
-        input:where(:not([type='button'], [type='reset'], [type='submit'])),
-        select,
-        textarea {
-          border-width: 0;
         }
       }
 
@@ -1532,22 +1404,6 @@ test(
         }
       }
 
-      /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
-
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
-      */
-      @layer base {
-        input:where(:not([type='button'], [type='reset'], [type='submit'])),
-        select,
-        textarea {
-          border-width: 0;
-        }
-      }
-
       --- ./src/root.4.css ---
       /* Inject missing @config due to nested imports with tailwind imports */
       @import './root.4/base.css';
@@ -1580,22 +1436,6 @@ test(
         }
       }
 
-      /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
-
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
-      */
-      @layer base {
-        input:where(:not([type='button'], [type='reset'], [type='submit'])),
-        select,
-        textarea {
-          border-width: 0;
-        }
-      }
-
       --- ./src/root.4/utilities.css ---
       @import 'tailwindcss/utilities' layer(utilities);
 
@@ -1620,22 +1460,6 @@ test(
         ::backdrop,
         ::file-selector-button {
           border-color: var(--color-gray-200, currentColor);
-        }
-      }
-
-      /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
-
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
-      */
-      @layer base {
-        input:where(:not([type='button'], [type='reset'], [type='submit'])),
-        select,
-        textarea {
-          border-width: 0;
         }
       }
       "
@@ -1693,22 +1517,6 @@ test(
         ::backdrop,
         ::file-selector-button {
           border-color: var(--color-gray-200, currentColor);
-        }
-      }
-
-      /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
-
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
-      */
-      @layer base {
-        input:where(:not([type='button'], [type='reset'], [type='submit'])),
-        select,
-        textarea {
-          border-width: 0;
         }
       }
 

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -279,22 +279,6 @@ test(
         }
       }
 
-      /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
-
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
-      */
-      @layer base {
-        input:where(:not([type='button'], [type='reset'], [type='submit'])),
-        select,
-        textarea {
-          border-width: 0;
-        }
-      }
-
       --- src/test.js ---
       export default {
         'shouldNotMigrate': !border.test + '',
@@ -402,22 +386,6 @@ test(
           border-color: var(--color-gray-200, currentColor);
         }
       }
-
-      /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
-
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
-      */
-      @layer base {
-        input:where(:not([type='button'], [type='reset'], [type='submit'])),
-        select,
-        textarea {
-          border-width: 0;
-        }
-      }
       "
     `)
 
@@ -499,22 +467,6 @@ test(
           border-color: var(--color-gray-200, currentColor);
         }
       }
-
-      /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
-
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
-      */
-      @layer base {
-        input:where(:not([type='button'], [type='reset'], [type='submit'])),
-        select,
-        textarea {
-          border-width: 0;
-        }
-      }
       "
     `)
 
@@ -586,22 +538,6 @@ test(
         ::backdrop,
         ::file-selector-button {
           border-color: var(--color-gray-200, currentColor);
-        }
-      }
-
-      /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
-
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
-      */
-      @layer base {
-        input:where(:not([type='button'], [type='reset'], [type='submit'])),
-        select,
-        textarea {
-          border-width: 0;
         }
       }
       "
@@ -681,22 +617,6 @@ test(
           border-color: var(--color-gray-200, currentColor);
         }
       }
-
-      /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
-
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
-      */
-      @layer base {
-        input:where(:not([type='button'], [type='reset'], [type='submit'])),
-        select,
-        textarea {
-          border-width: 0;
-        }
-      }
       "
     `)
 
@@ -768,22 +688,6 @@ test(
         ::backdrop,
         ::file-selector-button {
           border-color: var(--color-gray-200, currentColor);
-        }
-      }
-
-      /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
-
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
-      */
-      @layer base {
-        input:where(:not([type='button'], [type='reset'], [type='submit'])),
-        select,
-        textarea {
-          border-width: 0;
         }
       }
       "
@@ -898,22 +802,6 @@ test(
         }
       }
 
-      /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
-
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
-      */
-      @layer base {
-        input:where(:not([type='button'], [type='reset'], [type='submit'])),
-        select,
-        textarea {
-          border-width: 0;
-        }
-      }
-
       --- project-b/src/input.css ---
       @import 'tailwindcss';
 
@@ -936,22 +824,6 @@ test(
         ::backdrop,
         ::file-selector-button {
           border-color: var(--color-gray-200, currentColor);
-        }
-      }
-
-      /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
-
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
-      */
-      @layer base {
-        input:where(:not([type='button'], [type='reset'], [type='submit'])),
-        select,
-        textarea {
-          border-width: 0;
         }
       }
       "
@@ -1030,22 +902,6 @@ test(
           border-color: var(--color-gray-200, currentColor);
         }
       }
-
-      /*
-        Form elements have a 1px border by default in Tailwind CSS v4, so we've
-        added these compatibility styles to make sure everything still looks the
-        same as it did with Tailwind CSS v3.
-
-        If we ever want to remove these styles, we need to add \`border-0\` to
-        any form elements that shouldn't have a border.
-      */
-      @layer base {
-        input:where(:not([type='button'], [type='reset'], [type='submit'])),
-        select,
-        textarea {
-          border-width: 0;
-        }
-      }
       "
     `)
   },
@@ -1103,22 +959,6 @@ describe('border compatibility', () => {
           ::backdrop,
           ::file-selector-button {
             border-color: var(--color-gray-200, currentColor);
-          }
-        }
-
-        /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've
-          added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
-
-          If we ever want to remove these styles, we need to add \`border-0\` to
-          any form elements that shouldn't have a border.
-        */
-        @layer base {
-          input:where(:not([type='button'], [type='reset'], [type='submit'])),
-          select,
-          textarea {
-            border-width: 0;
           }
         }
         "
@@ -1182,22 +1022,6 @@ describe('border compatibility', () => {
             border-color: oklch(0.623 0.214 259.815);
           }
         }
-
-        /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've
-          added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
-
-          If we ever want to remove these styles, we need to add \`border-0\` to
-          any form elements that shouldn't have a border.
-        */
-        @layer base {
-          input:where(:not([type='button'], [type='reset'], [type='submit'])),
-          select,
-          textarea {
-            border-width: 0;
-          }
-        }
         "
       `)
     },
@@ -1241,22 +1065,6 @@ describe('border compatibility', () => {
         "
         --- src/input.css ---
         @import 'tailwindcss';
-
-        /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've
-          added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
-
-          If we ever want to remove these styles, we need to add \`border-0\` to
-          any form elements that shouldn't have a border.
-        */
-        @layer base {
-          input:where(:not([type='button'], [type='reset'], [type='submit'])),
-          select,
-          textarea {
-            border-width: 0;
-          }
-        }
         "
       `)
     },
@@ -1314,22 +1122,6 @@ describe('border compatibility', () => {
           ::backdrop,
           ::file-selector-button {
             border-color: var(--color-gray-200, currentColor);
-          }
-        }
-
-        /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've
-          added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
-
-          If we ever want to remove these styles, we need to add \`border-0\` to
-          any form elements that shouldn't have a border.
-        */
-        @layer base {
-          input:where(:not([type='button'], [type='reset'], [type='submit'])),
-          select,
-          textarea {
-            border-width: 0;
           }
         }
         "
@@ -1398,22 +1190,6 @@ describe('border compatibility', () => {
           ::backdrop,
           ::file-selector-button {
             border-color: var(--color-gray-200, currentColor);
-          }
-        }
-
-        /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've
-          added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
-
-          If we ever want to remove these styles, we need to add \`border-0\` to
-          any form elements that shouldn't have a border.
-        */
-        @layer base {
-          input:where(:not([type='button'], [type='reset'], [type='submit'])),
-          select,
-          textarea {
-            border-width: 0;
           }
         }
 
@@ -1534,22 +1310,6 @@ describe('border compatibility', () => {
           }
         }
 
-        /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've
-          added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
-
-          If we ever want to remove these styles, we need to add \`border-0\` to
-          any form elements that shouldn't have a border.
-        */
-        @layer base {
-          input:where(:not([type='button'], [type='reset'], [type='submit'])),
-          select,
-          textarea {
-            border-width: 0;
-          }
-        }
-
         .container {
           width: calc(var(--spacing) * 2);
           width: calc(var(--spacing) * 4.5);
@@ -1660,22 +1420,6 @@ describe('border compatibility', () => {
           ::backdrop,
           ::file-selector-button {
             border-color: var(--color-gray-200, currentColor);
-          }
-        }
-
-        /*
-          Form elements have a 1px border by default in Tailwind CSS v4, so we've
-          added these compatibility styles to make sure everything still looks the
-          same as it did with Tailwind CSS v3.
-
-          If we ever want to remove these styles, we need to add \`border-0\` to
-          any form elements that shouldn't have a border.
-        */
-        @layer base {
-          input:where(:not([type='button'], [type='reset'], [type='submit'])),
-          select,
-          textarea {
-            border-width: 0;
           }
         }
 

--- a/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
@@ -477,10 +477,6 @@ exports[`\`@import 'tailwindcss'\` is replaced with the generated CSS 1`] = `
     color: inherit;
   }
 
-  input:where(:not([type="button"], [type="reset"], [type="submit"])), select, textarea {
-    border-width: 1px;
-  }
-
   button, input:where([type="button"], [type="reset"], [type="submit"]) {
     appearance: button;
     background: none;

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-border-compatibility.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-border-compatibility.test.ts
@@ -48,22 +48,6 @@ it("should add compatibility CSS after the `@import 'tailwindcss'`", async () =>
       ::file-selector-button {
         border-color: var(--color-gray-200, currentColor);
       }
-    }
-
-    /*
-      Form elements have a 1px border by default in Tailwind CSS v4, so we've
-      added these compatibility styles to make sure everything still looks the
-      same as it did with Tailwind CSS v3.
-
-      If we ever want to remove these styles, we need to add \`border-0\` to
-      any form elements that shouldn't have a border.
-    */
-    @layer base {
-      input:where(:not([type='button'], [type='reset'], [type='submit'])),
-      select,
-      textarea {
-        border-width: 0;
-      }
     }"
   `)
 })
@@ -95,22 +79,6 @@ it('should add the compatibility CSS after the last `@import`', async () => {
       ::backdrop,
       ::file-selector-button {
         border-color: var(--color-gray-200, currentColor);
-      }
-    }
-
-    /*
-      Form elements have a 1px border by default in Tailwind CSS v4, so we've
-      added these compatibility styles to make sure everything still looks the
-      same as it did with Tailwind CSS v3.
-
-      If we ever want to remove these styles, we need to add \`border-0\` to
-      any form elements that shouldn't have a border.
-    */
-    @layer base {
-      input:where(:not([type='button'], [type='reset'], [type='submit'])),
-      select,
-      textarea {
-        border-width: 0;
       }
     }"
   `)
@@ -158,22 +126,6 @@ it('should add the compatibility CSS after the last import, even if a body-less 
       ::file-selector-button {
         border-color: var(--color-gray-200, currentColor);
       }
-    }
-
-    /*
-      Form elements have a 1px border by default in Tailwind CSS v4, so we've
-      added these compatibility styles to make sure everything still looks the
-      same as it did with Tailwind CSS v3.
-
-      If we ever want to remove these styles, we need to add \`border-0\` to
-      any form elements that shouldn't have a border.
-    */
-    @layer base {
-      input:where(:not([type='button'], [type='reset'], [type='submit'])),
-      select,
-      textarea {
-        border-width: 0;
-      }
     }"
   `)
 })
@@ -219,22 +171,6 @@ it('should add the compatibility CSS before the first `@layer base` (if the "tai
       ::backdrop,
       ::file-selector-button {
         border-color: var(--color-gray-200, currentColor);
-      }
-    }
-
-    /*
-      Form elements have a 1px border by default in Tailwind CSS v4, so we've
-      added these compatibility styles to make sure everything still looks the
-      same as it did with Tailwind CSS v3.
-
-      If we ever want to remove these styles, we need to add \`border-0\` to
-      any form elements that shouldn't have a border.
-    */
-    @layer base {
-      input:where(:not([type='button'], [type='reset'], [type='submit'])),
-      select,
-      textarea {
-        border-width: 0;
       }
     }
 
@@ -293,22 +229,6 @@ it('should add the compatibility CSS before the first `@layer base` (if the "tai
       ::backdrop,
       ::file-selector-button {
         border-color: var(--color-gray-200, currentColor);
-      }
-    }
-
-    /*
-      Form elements have a 1px border by default in Tailwind CSS v4, so we've
-      added these compatibility styles to make sure everything still looks the
-      same as it did with Tailwind CSS v3.
-
-      If we ever want to remove these styles, we need to add \`border-0\` to
-      any form elements that shouldn't have a border.
-    */
-    @layer base {
-      input:where(:not([type='button'], [type='reset'], [type='submit'])),
-      select,
-      textarea {
-        border-width: 0;
       }
     }
 

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-border-compatibility.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-border-compatibility.ts
@@ -30,24 +30,6 @@ const BORDER_COLOR_COMPATIBILITY_CSS = css`
   }
 `
 
-const BORDER_WIDTH_COMPATIBILITY_CSS = css`
-  /*
-    Form elements have a 1px border by default in Tailwind CSS v4, so we've
-    added these compatibility styles to make sure everything still looks the
-    same as it did with Tailwind CSS v3.
-
-    If we ever want to remove these styles, we need to add \`border-0\` to
-    any form elements that shouldn't have a border.
-  */
-  @layer base {
-    input:where(:not([type='button'], [type='reset'], [type='submit'])),
-    select,
-    textarea {
-      border-width: 0;
-    }
-  }
-`
-
 export function migrateBorderCompatibility({
   designSystem,
   userConfig,
@@ -84,7 +66,6 @@ export function migrateBorderCompatibility({
       compatibilityCssString += '\n\n'
     }
 
-    compatibilityCssString += BORDER_WIDTH_COMPATIBILITY_CSS
     compatibilityCssString = `\n@tw-bucket compatibility {\n${compatibilityCssString}\n}\n`
     let compatibilityCss = postcss.parse(compatibilityCssString)
 

--- a/packages/@tailwindcss-upgrade/src/index.test.ts
+++ b/packages/@tailwindcss-upgrade/src/index.test.ts
@@ -114,22 +114,6 @@ it('should migrate a stylesheet', async () => {
       }
     }
 
-    /*
-      Form elements have a 1px border by default in Tailwind CSS v4, so we've
-      added these compatibility styles to make sure everything still looks the
-      same as it did with Tailwind CSS v3.
-
-      If we ever want to remove these styles, we need to add \`border-0\` to
-      any form elements that shouldn't have a border.
-    */
-    @layer base {
-      input:where(:not([type='button'], [type='reset'], [type='submit'])),
-      select,
-      textarea {
-        border-width: 0;
-      }
-    }
-
     @utility b {
       z-index: 2;
     }
@@ -199,22 +183,6 @@ it('should migrate a stylesheet (with imports)', async () => {
       ::file-selector-button {
         border-color: var(--color-gray-200, currentColor);
       }
-    }
-
-    /*
-      Form elements have a 1px border by default in Tailwind CSS v4, so we've
-      added these compatibility styles to make sure everything still looks the
-      same as it did with Tailwind CSS v3.
-
-      If we ever want to remove these styles, we need to add \`border-0\` to
-      any form elements that shouldn't have a border.
-    */
-    @layer base {
-      input:where(:not([type='button'], [type='reset'], [type='submit'])),
-      select,
-      textarea {
-        border-width: 0;
-      }
     }"
   `)
 })
@@ -256,22 +224,6 @@ it('should migrate a stylesheet (with preceding rules that should be wrapped in 
       ::backdrop,
       ::file-selector-button {
         border-color: var(--color-gray-200, currentColor);
-      }
-    }
-
-    /*
-      Form elements have a 1px border by default in Tailwind CSS v4, so we've
-      added these compatibility styles to make sure everything still looks the
-      same as it did with Tailwind CSS v3.
-
-      If we ever want to remove these styles, we need to add \`border-0\` to
-      any form elements that shouldn't have a border.
-    */
-    @layer base {
-      input:where(:not([type='button'], [type='reset'], [type='submit'])),
-      select,
-      textarea {
-        border-width: 0;
       }
     }
 

--- a/packages/tailwindcss/preflight.css
+++ b/packages/tailwindcss/preflight.css
@@ -192,16 +192,6 @@ textarea,
 }
 
 /*
-  Reset the default inset border style for form controls to solid.
-*/
-
-input:where(:not([type='button'], [type='reset'], [type='submit'])),
-select,
-textarea {
-  border-width: 1px;
-}
-
-/*
   1. Remove the default background color of buttons by default.
   2. Correct the inability to style the border radius in iOS Safari.
 */


### PR DESCRIPTION
This PR reverts a change we made for v4 that added borders to inputs by default. It feels like we have to go further than this for this to actually be useful to anyone, and since there were no borders in v3 it's also a breaking change.

If we wanted to make form elements look more "normal" out of the box I think we need to do something more like this:

https://play.tailwindcss.com/icCwFLVp4z?file=css

But it's a huge rabbit hole and there are so many stupid details to get right that it feels like an insurmountable task, and if we can't go all the way with it it's better to just maximize compatibility with v3.