### PR TITLE
Use AST transformations in `@tailwindcss/postcss`

### DIFF
--- a/crates/oxide/src/scanner/allowed_paths.rs
+++ b/crates/oxide/src/scanner/allowed_paths.rs
@@ -40,7 +40,6 @@ pub fn resolve_paths(root: &Path) -> impl Iterator<Item = DirEntry> {
         .filter_map(Result::ok)
 }
 
-#[tracing::instrument(skip_all)]
 pub fn read_dir(root: &Path, depth: Option<usize>) -> impl Iterator<Item = DirEntry> {
     WalkBuilder::new(root)
         .hidden(false)

--- a/packages/@tailwindcss-node/src/index.ts
+++ b/packages/@tailwindcss-node/src/index.ts
@@ -1,7 +1,7 @@
 import * as Module from 'node:module'
 import { pathToFileURL } from 'node:url'
 import * as env from './env'
-export { __unstable__loadDesignSystem, compile, Features } from './compile'
+export { __unstable__loadDesignSystem, compile, compileAst, Features } from './compile'
 export * from './normalize-path'
 export { env }
 

--- a/packages/@tailwindcss-postcss/src/ast.test.ts
+++ b/packages/@tailwindcss-postcss/src/ast.test.ts
@@ -1,0 +1,107 @@
+import dedent from 'dedent'
+import postcss from 'postcss'
+import { expect, it } from 'vitest'
+import { toCss } from '../../tailwindcss/src/ast'
+import { parse } from '../../tailwindcss/src/css-parser'
+import { cssAstToPostCssAst, postCssAstToCssAst } from './ast'
+
+let css = dedent
+
+it('should convert a PostCSS AST into a Tailwind CSS AST', () => {
+  let input = css`
+    @charset "UTF-8";
+
+    @layer foo, bar, baz;
+
+    @import 'tailwindcss';
+
+    .foo {
+      color: red;
+
+      &:hover {
+        color: blue;
+      }
+
+      .bar {
+        color: green !important;
+        background-color: yellow;
+
+        @media (min-width: 640px) {
+          color: orange;
+        }
+      }
+    }
+  `
+
+  let ast = postcss.parse(input)
+  let transformedAst = postCssAstToCssAst(ast)
+
+  expect(toCss(transformedAst)).toMatchInlineSnapshot(`
+    "@charset "UTF-8";
+    @layer foo, bar, baz;
+    @import 'tailwindcss';
+    .foo {
+      color: red;
+      &:hover {
+        color: blue;
+      }
+      .bar {
+        color: green !important;
+        background-color: yellow;
+        @media (min-width: 640px) {
+          color: orange;
+        }
+      }
+    }
+    "
+  `)
+})
+
+it('should convert a Tailwind CSS AST into a PostCSS AST', () => {
+  let input = css`
+    @charset "UTF-8";
+
+    @layer foo, bar, baz;
+
+    @import 'tailwindcss';
+
+    .foo {
+      color: red;
+
+      &:hover {
+        color: blue;
+      }
+
+      .bar {
+        color: green !important;
+        background-color: yellow;
+
+        @media (min-width: 640px) {
+          color: orange;
+        }
+      }
+    }
+  `
+
+  let ast = parse(input)
+  let transformedAst = cssAstToPostCssAst(ast)
+
+  expect(transformedAst.toString()).toMatchInlineSnapshot(`
+    "@charset "UTF-8";
+    @layer foo, bar, baz;
+    @import 'tailwindcss';
+    .foo {
+        color: red;
+        &:hover {
+            color: blue
+        }
+        .bar {
+            color: green !important;
+            background-color: yellow;
+            @media (min-width: 640px) {
+                color: orange
+            }
+        }
+    }"
+  `)
+})

--- a/packages/@tailwindcss-postcss/src/ast.test.ts
+++ b/packages/@tailwindcss-postcss/src/ast.test.ts
@@ -93,13 +93,13 @@ it('should convert a Tailwind CSS AST into a PostCSS AST', () => {
     .foo {
         color: red;
         &:hover {
-            color: blue
+            color: blue;
         }
         .bar {
             color: green !important;
             background-color: yellow;
             @media (min-width: 640px) {
-                color: orange
+                color: orange;
             }
         }
     }"

--- a/packages/@tailwindcss-postcss/src/ast.ts
+++ b/packages/@tailwindcss-postcss/src/ast.ts
@@ -2,11 +2,13 @@ import postcss, {
   type ChildNode as PostCssChildNode,
   type Container as PostCssContainerNode,
   type Root as PostCssRoot,
+  type Source as PostcssSource,
 } from 'postcss'
 import { atRule, comment, decl, rule, type AstNode } from '../../tailwindcss/src/ast'
 
-export function cssAstToPostCssAst(ast: AstNode[]): PostCssRoot {
+export function cssAstToPostCssAst(ast: AstNode[], source: PostcssSource | undefined): PostCssRoot {
   let root = postcss.root()
+  root.source = source
 
   function transform(node: AstNode, parent: PostCssContainerNode) {
     // Declaration
@@ -16,12 +18,14 @@ export function cssAstToPostCssAst(ast: AstNode[]): PostCssRoot {
         value: node.value ?? '',
         important: node.important,
       })
+      astNode.source = source
       parent.append(astNode)
     }
 
     // Rule
     else if (node.kind === 'rule') {
       let astNode = postcss.rule({ selector: node.selector })
+      astNode.source = source
       parent.append(astNode)
       for (let child of node.nodes) {
         transform(child, astNode)
@@ -31,6 +35,7 @@ export function cssAstToPostCssAst(ast: AstNode[]): PostCssRoot {
     // AtRule
     else if (node.kind === 'at-rule') {
       let astNode = postcss.atRule({ name: node.name.slice(1), params: node.params })
+      astNode.source = source
       parent.append(astNode)
       for (let child of node.nodes) {
         transform(child, astNode)
@@ -40,6 +45,7 @@ export function cssAstToPostCssAst(ast: AstNode[]): PostCssRoot {
     // Comment
     else if (node.kind === 'comment') {
       let astNode = postcss.comment({ text: node.value })
+      astNode.source = source
       parent.append(astNode)
     }
 

--- a/packages/@tailwindcss-postcss/src/ast.ts
+++ b/packages/@tailwindcss-postcss/src/ast.ts
@@ -1,0 +1,98 @@
+import postcss, {
+  type ChildNode as PostCssChildNode,
+  type Container as PostCssContainerNode,
+  type Root as PostCssRoot,
+} from 'postcss'
+import { atRule, comment, decl, rule, type AstNode } from '../../tailwindcss/src/ast'
+
+export function cssAstToPostCssAst(ast: AstNode[]): PostCssRoot {
+  let root = postcss.root()
+
+  function transform(node: AstNode, parent: PostCssContainerNode) {
+    // Declaration
+    if (node.kind === 'declaration') {
+      parent.append(
+        postcss.decl({ prop: node.property, value: node.value ?? '', important: node.important }),
+      )
+    }
+
+    // Rule
+    else if (node.kind === 'rule') {
+      let astNode = postcss.rule({ selector: node.selector })
+      parent.append(astNode)
+      for (let child of node.nodes) {
+        transform(child, astNode)
+      }
+    }
+
+    // AtRule
+    else if (node.kind === 'at-rule') {
+      let astNode = postcss.atRule({ name: node.name.slice(1), params: node.params })
+      parent.append(astNode)
+      for (let child of node.nodes) {
+        transform(child, astNode)
+      }
+    }
+
+    // Comment
+    else if (node.kind === 'comment') {
+      parent.append(postcss.comment({ text: node.value }))
+    }
+
+    // AtRoot & Context should not happen
+    else if (node.kind === 'at-root' || node.kind === 'context') {
+    }
+
+    // Unknown
+    else {
+      node satisfies never
+    }
+  }
+
+  for (let node of ast) {
+    transform(node, root)
+  }
+
+  return root
+}
+
+export function postCssAstToCssAst(root: PostCssRoot): AstNode[] {
+  function transform(
+    node: PostCssChildNode,
+    parent: Extract<AstNode, { nodes: AstNode[] }>['nodes'],
+  ) {
+    // Declaration
+    if (node.type === 'decl') {
+      parent.push(decl(node.prop, node.value, node.important))
+    }
+
+    // Rule
+    else if (node.type === 'rule') {
+      let astNode = rule(node.selector)
+      node.each((child) => transform(child, astNode.nodes))
+      parent.push(astNode)
+    }
+
+    // AtRule
+    else if (node.type === 'atrule') {
+      let astNode = atRule(`@${node.name}`, node.params)
+      node.each((child) => transform(child, astNode.nodes))
+      parent.push(astNode)
+    }
+
+    // Comment
+    else if (node.type === 'comment') {
+      parent.push(comment(node.text))
+    }
+
+    // Unknown
+    else {
+      node satisfies never
+    }
+  }
+
+  let ast: AstNode[] = []
+  root.each((node) => transform(node, ast))
+
+  return ast
+}

--- a/packages/@tailwindcss-postcss/src/ast.ts
+++ b/packages/@tailwindcss-postcss/src/ast.ts
@@ -11,9 +11,12 @@ export function cssAstToPostCssAst(ast: AstNode[]): PostCssRoot {
   function transform(node: AstNode, parent: PostCssContainerNode) {
     // Declaration
     if (node.kind === 'declaration') {
-      parent.append(
-        postcss.decl({ prop: node.property, value: node.value ?? '', important: node.important }),
-      )
+      let astNode = postcss.decl({
+        prop: node.property,
+        value: node.value ?? '',
+        important: node.important,
+      })
+      parent.append(astNode)
     }
 
     // Rule
@@ -36,7 +39,8 @@ export function cssAstToPostCssAst(ast: AstNode[]): PostCssRoot {
 
     // Comment
     else if (node.kind === 'comment') {
-      parent.append(postcss.comment({ text: node.value }))
+      let astNode = postcss.comment({ text: node.value })
+      parent.append(astNode)
     }
 
     // AtRoot & Context should not happen

--- a/packages/@tailwindcss-postcss/src/ast.ts
+++ b/packages/@tailwindcss-postcss/src/ast.ts
@@ -26,6 +26,7 @@ export function cssAstToPostCssAst(ast: AstNode[], source: PostcssSource | undef
     else if (node.kind === 'rule') {
       let astNode = postcss.rule({ selector: node.selector })
       astNode.source = source
+      astNode.raws.semicolon = true
       parent.append(astNode)
       for (let child of node.nodes) {
         transform(child, astNode)
@@ -36,6 +37,7 @@ export function cssAstToPostCssAst(ast: AstNode[], source: PostcssSource | undef
     else if (node.kind === 'at-rule') {
       let astNode = postcss.atRule({ name: node.name.slice(1), params: node.params })
       astNode.source = source
+      astNode.raws.semicolon = true
       parent.append(astNode)
       for (let child of node.nodes) {
         transform(child, astNode)

--- a/packages/@tailwindcss-postcss/src/ast.ts
+++ b/packages/@tailwindcss-postcss/src/ast.ts
@@ -6,6 +6,8 @@ import postcss, {
 } from 'postcss'
 import { atRule, comment, decl, rule, type AstNode } from '../../tailwindcss/src/ast'
 
+const EXCLAMATION_MARK = 0x21
+
 export function cssAstToPostCssAst(ast: AstNode[], source: PostcssSource | undefined): PostCssRoot {
   let root = postcss.root()
   root.source = source
@@ -47,6 +49,10 @@ export function cssAstToPostCssAst(ast: AstNode[], source: PostcssSource | undef
     // Comment
     else if (node.kind === 'comment') {
       let astNode = postcss.comment({ text: node.value })
+      // Spaces are encoded in our node.value already, no need to add additional
+      // spaces.
+      astNode.raws.left = ''
+      astNode.raws.right = ''
       astNode.source = source
       parent.append(astNode)
     }
@@ -94,6 +100,7 @@ export function postCssAstToCssAst(root: PostCssRoot): AstNode[] {
 
     // Comment
     else if (node.type === 'comment') {
+      if (node.text.charCodeAt(0) !== EXCLAMATION_MARK) return
       parent.push(comment(node.text))
     }
 

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -218,7 +218,7 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
 
           if (context.ast !== ast) {
             // Convert our AST to a PostCSS AST
-            context.cachedAst = cssAstToPostCssAst(ast)
+            context.cachedAst = cssAstToPostCssAst(ast, root.source)
 
             if (optimize) {
               env.DEBUG && console.time('[@tailwindcss/postcss] Optimize CSS')

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -135,7 +135,6 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
           }
 
           let ast: AstNode[] = []
-          let css = ''
 
           if (
             rebuildStrategy === 'full' &&

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -236,7 +236,11 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
 
           env.DEBUG && console.time('[@tailwindcss/postcss] Update PostCSS AST')
           root.removeAll()
-          root.append(optimize ? context.optimizedPostCssAst.nodes : context.cachedPostCssAst.nodes)
+          root.append(
+            optimize
+              ? context.optimizedPostCssAst.clone().nodes
+              : context.cachedPostCssAst.clone().nodes,
+          )
 
           // Trick PostCSS into thinking the indent is 2 spaces, so it uses that
           // as the default instead of 4.

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -237,6 +237,11 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
           env.DEBUG && console.time('[@tailwindcss/postcss] Update PostCSS AST')
           root.removeAll()
           root.append(optimize ? context.optimizedPostCssAst.nodes : context.cachedPostCssAst.nodes)
+
+          // Trick PostCSS into thinking the indent is 2 spaces, so it uses that
+          // as the default instead of 4.
+          root.raws.indent = '  '
+
           env.DEBUG && console.timeEnd('[@tailwindcss/postcss] Update PostCSS AST')
           env.DEBUG && console.timeEnd('[@tailwindcss/postcss] Total time in @tailwindcss/postcss')
         },

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -217,9 +217,6 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
           env.DEBUG && console.timeEnd('[@tailwindcss/postcss] Build AST')
 
           if (context.ast !== ast) {
-            // Convert our AST to a PostCSS AST
-            context.cachedAst = cssAstToPostCssAst(ast, root.source)
-
             if (optimize) {
               env.DEBUG && console.time('[@tailwindcss/postcss] Optimize CSS')
               context.optimizedAst = postcss.parse(
@@ -229,6 +226,9 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
                 result.opts,
               )
               env.DEBUG && console.timeEnd('[@tailwindcss/postcss] Optimize CSS')
+            } else {
+              // Convert our AST to a PostCSS AST
+              context.cachedAst = cssAstToPostCssAst(ast, root.source)
             }
           }
 

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -225,7 +225,10 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
               env.DEBUG && console.timeEnd('[@tailwindcss/postcss] Optimize CSS')
             } else {
               // Convert our AST to a PostCSS AST
+              env.DEBUG && console.time('[@tailwindcss/postcss] Transform CSS AST into PostCSS AST')
               context.cachedPostCssAst = cssAstToPostCssAst(tailwindCssAst, root.source)
+              env.DEBUG &&
+                console.timeEnd('[@tailwindcss/postcss] Transform CSS AST into PostCSS AST')
             }
           }
 

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -22,7 +22,7 @@ interface CacheEntry {
 let cache = new QuickLRU<string, CacheEntry>({ maxSize: 50 })
 
 function getContextFromCache(inputFile: string, opts: PluginOptions): CacheEntry {
-  let key = `${inputFile}:${opts.base ?? ''}:${opts.optimize ?? ''}`
+  let key = `${inputFile}:${opts.base ?? ''}:${JSON.stringify(opts.optimize)}`
   if (cache.has(key)) return cache.get(key)!
   let entry = {
     mtimes: new Map<string, number>(),
@@ -231,6 +231,8 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
                 console.timeEnd('[@tailwindcss/postcss] Transform CSS AST into PostCSS AST')
             }
           }
+
+          context.tailwindCssAst = tailwindCssAst
 
           env.DEBUG && console.time('[@tailwindcss/postcss] Update PostCSS AST')
           root.removeAll()

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -6,7 +6,7 @@ import { Features as LightningCssFeatures, transform } from 'lightningcss'
 import fs from 'node:fs'
 import path from 'node:path'
 import postcss, { type AcceptedPlugin, type PluginCreator } from 'postcss'
-import type { AstNode } from '../../tailwindcss/src/ast'
+import { toCss, type AstNode } from '../../tailwindcss/src/ast'
 import { cssAstToPostCssAst, postCssAstToCssAst } from './ast'
 import fixRelativePathsPlugin from './postcss-fix-relative-paths'
 
@@ -212,9 +212,9 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
             }
           }
 
-          env.DEBUG && console.time('[@tailwindcss/postcss] Build CSS')
+          env.DEBUG && console.time('[@tailwindcss/postcss] Build AST')
           ast = context.compiler.build(candidates)
-          env.DEBUG && console.timeEnd('[@tailwindcss/postcss] Build CSS')
+          env.DEBUG && console.timeEnd('[@tailwindcss/postcss] Build AST')
 
           if (context.ast !== ast) {
             // Convert our AST to a PostCSS AST
@@ -223,7 +223,7 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
             if (optimize) {
               env.DEBUG && console.time('[@tailwindcss/postcss] Optimize CSS')
               context.optimizedAst = postcss.parse(
-                optimizeCss(context.cachedAst.toString(), {
+                optimizeCss(toCss(ast), {
                   minify: typeof optimize === 'object' ? optimize.minify : true,
                 }),
                 result.opts,

--- a/packages/tailwindcss/src/ast.test.ts
+++ b/packages/tailwindcss/src/ast.test.ts
@@ -1,9 +1,10 @@
 import { expect, it } from 'vitest'
-import { context, decl, styleRule, toCss, walk, WalkAction } from './ast'
+import { context, decl, optimizeAst, styleRule, toCss, walk, WalkAction } from './ast'
 import * as CSS from './css-parser'
 
 it('should pretty print an AST', () => {
-  expect(toCss(CSS.parse('.foo{color:red;&:hover{color:blue;}}'))).toMatchInlineSnapshot(`
+  expect(toCss(optimizeAst(CSS.parse('.foo{color:red;&:hover{color:blue;}}'))))
+    .toMatchInlineSnapshot(`
     ".foo {
       color: red;
       &:hover {
@@ -51,7 +52,7 @@ it('allows the placement of context nodes', () => {
   expect(blueContext).toEqual({ context: 'a' })
   expect(greenContext).toEqual({ context: 'b' })
 
-  expect(toCss(ast)).toMatchInlineSnapshot(`
+  expect(toCss(optimizeAst(ast))).toMatchInlineSnapshot(`
     ".foo {
       color: red;
     }

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -66,12 +66,12 @@ export function rule(selector: string, nodes: AstNode[] = []): StyleRule | AtRul
   return styleRule(selector, nodes)
 }
 
-export function decl(property: string, value: string | undefined): Declaration {
+export function decl(property: string, value: string | undefined, important = false): Declaration {
   return {
     kind: 'declaration',
     property,
     value,
-    important: false,
+    important,
   }
 }
 

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -208,18 +208,151 @@ export function walkDepth(
   }
 }
 
-export function toCss(ast: AstNode[]) {
-  let atRoots: string = ''
+// Optimize the AST for printing where all the special nodes that require custom
+// handling are handled such that the printing is a 1-to-1 transformation.
+export function optimizeAst(ast: AstNode[]) {
+  let atRoots: AstNode[] = []
   let seenAtProperties = new Set<string>()
   let propertyFallbacksRoot: Declaration[] = []
   let propertyFallbacksUniversal: Declaration[] = []
 
+  function transform(
+    node: AstNode,
+    parent: Extract<AstNode, { nodes: AstNode[] }>['nodes'],
+    depth = 0,
+  ) {
+    // Declaration
+    if (node.kind === 'declaration') {
+      if (node.property === '--tw-sort' || node.value === undefined || node.value === null) {
+        return
+      }
+      parent.push(node)
+    }
+
+    // Rule
+    else if (node.kind === 'rule') {
+      let copy = { ...node, nodes: [] }
+      for (let child of node.nodes) {
+        transform(child, copy.nodes, depth + 1)
+      }
+      parent.push(copy)
+    }
+
+    // AtRule `@property`
+    else if (node.kind === 'at-rule' && node.name === '@property' && depth === 0) {
+      // Don't output duplicate `@property` rules
+      if (seenAtProperties.has(node.params)) {
+        return
+      }
+
+      // Collect fallbacks for `@property` rules for Firefox support
+      // We turn these into rules on `:root` or `*` and some pseudo-elements
+      // based on the value of `inherits``
+      let property = node.params
+      let initialValue = null
+      let inherits = false
+
+      for (let prop of node.nodes) {
+        if (prop.kind !== 'declaration') continue
+        if (prop.property === 'initial-value') {
+          initialValue = prop.value
+        } else if (prop.property === 'inherits') {
+          inherits = prop.value === 'true'
+        }
+      }
+
+      if (inherits) {
+        propertyFallbacksRoot.push(decl(property, initialValue ?? 'initial'))
+      } else {
+        propertyFallbacksUniversal.push(decl(property, initialValue ?? 'initial'))
+      }
+
+      seenAtProperties.add(node.params)
+
+      let copy = { ...node, nodes: [] }
+      for (let child of node.nodes) {
+        transform(child, copy.nodes, depth + 1)
+      }
+      parent.push(copy)
+    }
+
+    // AtRule
+    else if (node.kind === 'at-rule') {
+      let copy = { ...node, nodes: [] }
+      for (let child of node.nodes) {
+        transform(child, copy.nodes, depth + 1)
+      }
+      parent.push(copy)
+    }
+
+    // AtRoot
+    else if (node.kind === 'at-root') {
+      for (let child of node.nodes) {
+        let newParent: AstNode[] = []
+        transform(child, newParent, 0)
+        for (let child of newParent) {
+          atRoots.push(child)
+        }
+      }
+    }
+
+    // Context
+    else if (node.kind === 'context') {
+      for (let child of node.nodes) {
+        transform(child, parent, depth)
+      }
+    }
+
+    // Comment
+    else if (node.kind === 'comment') {
+      parent.push(node)
+    }
+
+    // Unknown
+    else {
+      node satisfies never
+    }
+  }
+
+  let newAst: AstNode[] = []
+  for (let node of ast) {
+    transform(node, newAst, 0)
+  }
+
+  // Fallbacks
+  {
+    let fallbackAst = []
+
+    if (propertyFallbacksRoot.length > 0) {
+      fallbackAst.push(rule(':root', propertyFallbacksRoot))
+    }
+
+    if (propertyFallbacksUniversal.length > 0) {
+      fallbackAst.push(rule('*, ::before, ::after, ::backdrop', propertyFallbacksUniversal))
+    }
+
+    if (fallbackAst.length > 0) {
+      newAst.push(
+        atRule('@supports', '(-moz-orient: inline)', [atRule('@layer', 'base', fallbackAst)]),
+      )
+    }
+  }
+
+  return newAst.concat(atRoots)
+}
+
+export function toCss(ast: AstNode[]) {
   function stringify(node: AstNode, depth = 0): string {
     let css = ''
     let indent = '  '.repeat(depth)
 
+    // Declaration
+    if (node.kind === 'declaration') {
+      css += `${indent}${node.property}: ${node.value}${node.important ? ' !important' : ''};\n`
+    }
+
     // Rule
-    if (node.kind === 'rule') {
+    else if (node.kind === 'rule') {
       css += `${indent}${node.selector} {\n`
       for (let child of node.nodes) {
         css += stringify(child, depth + 1)
@@ -240,38 +373,6 @@ export function toCss(ast: AstNode[]) {
         return `${indent}${node.name} ${node.params};\n`
       }
 
-      //
-      else if (node.name === '@property' && depth === 0) {
-        // Don't output duplicate `@property` rules
-        if (seenAtProperties.has(node.params)) {
-          return ''
-        }
-
-        // Collect fallbacks for `@property` rules for Firefox support
-        // We turn these into rules on `:root` or `*` and some pseudo-elements
-        // based on the value of `inherits``
-        let property = node.params
-        let initialValue = null
-        let inherits = false
-
-        for (let prop of node.nodes) {
-          if (prop.kind !== 'declaration') continue
-          if (prop.property === 'initial-value') {
-            initialValue = prop.value
-          } else if (prop.property === 'inherits') {
-            inherits = prop.value === 'true'
-          }
-        }
-
-        if (inherits) {
-          propertyFallbacksRoot.push(decl(property, initialValue ?? 'initial'))
-        } else {
-          propertyFallbacksUniversal.push(decl(property, initialValue ?? 'initial'))
-        }
-
-        seenAtProperties.add(node.params)
-      }
-
       css += `${indent}${node.name}${node.params ? ` ${node.params} ` : ' '}{\n`
       for (let child of node.nodes) {
         css += stringify(child, depth + 1)
@@ -284,24 +385,16 @@ export function toCss(ast: AstNode[]) {
       css += `${indent}/*${node.value}*/\n`
     }
 
-    // Context Node
-    else if (node.kind === 'context') {
-      for (let child of node.nodes) {
-        css += stringify(child, depth)
-      }
+    // These should've been handled already by `prepareAstForPrinting` which
+    // means we can safely ignore them here. We return an empty string
+    // immediately to signal that something went wrong.
+    else if (node.kind === 'context' || node.kind === 'at-root') {
+      return ''
     }
 
-    // AtRoot Node
-    else if (node.kind === 'at-root') {
-      for (let child of node.nodes) {
-        atRoots += stringify(child, 0)
-      }
-      return css
-    }
-
-    // Declaration
-    else if (node.property !== '--tw-sort' && node.value !== undefined && node.value !== null) {
-      css += `${indent}${node.property}: ${node.value}${node.important ? ' !important' : ''};\n`
+    // Unknown
+    else {
+      node satisfies never
     }
 
     return css
@@ -316,23 +409,5 @@ export function toCss(ast: AstNode[]) {
     }
   }
 
-  let fallbackAst = []
-
-  if (propertyFallbacksRoot.length) {
-    fallbackAst.push(rule(':root', propertyFallbacksRoot))
-  }
-
-  if (propertyFallbacksUniversal.length) {
-    fallbackAst.push(rule('*, ::before, ::after, ::backdrop', propertyFallbacksUniversal))
-  }
-
-  let fallback = ''
-
-  if (fallbackAst.length) {
-    fallback = stringify(
-      atRule('@supports', '(-moz-orient: inline)', [atRule('@layer', 'base', fallbackAst)]),
-    )
-  }
-
-  return `${css}${fallback}${atRoots}`
+  return css
 }

--- a/packages/tailwindcss/src/compat/plugin-api.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.ts
@@ -17,10 +17,10 @@ import * as SelectorParser from './selector-parser'
 
 export type Config = UserConfig
 export type PluginFn = (api: PluginAPI) => void
-export type PluginWithConfig = { 
-  handler: PluginFn;
-  config?: UserConfig;
-  
+export type PluginWithConfig = {
+  handler: PluginFn
+  config?: UserConfig
+
   /** @internal */
   reference?: boolean
 }

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -1,6 +1,7 @@
 import {
   atRule,
   comment,
+  decl,
   rule,
   type AstNode,
   type AtRule,
@@ -434,15 +435,7 @@ export function parse(input: string) {
 
           // Attach the declaration to the parent.
           if (parent) {
-            let importantIdx = buffer.indexOf('!important', colonIdx + 1)
-            parent.nodes.push({
-              kind: 'declaration',
-              property: buffer.slice(0, colonIdx).trim(),
-              value: buffer
-                .slice(colonIdx + 1, importantIdx === -1 ? buffer.length : importantIdx)
-                .trim(),
-              important: importantIdx !== -1,
-            } satisfies Declaration)
+            parent.nodes.push(parseDeclaration(buffer, colonIdx))
           }
         }
       }
@@ -552,10 +545,9 @@ export function parseAtRule(buffer: string, nodes: AstNode[] = []): AtRule {
 
 function parseDeclaration(buffer: string, colonIdx: number = buffer.indexOf(':')): Declaration {
   let importantIdx = buffer.indexOf('!important', colonIdx + 1)
-  return {
-    kind: 'declaration',
-    property: buffer.slice(0, colonIdx).trim(),
-    value: buffer.slice(colonIdx + 1, importantIdx === -1 ? buffer.length : importantIdx).trim(),
-    important: importantIdx !== -1,
-  }
+  return decl(
+    buffer.slice(0, colonIdx).trim(),
+    buffer.slice(colonIdx + 1, importantIdx === -1 ? buffer.length : importantIdx).trim(),
+    importantIdx !== -1,
+  )
 }

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -594,7 +594,7 @@ export async function compileAst(
       }
 
       if (!utilitiesNode) {
-        if (compiled === null) compiled = optimizeAst(ast)
+        compiled ??= optimizeAst(ast)
         return compiled
       }
 
@@ -612,7 +612,7 @@ export async function compileAst(
       // If no new candidates were added, we can return the original CSS. This
       // currently assumes that we only add new candidates and never remove any.
       if (!didChange) {
-        if (compiled === null) compiled = optimizeAst(ast)
+        compiled ??= optimizeAst(ast)
         return compiled
       }
 
@@ -624,7 +624,7 @@ export async function compileAst(
       // CSS. This currently assumes that we only add new ast nodes and never
       // remove any.
       if (previousAstNodeCount === newNodes.length) {
-        if (compiled === null) compiled = optimizeAst(ast)
+        compiled ??= optimizeAst(ast)
         return compiled
       }
 

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -6,6 +6,7 @@ import {
   comment,
   context as contextNode,
   decl,
+  optimizeAst,
   rule,
   styleRule,
   toCss,
@@ -580,7 +581,7 @@ export async function compile(
   // resulted in a generated AST Node. All the other `rawCandidates` are invalid
   // and should be ignored.
   let allValidCandidates = new Set<string>()
-  let compiledCss = features !== Features.None ? toCss(ast) : css
+  let compiledCss = features !== Features.None ? toCss(optimizeAst(ast)) : css
   let previousAstNodeCount = 0
 
   return {
@@ -620,7 +621,8 @@ export async function compile(
         previousAstNodeCount = newNodes.length
 
         utilitiesNode.nodes = newNodes
-        compiledCss = toCss(ast)
+
+        compiledCss = toCss(optimizeAst(ast))
       }
 
       return compiledCss


### PR DESCRIPTION
This PR improves the `@tailwindcss/postcss` integration by using direct AST transformations between our own AST and PostCSS's AST. This allows us to skip a step where we convert our AST into a string, then parse it back into a PostCSS AST.

The only downside is that we still have to print the AST into a string if we want to optimize the CSS using Lightning CSS. Luckily this only happens in production (`NODE_ENV=production`).

This also introduces a new private `compileAst` API, that allows us to accept an AST as the input. This allows us to skip the PostCSS AST -> string -> parse into our own AST step.

To summarize:

Instead of:
- Input: `PostCSS AST` -> `.toString()` -> `CSS.parse(…)` -> `Tailwind CSS AST`
- Output: `Tailwind CSS AST` -> `toCSS(ast)` -> `postcss.parse(…)` -> `PostCSS AST`

We will now do this instead:
- Input: `PostCSS AST` -> `transform(…)` -> `Tailwind CSS AST`
- Output: `Tailwind CSS AST` -> `transform(…)` -> `PostCSS AST`


---

Running this on Catalyst, the time spent in the `@tailwindcss/postcss` looks like this:
- Before: median time per run: 19.407687 ms
- After: median time per run: 11.8796455 ms

This is tested on Catalyst which roughly generates ~208kb worth of CSS in dev mode.

While it's not a lot, skipping the stringification and parsing seems to improve this step by ~40%.

Note: these times exclude scanning the actual candidates and only time the work needed for parsing/stringifying the CSS from and into ASTs. The actual numbers are a bit higher because of the Oxide scanner reading files from disk. But since that part is going to be there no matter what, it's not fair to include it in this benchmark.