### PR TITLE
Improve debug logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix dependency related warnings when using `@tailwindcss/postcss` on Windows ([#15321](https://github.com/tailwindlabs/tailwindcss/pull/15321))
 - Skip creating a compiler for CSS files that should not be processed ([#15340](https://github.com/tailwindlabs/tailwindcss/pull/15340))
+- Improve debug logs to get better insights ([#15303](https://github.com/tailwindlabs/tailwindcss/pull/15303))
 
 ## [4.0.0-beta.6] - 2024-12-06
 

--- a/crates/oxide/src/lib.rs
+++ b/crates/oxide/src/lib.rs
@@ -24,7 +24,7 @@ pub mod paths;
 pub mod scanner;
 
 static SHOULD_TRACE: sync::LazyLock<bool> = sync::LazyLock::new(
-    || matches!(std::env::var("DEBUG"), Ok(value) if value.eq("*") || value.eq("1") || value.eq("true") || value.contains("tailwind")),
+    || matches!(std::env::var("DEBUG"), Ok(value) if value.eq("*") || (value.contains("tailwindcss:oxide") && !value.contains("-tailwindcss:oxide"))),
 );
 
 fn init_tracing() {

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -1,12 +1,11 @@
 import watcher from '@parcel/watcher'
-import { compile, env } from '@tailwindcss/node'
+import { compile, env, Instrumentation } from '@tailwindcss/node'
 import { clearRequireCache } from '@tailwindcss/node/require-cache'
 import { Scanner, type ChangedContent } from '@tailwindcss/oxide'
 import { Features, transform } from 'lightningcss'
 import { existsSync, type Stats } from 'node:fs'
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import { Instrumentation } from '../../../../@tailwindcss-node/src/instrumentation'
 import type { Arg, Result } from '../../utils/args'
 import { Disposables } from '../../utils/disposables'
 import {

--- a/packages/@tailwindcss-node/src/index.cts
+++ b/packages/@tailwindcss-node/src/index.cts
@@ -1,10 +1,10 @@
 import * as Module from 'node:module'
 import { pathToFileURL } from 'node:url'
 import * as env from './env'
-import * as instrumentation from './instrumentation'
 export * from './compile'
+export * from './instrumentation'
 export * from './normalize-path'
-export { env, instrumentation }
+export { env }
 
 // In Bun, ESM modules will also populate `require.cache`, so the module hook is
 // not necessary.

--- a/packages/@tailwindcss-node/src/index.cts
+++ b/packages/@tailwindcss-node/src/index.cts
@@ -1,9 +1,10 @@
 import * as Module from 'node:module'
 import { pathToFileURL } from 'node:url'
 import * as env from './env'
+import * as instrumentation from './instrumentation'
 export * from './compile'
 export * from './normalize-path'
-export { env }
+export { env, instrumentation }
 
 // In Bun, ESM modules will also populate `require.cache`, so the module hook is
 // not necessary.

--- a/packages/@tailwindcss-node/src/index.ts
+++ b/packages/@tailwindcss-node/src/index.ts
@@ -1,10 +1,10 @@
 import * as Module from 'node:module'
 import { pathToFileURL } from 'node:url'
 import * as env from './env'
-import * as instrumentation from './instrumentation'
 export { __unstable__loadDesignSystem, compile, compileAst, Features } from './compile'
+export * from './instrumentation'
 export * from './normalize-path'
-export { env, instrumentation }
+export { env }
 
 // In Bun, ESM modules will also populate `require.cache`, so the module hook is
 // not necessary.

--- a/packages/@tailwindcss-node/src/index.ts
+++ b/packages/@tailwindcss-node/src/index.ts
@@ -1,9 +1,10 @@
 import * as Module from 'node:module'
 import { pathToFileURL } from 'node:url'
 import * as env from './env'
+import * as instrumentation from './instrumentation'
 export { __unstable__loadDesignSystem, compile, compileAst, Features } from './compile'
 export * from './normalize-path'
-export { env }
+export { env, instrumentation }
 
 // In Bun, ESM modules will also populate `require.cache`, so the module hook is
 // not necessary.

--- a/packages/@tailwindcss-node/src/instrumentation.test.ts
+++ b/packages/@tailwindcss-node/src/instrumentation.test.ts
@@ -23,12 +23,14 @@ it('should add instrumentation', () => {
 
   I.report((output) => {
     expect(stripVTControlCharacters(output).replace(/\[.*\]/g, '[0.xxms]')).toMatchInlineSnapshot(`
-      "Hits:
+      "
+      Hits:
         Potato × 4
 
       Timers:
       [0.xxms] Foo
-      [0.xxms]   ↳ Bar × 100"
+      [0.xxms]   ↳ Bar × 100
+      "
     `)
   })
 })
@@ -49,9 +51,11 @@ it('should auto end pending timers when reporting', () => {
 
   I.report((output) => {
     expect(stripVTControlCharacters(output).replace(/\[.*\]/g, '[0.xxms]')).toMatchInlineSnapshot(`
-      "[0.xxms] Foo
+      "
+      [0.xxms] Foo
       [0.xxms]   ↳ Bar × 100
-      [0.xxms]   ↳ Baz"
+      [0.xxms]   ↳ Baz
+      "
     `)
   })
 })

--- a/packages/@tailwindcss-node/src/instrumentation.test.ts
+++ b/packages/@tailwindcss-node/src/instrumentation.test.ts
@@ -1,0 +1,57 @@
+import { stripVTControlCharacters } from 'util'
+import { expect, it } from 'vitest'
+import * as I from './instrumentation'
+
+it('should add instrumentation', () => {
+  I.reset()
+
+  I.start('Foo')
+  let x = 1
+  for (let i = 0; i < 100; i++) {
+    I.start('Bar')
+    x **= 2
+    I.end('Bar')
+  }
+  I.end('Foo')
+
+  I.hit('Potato')
+  I.hit('Potato')
+  I.hit('Potato')
+  I.hit('Potato')
+
+  expect.assertions(1)
+
+  I.report((output) => {
+    expect(stripVTControlCharacters(output).replace(/\[.*\]/g, '[0.xxms]')).toMatchInlineSnapshot(`
+      "Hits:
+        Potato × 4
+
+      Timers:
+      [0.xxms] Foo
+      [0.xxms]   ↳ Bar × 100"
+    `)
+  })
+})
+
+it('should auto end pending timers when reporting', () => {
+  I.reset()
+
+  I.start('Foo')
+  let x = 1
+  for (let i = 0; i < 100; i++) {
+    I.start('Bar')
+    x **= 2
+    I.end('Bar')
+  }
+  I.start('Baz')
+
+  expect.assertions(1)
+
+  I.report((output) => {
+    expect(stripVTControlCharacters(output).replace(/\[.*\]/g, '[0.xxms]')).toMatchInlineSnapshot(`
+      "[0.xxms] Foo
+      [0.xxms]   ↳ Bar × 100
+      [0.xxms]   ↳ Baz"
+    `)
+  })
+})

--- a/packages/@tailwindcss-node/src/instrumentation.test.ts
+++ b/packages/@tailwindcss-node/src/instrumentation.test.ts
@@ -1,9 +1,9 @@
 import { stripVTControlCharacters } from 'util'
 import { expect, it } from 'vitest'
-import * as I from './instrumentation'
+import { Instrumentation } from './instrumentation'
 
 it('should add instrumentation', () => {
-  I.reset()
+  let I = new Instrumentation()
 
   I.start('Foo')
   let x = 1
@@ -34,7 +34,7 @@ it('should add instrumentation', () => {
 })
 
 it('should auto end pending timers when reporting', () => {
-  I.reset()
+  let I = new Instrumentation()
 
   I.start('Foo')
   let x = 1

--- a/packages/@tailwindcss-node/src/instrumentation.ts
+++ b/packages/@tailwindcss-node/src/instrumentation.ts
@@ -90,6 +90,7 @@ export class Instrumentation implements Disposable {
     }
 
     flush(`\n${output.join('\n')}\n`)
+    this.reset()
   }
 
   [Symbol.dispose]() {

--- a/packages/@tailwindcss-node/src/instrumentation.ts
+++ b/packages/@tailwindcss-node/src/instrumentation.ts
@@ -1,4 +1,5 @@
 import { DefaultMap } from '../../tailwindcss/src/utils/default-map'
+import * as env from './env'
 
 export class Instrumentation implements Disposable {
   #hits = new DefaultMap(() => ({ value: 0 }))
@@ -88,11 +89,11 @@ export class Instrumentation implements Disposable {
       )
     }
 
-    flush(output.join('\n'))
+    flush(`\n${output.join('\n')}\n`)
   }
 
   [Symbol.dispose]() {
-    this.report()
+    env.DEBUG && this.report()
   }
 }
 

--- a/packages/@tailwindcss-node/src/instrumentation.ts
+++ b/packages/@tailwindcss-node/src/instrumentation.ts
@@ -6,7 +6,7 @@ export class Instrumentation implements Disposable {
   #timers = new DefaultMap(() => ({ value: 0n }))
   #timerStack: { id: string; label: string; namespace: string; value: bigint }[] = []
 
-  constructor(private defaultFlush = console.error) {}
+  constructor(private defaultFlush = (message: string) => process.stderr.write(`${message}\n`)) {}
 
   hit(label: string) {
     this.#hits.get(label).value++
@@ -81,7 +81,7 @@ export class Instrumentation implements Disposable {
     for (let label of this.#timers.keys()) {
       let depth = label.split('//').length
       output.push(
-        `${dim(`[${computed.get(label)!.padStart(max, ' ')}]`)}${'  '.repeat(depth - 1)}${depth === 1 ? ' ' : ' ↳ '}${label.split('//').pop()} ${
+        `${dim(`[${computed.get(label)!.padStart(max, ' ')}]`)}${'  '.repeat(depth - 1)}${depth === 1 ? ' ' : dim(' ↳ ')}${label.split('//').pop()} ${
           this.#hits.get(label).value === 1 ? '' : dim(blue(`× ${this.#hits.get(label).value}`))
         }`.trimEnd(),
       )

--- a/packages/@tailwindcss-node/src/instrumentation.ts
+++ b/packages/@tailwindcss-node/src/instrumentation.ts
@@ -1,50 +1,99 @@
 import { DefaultMap } from '../../tailwindcss/src/utils/default-map'
 
-const hits = new DefaultMap(() => ({ value: 0 }))
-const timerStack: {
-  id: string
-  label: string
-  namespace: string
-  value: bigint
-}[] = []
-const timers = new DefaultMap(() => ({ value: 0n }))
+export class Instrumentation implements Disposable {
+  #hits = new DefaultMap(() => ({ value: 0 }))
+  #timers = new DefaultMap(() => ({ value: 0n }))
+  #timerStack: { id: string; label: string; namespace: string; value: bigint }[] = []
 
-export function hit(label: string) {
-  hits.get(label).value++
-}
+  constructor(private defaultFlush = console.error) {}
 
-export function start(label: string) {
-  let namespace = timerStack.map((t) => t.label).join('//')
-  let id = `${namespace}${namespace.length === 0 ? '' : '//'}${label}`
-
-  hits.get(id).value++
-
-  // Create the timer if it doesn't exist yet
-  timers.get(id)
-
-  timerStack.push({ id, label, namespace, value: process.hrtime.bigint() })
-}
-
-export function end(label: string) {
-  let end = process.hrtime.bigint()
-
-  if (timerStack[timerStack.length - 1].label !== label) {
-    throw new Error(
-      `Mismatched timer label: \`${label}\`, expected \`${
-        timerStack[timerStack.length - 1].label
-      }\``,
-    )
+  hit(label: string) {
+    this.#hits.get(label).value++
   }
 
-  let parent = timerStack.pop()!
-  let elapsed = end - parent.value
-  timers.get(parent.id).value += elapsed
-}
+  start(label: string) {
+    let namespace = this.#timerStack.map((t) => t.label).join('//')
+    let id = `${namespace}${namespace.length === 0 ? '' : '//'}${label}`
 
-export function reset() {
-  hits.clear()
-  timers.clear()
-  timerStack.splice(0)
+    this.#hits.get(id).value++
+
+    // Create the timer if it doesn't exist yet
+    this.#timers.get(id)
+
+    this.#timerStack.push({ id, label, namespace, value: process.hrtime.bigint() })
+  }
+
+  end(label: string) {
+    let end = process.hrtime.bigint()
+
+    if (this.#timerStack[this.#timerStack.length - 1].label !== label) {
+      throw new Error(
+        `Mismatched timer label: \`${label}\`, expected \`${
+          this.#timerStack[this.#timerStack.length - 1].label
+        }\``,
+      )
+    }
+
+    let parent = this.#timerStack.pop()!
+    let elapsed = end - parent.value
+    this.#timers.get(parent.id).value += elapsed
+  }
+
+  reset() {
+    this.#hits.clear()
+    this.#timers.clear()
+    this.#timerStack.splice(0)
+  }
+
+  report(flush = this.defaultFlush) {
+    let output: string[] = []
+    let hasHits = false
+
+    // Auto end any pending timers
+    for (let i = this.#timerStack.length - 1; i >= 0; i--) {
+      this.end(this.#timerStack[i].label)
+    }
+
+    for (let [label, { value: count }] of this.#hits.entries()) {
+      if (this.#timers.has(label)) continue
+      if (output.length === 0) {
+        hasHits = true
+        output.push(white('Hits:'))
+      }
+
+      let depth = label.split('//').length
+      output.push(`${'  '.repeat(depth)}${label} ${dim(blue(`× ${count}`))}`)
+    }
+
+    if (this.#timers.size > 0 && hasHits) {
+      output.push(white('\nTimers:'))
+    }
+
+    let max = -Infinity
+    let computed = new Map<string, string>()
+    for (let [label, { value }] of this.#timers) {
+      let x = `${(Number(value) / 1e6).toFixed(2)}ms`
+      computed.set(label, x)
+      max = Math.max(max, x.length)
+    }
+
+    for (let label of this.#timers.keys()) {
+      let depth = label.split('//').length
+      output.push(
+        white(
+          `${dim(`[${computed.get(label)!.padStart(max, ' ')}]`)}${'  '.repeat(depth - 1)}${depth === 1 ? ' ' : ' ↳ '}${label.split('//').pop()} ${
+            this.#hits.get(label).value === 1 ? '' : dim(blue(`× ${this.#hits.get(label).value}`))
+          }`.trimEnd(),
+        ),
+      )
+    }
+
+    flush(output.join('\n'))
+  }
+
+  [Symbol.dispose]() {
+    this.report()
+  }
 }
 
 function white(input: string) {
@@ -57,50 +106,4 @@ function dim(input: string) {
 
 function blue(input: string) {
   return `\u001b[34m${input}\u001b[39m`
-}
-
-export function report(flush = console.error) {
-  let output: string[] = []
-  let hasHits = false
-
-  // Auto end any pending timers
-  for (let i = timerStack.length - 1; i >= 0; i--) {
-    end(timerStack[i].label)
-  }
-
-  for (let [label, { value: count }] of hits.entries()) {
-    if (timers.has(label)) continue
-    if (output.length === 0) {
-      hasHits = true
-      output.push(white('Hits:'))
-    }
-
-    let depth = label.split('//').length
-    output.push(`${'  '.repeat(depth)}${label} ${dim(blue(`× ${count}`))}`)
-  }
-
-  if (timers.size > 0 && hasHits) {
-    output.push(white('\nTimers:'))
-  }
-
-  let max = -Infinity
-  let computed = new Map<string, string>()
-  for (let [label, { value }] of timers) {
-    let x = `${(Number(value) / 1e6).toFixed(2)}ms`
-    computed.set(label, x)
-    max = Math.max(max, x.length)
-  }
-
-  for (let label of timers.keys()) {
-    let depth = label.split('//').length
-    output.push(
-      white(
-        `${dim(`[${computed.get(label)!.padStart(max, ' ')}]`)}${'  '.repeat(depth - 1)}${depth === 1 ? ' ' : ' ↳ '}${label.split('//').pop()} ${
-          hits.get(label).value === 1 ? '' : dim(blue(`× ${hits.get(label).value}`))
-        }`.trimEnd(),
-      ),
-    )
-  }
-
-  flush(output.join('\n'))
 }

--- a/packages/@tailwindcss-node/src/instrumentation.ts
+++ b/packages/@tailwindcss-node/src/instrumentation.ts
@@ -59,7 +59,7 @@ export class Instrumentation implements Disposable {
       if (this.#timers.has(label)) continue
       if (output.length === 0) {
         hasHits = true
-        output.push(white('Hits:'))
+        output.push('Hits:')
       }
 
       let depth = label.split('//').length
@@ -67,7 +67,7 @@ export class Instrumentation implements Disposable {
     }
 
     if (this.#timers.size > 0 && hasHits) {
-      output.push(white('\nTimers:'))
+      output.push('\nTimers:')
     }
 
     let max = -Infinity
@@ -81,11 +81,9 @@ export class Instrumentation implements Disposable {
     for (let label of this.#timers.keys()) {
       let depth = label.split('//').length
       output.push(
-        white(
-          `${dim(`[${computed.get(label)!.padStart(max, ' ')}]`)}${'  '.repeat(depth - 1)}${depth === 1 ? ' ' : ' ↳ '}${label.split('//').pop()} ${
-            this.#hits.get(label).value === 1 ? '' : dim(blue(`× ${this.#hits.get(label).value}`))
-          }`.trimEnd(),
-        ),
+        `${dim(`[${computed.get(label)!.padStart(max, ' ')}]`)}${'  '.repeat(depth - 1)}${depth === 1 ? ' ' : ' ↳ '}${label.split('//').pop()} ${
+          this.#hits.get(label).value === 1 ? '' : dim(blue(`× ${this.#hits.get(label).value}`))
+        }`.trimEnd(),
       )
     }
 
@@ -96,10 +94,6 @@ export class Instrumentation implements Disposable {
   [Symbol.dispose]() {
     env.DEBUG && this.report()
   }
-}
-
-function white(input: string) {
-  return `\u001b[37m${input}\u001b[39m`
 }
 
 function dim(input: string) {

--- a/packages/@tailwindcss-node/src/instrumentation.ts
+++ b/packages/@tailwindcss-node/src/instrumentation.ts
@@ -1,0 +1,106 @@
+import { DefaultMap } from '../../tailwindcss/src/utils/default-map'
+
+const hits = new DefaultMap(() => ({ value: 0 }))
+const timerStack: {
+  id: string
+  label: string
+  namespace: string
+  value: bigint
+}[] = []
+const timers = new DefaultMap(() => ({ value: 0n }))
+
+export function hit(label: string) {
+  hits.get(label).value++
+}
+
+export function start(label: string) {
+  let namespace = timerStack.map((t) => t.label).join('//')
+  let id = `${namespace}${namespace.length === 0 ? '' : '//'}${label}`
+
+  hits.get(id).value++
+
+  // Create the timer if it doesn't exist yet
+  timers.get(id)
+
+  timerStack.push({ id, label, namespace, value: process.hrtime.bigint() })
+}
+
+export function end(label: string) {
+  let end = process.hrtime.bigint()
+
+  if (timerStack[timerStack.length - 1].label !== label) {
+    throw new Error(
+      `Mismatched timer label: \`${label}\`, expected \`${
+        timerStack[timerStack.length - 1].label
+      }\``,
+    )
+  }
+
+  let parent = timerStack.pop()!
+  let elapsed = end - parent.value
+  timers.get(parent.id).value += elapsed
+}
+
+export function reset() {
+  hits.clear()
+  timers.clear()
+  timerStack.splice(0)
+}
+
+function white(input: string) {
+  return `\u001b[37m${input}\u001b[39m`
+}
+
+function dim(input: string) {
+  return `\u001b[2m${input}\u001b[22m`
+}
+
+function blue(input: string) {
+  return `\u001b[34m${input}\u001b[39m`
+}
+
+export function report(flush = console.error) {
+  let output: string[] = []
+  let hasHits = false
+
+  // Auto end any pending timers
+  for (let i = timerStack.length - 1; i >= 0; i--) {
+    end(timerStack[i].label)
+  }
+
+  for (let [label, { value: count }] of hits.entries()) {
+    if (timers.has(label)) continue
+    if (output.length === 0) {
+      hasHits = true
+      output.push(white('Hits:'))
+    }
+
+    let depth = label.split('//').length
+    output.push(`${'  '.repeat(depth)}${label} ${dim(blue(`× ${count}`))}`)
+  }
+
+  if (timers.size > 0 && hasHits) {
+    output.push(white('\nTimers:'))
+  }
+
+  let max = -Infinity
+  let computed = new Map<string, string>()
+  for (let [label, { value }] of timers) {
+    let x = `${(Number(value) / 1e6).toFixed(2)}ms`
+    computed.set(label, x)
+    max = Math.max(max, x.length)
+  }
+
+  for (let label of timers.keys()) {
+    let depth = label.split('//').length
+    output.push(
+      white(
+        `${dim(`[${computed.get(label)!.padStart(max, ' ')}]`)}${'  '.repeat(depth - 1)}${depth === 1 ? ' ' : ' ↳ '}${label.split('//').pop()} ${
+          hits.get(label).value === 1 ? '' : dim(blue(`× ${hits.get(label).value}`))
+        }`.trimEnd(),
+      ),
+    )
+  }
+
+  flush(output.join('\n'))
+}

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -72,6 +72,7 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
 
           // Bail out early if this is guaranteed to be a non-Tailwind CSS file.
           {
+            DEBUG && I.start('Quick bail check')
             let canBail = true
             root.walkAtRules((node) => {
               if (
@@ -86,6 +87,7 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
               }
             })
             if (canBail) return
+            DEBUG && I.end('Quick bail check')
           }
 
           let context = getContextFromCache(inputFile, opts)

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -118,6 +118,8 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
           context.compiler ??= await createCompiler()
 
           if (context.compiler.features === Features.None) {
+            env.DEBUG &&
+              console.timeEnd('[@tailwindcss/postcss] Total time in @tailwindcss/postcss')
             return
           }
 

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -1,5 +1,5 @@
 import QuickLRU from '@alloc/quick-lru'
-import { compileAst, env, Features, instrumentation as I } from '@tailwindcss/node'
+import { compileAst, env, Features, Instrumentation } from '@tailwindcss/node'
 import { clearRequireCache } from '@tailwindcss/node/require-cache'
 import { Scanner } from '@tailwindcss/oxide'
 import { Features as LightningCssFeatures, transform } from 'lightningcss'
@@ -62,7 +62,7 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
       {
         postcssPlugin: 'tailwindcss',
         async Once(root, { result }) {
-          env.DEBUG && I.reset()
+          using I = new Instrumentation()
 
           let inputFile = result.opts.from ?? ''
 
@@ -126,7 +126,6 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
           context.compiler ??= await createCompiler()
 
           if (context.compiler.features === Features.None) {
-            env.DEBUG && I.report()
             return
           }
 
@@ -294,7 +293,6 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
           env.DEBUG && I.end('Update PostCSS AST')
 
           env.DEBUG && I.end(`[@tailwindcss/postcss] ${relative(base, inputFile)}`)
-          env.DEBUG && I.report()
         },
       },
     ],

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -6,6 +6,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import type { Plugin, ResolvedConfig, Rollup, Update, ViteDevServer } from 'vite'
 
+const DEBUG = env.DEBUG
 const SPECIAL_QUERY_RE = /[?&](raw|url)\b/
 
 export default function tailwindcss(): Plugin[] {
@@ -120,9 +121,9 @@ export default function tailwindcss(): Plugin[] {
     if (generated === false) {
       return
     }
-    env.DEBUG && I.start('Optimize CSS')
+    DEBUG && I.start('Optimize CSS')
     let result = optimizeCss(generated, { minify })
-    env.DEBUG && I.end('Optimize CSS')
+    DEBUG && I.end('Optimize CSS')
     return result
   }
 
@@ -479,7 +480,7 @@ class Root {
       clearRequireCache(Array.from(this.dependencies))
       this.dependencies = new Set([idToPath(inputPath)])
 
-      env.DEBUG && I.start('Setup compiler')
+      DEBUG && I.start('Setup compiler')
       this.compiler = await compile(content, {
         base: inputBase,
         shouldRewriteUrls: true,
@@ -491,7 +492,7 @@ class Root {
         customCssResolver: this.customCssResolver,
         customJsResolver: this.customJsResolver,
       })
-      env.DEBUG && I.end('Setup compiler')
+      DEBUG && I.end('Setup compiler')
 
       let sources = (() => {
         // Disable auto source detection
@@ -524,11 +525,11 @@ class Root {
       // This should not be here, but right now the Vite plugin is setup where we
       // setup a new scanner and compiler every time we request the CSS file
       // (regardless whether it actually changed or not).
-      env.DEBUG && I.start('Scan for candidates')
+      DEBUG && I.start('Scan for candidates')
       for (let candidate of this.scanner.scan()) {
         this.candidates.add(candidate)
       }
-      env.DEBUG && I.end('Scan for candidates')
+      DEBUG && I.end('Scan for candidates')
     }
 
     if (this.compiler.features & Features.Utilities) {
@@ -576,13 +577,13 @@ class Root {
 
     this.requiresRebuild = true
 
-    env.DEBUG && I.start('Build CSS')
+    DEBUG && I.start('Build CSS')
     let result = this.compiler.build(
       this.overwriteCandidates
         ? this.overwriteCandidates
         : [...this.sharedCandidates(), ...this.candidates],
     )
-    env.DEBUG && I.end('Build CSS')
+    DEBUG && I.end('Build CSS')
 
     return result
   }
@@ -650,7 +651,7 @@ function svelteProcessor(roots: DefaultMap<string, Root>): Plugin {
         }) {
           if (!filename) return
           using I = new Instrumentation()
-          env.DEBUG && I.start('[@tailwindcss/vite] Preprocess svelte')
+          DEBUG && I.start('[@tailwindcss/vite] Preprocess svelte')
 
           // Create the ID used by Vite to identify the `<style>` contents. This
           // way, the Vite `transform` hook can find the right root and thus

--- a/packages/tsconfig.base.json
+++ b/packages/tsconfig.base.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "lib": ["ESNext", "DOM"],
-    "target": "ESNext",
+    "target": "es2022",
+    "lib": ["es2022", "esnext.disposable", "dom"],
+
     "module": "ESNext",
     "moduleDetection": "force",
     "allowJs": true,


### PR DESCRIPTION
This PR improves the debug logs for the `@tailwindcss/postcss` integration. It uses custom instrumentation to provide a nested but detailed overview of where time is spent during the build process.

The updated logs look like this:
```
[0.15ms] [@tailwindcss/postcss] src/app/geistsans_9fc57718.module.css
[0.14ms]   ↳ Quick bail check
[0.02ms] [@tailwindcss/postcss] src/app/geistsans_9fc57718.module.css
[0.01ms]   ↳ Quick bail check

[0.03ms] [@tailwindcss/postcss] src/app/geistmono_b9f59162.module.css
[0.02ms]   ↳ Quick bail check
[0.12ms] [@tailwindcss/postcss] src/app/geistmono_b9f59162.module.css
[0.11ms]   ↳ Quick bail check

[42.09ms] [@tailwindcss/postcss] src/app/globals.css
[ 0.01ms]   ↳ Quick bail check
[12.12ms]   ↳ Setup compiler
[ 0.11ms]     ↳ PostCSS AST -> Tailwind CSS AST
[11.99ms]     ↳ Create compiler
[ 0.07ms]   ↳ Register full rebuild paths
[ 0.06ms]   ↳ Setup scanner
[ 7.51ms]   ↳ Scan for candidates
[ 5.86ms]   ↳ Register dependency messages
[ 5.88ms]   ↳ Build utilities
[ 8.34ms]   ↳ Optimization
[ 0.23ms]     ↳ AST -> CSS
[ 4.20ms]     ↳ Lightning CSS
[ 3.89ms]     ↳ CSS -> PostCSS AST
[ 1.97ms]   ↳ Update PostCSS AST
```