### PR TITLE
Alias `@tailwindcss/upgrade` to the latest tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,6 +248,14 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Alias packages to `latest`
+        run: |
+          npm dist-tag add @tailwindcss/postcss@${{ env.TAG_NAME }} latest
+          npm dist-tag add @tailwindcss/vite@${{ env.TAG_NAME }} latest
+          npm dist-tag add @tailwindcss/upgrade@${{ env.TAG_NAME }} latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,8 +251,6 @@ jobs:
       - name: Alias packages to `latest`
         if: ${{ inputs.release_channel == "next" }}
         run: |
-          npm dist-tag add @tailwindcss/postcss@${{ env.TAG_NAME }} latest
-          npm dist-tag add @tailwindcss/vite@${{ env.TAG_NAME }} latest
           npm dist-tag add @tailwindcss/upgrade@${{ env.TAG_NAME }} latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,6 +249,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Alias packages to `latest`
+        if: ${{ inputs.release_channel == "next" }}
         run: |
           npm dist-tag add @tailwindcss/postcss@${{ env.TAG_NAME }} latest
           npm dist-tag add @tailwindcss/vite@${{ env.TAG_NAME }} latest


### PR DESCRIPTION
When releasing a new beta version, we publish everything to a `next` tag, this is important so that you can still use `npm install tailwindcss` and get the current v3 instead of the beta v4 version.

However, some packages don't have a meaning before the v4 release. This PR aliases the `next` tag to the `latest` tag for the following packages:

- `@tailwindcss/upgrade`

This in turn allow you to run `npx @tailwindcss/upgrade` for example, instead of using `npx @tailwindcss/upgrade@next`.

---

> [!NOTE]
>  I actually have no idea how to properly test this without actually running it in CI. The `npm dist-tag` command doesn't have a `--dry-run` flag. Additionally, when running this command locally we have to authenticate (obviously) and in CI we typically don't have to do this because of the `NODE_AUTH_TOKEN` (at least that's the case when running `npm publish`) so I'm hoping this Just Works™ as expected.
