### PR TITLE
Reset `<th>` alignment & font weight

### DIFF
--- a/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
@@ -460,6 +460,11 @@ exports[`\`@import 'tailwindcss'\` is replaced with the generated CSS 1`] = `
     border-collapse: collapse;
   }
 
+  th {
+    text-align: inherit;
+    font-weight: inherit;
+  }
+
   :-moz-focusring {
     outline: auto;
   }

--- a/packages/tailwindcss/preflight.css
+++ b/packages/tailwindcss/preflight.css
@@ -175,6 +175,15 @@ table {
 }
 
 /*
+  Remove default alignment and font-weight table header elements.
+*/
+
+th {
+  text-align: inherit;
+  font-weight: inherit;
+}
+
+/*
   Use the modern Firefox focus style for all focusable elements.
 */
 


### PR DESCRIPTION
Set the `<th>` alignment to inherit rather than centering it. Also reset the font weight like we do with `h1`,`h2`,...

Demo: https://codepen.io/MartijnCuppens/pen/PoqjNxx

Bootstrap reference: https://github.com/twbs/bootstrap/pull/30323
Issue with Safari: https://github.com/whatwg/html/issues/7978
Resolved issue: https://bugs.webkit.org/show_bug.cgi?id=138577 (you can check it with the codepen demo)