### PR TITLE
Add missing `layer(…)` to imports above Tailwind directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - _Upgrade (experimental)_: Ensure it's safe to migrate `blur`, `rounded`, or `shadow` ([#14979](https://github.com/tailwindlabs/tailwindcss/pull/14979))
 - _Upgrade (experimental)_: Do not rename classes using custom defined theme values ([#14976](https://github.com/tailwindlabs/tailwindcss/pull/14976))
 - _Upgrade (experimental)_: Ensure `@config` is injected in nearest common ancestor stylesheet ([#14989](https://github.com/tailwindlabs/tailwindcss/pull/14989))
+- _Upgrade (experimental)_: Add missing `layer(…)` to imports above Tailwind directives ([#14982](https://github.com/tailwindlabs/tailwindcss/pull/14982))
 
 ## [4.0.0-alpha.33] - 2024-11-11
 

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -1667,7 +1667,6 @@ test(
 
       --- ./src/index.css ---
       @import './tailwind-setup.css';
-      @import './tailwind-setup.utilities.css';
 
       --- ./src/base.css ---
       @import 'tailwindcss/theme' layer(theme);
@@ -1708,13 +1707,11 @@ test(
       --- ./src/tailwind-setup.css ---
       @import './base.css';
       @import './components.css';
+      @import './components.utilities.css';
       @import './utilities.css';
+      @import './utilities.utilities.css';
 
       @config '../tailwind.config.ts';
-
-      --- ./src/tailwind-setup.utilities.css ---
-      @import './components.utilities.css';
-      @import './utilities.utilities.css'
 
       --- ./src/typography.css ---
       .typography {
@@ -1809,7 +1806,6 @@ test(
 
       --- ./src/index.css ---
       @import './tailwind-setup.css';
-      @import './tailwind-setup.utilities.css';
 
       --- ./src/base.css ---
       @import 'tailwindcss/theme' layer(theme);
@@ -1850,15 +1846,13 @@ test(
       --- ./src/tailwind-setup.css ---
       @import './base.css';
       @import './components.css';
+      @import './components.utilities.css';
       @import './utilities.css';
+      @import './utilities.utilities.css';
 
       @theme {
         --color-my-red: red;
       }
-
-      --- ./src/tailwind-setup.utilities.css ---
-      @import './components.utilities.css';
-      @import './utilities.utilities.css'
 
       --- ./src/typography.css ---
       .typography {

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -454,6 +454,132 @@ test(
 )
 
 test(
+  'migrate imports with `layer(…)`',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "dependencies": {
+            "tailwindcss": "workspace:^",
+            "@tailwindcss/upgrade": "workspace:^"
+          }
+        }
+      `,
+      'tailwind.config.js': js`module.exports = {}`,
+      'src/index.css': css`
+        @import './base.css';
+        @import './components.css';
+        @import './utilities.css';
+        @import './mix.css';
+
+        @tailwind base;
+        @tailwind components;
+        @tailwind utilities;
+      `,
+      'src/base.css': css`
+        html {
+          color: red;
+        }
+      `,
+      'src/components.css': css`
+        @layer components {
+          .foo {
+            color: red;
+          }
+        }
+      `,
+      'src/utilities.css': css`
+        @layer utilities {
+          .bar {
+            color: red;
+          }
+        }
+      `,
+      'src/mix.css': css`
+        html {
+          color: blue;
+        }
+
+        @layer components {
+          .foo-mix {
+            color: red;
+          }
+        }
+
+        @layer utilities {
+          .bar-mix {
+            color: red;
+          }
+        }
+      `,
+    },
+  },
+  async ({ fs, exec }) => {
+    await exec('npx @tailwindcss/upgrade')
+
+    expect(await fs.dumpFiles('./src/**/*.css')).toMatchInlineSnapshot(`
+      "
+      --- ./src/index.css ---
+      @import './base.css' layer(base);
+      @import './components.css';
+      @import './utilities.css';
+      @import './mix.css' layer(base);
+      @import './mix.utilities.css';
+
+      @import 'tailwindcss';
+
+      /*
+        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        so we've added these compatibility styles to make sure everything still
+        looks the same as it did with Tailwind CSS v3.
+
+        If we ever want to remove these styles, we need to add an explicit border
+        color utility to any element that depends on these defaults.
+      */
+      @layer base {
+        *,
+        ::after,
+        ::before,
+        ::backdrop,
+        ::file-selector-button {
+          border-color: var(--color-gray-200, currentColor);
+        }
+      }
+
+      --- ./src/base.css ---
+      html {
+        color: red;
+      }
+
+      --- ./src/components.css ---
+      @utility foo {
+        color: red;
+      }
+
+      --- ./src/mix.css ---
+      html {
+        color: blue;
+      }
+
+      --- ./src/mix.utilities.css ---
+      @utility foo-mix {
+        color: red;
+      }
+
+      @utility bar-mix {
+        color: red;
+      }
+
+      --- ./src/utilities.css ---
+      @utility bar {
+        color: red;
+      }
+      "
+    `)
+  },
+)
+
+test(
   'migrates a simple postcss setup',
   {
     fs: {
@@ -1541,6 +1667,7 @@ test(
 
       --- ./src/index.css ---
       @import './tailwind-setup.css';
+      @import './tailwind-setup.utilities.css';
 
       --- ./src/base.css ---
       @import 'tailwindcss/theme' layer(theme);
@@ -1571,8 +1698,9 @@ test(
       }
 
       --- ./src/components.css ---
-      @import './typography.css';
+      @import './typography.css' layer(components);
 
+      --- ./src/components.utilities.css ---
       @utility foo {
         color: red;
       }
@@ -1584,6 +1712,10 @@ test(
 
       @config '../tailwind.config.ts';
 
+      --- ./src/tailwind-setup.utilities.css ---
+      @import './components.utilities.css';
+      @import './utilities.utilities.css'
+
       --- ./src/typography.css ---
       .typography {
         color: red;
@@ -1592,6 +1724,7 @@ test(
       --- ./src/utilities.css ---
       @import 'tailwindcss/utilities' layer(utilities);
 
+      --- ./src/utilities.utilities.css ---
       @utility bar {
         color: red;
       }
@@ -1676,6 +1809,7 @@ test(
 
       --- ./src/index.css ---
       @import './tailwind-setup.css';
+      @import './tailwind-setup.utilities.css';
 
       --- ./src/base.css ---
       @import 'tailwindcss/theme' layer(theme);
@@ -1706,8 +1840,9 @@ test(
       }
 
       --- ./src/components.css ---
-      @import './typography.css';
+      @import './typography.css' layer(components);
 
+      --- ./src/components.utilities.css ---
       @utility foo {
         color: red;
       }
@@ -1721,6 +1856,10 @@ test(
         --color-my-red: red;
       }
 
+      --- ./src/tailwind-setup.utilities.css ---
+      @import './components.utilities.css';
+      @import './utilities.utilities.css'
+
       --- ./src/typography.css ---
       .typography {
         color: red;
@@ -1729,6 +1868,7 @@ test(
       --- ./src/utilities.css ---
       @import 'tailwindcss/utilities' layer(utilities);
 
+      --- ./src/utilities.utilities.css ---
       @utility bar {
         color: red;
       }

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -1699,7 +1699,6 @@ test(
       --- ./src/components.css ---
       @import './typography.css' layer(components);
 
-      --- ./src/components.utilities.css ---
       @utility foo {
         color: red;
       }
@@ -1707,9 +1706,7 @@ test(
       --- ./src/tailwind-setup.css ---
       @import './base.css';
       @import './components.css';
-      @import './components.utilities.css';
       @import './utilities.css';
-      @import './utilities.utilities.css';
 
       @config '../tailwind.config.ts';
 
@@ -1721,7 +1718,6 @@ test(
       --- ./src/utilities.css ---
       @import 'tailwindcss/utilities' layer(utilities);
 
-      --- ./src/utilities.utilities.css ---
       @utility bar {
         color: red;
       }
@@ -1838,7 +1834,6 @@ test(
       --- ./src/components.css ---
       @import './typography.css' layer(components);
 
-      --- ./src/components.utilities.css ---
       @utility foo {
         color: red;
       }
@@ -1846,9 +1841,7 @@ test(
       --- ./src/tailwind-setup.css ---
       @import './base.css';
       @import './components.css';
-      @import './components.utilities.css';
       @import './utilities.css';
-      @import './utilities.utilities.css';
 
       @theme {
         --color-my-red: red;
@@ -1862,7 +1855,6 @@ test(
       --- ./src/utilities.css ---
       @import 'tailwindcss/utilities' layer(utilities);
 
-      --- ./src/utilities.utilities.css ---
       @utility bar {
         color: red;
       }

--- a/packages/@tailwindcss-upgrade/src/migrate.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate.ts
@@ -419,6 +419,9 @@ export async function split(stylesheets: Stylesheet[]) {
   let utilitySheets = new Map<Stylesheet, Stylesheet>()
 
   for (let sheet of stylesheets) {
+    // Root files don't need to be split
+    if (sheet.isTailwindRoot) continue
+
     // Ignore stylesheets that were not imported
     if (!sheet.file) continue
     if (sheet.parents.size === 0) continue

--- a/packages/@tailwindcss-upgrade/src/migrate.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate.ts
@@ -405,10 +405,6 @@ export async function split(stylesheets: Stylesheet[]) {
   let containsUtilities = new Set<Stylesheet>()
 
   for (let sheet of stylesheets) {
-    let layers = sheet.layers()
-    let isLayered = layers.has('utilities') || layers.has('components')
-    if (!isLayered) continue
-
     walk(sheet.root, (node) => {
       if (node.type !== 'atrule') return
       if (node.name !== 'utility') return

--- a/packages/@tailwindcss-upgrade/src/migrate.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate.ts
@@ -402,34 +402,62 @@ export async function split(stylesheets: Stylesheet[]) {
   }
 
   // Keep track of sheets that contain `@utility` rules
-  let containsUtilities = new Set<Stylesheet>()
+  let requiresSplit = new Set<Stylesheet>()
 
   for (let sheet of stylesheets) {
+    // Root files don't need to be split
+    if (sheet.isTailwindRoot) continue
+
+    let containsUtility = false
+    let containsUnsafe = sheet.layers().size > 0
+
     walk(sheet.root, (node) => {
-      if (node.type !== 'atrule') return
-      if (node.name !== 'utility') return
+      if (node.type === 'atrule' && node.name === 'utility') {
+        containsUtility = true
+      }
 
-      containsUtilities.add(sheet)
+      // Safe to keep without splitting
+      else if (
+        // An `@import "…" layer(…)` is safe
+        (node.type === 'atrule' && node.name === 'import' && node.params.includes('layer(')) ||
+        // @layer blocks are safe
+        (node.type === 'atrule' && node.name === 'layer') ||
+        // Comments are safe
+        node.type === 'comment'
+      ) {
+        return WalkAction.Skip
+      }
 
-      return WalkAction.Stop
+      // Everything else is not safe, and requires a split
+      else {
+        containsUnsafe = true
+      }
+
+      // We already know we need to split this sheet
+      if (containsUtility && containsUnsafe) {
+        return WalkAction.Stop
+      }
+
+      return WalkAction.Skip
     })
+
+    if (containsUtility && containsUnsafe) {
+      requiresSplit.add(sheet)
+    }
   }
 
   // Split every imported stylesheet into two parts
   let utilitySheets = new Map<Stylesheet, Stylesheet>()
 
   for (let sheet of stylesheets) {
-    // Root files don't need to be split
-    if (sheet.isTailwindRoot) continue
-
     // Ignore stylesheets that were not imported
     if (!sheet.file) continue
     if (sheet.parents.size === 0) continue
 
     // Skip stylesheets that don't have utilities
     // and don't have any children that have utilities
-    if (!containsUtilities.has(sheet)) {
-      if (!Array.from(sheet.descendants()).some((child) => containsUtilities.has(child))) {
+    if (!requiresSplit.has(sheet)) {
+      if (!Array.from(sheet.descendants()).some((child) => requiresSplit.has(child))) {
         continue
       }
     }


### PR DESCRIPTION
This PR fixes an issue where imports above Tailwind directives didn't get a `layer(…)` argument.

Given this CSS:
```css
@import "./typography.css";
@tailwind base;
@tailwind components;
@tailwind utilities;
```

It was migrated to:
```css
@import "./typography.css";
@import "tailwindcss";
```

But to ensure that the typography styles end up in the correct location, it requires the `layer(…)` argument.

This PR now migrates the input to:
```css
@import "./typography.css" layer(base);
@import "tailwindcss";
```

Test plan:
---

Added an integration test where an import receives the `layer(…)`, but an import that eventually contains `@utility` does not receive the `layer(…)` argument. This is necessary otherwise the `@utility` will be nested when we are processing the inlined CSS.

Running this on the Commit template, we do have a proper `layer(…)`
<img width="585" alt="image" src="https://github.com/user-attachments/assets/538055e6-a9ac-490d-981f-41065a6b59f9">

