### PR TITLE
Don’t detect arbitrary properties when preceded by an escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Use the correct property value for `place-content-between`, `place-content-around`, and `place-content-evenly` utilities ([#15440](https://github.com/tailwindlabs/tailwindcss/pull/15440))
+- Don’t detect arbitrary properties when preceded by an escape ([#15456](https://github.com/tailwindlabs/tailwindcss/pull/15456))
 
 ### Changed
 

--- a/crates/oxide/src/parser.rs
+++ b/crates/oxide/src/parser.rs
@@ -1636,7 +1636,7 @@ mod test {
     }
 
     #[test]
-    fn wip2() {
+    fn arbitrary_properties_are_not_picked_up_after_an_escape() {
         _please_trace();
         let candidates = run(
             r#"

--- a/crates/oxide/src/parser.rs
+++ b/crates/oxide/src/parser.rs
@@ -595,7 +595,7 @@ impl<'a> Extractor<'a> {
     fn parse_start(&mut self) -> ParseAction<'a> {
         match self.cursor.curr {
             // Enter arbitrary property mode
-            b'[' => {
+            b'[' if self.cursor.prev != b'\\' => {
                 trace!("Arbitrary::Start\t");
                 self.arbitrary = Arbitrary::Brackets {
                     start_idx: self.cursor.pos,
@@ -755,7 +755,7 @@ impl<'a> Extractor<'a> {
 
     #[inline(always)]
     fn parse_char(&mut self) -> ParseAction<'a> {
-        if !matches!(self.arbitrary, Arbitrary::None) {
+      if !matches!(self.arbitrary, Arbitrary::None) {
             self.parse_arbitrary()
         } else if self.in_candidate {
             self.parse_continue()
@@ -1633,5 +1633,16 @@ mod test {
                 "[.foo_&]:[color:red]",
             ]
         );
+    }
+
+    #[test]
+    fn wip2() {
+        _please_trace();
+        let candidates = run(
+            r"<!-- [!code word:group-has-\\[a\\]\\:block] -->",
+            false,
+        );
+
+        assert_eq!(candidates, vec!["!code", "a"]);
     }
 }

--- a/crates/oxide/src/parser.rs
+++ b/crates/oxide/src/parser.rs
@@ -1639,7 +1639,10 @@ mod test {
     fn wip2() {
         _please_trace();
         let candidates = run(
-            r"<!-- [!code word:group-has-\\[a\\]\\:block] -->",
+            r#"
+              <!-- [!code word:group-has-\\[a\\]\\:block] -->
+              \\[a\\]\\:block]
+            "#,
             false,
         );
 

--- a/crates/oxide/src/parser.rs
+++ b/crates/oxide/src/parser.rs
@@ -755,7 +755,7 @@ impl<'a> Extractor<'a> {
 
     #[inline(always)]
     fn parse_char(&mut self) -> ParseAction<'a> {
-      if !matches!(self.arbitrary, Arbitrary::None) {
+        if !matches!(self.arbitrary, Arbitrary::None) {
             self.parse_arbitrary()
         } else if self.in_candidate {
             self.parse_continue()


### PR DESCRIPTION
This is a targeted bug fix uncovered by the v4 docs.

Given this code:
```html
<!-- [!code word:group-has-\\[a\\]\\:block] -->
```

We'd pick up `[a\\]\\:block]` as a candidate which would then make it far enough to get output to CSS and throw an error. This makes sure we don't try to start an arbitrary property if the preceding character is a `\`

cc @RobinMalfait this look okay?