### PR TITLE
Implement `--spacing(…)`, `--alpha(…)` and `--theme(…)` CSS functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `@tailwindcss/browser` package to run Tailwind CSS in the browser ([#15558](https://github.com/tailwindlabs/tailwindcss/pull/15558))
 - Add `@reference "…"` API as a replacement for the previous `@import "…" reference` option ([#15565](https://github.com/tailwindlabs/tailwindcss/pull/15565))
 - Add functional utility syntax ([#15455](https://github.com/tailwindlabs/tailwindcss/pull/15455))
-- Add new `--spacing(…)`, `--alpha(…)` and `--theme(…)` CSS functions ([#15572](https://github.com/tailwindlabs/tailwindcss/pull/15572))
+- Add new `--spacing(…)`, `--alpha(…)`, and `--theme(…)` CSS functions ([#15572](https://github.com/tailwindlabs/tailwindcss/pull/15572))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `@tailwindcss/browser` package to run Tailwind CSS in the browser ([#15558](https://github.com/tailwindlabs/tailwindcss/pull/15558))
 - Add `@reference "…"` API as a replacement for the previous `@import "…" reference` option ([#15565](https://github.com/tailwindlabs/tailwindcss/pull/15565))
 - Add functional utility syntax ([#15455](https://github.com/tailwindlabs/tailwindcss/pull/15455))
+- Add new `--spacing(…)`, `--alpha(…)` and `--theme(…)` CSS functions ([#15572](https://github.com/tailwindlabs/tailwindcss/pull/15572))
 
 ### Fixed
 
@@ -790,3 +791,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.0.0-alpha.1] - 2024-03-06
 
 - First 4.0.0-alpha.1 release
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -791,4 +791,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.0.0-alpha.1] - 2024-03-06
 
 - First 4.0.0-alpha.1 release
-

--- a/packages/tailwindcss/src/compat/apply-compat-hooks.ts
+++ b/packages/tailwindcss/src/compat/apply-compat-hooks.ts
@@ -253,6 +253,29 @@ function upgradeToFullPluginSupport({
     userConfig,
   )
 
+  // Replace `resolveThemeValue` with a version that is backwards compatible
+  // with dot-notation but also aware of any JS theme configurations registered
+  // by plugins or JS config files. This is significantly slower than just
+  // upgrading dot-notation keys so we only use this version if plugins or
+  // config files are actually being used. In the future we may want to optimize
+  // this further by only doing this if plugins or config files _actually_
+  // registered JS config objects.
+  designSystem.resolveThemeValue = function resolveThemeValue(path: string, defaultValue?: string) {
+    let resolvedValue = pluginApi.theme(path, defaultValue)
+
+    if (Array.isArray(resolvedValue) && resolvedValue.length === 2) {
+      // When a tuple is returned, return the first element
+      return resolvedValue[0]
+    } else if (Array.isArray(resolvedValue)) {
+      // Arrays get serialized into a comma-separated lists
+      return resolvedValue.join(', ')
+    } else if (typeof resolvedValue === 'string') {
+      // Otherwise only allow string values here, objects (and namespace maps)
+      // are treated as non-resolved values for the CSS `theme()` function.
+      return resolvedValue
+    }
+  }
+
   let pluginApi = buildPluginApi(designSystem, ast, resolvedConfig, {
     set current(value: number) {
       features |= value
@@ -317,29 +340,6 @@ function upgradeToFullPluginSupport({
 
   for (let candidate of resolvedConfig.blocklist) {
     designSystem.invalidCandidates.add(candidate)
-  }
-
-  // Replace `resolveThemeValue` with a version that is backwards compatible
-  // with dot-notation but also aware of any JS theme configurations registered
-  // by plugins or JS config files. This is significantly slower than just
-  // upgrading dot-notation keys so we only use this version if plugins or
-  // config files are actually being used. In the future we may want to optimize
-  // this further by only doing this if plugins or config files _actually_
-  // registered JS config objects.
-  designSystem.resolveThemeValue = function resolveThemeValue(path: string, defaultValue?: string) {
-    let resolvedValue = pluginApi.theme(path, defaultValue)
-
-    if (Array.isArray(resolvedValue) && resolvedValue.length === 2) {
-      // When a tuple is returned, return the first element
-      return resolvedValue[0]
-    } else if (Array.isArray(resolvedValue)) {
-      // Arrays get serialized into a comma-separated lists
-      return resolvedValue.join(', ')
-    } else if (typeof resolvedValue === 'string') {
-      // Otherwise only allow string values here, objects (and namespace maps)
-      // are treated as non-resolved values for the CSS `theme()` function.
-      return resolvedValue
-    }
   }
 
   for (let file of resolvedConfig.content.files) {

--- a/packages/tailwindcss/src/compat/plugin-api.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.ts
@@ -95,7 +95,7 @@ export function buildPluginApi(
   let api: PluginAPI = {
     addBase(css) {
       let baseNodes = objectToAst(css)
-      featuresRef.current |= substituteFunctions(baseNodes, api.theme)
+      featuresRef.current |= substituteFunctions(baseNodes, designSystem)
       ast.push(atRule('@layer', 'base', baseNodes))
     },
 

--- a/packages/tailwindcss/src/compile.ts
+++ b/packages/tailwindcss/src/compile.ts
@@ -62,7 +62,7 @@ export function compileCandidates(
       try {
         substituteFunctions(
           rules.map(({ node }) => node),
-          designSystem.resolveThemeValue,
+          designSystem,
         )
       } catch (err) {
         // If substitution fails then the candidate likely contains a call to

--- a/packages/tailwindcss/src/css-functions.test.ts
+++ b/packages/tailwindcss/src/css-functions.test.ts
@@ -30,7 +30,7 @@ describe('--alpha(…)', () => {
         }
       `),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: --alpha(…) requires 2 arguments, e.g.: \`--alpha(var(--my-color), 50%)\`]`,
+      `[Error: The --alpha(…) function requires two arguments, e.g.: \`--alpha(var(--my-color), 50%)\`]`,
     )
   })
 
@@ -42,7 +42,7 @@ describe('--alpha(…)', () => {
         }
       `),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: --alpha(…) requires 2 arguments, e.g.: \`--alpha(red, 50%)\`]`,
+      `[Error: The --alpha(…) function requires two arguments, e.g.: \`--alpha(red, 50%)\`]`,
     )
   })
 
@@ -54,7 +54,7 @@ describe('--alpha(…)', () => {
         }
       `),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: --alpha(…) only aaccepts 2 arguments, e.g.: \`--alpha(red, 50%)\`]`,
+      `[Error: The --alpha(…) function only accepts two arguments, e.g.: \`--alpha(red, 50%)\`]`,
     )
   })
 })
@@ -112,7 +112,7 @@ describe('--spacing(…)', () => {
         }
       `),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: --spacing(…) depends on the \`--spacing\` theme value, but it was not found.]`,
+      `[Error: The --spacing(…) function requires that the \`--spacing\` theme variable be set, but it was not found.]`,
     )
   })
 
@@ -128,7 +128,7 @@ describe('--spacing(…)', () => {
         }
       `),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: --spacing(…) requires a single value, but received none.]`,
+      `[Error: The --spacing(…) function requires an argument, but received none.]`,
     )
   })
 
@@ -140,7 +140,7 @@ describe('--spacing(…)', () => {
         }
       `),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: --spacing(…) only accepts a single value, but received 3 values.]`,
+      `[Error: The --spacing(…) function only accepts a single argument, but received 3.]`,
     )
   })
 })

--- a/packages/tailwindcss/src/css-functions.test.ts
+++ b/packages/tailwindcss/src/css-functions.test.ts
@@ -112,7 +112,7 @@ describe('--spacing(…)', () => {
         }
       `),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: The --spacing(…) function requires that the \`--spacing\` theme variable be set, but it was not found.]`,
+      `[Error: The --spacing(…) function requires that the \`--spacing\` theme variable exists, but it was not found.]`,
     )
   })
 

--- a/packages/tailwindcss/src/css-functions.test.ts
+++ b/packages/tailwindcss/src/css-functions.test.ts
@@ -7,6 +7,92 @@ import { compileCss, optimizeCss } from './test-utils/run'
 
 const css = String.raw
 
+describe('--spacing(…)', () => {
+  test('--spacing(…)', async () => {
+    expect(
+      await compileCss(css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+
+        .foo {
+          margin: --spacing(4);
+        }
+      `),
+    ).toMatchInlineSnapshot(`
+      ":root {
+        --spacing: .25rem;
+      }
+
+      .foo {
+        margin: calc(var(--spacing) * 4);
+      }"
+    `)
+  })
+
+  test('--spacing(…) with inline `@theme` value', async () => {
+    expect(
+      await compileCss(css`
+        @theme inline {
+          --spacing: 0.25rem;
+        }
+
+        .foo {
+          margin: --spacing(4);
+        }
+      `),
+    ).toMatchInlineSnapshot(`
+      ":root {
+        --spacing: .25rem;
+      }
+
+      .foo {
+        margin: 1rem;
+      }"
+    `)
+  })
+
+  test('--spacing(…) relies on `--spacing` to be defined', async () => {
+    expect(() =>
+      compileCss(css`
+        .foo {
+          margin: --spacing(4);
+        }
+      `),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: --spacing(…) depends on the \`--spacing\` theme value, but it was not found.]`,
+    )
+  })
+
+  test('--spacing(…) requires a single value', async () => {
+    expect(() =>
+      compileCss(css`
+        @theme {
+          --spacing: 0.25rem;
+        }
+
+        .foo {
+          margin: --spacing();
+        }
+      `),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: --spacing(…) requires a single value, but received none.]`,
+    )
+  })
+
+  test('--spacing(…) does not have multiple arguments', async () => {
+    expect(() =>
+      compileCss(css`
+        .foo {
+          margin: --spacing(4, 5, 6);
+        }
+      `),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: --spacing(…) only accepts a single value, but received 3 values.]`,
+    )
+  })
+})
+
 describe('--theme(…)', () => {
   test('theme(--color-red-500)', async () => {
     expect(

--- a/packages/tailwindcss/src/css-functions.test.ts
+++ b/packages/tailwindcss/src/css-functions.test.ts
@@ -7,6 +7,58 @@ import { compileCss, optimizeCss } from './test-utils/run'
 
 const css = String.raw
 
+describe('--alpha(…)', () => {
+  test('--alpha(…)', async () => {
+    expect(
+      await compileCss(css`
+        .foo {
+          margin: --alpha(red, 50%);
+        }
+      `),
+    ).toMatchInlineSnapshot(`
+      ".foo {
+        margin: oklab(62.7955% .22486 .12584 / .5);
+      }"
+    `)
+  })
+
+  test('--alpha(…) errors when no arguments are used', async () => {
+    expect(() =>
+      compileCss(css`
+        .foo {
+          margin: --alpha();
+        }
+      `),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: --alpha(…) requires 2 arguments, e.g.: \`--alpha(var(--my-color), 50%)\`]`,
+    )
+  })
+
+  test('--alpha(…) errors when alpha value is missing', async () => {
+    expect(() =>
+      compileCss(css`
+        .foo {
+          margin: --alpha(red);
+        }
+      `),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: --alpha(…) requires 2 arguments, e.g.: \`--alpha(red, 50%)\`]`,
+    )
+  })
+
+  test('--alpha(…) errors multiple arguments are used', async () => {
+    expect(() =>
+      compileCss(css`
+        .foo {
+          margin: --alpha(red, 50%, blue);
+        }
+      `),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: --alpha(…) only aaccepts 2 arguments, e.g.: \`--alpha(red, 50%)\`]`,
+    )
+  })
+})
+
 describe('--spacing(…)', () => {
   test('--spacing(…)', async () => {
     expect(

--- a/packages/tailwindcss/src/css-functions.test.ts
+++ b/packages/tailwindcss/src/css-functions.test.ts
@@ -7,7 +7,30 @@ import { compileCss, optimizeCss } from './test-utils/run'
 
 const css = String.raw
 
-describe('theme function', () => {
+describe('--theme(…)', () => {
+  test('theme(--color-red-500)', async () => {
+    expect(
+      await compileCss(css`
+        @theme {
+          --color-red-500: #f00;
+        }
+        .red {
+          color: --theme(--color-red-500);
+        }
+      `),
+    ).toMatchInlineSnapshot(`
+      ":root {
+        --color-red-500: red;
+      }
+
+      .red {
+        color: red;
+      }"
+    `)
+  })
+})
+
+describe('theme(…)', () => {
   describe('in declaration values', () => {
     describe('without fallback values', () => {
       test('theme(colors.red.500)', async () => {

--- a/packages/tailwindcss/src/css-functions.ts
+++ b/packages/tailwindcss/src/css-functions.ts
@@ -5,6 +5,7 @@ import { segment } from './utils/segment'
 import * as ValueParser from './value-parser'
 
 const functions: Record<string, (designSystem: DesignSystem, ...args: string[]) => any> = {
+  '--theme': theme,
   theme,
 }
 

--- a/packages/tailwindcss/src/css-functions.ts
+++ b/packages/tailwindcss/src/css-functions.ts
@@ -1,13 +1,31 @@
 import { Features } from '.'
 import { walk, type AstNode } from './ast'
 import type { DesignSystem } from './design-system'
+import { withAlpha } from './utilities'
 import { segment } from './utils/segment'
 import * as ValueParser from './value-parser'
 
 const functions: Record<string, (designSystem: DesignSystem, ...args: string[]) => any> = {
+  '--alpha': alpha,
   '--spacing': spacing,
   '--theme': theme,
   theme,
+}
+
+function alpha(_designSystem: DesignSystem, value: string, alpha: string, ...rest: string[]) {
+  if (!value || !alpha) {
+    throw new Error(
+      `--alpha(…) requires 2 arguments, e.g.: \`--alpha(${value || 'var(--my-color)'}, ${alpha || '50%'})\``,
+    )
+  }
+
+  if (rest.length > 0) {
+    throw new Error(
+      `--alpha(…) only aaccepts 2 arguments, e.g.: \`--alpha(${value || 'var(--my-color)'}, ${alpha || '50%'})\``,
+    )
+  }
+
+  return withAlpha(value, alpha)
 }
 
 function spacing(designSystem: DesignSystem, value: string, ...rest: string[]) {

--- a/packages/tailwindcss/src/css-functions.ts
+++ b/packages/tailwindcss/src/css-functions.ts
@@ -5,8 +5,28 @@ import { segment } from './utils/segment'
 import * as ValueParser from './value-parser'
 
 const functions: Record<string, (designSystem: DesignSystem, ...args: string[]) => any> = {
+  '--spacing': spacing,
   '--theme': theme,
   theme,
+}
+
+function spacing(designSystem: DesignSystem, value: string, ...rest: string[]) {
+  if (!value) {
+    throw new Error(`--spacing(…) requires a single value, but received none.`)
+  }
+
+  if (rest.length > 0) {
+    throw new Error(
+      `--spacing(…) only accepts a single value, but received ${rest.length + 1} values.`,
+    )
+  }
+
+  let multiplier = designSystem.theme.resolve(null, ['--spacing'])
+  if (!multiplier) {
+    throw new Error('--spacing(…) depends on the `--spacing` theme value, but it was not found.')
+  }
+
+  return `calc(${multiplier} * ${value})`
 }
 
 function theme(designSystem: DesignSystem, path: string, ...fallback: string[]) {

--- a/packages/tailwindcss/src/css-functions.ts
+++ b/packages/tailwindcss/src/css-functions.ts
@@ -42,7 +42,7 @@ function spacing(designSystem: DesignSystem, value: string, ...rest: string[]) {
   let multiplier = designSystem.theme.resolve(null, ['--spacing'])
   if (!multiplier) {
     throw new Error(
-      'The --spacing(…) function requires that the `--spacing` theme variable be set, but it was not found.',
+      'The --spacing(…) function requires that the `--spacing` theme variable exists, but it was not found.',
     )
   }
 

--- a/packages/tailwindcss/src/css-functions.ts
+++ b/packages/tailwindcss/src/css-functions.ts
@@ -15,13 +15,13 @@ const functions: Record<string, (designSystem: DesignSystem, ...args: string[]) 
 function alpha(_designSystem: DesignSystem, value: string, alpha: string, ...rest: string[]) {
   if (!value || !alpha) {
     throw new Error(
-      `--alpha(…) requires 2 arguments, e.g.: \`--alpha(${value || 'var(--my-color)'}, ${alpha || '50%'})\``,
+      `The --alpha(…) function requires two arguments, e.g.: \`--alpha(${value || 'var(--my-color)'}, ${alpha || '50%'})\``,
     )
   }
 
   if (rest.length > 0) {
     throw new Error(
-      `--alpha(…) only aaccepts 2 arguments, e.g.: \`--alpha(${value || 'var(--my-color)'}, ${alpha || '50%'})\``,
+      `The --alpha(…) function only accepts two arguments, e.g.: \`--alpha(${value || 'var(--my-color)'}, ${alpha || '50%'})\``,
     )
   }
 
@@ -30,18 +30,20 @@ function alpha(_designSystem: DesignSystem, value: string, alpha: string, ...res
 
 function spacing(designSystem: DesignSystem, value: string, ...rest: string[]) {
   if (!value) {
-    throw new Error(`--spacing(…) requires a single value, but received none.`)
+    throw new Error(`The --spacing(…) function requires an argument, but received none.`)
   }
 
   if (rest.length > 0) {
     throw new Error(
-      `--spacing(…) only accepts a single value, but received ${rest.length + 1} values.`,
+      `The --spacing(…) function only accepts a single argument, but received ${rest.length + 1}.`,
     )
   }
 
   let multiplier = designSystem.theme.resolve(null, ['--spacing'])
   if (!multiplier) {
-    throw new Error('--spacing(…) depends on the `--spacing` theme value, but it was not found.')
+    throw new Error(
+      'The --spacing(…) function requires that the `--spacing` theme variable be set, but it was not found.',
+    )
   }
 
   return `calc(${multiplier} * ${value})`

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -533,7 +533,7 @@ async function parseCss(
     node.context = {}
   }
 
-  features |= substituteFunctions(ast, designSystem.resolveThemeValue)
+  features |= substituteFunctions(ast, designSystem)
   features |= substituteAtApply(ast, designSystem)
 
   // Remove `@utility`, we couldn't replace it before yet because we had to

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -17989,6 +17989,50 @@ describe('custom utilities', () => {
       `)
     })
 
+    test('using `--spacing(…)` shorthand', async () => {
+      let input = css`
+        @theme {
+          --spacing: 4px;
+        }
+
+        @utility example-* {
+          margin: --spacing(--value(number));
+        }
+
+        @tailwind utilities;
+      `
+
+      expect(await compileCss(input, ['example-12'])).toMatchInlineSnapshot(`
+        ":root {
+          --spacing: 4px;
+        }
+
+        .example-12 {
+          margin: calc(var(--spacing) * 12);
+        }"
+      `)
+    })
+
+    test('using `--spacing(…)` shorthand (inline theme)', async () => {
+      let input = css`
+        @theme inline reference {
+          --spacing: 4px;
+        }
+
+        @utility example-* {
+          margin: --spacing(--value(number));
+        }
+
+        @tailwind utilities;
+      `
+
+      expect(await compileCss(input, ['example-12'])).toMatchInlineSnapshot(`
+        ".example-12 {
+          margin: 48px;
+        }"
+      `)
+    })
+
     test('modifiers', async () => {
       let input = css`
         @theme reference {


### PR DESCRIPTION
This PR implements new CSS functions that you can use in your CSS (or even in arbitrary value position).

For starters, we renamed the `theme(…)` function to `--theme(…)`. The legacy `theme(…)` function is still available for backwards compatibility reasons, but this allows us to be future proof since `--foo(…)` is the syntax the CSS spec recommends. See: https://drafts.csswg.org/css-mixins/

In addition, this PR implements a new `--spacing(…)` function, this allows you to write:

```css
@import "tailwindcss";

@theme {
  --spacing: 0.25rem;
}

.foo {
  margin: --spacing(4):
}
```

This is syntax sugar over:
```css
@import "tailwindcss";

@theme {
  --spacing: 0.25rem;
}

.foo {
  margin: calc(var(--spacing) * 4);
}
```

If your `@theme` uses the `inline` keyword, we will also make sure to inline the value:

```css
@import "tailwindcss";

@theme inline {
  --spacing: 0.25rem;
}

.foo {
  margin: --spacing(4):
}
```

Boils down to:
```css
@import "tailwindcss";

@theme {
  --spacing: 0.25rem;
}

.foo {
  margin: calc(0.25rem * 4); /* And will be optimised to just 1rem */
}
```

---

Another new function function we added is the `--alpha(…)` function that requires a value, and a number / percentage value. This allows you to apply an alpha value to any color, but with a much shorter syntax:

```css
@import "tailwindcss";

.foo {
  color: --alpha(var(--color-red-500), 0.5);
}
```

This is syntax sugar over:
```css
@import "tailwindcss";

.foo {
  color: color-mix(in oklab, var(--color-red-500) 50%, transparent);
}
```
