### PR TITLE
Don't reset horizontal padding on date/time pseudo-elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Don't reset horizontal padding on date/time pseudo-elements ([#14959](https://github.com/tailwindlabs/tailwindcss/pull/14959))
 
 ## [4.0.0-alpha.32] - 2024-11-11
 

--- a/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
@@ -523,48 +523,39 @@ exports[`\`@import 'tailwindcss'\` is replaced with the generated CSS 1`] = `
   }
 
   ::-webkit-datetime-edit {
-    padding-top: 0;
-    padding-bottom: 0;
+    padding-block: 0;
   }
 
   ::-webkit-datetime-edit-year-field {
-    padding-top: 0;
-    padding-bottom: 0;
+    padding-block: 0;
   }
 
   ::-webkit-datetime-edit-month-field {
-    padding-top: 0;
-    padding-bottom: 0;
+    padding-block: 0;
   }
 
   ::-webkit-datetime-edit-day-field {
-    padding-top: 0;
-    padding-bottom: 0;
+    padding-block: 0;
   }
 
   ::-webkit-datetime-edit-hour-field {
-    padding-top: 0;
-    padding-bottom: 0;
+    padding-block: 0;
   }
 
   ::-webkit-datetime-edit-minute-field {
-    padding-top: 0;
-    padding-bottom: 0;
+    padding-block: 0;
   }
 
   ::-webkit-datetime-edit-second-field {
-    padding-top: 0;
-    padding-bottom: 0;
+    padding-block: 0;
   }
 
   ::-webkit-datetime-edit-millisecond-field {
-    padding-top: 0;
-    padding-bottom: 0;
+    padding-block: 0;
   }
 
   ::-webkit-datetime-edit-meridiem-field {
-    padding-top: 0;
-    padding-bottom: 0;
+    padding-block: 0;
   }
 
   summary {

--- a/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
@@ -518,44 +518,53 @@ exports[`\`@import 'tailwindcss'\` is replaced with the generated CSS 1`] = `
     display: inline-flex;
   }
 
-  ::-webkit-datetime-edit {
+  ::-webkit-datetime-edit-fields-wrapper {
     padding: 0;
+  }
+
+  ::-webkit-datetime-edit {
+    padding-top: 0;
+    padding-bottom: 0;
   }
 
   ::-webkit-datetime-edit-year-field {
-    padding: 0;
+    padding-top: 0;
+    padding-bottom: 0;
   }
 
   ::-webkit-datetime-edit-month-field {
-    padding: 0;
+    padding-top: 0;
+    padding-bottom: 0;
   }
 
   ::-webkit-datetime-edit-day-field {
-    padding: 0;
+    padding-top: 0;
+    padding-bottom: 0;
   }
 
   ::-webkit-datetime-edit-hour-field {
-    padding: 0;
+    padding-top: 0;
+    padding-bottom: 0;
   }
 
   ::-webkit-datetime-edit-minute-field {
-    padding: 0;
+    padding-top: 0;
+    padding-bottom: 0;
   }
 
   ::-webkit-datetime-edit-second-field {
-    padding: 0;
+    padding-top: 0;
+    padding-bottom: 0;
   }
 
   ::-webkit-datetime-edit-millisecond-field {
-    padding: 0;
+    padding-top: 0;
+    padding-bottom: 0;
   }
 
   ::-webkit-datetime-edit-meridiem-field {
-    padding: 0;
-  }
-
-  ::-webkit-datetime-edit-fields-wrapper {
-    padding: 0;
+    padding-top: 0;
+    padding-bottom: 0;
   }
 
   summary {

--- a/packages/tailwindcss/preflight.css
+++ b/packages/tailwindcss/preflight.css
@@ -248,6 +248,7 @@ progress {
   1. Ensure date/time inputs have the same height when empty in iOS Safari.
   2. Ensure text alignment can be changed on date/time inputs in iOS Safari.
 */
+
 ::-webkit-date-and-time-value {
   min-height: 1lh; /* 1 */
   text-align: inherit; /* 2 */
@@ -256,6 +257,7 @@ progress {
 /*
   Prevent height from changing on date/time inputs in macOS Safari when the input is set to `display: block`.
 */
+
 ::-webkit-datetime-edit {
   display: inline-flex;
 }
@@ -263,6 +265,11 @@ progress {
 /*
   Remove excess padding from pseudo-elements in date/time inputs to ensure consistent height across browsers.
 */
+
+::-webkit-datetime-edit-fields-wrapper {
+  padding: 0;
+}
+
 ::-webkit-datetime-edit,
 ::-webkit-datetime-edit-year-field,
 ::-webkit-datetime-edit-month-field,
@@ -271,9 +278,9 @@ progress {
 ::-webkit-datetime-edit-minute-field,
 ::-webkit-datetime-edit-second-field,
 ::-webkit-datetime-edit-millisecond-field,
-::-webkit-datetime-edit-meridiem-field,
-::-webkit-datetime-edit-fields-wrapper {
-  padding: 0;
+::-webkit-datetime-edit-meridiem-field {
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 /*

--- a/packages/tailwindcss/preflight.css
+++ b/packages/tailwindcss/preflight.css
@@ -279,8 +279,7 @@ progress {
 ::-webkit-datetime-edit-second-field,
 ::-webkit-datetime-edit-millisecond-field,
 ::-webkit-datetime-edit-meridiem-field {
-  padding-top: 0;
-  padding-bottom: 0;
+  padding-block: 0;
 }
 
 /*


### PR DESCRIPTION
Turns out all of these date/time pseudo elements have a bit of horizontal padding on them that we don't want to throw away when fixing the height issue, so this PR updates our reset to only remove vertical padding.

Here's a demo showing the difference, test in Safari or Chrome to see the difference in horizontal spacing:

https://play.tailwindcss.com/Opwa7pkDFP?file=css