### PR TITLE
Improve multi-root `@config` linking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         on-next-branch:
           - ${{ github.ref == 'refs/heads/next' }}
         exclude:
-          - on-next-branch: false
+          - on-next-branch: true
             runner: windows-latest
           - on-next-branch: false
             runner: macos-14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         on-next-branch:
           - ${{ github.ref == 'refs/heads/next' }}
         exclude:
-          - on-next-branch: true
+          - on-next-branch: false
             runner: windows-latest
           - on-next-branch: false
             runner: macos-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure `flex` is suggested ([#15014](https://github.com/tailwindlabs/tailwindcss/pull/15014))
 - _Upgrade (experimental)_: Resolve imports when specifying a CSS entry point on the command-line ([#15010](https://github.com/tailwindlabs/tailwindcss/pull/15010))
-- _Upgrade (experimental)_: Resolve nearest Tailwind config file, when CSS file does not contain `@config` ([#15001](https://github.com/tailwindlabs/tailwindcss/pull/15001))
+- _Upgrade (experimental)_: Resolve nearest Tailwind config file when CSS file does not contain `@config` ([#15001](https://github.com/tailwindlabs/tailwindcss/pull/15001))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure `flex` is suggested ([#15014](https://github.com/tailwindlabs/tailwindcss/pull/15014))
 - _Upgrade (experimental)_: Resolve imports when specifying a CSS entry point on the command-line ([#15010](https://github.com/tailwindlabs/tailwindcss/pull/15010))
+- _Upgrade (experimental)_: Resolve nearest Tailwind config file, when CSS file does not contain `@config` ([#15001](https://github.com/tailwindlabs/tailwindcss/pull/15001))
 
 ### Changed
 

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -1731,6 +1731,7 @@ test(
       'package.json': json`
         {
           "dependencies": {
+            "tailwindcss": "^3",
             "@tailwindcss/upgrade": "workspace:^"
           }
         }
@@ -1864,6 +1865,7 @@ test(
       'package.json': json`
         {
           "dependencies": {
+            "tailwindcss": "^3",
             "@tailwindcss/upgrade": "workspace:^"
           }
         }

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -1453,7 +1453,7 @@ test(
           ],
         }
       `,
-      'src/root.4/base.css': css`@import 'tailwindcss/preflight';`,
+      'src/root.4/base.css': css`@import 'tailwindcss/base';`,
       'src/root.4/utilities.css': css`@import 'tailwindcss/utilities';`,
 
       'src/root.5/index.css': css`@import './tailwind.css';`,
@@ -1564,7 +1564,8 @@ test(
       @config './tailwind.config.ts';
 
       --- ./src/root.4/base.css ---
-      @import 'tailwindcss/preflight';
+      @import 'tailwindcss/theme' layer(theme);
+      @import 'tailwindcss/preflight' layer(base);
 
       /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
@@ -1678,7 +1679,7 @@ test(
         @import './root.4/base.css';
         @import './root.4/utilities.css';
       `,
-      'src/root.4/base.css': css`@import 'tailwindcss/preflight';`,
+      'src/root.4/base.css': css`@import 'tailwindcss/base';`,
       'src/root.4/utilities.css': css`@import 'tailwindcss/utilities';`,
 
       'src/root.5.css': css`@import './root.5/tailwind.css';`,

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -1,4 +1,3 @@
-import { stripVTControlCharacters } from 'node:util'
 import { expect } from 'vitest'
 import { candidate, css, html, js, json, test, ts } from '../utils'
 
@@ -1694,33 +1693,7 @@ test(
       (e) => e.toString(),
     )
 
-    output = stripVTControlCharacters(output)
-      .replace(/tailwindcss v(.*)/g, 'tailwindcss') // Remove the version number from the error message
-      .replace(/\\/g, '/') // Make Windows paths look like Unix paths
-
-    expect(output).toMatchInlineSnapshot(`
-      "Error: Command failed: npx @tailwindcss/upgrade --force
-      ≈ tailwindcss
-
-      │ Searching for CSS files in the current directory and its subdirectories…
-
-      │ Linked \`./tailwind.config.ts\` to \`./src/root.1.css\`
-
-      │ Linked \`./tailwind.config.ts\` to \`./src/root.3.css\`
-
-      │ Linked \`./tailwind.config.ts\` to \`./src/root.4.css\`
-
-      │ Linked \`./tailwind.config.ts\` to \`./src/root.5/tailwind.css\`
-
-      │ You have multiple stylesheets that do not have an \`@config\`.
-      │ Please add a \`@config "…";\` referencing the correct Tailwind config file to:
-      │ - ./src/root.1.css
-      │ - ./src/root.3.css
-      │ - ./src/root.4.css
-      │ - ./src/root.5/tailwind.css
-
-      "
-    `)
+    expect(output).toMatch('Could not determine configuration file for:')
   },
 )
 

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -1662,13 +1662,13 @@ test(
 
     expect(await fs.dumpFiles('./src/**/*.{html,css}')).toMatchInlineSnapshot(`
       "
+      --- ./src/index.css ---
+      @import './tailwind-setup.css';
+
       --- ./src/index.html ---
       <div
         class="flex! sm:block! bg-linear-to-t bg-(--my-red)"
       ></div>
-
-      --- ./src/index.css ---
-      @import './tailwind-setup.css';
 
       --- ./src/base.css ---
       @import 'tailwindcss/theme' layer(theme);
@@ -1797,13 +1797,13 @@ test(
 
     expect(await fs.dumpFiles('./src/**/*.{html,css}')).toMatchInlineSnapshot(`
       "
+      --- ./src/index.css ---
+      @import './tailwind-setup.css';
+
       --- ./src/index.html ---
       <div
         class="flex! sm:block! bg-linear-to-t bg-(--my-red)"
       ></div>
-
-      --- ./src/index.css ---
-      @import './tailwind-setup.css';
 
       --- ./src/base.css ---
       @import 'tailwindcss/theme' layer(theme);
@@ -2105,13 +2105,6 @@ test(
     // Files should not be modified
     expect(await fs.dumpFiles('./*.{js,css,html}')).toMatchInlineSnapshot(`
       "
-      --- index.html ---
-      <div>
-        <div class="shadow shadow-sm shadow-xs"></div>
-        <div class="blur blur-xs"></div>
-        <div class="rounded rounded-sm"></div>
-      </div>
-
       --- index.css ---
       @import 'tailwindcss';
 
@@ -2141,6 +2134,13 @@ test(
           border-color: var(--color-gray-200, currentColor);
         }
       }
+
+      --- index.html ---
+      <div>
+        <div class="shadow shadow-sm shadow-xs"></div>
+        <div class="blur blur-xs"></div>
+        <div class="rounded rounded-sm"></div>
+      </div>
       "
     `)
   },
@@ -2196,9 +2196,6 @@ test(
     // Files should not be modified
     expect(await fs.dumpFiles('./*.{js,css,html,tsx}')).toMatchInlineSnapshot(`
       "
-      --- index.html ---
-      <div class="rounded-sm blur-sm shadow-sm"></div>
-
       --- index.css ---
       @import 'tailwindcss';
 
@@ -2219,6 +2216,9 @@ test(
           border-color: var(--color-gray-200, currentColor);
         }
       }
+
+      --- index.html ---
+      <div class="rounded-sm blur-sm shadow-sm"></div>
 
       --- example-component.tsx ---
       type Star = [

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -1703,13 +1703,13 @@ test(
 
       │ Searching for CSS files in the current directory and its subdirectories…
 
-      │ Found config file: \`./tailwind.config.ts\` for \`./src/root.1.css\`
+      │ Linked \`./tailwind.config.ts\` to \`./src/root.1.css\`
 
-      │ Found config file: \`./tailwind.config.ts\` for \`./src/root.3.css\`
+      │ Linked \`./tailwind.config.ts\` to \`./src/root.3.css\`
 
-      │ Found config file: \`./tailwind.config.ts\` for \`./src/root.4.css\`
+      │ Linked \`./tailwind.config.ts\` to \`./src/root.4.css\`
 
-      │ Found config file: \`./tailwind.config.ts\` for \`./src/root.5/tailwind.css\`
+      │ Linked \`./tailwind.config.ts\` to \`./src/root.5/tailwind.css\`
 
       │ You have multiple stylesheets that do not have an \`@config\`.
       │ Please add a \`@config "…";\` referencing the correct Tailwind config file to:

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -346,15 +346,21 @@ export function test(
                 let zParts = z[0].split('/')
 
                 let aFile = aParts.at(-1)
-                let zFile = aParts.at(-1)
+                let zFile = zParts.at(-1)
 
                 // Sort by depth, shallow first
                 if (aParts.length < zParts.length) return -1
                 if (aParts.length > zParts.length) return 1
 
+                // Sort by folder names, alphabetically
+                for (let i = 0; i < aParts.length - 1; i++) {
+                  let diff = aParts[i].localeCompare(zParts[i])
+                  if (diff !== 0) return diff
+                }
+
                 // Sort by filename, sort files named `index` before others
-                if (aFile?.startsWith('index')) return -1
-                if (zFile?.startsWith('index')) return 1
+                if (aFile?.startsWith('index') && !zFile?.startsWith('index')) return -1
+                if (zFile?.startsWith('index') && !aFile?.startsWith('index')) return 1
 
                 // Sort by filename, alphabetically
                 return a[0].localeCompare(z[0])

--- a/packages/@tailwindcss-upgrade/src/index.ts
+++ b/packages/@tailwindcss-upgrade/src/index.ts
@@ -23,7 +23,7 @@ import { args, type Arg } from './utils/args'
 import { isRepoDirty } from './utils/git'
 import { hoistStaticGlobParts } from './utils/hoist-static-glob-parts'
 import { pkg } from './utils/packages'
-import { eprintln, error, header, highlight, info, success } from './utils/renderer'
+import { eprintln, error, header, highlight, info, relative, success } from './utils/renderer'
 
 const options = {
   '--config': { type: 'string', description: 'Path to the configuration file', alias: '-c' },
@@ -110,7 +110,6 @@ async function run() {
     }
 
     // Migrate js config files, linked to stylesheets
-    info('Migrating JavaScript configuration files using the provided configuration file.')
     let configBySheet = new Map<Stylesheet, Awaited<ReturnType<typeof prepareConfig>>>()
     let jsConfigMigrationBySheet = new Map<
       Stylesheet,
@@ -122,6 +121,7 @@ async function run() {
       let config = await prepareConfig(sheet.linkedConfigPath, { base })
       configBySheet.set(sheet, config)
 
+      info(`Migrating JavaScript configuration file: \`${relative(config.configFilePath, base)}\``)
       let jsConfigMigration = await migrateJsConfig(
         config.designSystem,
         config.configFilePath,
@@ -138,9 +138,10 @@ async function run() {
     // Migrate source files, linked to config files
     {
       // Template migrations
-
-      info('Migrating templates using the provided configuration file.')
       for (let config of configBySheet.values()) {
+        info(
+          `Migrating templates using the provided configuration file: \`${relative(config.configFilePath, base)}\`.`,
+        )
         let set = new Set<string>()
         for (let globEntry of config.globs.flatMap((entry) => hoistStaticGlobParts(entry))) {
           let files = await globby([globEntry.pattern], {
@@ -161,12 +162,13 @@ async function run() {
         await Promise.allSettled(
           files.map((file) => migrateTemplate(config.designSystem, config.userConfig, file)),
         )
-      }
 
-      success('Template migration complete.')
+        success('↳ Template migration complete.')
+      }
     }
 
     // Migrate each CSS file
+    info('Migrating stylesheets')
     let migrateResults = await Promise.allSettled(
       stylesheets.map((sheet) => {
         let config = configBySheet.get(sheet)!
@@ -233,7 +235,7 @@ async function run() {
       await fs.writeFile(sheet.file, sheet.root.toString())
     }
 
-    success('Stylesheet migration complete.')
+    success('↳ Stylesheet migration complete.')
   }
 
   {

--- a/packages/@tailwindcss-upgrade/src/index.ts
+++ b/packages/@tailwindcss-upgrade/src/index.ts
@@ -121,7 +121,9 @@ async function run() {
       let config = await prepareConfig(sheet.linkedConfigPath, { base })
       configBySheet.set(sheet, config)
 
-      info(`Migrating JavaScript configuration file: \`${relative(config.configFilePath, base)}\``)
+      info(
+        `Migrating JavaScript configuration file: ${highlight(relative(config.configFilePath, base))}`,
+      )
       let jsConfigMigration = await migrateJsConfig(
         config.designSystem,
         config.configFilePath,
@@ -140,7 +142,7 @@ async function run() {
       // Template migrations
       for (let config of configBySheet.values()) {
         info(
-          `Migrating templates using the provided configuration file: \`${relative(config.configFilePath, base)}\`.`,
+          `Migrating templates using the provided configuration file: ${highlight(relative(config.configFilePath, base))}.`,
         )
         let set = new Set<string>()
         for (let globEntry of config.globs.flatMap((entry) => hoistStaticGlobParts(entry))) {

--- a/packages/@tailwindcss-upgrade/src/index.ts
+++ b/packages/@tailwindcss-upgrade/src/index.ts
@@ -142,7 +142,7 @@ async function run() {
       // Template migrations
       for (let config of configBySheet.values()) {
         info(
-          `Migrating templates using the provided configuration file: ${highlight(relative(config.configFilePath, base))}.`,
+          `Migrating templates found using configuration file: ${highlight(relative(config.configFilePath, base))}.`,
         )
         let set = new Set<string>()
         for (let globEntry of config.globs.flatMap((entry) => hoistStaticGlobParts(entry))) {

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -44,7 +44,7 @@ export async function migrateJsConfig(
 
   if (!canMigrateConfig(unresolvedConfig, source)) {
     info(
-      `Your configuration file at ${highlight(relative(fullConfigPath, base))} could not be automatically migrated to the new CSS configuration format, so your CSS has been updated to load your existing configuration file.`,
+      `The configuration file at ${highlight(relative(fullConfigPath, base))} could not be automatically migrated to the new CSS configuration format, so your CSS has been updated to load your existing configuration file.`,
     )
     return null
   }

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -19,7 +19,7 @@ import type { DesignSystem } from '../../tailwindcss/src/design-system'
 import { escape } from '../../tailwindcss/src/utils/escape'
 import { isValidSpacingMultiplier } from '../../tailwindcss/src/utils/infer-data-type'
 import { findStaticPlugins, type StaticPluginOptions } from './utils/extract-static-plugins'
-import { info } from './utils/renderer'
+import { info, relative } from './utils/renderer'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -44,7 +44,7 @@ export async function migrateJsConfig(
 
   if (!canMigrateConfig(unresolvedConfig, source)) {
     info(
-      'Your configuration file could not be automatically migrated to the new CSS configuration format, so your CSS has been updated to load your existing configuration file.',
+      `Your configuration file at \`${relative(fullConfigPath, base)}\` could not be automatically migrated to the new CSS configuration format, so your CSS has been updated to load your existing configuration file.`,
     )
     return null
   }

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -19,7 +19,7 @@ import type { DesignSystem } from '../../tailwindcss/src/design-system'
 import { escape } from '../../tailwindcss/src/utils/escape'
 import { isValidSpacingMultiplier } from '../../tailwindcss/src/utils/infer-data-type'
 import { findStaticPlugins, type StaticPluginOptions } from './utils/extract-static-plugins'
-import { info, relative } from './utils/renderer'
+import { highlight, info, relative } from './utils/renderer'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -44,7 +44,7 @@ export async function migrateJsConfig(
 
   if (!canMigrateConfig(unresolvedConfig, source)) {
     info(
-      `Your configuration file at \`${relative(fullConfigPath, base)}\` could not be automatically migrated to the new CSS configuration format, so your CSS has been updated to load your existing configuration file.`,
+      `Your configuration file at ${highlight(relative(fullConfigPath, base))} could not be automatically migrated to the new CSS configuration format, so your CSS has been updated to load your existing configuration file.`,
     )
     return null
   }

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -44,7 +44,7 @@ export async function migrateJsConfig(
 
   if (!canMigrateConfig(unresolvedConfig, source)) {
     info(
-      `The configuration file at ${highlight(relative(fullConfigPath, base))} could not be automatically migrated to the new CSS configuration format, so your CSS has been updated to load your existing configuration file.`,
+      `↳ The configuration file at ${highlight(relative(fullConfigPath, base))} could not be automatically migrated to the new CSS configuration format, so your CSS has been updated to load your existing configuration file.`,
     )
     return null
   }

--- a/packages/@tailwindcss-upgrade/src/migrate-postcss.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-postcss.ts
@@ -24,7 +24,7 @@ export async function migratePostCSSConfig(base: string) {
   // Priority 1: Handle JS config files
   let jsConfigPath = await detectJSConfigPath(base)
   if (jsConfigPath) {
-    let result = await migratePostCSSJSConfig(base, jsConfigPath)
+    let result = await migratePostCSSJSConfig(jsConfigPath)
 
     if (result) {
       didMigrate = true
@@ -41,7 +41,7 @@ export async function migratePostCSSConfig(base: string) {
     packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'))
   } catch {}
   if (!didMigrate && packageJson && 'postcss' in packageJson) {
-    let result = await migratePostCSSJsonConfig(base, packageJson.postcss)
+    let result = await migratePostCSSJsonConfig(packageJson.postcss)
 
     if (result) {
       await fs.writeFile(
@@ -64,7 +64,7 @@ export async function migratePostCSSConfig(base: string) {
       jsonConfig = JSON.parse(await fs.readFile(jsonConfigPath, 'utf-8'))
     } catch {}
     if (jsonConfig) {
-      let result = await migratePostCSSJsonConfig(base, jsonConfig)
+      let result = await migratePostCSSJsonConfig(jsonConfig)
 
       if (result) {
         await fs.writeFile(jsonConfigPath, JSON.stringify(result.json, null, 2))
@@ -108,10 +108,7 @@ export async function migratePostCSSConfig(base: string) {
   success(`↳ PostCSS config has been upgraded.`)
 }
 
-async function migratePostCSSJSConfig(
-  base: string,
-  configPath: string,
-): Promise<{
+async function migratePostCSSJSConfig(configPath: string): Promise<{
   didAddPostcssClient: boolean
   didRemoveAutoprefixer: boolean
   didRemovePostCSSImport: boolean
@@ -131,7 +128,7 @@ async function migratePostCSSJSConfig(
 
   info(`Attempt to upgrade the PostCSS config in file: ${configPath}`)
 
-  let isSimpleConfig = await isSimplePostCSSConfig(base, configPath)
+  let isSimpleConfig = await isSimplePostCSSConfig(configPath)
   if (!isSimpleConfig) {
     warn(`The PostCSS config contains dynamic JavaScript and can not be automatically migrated.`)
     return null
@@ -141,8 +138,7 @@ async function migratePostCSSJSConfig(
   let didRemoveAutoprefixer = false
   let didRemovePostCSSImport = false
 
-  let fullPath = path.resolve(base, configPath)
-  let content = await fs.readFile(fullPath, 'utf-8')
+  let content = await fs.readFile(configPath, 'utf-8')
   let lines = content.split('\n')
   let newLines: string[] = []
   for (let i = 0; i < lines.length; i++) {
@@ -186,15 +182,12 @@ async function migratePostCSSJSConfig(
       newLines.push(line)
     }
   }
-  await fs.writeFile(fullPath, newLines.join('\n'))
+  await fs.writeFile(configPath, newLines.join('\n'))
 
   return { didAddPostcssClient, didRemoveAutoprefixer, didRemovePostCSSImport }
 }
 
-async function migratePostCSSJsonConfig(
-  base: string,
-  json: any,
-): Promise<{
+async function migratePostCSSJsonConfig(json: any): Promise<{
   json: any
   didAddPostcssClient: boolean
   didRemoveAutoprefixer: boolean
@@ -291,7 +284,7 @@ async function detectJSConfigPath(base: string): Promise<null | string> {
     let fullPath = path.resolve(base, file)
     try {
       await fs.access(fullPath)
-      return file
+      return fullPath
     } catch {}
   }
   return null
@@ -308,15 +301,14 @@ async function detectJSONConfigPath(base: string): Promise<null | string> {
     let fullPath = path.resolve(base, file)
     try {
       await fs.access(fullPath)
-      return file
+      return fullPath
     } catch {}
   }
   return null
 }
 
-async function isSimplePostCSSConfig(base: string, configPath: string): Promise<boolean> {
-  let fullPath = path.resolve(base, configPath)
-  let content = await fs.readFile(fullPath, 'utf-8')
+async function isSimplePostCSSConfig(configPath: string): Promise<boolean> {
+  let content = await fs.readFile(configPath, 'utf-8')
   return (
     content.includes('tailwindcss:') &&
     !(

--- a/packages/@tailwindcss-upgrade/src/migrate-postcss.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-postcss.ts
@@ -126,7 +126,7 @@ async function migratePostCSSJSConfig(configPath: string): Promise<{
     return /['"]tailwindcss\/nesting['"]\: ?(\{\}|['"]postcss-nesting['"])/.test(line)
   }
 
-  info(`Attempt to upgrade the PostCSS config in file: ${highlight(relative(configPath))}`)
+  info(`Upgrading the PostCSS config in file: ${highlight(relative(configPath))}`)
 
   let isSimpleConfig = await isSimplePostCSSConfig(configPath)
   if (!isSimpleConfig) {

--- a/packages/@tailwindcss-upgrade/src/migrate-postcss.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-postcss.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { pkg } from './utils/packages'
-import { info, success, warn } from './utils/renderer'
+import { info, relative, success, warn } from './utils/renderer'
 
 // Migrates simple PostCSS setups. This is to cover non-dynamic config files
 // similar to the ones we have all over our docs:
@@ -126,7 +126,7 @@ async function migratePostCSSJSConfig(configPath: string): Promise<{
     return /['"]tailwindcss\/nesting['"]\: ?(\{\}|['"]postcss-nesting['"])/.test(line)
   }
 
-  info(`Attempt to upgrade the PostCSS config in file: ${configPath}`)
+  info(`Attempt to upgrade the PostCSS config in file: \`${relative(configPath)}\``)
 
   let isSimpleConfig = await isSimplePostCSSConfig(configPath)
   if (!isSimpleConfig) {

--- a/packages/@tailwindcss-upgrade/src/migrate-postcss.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-postcss.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { pkg } from './utils/packages'
-import { info, relative, success, warn } from './utils/renderer'
+import { highlight, info, relative, success, warn } from './utils/renderer'
 
 // Migrates simple PostCSS setups. This is to cover non-dynamic config files
 // similar to the ones we have all over our docs:
@@ -78,7 +78,7 @@ export async function migratePostCSSConfig(base: string) {
   }
 
   if (!didMigrate) {
-    info(`No PostCSS config found, skipping migration.`)
+    info('No PostCSS config found, skipping migration.')
     return
   }
 
@@ -126,7 +126,7 @@ async function migratePostCSSJSConfig(configPath: string): Promise<{
     return /['"]tailwindcss\/nesting['"]\: ?(\{\}|['"]postcss-nesting['"])/.test(line)
   }
 
-  info(`Attempt to upgrade the PostCSS config in file: \`${relative(configPath)}\``)
+  info(`Attempt to upgrade the PostCSS config in file: ${highlight(relative(configPath))}`)
 
   let isSimpleConfig = await isSimplePostCSSConfig(configPath)
   if (!isSimpleConfig) {

--- a/packages/@tailwindcss-upgrade/src/migrate-postcss.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-postcss.ts
@@ -105,7 +105,7 @@ export async function migratePostCSSConfig(base: string) {
     } catch {}
   }
 
-  success(`PostCSS config has been upgraded.`)
+  success(`↳ PostCSS config has been upgraded.`)
 }
 
 async function migratePostCSSJSConfig(

--- a/packages/@tailwindcss-upgrade/src/migrate-postcss.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-postcss.ts
@@ -92,6 +92,7 @@ export async function migratePostCSSConfig(base: string) {
     if (location !== null) {
       try {
         await pkg(base).add(['@tailwindcss/postcss@next'], location)
+        success(`↳ Installed package: ${highlight('@tailwindcss/postcss')}`)
       } catch {}
     }
   }
@@ -102,10 +103,15 @@ export async function migratePostCSSConfig(base: string) {
         didRemovePostCSSImport ? 'postcss-import' : null,
       ].filter(Boolean) as string[]
       await pkg(base).remove(packagesToRemove)
+      for (let pkg of packagesToRemove) {
+        success(`↳ Removed package: ${highlight(pkg)}`)
+      }
     } catch {}
   }
 
-  success(`↳ PostCSS config has been upgraded.`)
+  if (didMigrate && jsConfigPath) {
+    success(`↳ Migrated PostCSS configuration: ${highlight(relative(jsConfigPath, base))}`)
+  }
 }
 
 async function migratePostCSSJSConfig(configPath: string): Promise<{
@@ -126,11 +132,11 @@ async function migratePostCSSJSConfig(configPath: string): Promise<{
     return /['"]tailwindcss\/nesting['"]\: ?(\{\}|['"]postcss-nesting['"])/.test(line)
   }
 
-  info(`Upgrading the PostCSS config in file: ${highlight(relative(configPath))}`)
+  info('Migrating PostCSS configuration…')
 
   let isSimpleConfig = await isSimplePostCSSConfig(configPath)
   if (!isSimpleConfig) {
-    warn(`The PostCSS config contains dynamic JavaScript and can not be automatically migrated.`)
+    warn('The PostCSS config contains dynamic JavaScript and can not be automatically migrated.')
     return null
   }
 

--- a/packages/@tailwindcss-upgrade/src/migrate-prettier.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-prettier.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { pkg } from './utils/packages'
-import { success } from './utils/renderer'
+import { highlight, success } from './utils/renderer'
 
 export async function migratePrettierPlugin(base: string) {
   let packageJsonPath = path.resolve(base, 'package.json')
@@ -9,7 +9,7 @@ export async function migratePrettierPlugin(base: string) {
     let packageJson = await fs.readFile(packageJsonPath, 'utf-8')
     if (packageJson.includes('prettier-plugin-tailwindcss')) {
       await pkg(base).add(['prettier-plugin-tailwindcss@latest'])
-      success(`Prettier plugin migrated to latest version.`)
+      success(`↳ Updated package: ${highlight('prettier-plugin-tailwindcss')}`)
     }
   } catch {}
 }

--- a/packages/@tailwindcss-upgrade/src/migrate.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate.ts
@@ -377,9 +377,7 @@ export async function linkConfigs(
       localConfigPath = path.resolve(base, localConfigPath)
     }
 
-    info(
-      `Found config file: \`${relative(localConfigPath, base)}\` for \`${relative(sheet.file, base)}\``,
-    )
+    info(`Linked \`${relative(localConfigPath, base)}\` to \`${relative(sheet.file, base)}\``)
     configPathBySheet.set(sheet, localConfigPath)
     sheetByConfigPath.get(localConfigPath).add(sheet)
   }

--- a/packages/@tailwindcss-upgrade/src/migrate.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate.ts
@@ -19,7 +19,7 @@ import { migrateVariantsDirective } from './codemods/migrate-variants-directive'
 import type { JSConfigMigration } from './migrate-js-config'
 import { Stylesheet, type StylesheetConnection, type StylesheetId } from './stylesheet'
 import { detectConfigPath } from './template/prepare-config'
-import { error, info, relative } from './utils/renderer'
+import { error, highlight, info, relative } from './utils/renderer'
 import { resolveCssId } from './utils/resolve'
 import { walk, WalkAction } from './utils/walk'
 
@@ -377,7 +377,9 @@ export async function linkConfigs(
       localConfigPath = path.resolve(base, localConfigPath)
     }
 
-    info(`Linked \`${relative(localConfigPath, base)}\` to \`${relative(sheet.file, base)}\``)
+    info(
+      `Linked ${highlight(relative(localConfigPath, base))} to ${highlight(relative(sheet.file, base))}`,
+    )
     configPathBySheet.set(sheet, localConfigPath)
     sheetByConfigPath.get(localConfigPath).add(sheet)
   }

--- a/packages/@tailwindcss-upgrade/src/template/prepare-config.ts
+++ b/packages/@tailwindcss-upgrade/src/template/prepare-config.ts
@@ -6,7 +6,7 @@ import { loadModule } from '../../../@tailwindcss-node/src/compile'
 import { resolveConfig } from '../../../tailwindcss/src/compat/config/resolve-config'
 import type { Config } from '../../../tailwindcss/src/compat/plugin-api'
 import type { DesignSystem } from '../../../tailwindcss/src/design-system'
-import { error, relative } from '../utils/renderer'
+import { error, highlight, relative } from '../utils/renderer'
 import { migratePrefix } from './codemods/prefix'
 
 const __filename = fileURLToPath(import.meta.url)
@@ -106,7 +106,7 @@ export async function detectConfigPath(start: string, end: string = start) {
   }
 
   throw new Error(
-    `No configuration file found for \`${relative(start)}\`. Please provide a path to the Tailwind CSS v3 config file via the \`--config\` option.`,
+    `No configuration file found for ${highlight(relative(start))}. Please provide a path to the Tailwind CSS v3 config file via the ${highlight('--config')} option.`,
   )
 }
 

--- a/packages/@tailwindcss-upgrade/src/template/prepare-config.ts
+++ b/packages/@tailwindcss-upgrade/src/template/prepare-config.ts
@@ -6,7 +6,7 @@ import { loadModule } from '../../../@tailwindcss-node/src/compile'
 import { resolveConfig } from '../../../tailwindcss/src/compat/config/resolve-config'
 import type { Config } from '../../../tailwindcss/src/compat/plugin-api'
 import type { DesignSystem } from '../../../tailwindcss/src/design-system'
-import { error } from '../utils/renderer'
+import { error, relative } from '../utils/renderer'
 import { migratePrefix } from './codemods/prefix'
 
 const __filename = fileURLToPath(import.meta.url)
@@ -94,15 +94,36 @@ const DEFAULT_CONFIG_FILES = [
   './tailwind.config.cts',
   './tailwind.config.mts',
 ]
-export async function detectConfigPath(base: string) {
-  for (let file of DEFAULT_CONFIG_FILES) {
-    let fullPath = path.resolve(base, file)
-    try {
-      await fs.access(fullPath)
-      return file
-    } catch {}
+export async function detectConfigPath(start: string, end: string = start) {
+  for (let base of parentPaths(start, end)) {
+    for (let file of DEFAULT_CONFIG_FILES) {
+      let fullPath = path.resolve(base, file)
+      try {
+        await fs.access(fullPath)
+        return fullPath
+      } catch {}
+    }
   }
+
   throw new Error(
-    'No configuration file found. Please provide a path to the Tailwind CSS v3 config file via the `--config` option.',
+    `No configuration file found for \`${relative(start)}\`. Please provide a path to the Tailwind CSS v3 config file via the \`--config\` option.`,
   )
+}
+
+// Yields all parent paths from `from` to `to` (inclusive on both ends)
+function* parentPaths(from: string, to: string = from) {
+  let fromAbsolute = path.resolve(from)
+  let toAbsolute = path.resolve(to)
+
+  if (fromAbsolute === toAbsolute) {
+    yield fromAbsolute
+    return
+  }
+
+  let current = fromAbsolute
+  do {
+    yield current
+    current = path.dirname(current)
+  } while (current !== toAbsolute)
+  yield toAbsolute
 }

--- a/packages/@tailwindcss-upgrade/src/template/prepare-config.ts
+++ b/packages/@tailwindcss-upgrade/src/template/prepare-config.ts
@@ -115,6 +115,10 @@ function* parentPaths(from: string, to: string = from) {
   let fromAbsolute = path.resolve(from)
   let toAbsolute = path.resolve(to)
 
+  if (!fromAbsolute.startsWith(toAbsolute)) {
+    throw new Error(`The path ${from} is not a parent of ${to}`)
+  }
+
   if (fromAbsolute === toAbsolute) {
     yield fromAbsolute
     return


### PR DESCRIPTION
This PR improves the discoverability of Tailwind config files when we are trying to link them to your CSS files.

When you have multiple "root" CSS files in your project, and if they don't include an `@config` directive, then we tried to find the Tailwind config file in your current working directory.

This means that if you run the upgrade command from the root of your project, and you have a nested folder with a separate Tailwind setup, then the nested CSS file would link to the root Tailwind config file.

Visually, you can think of it like this:

```
.
├── admin
│   ├── src
│   │   └── styles
│   │       └── index.css       <-- This will be linked to (1)
│   └── tailwind.config.js      (2)
├── src
│   └── styles
│       └── index.css           <-- This will be linked to (1)
└── tailwind.config.js          (1)
```

If you run the upgrade command from the root of your project, then the `/src/styles/index.css` will be linked to `/tailwind.config.js` which is what we expect.

But `/admin/src/styles/index.css` will _also_ be linked to `/tailwind.config.js`

With this PR we improve this behavior by looking at the CSS file, and crawling up the parent tree. This mens that the new behavior looks like this:

```
.
├── admin
│   ├── src
│   │   └── styles
│   │       └── index.css       <-- This will be linked to (2)
│   └── tailwind.config.js      (2)
├── src
│   └── styles
│       └── index.css           <-- This will be linked to (1)
└── tailwind.config.js          (1)
```

Now `/src/styles/index.css` will be linked to `/tailwind.config.js`, and `/admin/src/styles/index.css` will be linked to `/admin/tailwind.config.js`.

When we discover the Tailwind config file, we will also print a message to the user to let them know which CSS file is linked to which Tailwind config file.

This should be a safe improvement because if your Tailwind config file had a different name, or if it lived in a sibling folder then Tailwind wouldn't find it either and you already required a `@config "…";` directive in your CSS file to point to the correct file.

In the unlikely event that it turns out that 2 (or more) CSS files resolve to the same to the same Tailwind config file, then an upgrade might not be safe and some manual intervention might be needed. In this case, we will show a warning about this.

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/7a1ad11d-18c5-4b7d-9a02-14f0116ae955">


Test plan:
---

- Added an integration test that properly links the nearest Tailwind config file by looking up the tree
- Added an integration test that resolves 2 or more CSS files to the same config file, resulting in an error where manual intervention is needed
- Ran it on the Tailwind UI codebase

Running this on Tailwind UI's codebase it looks like this:

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/21785428-5e0d-47f7-80ec-dab497f58784">

