### PR TITLE
Move `--container-prose` to `--max-width-prose`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Changed
+
+- Removed `--container-prose` in favor of a deprecated `--max-width-prose` theme variable so that `*-prose` is only available for max-width utilities and only for backward compatibility ([#15439](https://github.com/tailwindlabs/tailwindcss/pull/15439))
 
 ## [4.0.0-beta.8] - 2024-12-17
 

--- a/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
@@ -269,7 +269,6 @@ exports[`\`@import 'tailwindcss'\` is replaced with the generated CSS 1`] = `
     --container-5xl: 64rem;
     --container-6xl: 72rem;
     --container-7xl: 80rem;
-    --container-prose: 65ch;
     --text-xs: .75rem;
     --text-xs--line-height: calc(1 / .75);
     --text-sm: .875rem;

--- a/packages/tailwindcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/tailwindcss/src/__snapshots__/index.test.ts.snap
@@ -268,7 +268,6 @@ exports[`compiling CSS > \`@tailwind utilities\` is replaced by utilities using 
   --container-5xl: 64rem;
   --container-6xl: 72rem;
   --container-7xl: 80rem;
-  --container-prose: 65ch;
   --text-xs: .75rem;
   --text-xs--line-height: calc(1 / .75);
   --text-sm: .875rem;

--- a/packages/tailwindcss/theme.css
+++ b/packages/tailwindcss/theme.css
@@ -293,7 +293,6 @@
   --container-5xl: 64rem;
   --container-6xl: 72rem;
   --container-7xl: 80rem;
-  --container-prose: 65ch;
 
   --text-xs: 0.75rem;
   --text-xs--line-height: calc(1 / 0.75);
@@ -448,4 +447,5 @@
   --shadow-inner: inset 0 2px 4px 0 rgb(0 0 0 / 0.05);
   --drop-shadow: 0 1px 2px rgb(0 0 0 / 0.1), 0 1px 1px rgb(0 0 0 / 0.06);
   --radius: 0.25rem;
+  --max-width-prose: 65ch;
 }


### PR DESCRIPTION
We don’t want utilities like `basis-prose`, `w-prose`, etc existing nor a `@prose:*` variant. So we’re moving the theme key to `--max-width-*` to align with the definition as it was in v3.

cc @adamwathan 