### PR TITLE
Add `getThemeEntries` API

### DIFF
--- a/packages/tailwindcss/src/design-system.ts
+++ b/packages/tailwindcss/src/design-system.ts
@@ -1,7 +1,14 @@
 import { toCss } from './ast'
 import { parseCandidate, parseVariant, type Candidate, type Variant } from './candidate'
 import { compileAstNodes, compileCandidates } from './compile'
-import { getClassList, getVariants, type ClassEntry, type VariantEntry } from './intellisense'
+import {
+  getClassList,
+  getThemeEntries,
+  getVariants,
+  type ClassEntry,
+  type ThemeEntry,
+  type VariantEntry,
+} from './intellisense'
 import { getClassOrder } from './sort'
 import type { Theme, ThemeKey } from './theme'
 import { Utilities, createUtilities, withAlpha } from './utilities'
@@ -31,6 +38,7 @@ export type DesignSystem = {
 
   // Used by IntelliSense
   candidatesToCss(classes: string[]): (string | null)[]
+  getThemeEntries(): ThemeEntry[]
 }
 
 export function buildDesignSystem(theme: Theme): DesignSystem {
@@ -83,6 +91,9 @@ export function buildDesignSystem(theme: Theme): DesignSystem {
     },
     getVariants() {
       return getVariants(this)
+    },
+    getThemeEntries() {
+      return getThemeEntries()
     },
 
     parseCandidate(candidate: string) {

--- a/packages/tailwindcss/src/intellisense.test.ts
+++ b/packages/tailwindcss/src/intellisense.test.ts
@@ -431,3 +431,115 @@ test('Custom at-rule variants do not show up as a value under `group`', async ()
   expect(not.values).toContain('variant-3')
   expect(not.values).toContain('variant-4')
 })
+
+test('Can get a list of suggestable theme variables and namespaces', async () => {
+  let input = css`
+    @import 'tailwindcss/utilities';
+  `
+
+  let design = await __unstable__loadDesignSystem(input, {
+    loadStylesheet: async (_, base) => ({
+      base,
+      content: '@tailwind utilities;',
+    }),
+  })
+
+  let entries = design.getThemeEntries()
+
+  expect(entries).toMatchInlineSnapshot(`
+    [
+      {
+        "kind": "variable",
+        "name": "--default-transition-duration",
+      },
+      {
+        "kind": "variable",
+        "name": "--default-transition-timing-function",
+      },
+      {
+        "kind": "variable",
+        "name": "--default-font-family",
+      },
+      {
+        "kind": "variable",
+        "name": "--default-font-feature-settings",
+      },
+      {
+        "kind": "variable",
+        "name": "--default-font-variation-settings",
+      },
+      {
+        "kind": "variable",
+        "name": "--default-mono-font-family",
+      },
+      {
+        "kind": "variable",
+        "name": "--default-mono-font-feature-settings",
+      },
+      {
+        "kind": "variable",
+        "name": "--default-mono-font-variation-settings",
+      },
+      {
+        "kind": "namespace",
+        "name": "--breakpoint",
+      },
+      {
+        "kind": "namespace",
+        "name": "--color",
+      },
+      {
+        "kind": "namespace",
+        "name": "--animate",
+      },
+      {
+        "kind": "namespace",
+        "name": "--blur",
+      },
+      {
+        "kind": "namespace",
+        "name": "--radius",
+      },
+      {
+        "kind": "namespace",
+        "name": "--shadow",
+      },
+      {
+        "kind": "namespace",
+        "name": "--inset-shadow",
+      },
+      {
+        "kind": "namespace",
+        "name": "--drop-shadow",
+      },
+      {
+        "kind": "variable",
+        "name": "--spacing",
+      },
+      {
+        "kind": "namespace",
+        "name": "--container",
+      },
+      {
+        "kind": "namespace",
+        "name": "--font",
+      },
+      {
+        "kind": "namespace",
+        "name": "--font-size",
+      },
+      {
+        "kind": "namespace",
+        "name": "--tracking",
+      },
+      {
+        "kind": "namespace",
+        "name": "--leading",
+      },
+      {
+        "kind": "namespace",
+        "name": "--ease",
+      },
+    ]
+  `)
+})

--- a/packages/tailwindcss/src/intellisense.ts
+++ b/packages/tailwindcss/src/intellisense.ts
@@ -158,3 +158,37 @@ export function getVariants(design: DesignSystem) {
 
   return list
 }
+
+export interface ThemeEntry {
+  kind: 'namespace' | 'variable'
+  name: string
+}
+
+export function getThemeEntries(): ThemeEntry[] {
+  return [
+    // Polyfill data for older versions of the design system
+    { kind: 'variable', name: '--default-transition-duration' },
+    { kind: 'variable', name: '--default-transition-timing-function' },
+    { kind: 'variable', name: '--default-font-family' },
+    { kind: 'variable', name: '--default-font-feature-settings' },
+    { kind: 'variable', name: '--default-font-variation-settings' },
+    { kind: 'variable', name: '--default-mono-font-family' },
+    { kind: 'variable', name: '--default-mono-font-feature-settings' },
+    { kind: 'variable', name: '--default-mono-font-variation-settings' },
+    { kind: 'namespace', name: '--breakpoint' },
+    { kind: 'namespace', name: '--color' },
+    { kind: 'namespace', name: '--animate' },
+    { kind: 'namespace', name: '--blur' },
+    { kind: 'namespace', name: '--radius' },
+    { kind: 'namespace', name: '--shadow' },
+    { kind: 'namespace', name: '--inset-shadow' },
+    { kind: 'namespace', name: '--drop-shadow' },
+    { kind: 'variable', name: '--spacing' },
+    { kind: 'namespace', name: '--container' },
+    { kind: 'namespace', name: '--font' },
+    { kind: 'namespace', name: '--font-size' },
+    { kind: 'namespace', name: '--tracking' },
+    { kind: 'namespace', name: '--leading' },
+    { kind: 'namespace', name: '--ease' },
+  ]
+}


### PR DESCRIPTION
This adds an API that lets us provide `@theme` variable completions from within core. The old list was hardcoded in IntelliSense but since the names for some of these changed recently we need a way to control this from within Tailwind CSS itself.

IntelliSense PR: https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1104

Do we think this is worth a changelog entry? Kinda thinking not but idk