### PR TITLE
Fix resolution of imported CSS files in Vite SSR builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
         on-next-branch:
           - ${{ github.ref == 'refs/heads/next' }}
         exclude:
-          - on-next-branch: false
+          - on-next-branch: true
             runner: windows-latest
-          - on-next-branch: false
+          - on-next-branch: true
             runner: macos-14
 
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
         on-next-branch:
           - ${{ github.ref == 'refs/heads/next' }}
         exclude:
-          - on-next-branch: true
+          - on-next-branch: false
             runner: windows-latest
-          - on-next-branch: true
+          - on-next-branch: false
             runner: macos-14
 
     runs-on: ${{ matrix.runner }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure absolute `url()`s inside imported CSS files are not rebased when using `@tailwindcss/vite`
 - Fix issues with dev servers using Svelte 5 with the Vite plugin ([#15274](https://github.com/tailwindlabs/tailwindcss/issues/15274))
+- Fix resolution of imported CSS files in Vite SSR builds ([#15279](https://github.com/tailwindlabs/tailwindcss/issues/15279))
 
 ### Added
 

--- a/integrations/vite/ssr.test.ts
+++ b/integrations/vite/ssr.test.ts
@@ -1,141 +1,139 @@
-import { describe, expect } from 'vitest'
+import { expect } from 'vitest'
 import { candidate, css, html, json, test, ts } from '../utils'
 
-describe('SSR + Vite 5', () => {
-  test(
-    `Vite 5`,
-    {
-      fs: {
-        'package.json': json`
-          {
-            "type": "module",
-            "dependencies": {
-              "@tailwindcss/vite": "workspace:^",
-              "tailwindcss": "workspace:^"
-            },
-            "_comment": "This test uses Vite 5.3 on purpose. Do not upgrade it to Vite 6.",
-            "devDependencies": {
-              "vite": "^5.3"
-            }
+test(
+  `Vite 5`,
+  {
+    fs: {
+      'package.json': json`
+        {
+          "type": "module",
+          "dependencies": {
+            "@tailwindcss/vite": "workspace:^",
+            "tailwindcss": "workspace:^"
+          },
+          "_comment": "This test uses Vite 5.3 on purpose. Do not upgrade it to Vite 6.",
+          "devDependencies": {
+            "vite": "^5.3"
           }
-        `,
-        'vite.config.ts': ts`
-          import tailwindcss from '@tailwindcss/vite'
-          import { defineConfig } from 'vite'
+        }
+      `,
+      'vite.config.ts': ts`
+        import tailwindcss from '@tailwindcss/vite'
+        import { defineConfig } from 'vite'
 
-          export default defineConfig({
-            build: {
-              cssMinify: false,
-              ssrEmitAssets: true,
-            },
-            plugins: [tailwindcss()],
-            ssr: { resolve: { conditions: [] } },
-          })
-        `,
-        'index.html': html`
-          <body>
-            <div id="app"></div>
-            <script type="module" src="./src/index.ts"></script>
-          </body>
-        `,
-        'src/index.css': css`@import 'tailwindcss';`,
-        'src/index.ts': ts`
-          import './index.css'
+        export default defineConfig({
+          build: {
+            cssMinify: false,
+            ssrEmitAssets: true,
+          },
+          plugins: [tailwindcss()],
+          ssr: { resolve: { conditions: [] } },
+        })
+      `,
+      'index.html': html`
+        <body>
+          <div id="app"></div>
+          <script type="module" src="./src/index.ts"></script>
+        </body>
+      `,
+      'src/index.css': css`@import 'tailwindcss';`,
+      'src/index.ts': ts`
+        import './index.css'
 
-          document.querySelector('#app').innerHTML = \`
-            <div class="underline m-2">Hello, world!</div>
-          \`
-        `,
-        'server.ts': ts`
-          import css from './src/index.css?url'
+        document.querySelector('#app').innerHTML = \`
+          <div class="underline m-2">Hello, world!</div>
+        \`
+      `,
+      'server.ts': ts`
+        import css from './src/index.css?url'
 
-          document.querySelector('#app').innerHTML = \`
-            <link rel="stylesheet" href="\${css}">
-            <div class="underline m-2">Hello, world!</div>
-          \`
-        `,
-      },
+        document.querySelector('#app').innerHTML = \`
+          <link rel="stylesheet" href="\${css}">
+          <div class="underline m-2">Hello, world!</div>
+        \`
+      `,
     },
-    async ({ fs, exec }) => {
-      await exec('pnpm vite build --ssr server.ts')
+  },
+  async ({ fs, exec }) => {
+    await exec('pnpm vite build --ssr server.ts')
 
-      let files = await fs.glob('dist/**/*.css')
-      expect(files).toHaveLength(1)
-      let [filename] = files[0]
+    let files = await fs.glob('dist/**/*.css')
+    expect(files).toHaveLength(1)
+    let [filename] = files[0]
 
-      await fs.expectFileToContain(filename, [
-        //
-        candidate`underline`,
-        candidate`m-2`,
-      ])
-    },
-  )
+    await fs.expectFileToContain(filename, [
+      //
+      candidate`underline`,
+      candidate`m-2`,
+    ])
+  },
+)
 
-  test(
-    `Vite 6`,
-    {
-      fs: {
-        'package.json': json`
-          {
-            "type": "module",
-            "dependencies": {
-              "@tailwindcss/vite": "workspace:^",
-              "tailwindcss": "workspace:^"
-            },
-            "devDependencies": {
-              "vite": "^6.0"
-            }
+test(
+  `Vite 6`,
+  {
+    fs: {
+      'package.json': json`
+        {
+          "type": "module",
+          "dependencies": {
+            "@tailwindcss/vite": "workspace:^",
+            "tailwindcss": "workspace:^"
+          },
+          "devDependencies": {
+            "vite": "^6.0"
           }
-        `,
-        'vite.config.ts': ts`
-          import tailwindcss from '@tailwindcss/vite'
-          import { defineConfig } from 'vite'
+        }
+      `,
+      'vite.config.ts': ts`
+        import tailwindcss from '@tailwindcss/vite'
+        import { defineConfig } from 'vite'
 
-          export default defineConfig({
-            build: {
-              cssMinify: false,
-              ssrEmitAssets: true,
-            },
-            plugins: [tailwindcss()],
-            ssr: { resolve: { conditions: [] } },
-          })
-        `,
-        'index.html': html`
-          <body>
-            <div id="app"></div>
-            <script type="module" src="./src/index.ts"></script>
-          </body>
-        `,
-        'src/index.css': css`@import 'tailwindcss';`,
-        'src/index.ts': ts`
-          import './index.css'
+        export default defineConfig({
+          build: {
+            cssMinify: false,
+            ssrEmitAssets: true,
+          },
+          plugins: [tailwindcss()],
+          ssr: { resolve: { conditions: [] } },
+        })
+      `,
+      'index.html': html`
+        <body>
+          <div id="app"></div>
+          <script type="module" src="./src/index.ts"></script>
+        </body>
+      `,
+      'src/index.css': css`@import 'tailwindcss';`,
+      'src/index.ts': ts`
+        import './index.css'
 
-          document.querySelector('#app').innerHTML = \`
-            <div class="underline m-2">Hello, world!</div>
-          \`
-        `,
-        'server.ts': ts`
-          import css from './src/index.css?url'
+        document.querySelector('#app').innerHTML = \`
+          <div class="underline m-2">Hello, world!</div>
+        \`
+      `,
+      'server.ts': ts`
+        import css from './src/index.css?url'
 
-          document.querySelector('#app').innerHTML = \`
-            <link rel="stylesheet" href="\${css}">
-            <div class="underline m-2">Hello, world!</div>
-          \`
-        `,
-      },
+        document.querySelector('#app').innerHTML = \`
+          <link rel="stylesheet" href="\${css}">
+          <div class="underline m-2">Hello, world!</div>
+        \`
+      `,
     },
-    async ({ fs, exec }) => {
-      await exec('pnpm vite build --ssr server.ts')
+  },
+  async ({ fs, exec }) => {
+    await exec('pnpm vite build --ssr server.ts')
 
-      let files = await fs.glob('dist/**/*.css')
-      expect(files).toHaveLength(1)
-      let [filename] = files[0]
+    let files = await fs.glob('dist/**/*.css')
+    expect(files).toHaveLength(1)
+    let [filename] = files[0]
 
-      await fs.expectFileToContain(filename, [
-        //
-        candidate`underline`,
-        candidate`m-2`,
-      ])
-    },
-  )
-})
+    await fs.expectFileToContain(filename, [
+      //
+      candidate`underline`,
+      candidate`m-2`,
+    ])
+  },
+)

--- a/integrations/vite/ssr.test.ts
+++ b/integrations/vite/ssr.test.ts
@@ -34,7 +34,7 @@ describe('SSR + Vite 5', () => {
         `,
         'index.html': html`
           <body>
-            <div class="underline m-2">Hello, world!</div>
+            <div id="app"></div>
             <script type="module" src="./src/index.ts"></script>
           </body>
         `,
@@ -102,7 +102,7 @@ describe('SSR + Vite 5', () => {
         `,
         'index.html': html`
           <body>
-            <div class="underline m-2">Hello, world!</div>
+            <div id="app"></div>
             <script type="module" src="./src/index.ts"></script>
           </body>
         `,

--- a/integrations/vite/ssr.test.ts
+++ b/integrations/vite/ssr.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect } from 'vitest'
+import { candidate, css, html, json, test, ts } from '../utils'
+
+describe('SSR + Vite 5', () => {
+  test(
+    `Vite 5`,
+    {
+      fs: {
+        'package.json': json`
+          {
+            "type": "module",
+            "dependencies": {
+              "@tailwindcss/vite": "workspace:^",
+              "tailwindcss": "workspace:^"
+            },
+            "_comment": "This test uses Vite 5.3 on purpose. Do not upgrade it to Vite 6.",
+            "devDependencies": {
+              "vite": "^5.3"
+            }
+          }
+        `,
+        'vite.config.ts': ts`
+          import tailwindcss from '@tailwindcss/vite'
+          import { defineConfig } from 'vite'
+
+          export default defineConfig({
+            build: {
+              cssMinify: false,
+              ssrEmitAssets: true,
+            },
+            plugins: [tailwindcss()],
+            ssr: { resolve: { conditions: [] } },
+          })
+        `,
+        'index.html': html`
+          <body>
+            <div class="underline m-2">Hello, world!</div>
+            <script type="module" src="./src/index.ts"></script>
+          </body>
+        `,
+        'src/index.css': css`@import 'tailwindcss';`,
+        'src/index.ts': ts`
+          import './index.css'
+
+          document.querySelector('#app').innerHTML = \`
+            <div class="underline m-2">Hello, world!</div>
+          \`
+        `,
+        'server.ts': ts`
+          import css from './src/index.css?url'
+
+          document.querySelector('#app').innerHTML = \`
+            <link rel="stylesheet" href="\${css}">
+            <div class="underline m-2">Hello, world!</div>
+          \`
+        `,
+      },
+    },
+    async ({ fs, exec }) => {
+      await exec('pnpm vite build --ssr server.ts')
+
+      let files = await fs.glob('dist/**/*.css')
+      expect(files).toHaveLength(1)
+      let [filename] = files[0]
+
+      await fs.expectFileToContain(filename, [
+        //
+        candidate`underline`,
+        candidate`m-2`,
+      ])
+    },
+  )
+
+  test(
+    `Vite 6`,
+    {
+      fs: {
+        'package.json': json`
+          {
+            "type": "module",
+            "dependencies": {
+              "@tailwindcss/vite": "workspace:^",
+              "tailwindcss": "workspace:^"
+            },
+            "devDependencies": {
+              "vite": "^6.0"
+            }
+          }
+        `,
+        'vite.config.ts': ts`
+          import tailwindcss from '@tailwindcss/vite'
+          import { defineConfig } from 'vite'
+
+          export default defineConfig({
+            build: {
+              cssMinify: false,
+              ssrEmitAssets: true,
+            },
+            plugins: [tailwindcss()],
+            ssr: { resolve: { conditions: [] } },
+          })
+        `,
+        'index.html': html`
+          <body>
+            <div class="underline m-2">Hello, world!</div>
+            <script type="module" src="./src/index.ts"></script>
+          </body>
+        `,
+        'src/index.css': css`@import 'tailwindcss';`,
+        'src/index.ts': ts`
+          import './index.css'
+
+          document.querySelector('#app').innerHTML = \`
+            <div class="underline m-2">Hello, world!</div>
+          \`
+        `,
+        'server.ts': ts`
+          import css from './src/index.css?url'
+
+          document.querySelector('#app').innerHTML = \`
+            <link rel="stylesheet" href="\${css}">
+            <div class="underline m-2">Hello, world!</div>
+          \`
+        `,
+      },
+    },
+    async ({ fs, exec }) => {
+      await exec('pnpm vite build --ssr server.ts')
+
+      let files = await fs.glob('dist/**/*.css')
+      expect(files).toHaveLength(1)
+      let [filename] = files[0]
+
+      await fs.expectFileToContain(filename, [
+        //
+        candidate`underline`,
+        candidate`m-2`,
+      ])
+    },
+  )
+})

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -44,7 +44,7 @@ export default function tailwindcss(): Plugin[] {
       preferRelative: true,
     })
     function customCssResolver(id: string, base: string) {
-      return cssResolver(id, base, false, isSSR)
+      return cssResolver(id, base, true, isSSR)
     }
 
     let jsResolver = config!.createResolver(config!.resolve)


### PR DESCRIPTION
It seems this change makes the below mentioned issue go away and seems to generate the correct tailwindcss output file durring the ssr build. Big shoutout to @rossipedia for figuring this out.

I think you guys might want to take this over and own it as I'm not sure about other implications and if it breaks any other framework.

Fixes #15237
