### PR TITLE
Vite: Don't rebase absolute `url()`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Ensure absolute `url()`s inside imported CSS files are not rebased when using `@tailwindcss/vite`
 
 ## [4.0.0-beta.4] - 2024-11-29
 

--- a/packages/@tailwindcss-node/src/urls.ts
+++ b/packages/@tailwindcss-node/src/urls.ts
@@ -51,6 +51,8 @@ export async function rewriteUrls({
   let promises: Promise<void>[] = []
 
   function replacerForDeclaration(url: string) {
+    if (url[0] === '/') return url
+
     let absoluteUrl = path.posix.join(normalizePath(base), url)
     let relativeUrl = path.posix.relative(normalizePath(root), absoluteUrl)
 


### PR DESCRIPTION
Closes #15269

This PR fixes an issue where our Vite extension was rebasing absolute urls inside `@import`-ed files. We forgot to cover this when we implemented the URL rebasing.

## Test Plan

We validated that this fixes the repro in #15269:

<img width="851" alt="Screenshot 2024-12-02 at 18 07 35" src="https://github.com/user-attachments/assets/3b2c2be3-1f73-469e-9f64-301c6b948b02">

Also added a unit test for this.