### PR TITLE
Work around issue with Node 22 and Jiti

### DIFF
--- a/src/lib/load-config.ts
+++ b/src/lib/load-config.ts
@@ -33,6 +33,10 @@ function lazyJiti() {
 
 export function loadConfig(path: string): Config {
   let config = (function () {
+    // Always use jiti for now. There is a a bug that occurs in Node v22.12+
+    // where imported files return invalid results
+    return lazyJiti()(path)
+
     // Always use jiti for ESM or TS files
     if (
       path &&


### PR DESCRIPTION
Fixes #15374

If we always use Jiti the problem should, in theory, go away (I hope). It does mean that loading configs is slower than it would be if they're written in CJS but 🤷‍♂️ 

Wanna get this running with the integration tests to see if anything breaks.