### PR TITLE
Make `flex` a static utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure `flex` is suggested ([#15014](https://github.com/tailwindlabs/tailwindcss/pull/15014))
+
 ### Changed
 
 - Bring back support for color opacity modifiers to read from `--opacity-*` theme values ([#14278](https://github.com/tailwindlabs/tailwindcss/pull/14278))

--- a/packages/tailwindcss/src/__snapshots__/intellisense.test.ts.snap
+++ b/packages/tailwindcss/src/__snapshots__/intellisense.test.ts.snap
@@ -3718,6 +3718,7 @@ exports[`getClassList 1`] = `
   "fill-transparent/95",
   "fill-transparent/100",
   "fixed",
+  "flex",
   "flex-auto",
   "flex-col",
   "flex-col-reverse",

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -812,6 +812,7 @@ export function createUtilities(theme: Theme) {
   staticUtility('table-row-group', [['display', 'table-row-group']])
   staticUtility('table-row', [['display', 'table-row']])
   staticUtility('flow-root', [['display', 'flow-root']])
+  staticUtility('flex', [['display', 'flex']])
   staticUtility('grid', [['display', 'grid']])
   staticUtility('inline-grid', [['display', 'inline-grid']])
   staticUtility('contents', [['display', 'contents']])
@@ -932,10 +933,7 @@ export function createUtilities(theme: Theme) {
   // generate `flex: 1`. Our `functionalUtility` helper can't handle two properties
   // using the same namespace, so we handle this one manually.
   utilities.functional('flex', (candidate) => {
-    if (!candidate.value) {
-      if (candidate.modifier) return
-      return [decl('display', 'flex')]
-    }
+    if (!candidate.value) return
 
     if (candidate.value.kind === 'arbitrary') {
       if (candidate.modifier) return


### PR DESCRIPTION
This PR makes `flex` a static utility, which also means that it is located near the other static `display` utilities.

This is possible because we changed how `parseCandidate` returns an array of utilities instead of a single utility.

This makes the code more consistent and a bit easier to understand.

Bonus: turns out that `flex` was never suggested to intellisense, but now it is!
