### PR TITLE
Implement compat for `<alpha-value>` from v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reintroduce `max-w-screen-*` utilities that read from the `--breakpoint` namespace as deprecated utilities ([#15013](https://github.com/tailwindlabs/tailwindcss/pull/15013))
 - Support using CSS variables as arbitrary values without `var(…)` by using parentheses instead of square brackets (e.g. `bg-(--my-color)`) ([#15020](https://github.com/tailwindlabs/tailwindcss/pull/15020))
 - Add new `in-*` variant ([#15025](https://github.com/tailwindlabs/tailwindcss/pull/15025))
+- Support colors that use `<alpha-value>` in JS configs and plugins ([#15033](https://github.com/tailwindlabs/tailwindcss/pull/15033))
 - _Upgrade (experimental)_: Migrate `[&>*]` to the `*` variant ([#15022](https://github.com/tailwindlabs/tailwindcss/pull/15022))
 - _Upgrade (experimental)_: Migrate `[&_*]` to the `**` variant ([#15022](https://github.com/tailwindlabs/tailwindcss/pull/15022))
+- _Upgrade (experimental)_: Migrate colors that use `<alpha-value>` in JS configs ([#15033](https://github.com/tailwindlabs/tailwindcss/pull/15033))
 
 ### Fixed
 

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -29,6 +29,8 @@ test(
                 400: '#f87171',
                 500: 'red',
               },
+              steel: 'rgb(70 130 180 / <alpha-value>)',
+              smoke: 'rgba(245, 245, 245, var(--smoke-alpha, <alpha-value>))',
             },
             fontSize: {
               xs: ['0.75rem', { lineHeight: '1rem' }],
@@ -173,6 +175,9 @@ test(
         --color-red-400: #f87171;
         --color-red-500: #ef4444;
         --color-red-600: #dc2626;
+
+        --color-steel: rgb(70 130 180);
+        --color-smoke: rgba(245, 245, 245, var(--smoke-alpha, 1));
 
         --text-*: initial;
         --text-xs: 0.75rem;

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -114,6 +114,16 @@ async function migrateTheme(
       continue
     }
 
+    if (typeof value === 'string') {
+      // This is more advanced than the version in core as ideally something
+      // like `rgba(0 0 0 / <alpha-value>)` becomes `rgba(0 0 0)`. Since we know
+      // from the `/` that it's used in an alpha channel and we can remove it.
+      //
+      // In other cases we may not know exactly how its used, so we'll just
+      // replace it with `1` like core does.
+      value = value.replace(/\s*\/\s*<alpha-value>/, '').replace(/<alpha-value>/, '1')
+    }
+
     if (key[0] === 'keyframes') {
       continue
     }

--- a/packages/tailwindcss/src/compat/apply-config-to-theme.ts
+++ b/packages/tailwindcss/src/compat/apply-config-to-theme.ts
@@ -37,6 +37,10 @@ export function applyConfigToTheme(
       continue
     }
 
+    if (typeof value === 'string') {
+      value = value.replace(/<alpha-value>/g, '1')
+    }
+
     let name = keyPathToCssProperty(path)
     if (!name) continue
 

--- a/packages/tailwindcss/src/compat/plugin-functions.ts
+++ b/packages/tailwindcss/src/compat/plugin-functions.ts
@@ -30,6 +30,10 @@ export function createThemeFn(
 
       let configValue = resolveValue(get(configTheme() ?? {}, keypath) ?? null)
 
+      if (typeof configValue === 'string') {
+        configValue = configValue.replace('<alpha-value>', '1')
+      }
+
       // Resolved to a primitive value.
       if (typeof cssValue !== 'object') {
         if (typeof options !== 'object' && options & ThemeOptions.DEFAULT) {


### PR DESCRIPTION
This implements backwards compatibility for colors that use the old `<alpha-value>` feature from v3. We can do this by replacing `<alpha-value>` with `1` because we use `color-mix` to actually apply opacity modifiers in v4.