### PR TITLE
Use correct values for `float-start/end` and `clear-start/end`

### DIFF
--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -1360,26 +1360,26 @@ test('row-end', async () => {
 test('float', async () => {
   expect(await run(['float-start', 'float-end', 'float-right', 'float-left', 'float-none']))
     .toMatchInlineSnapshot(`
-    ".float-end {
-      float: end;
-    }
+      ".float-end {
+        float: inline-end;
+      }
 
-    .float-left {
-      float: left;
-    }
+      .float-left {
+        float: left;
+      }
 
-    .float-none {
-      float: none;
-    }
+      .float-none {
+        float: none;
+      }
 
-    .float-right {
-      float: right;
-    }
+      .float-right {
+        float: right;
+      }
 
-    .float-start {
-      float: start;
-    }"
-  `)
+      .float-start {
+        float: inline-start;
+      }"
+    `)
   expect(
     await run([
       'float',
@@ -1413,7 +1413,7 @@ test('clear', async () => {
     }
 
     .clear-end {
-      clear: end;
+      clear: inline-end;
     }
 
     .clear-left {
@@ -1429,7 +1429,7 @@ test('clear', async () => {
     }
 
     .clear-start {
-      clear: start;
+      clear: inline-start;
     }"
   `)
   expect(

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -719,8 +719,8 @@ export function createUtilities(theme: Theme) {
   /**
    * @css `float`
    */
-  staticUtility('float-start', [['float', 'start']])
-  staticUtility('float-end', [['float', 'end']])
+  staticUtility('float-start', [['float', 'inline-start']])
+  staticUtility('float-end', [['float', 'inline-end']])
   staticUtility('float-right', [['float', 'right']])
   staticUtility('float-left', [['float', 'left']])
   staticUtility('float-none', [['float', 'none']])
@@ -728,8 +728,8 @@ export function createUtilities(theme: Theme) {
   /**
    * @css `clear`
    */
-  staticUtility('clear-start', [['clear', 'start']])
-  staticUtility('clear-end', [['clear', 'end']])
+  staticUtility('clear-start', [['clear', 'inline-start']])
+  staticUtility('clear-end', [['clear', 'inline-end']])
   staticUtility('clear-right', [['clear', 'right']])
   staticUtility('clear-left', [['clear', 'left']])
   staticUtility('clear-both', [['clear', 'both']])


### PR DESCRIPTION
This PR fixes the `float-start/end` and `clear-start/end` utilities to use `inline-start` and `inline-end` instead of `start` and `end`, which aren't valid values.

Fixes #15255.