### PR TITLE
Improve performance of `@tailwindcss/postcss` and `@tailwindcss/vite`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Improve performance of `@tailwindcss/postcss` and `@tailwindcss/vite` ([#15226](https://github.com/tailwindlabs/tailwindcss/pull/15226))
+- Don't scan source files for utilities unless `@tailwind utilities` is present in the CSS in `@tailwindcss/postcss` and `@tailwindcss/vite` ([#15226](https://github.com/tailwindlabs/tailwindcss/pull/15226))
+- Skip reserializing CSS files that don't use Tailwind features in `@tailwindcss/postcss` and `@tailwindcss/vite` ([#15226](https://github.com/tailwindlabs/tailwindcss/pull/15226))
 
 ## [4.0.0-beta.3] - 2024-11-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Improve performance of `@tailwindcss/postcss` and `@tailwindcss/vite` ([#15226](https://github.com/tailwindlabs/tailwindcss/pull/15226))
 
 ## [4.0.0-beta.3] - 2024-11-27
 

--- a/packages/@tailwindcss-node/src/compile.ts
+++ b/packages/@tailwindcss-node/src/compile.ts
@@ -7,9 +7,12 @@ import { pathToFileURL } from 'node:url'
 import {
   __unstable__loadDesignSystem as ___unstable__loadDesignSystem,
   compile as _compile,
+  Features,
 } from 'tailwindcss'
 import { getModuleDependencies } from './get-module-dependencies'
 import { rewriteUrls } from './urls'
+
+export { Features }
 
 export type Resolver = (id: string, base: string) => Promise<string | false | undefined>
 

--- a/packages/@tailwindcss-node/src/compile.ts
+++ b/packages/@tailwindcss-node/src/compile.ts
@@ -16,6 +16,7 @@ export type Resolver = (id: string, base: string) => Promise<string | false | un
 export async function compile(
   css: string,
   {
+    buildAst = false,
     base,
     onDependency,
     shouldRewriteUrls,
@@ -23,6 +24,7 @@ export async function compile(
     customCssResolver,
     customJsResolver,
   }: {
+    buildAst?: boolean
     base: string
     onDependency: (path: string) => void
     shouldRewriteUrls?: boolean
@@ -32,6 +34,7 @@ export async function compile(
   },
 ) {
   let compiler = await _compile(css, {
+    buildAst,
     base,
     async loadModule(id, base) {
       return loadModule(id, base, onDependency, customJsResolver)

--- a/packages/@tailwindcss-node/src/compile.ts
+++ b/packages/@tailwindcss-node/src/compile.ts
@@ -19,7 +19,6 @@ export type Resolver = (id: string, base: string) => Promise<string | false | un
 export async function compile(
   css: string,
   {
-    buildAst = false,
     base,
     onDependency,
     shouldRewriteUrls,
@@ -27,7 +26,6 @@ export async function compile(
     customCssResolver,
     customJsResolver,
   }: {
-    buildAst?: boolean
     base: string
     onDependency: (path: string) => void
     shouldRewriteUrls?: boolean
@@ -37,7 +35,6 @@ export async function compile(
   },
 ) {
   let compiler = await _compile(css, {
-    buildAst,
     base,
     async loadModule(id, base) {
       return loadModule(id, base, onDependency, customJsResolver)

--- a/packages/@tailwindcss-node/src/index.ts
+++ b/packages/@tailwindcss-node/src/index.ts
@@ -1,7 +1,7 @@
 import * as Module from 'node:module'
 import { pathToFileURL } from 'node:url'
 import * as env from './env'
-export { __unstable__loadDesignSystem, compile } from './compile'
+export { __unstable__loadDesignSystem, compile, Features } from './compile'
 export * from './normalize-path'
 export { env }
 

--- a/packages/@tailwindcss-postcss/package.json
+++ b/packages/@tailwindcss-postcss/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "@types/postcss-import": "14.0.3",
+    "dedent": "1.5.3",
     "internal-example-plugin": "workspace:*",
     "postcss-import": "^16.1.0"
   }

--- a/packages/@tailwindcss-postcss/src/index.test.ts
+++ b/packages/@tailwindcss-postcss/src/index.test.ts
@@ -10,7 +10,11 @@ import tailwindcss from './index'
 // We place it in packages/ because Vitest runs in the monorepo root,
 // and packages/tailwindcss must be a sub-folder for
 // @import 'tailwindcss' to work.
-const INPUT_CSS_PATH = `${__dirname}/fixtures/example-project/input.css`
+function inputCssFilePath() {
+  // Including the current test name to ensure that the cache is invalidated per
+  // test otherwise the cache will be used across tests.
+  return `${__dirname}/fixtures/example-project/input.css?test=${expect.getState().currentTestName}`
+}
 
 const css = dedent
 
@@ -19,7 +23,7 @@ test("`@import 'tailwindcss'` is replaced with the generated CSS", async () => {
     tailwindcss({ base: `${__dirname}/fixtures/example-project`, optimize: { minify: false } }),
   ])
 
-  let result = await processor.process(`@import 'tailwindcss'`, { from: INPUT_CSS_PATH })
+  let result = await processor.process(`@import 'tailwindcss'`, { from: inputCssFilePath() })
 
   expect(result.css.trim()).toMatchSnapshot()
 
@@ -64,7 +68,7 @@ test('output is optimized by Lightning CSS', async () => {
         }
       }
     `,
-    { from: INPUT_CSS_PATH },
+    { from: inputCssFilePath() },
   )
 
   expect(result.css.trim()).toMatchInlineSnapshot(`
@@ -92,7 +96,7 @@ test('@apply can be used without emitting the theme in the CSS file', async () =
         @apply text-red-500;
       }
     `,
-    { from: INPUT_CSS_PATH },
+    { from: inputCssFilePath() },
   )
 
   expect(result.css.trim()).toMatchInlineSnapshot(`
@@ -113,7 +117,7 @@ describe('processing without specifying a base path', () => {
   test('the current working directory is used by default', async () => {
     let processor = postcss([tailwindcss({ optimize: { minify: false } })])
 
-    let result = await processor.process(`@import "tailwindcss"`, { from: INPUT_CSS_PATH })
+    let result = await processor.process(`@import "tailwindcss"`, { from: inputCssFilePath() })
 
     expect(result.css).toContain(
       ".md\\:\\[\\&\\:hover\\]\\:content-\\[\\'testing_default_base_path\\'\\]",
@@ -139,7 +143,7 @@ describe('plugins', () => {
         @import 'tailwindcss/utilities';
         @plugin './plugin.js';
       `,
-      { from: INPUT_CSS_PATH },
+      { from: inputCssFilePath() },
     )
 
     expect(result.css.trim()).toMatchInlineSnapshot(`
@@ -199,7 +203,7 @@ describe('plugins', () => {
         @import 'tailwindcss/utilities';
         @plugin 'internal-example-plugin';
       `,
-      { from: INPUT_CSS_PATH },
+      { from: inputCssFilePath() },
     )
 
     expect(result.css.trim()).toMatchInlineSnapshot(`
@@ -231,7 +235,7 @@ test('bail early when Tailwind is not used', async () => {
         color: red;
       }
     `,
-    { from: INPUT_CSS_PATH },
+    { from: inputCssFilePath() },
   )
 
   // `fixtures/example-project` includes an `underline` candidate. But since we

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -1,8 +1,8 @@
 import QuickLRU from '@alloc/quick-lru'
-import { compile, env } from '@tailwindcss/node'
+import { compile, env, Features } from '@tailwindcss/node'
 import { clearRequireCache } from '@tailwindcss/node/require-cache'
 import { Scanner } from '@tailwindcss/oxide'
-import { Features, transform } from 'lightningcss'
+import { Features as LightningCssFeatures, transform } from 'lightningcss'
 import fs from 'node:fs'
 import path from 'node:path'
 import postcss, {
@@ -98,7 +98,7 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
           // guarantee a `build()` function is available.
           context.compiler ??= await createCompiler()
 
-          if (context.compiler.tailwindCssType === 'none') {
+          if (context.compiler.features === Features.None) {
             return
           }
 
@@ -171,10 +171,11 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
           }
 
           env.DEBUG && console.time('[@tailwindcss/postcss] Scan for candidates')
-          let candidates = context.compiler.tailwindCssType === 'full' ? context.scanner.scan() : []
+          let candidates =
+            context.compiler.features & Features.Utilities ? context.scanner.scan() : []
           env.DEBUG && console.timeEnd('[@tailwindcss/postcss] Scan for candidates')
 
-          if (context.compiler.tailwindCssType === 'full') {
+          if (context.compiler.features & Features.Utilities) {
             // Add all found files as direct dependencies
             for (let file of context.scanner.files) {
               result.messages.push({
@@ -404,8 +405,8 @@ function optimizeCss(
       nonStandard: {
         deepSelectorCombinator: true,
       },
-      include: Features.Nesting,
-      exclude: Features.LogicalProperties,
+      include: LightningCssFeatures.Nesting,
+      exclude: LightningCssFeatures.LogicalProperties,
       targets: {
         safari: (16 << 16) | (4 << 8),
         ios_saf: (16 << 16) | (4 << 8),

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -63,7 +63,9 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
 
           async function createCompiler() {
             env.DEBUG && console.time('[@tailwindcss/postcss] Setup compiler')
-            clearRequireCache(context.fullRebuildPaths)
+            if (context.fullRebuildPaths.length > 0 && !isInitialBuild) {
+              clearRequireCache(context.fullRebuildPaths)
+            }
 
             context.fullRebuildPaths = []
 

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -5,13 +5,20 @@ import { Scanner } from '@tailwindcss/oxide'
 import { Features, transform } from 'lightningcss'
 import fs from 'node:fs'
 import path from 'node:path'
-import postcss, { type AcceptedPlugin, type PluginCreator } from 'postcss'
+import postcss, {
+  type AcceptedPlugin,
+  type PluginCreator,
+  type Container as PostCSSContainerNode,
+  type Node as PostCSSNode,
+} from 'postcss'
+import { type AstNode } from '../../tailwindcss/src/ast'
 import fixRelativePathsPlugin from './postcss-fix-relative-paths'
 
 interface CacheEntry {
   mtimes: Map<string, number>
   compiler: null | Awaited<ReturnType<typeof compile>>
   scanner: null | Scanner
+  ast: AstNode[] | null
   css: string
   optimizedCss: string
   fullRebuildPaths: string[]
@@ -25,6 +32,7 @@ function getContextFromCache(inputFile: string, opts: PluginOptions): CacheEntry
     mtimes: new Map<string, number>(),
     compiler: null,
     scanner: null,
+    ast: null,
     css: '',
     optimizedCss: '',
     fullRebuildPaths: [] as string[],
@@ -43,7 +51,8 @@ export type PluginOptions = {
 
 function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
   let base = opts.base ?? process.cwd()
-  let optimize = opts.optimize ?? process.env.NODE_ENV === 'production'
+  let inDevelopment = process.env.NODE_ENV !== 'production'
+  let optimize = opts.optimize ?? !inDevelopment
 
   return {
     postcssPlugin: '@tailwindcss/postcss',
@@ -70,6 +79,7 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
             context.fullRebuildPaths = []
 
             let compiler = await compile(root.toString(), {
+              buildAst: inDevelopment,
               base: inputBasePath,
               onDependency: (path) => {
                 context.fullRebuildPaths.push(path)
@@ -128,6 +138,7 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
             }
           }
 
+          let ast = null as AstNode[] | null
           let css = ''
 
           if (
@@ -205,28 +216,176 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
           }
 
           env.DEBUG && console.time('[@tailwindcss/postcss] Build CSS')
-          css = context.compiler.build(candidates)
+          let output = context.compiler.build(candidates)
+          if (typeof output === 'string') {
+            css = output
+          } else {
+            ast = output
+          }
           env.DEBUG && console.timeEnd('[@tailwindcss/postcss] Build CSS')
 
           // Replace CSS
-          if (css !== context.css && optimize) {
-            env.DEBUG && console.time('[@tailwindcss/postcss] Optimize CSS')
-            context.optimizedCss = optimizeCss(css, {
-              minify: typeof optimize === 'object' ? optimize.minify : true,
-            })
-            env.DEBUG && console.timeEnd('[@tailwindcss/postcss] Optimize CSS')
+          if (inDevelopment) {
+            if (ast !== context.ast) {
+              context.ast = ast
+            }
+          } else {
+            if (css !== context.css && optimize) {
+              env.DEBUG && console.time('[@tailwindcss/postcss] Optimize CSS')
+              context.optimizedCss = optimizeCss(css, {
+                minify: typeof optimize === 'object' ? optimize.minify : true,
+              })
+              env.DEBUG && console.timeEnd('[@tailwindcss/postcss] Optimize CSS')
+            }
           }
-          context.css = css
+
+          let postCssAst = null as PostCSSContainerNode | null
+          if (inDevelopment && context.ast) {
+            env.DEBUG && console.time('[@tailwindcss/postcss] Our AST -> PostCSS AST')
+            postCssAst = transformIntoPostCssAst(context.ast)
+            env.DEBUG && console.timeEnd('[@tailwindcss/postcss] Our AST -> PostCSS AST')
+          } else {
+            console.time('[@tailwindcss/postcss] string -> PostCSS AST')
+            postCssAst = postcss.parse(optimize ? context.optimizedCss : context.css, result.opts)
+            console.timeEnd('[@tailwindcss/postcss] string -> PostCSS AST')
+          }
 
           env.DEBUG && console.time('[@tailwindcss/postcss] Update PostCSS AST')
           root.removeAll()
-          root.append(postcss.parse(optimize ? context.optimizedCss : context.css, result.opts))
+          root.append(postCssAst)
           env.DEBUG && console.timeEnd('[@tailwindcss/postcss] Update PostCSS AST')
           env.DEBUG && console.timeEnd('[@tailwindcss/postcss] Total time in @tailwindcss/postcss')
         },
       },
     ],
   }
+}
+
+function transformIntoPostCssAst(ast: AstNode[]): PostCSSContainerNode {
+  let seenAtProperties = new Set<string>()
+  let propertyFallbacksRoot = [] as PostCSSNode[]
+  let propertyFallbacksUniversal = [] as PostCSSNode[]
+  let newRoot = postcss.root()
+  function transformNode(node: AstNode, parent: PostCSSContainerNode | null = null) {
+    let postCssNode = null as PostCSSNode | null
+
+    if (node.kind === 'comment') {
+      postCssNode = postcss.comment({ text: node.value })
+    } else if (node.kind === 'declaration') {
+      if (node.property === '--tw-sort') return
+      if (node.value === undefined) return
+      if (node.value === null) return
+
+      postCssNode = postcss.decl({
+        prop: node.property,
+        value: node.value ?? '',
+        important: node.important,
+      })
+    } else if (node.kind === 'at-rule') {
+      if (node.name === '@property') {
+        if (seenAtProperties.has(node.params)) return
+
+        // Collect fallbacks for `@property` rules for Firefox support
+        // We turn these into rules on `:root` or `*` and some pseudo-elements
+        // based on the value of `inherits``
+        let property = node.params
+        let initialValue = null
+        let inherits = false
+
+        for (let prop of node.nodes) {
+          if (prop.kind !== 'declaration') continue
+          if (prop.property === 'initial-value') {
+            initialValue = prop.value
+          } else if (prop.property === 'inherits') {
+            inherits = prop.value === 'true'
+          }
+        }
+
+        if (inherits) {
+          propertyFallbacksRoot.push(
+            postcss.decl({
+              prop: property,
+              value: initialValue ?? 'initial',
+            }),
+          )
+        } else {
+          propertyFallbacksUniversal.push(
+            postcss.decl({
+              prop: property,
+              value: initialValue ?? 'initial',
+            }),
+          )
+        }
+
+        seenAtProperties.add(node.params)
+      } else {
+        postCssNode = postcss.atRule({ name: node.name.slice(1), params: node.params })
+      }
+    } else if (node.kind === 'rule') {
+      postCssNode = postcss.rule({ selector: node.selector })
+    } else if (node.kind === 'at-root') {
+      let tmpRoot = postcss.root()
+      for (let child of node.nodes) {
+        transformNode(child, tmpRoot)
+      }
+      newRoot.append(tmpRoot)
+      return
+    } else if (node.kind === 'context') {
+      for (let child of node.nodes) {
+        transformNode(child, parent)
+      }
+      return
+    }
+
+    // Add the node to its parent's `nodes` array
+    if (parent && parent.append && postCssNode !== null) {
+      parent.append(postCssNode)
+    }
+
+    // Recursively transform children
+    if ('nodes' in node) {
+      for (let child of node.nodes) {
+        transformNode(child, postCssNode as PostCSSContainerNode)
+      }
+    }
+  }
+  for (let node of ast) {
+    transformNode(node, newRoot)
+  }
+  let fallbackAst = []
+  if (propertyFallbacksRoot.length) {
+    fallbackAst.push(
+      postcss.rule({
+        selector: ':root',
+        nodes: propertyFallbacksRoot,
+      }),
+    )
+  }
+  if (propertyFallbacksUniversal.length) {
+    fallbackAst.push(
+      postcss.rule({
+        selector: '*, ::before, ::after, ::backdrop',
+        nodes: propertyFallbacksUniversal,
+      }),
+    )
+  }
+  if (fallbackAst.length) {
+    newRoot.append(
+      postcss.atRule({
+        name: 'supports',
+        params: '(-moz-orient: inline)',
+        nodes: [
+          postcss.atRule({
+            name: 'layer',
+            params: 'base',
+            nodes: fallbackAst,
+          }),
+        ],
+      }),
+    )
+  }
+
+  return newRoot
 }
 
 function optimizeCss(

--- a/packages/@tailwindcss-upgrade/src/template/codemods/theme-to-var.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/theme-to-var.ts
@@ -13,7 +13,7 @@ import { toKeyPath } from '../../../../tailwindcss/src/utils/to-key-path'
 import * as ValueParser from '../../../../tailwindcss/src/value-parser'
 import { printCandidate } from '../candidates'
 
-export enum Convert {
+export const enum Convert {
   All = 0,
   MigrateModifier = 1 << 0,
   MigrateThemeOnly = 1 << 1,

--- a/packages/@tailwindcss-upgrade/src/utils/walk.ts
+++ b/packages/@tailwindcss-upgrade/src/utils/walk.ts
@@ -1,4 +1,4 @@
-export enum WalkAction {
+export const enum WalkAction {
   // Continue walking the tree. Default behavior.
   Continue,
 

--- a/packages/tailwindcss/src/apply.ts
+++ b/packages/tailwindcss/src/apply.ts
@@ -4,6 +4,8 @@ import type { DesignSystem } from './design-system'
 import { escape } from './utils/escape'
 
 export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
+  let usesAtApply = false
+
   walk(ast, (node, { replaceWith }) => {
     if (node.kind !== 'at-rule') return
 
@@ -18,6 +20,7 @@ export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
     }
 
     if (node.name !== '@apply') return
+    usesAtApply = true
 
     let candidates = node.params.split(/\s+/g)
 
@@ -75,4 +78,6 @@ export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
       replaceWith(newNodes)
     }
   })
+
+  return usesAtApply
 }

--- a/packages/tailwindcss/src/apply.ts
+++ b/packages/tailwindcss/src/apply.ts
@@ -1,11 +1,14 @@
+import { Features, type FeaturesRef } from '.'
 import { walk, WalkAction, type AstNode } from './ast'
 import { compileCandidates } from './compile'
 import type { DesignSystem } from './design-system'
 import { escape } from './utils/escape'
 
-export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
-  let usesAtApply = false
-
+export function substituteAtApply(
+  ast: AstNode[],
+  designSystem: DesignSystem,
+  featuresRef: FeaturesRef,
+) {
   walk(ast, (node, { replaceWith }) => {
     if (node.kind !== 'at-rule') return
 
@@ -20,7 +23,7 @@ export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
     }
 
     if (node.name !== '@apply') return
-    usesAtApply = true
+    featuresRef.current |= Features.AtApply
 
     let candidates = node.params.split(/\s+/g)
 
@@ -78,6 +81,4 @@ export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
       replaceWith(newNodes)
     }
   })
-
-  return usesAtApply
 }

--- a/packages/tailwindcss/src/apply.ts
+++ b/packages/tailwindcss/src/apply.ts
@@ -1,14 +1,11 @@
-import { Features, type FeaturesRef } from '.'
+import { Features } from '.'
 import { walk, WalkAction, type AstNode } from './ast'
 import { compileCandidates } from './compile'
 import type { DesignSystem } from './design-system'
 import { escape } from './utils/escape'
 
-export function substituteAtApply(
-  ast: AstNode[],
-  designSystem: DesignSystem,
-  featuresRef: FeaturesRef,
-) {
+export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
+  let features = Features.None
   walk(ast, (node, { replaceWith }) => {
     if (node.kind !== 'at-rule') return
 
@@ -23,7 +20,7 @@ export function substituteAtApply(
     }
 
     if (node.name !== '@apply') return
-    featuresRef.current |= Features.AtApply
+    features |= Features.AtApply
 
     let candidates = node.params.split(/\s+/g)
 
@@ -81,4 +78,5 @@ export function substituteAtApply(
       replaceWith(newNodes)
     }
   })
+  return features
 }

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -97,7 +97,7 @@ export function atRoot(nodes: AstNode[]): AtRoot {
   }
 }
 
-export enum WalkAction {
+export const enum WalkAction {
   /** Continue walking, which is the default */
   Continue,
 

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -251,13 +251,13 @@ export function toCss(ast: AstNode[]) {
         // We turn these into rules on `:root` or `*` and some pseudo-elements
         // based on the value of `inherits``
         let property = node.params
-        let initialValue = null as string | null
+        let initialValue = null
         let inherits = false
 
         for (let prop of node.nodes) {
           if (prop.kind !== 'declaration') continue
           if (prop.property === 'initial-value') {
-            initialValue = prop.value ?? null
+            initialValue = prop.value
           } else if (prop.property === 'inherits') {
             inherits = prop.value === 'true'
           }

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -131,7 +131,11 @@ export function walk(
     // whenever we encounter one, we immediately walk through its children and
     // furthermore we also don't update the parent.
     if (node.kind === 'context') {
-      walk(node.nodes, visit, parentPath, { ...context, ...node.context })
+      if (
+        walk(node.nodes, visit, parentPath, { ...context, ...node.context }) === WalkAction.Stop
+      ) {
+        return WalkAction.Stop
+      }
       continue
     }
 
@@ -150,13 +154,15 @@ export function walk(
       }) ?? WalkAction.Continue
 
     // Stop the walk entirely
-    if (status === WalkAction.Stop) return
+    if (status === WalkAction.Stop) return WalkAction.Stop
 
     // Skip visiting the children of this node
     if (status === WalkAction.Skip) continue
 
     if (node.kind === 'rule' || node.kind === 'at-rule') {
-      walk(node.nodes, visit, path, context)
+      if (walk(node.nodes, visit, path, context) === WalkAction.Stop) {
+        return WalkAction.Stop
+      }
     }
   }
 }

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -251,13 +251,13 @@ export function toCss(ast: AstNode[]) {
         // We turn these into rules on `:root` or `*` and some pseudo-elements
         // based on the value of `inherits``
         let property = node.params
-        let initialValue = null
+        let initialValue = null as string | null
         let inherits = false
 
         for (let prop of node.nodes) {
           if (prop.kind !== 'declaration') continue
           if (prop.property === 'initial-value') {
-            initialValue = prop.value
+            initialValue = prop.value ?? null
           } else if (prop.property === 'inherits') {
             inherits = prop.value === 'true'
           }

--- a/packages/tailwindcss/src/at-import.test.ts
+++ b/packages/tailwindcss/src/at-import.test.ts
@@ -1,10 +1,11 @@
+import dedent from 'dedent'
 import { expect, test, vi } from 'vitest'
 import type { Plugin } from './compat/plugin-api'
 import { compile, type Config } from './index'
 import plugin from './plugin'
 import { optimizeCss } from './test-utils/run'
 
-const css = String.raw
+const css = dedent
 
 async function run(
   css: string,
@@ -161,10 +162,7 @@ test('url() imports are passed-through', async () => {
       `,
       { loadStylesheet: () => Promise.reject(new Error('Unexpected stylesheet')), optimize: false },
     ),
-  ).resolves.toMatchInlineSnapshot(`
-    "@import url('example.css');
-    "
-  `)
+  ).resolves.toMatchInlineSnapshot(`"@import url('example.css');"`)
 
   await expect(
     run(
@@ -173,10 +171,7 @@ test('url() imports are passed-through', async () => {
       `,
       { loadStylesheet: () => Promise.reject(new Error('Unexpected stylesheet')), optimize: false },
     ),
-  ).resolves.toMatchInlineSnapshot(`
-    "@import url('./example.css');
-    "
-  `)
+  ).resolves.toMatchInlineSnapshot(`"@import url('./example.css');"`)
 
   await expect(
     run(
@@ -185,10 +180,7 @@ test('url() imports are passed-through', async () => {
       `,
       { loadStylesheet: () => Promise.reject(new Error('Unexpected stylesheet')), optimize: false },
     ),
-  ).resolves.toMatchInlineSnapshot(`
-    "@import url('/example.css');
-    "
-  `)
+  ).resolves.toMatchInlineSnapshot(`"@import url('/example.css');"`)
 
   await expect(
     run(
@@ -197,10 +189,7 @@ test('url() imports are passed-through', async () => {
       `,
       { loadStylesheet: () => Promise.reject(new Error('Unexpected stylesheet')), optimize: false },
     ),
-  ).resolves.toMatchInlineSnapshot(`
-    "@import url(example.css);
-    "
-  `)
+  ).resolves.toMatchInlineSnapshot(`"@import url(example.css);"`)
 
   await expect(
     run(
@@ -209,10 +198,7 @@ test('url() imports are passed-through', async () => {
       `,
       { loadStylesheet: () => Promise.reject(new Error('Unexpected stylesheet')), optimize: false },
     ),
-  ).resolves.toMatchInlineSnapshot(`
-    "@import url(./example.css);
-    "
-  `)
+  ).resolves.toMatchInlineSnapshot(`"@import url(./example.css);"`)
 
   await expect(
     run(
@@ -221,10 +207,7 @@ test('url() imports are passed-through', async () => {
       `,
       { loadStylesheet: () => Promise.reject(new Error('Unexpected stylesheet')), optimize: false },
     ),
-  ).resolves.toMatchInlineSnapshot(`
-    "@import url(/example.css);
-    "
-  `)
+  ).resolves.toMatchInlineSnapshot(`"@import url(/example.css);"`)
 })
 
 test('handles case-insensitive @import directive', async () => {

--- a/packages/tailwindcss/src/at-import.ts
+++ b/packages/tailwindcss/src/at-import.ts
@@ -16,10 +16,10 @@ export async function substituteAtImports(
 
   walk(ast, (node, { replaceWith }) => {
     if (node.kind === 'at-rule' && node.name === '@import') {
-      features |= Features.AtImport
-
       let parsed = parseImportParams(ValueParser.parse(node.params))
       if (parsed === null) return
+
+      features |= Features.AtImport
 
       let { uri, layer, media, supports } = parsed
 

--- a/packages/tailwindcss/src/at-import.ts
+++ b/packages/tailwindcss/src/at-import.ts
@@ -1,3 +1,4 @@
+import { Features, type FeaturesRef } from '.'
 import { atRule, context, walk, WalkAction, type AstNode } from './ast'
 import * as CSS from './css-parser'
 import * as ValueParser from './value-parser'
@@ -8,17 +9,17 @@ export async function substituteAtImports(
   ast: AstNode[],
   base: string,
   loadStylesheet: LoadStylesheet,
+  featuresRef: FeaturesRef,
   recurseCount = 0,
 ) {
-  let usesAtImport = false
   let promises: Promise<void>[] = []
 
   walk(ast, (node, { replaceWith }) => {
     if (node.kind === 'at-rule' && node.name === '@import') {
-      usesAtImport = true
-
       let parsed = parseImportParams(ValueParser.parse(node.params))
       if (parsed === null) return
+
+      featuresRef.current |= Features.AtImport
 
       let { uri, layer, media, supports } = parsed
 
@@ -42,7 +43,7 @@ export async function substituteAtImports(
 
           let loaded = await loadStylesheet(uri, base)
           let ast = CSS.parse(loaded.content)
-          await substituteAtImports(ast, loaded.base, loadStylesheet, recurseCount + 1)
+          await substituteAtImports(ast, loaded.base, loadStylesheet, featuresRef, recurseCount + 1)
 
           contextNode.nodes = buildImportNodes(
             [context({ base: loaded.base }, ast)],
@@ -64,8 +65,6 @@ export async function substituteAtImports(
   if (promises.length > 0) {
     await Promise.all(promises)
   }
-
-  return usesAtImport
 }
 
 // Modified and inlined version of `parse-statements` from

--- a/packages/tailwindcss/src/at-import.ts
+++ b/packages/tailwindcss/src/at-import.ts
@@ -10,10 +10,13 @@ export async function substituteAtImports(
   loadStylesheet: LoadStylesheet,
   recurseCount = 0,
 ) {
+  let usesAtImport = false
   let promises: Promise<void>[] = []
 
   walk(ast, (node, { replaceWith }) => {
     if (node.kind === 'at-rule' && node.name === '@import') {
+      usesAtImport = true
+
       let parsed = parseImportParams(ValueParser.parse(node.params))
       if (parsed === null) return
 
@@ -58,7 +61,11 @@ export async function substituteAtImports(
     }
   })
 
-  await Promise.all(promises)
+  if (promises.length > 0) {
+    await Promise.all(promises)
+  }
+
+  return usesAtImport
 }
 
 // Modified and inlined version of `parse-statements` from

--- a/packages/tailwindcss/src/compat/apply-compat-hooks.ts
+++ b/packages/tailwindcss/src/compat/apply-compat-hooks.ts
@@ -32,6 +32,7 @@ export async function applyCompatibilityHooks({
   ) => Promise<{ module: any; base: string }>
   globs: { origin?: string; pattern: string }[]
 }) {
+  let usesStatic = false
   let pluginPaths: [{ id: string; base: string }, CssPluginOptions | null][] = []
   let configPaths: { id: string; base: string }[] = []
 
@@ -98,6 +99,7 @@ export async function applyCompatibilityHooks({
       ])
 
       replaceWith([])
+      usesStatic = true
       return
     }
 
@@ -113,6 +115,7 @@ export async function applyCompatibilityHooks({
 
       configPaths.push({ id: node.params.slice(1, -1), base: context.base })
       replaceWith([])
+      usesStatic = true
       return
     }
   })
@@ -179,6 +182,8 @@ export async function applyCompatibilityHooks({
     configs,
     pluginDetails,
   })
+
+  return usesStatic
 }
 
 function upgradeToFullPluginSupport({

--- a/packages/tailwindcss/src/compat/apply-config-to-theme.ts
+++ b/packages/tailwindcss/src/compat/apply-config-to-theme.ts
@@ -213,7 +213,7 @@ function isValidThemeTuple(value: unknown): value is [string, Record<string, str
   return true
 }
 
-enum WalkAction {
+const enum WalkAction {
   /** Continue walking, which is the default */
   Continue,
 

--- a/packages/tailwindcss/src/compat/apply-config-to-theme.ts
+++ b/packages/tailwindcss/src/compat/apply-config-to-theme.ts
@@ -241,10 +241,12 @@ function walk(
     let result = callback(value, keyPath) ?? WalkAction.Continue
 
     if (result === WalkAction.Skip) continue
-    if (result === WalkAction.Stop) break
+    if (result === WalkAction.Stop) return WalkAction.Stop
 
     if (!Array.isArray(value) && typeof value !== 'object') continue
 
-    walk(value as any, keyPath, callback)
+    if (walk(value as any, keyPath, callback) === WalkAction.Stop) {
+      return WalkAction.Stop
+    }
   }
 }

--- a/packages/tailwindcss/src/compat/plugin-api.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.ts
@@ -1,3 +1,4 @@
+import type { FeaturesRef } from '..'
 import { substituteAtApply } from '../apply'
 import { atRule, decl, rule, walk, type AstNode } from '../ast'
 import type { Candidate, CandidateModifier, NamedUtilityValue } from '../candidate'
@@ -83,11 +84,12 @@ export function buildPluginApi(
   designSystem: DesignSystem,
   ast: AstNode[],
   resolvedConfig: ResolvedConfig,
+  featuresRef: FeaturesRef,
 ): PluginAPI {
   let api: PluginAPI = {
     addBase(css) {
       let baseNodes = objectToAst(css)
-      substituteFunctions(baseNodes, api.theme)
+      substituteFunctions(baseNodes, api.theme, featuresRef)
       ast.push(atRule('@layer', 'base', baseNodes))
     },
 
@@ -260,7 +262,7 @@ export function buildPluginApi(
 
         designSystem.utilities.static(className, () => {
           let clonedAst = structuredClone(ast)
-          substituteAtApply(clonedAst, designSystem)
+          substituteAtApply(clonedAst, designSystem, featuresRef)
           return clonedAst
         })
       }
@@ -382,7 +384,7 @@ export function buildPluginApi(
             }
 
             let ast = objectToAst(fn(value, { modifier }))
-            substituteAtApply(ast, designSystem)
+            substituteAtApply(ast, designSystem, featuresRef)
             return ast
           }
         }

--- a/packages/tailwindcss/src/compat/plugin-api.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.ts
@@ -1,4 +1,4 @@
-import type { FeaturesRef } from '..'
+import type { Features } from '..'
 import { substituteAtApply } from '../apply'
 import { atRule, decl, rule, walk, type AstNode } from '../ast'
 import type { Candidate, CandidateModifier, NamedUtilityValue } from '../candidate'
@@ -84,12 +84,12 @@ export function buildPluginApi(
   designSystem: DesignSystem,
   ast: AstNode[],
   resolvedConfig: ResolvedConfig,
-  featuresRef: FeaturesRef,
+  featuresRef: { current: Features },
 ): PluginAPI {
   let api: PluginAPI = {
     addBase(css) {
       let baseNodes = objectToAst(css)
-      substituteFunctions(baseNodes, api.theme, featuresRef)
+      featuresRef.current |= substituteFunctions(baseNodes, api.theme)
       ast.push(atRule('@layer', 'base', baseNodes))
     },
 
@@ -262,7 +262,7 @@ export function buildPluginApi(
 
         designSystem.utilities.static(className, () => {
           let clonedAst = structuredClone(ast)
-          substituteAtApply(clonedAst, designSystem, featuresRef)
+          featuresRef.current |= substituteAtApply(clonedAst, designSystem)
           return clonedAst
         })
       }
@@ -384,7 +384,7 @@ export function buildPluginApi(
             }
 
             let ast = objectToAst(fn(value, { modifier }))
-            substituteAtApply(ast, designSystem, featuresRef)
+            featuresRef.current |= substituteAtApply(ast, designSystem)
             return ast
           }
         }

--- a/packages/tailwindcss/src/compat/selector-parser.ts
+++ b/packages/tailwindcss/src/compat/selector-parser.ts
@@ -68,7 +68,7 @@ function value(value: string): SelectorValueNode {
   }
 }
 
-export enum SelectorWalkAction {
+export const enum SelectorWalkAction {
   /** Continue walking, which is the default */
   Continue,
 

--- a/packages/tailwindcss/src/compat/selector-parser.ts
+++ b/packages/tailwindcss/src/compat/selector-parser.ts
@@ -105,13 +105,15 @@ export function walk(
       }) ?? SelectorWalkAction.Continue
 
     // Stop the walk entirely
-    if (status === SelectorWalkAction.Stop) return
+    if (status === SelectorWalkAction.Stop) return SelectorWalkAction.Stop
 
     // Skip visiting the children of this node
     if (status === SelectorWalkAction.Skip) continue
 
     if (node.kind === 'function') {
-      walk(node.nodes, visit, node)
+      if (walk(node.nodes, visit, node) === SelectorWalkAction.Stop) {
+        return SelectorWalkAction.Stop
+      }
     }
   }
 }

--- a/packages/tailwindcss/src/compile.ts
+++ b/packages/tailwindcss/src/compile.ts
@@ -63,7 +63,6 @@ export function compileCandidates(
         substituteFunctions(
           rules.map(({ node }) => node),
           designSystem.resolveThemeValue,
-          { current: 0 },
         )
       } catch (err) {
         // If substitution fails then the candidate likely contains a call to

--- a/packages/tailwindcss/src/compile.ts
+++ b/packages/tailwindcss/src/compile.ts
@@ -63,6 +63,7 @@ export function compileCandidates(
         substituteFunctions(
           rules.map(({ node }) => node),
           designSystem.resolveThemeValue,
+          { current: 0 },
         )
       } catch (err) {
         // If substitution fails then the candidate likely contains a call to

--- a/packages/tailwindcss/src/css-functions.ts
+++ b/packages/tailwindcss/src/css-functions.ts
@@ -1,3 +1,4 @@
+import { Features, type FeaturesRef } from '.'
 import { walk, type AstNode } from './ast'
 import * as ValueParser from './value-parser'
 import { type ValueAstNode } from './value-parser'
@@ -6,12 +7,15 @@ export const THEME_FUNCTION_INVOCATION = 'theme('
 
 type ResolveThemeValue = (path: string) => string | undefined
 
-export function substituteFunctions(ast: AstNode[], resolveThemeValue: ResolveThemeValue) {
-  let usesFunctions = false
+export function substituteFunctions(
+  ast: AstNode[],
+  resolveThemeValue: ResolveThemeValue,
+  featuresRef: FeaturesRef,
+) {
   walk(ast, (node) => {
     // Find all declaration values
     if (node.kind === 'declaration' && node.value?.includes(THEME_FUNCTION_INVOCATION)) {
-      usesFunctions = true
+      featuresRef.current |= Features.ThemeFunction
       node.value = substituteFunctionsInValue(node.value, resolveThemeValue)
       return
     }
@@ -25,12 +29,11 @@ export function substituteFunctions(ast: AstNode[], resolveThemeValue: ResolveTh
           node.name === '@supports') &&
         node.params.includes(THEME_FUNCTION_INVOCATION)
       ) {
-        usesFunctions = true
+        featuresRef.current |= Features.ThemeFunction
         node.params = substituteFunctionsInValue(node.params, resolveThemeValue)
       }
     }
   })
-  return usesFunctions
 }
 
 export function substituteFunctionsInValue(

--- a/packages/tailwindcss/src/css-functions.ts
+++ b/packages/tailwindcss/src/css-functions.ts
@@ -7,9 +7,11 @@ export const THEME_FUNCTION_INVOCATION = 'theme('
 type ResolveThemeValue = (path: string) => string | undefined
 
 export function substituteFunctions(ast: AstNode[], resolveThemeValue: ResolveThemeValue) {
+  let usesFunctions = false
   walk(ast, (node) => {
     // Find all declaration values
     if (node.kind === 'declaration' && node.value?.includes(THEME_FUNCTION_INVOCATION)) {
+      usesFunctions = true
       node.value = substituteFunctionsInValue(node.value, resolveThemeValue)
       return
     }
@@ -23,10 +25,12 @@ export function substituteFunctions(ast: AstNode[], resolveThemeValue: ResolveTh
           node.name === '@supports') &&
         node.params.includes(THEME_FUNCTION_INVOCATION)
       ) {
+        usesFunctions = true
         node.params = substituteFunctionsInValue(node.params, resolveThemeValue)
       }
     }
   })
+  return usesFunctions
 }
 
 export function substituteFunctionsInValue(

--- a/packages/tailwindcss/src/css-functions.ts
+++ b/packages/tailwindcss/src/css-functions.ts
@@ -1,4 +1,4 @@
-import { Features, type FeaturesRef } from '.'
+import { Features } from '.'
 import { walk, type AstNode } from './ast'
 import * as ValueParser from './value-parser'
 import { type ValueAstNode } from './value-parser'
@@ -7,15 +7,12 @@ export const THEME_FUNCTION_INVOCATION = 'theme('
 
 type ResolveThemeValue = (path: string) => string | undefined
 
-export function substituteFunctions(
-  ast: AstNode[],
-  resolveThemeValue: ResolveThemeValue,
-  featuresRef: FeaturesRef,
-) {
+export function substituteFunctions(ast: AstNode[], resolveThemeValue: ResolveThemeValue) {
+  let features = Features.None
   walk(ast, (node) => {
     // Find all declaration values
     if (node.kind === 'declaration' && node.value?.includes(THEME_FUNCTION_INVOCATION)) {
-      featuresRef.current |= Features.ThemeFunction
+      features |= Features.ThemeFunction
       node.value = substituteFunctionsInValue(node.value, resolveThemeValue)
       return
     }
@@ -29,11 +26,12 @@ export function substituteFunctions(
           node.name === '@supports') &&
         node.params.includes(THEME_FUNCTION_INVOCATION)
       ) {
-        featuresRef.current |= Features.ThemeFunction
+        features |= Features.ThemeFunction
         node.params = substituteFunctionsInValue(node.params, resolveThemeValue)
       }
     }
   })
+  return features
 }
 
 export function substituteFunctionsInValue(

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -530,7 +530,7 @@ export async function compile(
 }> {
   let { designSystem, ast, globs, root, utilitiesNode, tailwindCssType } = await parseCss(css, opts)
 
-  if (process.env.NODE_ENV !== 'test') {
+  if (process.env.NODE_ENV !== 'test' && tailwindCssType === 'full') {
     ast.unshift(comment(`! tailwindcss v${version} | MIT License | https://tailwindcss.com `))
   }
 

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -549,7 +549,7 @@ export async function compile(
   // resulted in a generated AST Node. All the other `rawCandidates` are invalid
   // and should be ignored.
   let allValidCandidates = new Set<string>()
-  let compiledCss = features !== Features.None ? toCss(ast) : ''
+  let compiledCss = features !== Features.None ? toCss(ast) : css
   let previousAstNodeCount = 0
 
   return {

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -33,7 +33,6 @@ const IS_VALID_PREFIX = /^[a-z]+$/
 const IS_VALID_UTILITY_NAME = /^[a-z][a-zA-Z0-9/%._-]*$/
 
 type CompileOptions = {
-  buildAst?: boolean
   base?: string
   loadModule?: (
     id: string,
@@ -529,7 +528,7 @@ export async function compile(
   globs: { base: string; pattern: string }[]
   root: Root
   features: Features
-  build(candidates: string[]): any
+  build(candidates: string[]): string
 }> {
   let { designSystem, ast, globs, root, utilitiesNode, features } = await parseCss(css, opts)
 
@@ -546,7 +545,7 @@ export async function compile(
   // resulted in a generated AST Node. All the other `rawCandidates` are invalid
   // and should be ignored.
   let allValidCandidates = new Set<string>()
-  let compiledCss = features & Features.None && !opts.buildAst ? toCss(ast) : ''
+  let compiledCss = features & Features.None ? toCss(ast) : ''
   let previousAstNodeCount = 0
 
   return {
@@ -568,7 +567,7 @@ export async function compile(
       // If no new candidates were added, we can return the original CSS. This
       // currently assumes that we only add new candidates and never remove any.
       if (!didChange) {
-        return opts.buildAst ? ast : compiledCss
+        return compiledCss
       }
 
       if (utilitiesNode) {
@@ -580,21 +579,16 @@ export async function compile(
         // CSS. This currently assumes that we only add new ast nodes and never
         // remove any.
         if (previousAstNodeCount === newNodes.length) {
-          return opts.buildAst ? ast : compiledCss
+          return compiledCss
         }
 
         previousAstNodeCount = newNodes.length
 
         utilitiesNode.nodes = newNodes
-
-        if (!opts.buildAst) {
-          compiledCss = toCss(ast)
-        }
+        compiledCss = toCss(ast)
       }
 
-      return opts.buildAst
-        ? ast.slice() // Return a new AST with shared nodes
-        : compiledCss
+      return compiledCss
     },
   }
 }

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -69,6 +69,26 @@ function parseThemeOptions(params: string) {
   return [options, prefix] as const
 }
 
+type Root =
+  // Unknown root
+  | null
+
+  // Explicitly no root specified via `source(none)`
+  | 'none'
+
+  // Specified via `source(…)`, relative to the `base`
+  | { base: string; pattern: string }
+
+type TailwindCssType =
+  // No Tailwind specific CSS used
+  | 'none'
+
+  // Some Tailwind specific CSS used, such as `@apply`, but no `@tailwind utilities`
+  | 'static'
+
+  // Full Tailwind CSS build required
+  | 'full'
+
 async function parseCss(
   css: string,
   {
@@ -79,7 +99,7 @@ async function parseCss(
 ) {
   let ast = [contextNode({ base }, CSS.parse(css))] as AstNode[]
 
-  await substituteAtImports(ast, base, loadStylesheet)
+  let usesAtImport = await substituteAtImports(ast, base, loadStylesheet)
 
   let important = null as boolean | null
   let theme = new Theme()
@@ -88,11 +108,8 @@ async function parseCss(
   let firstThemeRule = null as StyleRule | null
   let utilitiesNode = null as AtRule | null
   let globs: { base: string; pattern: string }[] = []
-  let root:
-    | null // Unknown root
-    | 'none' // Explicitly no root specified via `source(none)`
-    // Specified via `source(…)`, relative to the `base`
-    | { base: string; pattern: string } = null
+  let root = null as Root
+  let tailwindCssType = (usesAtImport ? 'static' : 'none') as TailwindCssType
 
   // Handle at-rules
   walk(ast, (node, { parent, replaceWith, context }) => {
@@ -138,6 +155,7 @@ async function parseCss(
       }
 
       utilitiesNode = node
+      tailwindCssType = 'full'
     }
 
     // Collect custom `@utility` at-rules
@@ -414,7 +432,10 @@ async function parseCss(
   // of random arguments because it really just needs access to "the world" to
   // do whatever ungodly things it needs to do to make things backwards
   // compatible without polluting core.
-  await applyCompatibilityHooks({ designSystem, base, ast, loadModule, globs })
+  let usesStatic = await applyCompatibilityHooks({ designSystem, base, ast, loadModule, globs })
+  if (usesStatic && tailwindCssType === 'none') {
+    tailwindCssType = 'static'
+  }
 
   for (let customVariant of customVariants) {
     customVariant(designSystem)
@@ -464,9 +485,15 @@ async function parseCss(
   }
 
   // Replace `@apply` rules with the actual utility classes.
-  substituteAtApply(ast, designSystem)
+  let usesAtApply = substituteAtApply(ast, designSystem)
+  if (tailwindCssType === 'none' && usesAtApply) {
+    tailwindCssType = 'static'
+  }
 
-  substituteFunctions(ast, designSystem.resolveThemeValue)
+  let usesCssFunctions = substituteFunctions(ast, designSystem.resolveThemeValue)
+  if (tailwindCssType === 'none' && usesCssFunctions) {
+    tailwindCssType = 'static'
+  }
 
   // Remove `@utility`, we couldn't replace it before yet because we had to
   // handle the nested `@apply` at-rules first.
@@ -488,6 +515,7 @@ async function parseCss(
     globs,
     root,
     utilitiesNode,
+    tailwindCssType,
   }
 }
 
@@ -496,13 +524,11 @@ export async function compile(
   opts: CompileOptions = {},
 ): Promise<{
   globs: { base: string; pattern: string }[]
-  root:
-    | null // Unknown root
-    | 'none' // Explicitly no root specified via `source(none)`
-    | { base: string; pattern: string } // Specified via `source(…)`, relative to the `base`
+  root: Root
+  tailwindCssType: TailwindCssType
   build(candidates: string[]): string
 }> {
-  let { designSystem, ast, globs, root, utilitiesNode } = await parseCss(css, opts)
+  let { designSystem, ast, globs, root, utilitiesNode, tailwindCssType } = await parseCss(css, opts)
 
   if (process.env.NODE_ENV !== 'test') {
     ast.unshift(comment(`! tailwindcss v${version} | MIT License | https://tailwindcss.com `))
@@ -517,12 +543,13 @@ export async function compile(
   // resulted in a generated AST Node. All the other `rawCandidates` are invalid
   // and should be ignored.
   let allValidCandidates = new Set<string>()
-  let compiledCss = toCss(ast)
+  let compiledCss = tailwindCssType !== 'none' ? toCss(ast) : ''
   let previousAstNodeCount = 0
 
   return {
     globs,
     root,
+    tailwindCssType,
     build(newRawCandidates: string[]) {
       let didChange = false
 

--- a/packages/tailwindcss/src/value-parser.ts
+++ b/packages/tailwindcss/src/value-parser.ts
@@ -39,7 +39,7 @@ function separator(value: string): ValueSeparatorNode {
   }
 }
 
-export enum ValueWalkAction {
+export const enum ValueWalkAction {
   /** Continue walking, which is the default */
   Continue,
 

--- a/packages/tailwindcss/src/value-parser.ts
+++ b/packages/tailwindcss/src/value-parser.ts
@@ -76,13 +76,15 @@ export function walk(
       }) ?? ValueWalkAction.Continue
 
     // Stop the walk entirely
-    if (status === ValueWalkAction.Stop) return
+    if (status === ValueWalkAction.Stop) return ValueWalkAction.Stop
 
     // Skip visiting the children of this node
     if (status === ValueWalkAction.Skip) continue
 
     if (node.kind === 'function') {
-      walk(node.nodes, visit, node)
+      if (walk(node.nodes, visit, node) === ValueWalkAction.Stop) {
+        return ValueWalkAction.Stop
+      }
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       '@types/postcss-import':
         specifier: 14.0.3
         version: 14.0.3
+      dedent:
+        specifier: 1.5.3
+        version: 1.5.3
       internal-example-plugin:
         specifier: workspace:*
         version: link:../internal-example-plugin
@@ -1477,11 +1480,13 @@ packages:
   '@parcel/watcher-darwin-arm64@2.5.0':
     resolution: {integrity: sha512-hyZ3TANnzGfLpRA2s/4U1kbw2ZI4qGxaRJbBH2DCSREFfubMswheh8TeiC1sGZ3z2jUf3s37P0BBlrD3sjVTUw==}
     engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
     os: [darwin]
 
   '@parcel/watcher-darwin-x64@2.5.0':
     resolution: {integrity: sha512-9rhlwd78saKf18fT869/poydQK8YqlU26TMiNg7AIu7eBp9adqbJZqmdFOsbZ5cnLp5XvRo9wcFmNHgHdWaGYA==}
     engines: {node: '>= 10.0.0'}
+    cpu: [x64]
     os: [darwin]
 
   '@parcel/watcher-freebsd-x64@2.5.0':
@@ -1505,21 +1510,25 @@ packages:
   '@parcel/watcher-linux-arm64-glibc@2.5.0':
     resolution: {integrity: sha512-BfNjXwZKxBy4WibDb/LDCriWSKLz+jJRL3cM/DllnHH5QUyoiUNEp3GmL80ZqxeumoADfCCP19+qiYiC8gUBjA==}
     engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
     os: [linux]
 
   '@parcel/watcher-linux-arm64-musl@2.5.0':
     resolution: {integrity: sha512-S1qARKOphxfiBEkwLUbHjCY9BWPdWnW9j7f7Hb2jPplu8UZ3nes7zpPOW9bkLbHRvWM0WDTsjdOTUgW0xLBN1Q==}
     engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
     os: [linux]
 
   '@parcel/watcher-linux-x64-glibc@2.5.0':
     resolution: {integrity: sha512-d9AOkusyXARkFD66S6zlGXyzx5RvY+chTP9Jp0ypSTC9d4lzyRs9ovGf/80VCxjKddcUvnsGwCHWuF2EoPgWjw==}
     engines: {node: '>= 10.0.0'}
+    cpu: [x64]
     os: [linux]
 
   '@parcel/watcher-linux-x64-musl@2.5.0':
     resolution: {integrity: sha512-iqOC+GoTDoFyk/VYSFHwjHhYrk8bljW6zOhPuhi5t9ulqiYq1togGJB5e3PwYVFFfeVgc6pbz3JdQyDoBszVaA==}
     engines: {node: '>= 10.0.0'}
+    cpu: [x64]
     os: [linux]
 
   '@parcel/watcher-win32-arm64@2.5.0':
@@ -1537,6 +1546,7 @@ packages:
   '@parcel/watcher-win32-x64@2.5.0':
     resolution: {integrity: sha512-lPrxve92zEHdgeff3aiu4gDOIt4u7sJYha6wbdEZDCDUhtjTsOMiaJzG5lMY4GkWH8p0fMmO2Ppq5G5XXG+DQw==}
     engines: {node: '>= 10.0.0'}
+    cpu: [x64]
     os: [win32]
 
   '@parcel/watcher@2.5.0':
@@ -2032,6 +2042,7 @@ packages:
 
   bun@1.1.29:
     resolution: {integrity: sha512-SKhpyKNZtgxrVel9ec9xon3LDv8mgpiuFhARgcJo1YIbggY2PBrKHRNiwQ6Qlb+x3ivmRurfuwWgwGexjpgBRg==}
+    cpu: [arm64, x64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -2854,11 +2865,13 @@ packages:
   lightningcss-darwin-arm64@1.26.0:
     resolution: {integrity: sha512-n4TIvHO1NY1ondKFYpL2ZX0bcC2y6yjXMD6JfyizgR8BCFNEeArINDzEaeqlfX9bXz73Bpz/Ow0nu+1qiDrBKg==}
     engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
     os: [darwin]
 
   lightningcss-darwin-x64@1.26.0:
     resolution: {integrity: sha512-Rf9HuHIDi1R6/zgBkJh25SiJHF+dm9axUZW/0UoYCW1/8HV0gMI0blARhH4z+REmWiU1yYT/KyNF3h7tHyRXUg==}
     engines: {node: '>= 12.0.0'}
+    cpu: [x64]
     os: [darwin]
 
   lightningcss-freebsd-x64@1.26.0:
@@ -2876,21 +2889,25 @@ packages:
   lightningcss-linux-arm64-gnu@1.26.0:
     resolution: {integrity: sha512-iJmZM7fUyVjH+POtdiCtExG+67TtPUTer7K/5A8DIfmPfrmeGvzfRyBltGhQz13Wi15K1lf2cPYoRaRh6vcwNA==}
     engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
     os: [linux]
 
   lightningcss-linux-arm64-musl@1.26.0:
     resolution: {integrity: sha512-XxoEL++tTkyuvu+wq/QS8bwyTXZv2y5XYCMcWL45b8XwkiS8eEEEej9BkMGSRwxa5J4K+LDeIhLrS23CpQyfig==}
     engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
     os: [linux]
 
   lightningcss-linux-x64-gnu@1.26.0:
     resolution: {integrity: sha512-1dkTfZQAYLj8MUSkd6L/+TWTG8V6Kfrzfa0T1fSlXCXQHrt1HC1/UepXHtKHDt/9yFwyoeayivxXAsApVxn6zA==}
     engines: {node: '>= 12.0.0'}
+    cpu: [x64]
     os: [linux]
 
   lightningcss-linux-x64-musl@1.26.0:
     resolution: {integrity: sha512-yX3Rk9m00JGCUzuUhFEojY+jf/6zHs3XU8S8Vk+FRbnr4St7cjyMXdNjuA2LjiT8e7j8xHRCH8hyZ4H/btRE4A==}
     engines: {node: '>= 12.0.0'}
+    cpu: [x64]
     os: [linux]
 
   lightningcss-win32-arm64-msvc@1.26.0:
@@ -2902,6 +2919,7 @@ packages:
   lightningcss-win32-x64-msvc@1.26.0:
     resolution: {integrity: sha512-pYS3EyGP3JRhfqEFYmfFDiZ9/pVNfy8jVIYtrx9TVNusVyDK3gpW1w/rbvroQ4bDJi7grdUtyrYU6V2xkY/bBw==}
     engines: {node: '>= 12.0.0'}
+    cpu: [x64]
     os: [win32]
 
   lightningcss@1.26.0:
@@ -5685,7 +5703,7 @@ snapshots:
       eslint: 9.15.0(jiti@2.4.0)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@2.4.0))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint@9.15.0(jiti@2.4.0))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@2.4.0))
       eslint-plugin-jsx-a11y: 6.10.1(eslint@9.15.0(jiti@2.4.0))
       eslint-plugin-react: 7.37.2(eslint@9.15.0(jiti@2.4.0))
       eslint-plugin-react-hooks: 5.0.0(eslint@9.15.0(jiti@2.4.0))
@@ -5705,7 +5723,7 @@ snapshots:
       eslint: 9.15.0(jiti@2.4.0)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@2.4.0))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@2.4.0))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.6.3))(eslint@9.15.0(jiti@2.4.0))
       eslint-plugin-jsx-a11y: 6.10.1(eslint@9.15.0(jiti@2.4.0))
       eslint-plugin-react: 7.37.2(eslint@9.15.0(jiti@2.4.0))
       eslint-plugin-react-hooks: 5.0.0(eslint@9.15.0(jiti@2.4.0))
@@ -5730,13 +5748,13 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 9.15.0(jiti@2.4.0)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@2.4.0))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint@9.15.0(jiti@2.4.0))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@2.4.0))
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
@@ -5749,20 +5767,20 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 9.15.0(jiti@2.4.0)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@2.4.0))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@2.4.0))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.6.3))(eslint@9.15.0(jiti@2.4.0))
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@2.4.0)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -5773,7 +5791,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@2.4.0)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -5784,7 +5802,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint@9.15.0(jiti@2.4.0)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@2.4.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -5795,7 +5813,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.15.0(jiti@2.4.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@2.4.0))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -5813,7 +5831,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@2.4.0)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.6.3))(eslint@9.15.0(jiti@2.4.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -5824,7 +5842,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.15.0(jiti@2.4.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@2.4.0))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.0))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@2.4.0)))(eslint@9.15.0(jiti@2.4.0))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3


### PR DESCRIPTION
This PR improves the performance of the `@tailwindcss/postcss` and `@tailwindcss/vite` implementations.

The issue is that in some scenarios, if you have multiple `.css` files, then all of the CSS files are ran through the Tailwind CSS compiler. The issue with this is that in a lot of cases, the CSS files aren't even related to Tailwind CSS at all.

E.g.: in a Next.js project, if you use the `next/font/local` tool, then every font you used will be in a separate CSS file. This means that we run Tailwind CSS in all these files as well.

That said, running Tailwind CSS on these files isn't the end of the world because we still need to handle `@import` in case `@tailwind utilities` is being used. However, we also run the auto source detection logic for every CSS file in the system. This part is bad.

To solve this, this PR introduces an internal `features` to collect what CSS features are used throughout the system (`@import`, `@plugin`, `@apply`, `@tailwind utilities`, etc…)

The `@tailwindcss/postcss` and `@tailwindcss/vite` plugin can use that information to decide if they can take some shortcuts or not.

---

Overall, this means that we don't run the slow parts of Tailwind CSS if we don't need to.
