### PR TITLE
Add musl binaries to the Standalone CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,7 +265,9 @@ jobs:
           files: |
             packages/@tailwindcss-standalone/dist/sha256sums.txt
             packages/@tailwindcss-standalone/dist/tailwindcss-linux-arm64
+            packages/@tailwindcss-standalone/dist/tailwindcss-linux-arm64-musl
             packages/@tailwindcss-standalone/dist/tailwindcss-linux-x64
+            packages/@tailwindcss-standalone/dist/tailwindcss-linux-x64-musl
             packages/@tailwindcss-standalone/dist/tailwindcss-macos-arm64
             packages/@tailwindcss-standalone/dist/tailwindcss-macos-x64
             packages/@tailwindcss-standalone/dist/tailwindcss-windows-x64.exe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `@reference "…"` API as a replacement for the previous `@import "…" reference` option ([#15565](https://github.com/tailwindlabs/tailwindcss/pull/15565))
 - Add functional utility syntax ([#15455](https://github.com/tailwindlabs/tailwindcss/pull/15455))
 - Add new `--spacing(…)`, `--alpha(…)`, and `--theme(…)` CSS functions ([#15572](https://github.com/tailwindlabs/tailwindcss/pull/15572))
+- Add Linux musl builds of the Standalone CLI ([#15567](https://github.com/tailwindlabs/tailwindcss/pull/15567))
 
 ### Fixed
 

--- a/packages/@tailwindcss-standalone/package.json
+++ b/packages/@tailwindcss-standalone/package.json
@@ -43,7 +43,7 @@
     "@parcel/watcher-linux-x64-musl": "^2.5.0",
     "@parcel/watcher-win32-x64": "^2.5.0",
     "@types/bun": "^1.1.14",
-    "bun": "1.1.42",
+    "bun": "1.1.43",
     "lightningcss-darwin-arm64": "^1.25.1",
     "lightningcss-darwin-x64": "^1.25.1",
     "lightningcss-linux-arm64-gnu": "^1.25.1",

--- a/packages/@tailwindcss-standalone/scripts/build.ts
+++ b/packages/@tailwindcss-standalone/scripts/build.ts
@@ -46,7 +46,9 @@ await mkdir(path.resolve(__dirname, '../dist'), { recursive: true })
 // Build platform binaries and checksum them
 let results = await Promise.all([
   build('bun-linux-arm64', './tailwindcss-linux-arm64'),
+  build('bun-linux-arm64-musl', './tailwindcss-linux-arm64-musl'),
   build('bun-linux-x64', './tailwindcss-linux-x64'),
+  build('bun-linux-x64-musl', './tailwindcss-linux-x64-musl'),
   // build('linux-armv7', 'tailwindcss-linux-armv7'),
   build('bun-darwin-arm64', './tailwindcss-macos-arm64'),
   build('bun-darwin-x64', './tailwindcss-macos-x64'),

--- a/patches/@parcel__watcher@2.5.0.patch
+++ b/patches/@parcel__watcher@2.5.0.patch
@@ -1,8 +1,8 @@
 diff --git a/index.js b/index.js
-index 8afb2b1126dcc687b7ff9b631589da252c1f9c22..f3b1158eb5612235388ff5f5347f6edcbf323090 100644
+index 8afb2b1126dcc687b7ff9b631589da252c1f9c22..398af238a439912d150b3573367873d2a9a311e3 100644
 --- a/index.js
 +++ b/index.js
-@@ -1,41 +1,27 @@
+@@ -1,41 +1,34 @@
 -const {createWrapper} = require('./wrapper');
 +const { createWrapper } = require('./wrapper')
  
@@ -17,11 +17,12 @@ index 8afb2b1126dcc687b7ff9b631589da252c1f9c22..f3b1158eb5612235388ff5f5347f6edc
 -}
 +function loadPackage() {
 +  if (process.platform === 'linux') {
-+    let { MUSL, GLIBC, family, familySync } = require('detect-libc')
-+    // Bun polyfills `detect-libc` in compiled binaries. We rely on
-+    // detect-libc@1.0.3 but the polyfilled version is 2.x. In detect-libc@2x
-+    // there is a `familySync` function that we can use instead.
-+    if (typeof familySync === 'function') family = familySync()
++    if (process.env.PLATFORM_LIBC === "musl") {
++      return require(`@parcel/watcher-${process.platform}-${process.arch}-musl`)
++    } else if (process.env.PLATFORM_LIBC === "glibc") {
++      return require(`@parcel/watcher-${process.platform}-${process.arch}-glibc`)
++    } else {
++      let { MUSL, GLIBC, family, familySync } = require('detect-libc')
  
 -let binding;
 -try {
@@ -37,24 +38,30 @@ index 8afb2b1126dcc687b7ff9b631589da252c1f9c22..f3b1158eb5612235388ff5f5347f6edc
 -    } catch (err) {
 -      handleError(err);
 -      throw new Error(`No prebuild or local build of @parcel/watcher found. Tried ${name}. Please ensure it is installed (don't use --no-optional when installing with npm). Otherwise it is possible we don't support your platform yet. If this is the case, please report an issue to https://github.com/parcel-bundler/watcher.`);
-+    if (family === MUSL) {
-+      return require(`@parcel/watcher-${process.platform}-${process.arch}-musl`)
-+    } else if (family === GLIBC) {
-+      return require(`@parcel/watcher-${process.platform}-${process.arch}-glibc`)
-+    } else {
-+      throw new Error(`Unsupported libc on: ${process.platform}-${process.arch}`)
-     }
+-    }
+-  }
+-}
++      // Bun polyfills `detect-libc` in compiled binaries. We rely on
++      // detect-libc@1.0.3 but the polyfilled version is 2.x. In detect-libc@2x
++      // there is a `familySync` function that we can use instead.
++      if (typeof familySync === 'function') family = familySync()
+ 
+-function handleError(err) {
+-  if (err?.code !== 'MODULE_NOT_FOUND') {
+-    throw err;
++      if (family === MUSL) {
++        return require(`@parcel/watcher-${process.platform}-${process.arch}-musl`)
++      } else if (family === GLIBC) {
++        return require(`@parcel/watcher-${process.platform}-${process.arch}-glibc`)
++      } else {
++        throw new Error(`Unsupported libc on: ${process.platform}-${process.arch}`)
++      }
++    }
 +  } else {
 +    return require(`@parcel/watcher-${process.platform}-${process.arch}`)
    }
  }
  
--function handleError(err) {
--  if (err?.code !== 'MODULE_NOT_FOUND') {
--    throw err;
--  }
--}
--
 -const wrapper = createWrapper(binding);
 -exports.writeSnapshot = wrapper.writeSnapshot;
 -exports.getEventsSince = wrapper.getEventsSince;

--- a/patches/lightningcss@1.26.0.patch
+++ b/patches/lightningcss@1.26.0.patch
@@ -1,8 +1,8 @@
 diff --git a/node/index.js b/node/index.js
-index a9f2f6d5f3394329fcf8bc06af549030c01167a5..b92cc804adb694dbb17ee48368f13a03dd729267 100644
+index a9f2f6d5f3394329fcf8bc06af549030c01167a5..db3b1c6cab5e4bac140d2f7a2b2e041d9a0a8a36 100644
 --- a/node/index.js
 +++ b/node/index.js
-@@ -1,27 +1,32 @@
+@@ -1,27 +1,43 @@
 -let parts = [process.platform, process.arch];
 -if (process.platform === 'linux') {
 -  const { MUSL, family } = require('detect-libc');
@@ -18,11 +18,16 @@ index a9f2f6d5f3394329fcf8bc06af549030c01167a5..b92cc804adb694dbb17ee48368f13a03
 -}
 +function loadPackage() {
 +  if (process.platform === "linux") {
-+    let { MUSL, GLIBC, family, familySync } = require("detect-libc");
-+    // Bun polyfills `detect-libc` in compiled binaries. We rely on
-+    // detect-libc@1.0.3 but the polyfilled version is 2.x. In detect-libc@2x
-+    // there is a `familySync` function that we can use instead.
-+    if (typeof familySync === 'function') family = familySync()
++    if (process.env.PLATFORM_LIBC === 'musl') {
++      return require(`lightningcss-${process.platform}-${process.arch}-musl`);
++    } else if (process.env.PLATFORM_LIBC === 'glibc') {
++      if (process.arch === "arm") {
++        return require(`lightningcss-${process.platform}-${process.arch}-gnueabihf`);
++      } else {
++        return require(`lightningcss-${process.platform}-${process.arch}-gnu`);
++      }
++    } else {
++      let { MUSL, GLIBC, family, familySync } = require('detect-libc')
  
 -if (process.env.CSS_TRANSFORMER_WASM) {
 -  module.exports = require(`../pkg`);
@@ -31,18 +36,24 @@ index a9f2f6d5f3394329fcf8bc06af549030c01167a5..b92cc804adb694dbb17ee48368f13a03
 -    module.exports = require(`lightningcss-${parts.join('-')}`);
 -  } catch (err) {
 -    module.exports = require(`../lightningcss.${parts.join('-')}.node`);
-+    if (family === MUSL) {
-+      return require(`lightningcss-${process.platform}-${process.arch}-musl`);
-+    } else if (family === GLIBC) {
-+      if (process.arch === "arm") {
-+        return require(`lightningcss-${process.platform}-${process.arch}-gnueabihf`);
++      // Bun polyfills `detect-libc` in compiled binaries. We rely on
++      // detect-libc@1.0.3 but the polyfilled version is 2.x. In detect-libc@2x
++      // there is a `familySync` function that we can use instead.
++      if (typeof familySync === 'function') family = familySync()
++
++      if (family === MUSL) {
++        return require(`lightningcss-${process.platform}-${process.arch}-musl`);
++      } else if (family === GLIBC) {
++        if (process.arch === "arm") {
++          return require(`lightningcss-${process.platform}-${process.arch}-gnueabihf`);
++        } else {
++          return require(`lightningcss-${process.platform}-${process.arch}-gnu`);
++        }
 +      } else {
-+        return require(`lightningcss-${process.platform}-${process.arch}-gnu`);
++        throw new Error(
++          `Unsupported libc on: ${process.platform}-${process.arch}`
++        );
 +      }
-+    } else {
-+      throw new Error(
-+        `Unsupported libc on: ${process.platform}-${process.arch}`
-+      );
 +    }
 +  } else if (process.platform === "win32") {
 +    return require(`lightningcss-${process.platform}-${process.arch}-msvc`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,10 +18,10 @@ catalogs:
 
 patchedDependencies:
   '@parcel/watcher@2.5.0':
-    hash: pyfayeoxwesjxsefsxp3jpev4q
+    hash: zs2vvlrje3h42xp5ed2v44fep4
     path: patches/@parcel__watcher@2.5.0.patch
   lightningcss@1.26.0:
-    hash: 5hwfyehqvg5wjb7mwtdvubqbl4
+    hash: gkqcezdn4goium3e3s43dhy4by
     path: patches/lightningcss@1.26.0.patch
 
 importers:
@@ -60,7 +60,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^2.0.5
-        version: 2.0.5(@types/node@20.14.13)(lightningcss@1.26.0(patch_hash=5hwfyehqvg5wjb7mwtdvubqbl4))(terser@5.31.6)
+        version: 2.0.5(@types/node@20.14.13)(lightningcss@1.26.0(patch_hash=gkqcezdn4goium3e3s43dhy4by))(terser@5.31.6)
 
   crates/node:
     optionalDependencies:
@@ -151,7 +151,7 @@ importers:
     dependencies:
       '@parcel/watcher':
         specifier: ^2.5.0
-        version: 2.5.0(patch_hash=pyfayeoxwesjxsefsxp3jpev4q)
+        version: 2.5.0(patch_hash=zs2vvlrje3h42xp5ed2v44fep4)
       '@tailwindcss/node':
         specifier: workspace:^
         version: link:../@tailwindcss-node
@@ -163,7 +163,7 @@ importers:
         version: 5.17.1
       lightningcss:
         specifier: 'catalog:'
-        version: 1.26.0(patch_hash=5hwfyehqvg5wjb7mwtdvubqbl4)
+        version: 1.26.0(patch_hash=gkqcezdn4goium3e3s43dhy4by)
       mri:
         specifier: ^1.2.0
         version: 1.2.0
@@ -199,7 +199,7 @@ importers:
         version: link:../../crates/node
       lightningcss:
         specifier: 'catalog:'
-        version: 1.26.0(patch_hash=5hwfyehqvg5wjb7mwtdvubqbl4)
+        version: 1.26.0(patch_hash=gkqcezdn4goium3e3s43dhy4by)
       postcss:
         specifier: ^8.4.41
         version: 8.4.41
@@ -272,8 +272,8 @@ importers:
         specifier: ^1.1.14
         version: 1.1.14
       bun:
-        specifier: 1.1.42
-        version: 1.1.42
+        specifier: 1.1.43
+        version: 1.1.43
       lightningcss-darwin-arm64:
         specifier: ^1.25.1
         version: 1.26.0
@@ -367,7 +367,7 @@ importers:
         version: link:../../crates/node
       lightningcss:
         specifier: 'catalog:'
-        version: 1.26.0(patch_hash=5hwfyehqvg5wjb7mwtdvubqbl4)
+        version: 1.26.0(patch_hash=gkqcezdn4goium3e3s43dhy4by)
       tailwindcss:
         specifier: workspace:*
         version: link:../tailwindcss
@@ -377,7 +377,7 @@ importers:
         version: 20.14.13
       vite:
         specifier: 'catalog:'
-        version: 6.0.0(@types/node@20.14.13)(jiti@2.4.2)(lightningcss@1.26.0(patch_hash=5hwfyehqvg5wjb7mwtdvubqbl4))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0)
+        version: 6.0.0(@types/node@20.14.13)(jiti@2.4.2)(lightningcss@1.26.0(patch_hash=gkqcezdn4goium3e3s43dhy4by))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0)
 
   packages/internal-example-plugin: {}
 
@@ -394,7 +394,7 @@ importers:
         version: 1.5.3
       lightningcss:
         specifier: 'catalog:'
-        version: 1.26.0(patch_hash=5hwfyehqvg5wjb7mwtdvubqbl4)
+        version: 1.26.0(patch_hash=gkqcezdn4goium3e3s43dhy4by)
 
   playgrounds/nextjs:
     dependencies:
@@ -480,7 +480,7 @@ importers:
         version: link:../../packages/@tailwindcss-vite
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@6.0.0(@types/node@20.14.13)(jiti@2.4.2)(lightningcss@1.26.0(patch_hash=5hwfyehqvg5wjb7mwtdvubqbl4))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0))
+        version: 4.3.4(vite@6.0.0(@types/node@20.14.13)(jiti@2.4.2)(lightningcss@1.26.0(patch_hash=gkqcezdn4goium3e3s43dhy4by))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0))
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -502,7 +502,7 @@ importers:
         version: 1.1.29
       vite:
         specifier: 'catalog:'
-        version: 6.0.0(@types/node@20.14.13)(jiti@2.4.2)(lightningcss@1.26.0(patch_hash=5hwfyehqvg5wjb7mwtdvubqbl4))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0)
+        version: 6.0.0(@types/node@20.14.13)(jiti@2.4.2)(lightningcss@1.26.0(patch_hash=gkqcezdn4goium3e3s43dhy4by))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0)
 
 packages:
 
@@ -1430,8 +1430,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@oven/bun-darwin-aarch64@1.1.42':
-    resolution: {integrity: sha512-7kQkTVr99ndcU72xlIzA2QLavvT/DnEhvwTAq7LKi9/P3GtSAkhoA6UWZUa7pYw7OYHpUrEGXlV+PR3LllkGnw==}
+  '@oven/bun-darwin-aarch64@1.1.43':
+    resolution: {integrity: sha512-hOlLk6m/6Lfb5IV6LWDbuMNQHu6kP0f6HMDdLmsdlIBClgDhR0wRVLfeMuaZnUAdzLfWSJpHlsGn9wOp/ePB0g==}
     cpu: [arm64]
     os: [darwin]
 
@@ -1440,8 +1440,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@oven/bun-darwin-x64-baseline@1.1.42':
-    resolution: {integrity: sha512-26mtzVRLp/x89s27fXExG1vCCBOOFHLdqVYg/lHZMdDNHSh7Q7UiUhDRa+aVBlbsaGfw1LzoXdhh7Zy2hlF/6w==}
+  '@oven/bun-darwin-x64-baseline@1.1.43':
+    resolution: {integrity: sha512-J4MNzMef+uqJdNTlRfeKOhQ9DSCyls3LeGeDBGrgsc+b3SqH8tW3hrHjMChl+oRj4TGl3tRzBvUItUFqStvKtw==}
     cpu: [x64]
     os: [darwin]
 
@@ -1450,13 +1450,13 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@oven/bun-darwin-x64@1.1.42':
-    resolution: {integrity: sha512-2IPJnLvwLlD8YaXPbWwlpw2UvVrZE6/0uRbcSJNzZQAAZjEfN8AodqNRhggptn0A9vDmAw6q1U07QbiE4ilofw==}
+  '@oven/bun-darwin-x64@1.1.43':
+    resolution: {integrity: sha512-6jR/FpiIb9+qEep0FVaaap7enSuTDKKJt6BApHTPoV5TcZddZUeBxnDLiUjB4WiIEqv4JroGy0WmaCI8tXxawA==}
     cpu: [x64]
     os: [darwin]
 
-  '@oven/bun-linux-aarch64-musl@1.1.42':
-    resolution: {integrity: sha512-PwbNLoirazjTYTSydn2AnId0jBJexZ99cwftOfdzIGCF5anEWvNEZ8PL4o79jHIhE0t01qGc8br9fQbiQ+iArw==}
+  '@oven/bun-linux-aarch64-musl@1.1.43':
+    resolution: {integrity: sha512-PqzSC/+vk6HtVRBq/uSU3Xozw7uixk8ATLXiSImlL0kvrrL/aQJ+GVmlJxAN045+dJhnAXDsy3tkPITqWiQOsw==}
     cpu: [aarch64]
     os: [linux]
 
@@ -1465,8 +1465,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@oven/bun-linux-aarch64@1.1.42':
-    resolution: {integrity: sha512-qkoqI+oMcQ8GUej71qkAVj/VLlVpoBRyiYBQYq4yWsy+FU2jr2KWTeNZWrsY2crDiZj38AMNXJiKBr/EMy4MRg==}
+  '@oven/bun-linux-aarch64@1.1.43':
+    resolution: {integrity: sha512-tVAbBN53tDvweeV2rT0j37jOBgYNhFTC6JtOHZjlP8bETaVH4CikLQQGJLKclkqmOFROb00FpIS1ef/jxSqumA==}
     cpu: [arm64]
     os: [linux]
 
@@ -1475,18 +1475,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@oven/bun-linux-x64-baseline@1.1.42':
-    resolution: {integrity: sha512-UzRNXgHEARFECgz30eot23OnPzd0J2L5SEsGhnGRhfJ706kjz0XmuGMnb9nmnoyHBcd2iSjk4nci1BlGmu4wCA==}
+  '@oven/bun-linux-x64-baseline@1.1.43':
+    resolution: {integrity: sha512-/eDhCXS7Jl34LGSYAcg53hCPeUyhKGzA7FDFAA8lYeUkqchZkEJoBtqcT/bKjQBrEMDlZHsdvmYwkckqjmdpvw==}
     cpu: [x64]
     os: [linux]
 
-  '@oven/bun-linux-x64-musl-baseline@1.1.42':
-    resolution: {integrity: sha512-zgeiYJRGO3K4uK6Qdj1B5ZbU9NJxLwF9YGDFu9MtqEplyGNq7SpeuamvcP6SlZGgrVnc3AWrHFEYrVlv5Lqt+w==}
+  '@oven/bun-linux-x64-musl-baseline@1.1.43':
+    resolution: {integrity: sha512-GiO280I+agtsGKF7xv0GqLPowOuT48x1n+Pd/FehqmUG2UwbWFQ3LCvGfSpuiJPg7+LGK+ZYC7FZnJLWNO5btQ==}
     cpu: [x64]
     os: [linux]
 
-  '@oven/bun-linux-x64-musl@1.1.42':
-    resolution: {integrity: sha512-Djye8lPlhVNXdGbMF4bShVop8qvqPhPuPrhxEHfYJ8qhudSs2MiOWR5stvBWe8KLKahqDAWfWXuxByAXVhqb2Q==}
+  '@oven/bun-linux-x64-musl@1.1.43':
+    resolution: {integrity: sha512-eSK7TYBQBGoSErD9clZhM1XGdUryCRr4J0qX/SpV2KHUGTq04wah0r6do2qnG4ijH5+2m9Kz3kc72bt7EM97mg==}
     cpu: [x64]
     os: [linux]
 
@@ -1495,8 +1495,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@oven/bun-linux-x64@1.1.42':
-    resolution: {integrity: sha512-rV8Eqnvo/1z0nwYSiLrbl0F4G8uFQxlGA4P0zggW9W4PSiSHSRhG1aazG/8esBLzJI9CdFNncrtmiRTmWl1mIg==}
+  '@oven/bun-linux-x64@1.1.43':
+    resolution: {integrity: sha512-vuvBcPbygUZQggLjj1MAt4telEllv2+4k5O6IkYHdkytRqqtBrMSvwh4Rb4pdu0LyCxFF5eTm5sUew7tZMBvfw==}
     cpu: [x64]
     os: [linux]
 
@@ -1505,8 +1505,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oven/bun-windows-x64-baseline@1.1.42':
-    resolution: {integrity: sha512-xnlYa1jKknImCw7xmSD91H8e+w3BC6mIShOfHhFWfNhdyvEtundXhIu7VddwxKBMs5S/iiFJiutnZ2EyLq4CAQ==}
+  '@oven/bun-windows-x64-baseline@1.1.43':
+    resolution: {integrity: sha512-Fj1yGoK9ki0KdSAkWLlF41BzLeaohGSEEYPnxIDDULVhD3zFqPzqdqEQ1/NBsH3px/dJmB22vmM4BOMCYuFAiQ==}
     cpu: [x64]
     os: [win32]
 
@@ -1515,8 +1515,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oven/bun-windows-x64@1.1.42':
-    resolution: {integrity: sha512-6eyHs6fVRCy0ujltYTwSX3bug+PqlgZRBv8x0PPekviaCJWYrFKVpHodA2972+Mih2pATurBSX2sLVq5uJUU7Q==}
+  '@oven/bun-windows-x64@1.1.43':
+    resolution: {integrity: sha512-FesAYHGCWOJ+28041NgVsxPmqCIx1xXJwXJykpAczk1iaLKGHftSTprE1JV0vp2R/mPHFewV2Ktn5rQuExpiGg==}
     cpu: [x64]
     os: [win32]
 
@@ -2084,8 +2084,9 @@ packages:
     os: [darwin, linux, win32]
     hasBin: true
 
-  bun@1.1.42:
-    resolution: {integrity: sha512-PckeNolMEBaBEzixTMvp0jJD9r/9lly8AfctILi1ve14zwwChFjsxI4TJLQO2yezzOjVeG0u7xf8WQFbS7GjAA==}
+  bun@1.1.43:
+    resolution: {integrity: sha512-8Acq5NuECRXx62jVera3rnLcsaHh4/k5Res3dOQFv783nyRKo39W3DHlenGlXB9bNWbtRybBEvkKaH+zdwzLHw==}
+    cpu: [arm64, x64, aarch64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -4642,58 +4643,58 @@ snapshots:
   '@oven/bun-darwin-aarch64@1.1.29':
     optional: true
 
-  '@oven/bun-darwin-aarch64@1.1.42':
+  '@oven/bun-darwin-aarch64@1.1.43':
     optional: true
 
   '@oven/bun-darwin-x64-baseline@1.1.29':
     optional: true
 
-  '@oven/bun-darwin-x64-baseline@1.1.42':
+  '@oven/bun-darwin-x64-baseline@1.1.43':
     optional: true
 
   '@oven/bun-darwin-x64@1.1.29':
     optional: true
 
-  '@oven/bun-darwin-x64@1.1.42':
+  '@oven/bun-darwin-x64@1.1.43':
     optional: true
 
-  '@oven/bun-linux-aarch64-musl@1.1.42':
+  '@oven/bun-linux-aarch64-musl@1.1.43':
     optional: true
 
   '@oven/bun-linux-aarch64@1.1.29':
     optional: true
 
-  '@oven/bun-linux-aarch64@1.1.42':
+  '@oven/bun-linux-aarch64@1.1.43':
     optional: true
 
   '@oven/bun-linux-x64-baseline@1.1.29':
     optional: true
 
-  '@oven/bun-linux-x64-baseline@1.1.42':
+  '@oven/bun-linux-x64-baseline@1.1.43':
     optional: true
 
-  '@oven/bun-linux-x64-musl-baseline@1.1.42':
+  '@oven/bun-linux-x64-musl-baseline@1.1.43':
     optional: true
 
-  '@oven/bun-linux-x64-musl@1.1.42':
+  '@oven/bun-linux-x64-musl@1.1.43':
     optional: true
 
   '@oven/bun-linux-x64@1.1.29':
     optional: true
 
-  '@oven/bun-linux-x64@1.1.42':
+  '@oven/bun-linux-x64@1.1.43':
     optional: true
 
   '@oven/bun-windows-x64-baseline@1.1.29':
     optional: true
 
-  '@oven/bun-windows-x64-baseline@1.1.42':
+  '@oven/bun-windows-x64-baseline@1.1.43':
     optional: true
 
   '@oven/bun-windows-x64@1.1.29':
     optional: true
 
-  '@oven/bun-windows-x64@1.1.42':
+  '@oven/bun-windows-x64@1.1.43':
     optional: true
 
   '@parcel/watcher-android-arm64@2.5.0':
@@ -4733,7 +4734,7 @@ snapshots:
 
   '@parcel/watcher-win32-x64@2.5.0': {}
 
-  '@parcel/watcher@2.5.0(patch_hash=pyfayeoxwesjxsefsxp3jpev4q)':
+  '@parcel/watcher@2.5.0(patch_hash=zs2vvlrje3h42xp5ed2v44fep4)':
     dependencies:
       detect-libc: 1.0.3
       is-glob: 4.0.3
@@ -5104,14 +5105,14 @@ snapshots:
       '@typescript-eslint/types': 8.11.0
       eslint-visitor-keys: 3.4.3
 
-  '@vitejs/plugin-react@4.3.4(vite@6.0.0(@types/node@20.14.13)(jiti@2.4.2)(lightningcss@1.26.0(patch_hash=5hwfyehqvg5wjb7mwtdvubqbl4))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0))':
+  '@vitejs/plugin-react@4.3.4(vite@6.0.0(@types/node@20.14.13)(jiti@2.4.2)(lightningcss@1.26.0(patch_hash=gkqcezdn4goium3e3s43dhy4by))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.0.0(@types/node@20.14.13)(jiti@2.4.2)(lightningcss@1.26.0(patch_hash=5hwfyehqvg5wjb7mwtdvubqbl4))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0)
+      vite: 6.0.0(@types/node@20.14.13)(jiti@2.4.2)(lightningcss@1.26.0(patch_hash=gkqcezdn4goium3e3s43dhy4by))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5316,19 +5317,19 @@ snapshots:
       '@oven/bun-windows-x64': 1.1.29
       '@oven/bun-windows-x64-baseline': 1.1.29
 
-  bun@1.1.42:
+  bun@1.1.43:
     optionalDependencies:
-      '@oven/bun-darwin-aarch64': 1.1.42
-      '@oven/bun-darwin-x64': 1.1.42
-      '@oven/bun-darwin-x64-baseline': 1.1.42
-      '@oven/bun-linux-aarch64': 1.1.42
-      '@oven/bun-linux-aarch64-musl': 1.1.42
-      '@oven/bun-linux-x64': 1.1.42
-      '@oven/bun-linux-x64-baseline': 1.1.42
-      '@oven/bun-linux-x64-musl': 1.1.42
-      '@oven/bun-linux-x64-musl-baseline': 1.1.42
-      '@oven/bun-windows-x64': 1.1.42
-      '@oven/bun-windows-x64-baseline': 1.1.42
+      '@oven/bun-darwin-aarch64': 1.1.43
+      '@oven/bun-darwin-x64': 1.1.43
+      '@oven/bun-darwin-x64-baseline': 1.1.43
+      '@oven/bun-linux-aarch64': 1.1.43
+      '@oven/bun-linux-aarch64-musl': 1.1.43
+      '@oven/bun-linux-x64': 1.1.43
+      '@oven/bun-linux-x64-baseline': 1.1.43
+      '@oven/bun-linux-x64-musl': 1.1.43
+      '@oven/bun-linux-x64-musl-baseline': 1.1.43
+      '@oven/bun-windows-x64': 1.1.43
+      '@oven/bun-windows-x64-baseline': 1.1.43
 
   bundle-require@5.0.0(esbuild@0.23.0):
     dependencies:
@@ -5789,7 +5790,7 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 9.15.0(jiti@2.4.2)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.2))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.2))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.2))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@2.4.2)))(eslint@9.15.0(jiti@2.4.2))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -5808,7 +5809,7 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 9.15.0(jiti@2.4.2)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@2.4.2)))(eslint@9.15.0(jiti@2.4.2))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -5821,7 +5822,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.2))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.2))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.2))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@2.4.2)))(eslint@9.15.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -5832,7 +5833,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@2.4.2)))(eslint@9.15.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -5854,7 +5855,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.15.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.2))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.2))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.2))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@2.4.2)))(eslint@9.15.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -5883,7 +5884,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.15.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.15.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.15.0(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.15.0(jiti@2.4.2)))(eslint@9.15.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -6471,7 +6472,7 @@ snapshots:
 
   lightningcss-win32-x64-msvc@1.26.0: {}
 
-  lightningcss@1.26.0(patch_hash=5hwfyehqvg5wjb7mwtdvubqbl4):
+  lightningcss@1.26.0(patch_hash=gkqcezdn4goium3e3s43dhy4by):
     dependencies:
       detect-libc: 1.0.3
     optionalDependencies:
@@ -6494,7 +6495,7 @@ snapshots:
 
   listhen@1.9.0:
     dependencies:
-      '@parcel/watcher': 2.5.0(patch_hash=pyfayeoxwesjxsefsxp3jpev4q)
+      '@parcel/watcher': 2.5.0(patch_hash=zs2vvlrje3h42xp5ed2v44fep4)
       '@parcel/watcher-wasm': 2.5.0
       citty: 0.1.6
       clipboardy: 4.0.0
@@ -7462,13 +7463,13 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-node@2.0.5(@types/node@20.14.13)(lightningcss@1.26.0(patch_hash=5hwfyehqvg5wjb7mwtdvubqbl4))(terser@5.31.6):
+  vite-node@2.0.5(@types/node@20.14.13)(lightningcss@1.26.0(patch_hash=gkqcezdn4goium3e3s43dhy4by))(terser@5.31.6):
     dependencies:
       cac: 6.7.14
       debug: 4.3.6
       pathe: 1.1.2
       tinyrainbow: 1.2.0
-      vite: 5.4.0(@types/node@20.14.13)(lightningcss@1.26.0(patch_hash=5hwfyehqvg5wjb7mwtdvubqbl4))(terser@5.31.6)
+      vite: 5.4.0(@types/node@20.14.13)(lightningcss@1.26.0(patch_hash=gkqcezdn4goium3e3s43dhy4by))(terser@5.31.6)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -7480,7 +7481,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.0(@types/node@20.14.13)(lightningcss@1.26.0(patch_hash=5hwfyehqvg5wjb7mwtdvubqbl4))(terser@5.31.6):
+  vite@5.4.0(@types/node@20.14.13)(lightningcss@1.26.0(patch_hash=gkqcezdn4goium3e3s43dhy4by))(terser@5.31.6):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.49
@@ -7488,10 +7489,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.14.13
       fsevents: 2.3.3
-      lightningcss: 1.26.0(patch_hash=5hwfyehqvg5wjb7mwtdvubqbl4)
+      lightningcss: 1.26.0(patch_hash=gkqcezdn4goium3e3s43dhy4by)
       terser: 5.31.6
 
-  vite@6.0.0(@types/node@20.14.13)(jiti@2.4.2)(lightningcss@1.26.0(patch_hash=5hwfyehqvg5wjb7mwtdvubqbl4))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0):
+  vite@6.0.0(@types/node@20.14.13)(jiti@2.4.2)(lightningcss@1.26.0(patch_hash=gkqcezdn4goium3e3s43dhy4by))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0):
     dependencies:
       esbuild: 0.24.0
       postcss: 8.4.49
@@ -7500,12 +7501,12 @@ snapshots:
       '@types/node': 20.14.13
       fsevents: 2.3.3
       jiti: 2.4.2
-      lightningcss: 1.26.0(patch_hash=5hwfyehqvg5wjb7mwtdvubqbl4)
+      lightningcss: 1.26.0(patch_hash=gkqcezdn4goium3e3s43dhy4by)
       terser: 5.31.6
       tsx: 4.19.1
       yaml: 2.6.0
 
-  vitest@2.0.5(@types/node@20.14.13)(lightningcss@1.26.0(patch_hash=5hwfyehqvg5wjb7mwtdvubqbl4))(terser@5.31.6):
+  vitest@2.0.5(@types/node@20.14.13)(lightningcss@1.26.0(patch_hash=gkqcezdn4goium3e3s43dhy4by))(terser@5.31.6):
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@vitest/expect': 2.0.5
@@ -7523,8 +7524,8 @@ snapshots:
       tinybench: 2.9.0
       tinypool: 1.0.0
       tinyrainbow: 1.2.0
-      vite: 5.4.0(@types/node@20.14.13)(lightningcss@1.26.0(patch_hash=5hwfyehqvg5wjb7mwtdvubqbl4))(terser@5.31.6)
-      vite-node: 2.0.5(@types/node@20.14.13)(lightningcss@1.26.0(patch_hash=5hwfyehqvg5wjb7mwtdvubqbl4))(terser@5.31.6)
+      vite: 5.4.0(@types/node@20.14.13)(lightningcss@1.26.0(patch_hash=gkqcezdn4goium3e3s43dhy4by))(terser@5.31.6)
+      vite-node: 2.0.5(@types/node@20.14.13)(lightningcss@1.26.0(patch_hash=gkqcezdn4goium3e3s43dhy4by))(terser@5.31.6)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.14.13


### PR DESCRIPTION
Closes #15031

This adds musl binaries for the Standalone CLI on Linux aarch64 (ARM 64-bit) and x86_64 (Intel/AMD 64-bit).

I tested this by temporarily running the release workflow (without publishing) to build the Standalone CLI, downloading the artifacts, and running the musl binaries in two docker containers.

![linux-arm64-musl](https://github.com/user-attachments/assets/67fd4748-afe2-44f7-82a1-5a12eafdbc72)

![linux-x64-musl](https://github.com/user-attachments/assets/794ad26e-3389-413e-8888-aac054d61eeb)

(sorry for the potato screenshot — tested x64 through my AMD Windows machine over parsec)
