### PR TITLE
Update codemod to restore border color on form elements

### DIFF
--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -150,7 +150,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -259,7 +260,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -340,7 +342,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -429,7 +432,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -523,7 +527,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -649,7 +654,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -1170,7 +1176,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -1635,7 +1642,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -1676,7 +1684,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -1727,7 +1736,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -1773,7 +1783,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -1821,7 +1832,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -2018,7 +2030,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -2171,7 +2184,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -2305,7 +2319,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -2397,7 +2412,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -2639,7 +2655,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -2740,7 +2757,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -2870,7 +2888,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -3065,7 +3084,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -297,7 +297,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -423,7 +424,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -522,7 +524,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -613,7 +616,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -708,7 +712,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -799,7 +804,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -928,7 +934,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -970,7 +977,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -1064,7 +1072,8 @@ test(
         ::after,
         ::before,
         ::backdrop,
-        ::file-selector-button {
+        ::file-selector-button,
+        :is(input, textarea, select, button) {
           border-color: var(--color-gray-200, currentColor);
         }
       }
@@ -1141,7 +1150,8 @@ describe('border compatibility', () => {
           ::after,
           ::before,
           ::backdrop,
-          ::file-selector-button {
+          ::file-selector-button,
+          :is(input, textarea, select, button) {
             border-color: var(--color-gray-200, currentColor);
           }
         }
@@ -1220,7 +1230,8 @@ describe('border compatibility', () => {
           ::after,
           ::before,
           ::backdrop,
-          ::file-selector-button {
+          ::file-selector-button,
+          :is(input, textarea, select, button) {
             border-color: oklch(0.623 0.214 259.815);
           }
         }
@@ -1358,7 +1369,8 @@ describe('border compatibility', () => {
           ::after,
           ::before,
           ::backdrop,
-          ::file-selector-button {
+          ::file-selector-button,
+          :is(input, textarea, select, button) {
             border-color: var(--color-gray-200, currentColor);
           }
         }
@@ -1444,7 +1456,8 @@ describe('border compatibility', () => {
           ::after,
           ::before,
           ::backdrop,
-          ::file-selector-button {
+          ::file-selector-button,
+          :is(input, textarea, select, button) {
             border-color: var(--color-gray-200, currentColor);
           }
         }
@@ -1579,7 +1592,8 @@ describe('border compatibility', () => {
           ::after,
           ::before,
           ::backdrop,
-          ::file-selector-button {
+          ::file-selector-button,
+          :is(input, textarea, select, button) {
             border-color: var(--color-gray-200, currentColor);
           }
         }
@@ -1710,7 +1724,8 @@ describe('border compatibility', () => {
           ::after,
           ::before,
           ::backdrop,
-          ::file-selector-button {
+          ::file-selector-button,
+          :is(input, textarea, select, button) {
             border-color: var(--color-gray-200, currentColor);
           }
         }
@@ -1830,7 +1845,8 @@ describe('border compatibility', () => {
           ::after,
           ::before,
           ::backdrop,
-          ::file-selector-button {
+          ::file-selector-button,
+          :is(input, textarea, select, button) {
             border-color: var(--color-gray-200, currentColor);
           }
         }

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-preflight.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-preflight.test.ts
@@ -62,7 +62,8 @@ it("should add compatibility CSS after the `@import 'tailwindcss'`", async () =>
       ::after,
       ::before,
       ::backdrop,
-      ::file-selector-button {
+      ::file-selector-button,
+      :is(input, textarea, select, button) {
         border-color: var(--color-gray-200, currentColor);
       }
     }"
@@ -111,7 +112,8 @@ it('should add the compatibility CSS after the last `@import`', async () => {
       ::after,
       ::before,
       ::backdrop,
-      ::file-selector-button {
+      ::file-selector-button,
+      :is(input, textarea, select, button) {
         border-color: var(--color-gray-200, currentColor);
       }
     }"
@@ -174,7 +176,8 @@ it('should add the compatibility CSS after the last import, even if a body-less 
       ::after,
       ::before,
       ::backdrop,
-      ::file-selector-button {
+      ::file-selector-button,
+      :is(input, textarea, select, button) {
         border-color: var(--color-gray-200, currentColor);
       }
     }"
@@ -237,7 +240,8 @@ it('should add the compatibility CSS before the first `@layer base` (if the "tai
       ::after,
       ::before,
       ::backdrop,
-      ::file-selector-button {
+      ::file-selector-button,
+      :is(input, textarea, select, button) {
         border-color: var(--color-gray-200, currentColor);
       }
     }
@@ -312,7 +316,8 @@ it('should add the compatibility CSS before the first `@layer base` (if the "tai
       ::after,
       ::before,
       ::backdrop,
-      ::file-selector-button {
+      ::file-selector-button,
+      :is(input, textarea, select, button) {
         border-color: var(--color-gray-200, currentColor);
       }
     }

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-preflight.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-preflight.ts
@@ -24,7 +24,8 @@ const BORDER_COLOR_COMPATIBILITY_CSS = css`
     ::after,
     ::before,
     ::backdrop,
-    ::file-selector-button {
+    ::file-selector-button,
+    :is(input, textarea, select, button) {
       border-color: theme(borderColor.DEFAULT);
     }
   }

--- a/packages/@tailwindcss-upgrade/src/index.test.ts
+++ b/packages/@tailwindcss-upgrade/src/index.test.ts
@@ -126,7 +126,8 @@ it('should migrate a stylesheet', async () => {
       ::after,
       ::before,
       ::backdrop,
-      ::file-selector-button {
+      ::file-selector-button,
+      :is(input, textarea, select, button) {
         border-color: var(--color-gray-200, currentColor);
       }
     }
@@ -214,7 +215,8 @@ it('should migrate a stylesheet (with imports)', async () => {
       ::after,
       ::before,
       ::backdrop,
-      ::file-selector-button {
+      ::file-selector-button,
+      :is(input, textarea, select, button) {
         border-color: var(--color-gray-200, currentColor);
       }
     }"
@@ -273,7 +275,8 @@ it('should migrate a stylesheet (with preceding rules that should be wrapped in 
       ::after,
       ::before,
       ::backdrop,
-      ::file-selector-button {
+      ::file-selector-button,
+      :is(input, textarea, select, button) {
         border-color: var(--color-gray-200, currentColor);
       }
     }


### PR DESCRIPTION
This PR updates the upgrade codemod to also restore the border color on form elements, since the current `*` selector doesn't catch these elements since it has a lower specificity (`0,0,0`) than the form element styles in preflight (`0,0,1`).

I considered putting this in the form reset CSS instead, but it's possible that someone might be okay with removing that reset from their project but still needs to the border color reset—basically if they're using the `border` class on all their buttons and form controls, and relying on the default border color in certain situations.