### PR TITLE
Add missing `main` field for `@tailwindcss/browser`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Add missing `main` and `browser` fields for `@tailwindcss/browser` ([#15594](https://github.com/tailwindlabs/tailwindcss/pull/15594))
 
 ## [4.0.0-beta.9] - 2025-01-09
 

--- a/packages/@tailwindcss-browser/package.json
+++ b/packages/@tailwindcss-browser/package.json
@@ -3,6 +3,7 @@
   "version": "4.0.0-beta.9",
   "description": "A utility-first CSS framework for rapidly building custom user interfaces.",
   "license": "MIT",
+  "main": "./dist/index.mjs",
   "repository": {
     "type": "git",
     "url": "https://github.com/tailwindlabs/tailwindcss.git",

--- a/packages/@tailwindcss-browser/package.json
+++ b/packages/@tailwindcss-browser/package.json
@@ -4,6 +4,7 @@
   "description": "A utility-first CSS framework for rapidly building custom user interfaces.",
   "license": "MIT",
   "main": "./dist/index.mjs",
+  "browser": "./dist/index.mjs",
   "repository": {
     "type": "git",
     "url": "https://github.com/tailwindlabs/tailwindcss.git",


### PR DESCRIPTION
This PR adds a `main` and `browser` field for the `@tailwindcss/browser` package.

In the package, we do have the `exports` field setup, which is an alternative to the `main` field according to the docs:

> The "exports" provides a modern alternative to "main" …
>
> — https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#exports

However, if you look at the unpkg link: https://unpkg.com/@tailwindcss/browser, it tries to load the `index.js` file. This is probably a bug in the unpkg resolver.

That said, if you look at other CDNs such as esm.sh, it does resolve correctly: https://esm.sh/@tailwindcss/browser

According to the npm docs:

> If `main` is not set, it defaults to `index.js` in the package's root folder.
>
> — https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#main

This explains why unpkg is trying to load the `index.js` file.


Additionally, the npm docs also mention the `browser` field:

> If your module is meant to be used client-side the browser field should be used instead of the main field. This is helpful to hint users that it might rely on primitives that aren't available in Node.js modules. (e.g. window)
>
> — https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#browser

So this PR also adds that field just to be sure.
