### PR TITLE
Reintroduce deprecated theme values

### DIFF
--- a/packages/tailwindcss/theme.css
+++ b/packages/tailwindcss/theme.css
@@ -458,3 +458,11 @@
     }
   }
 }
+
+/* Deprecated */
+@theme default inline reference {
+  --blur: 8px;
+  --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  --drop-shadow: 0 1px 2px rgb(0 0 0 / 0.1), 0 1px 1px rgb(0 0 0 / 0.06);
+  --radius: 0.25rem;
+}


### PR DESCRIPTION
This PR reintroduces the `blur`, `shadow`, `drop-shadow`, and `rounded` utilities that were removed in #14849, just to preserve backward compatibility as much as possible.

These values are still considered deprecated, and we register them as `inline reference` with the theme to ensure they don't produce any CSS variables in output:

```css
/* Deprecated */
@theme default inline reference {
  --blur: 8px;
  --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
  --drop-shadow: 0 1px 2px rgb(0 0 0 / 0.1), 0 1px 1px rgb(0 0 0 / 0.06);
  --radius: 0.25rem;
}
```

These values won't be included in the documentation, and in the future we'll add an option to explicitly register things as `deprecated` so that they don't appear as completions in IntelliSense either.