### PR TITLE
Vite: Process `<style>` blocks inside Svelte files as a post-processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Removed `--container-prose` in favor of a deprecated `--max-width-prose` theme variable so that `*-prose` is only available for max-width utilities and only for backward compatibility ([#15439](https://github.com/tailwindlabs/tailwindcss/pull/15439))
+- Use Vite post-processor APIs for processing Svelte `<style>` blocks ([#15436](https://github.com/tailwindlabs/tailwindcss/pull/15436))
 
 ## [4.0.0-beta.8] - 2024-12-17
 

--- a/integrations/vite/svelte.test.ts
+++ b/integrations/vite/svelte.test.ts
@@ -57,19 +57,19 @@ test(
         <h1 class="global local underline">Hello {name}!</h1>
 
         <style>
-          @import 'tailwindcss' reference;
           @import './other.css';
+          @reference 'tailwindcss';
         </style>
       `,
       'src/other.css': css`
         .local {
           @apply text-red-500;
-          animation: 2s ease-in-out 0s infinite localKeyframes;
+          animation: 2s ease-in-out infinite localKeyframes;
         }
 
         :global(.global) {
           @apply text-green-500;
-          animation: 2s ease-in-out 0s infinite globalKeyframes;
+          animation: 2s ease-in-out infinite globalKeyframes;
         }
 
         @keyframes -global-globalKeyframes {
@@ -93,18 +93,21 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    await exec('pnpm vite build')
+    let output = await exec('pnpm vite build')
 
     let files = await fs.glob('dist/**/*.css')
     expect(files).toHaveLength(1)
 
     await fs.expectFileToContain(files[0][0], [
       candidate`underline`,
-      '.global{color:var(--color-green-500);animation:2s ease-in-out 0s infinite globalKeyframes}',
-      /\.local.svelte-.*\{color:var\(--color-red-500\);animation:2s ease-in-out 0s infinite svelte-.*-localKeyframes\}/,
+      '.global{color:var(--color-green-500);animation:2s ease-in-out infinite globalKeyframes}',
+      /\.local.svelte-.*\{color:var\(--color-red-500\);animation:2s ease-in-out infinite svelte-.*-localKeyframes\}/,
       /@keyframes globalKeyframes\{/,
       /@keyframes svelte-.*-localKeyframes\{/,
     ])
+
+    // Should not print any warnings
+    expect(output).not.toContain('vite-plugin-svelte')
   },
 )
 
@@ -164,20 +167,20 @@ test(
         <h1 class="local global underline">Hello {name}!</h1>
 
         <style>
-          @import 'tailwindcss' reference;
           @import './other.css';
+          @reference 'tailwindcss';
         </style>
       `,
       'src/index.css': css` @import 'tailwindcss'; `,
       'src/other.css': css`
         .local {
           @apply text-red-500;
-          animation: 2s ease-in-out 0s infinite localKeyframes;
+          animation: 2s ease-in-out infinite localKeyframes;
         }
 
         :global(.global) {
           @apply text-green-500;
-          animation: 2s ease-in-out 0s infinite globalKeyframes;
+          animation: 2s ease-in-out infinite globalKeyframes;
         }
 
         @keyframes -global-globalKeyframes {
@@ -210,10 +213,10 @@ test(
       let [, css] = files[0]
       expect(css).toContain(candidate`underline`)
       expect(css).toContain(
-        '.global{color:var(--color-green-500);animation:2s ease-in-out 0s infinite globalKeyframes}',
+        '.global{color:var(--color-green-500);animation:2s ease-in-out infinite globalKeyframes}',
       )
       expect(css).toMatch(
-        /\.local.svelte-.*\{color:var\(--color-red-500\);animation:2s ease-in-out 0s infinite svelte-.*-localKeyframes\}/,
+        /\.local.svelte-.*\{color:var\(--color-red-500\);animation:2s ease-in-out infinite svelte-.*-localKeyframes\}/,
       )
       expect(css).toMatch(/@keyframes globalKeyframes\{/)
       expect(css).toMatch(/@keyframes svelte-.*-localKeyframes\{/)
@@ -235,10 +238,10 @@ test(
       let [, css] = files[0]
       expect(css).toContain(candidate`font-bold`)
       expect(css).toContain(
-        '.global{color:var(--color-green-500);animation:2s ease-in-out 0s infinite globalKeyframes}',
+        '.global{color:var(--color-green-500);animation:2s ease-in-out infinite globalKeyframes}',
       )
       expect(css).toMatch(
-        /\.local.svelte-.*\{color:var\(--color-red-500\);animation:2s ease-in-out 0s infinite svelte-.*-localKeyframes\}/,
+        /\.local.svelte-.*\{color:var\(--color-red-500\);animation:2s ease-in-out infinite svelte-.*-localKeyframes\}/,
       )
       expect(css).toMatch(/@keyframes globalKeyframes\{/)
       expect(css).toMatch(/@keyframes svelte-.*-localKeyframes\{/)

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -306,10 +306,7 @@ function isPotentialCssRootFile(id: string) {
   if (id.includes('/.vite/')) return
   let extension = getExtension(id)
   let isCssFile =
-    (extension === 'css' ||
-      (extension === 'vue' && id.includes('&lang.css')) ||
-      (extension === 'astro' && id.includes('&lang.css')) ||
-      (extension === 'svelte' && id.includes('&lang.css')))
+    (extension === 'css' || id.includes('&lang.css')) &&
     // Don't intercept special static asset resources
     !SPECIAL_QUERY_RE.test(id)
 


### PR DESCRIPTION
This PR changes the Svelte integration to be a post-processor similar to what we're doing for `<style>` blocks in Astro and Vue files.

More details can be found in the GitHub discussion: https://github.com/sveltejs/svelte/discussions/14668#discussioncomment-11620743