### PR TITLE
Add `details-content` variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- _Experimental_: Add `details-content` variant ([#15319](https://github.com/tailwindlabs/tailwindcss/pull/15319))
 - _Experimental_: Add `inverted-colors` variant ([#11693](https://github.com/tailwindlabs/tailwindcss/pull/11693))
 - _Experimental_: Add `user-valid` and `user-invalid` variants ([#12370](https://github.com/tailwindlabs/tailwindcss/pull/12370))
 - _Experimental_: Add `wrap-anywhere`, `wrap-break-word`, and `wrap-normal` utilities ([#12128](https://github.com/tailwindlabs/tailwindcss/pull/12128))

--- a/packages/tailwindcss/src/__snapshots__/intellisense.test.ts.snap
+++ b/packages/tailwindcss/src/__snapshots__/intellisense.test.ts.snap
@@ -8613,6 +8613,13 @@ exports[`getVariants 1`] = `
   {
     "hasDash": true,
     "isArbitrary": false,
+    "name": "details-content",
+    "selectors": [Function],
+    "values": [],
+  },
+  {
+    "hasDash": true,
+    "isArbitrary": false,
     "name": "before",
     "selectors": [Function],
     "values": [],

--- a/packages/tailwindcss/src/feature-flags.ts
+++ b/packages/tailwindcss/src/feature-flags.ts
@@ -1,3 +1,4 @@
+export const enableDetailsContent = process.env.FEATURES_ENV !== 'stable'
 export const enableInvertedColors = process.env.FEATURES_ENV !== 'stable'
 export const enableUserValid = process.env.FEATURES_ENV !== 'stable'
 export const enableWrapAnywhere = process.env.FEATURES_ENV !== 'stable'

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -95,6 +95,15 @@ test('backdrop', async () => {
   expect(await run(['backdrop/foo:flex'])).toEqual('')
 })
 
+test('details-content', async () => {
+  expect(await run(['details-content:flex'])).toMatchInlineSnapshot(`
+    ".details-content\\:flex::details-content {
+      display: flex;
+    }"
+  `)
+  expect(await run(['details-content/foo:flex'])).toEqual('')
+})
+
 test('before', async () => {
   expect(await run(['before:flex'])).toMatchInlineSnapshot(`
     ".before\\:flex:before {
@@ -2092,6 +2101,7 @@ test('variant order', async () => {
         'data-custom:flex',
         'data-[custom=true]:flex',
         'default:flex',
+        'details-content:flex',
         'disabled:flex',
         'empty:flex',
         'enabled:flex',
@@ -2175,6 +2185,10 @@ test('variant order', async () => {
     }
 
     .placeholder\\:flex::placeholder, .backdrop\\:flex::backdrop {
+      display: flex;
+    }
+
+    .details-content\\:flex::details-content {
       display: flex;
     }
 

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -12,7 +12,7 @@ import {
   type StyleRule,
 } from './ast'
 import { type Variant } from './candidate'
-import { enableInvertedColors, enableUserValid } from './feature-flags'
+import { enableDetailsContent, enableInvertedColors, enableUserValid } from './feature-flags'
 import type { Theme } from './theme'
 import { compareBreakpoints } from './utils/compare-breakpoints'
 import { DefaultMap } from './utils/default-map'
@@ -628,7 +628,9 @@ export function createVariants(theme: Theme): Variants {
   staticVariant('file', ['&::file-selector-button'])
   staticVariant('placeholder', ['&::placeholder'])
   staticVariant('backdrop', ['&::backdrop'])
-  staticVariant('details-content', ['&::details-content'])
+  if (enableDetailsContent) {
+    staticVariant('details-content', ['&::details-content'])
+  }
 
   {
     function contentProperties() {

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -628,6 +628,7 @@ export function createVariants(theme: Theme): Variants {
   staticVariant('file', ['&::file-selector-button'])
   staticVariant('placeholder', ['&::placeholder'])
   staticVariant('backdrop', ['&::backdrop'])
+  staticVariant('details-content', ['&::details-content'])
 
   {
     function contentProperties() {


### PR DESCRIPTION
This matches the new `::details-content` pseudo element.

See https://developer.chrome.com/blog/styling-details#the_details-content_pseudo for more info.

Currently shipped in Chromium, in development in WebKit and no development yet in Firefox but they're [supportive](https://github.com/mozilla/standards-positions/issues/1027).
