### PR TITLE
Resolve imports from CSS file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Ensure `flex` is suggested ([#15014](https://github.com/tailwindlabs/tailwindcss/pull/15014))
+- _Upgrade (experimental)_: Resolve imports from passed CSS file(s) ([#15010](https://github.com/tailwindlabs/tailwindcss/pull/15010))
 
 ### Changed
 

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -239,7 +239,7 @@ test(
       'package.json': json`
         {
           "dependencies": {
-            "tailwindcss": "workspace:^",
+            "tailwindcss": "^3",
             "@tailwindcss/upgrade": "workspace:^"
           }
         }
@@ -1000,14 +1000,14 @@ test(
       'package.json': json`
         {
           "dependencies": {
-            "tailwindcss": "workspace:^",
+            "tailwindcss": "^3",
             "@tailwindcss/upgrade": "workspace:^"
           }
         }
       `,
       'tailwind.config.js': js`module.exports = {}`,
       'src/index.css': css`
-        @import 'tailwindcss';
+        @import 'tailwindcss/tailwind.css';
         @import './utilities.css' layer(utilities);
       `,
       'src/utilities.css': css`
@@ -1069,7 +1069,7 @@ test(
       'package.json': json`
         {
           "dependencies": {
-            "tailwindcss": "workspace:^",
+            "tailwindcss": "^3",
             "@tailwindcss/upgrade": "workspace:^"
           }
         }
@@ -1123,7 +1123,7 @@ test(
       'package.json': json`
         {
           "dependencies": {
-            "tailwindcss": "workspace:^",
+            "tailwindcss": "^3",
             "@tailwindcss/cli": "workspace:^",
             "@tailwindcss/upgrade": "workspace:^"
           }
@@ -1310,7 +1310,7 @@ test(
       'package.json': json`
         {
           "dependencies": {
-            "tailwindcss": "workspace:^",
+            "tailwindcss": "^3",
             "@tailwindcss/cli": "workspace:^",
             "@tailwindcss/upgrade": "workspace:^"
           }
@@ -1376,6 +1376,7 @@ test(
       'package.json': json`
         {
           "dependencies": {
+            "tailwindcss": "^3",
             "@tailwindcss/upgrade": "workspace:^"
           }
         }
@@ -1435,7 +1436,7 @@ test(
       'src/root.5.css': css`@import './root.5/tailwind.css';`,
       'src/root.5/tailwind.css': css`
         /* Inject missing @config in this file, due to full import */
-        @import 'tailwindcss';
+        @import 'tailwindcss/tailwind.css';
       `,
     },
   },
@@ -1871,7 +1872,7 @@ test(
       'package.json': json`
         {
           "dependencies": {
-            "tailwindcss": "workspace:^",
+            "tailwindcss": "^3",
             "@tailwindcss/upgrade": "workspace:^"
           }
         }
@@ -1933,7 +1934,7 @@ test(
       'package.json': json`
         {
           "dependencies": {
-            "tailwindcss": "workspace:^",
+            "tailwindcss": "^3",
             "@tailwindcss/upgrade": "workspace:^"
           }
         }
@@ -2017,7 +2018,7 @@ test(
       'package.json': json`
         {
           "dependencies": {
-            "tailwindcss": "workspace:^",
+            "tailwindcss": "^3",
             "@tailwindcss/upgrade": "workspace:^"
           },
           "devDependencies": {
@@ -2047,7 +2048,7 @@ test(
       'package.json': json`
         {
           "dependencies": {
-            "tailwindcss": "^3.4.14",
+            "tailwindcss": "^3",
             "@tailwindcss/upgrade": "workspace:^"
           },
           "devDependencies": {
@@ -2152,7 +2153,7 @@ test(
       'package.json': json`
         {
           "dependencies": {
-            "tailwindcss": "^3.4.14",
+            "tailwindcss": "^3",
             "@tailwindcss/upgrade": "workspace:^"
           },
           "devDependencies": {
@@ -2244,7 +2245,7 @@ test(
       'package.json': json`
         {
           "dependencies": {
-            "tailwindcss": "^3.4.14",
+            "tailwindcss": "^3",
             "@tailwindcss/upgrade": "workspace:^"
           }
         }

--- a/packages/@tailwindcss-upgrade/src/index.ts
+++ b/packages/@tailwindcss-upgrade/src/index.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
-import { globby } from 'globby'
+import { globby, isGitIgnored } from 'globby'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import postcss from 'postcss'
+import atImport from 'postcss-import'
 import { formatNodes } from './codemods/format-nodes'
 import { sortBuckets } from './codemods/sort-buckets'
 import { help } from './commands/help'
@@ -78,19 +79,44 @@ async function run() {
     // Ensure we are only dealing with CSS files
     files = files.filter((file) => file.endsWith('.css'))
 
-    // Analyze the stylesheets
-    let loadResults = await Promise.allSettled(files.map((filepath) => Stylesheet.load(filepath)))
+    // Load the stylesheets and their imports
+    let sheetsByFile = new Map<string, Stylesheet>()
+    let isIgnored = await isGitIgnored()
+    let queue = files.slice()
+    while (queue.length > 0) {
+      let file = queue.shift()!
 
-    // Load and parse all stylesheets
-    for (let result of loadResults) {
-      if (result.status === 'rejected') {
-        error(`${result.reason}`)
+      // Already handled
+      if (sheetsByFile.has(file)) continue
+
+      // We don't want to process ignored files (like node_modules)
+      if (isIgnored(file)) continue
+
+      let sheet = await Stylesheet.load(file).catch((e) => {
+        error(`${e}`)
+        return null
+      })
+      if (!sheet) continue
+
+      // Track the sheet by its file
+      sheetsByFile.set(file, sheet)
+
+      // We process the stylesheet which will also process its imports and
+      // inline everything. We still want to handle the imports separately, so
+      // we just use the postcss-import messages to find the imported files.
+      //
+      // We can't use the `sheet.root` directly because this will mutate the
+      // `sheet.root`
+      let processed = await postcss().use(atImport()).process(sheet.root.toString(), { from: file })
+
+      for (let msg of processed.messages) {
+        if (msg.type === 'dependency' && msg.plugin === 'postcss-import') {
+          queue.push(msg.file)
+        }
       }
     }
 
-    let stylesheets = loadResults
-      .filter((result) => result.status === 'fulfilled')
-      .map((result) => result.value)
+    let stylesheets = Array.from(sheetsByFile.values())
 
     // Analyze the stylesheets
     try {

--- a/packages/@tailwindcss-upgrade/src/index.ts
+++ b/packages/@tailwindcss-upgrade/src/index.ts
@@ -67,9 +67,7 @@ async function run() {
 
     // Discover CSS files in case no files were provided
     if (files.length === 0) {
-      info(
-        'No input stylesheets provided. Searching for CSS files in the current directory and its subdirectories…',
-      )
+      info('Searching for CSS files in the current directory and its subdirectories…')
 
       files = await globby(['**/*.css'], {
         absolute: true,

--- a/packages/@tailwindcss-upgrade/src/stylesheet.ts
+++ b/packages/@tailwindcss-upgrade/src/stylesheet.ts
@@ -1,3 +1,4 @@
+import * as fsSync from 'node:fs'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import * as util from 'node:util'
@@ -67,6 +68,15 @@ export class Stylesheet {
     filepath = path.resolve(process.cwd(), filepath)
 
     let css = await fs.readFile(filepath, 'utf-8')
+    let root = postcss.parse(css, { from: filepath })
+
+    return new Stylesheet(root, filepath)
+  }
+
+  static loadSync(filepath: string) {
+    filepath = path.resolve(process.cwd(), filepath)
+
+    let css = fsSync.readFileSync(filepath, 'utf-8')
     let root = postcss.parse(css, { from: filepath })
 
     return new Stylesheet(root, filepath)


### PR DESCRIPTION
This PR adds an improvement to the upgrade tool to make sure that if you pass a single CSS file, that the upgrade tool resolves all the imports in that file and processes them as well.


Test plan:
---

Created a project where `index.css` imports `other.css`. Another `leave-me-alone.css` is created to proof that this file is _not_ changed. Running the upgrade guide using `index.css` also migrates `other.css` but not `leave-me-alone.css`.

Here is a video so you don't have to manually create it:


https://github.com/user-attachments/assets/20decf77-77d2-4a7c-8ff1-accb1c77f8c1

