### PR TITLE
Re-introduce automatic var injection shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Reintroduce `max-w-screen-*` utilities that read from the `--breakpoint` namespace as deprecated utilities ([#15013](https://github.com/tailwindlabs/tailwindcss/pull/15013))
+- Re-introduce automatic var injection shorthand ([#15020](https://github.com/tailwindlabs/tailwindcss/pull/15020))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Reintroduce `max-w-screen-*` utilities that read from the `--breakpoint` namespace as deprecated utilities ([#15013](https://github.com/tailwindlabs/tailwindcss/pull/15013))
-- Re-introduce automatic var injection shorthand ([#15020](https://github.com/tailwindlabs/tailwindcss/pull/15020))
+- Support using CSS variables as arbitrary values without `var(…)` by using parentheses instead of square brackets (e.g. `bg-(--my-color)`) ([#15020](https://github.com/tailwindlabs/tailwindcss/pull/15020))
 
 ### Fixed
 

--- a/crates/oxide/src/parser.rs
+++ b/crates/oxide/src/parser.rs
@@ -978,6 +978,18 @@ mod test {
     }
 
     #[test]
+    fn it_can_parse_utilities_with_arbitrary_var_shorthand() {
+        let candidates = run("m-(--my-var)", false);
+        assert_eq!(candidates, vec!["m-(--my-var)"]);
+    }
+
+    #[test]
+    fn it_can_parse_utilities_with_arbitrary_var_shorthand_as_modifier() {
+        let candidates = run("bg-(--my-color)/(--my-opacity)", false);
+        assert_eq!(candidates, vec!["bg-(--my-color)/(--my-opacity)"]);
+    }
+
+    #[test]
     fn it_throws_away_arbitrary_values_that_are_unbalanced() {
         let candidates = run("m-[calc(100px*2]", false);
         assert!(candidates.is_empty());

--- a/crates/oxide/src/parser.rs
+++ b/crates/oxide/src/parser.rs
@@ -461,7 +461,7 @@ impl<'a> Extractor<'a> {
 
     #[inline(always)]
     fn parse_arbitrary(&mut self) -> ParseAction<'a> {
-        // In this we could technically use memchr 6 times (then looped) to find the indexes / bounds of arbitrary valuesq
+        // In this we could technically use memchr 6 times (then looped) to find the indexes / bounds of arbitrary values
         if self.in_escape {
             return self.parse_escaped();
         }

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -100,7 +100,7 @@ test(
       --- ./src/index.html ---
       <h1>🤠👋</h1>
       <div
-        class="flex! sm:block! bg-linear-to-t bg-[var(--my-red)] max-w-[var(--breakpoint-md)] ml-[var(--breakpoint-md)]"
+        class="flex! sm:block! bg-linear-to-t bg-(--my-red) max-w-(--breakpoint-md) ml-(--breakpoint-md)"
       ></div>
       <!-- Migrate to sm -->
       <div class="blur-sm shadow-sm rounded-sm inset-shadow-sm drop-shadow-sm"></div>
@@ -151,9 +151,9 @@ test(
       candidate`flex!`,
       candidate`sm:block!`,
       candidate`bg-linear-to-t`,
-      candidate`bg-[var(--my-red)]`,
-      candidate`max-w-[var(--breakpoint-md)]`,
-      candidate`ml-[var(--breakpoint-md)`,
+      candidate`bg-(--my-red)`,
+      candidate`max-w-(--breakpoint-md)`,
+      candidate`ml-(--breakpoint-md)`,
     ])
   },
 )
@@ -639,7 +639,7 @@ test(
       'src/index.html',
       // prettier-ignore
       js`
-        <div class="bg-[var(--my-red)]"></div>
+        <div class="bg-(--my-red)"></div>
       `,
     )
 
@@ -798,7 +798,7 @@ test(
       'src/index.html',
       // prettier-ignore
       js`
-        <div class="bg-[var(--my-red)]"></div>
+        <div class="bg-(--my-red)"></div>
       `,
     )
 
@@ -873,7 +873,7 @@ test(
       'src/index.html',
       // prettier-ignore
       js`
-        <div class="bg-[var(--my-red)]"></div>
+        <div class="bg-(--my-red)"></div>
       `,
     )
 
@@ -1447,7 +1447,7 @@ test(
       "
       --- ./src/index.html ---
       <div
-        class="flex! sm:block! bg-linear-to-t bg-[var(--my-red)]"
+        class="flex! sm:block! bg-linear-to-t bg-(--my-red)"
       ></div>
 
       --- ./src/root.1.css ---
@@ -1664,7 +1664,7 @@ test(
       "
       --- ./src/index.html ---
       <div
-        class="flex! sm:block! bg-linear-to-t bg-[var(--my-red)]"
+        class="flex! sm:block! bg-linear-to-t bg-(--my-red)"
       ></div>
 
       --- ./src/index.css ---
@@ -1799,7 +1799,7 @@ test(
       "
       --- ./src/index.html ---
       <div
-        class="flex! sm:block! bg-linear-to-t bg-[var(--my-red)]"
+        class="flex! sm:block! bg-linear-to-t bg-(--my-red)"
       ></div>
 
       --- ./src/index.css ---

--- a/packages/@tailwindcss-upgrade/src/template/candidates.test.ts
+++ b/packages/@tailwindcss-upgrade/src/template/candidates.test.ts
@@ -123,7 +123,7 @@ const candidates = [
   ['bg-[no-repeat_url(/image_13.png)]', 'bg-[no-repeat_url(/image_13.png)]'],
   [
     'bg-[var(--spacing-0_5,_var(--spacing-1_5,_3rem))]',
-    'bg-[var(--spacing-0_5,var(--spacing-1_5,3rem))]',
+    'bg-(--spacing-0_5,var(--spacing-1_5,3rem))',
   ],
 ]
 

--- a/packages/@tailwindcss-upgrade/src/template/codemods/automatic-var-injection.test.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/automatic-var-injection.test.ts
@@ -9,10 +9,10 @@ test.each([
   ['[--my-color:--my-other-color]', '[--my-color:var(--my-other-color)]'],
 
   // Arbitrary values for functional candidates
-  ['bg-[--my-color]', 'bg-[var(--my-color)]'],
-  ['bg-[color:--my-color]', 'bg-[color:var(--my-color)]'],
-  ['border-[length:--my-length]', 'border-[length:var(--my-length)]'],
-  ['border-[line-width:--my-width]', 'border-[line-width:var(--my-width)]'],
+  ['bg-[--my-color]', 'bg-(--my-color)'],
+  ['bg-[color:--my-color]', 'bg-(color:--my-color)'],
+  ['border-[length:--my-length]', 'border-(length:--my-length)'],
+  ['border-[line-width:--my-width]', 'border-(line-width:--my-width)'],
 
   // Can clean up the workaround for opting out of automatic var injection
   ['bg-[_--my-color]', 'bg-[--my-color]'],
@@ -21,19 +21,19 @@ test.each([
   ['border-[line-width:_--my-width]', 'border-[line-width:--my-width]'],
 
   // Modifiers
-  ['[color:--my-color]/[--my-opacity]', '[color:var(--my-color)]/[var(--my-opacity)]'],
-  ['bg-red-500/[--my-opacity]', 'bg-red-500/[var(--my-opacity)]'],
-  ['bg-[--my-color]/[--my-opacity]', 'bg-[var(--my-color)]/[var(--my-opacity)]'],
-  ['bg-[color:--my-color]/[--my-opacity]', 'bg-[color:var(--my-color)]/[var(--my-opacity)]'],
+  ['[color:--my-color]/[--my-opacity]', '[color:var(--my-color)]/(--my-opacity)'],
+  ['bg-red-500/[--my-opacity]', 'bg-red-500/(--my-opacity)'],
+  ['bg-[--my-color]/[--my-opacity]', 'bg-(--my-color)/(--my-opacity)'],
+  ['bg-[color:--my-color]/[--my-opacity]', 'bg-(color:--my-color)/(--my-opacity)'],
 
   // Can clean up the workaround for opting out of automatic var injection
   ['[color:--my-color]/[_--my-opacity]', '[color:var(--my-color)]/[--my-opacity]'],
   ['bg-red-500/[_--my-opacity]', 'bg-red-500/[--my-opacity]'],
-  ['bg-[--my-color]/[_--my-opacity]', 'bg-[var(--my-color)]/[--my-opacity]'],
-  ['bg-[color:--my-color]/[_--my-opacity]', 'bg-[color:var(--my-color)]/[--my-opacity]'],
+  ['bg-[--my-color]/[_--my-opacity]', 'bg-(--my-color)/[--my-opacity]'],
+  ['bg-[color:--my-color]/[_--my-opacity]', 'bg-(color:--my-color)/[--my-opacity]'],
 
   // Variants
-  ['supports-[--test]:flex', 'supports-[var(--test)]:flex'],
+  ['supports-[--test]:flex', 'supports-(--test):flex'],
   ['supports-[_--test]:flex', 'supports-[--test]:flex'],
 
   // Some properties never had var() injection in v3.

--- a/packages/@tailwindcss-upgrade/src/template/codemods/theme-to-var.test.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/theme-to-var.test.ts
@@ -19,11 +19,11 @@ test.each([
   // Convert to `var(…)` if we can resolve the path
   ['[color:theme(colors.red.500)]', '[color:var(--color-red-500)]'], // Arbitrary property
   ['[color:theme(colors.red.500)]/50', '[color:var(--color-red-500)]/50'], // Arbitrary property + modifier
-  ['bg-[theme(colors.red.500)]', 'bg-[var(--color-red-500)]'], // Arbitrary value
+  ['bg-[theme(colors.red.500)]', 'bg-(--color-red-500)'], // Arbitrary value
   ['bg-[size:theme(spacing.4)]', 'bg-[size:calc(var(--spacing)*4)]'], // Arbitrary value + data type hint
 
   // Convert to `var(…)` if we can resolve the path, but keep fallback values
-  ['bg-[theme(colors.red.500,red)]', 'bg-[var(--color-red-500,red)]'],
+  ['bg-[theme(colors.red.500,red)]', 'bg-(--color-red-500,red)'],
 
   // Keep `theme(…)` if we can't resolve the path
   ['bg-[theme(colors.foo.1000)]', 'bg-[theme(colors.foo.1000)]'],
@@ -66,13 +66,13 @@ test.each([
   // Arbitrary property, with more complex modifier (we only allow whole numbers
   // as bare modifiers). Convert the complex numbers to arbitrary values instead.
   ['[color:theme(colors.red.500/12.34%)]', '[color:var(--color-red-500)]/[12.34%]'],
-  ['[color:theme(colors.red.500/var(--opacity))]', '[color:var(--color-red-500)]/[var(--opacity)]'],
+  ['[color:theme(colors.red.500/var(--opacity))]', '[color:var(--color-red-500)]/(--opacity)'],
   ['[color:theme(colors.red.500/.12345)]', '[color:var(--color-red-500)]/[12.345]'],
   ['[color:theme(colors.red.500/50.25%)]', '[color:var(--color-red-500)]/[50.25%]'],
 
   // Arbitrary value
-  ['bg-[theme(colors.red.500/75%)]', 'bg-[var(--color-red-500)]/75'],
-  ['bg-[theme(colors.red.500/12.34%)]', 'bg-[var(--color-red-500)]/[12.34%]'],
+  ['bg-[theme(colors.red.500/75%)]', 'bg-(--color-red-500)/75'],
+  ['bg-[theme(colors.red.500/12.34%)]', 'bg-(--color-red-500)/[12.34%]'],
 
   // Arbitrary property that already contains a modifier
   ['[color:theme(colors.red.500/50%)]/50', '[color:theme(--color-red-500/50%)]/50'],
@@ -109,8 +109,8 @@ test.each([
   ['[--foo:theme(transitionDuration.500)]', '[--foo:theme(transitionDuration.500)]'],
 
   // Renamed theme keys
-  ['max-w-[theme(screens.md)]', 'max-w-[var(--breakpoint-md)]'],
-  ['w-[theme(maxWidth.md)]', 'w-[var(--container-md)]'],
+  ['max-w-[theme(screens.md)]', 'max-w-(--breakpoint-md)'],
+  ['w-[theme(maxWidth.md)]', 'w-(--container-md)'],
 
   // Invalid cases
   ['[--foo:theme(colors.red.500/50/50)]', '[--foo:theme(colors.red.500/50/50)]'],

--- a/packages/tailwindcss/src/candidate.test.ts
+++ b/packages/tailwindcss/src/candidate.test.ts
@@ -167,6 +167,35 @@ it('should parse a simple utility with an arbitrary variant', () => {
   `)
 })
 
+it('should parse an arbitrary variant using the automatic var shorthand', () => {
+  let utilities = new Utilities()
+  utilities.static('flex', () => [])
+  let variants = new Variants()
+  variants.functional('supports', () => {})
+
+  expect(run('supports-(--test):flex', { utilities, variants })).toMatchInlineSnapshot(`
+    [
+      {
+        "important": false,
+        "kind": "static",
+        "raw": "supports-(--test):flex",
+        "root": "flex",
+        "variants": [
+          {
+            "kind": "functional",
+            "modifier": null,
+            "root": "supports",
+            "value": {
+              "kind": "arbitrary",
+              "value": "var(--test)",
+            },
+          },
+        ],
+      },
+    ]
+  `)
+})
+
 it('should parse a simple utility with a parameterized variant', () => {
   let utilities = new Utilities()
   utilities.static('flex', () => [])
@@ -511,6 +540,29 @@ it('should parse a utility with an arbitrary value', () => {
   `)
 })
 
+it('should parse a utility with an arbitrary value with parens', () => {
+  let utilities = new Utilities()
+  utilities.functional('bg', () => [])
+
+  expect(run('bg-(--my-color)', { utilities })).toMatchInlineSnapshot(`
+    [
+      {
+        "important": false,
+        "kind": "functional",
+        "modifier": null,
+        "raw": "bg-(--my-color)",
+        "root": "bg",
+        "value": {
+          "dataType": null,
+          "kind": "arbitrary",
+          "value": "var(--my-color)",
+        },
+        "variants": [],
+      },
+    ]
+  `)
+})
+
 it('should parse a utility with an arbitrary value including a typehint', () => {
   let utilities = new Utilities()
   utilities.functional('bg', () => [])
@@ -527,6 +579,52 @@ it('should parse a utility with an arbitrary value including a typehint', () => 
           "dataType": "color",
           "kind": "arbitrary",
           "value": "var(--value)",
+        },
+        "variants": [],
+      },
+    ]
+  `)
+})
+
+it('should parse a utility with an arbitrary value with parens including a typehint', () => {
+  let utilities = new Utilities()
+  utilities.functional('bg', () => [])
+
+  expect(run('bg-(color:--my-color)', { utilities })).toMatchInlineSnapshot(`
+    [
+      {
+        "important": false,
+        "kind": "functional",
+        "modifier": null,
+        "raw": "bg-(color:--my-color)",
+        "root": "bg",
+        "value": {
+          "dataType": "color",
+          "kind": "arbitrary",
+          "value": "var(--my-color)",
+        },
+        "variants": [],
+      },
+    ]
+  `)
+})
+
+it('should parse a utility with an arbitrary value with parens and a fallback', () => {
+  let utilities = new Utilities()
+  utilities.functional('bg', () => [])
+
+  expect(run('bg-(color:--my-color,#0088cc)', { utilities })).toMatchInlineSnapshot(`
+    [
+      {
+        "important": false,
+        "kind": "functional",
+        "modifier": null,
+        "raw": "bg-(color:--my-color,#0088cc)",
+        "root": "bg",
+        "value": {
+          "dataType": "color",
+          "kind": "arbitrary",
+          "value": "var(--my-color,#0088cc)",
         },
         "variants": [],
       },
@@ -745,6 +843,32 @@ it('should parse a utility with an implicit variable as the modifier', () => {
           "value": "var(--value)",
         },
         "raw": "bg-red-500/[var(--value)]",
+        "root": "bg",
+        "value": {
+          "fraction": null,
+          "kind": "named",
+          "value": "red-500",
+        },
+        "variants": [],
+      },
+    ]
+  `)
+})
+
+it('should parse a utility with an implicit variable as the modifier using the shorthand', () => {
+  let utilities = new Utilities()
+  utilities.functional('bg', () => [])
+
+  expect(run('bg-red-500/(--value)', { utilities })).toMatchInlineSnapshot(`
+    [
+      {
+        "important": false,
+        "kind": "functional",
+        "modifier": {
+          "kind": "arbitrary",
+          "value": "var(--value)",
+        },
+        "raw": "bg-red-500/(--value)",
         "root": "bg",
         "value": {
           "fraction": null,

--- a/packages/tailwindcss/src/candidate.ts
+++ b/packages/tailwindcss/src/candidate.ts
@@ -346,9 +346,9 @@ export function* parseCandidate(input: string, designSystem: DesignSystem): Iter
   // ^^           -> Root
   //    ^^^^^^^^^ -> Arbitrary value
   //
-  // bg-red-[#0088cc]
-  // ^^^^^^           -> Root
-  //        ^^^^^^^^^ -> Arbitrary value
+  // border-l-[#0088cc]
+  // ^^^^^^^^           -> Root
+  //          ^^^^^^^^^ -> Arbitrary value
   // ```
   if (baseWithoutModifier[baseWithoutModifier.length - 1] === ']') {
     let idx = baseWithoutModifier.indexOf('-[')

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -127,7 +127,7 @@ describe('compiling CSS', () => {
           @tailwind utilities;
         `,
         [
-          'bg-[no-repeat_url(./my_file.jpg)',
+          'bg-[no-repeat_url(./my_file.jpg)]',
           'ml-[var(--spacing-1_5,_var(--spacing-2_5,_1rem))]',
           'ml-[theme(--spacing-1_5,theme(--spacing-2_5,_1rem)))]',
         ],
@@ -146,8 +146,8 @@ describe('compiling CSS', () => {
         margin-left: var(--spacing-1_5, var(--spacing-2_5, 1rem));
       }
 
-      .bg-\\[no-repeat_url\\(\\.\\/my_file\\.jpg\\) {
-        background-color: no-repeat url("./")my file. jpg;
+      .bg-\\[no-repeat_url\\(\\.\\/my_file\\.jpg\\)\\] {
+        background-color: no-repeat url("./my_file.jpg");
       }"
     `)
   })

--- a/packages/tailwindcss/src/intellisense.test.ts
+++ b/packages/tailwindcss/src/intellisense.test.ts
@@ -365,7 +365,7 @@ test('Functional utilities from plugins are listed in hovers and completions', a
 
   expect(classNames).not.toContain('custom-2-unknown')
 
-  // matchUtilities with a any modifiers
+  // matchUtilities with any modifiers
   expect(classNames).toContain('custom-3-red')
   expect(classMap.get('custom-3-red')?.modifiers).toEqual([])
 


### PR DESCRIPTION
This PR re-introduces the automatic var injection feature.

For some backstory, we used to support classes such as `bg-[--my-color]` that resolved as-if you wrote `bg-[var(--my-color)]`. 

The is issue is that some newer CSS properties accepts dashed-idents (without the `var(…)`). This means that some properties accept `view-timeline-name: --my-name;` (see: https://developer.mozilla.org/en-US/docs/Web/CSS/view-timeline-name).

To make this a tiny bit worse, these properties _also_ accept `var(--my-name-reference)` where the variable `--my-name-reference` could reference a dashed-ident such as `--my-name`.

This makes the `bg-[--my-color]` ambiguous because we don't know if you want `var(--my-color)` or `--my-color`.

With this PR, we bring back the automatic var injection feature as syntactic sugar, but we use a different syntax to avoid the ambiguity. Instead of `bg-[--my-color]`, you can now write `bg-(--my-color)` to get the same effect as `bg-[var(--my-color)]`.

This also applies to modifiers, so `bg-red-500/[var(--my-opacity)]` can be written as `bg-red-500/(--my-opacity)`. To go full circle, you can rewrite `bg-[var(--my-color)]/[var(--my-opacity)]` as `bg-(--my-color)/(--my-opacity)`.

---

This is implemented as syntactical sugar at the parsing stage and handled when re-printing. Internally the system (and every plugin) still see the proper `var(--my-color)` value.

Since this is also handled during printing of the candidate, codemods don't need to be changed but they will provide the newly updated syntax. 

E.g.: running this on the Catalyst codebase, you'll now see changes like this:
<img width="542" alt="image" src="https://github.com/user-attachments/assets/8f0e26f8-f4c9-4cdc-9f28-52307c38610e">

Whereas before we converted this to the much longer `min-w-[var(--button-width)]`.

---

Additionally, this required some changes to the Oxide scanner to make sure that `(` and `)` are valid characters for arbitrary-like values.
