### PR TITLE
Skip creating a compiler for CSS files that should not be processed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix dependency related warnings when using `@tailwindcss/postcss` on Windows ([#15321](https://github.com/tailwindlabs/tailwindcss/pull/15321))
+- Skip creating a compiler for CSS files that should not be processed ([#15340](https://github.com/tailwindlabs/tailwindcss/pull/15340))
 
 ## [4.0.0-beta.6] - 2024-12-06
 
@@ -749,3 +750,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move the CLI into a separate `@tailwindcss/cli` package ([#13095](https://github.com/tailwindlabs/tailwindcss/pull/13095))
 
 ## [4.0.0-alpha.1] - 2024-03-06
+

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -63,6 +63,29 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
         postcssPlugin: 'tailwindcss',
         async Once(root, { result }) {
           env.DEBUG && console.time('[@tailwindcss/postcss] Total time in @tailwindcss/postcss')
+
+          // Bail out early if this is guaranteed to be a non-Tailwind CSS file.
+          {
+            let canBail = true
+            root.walkAtRules((node) => {
+              if (
+                node.name === 'import' ||
+                node.name === 'theme' ||
+                node.name === 'config' ||
+                node.name === 'plugin' ||
+                node.name === 'apply'
+              ) {
+                canBail = false
+                return false
+              }
+            })
+            if (canBail) {
+              env.DEBUG &&
+                console.timeEnd('[@tailwindcss/postcss] Total time in @tailwindcss/postcss')
+              return
+            }
+          }
+
           let inputFile = result.opts.from ?? ''
           let context = getContextFromCache(inputFile, opts)
           let inputBasePath = path.dirname(path.resolve(inputFile))


### PR DESCRIPTION
This PR skips creating a compiler in the `@tailwindcss/postcss` implementation if we know that the CSS file we are handling is definitely not a Tailwind CSS file.

This is a performance improvement for initial builds where some CSS files would've been handling by Tailwind CSS but shouldn't. E.g.: When setting up custom fonts in Next.js applications, each font will have it's own CSS file that is passed to `@tailwindcss/postcss`.

Since they don't contain `@import` or any other Tailwind CSS directives, we can just skip them.
