### PR TITLE
Upgrade: Error when project is already using Tailwind CSS v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add new `in-*` variant ([#15025](https://github.com/tailwindlabs/tailwindcss/pull/15025))
 - _Upgrade (experimental)_: Migrate `[&>*]` to the `*` variant ([#15022](https://github.com/tailwindlabs/tailwindcss/pull/15022))
 - _Upgrade (experimental)_: Migrate `[&_*]` to the `**` variant ([#15022](https://github.com/tailwindlabs/tailwindcss/pull/15022))
+- _Upgrade (experimental)_: Warn when trying to migrating a project that is not on Tailwind CSS v3 ([#15015](https://github.com/tailwindlabs/tailwindcss/pull/15015))
 
 ### Fixed
 

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -1,4 +1,3 @@
-import { stripVTControlCharacters } from 'node:util'
 import { expect } from 'vitest'
 import { candidate, css, html, js, json, test, ts } from '../utils'
 
@@ -2492,10 +2491,6 @@ test(
     let output = await exec('npx @tailwindcss/upgrade', {}, { ignoreStdErr: true }).catch((e) =>
       e.toString(),
     )
-
-    output = stripVTControlCharacters(output)
-      .replace(/tailwindcss v(.*)/g, 'tailwindcss') // Remove the version number from the error message
-      .replace(/\\/g, '/') // Make Windows paths look like Unix paths
 
     expect(output).toMatch(
       /Tailwind CSS v.* found. The migration tool can only be run on v3 projects./,

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -2464,7 +2464,7 @@ test(
   },
 )
 
-test(
+test.only(
   'requires Tailwind v3 before attempting an upgrade',
   {
     fs: {

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -2464,7 +2464,7 @@ test(
   },
 )
 
-test.only(
+test(
   'requires Tailwind v3 before attempting an upgrade',
   {
     fs: {

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -954,6 +954,7 @@ test(
       'package.json': json`
         {
           "dependencies": {
+            "tailwindcss": "^3",
             "@tailwindcss/upgrade": "workspace:^"
           }
         }

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -9,6 +9,7 @@ test(
       'package.json': json`
         {
           "dependencies": {
+            "tailwindcss": "^3",
             "@tailwindcss/upgrade": "workspace:^"
           }
         }
@@ -297,6 +298,7 @@ test(
       'package.json': json`
         {
           "dependencies": {
+            "tailwindcss": "^3",
             "@tailwindcss/typography": "^0.5.15",
             "@tailwindcss/upgrade": "workspace:^"
           }
@@ -404,6 +406,7 @@ test(
       'package.json': json`
         {
           "dependencies": {
+            "tailwindcss": "^3",
             "@tailwindcss/upgrade": "workspace:^"
           }
         }
@@ -485,6 +488,7 @@ test(
       'package.json': json`
         {
           "dependencies": {
+            "tailwindcss": "^3",
             "@tailwindcss/upgrade": "workspace:^"
           }
         }
@@ -572,6 +576,7 @@ test(
       'package.json': json`
         {
           "dependencies": {
+            "tailwindcss": "^3",
             "@tailwindcss/upgrade": "workspace:^"
           }
         }
@@ -640,6 +645,7 @@ test(
       'package.json': json`
         {
           "dependencies": {
+            "tailwindcss": "^3",
             "@tailwindcss/upgrade": "workspace:^"
           }
         }
@@ -718,6 +724,7 @@ test(
       'package.json': json`
         {
           "dependencies": {
+            "tailwindcss": "^3",
             "@tailwindcss/upgrade": "workspace:^"
           }
         }
@@ -838,6 +845,7 @@ test(
       'package.json': json`
         {
           "dependencies": {
+            "tailwindcss": "^3",
             "@tailwindcss/upgrade": "workspace:^"
           }
         }
@@ -915,6 +923,7 @@ describe('border compatibility', () => {
         'package.json': json`
           {
             "dependencies": {
+              "tailwindcss": "^3",
               "@tailwindcss/upgrade": "workspace:^"
             }
           }
@@ -973,6 +982,7 @@ describe('border compatibility', () => {
         'package.json': json`
           {
             "dependencies": {
+              "tailwindcss": "^3",
               "@tailwindcss/upgrade": "workspace:^"
             }
           }
@@ -1034,6 +1044,7 @@ describe('border compatibility', () => {
         'package.json': json`
           {
             "dependencies": {
+              "tailwindcss": "^3",
               "@tailwindcss/upgrade": "workspace:^"
             }
           }
@@ -1077,6 +1088,7 @@ describe('border compatibility', () => {
         'package.json': json`
           {
             "dependencies": {
+              "tailwindcss": "^3",
               "@tailwindcss/upgrade": "workspace:^"
             }
           }
@@ -1136,6 +1148,7 @@ describe('border compatibility', () => {
         'package.json': json`
           {
             "dependencies": {
+              "tailwindcss": "^3",
               "@tailwindcss/upgrade": "workspace:^"
             }
           }
@@ -1219,6 +1232,7 @@ describe('border compatibility', () => {
         'package.json': json`
           {
             "dependencies": {
+              "tailwindcss": "^3",
               "@tailwindcss/upgrade": "workspace:^"
             }
           }
@@ -1330,6 +1344,7 @@ describe('border compatibility', () => {
         'package.json': json`
           {
             "dependencies": {
+              "tailwindcss": "^3",
               "@tailwindcss/upgrade": "workspace:^"
             }
           }
@@ -1443,6 +1458,7 @@ describe('border compatibility', () => {
         'package.json': json`
           {
             "dependencies": {
+              "tailwindcss": "^3",
               "@tailwindcss/upgrade": "workspace:^"
             }
           }

--- a/packages/@tailwindcss-upgrade/src/index.ts
+++ b/packages/@tailwindcss-upgrade/src/index.ts
@@ -62,6 +62,7 @@ async function run() {
 
     // Require an installed `tailwindcss` version < 4
     let tailwindVersion = await getPackageVersion('tailwindcss', base)
+    console.error({ tailwindVersion })
     if (tailwindVersion && Number(tailwindVersion.split('.')[0]) !== 3) {
       error(
         `Tailwind CSS v${tailwindVersion} found. The migration tool can only be run on v3 projects.`,

--- a/packages/@tailwindcss-upgrade/src/index.ts
+++ b/packages/@tailwindcss-upgrade/src/index.ts
@@ -62,7 +62,7 @@ async function run() {
 
     // Require an installed `tailwindcss` version < 4
     let tailwindVersion = await getPackageVersion('tailwindcss', base)
-    if (tailwindVersion && Number(tailwindVersion.split('.')[0]) > 3) {
+    if (tailwindVersion && Number(tailwindVersion.split('.')[0]) !== 3) {
       error(
         `Tailwind CSS v${tailwindVersion} found. The migration tool can only be run on v3 projects.`,
       )

--- a/packages/@tailwindcss-upgrade/src/index.ts
+++ b/packages/@tailwindcss-upgrade/src/index.ts
@@ -62,7 +62,6 @@ async function run() {
 
     // Require an installed `tailwindcss` version < 4
     let tailwindVersion = await getPackageVersion('tailwindcss', base)
-    console.error({ tailwindVersion })
     if (tailwindVersion && Number(tailwindVersion.split('.')[0]) !== 3) {
       error(
         `Tailwind CSS v${tailwindVersion} found. The migration tool can only be run on v3 projects.`,

--- a/packages/@tailwindcss-upgrade/src/index.ts
+++ b/packages/@tailwindcss-upgrade/src/index.ts
@@ -59,18 +59,15 @@ async function run() {
       )
       process.exit(1)
     }
+  }
 
-    // Require an installed `tailwindcss` version < 4
-    let tailwindVersion = await getPackageVersion('tailwindcss', base)
-    if (tailwindVersion && Number(tailwindVersion.split('.')[0]) !== 3) {
-      error(
-        `Tailwind CSS v${tailwindVersion} found. The migration tool can only be run on v3 projects.`,
-      )
-      info(
-        `You may use the ${highlight('--force')} flag to silence this warning and perform the migration.`,
-      )
-      process.exit(1)
-    }
+  // Require an installed `tailwindcss` version < 4
+  let tailwindVersion = await getPackageVersion('tailwindcss', base)
+  if (tailwindVersion && Number(tailwindVersion.split('.')[0]) !== 3) {
+    error(
+      `Tailwind CSS v${tailwindVersion} found. The migration tool can only be run on v3 projects.`,
+    )
+    process.exit(1)
   }
 
   {

--- a/packages/@tailwindcss-upgrade/src/utils/package-version.ts
+++ b/packages/@tailwindcss-upgrade/src/utils/package-version.ts
@@ -1,4 +1,7 @@
 import fs from 'node:fs/promises'
+import { createRequire } from 'node:module'
+
+const localResolve = createRequire(import.meta.url).resolve
 
 /**
  * Resolves the version string of an npm dependency installed in the based
@@ -6,7 +9,7 @@ import fs from 'node:fs/promises'
  */
 export async function getPackageVersion(pkg: string, base: string): Promise<string | null> {
   try {
-    let packageJson = require.resolve(`${pkg}/package.json`, { paths: [base] })
+    let packageJson = localResolve(`${pkg}/package.json`, { paths: [base] })
     let { version } = JSON.parse(await fs.readFile(packageJson, 'utf8'))
     return version
   } catch {

--- a/packages/@tailwindcss-upgrade/src/utils/package-version.ts
+++ b/packages/@tailwindcss-upgrade/src/utils/package-version.ts
@@ -1,0 +1,17 @@
+import fs from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+/**
+ * Resolves the version string of an npm dependency installed in the based
+ * directory.
+ */
+export async function getPackageVersion(pkg: string, base: string): Promise<string | null> {
+  try {
+    console.log('getPackageVersion', pkg, base)
+    const packageJson = resolve(base, 'node_modules', pkg, 'package.json')
+    const { version } = JSON.parse(await fs.readFile(packageJson, 'utf8'))
+    return version
+  } catch {
+    return null
+  }
+}

--- a/packages/@tailwindcss-upgrade/src/utils/package-version.ts
+++ b/packages/@tailwindcss-upgrade/src/utils/package-version.ts
@@ -1,5 +1,4 @@
 import fs from 'node:fs/promises'
-import { resolve } from 'node:path'
 
 /**
  * Resolves the version string of an npm dependency installed in the based
@@ -7,9 +6,8 @@ import { resolve } from 'node:path'
  */
 export async function getPackageVersion(pkg: string, base: string): Promise<string | null> {
   try {
-    console.log('getPackageVersion', pkg, base)
-    const packageJson = resolve(base, 'node_modules', pkg, 'package.json')
-    const { version } = JSON.parse(await fs.readFile(packageJson, 'utf8'))
+    let packageJson = require.resolve(`${pkg}/package.json`, { paths: [base] })
+    let { version } = JSON.parse(await fs.readFile(packageJson, 'utf8'))
     return version
   } catch {
     return null


### PR DESCRIPTION
In some local testing we ran the `@tailwindcss/upgrade` command twice in a row. It would be great to get some feedback that this is not working, so this PR now checks if it can resolve the installed version of `tailwindcss` and if it can, it requires it to be < 4 (you can bypass this check with `--force`).