### PR TITLE
Remove redundant `line-height` from `body`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `border-[12px_4px]` being interpreted as a `border-color` instead of a `border-width` ([#17248](https://github.com/tailwindlabs/tailwindcss/pull/17248))
 - Use the `oklab(…)` function when applying opacity to `currentColor` to work around a crash in Safari 16.4 and 16.5 ([#17247](https://github.com/tailwindlabs/tailwindcss/pull/17247))
 - Pre-process `<template lang="…">` in Vue files ([#17252](https://github.com/tailwindlabs/tailwindcss/pull/17252))
+- Remove redundant `line-height: initial` from Preflight ([#15212](https://github.com/tailwindlabs/tailwindcss/pull/15212))
 
 ## [4.0.14] - 2025-03-13
 

--- a/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
@@ -43,10 +43,6 @@ exports[`\`@import 'tailwindcss'\` is replaced with the generated CSS 1`] = `
     -webkit-tap-highlight-color: transparent;
   }
 
-  body {
-    line-height: inherit;
-  }
-
   hr {
     height: 0;
     color: inherit;

--- a/packages/tailwindcss/preflight.css
+++ b/packages/tailwindcss/preflight.css
@@ -46,14 +46,6 @@ html,
 }
 
 /*
-  Inherit line-height from `html` so users can set them as a class directly on the `html` element.
-*/
-
-body {
-  line-height: inherit;
-}
-
-/*
   1. Add the correct height in Firefox.
   2. Correct the inheritance of border color in Firefox. (https://bugzilla.mozilla.org/show_bug.cgi?id=190655)
   3. Reset the default border style to a 1px solid border.


### PR DESCRIPTION
It was added in #2729 to override line heights set on the body by modern-normalize. However,  it appears that modern-normalize never included any line-height definitions—only a font-family rule was present.

Ref: https://github.com/sindresorhus/modern-normalize/blob/v1.1.0/modern-normalize.css