### PR TITLE
Expose `flattenColorPalette`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Added
+
+- Add support for `tailwindcss/lib/util/flattenColorPalette` exports ([#15318](https://github.com/tailwindlabs/tailwindcss/pull/15318))
 
 ## [4.0.0-beta.5] - 2024-12-04
 

--- a/packages/tailwindcss/package.json
+++ b/packages/tailwindcss/package.json
@@ -96,8 +96,8 @@
         "import": "./dist/colors.mjs"
       },
       "./lib/util/flattenColorPalette": {
-        "require": "./dist/flattenColorPalette.js",
-        "import": "./dist/flattenColorPalette.mjs"
+        "require": "./dist/flatten-color-palette.js",
+        "import": "./dist/flatten-color-palette.mjs"
       },
       "./package.json": "./package.json",
       "./index.css": "./index.css",

--- a/packages/tailwindcss/package.json
+++ b/packages/tailwindcss/package.json
@@ -31,6 +31,10 @@
       "require": "./src/compat/colors.cts",
       "import": "./src/compat/colors.ts"
     },
+    "./lib/util/flattenColorPalette": {
+      "require": "./src/compat/flatten-color-palette.cts",
+      "import": "./src/compat/flatten-color-palette.ts"
+    },
     "./defaultTheme": {
       "require": "./src/compat/default-theme.cts",
       "import": "./src/compat/default-theme.ts"
@@ -90,6 +94,10 @@
       "./colors.js": {
         "require": "./dist/colors.js",
         "import": "./dist/colors.mjs"
+      },
+      "./lib/util/flattenColorPalette": {
+        "require": "./dist/flattenColorPalette.js",
+        "import": "./dist/flattenColorPalette.mjs"
       },
       "./package.json": "./package.json",
       "./index.css": "./index.css",

--- a/packages/tailwindcss/src/compat/config.test.ts
+++ b/packages/tailwindcss/src/compat/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, vi } from 'vitest'
 import { compile, type Config } from '..'
 import { default as plugin } from '../plugin'
-import { flattenColorPalette } from './flatten-color-palette'
+import flattenColorPalette from './flatten-color-palette'
 
 const css = String.raw
 

--- a/packages/tailwindcss/src/compat/flatten-color-palette.cts
+++ b/packages/tailwindcss/src/compat/flatten-color-palette.cts
@@ -1,0 +1,8 @@
+import flattenColorTheme from './flatten-color-palette.ts'
+
+// This file exists so that `default-theme.ts` can be written one time but be
+// compatible with both CJS and ESM. Without it we get a `.default` export when
+// using `require` in CJS.
+
+// @ts-ignore
+export = flattenColorTheme

--- a/packages/tailwindcss/src/compat/flatten-color-palette.cts
+++ b/packages/tailwindcss/src/compat/flatten-color-palette.cts
@@ -1,8 +1,8 @@
-import flattenColorTheme from './flatten-color-palette.ts'
+import flattenColorPalette from './flatten-color-palette.ts'
 
-// This file exists so that `default-theme.ts` can be written one time but be
-// compatible with both CJS and ESM. Without it we get a `.default` export when
-// using `require` in CJS.
+// This file exists so that `flatten-color-palette.ts` can be written one time
+// but be compatible with both CJS and ESM. Without it we get a `.default`
+// export when using `require` in CJS.
 
 // @ts-ignore
-export = flattenColorTheme
+export = flattenColorPalette

--- a/packages/tailwindcss/src/compat/flatten-color-palette.test.ts
+++ b/packages/tailwindcss/src/compat/flatten-color-palette.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { flattenColorPalette } from './flatten-color-palette'
+import flattenColorPalette from './flatten-color-palette'
 
 test('it should handle private __CSS_VALUES__ to resolve to the right value', () => {
   expect(

--- a/packages/tailwindcss/src/compat/flatten-color-palette.ts
+++ b/packages/tailwindcss/src/compat/flatten-color-palette.ts
@@ -4,7 +4,7 @@ type Colors = {
   [key: string | number]: string | Colors
 }
 
-export function flattenColorPalette(colors: Colors) {
+export default function flattenColorPalette(colors: Colors) {
   let result: Record<string, string> = {}
 
   for (let [root, children] of Object.entries(colors ?? {})) {

--- a/packages/tailwindcss/tsup.config.ts
+++ b/packages/tailwindcss/tsup.config.ts
@@ -10,7 +10,7 @@ export default defineConfig([
       plugin: 'src/plugin.ts',
       colors: 'src/compat/colors.ts',
       'default-theme': 'src/compat/default-theme.ts',
-      flattenColorPalette: 'src/compat/flatten-color-palette.ts',
+      'flatten-color-palette': 'src/compat/flatten-color-palette.ts',
     },
   },
   {
@@ -22,7 +22,7 @@ export default defineConfig([
       lib: 'src/index.cts',
       colors: 'src/compat/colors.cts',
       'default-theme': 'src/compat/default-theme.cts',
-      flattenColorPalette: 'src/compat/flatten-color-palette.cts',
+      'flatten-color-palette': 'src/compat/flatten-color-palette.cts',
     },
   },
 ])

--- a/packages/tailwindcss/tsup.config.ts
+++ b/packages/tailwindcss/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig([
       plugin: 'src/plugin.ts',
       colors: 'src/compat/colors.ts',
       'default-theme': 'src/compat/default-theme.ts',
+      flattenColorPalette: 'src/compat/flatten-color-palette.ts',
     },
   },
   {
@@ -21,6 +22,7 @@ export default defineConfig([
       lib: 'src/index.cts',
       colors: 'src/compat/colors.cts',
       'default-theme': 'src/compat/default-theme.cts',
+      flattenColorPalette: 'src/compat/flatten-color-palette.cts',
     },
   },
 ])


### PR DESCRIPTION
Resolves #15315 

It looks like we implemented this in Core but forgot to expose it from the distributed package (the references are only used for testing plugins internally right now). This exposes `flattenColorPalette` under the old import path of `tailwindcss/lib/util/flattenColorPalette`.

## Test Plan

Added the following plugin to the Vite example and ensured it works as expected:

```ts
import flattenColorPalette from 'tailwindcss/lib/util/flattenColorPalette'
import plugin from 'tailwindcss/plugin'

export default plugin(({ matchUtilities, theme }) => {
  matchUtilities(
    {
      'hover-bg': (value) => {
        return {
          '&:hover': {
            backgroundColor: value,
          },
        }
      },
    },
    { values: flattenColorPalette(theme('colors')) },
  )
})
```

<img width="462" alt="Screenshot 2024-12-06 at 11 47 44" src="https://github.com/user-attachments/assets/11163390-053e-4c6e-8cb9-ae67184ad594">
