### PR TITLE
Fixed definition of `place-content-*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Fixed definition of `place-content-between`, `place-content-around`, `place-content-evenly` ([#15440](https://github.com/tailwindlabs/tailwindcss/pull/15440))
 
 ## [4.0.0-beta.8] - 2024-12-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed definition of `place-content-between`, `place-content-around`, `place-content-evenly` ([#15440](https://github.com/tailwindlabs/tailwindcss/pull/15440))
+- Use the correct property value for `place-content-between`, `place-content-around`, and `place-content-evenly` utilities ([#15440](https://github.com/tailwindlabs/tailwindcss/pull/15440))
 
 ## [4.0.0-beta.8] - 2024-12-17
 

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -7454,7 +7454,7 @@ test('place-content', async () => {
     ]),
   ).toMatchInlineSnapshot(`
     ".place-content-around {
-      place-content: around;
+      place-content: space-around;
     }
 
     .place-content-baseline {
@@ -7462,7 +7462,7 @@ test('place-content', async () => {
     }
 
     .place-content-between {
-      place-content: between;
+      place-content: space-between;
     }
 
     .place-content-center {
@@ -7474,7 +7474,7 @@ test('place-content', async () => {
     }
 
     .place-content-evenly {
-      place-content: evenly;
+      place-content: space-evenly;
     }
 
     .place-content-start {

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -1780,9 +1780,9 @@ export function createUtilities(theme: Theme) {
   staticUtility('place-content-center', [['place-content', 'center']])
   staticUtility('place-content-start', [['place-content', 'start']])
   staticUtility('place-content-end', [['place-content', 'end']])
-  staticUtility('place-content-between', [['place-content', 'between']])
-  staticUtility('place-content-around', [['place-content', 'around']])
-  staticUtility('place-content-evenly', [['place-content', 'evenly']])
+  staticUtility('place-content-between', [['place-content', 'space-between']])
+  staticUtility('place-content-around', [['place-content', 'space-around']])
+  staticUtility('place-content-evenly', [['place-content', 'space-evenly']])
   staticUtility('place-content-baseline', [['place-content', 'baseline']])
   staticUtility('place-content-stretch', [['place-content', 'stretch']])
 


### PR DESCRIPTION
The utilities `place-content-between`, `place-content-around`, and `place-content-evenly` are defined incorrectly. This PR fixes them.
