### PR TITLE
Upgrade: Do not migrate `overflow-clip` utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- _Upgrade (experimental)_: Do not migrate `overflow-clip` utility ([#15244](https://github.com/tailwindlabs/tailwindcss/pull/15244))
 
 ## [4.0.0-beta.3] - 2024-11-27
 

--- a/packages/@tailwindcss-upgrade/src/template/codemods/simple-legacy-classes.test.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/simple-legacy-classes.test.ts
@@ -3,7 +3,6 @@ import { expect, test } from 'vitest'
 import { simpleLegacyClasses } from './simple-legacy-classes'
 
 test.each([
-  ['overflow-clip', 'text-clip'],
   ['overflow-ellipsis', 'text-ellipsis'],
   ['flex-grow', 'grow'],
   ['flex-grow-0', 'grow-0'],
@@ -17,6 +16,9 @@ test.each([
   ['max-lg:hover:!decoration-slice', 'max-lg:hover:box-decoration-slice!'],
 
   ['focus:outline-none', 'focus:outline-hidden'],
+
+  // Should not convert v2 utilities
+  ['overflow-clip', 'overflow-clip'],
 ])('%s => %s', async (candidate, result) => {
   let designSystem = await __unstable__loadDesignSystem('@import "tailwindcss";', {
     base: __dirname,

--- a/packages/@tailwindcss-upgrade/src/template/codemods/simple-legacy-classes.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/simple-legacy-classes.ts
@@ -5,7 +5,6 @@ import { printCandidate } from '../candidates'
 // Classes that used to exist in Tailwind CSS v3, but do not exist in Tailwind
 // CSS v4 anymore.
 const LEGACY_CLASS_MAP = {
-  'overflow-clip': 'text-clip',
   'overflow-ellipsis': 'text-ellipsis',
 
   'flex-grow': 'grow',


### PR DESCRIPTION
`overflow-clip` was the name for `text-clip` in v4. However, that was changed in v3 already so in v3 `overflow-clip` is already doing the same as in v4. Hence a codemod is not necessary.