### PR TITLE
Do not migrate legacy classes with custom values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Ensure that CSS inside Svelte `<style>` blocks always run the expected Svelte processors when using the Vite extension ([#14981](https://github.com/tailwindlabs/tailwindcss/pull/14981))
-- _Upgrade (experimental)_: Do not migrate legacy classes with custom values ([#14976](https://github.com/tailwindlabs/tailwindcss/pull/14976))
 - _Upgrade (experimental)_: Ensure it's safe to migrate `blur`, `rounded`, or `shadow` ([#14979](https://github.com/tailwindlabs/tailwindcss/pull/14979))
+- _Upgrade (experimental)_: Do not rename classes using custom defined theme values ([#14976](https://github.com/tailwindlabs/tailwindcss/pull/14976))
 
 ## [4.0.0-alpha.33] - 2024-11-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Ensure that CSS inside Svelte `<style>` blocks always run the expected Svelte processors when using the Vite extension ([#14981](https://github.com/tailwindlabs/tailwindcss/pull/14981))
+- _Upgrade (experimental)_: Do not migrate legacy classes with custom values ([#14976](https://github.com/tailwindlabs/tailwindcss/pull/14976))
 
 ## [4.0.0-alpha.33] - 2024-11-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure that CSS inside Svelte `<style>` blocks always run the expected Svelte processors when using the Vite extension ([#14981](https://github.com/tailwindlabs/tailwindcss/pull/14981))
 - _Upgrade (experimental)_: Do not migrate legacy classes with custom values ([#14976](https://github.com/tailwindlabs/tailwindcss/pull/14976))
+- _Upgrade (experimental)_: Ensure it's safe to migrate `blur`, `rounded`, or `shadow` ([#14979](https://github.com/tailwindlabs/tailwindcss/pull/14979))
 
 ## [4.0.0-alpha.33] - 2024-11-11
 

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -1642,3 +1642,108 @@ test(
     expect(pkg.devDependencies['prettier-plugin-tailwindcss']).not.toEqual('0.5.0')
   },
 )
+
+test(
+  'only migrate legacy classes when it is safe to do so',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "dependencies": {
+            "tailwindcss": "^3.4.14",
+            "@tailwindcss/upgrade": "workspace:^"
+          },
+          "devDependencies": {
+            "prettier-plugin-tailwindcss": "0.5.0"
+          }
+        }
+      `,
+      'tailwind.config.js': js`
+        module.exports = {
+          content: ['./*.html'],
+          theme: {
+            // Overrides the default boxShadow entirely so none of the
+            // migrations are safe.
+            boxShadow: {
+              DEFAULT: '0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)',
+            },
+
+            extend: {
+              // Changes the "before" class definition. 'blur' -> 'blur-sm' is
+              // not safe because 'blur' has a custom value.
+              //
+              // But 'blur-sm' -> 'blur-xs' is safe because 'blur-xs' uses the
+              // default value.
+              blur: {
+                DEFAULT: 'var(--custom-default-blur)',
+              },
+
+              // Changes the "after" class definition. 'rounded' -> 'rounded-sm' is
+              // not safe because 'rounded-sm' has a custom value.
+              borderRadius: {
+                sm: 'var(--custom-rounded-sm)',
+              },
+            },
+          },
+        }
+      `,
+      'index.css': css`
+        @tailwind base;
+        @tailwind components;
+        @tailwind utilities;
+      `,
+      'index.html': html`
+        <div>
+          <div class="shadow shadow-sm shadow-xs"></div>
+          <div class="blur blur-sm"></div>
+          <div class="rounded rounded-sm"></div>
+        </div>
+      `,
+    },
+  },
+  async ({ fs, exec }) => {
+    await exec('npx @tailwindcss/upgrade --force')
+
+    // Files should not be modified
+    expect(await fs.dumpFiles('./*.{js,css,html}')).toMatchInlineSnapshot(`
+      "
+      --- index.html ---
+      <div>
+        <div class="shadow shadow-sm shadow-xs"></div>
+        <div class="blur blur-xs"></div>
+        <div class="rounded rounded-sm"></div>
+      </div>
+
+      --- index.css ---
+      @import 'tailwindcss';
+
+      @theme {
+        --shadow-*: initial;
+        --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+
+        --blur: var(--custom-default-blur);
+
+        --radius-sm: var(--custom-rounded-sm);
+      }
+
+      /*
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        so we've added these compatibility styles to make sure everything still
+        looks the same as it did with Tailwind CSS v3.
+
+        If we ever want to remove these styles, we need to add an explicit border
+        color utility to any element that depends on these defaults.
+      */
+      @layer base {
+        *,
+        ::after,
+        ::before,
+        ::backdrop,
+        ::file-selector-button {
+          border-color: var(--color-gray-200, currentColor);
+        }
+      }
+      "
+    `)
+  },
+)

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -421,6 +421,20 @@ export function test(
 
       options.onTestFinished(dispose)
 
+      // Make it a git repository, and commit all files
+      if (only || debug) {
+        try {
+          await context.exec('git init', { cwd: root })
+          await context.exec('git add --all', { cwd: root })
+          await context.exec('git commit -m "before migration"', { cwd: root })
+        } catch (error: any) {
+          console.error(error)
+          console.error(error.stdout?.toString())
+          console.error(error.stderr?.toString())
+          throw error
+        }
+      }
+
       return await testCallback(context)
     },
   )

--- a/packages/@tailwindcss-upgrade/src/template/codemods/important.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/important.ts
@@ -2,19 +2,7 @@ import type { Config } from 'tailwindcss'
 import { parseCandidate } from '../../../../tailwindcss/src/candidate'
 import type { DesignSystem } from '../../../../tailwindcss/src/design-system'
 import { printCandidate } from '../candidates'
-
-const QUOTES = ['"', "'", '`']
-const LOGICAL_OPERATORS = ['&&', '||', '===', '==', '!=', '!==', '>', '>=', '<', '<=']
-const CONDITIONAL_TEMPLATE_SYNTAX = [
-  // Vue
-  /v-else-if=['"]$/,
-  /v-if=['"]$/,
-  /v-show=['"]$/,
-
-  // Alpine
-  /x-if=['"]$/,
-  /x-show=['"]$/,
-]
+import { isSafeMigration } from '../is-safe-migration'
 
 // In v3 the important modifier `!` sits in front of the utility itself, not
 // before any of the variants. In v4, we want it to be at the end of the utility
@@ -46,56 +34,8 @@ export function important(
       // with v3 in that it can read `!` in the front of the utility too, we err
       // on the side of caution and only migrate candidates that we are certain
       // are inside of a string.
-      if (location) {
-        let currentLineBeforeCandidate = ''
-        for (let i = location.start - 1; i >= 0; i--) {
-          let char = location.contents.at(i)!
-          if (char === '\n') {
-            break
-          }
-          currentLineBeforeCandidate = char + currentLineBeforeCandidate
-        }
-        let currentLineAfterCandidate = ''
-        for (let i = location.end; i < location.contents.length; i++) {
-          let char = location.contents.at(i)!
-          if (char === '\n') {
-            break
-          }
-          currentLineAfterCandidate += char
-        }
-
-        // Heuristic 1: Require the candidate to be inside quotes
-        let isQuoteBeforeCandidate = QUOTES.some((quote) =>
-          currentLineBeforeCandidate.includes(quote),
-        )
-        let isQuoteAfterCandidate = QUOTES.some((quote) =>
-          currentLineAfterCandidate.includes(quote),
-        )
-        if (!isQuoteBeforeCandidate || !isQuoteAfterCandidate) {
-          continue nextCandidate
-        }
-
-        // Heuristic 2: Disallow object access immediately following the candidate
-        if (currentLineAfterCandidate[0] === '.') {
-          continue nextCandidate
-        }
-
-        // Heuristic 3: Disallow logical operators preceding or following the candidate
-        for (let operator of LOGICAL_OPERATORS) {
-          if (
-            currentLineAfterCandidate.trim().startsWith(operator) ||
-            currentLineBeforeCandidate.trim().endsWith(operator)
-          ) {
-            continue nextCandidate
-          }
-        }
-
-        // Heuristic 4: Disallow conditional template syntax
-        for (let rule of CONDITIONAL_TEMPLATE_SYNTAX) {
-          if (rule.test(currentLineBeforeCandidate)) {
-            continue nextCandidate
-          }
-        }
+      if (location && !isSafeMigration(location)) {
+        continue nextCandidate
       }
 
       // The printCandidate function will already put the exclamation mark in

--- a/packages/@tailwindcss-upgrade/src/template/codemods/legacy-classes.test.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/legacy-classes.test.ts
@@ -19,6 +19,14 @@ test.each([
 
   ['blur', 'blur-sm'],
   ['blur-sm', 'blur-xs'],
+
+  ['blur!', 'blur-sm!'],
+  ['hover:blur', 'hover:blur-sm'],
+  ['hover:blur!', 'hover:blur-sm!'],
+
+  ['hover:blur-sm', 'hover:blur-xs'],
+  ['blur-sm!', 'blur-xs!'],
+  ['hover:blur-sm!', 'hover:blur-xs!'],
 ])('%s => %s', async (candidate, result) => {
   let designSystem = await __unstable__loadDesignSystem('@import "tailwindcss";', {
     base: __dirname,

--- a/packages/@tailwindcss-upgrade/src/template/codemods/legacy-classes.test.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/legacy-classes.test.ts
@@ -1,0 +1,28 @@
+import { __unstable__loadDesignSystem } from '@tailwindcss/node'
+import { expect, test } from 'vitest'
+import { legacyClasses } from './legacy-classes'
+
+test.each([
+  ['shadow', 'shadow-sm'],
+  ['shadow-sm', 'shadow-xs'],
+  ['shadow-xs', 'shadow-2xs'],
+
+  ['inset-shadow', 'inset-shadow-sm'],
+  ['inset-shadow-sm', 'inset-shadow-xs'],
+  ['inset-shadow-xs', 'inset-shadow-2xs'],
+
+  ['drop-shadow', 'drop-shadow-sm'],
+  ['drop-shadow-sm', 'drop-shadow-xs'],
+
+  ['rounded', 'rounded-sm'],
+  ['rounded-sm', 'rounded-xs'],
+
+  ['blur', 'blur-sm'],
+  ['blur-sm', 'blur-xs'],
+])('%s => %s', async (candidate, result) => {
+  let designSystem = await __unstable__loadDesignSystem('@import "tailwindcss";', {
+    base: __dirname,
+  })
+
+  expect(await legacyClasses(designSystem, {}, candidate)).toEqual(result)
+})

--- a/packages/@tailwindcss-upgrade/src/template/codemods/legacy-classes.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/legacy-classes.ts
@@ -1,0 +1,110 @@
+import { __unstable__loadDesignSystem } from '@tailwindcss/node'
+import path from 'node:path'
+import url from 'node:url'
+import type { Config } from 'tailwindcss'
+import type { DesignSystem } from '../../../../tailwindcss/src/design-system'
+import { printCandidate } from '../candidates'
+
+const __filename = url.fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const LEGACY_CLASS_MAP = {
+  shadow: 'shadow-sm',
+  'shadow-sm': 'shadow-xs',
+  'shadow-xs': 'shadow-2xs',
+
+  'inset-shadow': 'inset-shadow-sm',
+  'inset-shadow-sm': 'inset-shadow-xs',
+  'inset-shadow-xs': 'inset-shadow-2xs',
+
+  'drop-shadow': 'drop-shadow-sm',
+  'drop-shadow-sm': 'drop-shadow-xs',
+
+  rounded: 'rounded-sm',
+  'rounded-sm': 'rounded-xs',
+
+  blur: 'blur-sm',
+  'blur-sm': 'blur-xs',
+}
+
+const THEME_KEYS = {
+  shadow: '--shadow',
+  'shadow-sm': '--shadow-sm',
+  'shadow-xs': '--shadow-xs',
+  'shadow-2xs': '--shadow-2xs',
+
+  'drop-shadow': '--drop-shadow',
+  'drop-shadow-sm': '--drop-shadow-sm',
+  'drop-shadow-xs': '--drop-shadow-xs',
+
+  rounded: '--radius',
+  'rounded-sm': '--radius-sm',
+  'rounded-xs': '--radius-xs',
+
+  blur: '--blur',
+  'blur-sm': '--blur-sm',
+  'blur-xs': '--blur-xs',
+}
+
+const SEEDED = new WeakSet<DesignSystem>()
+
+export async function legacyClasses(
+  designSystem: DesignSystem,
+  _userConfig: Config,
+  rawCandidate: string,
+): Promise<string> {
+  // Prepare design system with the unknown legacy classes
+  if (!SEEDED.has(designSystem)) {
+    for (let old in LEGACY_CLASS_MAP) {
+      designSystem.utilities.static(old, () => [])
+    }
+    SEEDED.add(designSystem)
+  }
+
+  let defaultDesignSystem = await __unstable__loadDesignSystem('@import "tailwindcss";', {
+    base: __dirname,
+  })
+
+  for (let candidate of designSystem.parseCandidate(rawCandidate)) {
+    if (candidate.kind === 'static' && Object.hasOwn(LEGACY_CLASS_MAP, candidate.root)) {
+      let fromThemeKey = THEME_KEYS[candidate.root as keyof typeof THEME_KEYS]
+      let toThemeKey =
+        THEME_KEYS[
+          LEGACY_CLASS_MAP[
+            candidate.root as keyof typeof LEGACY_CLASS_MAP
+          ] as keyof typeof THEME_KEYS
+        ]
+
+      if (fromThemeKey && toThemeKey) {
+        // Migrating something that resolves to a value in the theme.
+        let customFrom = designSystem.resolveThemeValue(fromThemeKey)
+        let defaultFrom = defaultDesignSystem.resolveThemeValue(fromThemeKey)
+        let customTo = designSystem.resolveThemeValue(toThemeKey)
+        let defaultTo = defaultDesignSystem.resolveThemeValue(toThemeKey)
+
+        // The new theme value is not defined, which means we can't safely
+        // migrate the utility.
+        if (customTo === undefined) {
+          continue
+        }
+
+        // The "from" theme value changed compared to the default theme value.
+        if (customFrom !== defaultFrom) {
+          continue
+        }
+
+        // The "to" theme value changed compared to the default theme value.
+        if (customTo !== defaultTo) {
+          continue
+        }
+      }
+
+      return printCandidate(designSystem, {
+        ...candidate,
+        root: LEGACY_CLASS_MAP[candidate.root as keyof typeof LEGACY_CLASS_MAP],
+      })
+    }
+  }
+
+  return rawCandidate
+}

--- a/packages/@tailwindcss-upgrade/src/template/codemods/simple-legacy-classes.test.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/simple-legacy-classes.test.ts
@@ -16,28 +16,11 @@ test.each([
   ['max-lg:hover:decoration-slice!', 'max-lg:hover:box-decoration-slice!'],
   ['max-lg:hover:!decoration-slice', 'max-lg:hover:box-decoration-slice!'],
 
-  ['shadow', 'shadow-sm'],
-  ['shadow-sm', 'shadow-xs'],
-  ['shadow-xs', 'shadow-2xs'],
-
-  ['inset-shadow', 'inset-shadow-sm'],
-  ['inset-shadow-sm', 'inset-shadow-xs'],
-  ['inset-shadow-xs', 'inset-shadow-2xs'],
-
-  ['drop-shadow', 'drop-shadow-sm'],
-  ['drop-shadow-sm', 'drop-shadow-xs'],
-
-  ['rounded', 'rounded-sm'],
-  ['rounded-sm', 'rounded-xs'],
-
-  ['blur', 'blur-sm'],
-  ['blur-sm', 'blur-xs'],
-
   ['focus:outline-none', 'focus:outline-hidden'],
 ])('%s => %s', async (candidate, result) => {
   let designSystem = await __unstable__loadDesignSystem('@import "tailwindcss";', {
     base: __dirname,
   })
 
-  expect(await simpleLegacyClasses(designSystem, {}, candidate)).toEqual(result)
+  expect(simpleLegacyClasses(designSystem, {}, candidate)).toEqual(result)
 })

--- a/packages/@tailwindcss-upgrade/src/template/codemods/simple-legacy-classes.test.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/simple-legacy-classes.test.ts
@@ -39,5 +39,5 @@ test.each([
     base: __dirname,
   })
 
-  expect(simpleLegacyClasses(designSystem, {}, candidate)).toEqual(result)
+  expect(await simpleLegacyClasses(designSystem, {}, candidate)).toEqual(result)
 })

--- a/packages/@tailwindcss-upgrade/src/template/codemods/simple-legacy-classes.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/simple-legacy-classes.ts
@@ -1,6 +1,12 @@
+import { __unstable__loadDesignSystem } from '@tailwindcss/node'
+import path from 'node:path'
+import url from 'node:url'
 import type { Config } from 'tailwindcss'
 import type { DesignSystem } from '../../../../tailwindcss/src/design-system'
 import { printCandidate } from '../candidates'
+
+const __filename = url.fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 // Classes that used to exist in Tailwind CSS v3, but do not exist in Tailwind
 // CSS v4 anymore.
@@ -35,27 +41,30 @@ const LEGACY_CLASS_MAP = {
 }
 
 const THEME_KEYS = {
-  shadow: 'boxShadow',
-  'shadow-sm': 'boxShadow',
-  'shadow-xs': 'boxShadow',
+  shadow: '--shadow',
+  'shadow-sm': '--shadow-sm',
+  'shadow-xs': '--shadow-xs',
+  'shadow-2xs': '--shadow-2xs',
 
-  'drop-shadow': 'dropShadow',
-  'drop-shadow-sm': 'dropShadow',
+  'drop-shadow': '--drop-shadow',
+  'drop-shadow-sm': '--drop-shadow-sm',
 
-  rounded: 'borderRadius',
-  'rounded-sm': 'borderRadius',
+  rounded: '--radius',
+  'rounded-sm': '--radius-sm',
+  'rounded-xs': '--radius-xs',
 
-  blur: 'blur',
-  'blur-sm': 'blur',
+  blur: '--blur',
+  'blur-sm': '--blur-sm',
+  'blur-xs': '--blur-xs',
 }
 
 const SEEDED = new WeakSet<DesignSystem>()
 
-export function simpleLegacyClasses(
+export async function simpleLegacyClasses(
   designSystem: DesignSystem,
-  userConfig: Config,
+  _userConfig: Config,
   rawCandidate: string,
-): string {
+): Promise<string> {
   // Prepare design system with the unknown legacy classes
   if (!SEEDED.has(designSystem)) {
     for (let old in LEGACY_CLASS_MAP) {
@@ -64,17 +73,42 @@ export function simpleLegacyClasses(
     SEEDED.add(designSystem)
   }
 
+  let defaultDesignSystem = await __unstable__loadDesignSystem('@import "tailwindcss";', {
+    base: __dirname,
+  })
+
   for (let candidate of designSystem.parseCandidate(rawCandidate)) {
     if (candidate.kind === 'static' && Object.hasOwn(LEGACY_CLASS_MAP, candidate.root)) {
-      let themeKey = THEME_KEYS[candidate.root as keyof typeof THEME_KEYS]
-      if (
-        themeKey &&
-        // Theme was overwritten
-        (userConfig?.theme?.[themeKey] !== undefined ||
-          // Theme extend was overwritten
-          userConfig?.theme?.extend?.[themeKey] !== undefined)
-      ) {
-        continue
+      let fromThemeKey = THEME_KEYS[candidate.root as keyof typeof THEME_KEYS]
+      let toThemeKey =
+        THEME_KEYS[
+          LEGACY_CLASS_MAP[
+            candidate.root as keyof typeof LEGACY_CLASS_MAP
+          ] as keyof typeof THEME_KEYS
+        ]
+
+      // Migrating something that resolves to a value in the theme.
+      if (fromThemeKey && toThemeKey) {
+        let customFrom = designSystem.resolveThemeValue(fromThemeKey)
+        let defaultFrom = defaultDesignSystem.resolveThemeValue(fromThemeKey)
+        let customTo = designSystem.resolveThemeValue(toThemeKey)
+        let defaultTo = defaultDesignSystem.resolveThemeValue(toThemeKey)
+
+        // The new theme value is not defined, which means we can't safely migrate
+        // the utility.
+        if (customTo === undefined) {
+          continue
+        }
+
+        // The "from" theme value changed compared to the default theme value.
+        if (customFrom !== defaultFrom) {
+          continue
+        }
+
+        // The "to" theme value changed compared to the default theme value.
+        if (customTo !== defaultTo) {
+          continue
+        }
       }
 
       return printCandidate(designSystem, {

--- a/packages/@tailwindcss-upgrade/src/template/codemods/simple-legacy-classes.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/simple-legacy-classes.ts
@@ -1,70 +1,31 @@
-import { __unstable__loadDesignSystem } from '@tailwindcss/node'
-import path from 'node:path'
-import url from 'node:url'
 import type { Config } from 'tailwindcss'
 import type { DesignSystem } from '../../../../tailwindcss/src/design-system'
 import { printCandidate } from '../candidates'
-
-const __filename = url.fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
 
 // Classes that used to exist in Tailwind CSS v3, but do not exist in Tailwind
 // CSS v4 anymore.
 const LEGACY_CLASS_MAP = {
   'overflow-clip': 'text-clip',
   'overflow-ellipsis': 'text-ellipsis',
+
   'flex-grow': 'grow',
   'flex-grow-0': 'grow-0',
   'flex-shrink': 'shrink',
   'flex-shrink-0': 'shrink-0',
+
   'decoration-clone': 'box-decoration-clone',
   'decoration-slice': 'box-decoration-slice',
-
-  shadow: 'shadow-sm',
-  'shadow-sm': 'shadow-xs',
-  'shadow-xs': 'shadow-2xs',
-
-  'inset-shadow': 'inset-shadow-sm',
-  'inset-shadow-sm': 'inset-shadow-xs',
-  'inset-shadow-xs': 'inset-shadow-2xs',
-
-  'drop-shadow': 'drop-shadow-sm',
-  'drop-shadow-sm': 'drop-shadow-xs',
-
-  rounded: 'rounded-sm',
-  'rounded-sm': 'rounded-xs',
-
-  blur: 'blur-sm',
-  'blur-sm': 'blur-xs',
 
   'outline-none': 'outline-hidden',
 }
 
-const THEME_KEYS = {
-  shadow: '--shadow',
-  'shadow-sm': '--shadow-sm',
-  'shadow-xs': '--shadow-xs',
-  'shadow-2xs': '--shadow-2xs',
-
-  'drop-shadow': '--drop-shadow',
-  'drop-shadow-sm': '--drop-shadow-sm',
-
-  rounded: '--radius',
-  'rounded-sm': '--radius-sm',
-  'rounded-xs': '--radius-xs',
-
-  blur: '--blur',
-  'blur-sm': '--blur-sm',
-  'blur-xs': '--blur-xs',
-}
-
 const SEEDED = new WeakSet<DesignSystem>()
 
-export async function simpleLegacyClasses(
+export function simpleLegacyClasses(
   designSystem: DesignSystem,
   _userConfig: Config,
   rawCandidate: string,
-): Promise<string> {
+): string {
   // Prepare design system with the unknown legacy classes
   if (!SEEDED.has(designSystem)) {
     for (let old in LEGACY_CLASS_MAP) {
@@ -73,44 +34,8 @@ export async function simpleLegacyClasses(
     SEEDED.add(designSystem)
   }
 
-  let defaultDesignSystem = await __unstable__loadDesignSystem('@import "tailwindcss";', {
-    base: __dirname,
-  })
-
   for (let candidate of designSystem.parseCandidate(rawCandidate)) {
     if (candidate.kind === 'static' && Object.hasOwn(LEGACY_CLASS_MAP, candidate.root)) {
-      let fromThemeKey = THEME_KEYS[candidate.root as keyof typeof THEME_KEYS]
-      let toThemeKey =
-        THEME_KEYS[
-          LEGACY_CLASS_MAP[
-            candidate.root as keyof typeof LEGACY_CLASS_MAP
-          ] as keyof typeof THEME_KEYS
-        ]
-
-      // Migrating something that resolves to a value in the theme.
-      if (fromThemeKey && toThemeKey) {
-        let customFrom = designSystem.resolveThemeValue(fromThemeKey)
-        let defaultFrom = defaultDesignSystem.resolveThemeValue(fromThemeKey)
-        let customTo = designSystem.resolveThemeValue(toThemeKey)
-        let defaultTo = defaultDesignSystem.resolveThemeValue(toThemeKey)
-
-        // The new theme value is not defined, which means we can't safely migrate
-        // the utility.
-        if (customTo === undefined) {
-          continue
-        }
-
-        // The "from" theme value changed compared to the default theme value.
-        if (customFrom !== defaultFrom) {
-          continue
-        }
-
-        // The "to" theme value changed compared to the default theme value.
-        if (customTo !== defaultTo) {
-          continue
-        }
-      }
-
       return printCandidate(designSystem, {
         ...candidate,
         root: LEGACY_CLASS_MAP[candidate.root as keyof typeof LEGACY_CLASS_MAP],

--- a/packages/@tailwindcss-upgrade/src/template/is-safe-migration.ts
+++ b/packages/@tailwindcss-upgrade/src/template/is-safe-migration.ts
@@ -1,0 +1,62 @@
+const QUOTES = ['"', "'", '`']
+const LOGICAL_OPERATORS = ['&&', '||', '?', '===', '==', '!=', '!==', '>', '>=', '<', '<=']
+const CONDITIONAL_TEMPLATE_SYNTAX = [
+  // Vue
+  /v-else-if=['"]$/,
+  /v-if=['"]$/,
+  /v-show=['"]$/,
+
+  // Alpine
+  /x-if=['"]$/,
+  /x-show=['"]$/,
+]
+
+export function isSafeMigration(location: { contents: string; start: number; end: number }) {
+  let currentLineBeforeCandidate = ''
+  for (let i = location.start - 1; i >= 0; i--) {
+    let char = location.contents.at(i)!
+    if (char === '\n') {
+      break
+    }
+    currentLineBeforeCandidate = char + currentLineBeforeCandidate
+  }
+  let currentLineAfterCandidate = ''
+  for (let i = location.end; i < location.contents.length; i++) {
+    let char = location.contents.at(i)!
+    if (char === '\n') {
+      break
+    }
+    currentLineAfterCandidate += char
+  }
+
+  // Heuristic 1: Require the candidate to be inside quotes
+  let isQuoteBeforeCandidate = QUOTES.some((quote) => currentLineBeforeCandidate.includes(quote))
+  let isQuoteAfterCandidate = QUOTES.some((quote) => currentLineAfterCandidate.includes(quote))
+  if (!isQuoteBeforeCandidate || !isQuoteAfterCandidate) {
+    return false
+  }
+
+  // Heuristic 2: Disallow object access immediately following the candidate
+  if (currentLineAfterCandidate[0] === '.') {
+    return false
+  }
+
+  // Heuristic 3: Disallow logical operators preceding or following the candidate
+  for (let operator of LOGICAL_OPERATORS) {
+    if (
+      currentLineAfterCandidate.trim().startsWith(operator) ||
+      currentLineBeforeCandidate.trim().endsWith(operator)
+    ) {
+      return false
+    }
+  }
+
+  // Heuristic 4: Disallow conditional template syntax
+  for (let rule of CONDITIONAL_TEMPLATE_SYNTAX) {
+    if (rule.test(currentLineBeforeCandidate)) {
+      return false
+    }
+  }
+
+  return true
+}

--- a/packages/@tailwindcss-upgrade/src/template/migrate.ts
+++ b/packages/@tailwindcss-upgrade/src/template/migrate.ts
@@ -25,7 +25,7 @@ export type Migration = (
     start: number
     end: number
   },
-) => string
+) => string | Promise<string>
 
 export const DEFAULT_MIGRATIONS: Migration[] = [
   prefix,
@@ -41,7 +41,7 @@ export const DEFAULT_MIGRATIONS: Migration[] = [
   modernizeArbitraryValues,
 ]
 
-export function migrateCandidate(
+export async function migrateCandidate(
   designSystem: DesignSystem,
   userConfig: Config,
   rawCandidate: string,
@@ -51,9 +51,9 @@ export function migrateCandidate(
     start: number
     end: number
   },
-): string {
+): Promise<string> {
   for (let migration of DEFAULT_MIGRATIONS) {
-    rawCandidate = migration(designSystem, userConfig, rawCandidate, location)
+    rawCandidate = await migration(designSystem, userConfig, rawCandidate, location)
   }
   return rawCandidate
 }
@@ -69,7 +69,7 @@ export default async function migrateContents(
   let changes: StringChange[] = []
 
   for (let { rawCandidate, start, end } of candidates) {
-    let migratedCandidate = migrateCandidate(designSystem, userConfig, rawCandidate, {
+    let migratedCandidate = await migrateCandidate(designSystem, userConfig, rawCandidate, {
       contents,
       start,
       end,

--- a/packages/@tailwindcss-upgrade/src/template/migrate.ts
+++ b/packages/@tailwindcss-upgrade/src/template/migrate.ts
@@ -8,6 +8,7 @@ import { automaticVarInjection } from './codemods/automatic-var-injection'
 import { bgGradient } from './codemods/bg-gradient'
 import { important } from './codemods/important'
 import { legacyArbitraryValues } from './codemods/legacy-arbitrary-values'
+import { legacyClasses } from './codemods/legacy-classes'
 import { maxWidthScreen } from './codemods/max-width-screen'
 import { modernizeArbitraryValues } from './codemods/modernize-arbitrary-values'
 import { prefix } from './codemods/prefix'
@@ -32,6 +33,7 @@ export const DEFAULT_MIGRATIONS: Migration[] = [
   important,
   bgGradient,
   simpleLegacyClasses,
+  legacyClasses,
   maxWidthScreen,
   themeToVar,
   variantOrder, // Has to happen before migrations that modify variants


### PR DESCRIPTION
This PR fixes an issue where we migrated classes such as `rounded` to `rounded-sm` (see: https://github.com/tailwindlabs/tailwindcss/pull/14875)

However, if you override the values in your `tailwind.config.js` file, then the migration might not be correct.

This PR makes sure to only migrate the classes if you haven't overridden the values in your `tailwind.config.js` file.
