### PR TITLE
Ensure consistent opacity for disabled form controls in all browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support opacity values in increments of `0.25` by default ([#14980](https://github.com/tailwindlabs/tailwindcss/pull/14980))
 - Support specifying the color interpolation method for gradients via modifier ([#14984](https://github.com/tailwindlabs/tailwindcss/pull/14984))
 
+### Changed
+
+- Set `opacity: 1` on disabled form controls in Preflight to ensure consistency across all browsers ([#14991](https://github.com/tailwindlabs/tailwindcss/pull/14991))
+
 ## [4.0.0-alpha.33] - 2024-11-11
 
 ### Fixed

--- a/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
@@ -475,6 +475,14 @@ exports[`\`@import 'tailwindcss'\` is replaced with the generated CSS 1`] = `
     color: inherit;
   }
 
+  ::file-selector-button:where() {
+    opacity: 1;
+  }
+
+  :is(button, input, optgroup, select, textarea):where([disabled]) {
+    opacity: 1;
+  }
+
   button, input:where([type="button"], [type="reset"], [type="submit"]) {
     appearance: button;
     background: none;

--- a/packages/tailwindcss/preflight.css
+++ b/packages/tailwindcss/preflight.css
@@ -175,7 +175,8 @@ table {
 }
 
 /*
-  Inherit font styles in all browsers.
+  1. Inherit font styles in all browsers.
+  2. Ensure the opacity of disabled controls is consistent in all browsers;
 */
 
 button,
@@ -184,11 +185,15 @@ optgroup,
 select,
 textarea,
 ::file-selector-button {
-  font: inherit;
-  font-feature-settings: inherit;
-  font-variation-settings: inherit;
-  letter-spacing: inherit;
-  color: inherit;
+  font: inherit; /* 1 */
+  font-feature-settings: inherit; /* 1 */
+  font-variation-settings: inherit; /* 1 */
+  letter-spacing: inherit; /* 1 */
+  color: inherit; /* 1 */
+
+  &:where([disabled]) {
+    opacity: 1; /* 2 */
+  }
 }
 
 /*


### PR DESCRIPTION
We noticed that in Chrome, disabled `<select>` elements were being rendered at 70% opacity, but were being rendered at 100% opacity in Firefox and Safari. After some research, we learned that all form controls in all browsers are rendered at a lower opacity when disabled _if you don't include our other Preflight styles_, but some of the other normalizations we do in Preflight (specifically stuff around borders) causes each browser to abandon their default/native control styles, and only Chrome persists the user-agent opacity setting it was using for the untouched native control.

This PR just sets the opacity for all disabled elements to `1` so that there are no surprises and you can style your disabled elements however you want. This is something we ran into on Catalyst, and had to add `disabled:opacity-100` to our select controls to avoid since we had our own custom styles for them.