### PR TITLE
Generate the correct CSS for the `break-keep` utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use configured `--letter-spacing` values for custom font size utilities ([#15099](https://github.com/tailwindlabs/tailwindcss/pull/15099))
 - Ensure `space-x/y-*` and `divide-x/y-*` with variants can undo `space-x/y-reverse` and `divide-x/y-reverse` ([#15094](https://github.com/tailwindlabs/tailwindcss/pull/15094))
+- Generate the correct CSS for the `break-keep` utility ([#15108](https://github.com/tailwindlabs/tailwindcss/pull/15108))
 - _Upgrade (experimental)_: Always add `layer(…)` as the first param to `@import` ([#15102](https://github.com/tailwindlabs/tailwindcss/pull/15102))
 
 ### Changed

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -9212,23 +9212,23 @@ test('text-wrap', async () => {
 test('overflow-wrap', async () => {
   expect(await run(['break-normal', 'break-words', 'break-all', 'break-keep']))
     .toMatchInlineSnapshot(`
-    ".break-normal {
-      overflow-wrap: normal;
-      word-break: normal;
-    }
+      ".break-normal {
+        overflow-wrap: normal;
+        word-break: normal;
+      }
 
-    .break-words {
-      overflow-wrap: break-word;
-    }
+      .break-words {
+        overflow-wrap: break-word;
+      }
 
-    .break-all {
-      word-break: break-all;
-    }
+      .break-all {
+        word-break: break-all;
+      }
 
-    .break-keep {
-      word-break: break-keep;
-    }"
-  `)
+      .break-keep {
+        word-break: keep-all;
+      }"
+    `)
   expect(
     await run([
       '-break-normal',

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -1963,7 +1963,7 @@ export function createUtilities(theme: Theme) {
   ])
   staticUtility('break-words', [['overflow-wrap', 'break-word']])
   staticUtility('break-all', [['word-break', 'break-all']])
-  staticUtility('break-keep', [['word-break', 'break-keep']])
+  staticUtility('break-keep', [['word-break', 'keep-all']])
 
   {
     // border-radius


### PR DESCRIPTION
Fixes https://github.com/tailwindlabs/tailwindcss/issues/15107.

Previously we were generating `word-break: break-keep` when it should be `word-break: keep-all`.