### PR TITLE
Add codemod and interop for legacy `container` component configu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support opacity values in increments of `0.25` by default ([#14980](https://github.com/tailwindlabs/tailwindcss/pull/14980))
 - Support specifying the color interpolation method for gradients via modifier ([#14984](https://github.com/tailwindlabs/tailwindcss/pull/14984))
-- Reintroduce `container` component as a utility ([#14993](https://github.com/tailwindlabs/tailwindcss/pull/14993))
+- Reintroduce `container` component as a utility ([#14993](https://github.com/tailwindlabs/tailwindcss/pull/14993), [#14999](https://github.com/tailwindlabs/tailwindcss/pull/14999))
+- _Upgrade (experimental)_: Migrate `container` component configuration to CSS ([#14999](https://github.com/tailwindlabs/tailwindcss/pull/14999))
 
 ### Fixed
 

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -1495,11 +1495,8 @@ describe('border compatibility', () => {
           @media (width >= theme(--breakpoint-sm)) {
             max-width: none;
           }
-          @media (width >= theme(--breakpoint-md)) {
-            max-width: var(--breakpoint-md);
-          }
-          @media (width >= theme(--breakpoint-lg)) {
-            max-width: none;
+          @media (width >= 48rem) {
+            max-width: 48rem;
           }
           @media (width >= 1280px) {
             max-width: 1280px;

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -1501,9 +1501,15 @@ describe('border compatibility', () => {
             max-width: none;
           }
           @media (width >= theme(--breakpoint-xl)) {
-            max-width: 1280px;
+            max-width: none;
           }
           @media (width >= theme(--breakpoint-2xl)) {
+            max-width: none;
+          }
+          @media (width >= 1280px) {
+            max-width: 1280px;
+          }
+          @media (width >= 1536px) {
             max-width: 1536px;
             padding-inline: 4rem;
           }

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -1460,6 +1460,7 @@ describe('border compatibility', () => {
                   '2xl': '4rem',
                 },
                 screens: {
+                  md: '48rem', // Matches a default --breakpoint
                   xl: '1280px',
                   '2xl': '1536px',
                 },
@@ -1494,9 +1495,6 @@ describe('border compatibility', () => {
           @media (width >= theme(--breakpoint-sm)) {
             max-width: none;
           }
-          @media (width >= theme(--breakpoint-md)) {
-            max-width: none;
-          }
           @media (width >= theme(--breakpoint-lg)) {
             max-width: none;
           }
@@ -1506,6 +1504,7 @@ describe('border compatibility', () => {
           @media (width >= theme(--breakpoint-2xl)) {
             max-width: none;
           }
+          @media (width >= 48rem);
           @media (width >= 1280px) {
             max-width: 1280px;
           }

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -1495,16 +1495,12 @@ describe('border compatibility', () => {
           @media (width >= theme(--breakpoint-sm)) {
             max-width: none;
           }
+          @media (width >= theme(--breakpoint-md)) {
+            max-width: var(--breakpoint-md);
+          }
           @media (width >= theme(--breakpoint-lg)) {
             max-width: none;
           }
-          @media (width >= theme(--breakpoint-xl)) {
-            max-width: none;
-          }
-          @media (width >= theme(--breakpoint-2xl)) {
-            max-width: none;
-          }
-          @media (width >= 48rem);
           @media (width >= 1280px) {
             max-width: 1280px;
           }

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -1436,7 +1436,7 @@ describe('border compatibility', () => {
     },
   )
 
-  test.only(
+  test(
     'migrates `container` component configurations',
     {
       fs: {
@@ -1491,23 +1491,21 @@ describe('border compatibility', () => {
         @utility container {
           margin-inline: auto;
           padding-inline: 2rem;
-          @media (width >= theme(--breakpoint-2xl)) {
-            padding-inline: 4rem;
-          }
           @media (width >= theme(--breakpoint-sm)) {
-            padding-inline: none;
+            max-width: none;
           }
           @media (width >= theme(--breakpoint-md)) {
-            padding-inline: none;
+            max-width: none;
           }
           @media (width >= theme(--breakpoint-lg)) {
-            padding-inline: none;
+            max-width: none;
           }
           @media (width >= theme(--breakpoint-xl)) {
-            padding-inline: 1280px;
+            max-width: 1280px;
           }
           @media (width >= theme(--breakpoint-2xl)) {
-            padding-inline: 1536px;
+            max-width: 1536px;
+            padding-inline: 4rem;
           }
         }
 

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url'
 import { type Config } from 'tailwindcss'
 import defaultTheme from 'tailwindcss/defaultTheme'
 import { loadModule } from '../../@tailwindcss-node/src/compile'
-import { toCss, type AstNode } from '../../tailwindcss/src/ast'
+import { atRule, toCss, type AstNode } from '../../tailwindcss/src/ast'
 import {
   keyPathToCssProperty,
   themeableValues,
@@ -13,6 +13,7 @@ import {
 import { keyframesToRules } from '../../tailwindcss/src/compat/apply-keyframes-to-theme'
 import { resolveConfig, type ConfigFile } from '../../tailwindcss/src/compat/config/resolve-config'
 import type { ResolvedConfig, ThemeConfig } from '../../tailwindcss/src/compat/config/types'
+import { buildCustomContainerUtilityRules } from '../../tailwindcss/src/compat/container'
 import { darkModePlugin } from '../../tailwindcss/src/compat/dark-mode'
 import type { DesignSystem } from '../../tailwindcss/src/design-system'
 import { escape } from '../../tailwindcss/src/utils/escape'
@@ -148,6 +149,14 @@ async function migrateTheme(
   }
 
   css += '}\n' // @theme
+
+  if ('container' in resolvedConfig.theme) {
+    let rules = buildCustomContainerUtilityRules(resolvedConfig.theme.container, designSystem)
+    if (rules.length > 0) {
+      css += '\n' + toCss([atRule('@utility', 'container', rules)])
+    }
+  }
+
   css += '}\n' // @tw-bucket
 
   return css

--- a/packages/tailwindcss/src/compat/apply-compat-hooks.ts
+++ b/packages/tailwindcss/src/compat/apply-compat-hooks.ts
@@ -6,6 +6,7 @@ import { applyKeyframesToTheme } from './apply-keyframes-to-theme'
 import { createCompatConfig } from './config/create-compat-config'
 import { resolveConfig } from './config/resolve-config'
 import type { UserConfig } from './config/types'
+import { registerContainerCompat } from './container'
 import { darkModePlugin } from './dark-mode'
 import { buildPluginApi, type CssPluginOptions, type Plugin } from './plugin-api'
 import { registerScreensConfig } from './screens-config'
@@ -239,6 +240,7 @@ function upgradeToFullPluginSupport({
 
   registerThemeVariantOverrides(resolvedUserConfig, designSystem)
   registerScreensConfig(resolvedUserConfig, designSystem)
+  registerContainerCompat(resolvedUserConfig, designSystem)
 
   // If a prefix has already been set in CSS don't override it
   if (!designSystem.theme.prefix && resolvedConfig.prefix) {

--- a/packages/tailwindcss/src/compat/apply-config-to-theme.ts
+++ b/packages/tailwindcss/src/compat/apply-config-to-theme.ts
@@ -128,6 +128,9 @@ export function themeableValues(config: ResolvedConfig['theme']): [string[], unk
 const IS_VALID_KEY = /^[a-zA-Z0-9-_%/\.]+$/
 
 export function keyPathToCssProperty(path: string[]) {
+  // The legacy container component config should not be included in the Theme
+  if (path[0] === 'container') return null
+
   path = structuredClone(path)
 
   if (path[0] === 'animation') path[0] = 'animate'

--- a/packages/tailwindcss/src/compat/container-config.test.ts
+++ b/packages/tailwindcss/src/compat/container-config.test.ts
@@ -305,13 +305,31 @@ test('combines custom padding and screen overwrites', async () => {
     }),
   })
 
-  expect(compiler.build(['container'])).toMatchInlineSnapshot(`
+  expect(compiler.build(['container', '!container'])).toMatchInlineSnapshot(`
     ":root {
       --breakpoint-sm: 40rem;
       --breakpoint-md: 48rem;
       --breakpoint-lg: 64rem;
       --breakpoint-xl: 80rem;
       --breakpoint-2xl: 96rem;
+    }
+    .\\!container {
+      width: 100% !important;
+      @media (width >= 40rem) {
+        max-width: 40rem !important;
+      }
+      @media (width >= 48rem) {
+        max-width: 48rem !important;
+      }
+      @media (width >= 64rem) {
+        max-width: 64rem !important;
+      }
+      @media (width >= 80rem) {
+        max-width: 80rem !important;
+      }
+      @media (width >= 96rem) {
+        max-width: 96rem !important;
+      }
     }
     .container {
       width: 100%;
@@ -329,6 +347,23 @@ test('combines custom padding and screen overwrites', async () => {
       }
       @media (width >= 96rem) {
         max-width: 96rem;
+      }
+    }
+    .\\!container {
+      margin-inline: auto !important;
+      padding-inline: 2rem !important;
+      @media (width >= 40rem) {
+        max-width: none !important;
+      }
+      @media (width >= 64rem) {
+        max-width: none !important;
+      }
+      @media (width >= 80rem) {
+        max-width: var(--breakpoint-xl) !important;
+      }
+      @media (width >= 96rem) {
+        max-width: var(--breakpoint-2xl) !important;
+        padding-inline: 4rem !important;
       }
     }
     .container {

--- a/packages/tailwindcss/src/compat/container-config.test.ts
+++ b/packages/tailwindcss/src/compat/container-config.test.ts
@@ -1,0 +1,271 @@
+import { expect, test } from 'vitest'
+import { compile } from '..'
+
+const css = String.raw
+
+test('creates a custom utility to extend the built-in container', async () => {
+  let input = css`
+    @theme default {
+      --breakpoint-sm: 40rem;
+      --breakpoint-md: 48rem;
+      --breakpoint-lg: 64rem;
+      --breakpoint-xl: 80rem;
+      --breakpoint-2xl: 96rem;
+    }
+    @config "./config.js";
+    @tailwind utilities;
+  `
+
+  let compiler = await compile(input, {
+    loadModule: async () => ({
+      module: {
+        theme: {
+          container: {
+            center: true,
+            padding: '2rem',
+          },
+        },
+      },
+      base: '/root',
+    }),
+  })
+
+  expect(compiler.build(['container'])).toMatchInlineSnapshot(`
+    ":root {
+      --breakpoint-sm: 40rem;
+      --breakpoint-md: 48rem;
+      --breakpoint-lg: 64rem;
+      --breakpoint-xl: 80rem;
+      --breakpoint-2xl: 96rem;
+    }
+    .container {
+      width: 100%;
+      @media (min-width: 40rem) {
+        max-width: 40rem;
+      }
+      @media (min-width: 48rem) {
+        max-width: 48rem;
+      }
+      @media (min-width: 64rem) {
+        max-width: 64rem;
+      }
+      @media (min-width: 80rem) {
+        max-width: 80rem;
+      }
+      @media (min-width: 96rem) {
+        max-width: 96rem;
+      }
+    }
+    .container {
+      margin-inline: auto;
+      padding-inline: 2rem;
+    }
+    "
+  `)
+})
+
+test('allows padding to be defined at custom breakpoints', async () => {
+  let input = css`
+    @theme default {
+      --breakpoint-sm: 40rem;
+      --breakpoint-md: 48rem;
+      --breakpoint-lg: 64rem;
+      --breakpoint-xl: 80rem;
+      --breakpoint-2xl: 96rem;
+    }
+    @config "./config.js";
+    @tailwind utilities;
+  `
+
+  let compiler = await compile(input, {
+    loadModule: async () => ({
+      module: {
+        theme: {
+          container: {
+            padding: {
+              // The order here is messed up on purpose
+              '2xl': '3rem',
+              DEFAULT: '1rem',
+              lg: '2rem',
+            },
+          },
+        },
+      },
+      base: '/root',
+    }),
+  })
+
+  expect(compiler.build(['container'])).toMatchInlineSnapshot(`
+    ":root {
+      --breakpoint-sm: 40rem;
+      --breakpoint-md: 48rem;
+      --breakpoint-lg: 64rem;
+      --breakpoint-xl: 80rem;
+      --breakpoint-2xl: 96rem;
+    }
+    .container {
+      width: 100%;
+      @media (min-width: 40rem) {
+        max-width: 40rem;
+      }
+      @media (min-width: 48rem) {
+        max-width: 48rem;
+      }
+      @media (min-width: 64rem) {
+        max-width: 64rem;
+      }
+      @media (min-width: 80rem) {
+        max-width: 80rem;
+      }
+      @media (min-width: 96rem) {
+        max-width: 96rem;
+      }
+    }
+    .container {
+      padding-inline: 1rem;
+      @media (width >= 64rem) {
+        padding-inline: 2rem;
+      }
+      @media (width >= 96rem) {
+        padding-inline: 3rem;
+      }
+    }
+    "
+  `)
+})
+
+test('allows breakpoints to be overwritten', async () => {
+  let input = css`
+    @theme default {
+      --breakpoint-sm: 40rem;
+      --breakpoint-md: 48rem;
+      --breakpoint-lg: 64rem;
+      --breakpoint-xl: 80rem;
+      --breakpoint-2xl: 96rem;
+    }
+    @config "./config.js";
+    @tailwind utilities;
+  `
+
+  let compiler = await compile(input, {
+    loadModule: async () => ({
+      module: {
+        theme: {
+          container: {
+            screens: {
+              xl: '1280px',
+              '2xl': '1536px',
+            },
+          },
+        },
+      },
+      base: '/root',
+    }),
+  })
+
+  expect(compiler.build(['container'])).toMatchInlineSnapshot(`
+    ":root {
+      --breakpoint-sm: 40rem;
+      --breakpoint-md: 48rem;
+      --breakpoint-lg: 64rem;
+      --breakpoint-xl: 80rem;
+      --breakpoint-2xl: 96rem;
+    }
+    .container {
+      width: 100%;
+      @media (min-width: 40rem) {
+        max-width: 40rem;
+      }
+      @media (min-width: 48rem) {
+        max-width: 48rem;
+      }
+      @media (min-width: 64rem) {
+        max-width: 64rem;
+      }
+      @media (min-width: 80rem) {
+        max-width: 80rem;
+      }
+      @media (min-width: 96rem) {
+        max-width: 96rem;
+      }
+    }
+    .container {
+      @media (width >= 40rem) {
+        padding-inline: none;
+      }
+      @media (width >= 48rem) {
+        padding-inline: none;
+      }
+      @media (width >= 64rem) {
+        padding-inline: none;
+      }
+      @media (width >= 80rem) {
+        padding-inline: 1280px;
+      }
+      @media (width >= 96rem) {
+        padding-inline: 1536px;
+      }
+    }
+    "
+  `)
+})
+
+test('legacy container component does not interfere with new --container variables', async () => {
+  let input = css`
+    @theme default {
+      --container-3xs: 16rem;
+      --container-2xs: 18rem;
+      --container-xs: 20rem;
+      --container-sm: 24rem;
+      --container-md: 28rem;
+      --container-lg: 32rem;
+      --container-xl: 36rem;
+      --container-2xl: 42rem;
+      --container-3xl: 48rem;
+      --container-4xl: 56rem;
+      --container-5xl: 64rem;
+      --container-6xl: 72rem;
+      --container-7xl: 80rem;
+      --container-prose: 65ch;
+    }
+    @config "./config.js";
+    @tailwind utilities;
+  `
+
+  let compiler = await compile(input, {
+    loadModule: async () => ({
+      module: {
+        theme: {
+          container: {
+            center: true,
+            padding: '2rem',
+          },
+        },
+      },
+      base: '/root',
+    }),
+  })
+
+  expect(compiler.build(['max-w-sm'])).toMatchInlineSnapshot(`
+    ":root {
+      --container-3xs: 16rem;
+      --container-2xs: 18rem;
+      --container-xs: 20rem;
+      --container-sm: 24rem;
+      --container-md: 28rem;
+      --container-lg: 32rem;
+      --container-xl: 36rem;
+      --container-2xl: 42rem;
+      --container-3xl: 48rem;
+      --container-4xl: 56rem;
+      --container-5xl: 64rem;
+      --container-6xl: 72rem;
+      --container-7xl: 80rem;
+      --container-prose: 65ch;
+    }
+    .max-w-sm {
+      max-width: var(--container-sm);
+    }
+    "
+  `)
+})

--- a/packages/tailwindcss/src/compat/container-config.test.ts
+++ b/packages/tailwindcss/src/compat/container-config.test.ts
@@ -200,10 +200,10 @@ test('allows breakpoints to be overwritten', async () => {
         max-width: none;
       }
       @media (width >= 80rem) {
-        max-width: 1280px;
+        max-width: var(--breakpoint-xl);
       }
       @media (width >= 96rem) {
-        max-width: 1536px;
+        max-width: var(--breakpoint-2xl);
       }
     }
     "
@@ -294,6 +294,7 @@ test('combines custom padding and screen overwrites', async () => {
               '2xl': '4rem',
             },
             screens: {
+              md: '48rem',
               xl: '1280px',
               '2xl': '1536px',
             },
@@ -336,17 +337,14 @@ test('combines custom padding and screen overwrites', async () => {
       @media (width >= 40rem) {
         max-width: none;
       }
-      @media (width >= 48rem) {
-        max-width: none;
-      }
       @media (width >= 64rem) {
         max-width: none;
       }
       @media (width >= 80rem) {
-        max-width: 1280px;
+        max-width: var(--breakpoint-xl);
       }
       @media (width >= 96rem) {
-        max-width: 1536px;
+        max-width: var(--breakpoint-2xl);
         padding-inline: 4rem;
       }
     }

--- a/packages/tailwindcss/src/compat/container-config.test.ts
+++ b/packages/tailwindcss/src/compat/container-config.test.ts
@@ -40,19 +40,19 @@ test('creates a custom utility to extend the built-in container', async () => {
     }
     .container {
       width: 100%;
-      @media (min-width: 40rem) {
+      @media (width >= 40rem) {
         max-width: 40rem;
       }
-      @media (min-width: 48rem) {
+      @media (width >= 48rem) {
         max-width: 48rem;
       }
-      @media (min-width: 64rem) {
+      @media (width >= 64rem) {
         max-width: 64rem;
       }
-      @media (min-width: 80rem) {
+      @media (width >= 80rem) {
         max-width: 80rem;
       }
-      @media (min-width: 96rem) {
+      @media (width >= 96rem) {
         max-width: 96rem;
       }
     }
@@ -105,19 +105,19 @@ test('allows padding to be defined at custom breakpoints', async () => {
     }
     .container {
       width: 100%;
-      @media (min-width: 40rem) {
+      @media (width >= 40rem) {
         max-width: 40rem;
       }
-      @media (min-width: 48rem) {
+      @media (width >= 48rem) {
         max-width: 48rem;
       }
-      @media (min-width: 64rem) {
+      @media (width >= 64rem) {
         max-width: 64rem;
       }
-      @media (min-width: 80rem) {
+      @media (width >= 80rem) {
         max-width: 80rem;
       }
-      @media (min-width: 96rem) {
+      @media (width >= 96rem) {
         max-width: 96rem;
       }
     }
@@ -173,37 +173,37 @@ test('allows breakpoints to be overwritten', async () => {
     }
     .container {
       width: 100%;
-      @media (min-width: 40rem) {
+      @media (width >= 40rem) {
         max-width: 40rem;
       }
-      @media (min-width: 48rem) {
+      @media (width >= 48rem) {
         max-width: 48rem;
       }
-      @media (min-width: 64rem) {
+      @media (width >= 64rem) {
         max-width: 64rem;
       }
-      @media (min-width: 80rem) {
+      @media (width >= 80rem) {
         max-width: 80rem;
       }
-      @media (min-width: 96rem) {
+      @media (width >= 96rem) {
         max-width: 96rem;
       }
     }
     .container {
       @media (width >= 40rem) {
-        padding-inline: none;
+        max-width: none;
       }
       @media (width >= 48rem) {
-        padding-inline: none;
+        max-width: none;
       }
       @media (width >= 64rem) {
-        padding-inline: none;
+        max-width: none;
       }
       @media (width >= 80rem) {
-        padding-inline: 1280px;
+        max-width: 1280px;
       }
       @media (width >= 96rem) {
-        padding-inline: 1536px;
+        max-width: 1536px;
       }
     }
     "
@@ -265,6 +265,90 @@ test('legacy container component does not interfere with new --container variabl
     }
     .max-w-sm {
       max-width: var(--container-sm);
+    }
+    "
+  `)
+})
+
+test('combines custom padding and screen overwrites', async () => {
+  let input = css`
+    @theme default {
+      --breakpoint-sm: 40rem;
+      --breakpoint-md: 48rem;
+      --breakpoint-lg: 64rem;
+      --breakpoint-xl: 80rem;
+      --breakpoint-2xl: 96rem;
+    }
+    @config "./config.js";
+    @tailwind utilities;
+  `
+
+  let compiler = await compile(input, {
+    loadModule: async () => ({
+      module: {
+        theme: {
+          container: {
+            center: true,
+            padding: {
+              DEFAULT: '2rem',
+              '2xl': '4rem',
+            },
+            screens: {
+              xl: '1280px',
+              '2xl': '1536px',
+            },
+          },
+        },
+      },
+      base: '/root',
+    }),
+  })
+
+  expect(compiler.build(['container'])).toMatchInlineSnapshot(`
+    ":root {
+      --breakpoint-sm: 40rem;
+      --breakpoint-md: 48rem;
+      --breakpoint-lg: 64rem;
+      --breakpoint-xl: 80rem;
+      --breakpoint-2xl: 96rem;
+    }
+    .container {
+      width: 100%;
+      @media (width >= 40rem) {
+        max-width: 40rem;
+      }
+      @media (width >= 48rem) {
+        max-width: 48rem;
+      }
+      @media (width >= 64rem) {
+        max-width: 64rem;
+      }
+      @media (width >= 80rem) {
+        max-width: 80rem;
+      }
+      @media (width >= 96rem) {
+        max-width: 96rem;
+      }
+    }
+    .container {
+      margin-inline: auto;
+      padding-inline: 2rem;
+      @media (width >= 40rem) {
+        max-width: none;
+      }
+      @media (width >= 48rem) {
+        max-width: none;
+      }
+      @media (width >= 64rem) {
+        max-width: none;
+      }
+      @media (width >= 80rem) {
+        max-width: 1280px;
+      }
+      @media (width >= 96rem) {
+        max-width: 1536px;
+        padding-inline: 4rem;
+      }
     }
     "
   `)

--- a/packages/tailwindcss/src/compat/container-config.test.ts
+++ b/packages/tailwindcss/src/compat/container-config.test.ts
@@ -528,7 +528,6 @@ test('combines custom padding and screen overwrites', async () => {
       @media (width >= 96rem) {
         max-width: none !important;
       }
-      @media (width >= 48rem);
       @media (width >= 1280px) {
         max-width: 1280px !important;
       }
@@ -552,7 +551,6 @@ test('combines custom padding and screen overwrites', async () => {
       @media (width >= 96rem) {
         max-width: none;
       }
-      @media (width >= 48rem);
       @media (width >= 1280px) {
         max-width: 1280px;
       }

--- a/packages/tailwindcss/src/compat/container-config.test.ts
+++ b/packages/tailwindcss/src/compat/container-config.test.ts
@@ -518,3 +518,86 @@ test('combines custom padding and screen overwrites', async () => {
     "
   `)
 })
+
+test('filters out complex breakpoints', async () => {
+  let input = css`
+    @theme default {
+      --breakpoint-sm: 40rem;
+      --breakpoint-md: 48rem;
+      --breakpoint-lg: 64rem;
+      --breakpoint-xl: 80rem;
+      --breakpoint-2xl: 96rem;
+    }
+    @config "./config.js";
+    @tailwind utilities;
+  `
+
+  let compiler = await compile(input, {
+    loadModule: async () => ({
+      module: {
+        theme: {
+          container: {
+            center: true,
+            padding: {
+              DEFAULT: '2rem',
+              '2xl': '4rem',
+            },
+            screens: {
+              sm: '20px',
+              md: { min: '100px' },
+              lg: { max: '200px' },
+              xl: { min: '300px', max: '400px' },
+              '2xl': { raw: 'print' },
+            },
+          },
+        },
+      },
+      base: '/root',
+    }),
+  })
+
+  expect(compiler.build(['container'])).toMatchInlineSnapshot(`
+    ":root {
+      --breakpoint-sm: 40rem;
+      --breakpoint-md: 48rem;
+      --breakpoint-lg: 64rem;
+      --breakpoint-xl: 80rem;
+      --breakpoint-2xl: 96rem;
+    }
+    .container {
+      width: 100%;
+      @media (width >= 40rem) {
+        max-width: 40rem;
+      }
+      @media (width >= 48rem) {
+        max-width: 48rem;
+      }
+      @media (width >= 64rem) {
+        max-width: 64rem;
+      }
+      @media (width >= 80rem) {
+        max-width: 80rem;
+      }
+      @media (width >= 96rem) {
+        max-width: 96rem;
+      }
+    }
+    .container {
+      margin-inline: auto;
+      padding-inline: 2rem;
+      @media (width >= 40rem) {
+        max-width: none;
+      }
+      @media (width >= 20px) {
+        max-width: 20px;
+      }
+      @media (width >= 100px) {
+        max-width: 100px;
+      }
+      @media (width >= 300px) {
+        max-width: 300px;
+      }
+    }
+    "
+  `)
+})

--- a/packages/tailwindcss/src/compat/container-config.test.ts
+++ b/packages/tailwindcss/src/compat/container-config.test.ts
@@ -200,10 +200,174 @@ test('allows breakpoints to be overwritten', async () => {
         max-width: none;
       }
       @media (width >= 80rem) {
-        max-width: var(--breakpoint-xl);
+        max-width: none;
       }
       @media (width >= 96rem) {
-        max-width: var(--breakpoint-2xl);
+        max-width: none;
+      }
+      @media (width >= 1280px) {
+        max-width: 1280px;
+      }
+      @media (width >= 1536px) {
+        max-width: 1536px;
+      }
+    }
+    "
+  `)
+})
+
+test('padding applies to custom `container` screens', async () => {
+  let input = css`
+    @theme default {
+      --breakpoint-sm: 40rem;
+      --breakpoint-md: 48rem;
+      --breakpoint-lg: 64rem;
+      --breakpoint-xl: 80rem;
+      --breakpoint-2xl: 96rem;
+    }
+    @config "./config.js";
+    @tailwind utilities;
+  `
+
+  let compiler = await compile(input, {
+    loadModule: async () => ({
+      module: {
+        theme: {
+          container: {
+            padding: {
+              sm: '2rem',
+              md: '3rem',
+            },
+            screens: {
+              md: '48rem',
+            },
+          },
+        },
+      },
+      base: '/root',
+    }),
+  })
+
+  expect(compiler.build(['container'])).toMatchInlineSnapshot(`
+    ":root {
+      --breakpoint-sm: 40rem;
+      --breakpoint-md: 48rem;
+      --breakpoint-lg: 64rem;
+      --breakpoint-xl: 80rem;
+      --breakpoint-2xl: 96rem;
+    }
+    .container {
+      width: 100%;
+      @media (width >= 40rem) {
+        max-width: 40rem;
+      }
+      @media (width >= 48rem) {
+        max-width: 48rem;
+      }
+      @media (width >= 64rem) {
+        max-width: 64rem;
+      }
+      @media (width >= 80rem) {
+        max-width: 80rem;
+      }
+      @media (width >= 96rem) {
+        max-width: 96rem;
+      }
+    }
+    .container {
+      @media (width >= 40rem) {
+        max-width: none;
+      }
+      @media (width >= 64rem) {
+        max-width: none;
+      }
+      @media (width >= 80rem) {
+        max-width: none;
+      }
+      @media (width >= 96rem) {
+        max-width: none;
+      }
+      @media (width >= 48rem) {
+        padding-inline: 3rem;
+      }
+    }
+    "
+  `)
+})
+
+test("an empty `screen` config will undo all custom media screens and won't apply any breakpoint-specific padding", async () => {
+  let input = css`
+    @theme default {
+      --breakpoint-sm: 40rem;
+      --breakpoint-md: 48rem;
+      --breakpoint-lg: 64rem;
+      --breakpoint-xl: 80rem;
+      --breakpoint-2xl: 96rem;
+    }
+    @config "./config.js";
+    @tailwind utilities;
+  `
+
+  let compiler = await compile(input, {
+    loadModule: async () => ({
+      module: {
+        theme: {
+          container: {
+            padding: {
+              DEFAULT: '1rem',
+              sm: '2rem',
+              md: '3rem',
+            },
+            screens: {},
+          },
+        },
+      },
+      base: '/root',
+    }),
+  })
+
+  expect(compiler.build(['container'])).toMatchInlineSnapshot(`
+    ":root {
+      --breakpoint-sm: 40rem;
+      --breakpoint-md: 48rem;
+      --breakpoint-lg: 64rem;
+      --breakpoint-xl: 80rem;
+      --breakpoint-2xl: 96rem;
+    }
+    .container {
+      width: 100%;
+      @media (width >= 40rem) {
+        max-width: 40rem;
+      }
+      @media (width >= 48rem) {
+        max-width: 48rem;
+      }
+      @media (width >= 64rem) {
+        max-width: 64rem;
+      }
+      @media (width >= 80rem) {
+        max-width: 80rem;
+      }
+      @media (width >= 96rem) {
+        max-width: 96rem;
+      }
+    }
+    .container {
+      padding-inline: 1rem;
+      @media (width >= 40rem) {
+        max-width: none;
+      }
+      @media (width >= 48rem) {
+        max-width: none;
+      }
+      @media (width >= 64rem) {
+        max-width: none;
+      }
+      @media (width >= 80rem) {
+        max-width: none;
+      }
+      @media (width >= 96rem) {
+        max-width: none;
       }
     }
     "
@@ -294,7 +458,7 @@ test('combines custom padding and screen overwrites', async () => {
               '2xl': '4rem',
             },
             screens: {
-              md: '48rem',
+              md: '48rem', // Matches a default --breakpoint
               xl: '1280px',
               '2xl': '1536px',
             },
@@ -359,10 +523,17 @@ test('combines custom padding and screen overwrites', async () => {
         max-width: none !important;
       }
       @media (width >= 80rem) {
-        max-width: var(--breakpoint-xl) !important;
+        max-width: none !important;
       }
       @media (width >= 96rem) {
-        max-width: var(--breakpoint-2xl) !important;
+        max-width: none !important;
+      }
+      @media (width >= 48rem);
+      @media (width >= 1280px) {
+        max-width: 1280px !important;
+      }
+      @media (width >= 1536px) {
+        max-width: 1536px !important;
         padding-inline: 4rem !important;
       }
     }
@@ -376,10 +547,17 @@ test('combines custom padding and screen overwrites', async () => {
         max-width: none;
       }
       @media (width >= 80rem) {
-        max-width: var(--breakpoint-xl);
+        max-width: none;
       }
       @media (width >= 96rem) {
-        max-width: var(--breakpoint-2xl);
+        max-width: none;
+      }
+      @media (width >= 48rem);
+      @media (width >= 1280px) {
+        max-width: 1280px;
+      }
+      @media (width >= 1536px) {
+        max-width: 1536px;
         padding-inline: 4rem;
       }
     }

--- a/packages/tailwindcss/src/compat/container-config.test.ts
+++ b/packages/tailwindcss/src/compat/container-config.test.ts
@@ -267,12 +267,7 @@ test('padding applies to custom `container` screens', async () => {
         max-width: none;
       }
       @media (width >= 48rem) {
-        max-width: var(--breakpoint-md);
-      }
-      @media (width >= 64rem) {
-        max-width: none;
-      }
-      @media (width >= 48rem) {
+        max-width: 48rem;
         padding-inline: 3rem;
       }
     }
@@ -493,10 +488,7 @@ test('combines custom padding and screen overwrites', async () => {
         max-width: none !important;
       }
       @media (width >= 48rem) {
-        max-width: var(--breakpoint-md) !important;
-      }
-      @media (width >= 64rem) {
-        max-width: none !important;
+        max-width: 48rem !important;
       }
       @media (width >= 1280px) {
         max-width: 1280px !important;
@@ -513,10 +505,7 @@ test('combines custom padding and screen overwrites', async () => {
         max-width: none;
       }
       @media (width >= 48rem) {
-        max-width: var(--breakpoint-md);
-      }
-      @media (width >= 64rem) {
-        max-width: none;
+        max-width: 48rem;
       }
       @media (width >= 1280px) {
         max-width: 1280px;

--- a/packages/tailwindcss/src/compat/container-config.test.ts
+++ b/packages/tailwindcss/src/compat/container-config.test.ts
@@ -193,18 +193,6 @@ test('allows breakpoints to be overwritten', async () => {
       @media (width >= 40rem) {
         max-width: none;
       }
-      @media (width >= 48rem) {
-        max-width: none;
-      }
-      @media (width >= 64rem) {
-        max-width: none;
-      }
-      @media (width >= 80rem) {
-        max-width: none;
-      }
-      @media (width >= 96rem) {
-        max-width: none;
-      }
       @media (width >= 1280px) {
         max-width: 1280px;
       }
@@ -278,13 +266,10 @@ test('padding applies to custom `container` screens', async () => {
       @media (width >= 40rem) {
         max-width: none;
       }
+      @media (width >= 48rem) {
+        max-width: var(--breakpoint-md);
+      }
       @media (width >= 64rem) {
-        max-width: none;
-      }
-      @media (width >= 80rem) {
-        max-width: none;
-      }
-      @media (width >= 96rem) {
         max-width: none;
       }
       @media (width >= 48rem) {
@@ -355,18 +340,6 @@ test("an empty `screen` config will undo all custom media screens and won't appl
     .container {
       padding-inline: 1rem;
       @media (width >= 40rem) {
-        max-width: none;
-      }
-      @media (width >= 48rem) {
-        max-width: none;
-      }
-      @media (width >= 64rem) {
-        max-width: none;
-      }
-      @media (width >= 80rem) {
-        max-width: none;
-      }
-      @media (width >= 96rem) {
         max-width: none;
       }
     }
@@ -519,13 +492,10 @@ test('combines custom padding and screen overwrites', async () => {
       @media (width >= 40rem) {
         max-width: none !important;
       }
+      @media (width >= 48rem) {
+        max-width: var(--breakpoint-md) !important;
+      }
       @media (width >= 64rem) {
-        max-width: none !important;
-      }
-      @media (width >= 80rem) {
-        max-width: none !important;
-      }
-      @media (width >= 96rem) {
         max-width: none !important;
       }
       @media (width >= 1280px) {
@@ -542,13 +512,10 @@ test('combines custom padding and screen overwrites', async () => {
       @media (width >= 40rem) {
         max-width: none;
       }
+      @media (width >= 48rem) {
+        max-width: var(--breakpoint-md);
+      }
       @media (width >= 64rem) {
-        max-width: none;
-      }
-      @media (width >= 80rem) {
-        max-width: none;
-      }
-      @media (width >= 96rem) {
         max-width: none;
       }
       @media (width >= 1280px) {

--- a/packages/tailwindcss/src/compat/container.ts
+++ b/packages/tailwindcss/src/compat/container.ts
@@ -58,7 +58,11 @@ export function buildCustomContainerUtilityRules(
     }
 
     for (let [key, value] of Object.entries(screens)) {
-      breakpointOverwrites.set(key, [decl('max-width', value)])
+      let coreBreakpoint = breakpoints.find(([k]) => k === key)
+      if (coreBreakpoint && value === coreBreakpoint[1]) {
+        continue
+      }
+      breakpointOverwrites.set(key, [decl('max-width', `var(--breakpoint-${key})`)])
     }
   }
 

--- a/packages/tailwindcss/src/compat/container.ts
+++ b/packages/tailwindcss/src/compat/container.ts
@@ -124,7 +124,7 @@ export function buildCustomContainerUtilityRules(
 
   if (breakpointOverwrites) {
     for (let [, { rule, nodes }] of breakpointOverwrites) {
-      rules.push(atRule('@media', rule, nodes))
+      if (nodes.length > 0) rules.push(atRule('@media', rule, nodes))
     }
   }
 

--- a/packages/tailwindcss/src/compat/container.ts
+++ b/packages/tailwindcss/src/compat/container.ts
@@ -1,0 +1,91 @@
+import { atRule, decl, type AstNode } from '../ast'
+import type { DesignSystem } from '../design-system'
+import { compareBreakpoints } from '../utils/compare-breakpoints'
+import type { ResolvedConfig } from './config/types'
+
+export function registerContainerCompat(userConfig: ResolvedConfig, designSystem: DesignSystem) {
+  let container = userConfig.theme.container || {}
+
+  if (typeof container !== 'object' || container === null) {
+    return
+  }
+
+  let rules = buildCustomContainerUtilityRules(container, designSystem)
+
+  if (rules.length === 0) {
+    return
+  }
+
+  designSystem.utilities.static('container', () => rules)
+}
+
+export function buildCustomContainerUtilityRules(
+  {
+    center,
+    padding,
+    screens,
+  }: {
+    center?: boolean
+    padding?: string | {}
+    screens?: {}
+  },
+  designSystem: DesignSystem,
+): AstNode[] {
+  let rules = []
+
+  if (center) {
+    rules.push(decl('margin-inline', 'auto'))
+  }
+
+  if (typeof padding === 'string') {
+    rules.push(decl('padding-inline', padding))
+  }
+
+  if (typeof padding === 'object' && padding !== null) {
+    if ('DEFAULT' in padding && typeof padding.DEFAULT === 'string') {
+      rules.push(decl('padding-inline', padding.DEFAULT))
+    }
+
+    let breakpoints = Object.entries(padding)
+      .filter(([key]) => key !== 'DEFAULT')
+      .map(([key, value]) => {
+        return [key, designSystem.theme.resolveValue(key, ['--breakpoint']), value]
+      })
+      .filter(Boolean) as [string, string, string][]
+    breakpoints.sort((a, z) => compareBreakpoints(a[1], z[1], 'asc'))
+
+    for (let [key, , value] of breakpoints) {
+      rules.push(
+        atRule('@media', `(width >= theme(--breakpoint-${key}))`, [decl('padding-inline', value)]),
+      )
+    }
+  }
+
+  if (typeof screens === 'object' && screens !== null) {
+    // When setting a the `screens` in v3, you were overwriting the default
+    // screens config. To do this in v4, you have to manually unset all core
+    // screens.
+
+    let breakpoints = Array.from(designSystem.theme.namespace('--breakpoint').entries())
+    breakpoints.sort((a, z) => compareBreakpoints(a[1], z[1], 'asc'))
+
+    for (let [key] of breakpoints) {
+      if (!key) continue
+      if (!(key in screens)) {
+        rules.push(
+          atRule('@media', `(width >= theme(--breakpoint-${key}))`, [
+            decl('padding-inline', 'none'),
+          ]),
+        )
+      }
+    }
+
+    for (let [key, value] of Object.entries(screens)) {
+      rules.push(
+        atRule('@media', `(width >= theme(--breakpoint-${key}))`, [decl('padding-inline', value)]),
+      )
+    }
+  }
+
+  return rules
+}

--- a/packages/tailwindcss/src/compat/container.ts
+++ b/packages/tailwindcss/src/compat/container.ts
@@ -56,47 +56,15 @@ export function buildCustomContainerUtilityRules(
 
     let breakpoints = Array.from(designSystem.theme.namespace('--breakpoint').entries())
     breakpoints.sort((a, z) => compareBreakpoints(a[1], z[1], 'asc'))
-
-    let didUnsetPreviousRange = false
-    for (let [key, value] of breakpoints) {
-      // If we happen to find a `--breakpoint-*` variable with the same key and
-      // value, it will already be part of the core utility and we can skip it.
-      if (!key) continue
-      if (key in screens && (screens as Record<string, string>)[key] === value) {
-        if (didUnsetPreviousRange) {
-          rules.push(
-            atRule('@media', `(width >= theme(--breakpoint-${key}))`, [
-              decl('max-width', `var(--breakpoint-${key})`),
-            ]),
-          )
-          didUnsetPreviousRange = false
-        }
-
-        breakpointOverwrites.set(key, {
-          rule: `(width >= ${value})`,
-          nodes: [],
-        })
-        continue
-      }
-
-      if (!didUnsetPreviousRange) {
-        // We do not want to collect this core breakpoint in the `breakpointOverwrites`
-        // map, since it will not be relevant for subsequent
-        rules.push(
-          atRule('@media', `(width >= theme(--breakpoint-${key}))`, [decl('max-width', 'none')]),
-        )
-        didUnsetPreviousRange = true
-      }
+    if (breakpoints.length > 0) {
+      let [key] = breakpoints[0]
+      // Unset all default breakpoints
+      rules.push(
+        atRule('@media', `(width >= theme(--breakpoint-${key}))`, [decl('max-width', 'none')]),
+      )
     }
 
     for (let [key, value] of Object.entries(screens)) {
-      // If we happen to find a `--breakpoint-*` variable with the same key and
-      // value, it will already be part of the core utility and we can skip it.
-      let coreBreakpoint = breakpoints.find(([k]) => k === key)
-      if (coreBreakpoint && value === coreBreakpoint[1]) {
-        continue
-      }
-
       // We're inlining the breakpoint values because the screens configured in
       // the `container` option do not have to match the ones defined in the
       // root `screen` setting.

--- a/packages/tailwindcss/src/compat/container.ts
+++ b/packages/tailwindcss/src/compat/container.ts
@@ -1,4 +1,4 @@
-import { atRule, decl, type AstNode } from '../ast'
+import { atRule, decl, type AstNode, type AtRule } from '../ast'
 import type { DesignSystem } from '../design-system'
 import { compareBreakpoints } from '../utils/compare-breakpoints'
 import type { ResolvedConfig } from './config/types'
@@ -32,7 +32,7 @@ export function buildCustomContainerUtilityRules(
   designSystem: DesignSystem,
 ): AstNode[] {
   let rules = []
-  let breakpointOverwrites: null | Map<string, { nodes: AstNode[]; rule: string }> = null
+  let breakpointOverwrites: null | Map<string, AtRule> = null
 
   if (center) {
     rules.push(decl('margin-inline', 'auto'))
@@ -76,10 +76,10 @@ export function buildCustomContainerUtilityRules(
       // We're inlining the breakpoint values because the screens configured in
       // the `container` option do not have to match the ones defined in the
       // root `screen` setting.
-      breakpointOverwrites.set(key, {
-        rule: `(width >= ${value})`,
-        nodes: [decl('max-width', value)],
-      })
+      breakpointOverwrites.set(
+        key,
+        atRule('@media', `(width >= ${value})`, [decl('max-width', value)]),
+      )
     }
   }
 
@@ -111,8 +111,8 @@ export function buildCustomContainerUtilityRules(
   }
 
   if (breakpointOverwrites) {
-    for (let [, { rule, nodes }] of breakpointOverwrites) {
-      if (nodes.length > 0) rules.push(atRule('@media', rule, nodes))
+    for (let [, rule] of breakpointOverwrites) {
+      rules.push(rule)
     }
   }
 

--- a/packages/tailwindcss/src/compat/container.ts
+++ b/packages/tailwindcss/src/compat/container.ts
@@ -16,7 +16,7 @@ export function registerContainerCompat(userConfig: ResolvedConfig, designSystem
     return
   }
 
-  designSystem.utilities.static('container', () => rules)
+  designSystem.utilities.static('container', () => structuredClone(rules))
 }
 
 export function buildCustomContainerUtilityRules(

--- a/packages/tailwindcss/src/compat/container.ts
+++ b/packages/tailwindcss/src/compat/container.ts
@@ -65,6 +65,14 @@ export function buildCustomContainerUtilityRules(
     }
 
     for (let [key, value] of Object.entries(screens)) {
+      if (typeof value === 'object') {
+        if ('min' in value) {
+          value = value.min
+        } else {
+          continue
+        }
+      }
+
       // We're inlining the breakpoint values because the screens configured in
       // the `container` option do not have to match the ones defined in the
       // root `screen` setting.

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -904,7 +904,7 @@ export function createUtilities(theme: Theme) {
 
     let decls: AstNode[] = [decl('--tw-sort', '--tw-container-component'), decl('width', '100%')]
     for (let breakpoint of breakpoints) {
-      decls.push(atRule('@media', `(min-width: ${breakpoint})`, [decl('max-width', breakpoint)]))
+      decls.push(atRule('@media', `(width >= ${breakpoint})`, [decl('max-width', breakpoint)]))
     }
 
     return decls


### PR DESCRIPTION
This PR adds support for handling v3 [`container` customizations ](https://tailwindcss.com/docs/container#customizing). This is done by adding a custom utility to extend the core `container` utility. A concrete example can be taken from the added integration test.

### Input

```ts
/** @type {import('tailwindcss').Config} */
export default {
  content: ['./src/**/*.html'],
  theme: {
    container: {
      center: true,
      padding: {
        DEFAULT: '2rem',
        '2xl': '4rem',
      },
      screens: {
        md: '48rem', // Matches a default --breakpoint
        xl: '1280px',
        '2xl': '1536px',
      },
    },
  },
}
```

### Output

```css
@import "tailwindcss";

@utility container {
  margin-inline: auto;
  padding-inline: 2rem;

  @media (width >= theme(--breakpoint-sm)) {
    max-width: none;
  }

  @media (width >= 48rem) {
    max-width: 48rem;
  }

  @media (width >= 1280px) {
    max-width: 1280px;
  }

  @media (width >= 1536px) {
    max-width: 1536px;
    padding-inline: 4rem;
  }
}
````


## Test Plan

This PR adds extensive tests to the compat layer as part of unit tests. Additionally it does at a test to the codemod setup that shows that the right `@utility` code is generated. Furthermore I compared the implementation against v3 on both the compat layer and the custom `@utility`:

https://github.com/user-attachments/assets/44d6cbfb-4861-4225-9593-602b719f628f

