### PR TITLE
Update default `drop-shadow-*` values to use a single shadow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `drop-shadow-*` when multiple shadows are used in the theme ([#15056](https://github.com/tailwindlabs/tailwindcss/pull/15056))
 - _Upgrade (experimental)_: Ensure migrating to the `in-*` requires a descendant selector ([#15054](https://github.com/tailwindlabs/tailwindcss/pull/15054))
 
 ## [4.0.0-alpha.35] - 2024-11-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix `drop-shadow-*` when multiple shadows are used in the theme ([#15056](https://github.com/tailwindlabs/tailwindcss/pull/15056))
 - _Upgrade (experimental)_: Ensure migrating to the `in-*` requires a descendant selector ([#15054](https://github.com/tailwindlabs/tailwindcss/pull/15054))
+
+### Changed
+
+- Use single drop shadow values instead of multiple ([#15056](https://github.com/tailwindlabs/tailwindcss/pull/15056))
 
 ## [4.0.0-alpha.35] - 2024-11-20
 

--- a/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
@@ -335,10 +335,10 @@ exports[`\`@import 'tailwindcss'\` is replaced with the generated CSS 1`] = `
     --inset-shadow-xs: inset 0 1px 1px #0000000d;
     --inset-shadow-sm: inset 0 2px 4px #0000000d;
     --drop-shadow-xs: 0 1px 1px #0000000d;
-    --drop-shadow-sm: 0 1px 2px #0000001a, 0 1px 1px #0000000f;
-    --drop-shadow-md: 0 4px 3px #00000012, 0 2px 2px #0000000f;
-    --drop-shadow-lg: 0 10px 8px #0000000a, 0 4px 3px #0000001a;
-    --drop-shadow-xl: 0 20px 13px #00000008, 0 8px 5px #00000014;
+    --drop-shadow-sm: 0 1px 2px #00000026;
+    --drop-shadow-md: 0 3px 3px #0000001f;
+    --drop-shadow-lg: 0 4px 4px #00000026;
+    --drop-shadow-xl: 0 9px 7px #0000001a;
     --drop-shadow-2xl: 0 25px 25px #00000026;
     --ease-in: cubic-bezier(.4, 0, 1, 1);
     --ease-out: cubic-bezier(0, 0, .2, 1);

--- a/packages/tailwindcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/tailwindcss/src/__snapshots__/index.test.ts.snap
@@ -334,10 +334,10 @@ exports[`compiling CSS > \`@tailwind utilities\` is replaced by utilities using 
   --inset-shadow-xs: inset 0 1px 1px #0000000d;
   --inset-shadow-sm: inset 0 2px 4px #0000000d;
   --drop-shadow-xs: 0 1px 1px #0000000d;
-  --drop-shadow-sm: 0 1px 2px #0000001a, 0 1px 1px #0000000f;
-  --drop-shadow-md: 0 4px 3px #00000012, 0 2px 2px #0000000f;
-  --drop-shadow-lg: 0 10px 8px #0000000a, 0 4px 3px #0000001a;
-  --drop-shadow-xl: 0 20px 13px #00000008, 0 8px 5px #00000014;
+  --drop-shadow-sm: 0 1px 2px #00000026;
+  --drop-shadow-md: 0 3px 3px #0000001f;
+  --drop-shadow-lg: 0 4px 4px #00000026;
+  --drop-shadow-xl: 0 9px 7px #0000001a;
   --drop-shadow-2xl: 0 25px 25px #00000026;
   --ease-in: cubic-bezier(.4, 0, 1, 1);
   --ease-out: cubic-bezier(0, 0, .2, 1);

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -13694,7 +13694,7 @@ test('filter', async () => {
     }
 
     .drop-shadow {
-      --tw-drop-shadow: drop-shadow(0 1px 2px #0000001a) drop-shadow(0 1px 1px #0000000f);
+      --tw-drop-shadow: drop-shadow(var(--drop-shadow));
       filter: var(--tw-blur, ) var(--tw-brightness, ) var(--tw-contrast, ) var(--tw-grayscale, ) var(--tw-hue-rotate, ) var(--tw-invert, ) var(--tw-saturate, ) var(--tw-sepia, ) var(--tw-drop-shadow, );
     }
 
@@ -13704,7 +13704,7 @@ test('filter', async () => {
     }
 
     .drop-shadow-xl {
-      --tw-drop-shadow: drop-shadow(0 20px 13px #00000008) drop-shadow(0 8px 5px #00000014);
+      --tw-drop-shadow: drop-shadow(var(--drop-shadow-xl));
       filter: var(--tw-blur, ) var(--tw-brightness, ) var(--tw-contrast, ) var(--tw-grayscale, ) var(--tw-hue-rotate, ) var(--tw-invert, ) var(--tw-saturate, ) var(--tw-sepia, ) var(--tw-drop-shadow, );
     }
 

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -13698,7 +13698,7 @@ test('filter', async () => {
     }
 
     .drop-shadow-xl {
-      --tw-drop-shadow: drop-shadow(var(--drop-shadow-xl));
+      --tw-drop-shadow: drop-shadow(0 20px 13px #00000008) drop-shadow(0 8px 5px #00000014);
       filter: var(--tw-blur, ) var(--tw-brightness, ) var(--tw-contrast, ) var(--tw-grayscale, ) var(--tw-hue-rotate, ) var(--tw-invert, ) var(--tw-saturate, ) var(--tw-sepia, ) var(--tw-drop-shadow, );
     }
 

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -13613,8 +13613,8 @@ test('filter', async () => {
       css`
         @theme {
           --blur-xl: 24px;
-          --drop-shadow: 0 1px 2px rgb(0 0 0 / 0.1), 0 1px 1px rgb(0 0 0 / 0.06);
-          --drop-shadow-xl: 0 20px 13px rgb(0 0 0 / 0.03), 0 8px 5px rgb(0 0 0 / 0.08);
+          --drop-shadow: 0 1px 1px rgb(0 0 0 / 0.05);
+          --drop-shadow-xl: 0 9px 7px rgb(0 0 0 / 0.1);
         }
         @tailwind utilities;
       `,
@@ -13654,8 +13654,8 @@ test('filter', async () => {
   ).toMatchInlineSnapshot(`
     ":root {
       --blur-xl: 24px;
-      --drop-shadow: 0 1px 2px #0000001a, 0 1px 1px #0000000f;
-      --drop-shadow-xl: 0 20px 13px #00000008, 0 8px 5px #00000014;
+      --drop-shadow: 0 1px 1px #0000000d;
+      --drop-shadow-xl: 0 9px 7px #0000001a;
     }
 
     .blur-\\[4px\\] {

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -13639,6 +13639,7 @@ test('filter', async () => {
         'invert',
         'invert-0',
         'invert-[var(--value)]',
+        'drop-shadow',
         'drop-shadow-xl',
         'drop-shadow-[0_0_red]',
         'saturate-0',
@@ -13689,6 +13690,11 @@ test('filter', async () => {
 
     .contrast-\\[1\\.23\\] {
       --tw-contrast: contrast(1.23);
+      filter: var(--tw-blur, ) var(--tw-brightness, ) var(--tw-contrast, ) var(--tw-grayscale, ) var(--tw-hue-rotate, ) var(--tw-invert, ) var(--tw-saturate, ) var(--tw-sepia, ) var(--tw-drop-shadow, );
+    }
+
+    .drop-shadow {
+      --tw-drop-shadow: drop-shadow(0 1px 2px #0000001a) drop-shadow(0 1px 1px #0000000f);
       filter: var(--tw-blur, ) var(--tw-brightness, ) var(--tw-contrast, ) var(--tw-grayscale, ) var(--tw-hue-rotate, ) var(--tw-invert, ) var(--tw-saturate, ) var(--tw-sepia, ) var(--tw-drop-shadow, );
     }
 

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -250,6 +250,7 @@ export function createUtilities(theme: Theme) {
     supportsNegative?: boolean
     supportsFractions?: boolean
     themeKeys?: ThemeKey[]
+    inlineThemeValues?: boolean
     defaultValue?: string | null
     handleBareValue?: (value: NamedUtilityValue) => string | null
     handleNegativeBareValue?: (value: NamedUtilityValue) => string | null
@@ -280,10 +281,17 @@ export function createUtilities(theme: Theme) {
           if (candidate.modifier) return
           value = candidate.value.value
         } else {
-          value = theme.resolve(
-            candidate.value.fraction ?? candidate.value.value,
-            desc.themeKeys ?? [],
-          )
+          if (desc.inlineThemeValues) {
+            value = theme.resolveValue(
+              candidate.value.fraction ?? candidate.value.value,
+              desc.themeKeys ?? [],
+            )
+          } else {
+            value = theme.resolve(
+              candidate.value.fraction ?? candidate.value.value,
+              desc.themeKeys ?? [],
+            )
+          }
 
           // Automatically handle things like `w-1/2` without requiring `1/2` to
           // exist as a theme value.
@@ -3473,6 +3481,7 @@ export function createUtilities(theme: Theme) {
     ])
     functionalUtility('drop-shadow', {
       themeKeys: ['--drop-shadow'],
+      inlineThemeValues: true,
       handle: (value) => [
         filterProperties(),
         decl(

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -250,7 +250,6 @@ export function createUtilities(theme: Theme) {
     supportsNegative?: boolean
     supportsFractions?: boolean
     themeKeys?: ThemeKey[]
-    inlineThemeValues?: boolean
     defaultValue?: string | null
     handleBareValue?: (value: NamedUtilityValue) => string | null
     handleNegativeBareValue?: (value: NamedUtilityValue) => string | null
@@ -276,24 +275,15 @@ export function createUtilities(theme: Theme) {
           value =
             desc.defaultValue !== undefined
               ? desc.defaultValue
-              : desc.inlineThemeValues
-                ? theme.resolveValue(null, desc.themeKeys ?? [])
-                : theme.resolve(null, desc.themeKeys ?? [])
+              : theme.resolve(null, desc.themeKeys ?? [])
         } else if (candidate.value.kind === 'arbitrary') {
           if (candidate.modifier) return
           value = candidate.value.value
         } else {
-          if (desc.inlineThemeValues) {
-            value = theme.resolveValue(
-              candidate.value.fraction ?? candidate.value.value,
-              desc.themeKeys ?? [],
-            )
-          } else {
-            value = theme.resolve(
-              candidate.value.fraction ?? candidate.value.value,
-              desc.themeKeys ?? [],
-            )
-          }
+          value = theme.resolve(
+            candidate.value.fraction ?? candidate.value.value,
+            desc.themeKeys ?? [],
+          )
 
           // Automatically handle things like `w-1/2` without requiring `1/2` to
           // exist as a theme value.
@@ -3483,7 +3473,6 @@ export function createUtilities(theme: Theme) {
     ])
     functionalUtility('drop-shadow', {
       themeKeys: ['--drop-shadow'],
-      inlineThemeValues: true,
       handle: (value) => [
         filterProperties(),
         decl(

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -276,7 +276,9 @@ export function createUtilities(theme: Theme) {
           value =
             desc.defaultValue !== undefined
               ? desc.defaultValue
-              : theme.resolve(null, desc.themeKeys ?? [])
+              : desc.inlineThemeValues
+                ? theme.resolveValue(null, desc.themeKeys ?? [])
+                : theme.resolve(null, desc.themeKeys ?? [])
         } else if (candidate.value.kind === 'arbitrary') {
           if (candidate.modifier) return
           value = candidate.value.value

--- a/packages/tailwindcss/theme.css
+++ b/packages/tailwindcss/theme.css
@@ -367,10 +367,10 @@
   --inset-shadow-sm: inset 0 2px 4px rgb(0 0 0 / 0.05);
 
   --drop-shadow-xs: 0 1px 1px rgb(0 0 0 / 0.05);
-  --drop-shadow-sm: 0 1px 2px rgb(0 0 0 / 0.1), 0 1px 1px rgb(0 0 0 / 0.06);
-  --drop-shadow-md: 0 4px 3px rgb(0 0 0 / 0.07), 0 2px 2px rgb(0 0 0 / 0.06);
-  --drop-shadow-lg: 0 10px 8px rgb(0 0 0 / 0.04), 0 4px 3px rgb(0 0 0 / 0.1);
-  --drop-shadow-xl: 0 20px 13px rgb(0 0 0 / 0.03), 0 8px 5px rgb(0 0 0 / 0.08);
+  --drop-shadow-sm: 0 1px 2px rgb(0 0 0 / 0.15);
+  --drop-shadow-md: 0 3px 3px rgb(0 0 0 / 0.12);
+  --drop-shadow-lg: 0 4px 4px rgb(0 0 0 / 0.15);
+  --drop-shadow-xl: 0 9px 7px rgb(0 0 0 / 0.1);
   --drop-shadow-2xl: 0 25px 25px rgb(0 0 0 / 0.15);
 
   --ease-in: cubic-bezier(0.4, 0, 1, 1);


### PR DESCRIPTION
This PR updates the default `drop-shadow-*` values to use a single shadow instead of multiple shadows.

This ensures that the usage with `drop-shadow(var(--drop-shadow-xl))` is correct because the `drop-shadow(…)` needs to encode a single drop shadow.
