### PR TITLE
Revert new default form styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Changed
+
+- Revert the new base styles for buttons and form controls ([#15100](https://github.com/tailwindlabs/tailwindcss/pull/15100))
 
 ## [4.0.0-beta.1] - 2024-11-21
 

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -121,23 +121,6 @@ test(
       @import 'tailwindcss';
 
       /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
-
-      /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
@@ -230,23 +213,6 @@ test(
       @import 'tailwindcss' prefix(tw);
 
       /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
-
-      /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
@@ -309,23 +275,6 @@ test(
       "
       --- ./src/index.css ---
       @import 'tailwindcss';
-
-      /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
 
       /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
@@ -398,23 +347,6 @@ test(
       "
       --- ./src/index.css ---
       @import 'tailwindcss';
-
-      /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
 
       /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
@@ -492,23 +424,6 @@ test(
       "
       --- ./src/index.css ---
       @import 'tailwindcss';
-
-      /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
 
       /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
@@ -618,23 +533,6 @@ test(
       @import './mix.utilities.css';
 
       @import 'tailwindcss';
-
-      /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
 
       /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
@@ -1141,23 +1039,6 @@ test(
       @import './utilities.css';
 
       /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
-
-      /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
@@ -1606,23 +1487,6 @@ test(
       @config './tailwind.config.ts';
 
       /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
-
-      /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
@@ -1645,23 +1509,6 @@ test(
       @import 'tailwindcss';
 
       @config "../../tailwind.config.ts";
-
-      /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
 
       /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
@@ -1698,23 +1545,6 @@ test(
       }
 
       /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
-
-      /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
@@ -1742,23 +1572,6 @@ test(
       --- ./src/root.4/base.css ---
       @import 'tailwindcss/theme' layer(theme);
       @import 'tailwindcss/preflight' layer(base);
-
-      /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
 
       /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
@@ -1790,23 +1603,6 @@ test(
       @import 'tailwindcss';
 
       @config '../../tailwind.config.ts';
-
-      /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
 
       /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
@@ -1989,23 +1785,6 @@ test(
       @import 'tailwindcss/preflight' layer(base);
 
       /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
-
-      /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
@@ -2142,23 +1921,6 @@ test(
       @import 'tailwindcss/preflight' layer(base);
 
       /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
-
-      /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
@@ -2276,23 +2038,6 @@ test(
       @import 'tailwindcss/preflight' layer(base);
 
       /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
-
-      /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
@@ -2366,23 +2111,6 @@ test(
       --- ./src/index.css ---
       @import 'tailwindcss';
       @import './styles/components.css' layer(components);
-
-      /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
 
       /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
@@ -2610,23 +2338,6 @@ test(
       }
 
       /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
-
-      /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
@@ -2709,23 +2420,6 @@ test(
       "
       --- index.css ---
       @import 'tailwindcss';
-
-      /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
 
       /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
@@ -2839,23 +2533,6 @@ test(
       --- ./src/base.css ---
       @import 'tailwindcss/theme' layer(theme);
       @import 'tailwindcss/preflight' layer(base);
-
-      /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
 
       /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
@@ -3033,23 +2710,6 @@ test(
         --opacity-50_50: 50.5%;
         --opacity-75\\%: 75%;
         --opacity-100\\%: 100%;
-      }
-
-      /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
       }
 
       /*

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -268,23 +268,6 @@ test(
       }
 
       /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
-
-      /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
@@ -394,23 +377,6 @@ test(
       }
 
       /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
-
-      /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
@@ -493,23 +459,6 @@ test(
       }
 
       /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
-
-      /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
@@ -582,23 +531,6 @@ test(
       @import 'tailwindcss';
 
       @config '../tailwind.config.ts';
-
-      /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
 
       /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
@@ -679,23 +611,6 @@ test(
       @config '../tailwind.config.ts';
 
       /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
-
-      /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
@@ -768,23 +683,6 @@ test(
       @import 'tailwindcss';
 
       @config '../tailwind.config.ts';
-
-      /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
 
       /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
@@ -899,23 +797,6 @@ test(
       }
 
       /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
-
-      /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
@@ -938,23 +819,6 @@ test(
 
       @theme {
         --color-primary: blue;
-      }
-
-      /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
       }
 
       /*
@@ -1035,23 +899,6 @@ test(
       }
 
       /*
-        In Tailwind CSS v4, basic styles are applied to form elements by default. To
-        maintain compatibility with v3, the following resets have been added:
-      */
-      @layer base {
-        input,
-        textarea,
-        select,
-        button {
-          border: 0px solid;
-          border-radius: 0;
-          padding: 0;
-          color: inherit;
-          background-color: transparent;
-        }
-      }
-
-      /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
@@ -1110,23 +957,6 @@ describe('border compatibility', () => {
         "
         --- src/input.css ---
         @import 'tailwindcss';
-
-        /*
-          In Tailwind CSS v4, basic styles are applied to form elements by default. To
-          maintain compatibility with v3, the following resets have been added:
-        */
-        @layer base {
-          input,
-          textarea,
-          select,
-          button {
-            border: 0px solid;
-            border-radius: 0;
-            padding: 0;
-            color: inherit;
-            background-color: transparent;
-          }
-        }
 
         /*
           The default border color has changed to \`currentColor\` in Tailwind CSS v4,
@@ -1191,23 +1021,6 @@ describe('border compatibility', () => {
         @import 'tailwindcss';
 
         /*
-          In Tailwind CSS v4, basic styles are applied to form elements by default. To
-          maintain compatibility with v3, the following resets have been added:
-        */
-        @layer base {
-          input,
-          textarea,
-          select,
-          button {
-            border: 0px solid;
-            border-radius: 0;
-            padding: 0;
-            color: inherit;
-            background-color: transparent;
-          }
-        }
-
-        /*
           The default border color has changed to \`currentColor\` in Tailwind CSS v4,
           so we've added these compatibility styles to make sure everything still
           looks the same as it did with Tailwind CSS v3.
@@ -1268,23 +1081,6 @@ describe('border compatibility', () => {
         "
         --- src/input.css ---
         @import 'tailwindcss';
-
-        /*
-          In Tailwind CSS v4, basic styles are applied to form elements by default. To
-          maintain compatibility with v3, the following resets have been added:
-        */
-        @layer base {
-          input,
-          textarea,
-          select,
-          button {
-            border: 0px solid;
-            border-radius: 0;
-            padding: 0;
-            color: inherit;
-            background-color: transparent;
-          }
-        }
         "
       `)
     },
@@ -1327,23 +1123,6 @@ describe('border compatibility', () => {
 
         --- src/tailwind.css ---
         @import 'tailwindcss';
-
-        /*
-          In Tailwind CSS v4, basic styles are applied to form elements by default. To
-          maintain compatibility with v3, the following resets have been added:
-        */
-        @layer base {
-          input,
-          textarea,
-          select,
-          button {
-            border: 0px solid;
-            border-radius: 0;
-            padding: 0;
-            color: inherit;
-            background-color: transparent;
-          }
-        }
 
         /*
           The default border color has changed to \`currentColor\` in Tailwind CSS v4,
@@ -1413,23 +1192,6 @@ describe('border compatibility', () => {
         --- src/base.css ---
         @import 'tailwindcss/theme' layer(theme);
         @import 'tailwindcss/preflight' layer(base);
-
-        /*
-          In Tailwind CSS v4, basic styles are applied to form elements by default. To
-          maintain compatibility with v3, the following resets have been added:
-        */
-        @layer base {
-          input,
-          textarea,
-          select,
-          button {
-            border: 0px solid;
-            border-radius: 0;
-            padding: 0;
-            color: inherit;
-            background-color: transparent;
-          }
-        }
 
         /*
           The default border color has changed to \`currentColor\` in Tailwind CSS v4,
@@ -1550,23 +1312,6 @@ describe('border compatibility', () => {
         }
 
         /*
-          In Tailwind CSS v4, basic styles are applied to form elements by default. To
-          maintain compatibility with v3, the following resets have been added:
-        */
-        @layer base {
-          input,
-          textarea,
-          select,
-          button {
-            border: 0px solid;
-            border-radius: 0;
-            padding: 0;
-            color: inherit;
-            background-color: transparent;
-          }
-        }
-
-        /*
           The default border color has changed to \`currentColor\` in Tailwind CSS v4,
           so we've added these compatibility styles to make sure everything still
           looks the same as it did with Tailwind CSS v3.
@@ -1681,23 +1426,6 @@ describe('border compatibility', () => {
         }
 
         /*
-          In Tailwind CSS v4, basic styles are applied to form elements by default. To
-          maintain compatibility with v3, the following resets have been added:
-        */
-        @layer base {
-          input,
-          textarea,
-          select,
-          button {
-            border: 0px solid;
-            border-radius: 0;
-            padding: 0;
-            color: inherit;
-            background-color: transparent;
-          }
-        }
-
-        /*
           The default border color has changed to \`currentColor\` in Tailwind CSS v4,
           so we've added these compatibility styles to make sure everything still
           looks the same as it did with Tailwind CSS v3.
@@ -1797,23 +1525,6 @@ describe('border compatibility', () => {
           @media (width >= 1536px) {
             max-width: 1536px;
             padding-inline: 4rem;
-          }
-        }
-
-        /*
-          In Tailwind CSS v4, basic styles are applied to form elements by default. To
-          maintain compatibility with v3, the following resets have been added:
-        */
-        @layer base {
-          input,
-          textarea,
-          select,
-          button {
-            border: 0px solid;
-            border-radius: 0;
-            padding: 0;
-            color: inherit;
-            background-color: transparent;
           }
         }
 

--- a/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
@@ -393,11 +393,6 @@ exports[`\`@import 'tailwindcss'\` is replaced with the generated CSS 1`] = `
     font-feature-settings: var(--default-font-feature-settings, normal);
     font-variation-settings: var(--default-font-variation-settings, normal);
     -webkit-tap-highlight-color: transparent;
-    --lightningcss-light: initial;
-    --lightningcss-dark: ;
-    --lightningcss-light: initial;
-    --lightningcss-dark: ;
-    color-scheme: light;
   }
 
   body {
@@ -496,6 +491,9 @@ exports[`\`@import 'tailwindcss'\` is replaced with the generated CSS 1`] = `
     font-variation-settings: inherit;
     letter-spacing: inherit;
     color: inherit;
+    opacity: 1;
+    background-color: #0000;
+    border-radius: 0;
   }
 
   ::file-selector-button {
@@ -504,6 +502,21 @@ exports[`\`@import 'tailwindcss'\` is replaced with the generated CSS 1`] = `
     font-variation-settings: inherit;
     letter-spacing: inherit;
     color: inherit;
+    opacity: 1;
+    background-color: #0000;
+    border-radius: 0;
+  }
+
+  :where(select:is([multiple], [size])) optgroup {
+    font-weight: bolder;
+  }
+
+  :where(select:is([multiple], [size])) optgroup option {
+    padding-inline-start: 20px;
+  }
+
+  ::file-selector-button {
+    margin-inline-end: 4px;
   }
 
   ::placeholder {
@@ -586,89 +599,6 @@ exports[`\`@import 'tailwindcss'\` is replaced with the generated CSS 1`] = `
 
   ::-webkit-outer-spin-button {
     height: auto;
-  }
-
-  select, textarea, input:where([type="text"], [type="email"], [type="password"], [type="date"], [type="datetime-local"], [type="month"], [type="number"], [type="search"], [type="time"], [type="week"], [type="tel"], [type="url"]) {
-    color: var(--lightningcss-light, #000) var(--lightningcss-dark, #fff);
-    background-color: var(--lightningcss-light, #fff) var(--lightningcss-dark, #ffffff1a);
-    border: 1px solid var(--lightningcss-light, #00000080) var(--lightningcss-dark, #ffffff40);
-    border-radius: 3px;
-    padding-block: 2px;
-    padding-inline: 4px;
-  }
-
-  :where(select:not([multiple], [size])) option, :where(select:not([multiple], [size])) optgroup {
-    color: fieldtext;
-    background-color: field;
-  }
-
-  :where(select:is([multiple], [size])) optgroup {
-    font-weight: bold;
-  }
-
-  :where(select:is([multiple], [size])) optgroup option {
-    padding-inline-start: 20px;
-  }
-
-  select:where(:disabled), textarea:where(:disabled), input:where([type="text"], [type="email"], [type="password"], [type="date"], [type="datetime-local"], [type="month"], [type="number"], [type="search"], [type="time"], [type="week"], [type="tel"], [type="url"]):where(:disabled) {
-    opacity: 1;
-    color: var(--lightningcss-light, #00000080) var(--lightningcss-dark, #ffffff80);
-    background-color: var(--lightningcss-light, #00000006) var(--lightningcss-dark, #ffffff1a);
-    border-color: var(--lightningcss-light, #0003) var(--lightningcss-dark, #ffffff26);
-  }
-
-  button, input:where([type="button"], [type="reset"], [type="submit"]) {
-    color: var(--lightningcss-light, #000) var(--lightningcss-dark, #fff);
-    background-color: var(--lightningcss-light, #0000000d) var(--lightningcss-dark, #fff6);
-    border: 1px solid var(--lightningcss-light, #00000080) var(--lightningcss-dark, #ffffff1a);
-    border-radius: 4px;
-    padding-block: 2px;
-    padding-inline: 4px;
-  }
-
-  ::file-selector-button {
-    color: var(--lightningcss-light, #000) var(--lightningcss-dark, #fff);
-    background-color: var(--lightningcss-light, #0000000d) var(--lightningcss-dark, #fff6);
-    border: 1px solid var(--lightningcss-light, #00000080) var(--lightningcss-dark, #ffffff1a);
-    border-radius: 4px;
-    padding-block: 2px;
-    padding-inline: 4px;
-  }
-
-  button:where(:hover), input:where([type="button"], [type="reset"], [type="submit"]):where(:hover) {
-    background-color: var(--lightningcss-light, #0000001a) var(--lightningcss-dark, #ffffff73);
-  }
-
-  ::file-selector-button:where(:hover) {
-    background-color: var(--lightningcss-light, #0000001a) var(--lightningcss-dark, #ffffff73);
-  }
-
-  button:where(:active), input:where([type="button"], [type="reset"], [type="submit"]):where(:active) {
-    background-color: var(--lightningcss-light, #00000006) var(--lightningcss-dark, #ffffff4d);
-  }
-
-  ::file-selector-button:where(:active) {
-    background-color: var(--lightningcss-light, #00000006) var(--lightningcss-dark, #ffffff4d);
-  }
-
-  button:where(:disabled), input:where([type="button"], [type="reset"], [type="submit"]):where(:disabled) {
-    opacity: 1;
-    background-color: var(--lightningcss-light, #00000006) var(--lightningcss-dark, #ffffff40);
-    border-color: var(--lightningcss-light, #0003) var(--lightningcss-dark, #ffffff1a);
-  }
-
-  :where(input:disabled)::file-selector-button {
-    opacity: 1;
-    background-color: var(--lightningcss-light, #00000006) var(--lightningcss-dark, #ffffff40);
-    border-color: var(--lightningcss-light, #0003) var(--lightningcss-dark, #ffffff1a);
-  }
-
-  input:where([type="file"]:disabled) {
-    color: var(--lightningcss-light, #00000080) var(--lightningcss-dark, #ffffff80);
-  }
-
-  ::file-selector-button {
-    margin-inline-end: 4px;
   }
 
   [hidden]:where(:not([hidden="until-found"])) {

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-preflight.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-preflight.test.ts
@@ -33,23 +33,6 @@ it("should add compatibility CSS after the `@import 'tailwindcss'`", async () =>
     "@import 'tailwindcss';
 
     /*
-      In Tailwind CSS v4, basic styles are applied to form elements by default. To
-      maintain compatibility with v3, the following resets have been added:
-    */
-    @layer base {
-      input,
-      textarea,
-      select,
-      button {
-        border: 0px solid;
-        border-radius: 0;
-        padding: 0;
-        color: inherit;
-        background-color: transparent;
-      }
-    }
-
-    /*
       The default border color has changed to \`currentColor\` in Tailwind CSS v4,
       so we've added these compatibility styles to make sure everything still
       looks the same as it did with Tailwind CSS v3.
@@ -80,23 +63,6 @@ it('should add the compatibility CSS after the last `@import`', async () => {
     "@import 'tailwindcss';
     @import './foo.css';
     @import './bar.css';
-
-    /*
-      In Tailwind CSS v4, basic styles are applied to form elements by default. To
-      maintain compatibility with v3, the following resets have been added:
-    */
-    @layer base {
-      input,
-      textarea,
-      select,
-      button {
-        border: 0px solid;
-        border-radius: 0;
-        padding: 0;
-        color: inherit;
-        background-color: transparent;
-      }
-    }
 
     /*
       The default border color has changed to \`currentColor\` in Tailwind CSS v4,
@@ -145,23 +111,6 @@ it('should add the compatibility CSS after the last import, even if a body-less 
     @import './bar.css';
 
     /*
-      In Tailwind CSS v4, basic styles are applied to form elements by default. To
-      maintain compatibility with v3, the following resets have been added:
-    */
-    @layer base {
-      input,
-      textarea,
-      select,
-      button {
-        border: 0px solid;
-        border-radius: 0;
-        padding: 0;
-        color: inherit;
-        background-color: transparent;
-      }
-    }
-
-    /*
       The default border color has changed to \`currentColor\` in Tailwind CSS v4,
       so we've added these compatibility styles to make sure everything still
       looks the same as it did with Tailwind CSS v3.
@@ -205,23 +154,6 @@ it('should add the compatibility CSS before the first `@layer base` (if the "tai
     "@import 'tailwindcss';
 
     @variant foo {
-    }
-
-    /*
-      In Tailwind CSS v4, basic styles are applied to form elements by default. To
-      maintain compatibility with v3, the following resets have been added:
-    */
-    @layer base {
-      input,
-      textarea,
-      select,
-      button {
-        border: 0px solid;
-        border-radius: 0;
-        padding: 0;
-        color: inherit;
-        background-color: transparent;
-      }
     }
 
     /*
@@ -280,23 +212,6 @@ it('should add the compatibility CSS before the first `@layer base` (if the "tai
     "@import 'tailwindcss/preflight';
 
     @variant foo {
-    }
-
-    /*
-      In Tailwind CSS v4, basic styles are applied to form elements by default. To
-      maintain compatibility with v3, the following resets have been added:
-    */
-    @layer base {
-      input,
-      textarea,
-      select,
-      button {
-        border: 0px solid;
-        border-radius: 0;
-        padding: 0;
-        color: inherit;
-        background-color: transparent;
-      }
     }
 
     /*

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-preflight.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-preflight.ts
@@ -30,25 +30,6 @@ const BORDER_COLOR_COMPATIBILITY_CSS = css`
   }
 `
 
-const FORMS_RESET_CSS = css`
-  /*
-    In Tailwind CSS v4, basic styles are applied to form elements by default. To
-    maintain compatibility with v3, the following resets have been added:
-  */
-  @layer base {
-    input,
-    textarea,
-    select,
-    button {
-      border: 0px solid;
-      border-radius: 0;
-      padding: 0;
-      color: inherit;
-      background-color: transparent;
-    }
-  }
-`
-
 export function migratePreflight({
   designSystem,
   userConfig,
@@ -79,7 +60,7 @@ export function migratePreflight({
     if (!isTailwindRoot) return
 
     // Figure out the compatibility CSS to inject
-    let compatibilityCssString = FORMS_RESET_CSS + '\n\n'
+    let compatibilityCssString = ''
     if (defaultBorderColor !== DEFAULT_BORDER_COLOR) {
       compatibilityCssString += BORDER_COLOR_COMPATIBILITY_CSS
       compatibilityCssString += '\n\n'

--- a/packages/@tailwindcss-upgrade/src/index.test.ts
+++ b/packages/@tailwindcss-upgrade/src/index.test.ts
@@ -97,23 +97,6 @@ it('should migrate a stylesheet', async () => {
     "@import 'tailwindcss';
 
     /*
-      In Tailwind CSS v4, basic styles are applied to form elements by default. To
-      maintain compatibility with v3, the following resets have been added:
-    */
-    @layer base {
-      input,
-      textarea,
-      select,
-      button {
-        border: 0px solid;
-        border-radius: 0;
-        padding: 0;
-        color: inherit;
-        background-color: transparent;
-      }
-    }
-
-    /*
       The default border color has changed to \`currentColor\` in Tailwind CSS v4,
       so we've added these compatibility styles to make sure everything still
       looks the same as it did with Tailwind CSS v3.
@@ -185,23 +168,6 @@ it('should migrate a stylesheet (with imports)', async () => {
     @import './my-utilities.css' layer(utilities);
 
     /*
-      In Tailwind CSS v4, basic styles are applied to form elements by default. To
-      maintain compatibility with v3, the following resets have been added:
-    */
-    @layer base {
-      input,
-      textarea,
-      select,
-      button {
-        border: 0px solid;
-        border-radius: 0;
-        padding: 0;
-        color: inherit;
-        background-color: transparent;
-      }
-    }
-
-    /*
       The default border color has changed to \`currentColor\` in Tailwind CSS v4,
       so we've added these compatibility styles to make sure everything still
       looks the same as it did with Tailwind CSS v3.
@@ -242,23 +208,6 @@ it('should migrate a stylesheet (with preceding rules that should be wrapped in 
     @layer foo, bar, baz;
     /**! My license comment */
     @import 'tailwindcss';
-
-    /*
-      In Tailwind CSS v4, basic styles are applied to form elements by default. To
-      maintain compatibility with v3, the following resets have been added:
-    */
-    @layer base {
-      input,
-      textarea,
-      select,
-      button {
-        border: 0px solid;
-        border-radius: 0;
-        padding: 0;
-        color: inherit;
-        background-color: transparent;
-      }
-    }
 
     /*
       The default border color has changed to \`currentColor\` in Tailwind CSS v4,

--- a/packages/tailwindcss/preflight.css
+++ b/packages/tailwindcss/preflight.css
@@ -23,7 +23,6 @@
   5. Use the user's configured `sans` font-feature-settings by default.
   6. Use the user's configured `sans` font-variation-settings by default.
   7. Disable tap highlights on iOS.
-  8. Set a default `color-scheme`.
 */
 
 html,
@@ -44,7 +43,6 @@ html,
   font-feature-settings: var(--default-font-feature-settings, normal); /* 5 */
   font-variation-settings: var(--default-font-variation-settings, normal); /* 6 */
   -webkit-tap-highlight-color: transparent; /* 7 */
-  color-scheme: light; /* 8 */
 }
 
 /*
@@ -239,7 +237,10 @@ video {
 }
 
 /*
-  Inherit font styles in all browsers.
+  1. Inherit font styles in all browsers.
+  2. Remove border radius in all browsers.
+  3. Remove background color in all browsers.
+  4. Ensure consistent opacity for disabled states in all browsers.
 */
 
 button,
@@ -248,11 +249,38 @@ select,
 optgroup,
 textarea,
 ::file-selector-button {
-  font: inherit;
-  font-feature-settings: inherit;
-  font-variation-settings: inherit;
-  letter-spacing: inherit;
-  color: inherit;
+  font: inherit; /* 1 */
+  font-feature-settings: inherit; /* 1 */
+  font-variation-settings: inherit; /* 1 */
+  letter-spacing: inherit; /* 1 */
+  color: inherit; /* 1 */
+  border-radius: 0; /* 2 */
+  background-color: transparent; /* 3 */
+  opacity: 1; /* 4 */
+}
+
+/*
+  Restore default font weight.
+*/
+
+:where(select:is([multiple], [size])) optgroup {
+  font-weight: bolder;
+}
+
+/*
+  Restore indentation.
+*/
+
+:where(select:is([multiple], [size])) optgroup option {
+  padding-inline-start: 20px;
+}
+
+/*
+  Restore space after button.
+*/
+
+::file-selector-button {
+  margin-inline-end: 4px;
 }
 
 /*
@@ -344,113 +372,6 @@ input:where([type='button'], [type='reset'], [type='submit']),
 ::-webkit-inner-spin-button,
 ::-webkit-outer-spin-button {
   height: auto;
-}
-
-/*
-  Apply consistent base form control styles across browsers.
-*/
-
-select,
-textarea,
-input:where(
-    [type='text'],
-    [type='email'],
-    [type='password'],
-    [type='date'],
-    [type='datetime-local'],
-    [type='month'],
-    [type='number'],
-    [type='search'],
-    [type='time'],
-    [type='week'],
-    [type='tel'],
-    [type='url']
-  ) {
-  border-radius: 3px;
-  padding-inline: 4px;
-  padding-block: 2px;
-  color: light-dark(black, white);
-  background-color: light-dark(white, rgb(255 255 255 / 10%));
-  border: 1px solid light-dark(rgb(0 0 0 / 50%), rgb(255 255 255 / 25%));
-}
-
-:where(select:not([multiple], [size])) option,
-:where(select:not([multiple], [size])) optgroup {
-  color: FieldText;
-  background-color: Field;
-}
-
-:where(select:is([multiple], [size])) optgroup {
-  font-weight: bold;
-}
-
-:where(select:is([multiple], [size])) optgroup option {
-  padding-inline-start: 20px;
-}
-
-select:where(:disabled),
-textarea:where(:disabled),
-input:where(
-    [type='text'],
-    [type='email'],
-    [type='password'],
-    [type='date'],
-    [type='datetime-local'],
-    [type='month'],
-    [type='number'],
-    [type='search'],
-    [type='time'],
-    [type='week'],
-    [type='tel'],
-    [type='url']
-  ):where(:disabled) {
-  opacity: 1;
-  color: light-dark(rgb(0 0 0 / 50%), rgb(255 255 255 / 50%));
-  background-color: light-dark(rgb(0 0 0 / 2.5%), rgb(255 255 255 / 10%));
-  border-color: light-dark(rgb(0 0 0 / 20%), rgb(255 255 255 / 15%));
-}
-
-/*
-  Apply consistent base button styles across browsers.
-*/
-
-button,
-::file-selector-button,
-input:where([type='button'], [type='reset'], [type='submit']) {
-  border-radius: 4px;
-  padding-inline: 4px;
-  padding-block: 2px;
-  color: light-dark(#000, #fff);
-  background-color: light-dark(rgb(0 0 0 / 5%), rgb(255 255 255 / 40%));
-  border: 1px solid light-dark(rgb(0 0 0 / 50%), rgb(255 255 255 / 10%));
-}
-
-button:where(:hover),
-::file-selector-button:where(:hover),
-input:where([type='button'], [type='reset'], [type='submit']):where(:hover) {
-  background-color: light-dark(rgb(0 0 0 / 10%), rgb(255 255 255 / 45%));
-}
-
-button:where(:active),
-::file-selector-button:where(:active),
-input:where([type='button'], [type='reset'], [type='submit']):where(:active) {
-  background-color: light-dark(rgb(0 0 0 / 2.5%), rgb(255 255 255 / 30%));
-}
-
-button:where(:disabled),
-:where(input:disabled)::file-selector-button,
-input:where([type='button'], [type='reset'], [type='submit']):where(:disabled) {
-  opacity: 1;
-  background-color: light-dark(rgb(0 0 0 / 2.5%), rgb(255 255 255 / 25%));
-  border-color: light-dark(rgb(0 0 0 / 20%), rgb(255 255 255 / 10%));
-}
-
-input:where([type='file']:disabled) {
-  color: light-dark(rgb(0 0 0 / 50%), rgb(255 255 255 / 50%));
-}
-
-::file-selector-button {
-  margin-inline-end: 4px;
 }
 
 /*


### PR DESCRIPTION
Closes #15071

This PR reverts the changes in #15036 which add consistent base styles for buttons and form controls to Preflight.

While this felt like a good idea (for the reasons explained in that PR), practically this is just too disruptive of a change for people upgrading from v3 to v4.

While updating some of our projects to v4 we found ourselves adding classes to undo styles more often than we expected, and it also felt inconsistent to have to use a different set of classes to style a link or a button when we wanted them to look the same.

We also decided it feels a little strange that you could change the border color of an element without ever specifying that it should have a border, for example this just feels a little wrong:

```html
<button class="border-blue-500">
```

We also needed to set a default `color-scheme` value for any of this stuff to work which breaks the ability to use the `color-scheme` meta tag.

Since this change was a fairly major breaking change and we aren't feeling much benefit from it, it doesn't feel worth making this change for v4.