### PR TITLE
Fix PostCSS watcher warnings on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
           - ${{ github.ref == 'refs/heads/next' }}
         exclude:
           - on-next-branch: false
-            runner: windows-latest
-          - on-next-branch: false
             runner: macos-14
 
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
           - ${{ github.ref == 'refs/heads/next' }}
         exclude:
           - on-next-branch: false
+            runner: windows-latest
+          - on-next-branch: false
             runner: macos-14
 
     runs-on: ${{ matrix.runner }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Ensure `@import "…" reference` never generates utilities ([#15307](https://github.com/tailwindlabs/tailwindcss/pull/15307))
+- Fix dependency related warnings when using `@tailwindcss/postcss` on Windows
 
 ## [4.0.0-beta.5] - 2024-12-04
 

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -106,7 +106,7 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
               result.messages.push({
                 type: 'dependency',
                 plugin: '@tailwindcss/postcss',
-                file,
+                file: path.resolve(file),
                 parent: result.opts.from,
               })
             }
@@ -174,7 +174,7 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
               result.messages.push({
                 type: 'dependency',
                 plugin: '@tailwindcss/postcss',
-                file,
+                file: path.resolve(file),
                 parent: result.opts.from,
               })
             }
@@ -194,14 +194,14 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
                 result.messages.push({
                   type: 'dependency',
                   plugin: '@tailwindcss/postcss',
-                  file: globBase,
+                  file: path.resolve(globBase),
                   parent: result.opts.from,
                 })
               } else {
                 result.messages.push({
                   type: 'dir-dependency',
                   plugin: '@tailwindcss/postcss',
-                  dir: globBase,
+                  dir: path.resolve(globBase),
                   glob: pattern,
                   parent: result.opts.from,
                 })


### PR DESCRIPTION
Resolves #15320
Resolves #15175

Turns out that the postcss file watcher does not like our Unix based paths and will print a warning about them. This fixes the issue by calling `path.resolve()` to convert it back to a Windows-style absolute path if necessary. 

## Test Plan

Tested on Windows with a new Next.js 14 project. Ensured that file reloads also still work (changes to the `tsx` file are picked up correctly). Also ensure that the CI runs on Windows.

### Before

<img width="1178" alt="Screenshot 2024-12-06 at 13 12 23" src="https://github.com/user-attachments/assets/70c1fe45-6983-4fb4-9889-716a0cbef03a">

### After

<img width="1196" alt="Screenshot 2024-12-06 at 13 23 24" src="https://github.com/user-attachments/assets/0b9e3ff7-c5b6-4ccb-85a9-e7ba7aee355a">
