### PR TITLE
Add link to changelog website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-View the interactive changelog [tailwind.openchangelog.com](https://tailwind.openchangelog.com).
+View the interactive changelog at [tailwind.openchangelog.com](https://tailwind.openchangelog.com).
 
 
 ## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+View the interactive changelog [tailwind.openchangelog.com](https://tailwind.openchangelog.com).
+
+
 ## [Unreleased]
 
 ### Added


### PR DESCRIPTION
Hi, I'm the creator of [Openchangelog](https://github.com/JonasHiltl/openchangelog) and a big fan of Tailwind.

I created a changelog website for Tailwind using Openchangelog which you can check out at [tailwind.openchangelog.com](https://tailwind.openchangelog.com). 
Since I'm a big fans of Tailwind, I made sure to use the Tailwind typography plugin to keep the changelog articles looking clean.

Would love to have this linked in your `CHANGELOG.md` to make it more accessible, since who really wants to read a `CHANGELOG.md` file when they could have a beautiful, styled website.