### PR TITLE
Discard invalid variants such as `data-checked-[selected=1]:*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add missing `main` and `browser` fields for `@tailwindcss/browser` ([#15594](https://github.com/tailwindlabs/tailwindcss/pull/15594))
 - _Upgrade (experimental)_: Pretty print `--spacing(…)` to prevent ambiguity ([#15596](https://github.com/tailwindlabs/tailwindcss/pull/15596))
+- Discard invalid variants such as `data-checked-[selected=1]:*` ([#15629](https://github.com/tailwindlabs/tailwindcss/pull/15629))
 
 ## [4.0.0-beta.9] - 2025-01-09
 

--- a/packages/tailwindcss/src/candidate.test.ts
+++ b/packages/tailwindcss/src/candidate.test.ts
@@ -864,6 +864,30 @@ it('should not parse invalid arbitrary values in variants', () => {
 
     'data-foo-[var(--value)]:flex!',
     'data-foo[var(--value)]:flex!',
+
+    'data-foo-(color:--value):flex',
+    'data-foo(color:--value):flex',
+
+    'data-foo-(color:--value)/50:flex',
+    'data-foo(color:--value)/50:flex',
+
+    'data-foo-(color:--value)/(--mod):flex',
+    'data-foo(color:--value)/(--mod):flex',
+
+    'data-foo-(color:--value)/(number:--mod):flex',
+    'data-foo(color:--value)/(number:--mod):flex',
+
+    'data-foo-(--value):flex',
+    'data-foo(--value):flex',
+
+    'data-foo-(--value)/50:flex',
+    'data-foo(--value)/50:flex',
+
+    'data-foo-(--value)/(--mod):flex',
+    'data-foo(--value)/(--mod):flex',
+
+    'data-foo-(--value)/(number:--mod):flex',
+    'data-foo(--value)/(number:--mod):flex',
   ]) {
     expect(run(candidate, { utilities, variants })).toEqual([])
   }

--- a/packages/tailwindcss/src/candidate.test.ts
+++ b/packages/tailwindcss/src/candidate.test.ts
@@ -836,6 +836,39 @@ it('should not parse invalid arbitrary values', () => {
   }
 })
 
+it('should not parse invalid arbitrary values in variants', () => {
+  let utilities = new Utilities()
+  utilities.static('flex', () => [])
+
+  let variants = new Variants()
+  variants.functional('data', () => {})
+
+  for (let candidate of [
+    'data-foo-[#0088cc]:flex',
+    'data-foo[#0088cc]:flex',
+
+    'data-foo-[color:var(--value)]:flex',
+    'data-foo[color:var(--value)]:flex',
+
+    'data-foo-[#0088cc]/50:flex',
+    'data-foo[#0088cc]/50:flex',
+
+    'data-foo-[#0088cc]/[50%]:flex',
+    'data-foo[#0088cc]/[50%]:flex',
+
+    'data-foo-[#0088cc]:flex!',
+    'data-foo[#0088cc]:flex!',
+
+    'data-foo-[var(--value)]:flex',
+    'data-foo[var(--value)]:flex',
+
+    'data-foo-[var(--value)]:flex!',
+    'data-foo[var(--value)]:flex!',
+  ]) {
+    expect(run(candidate, { utilities, variants })).toEqual([])
+  }
+})
+
 it('should parse a utility with an implicit variable as the modifier', () => {
   let utilities = new Utilities()
   utilities.functional('bg', () => [])
@@ -964,6 +997,18 @@ it('should parse a utility with an explicit variable as the modifier that is imp
       },
     ]
   `)
+})
+
+it('should not parse a partial variant', () => {
+  let utilities = new Utilities()
+  utilities.static('flex', () => [])
+
+  let variants = new Variants()
+  variants.static('open', () => {})
+  variants.functional('data', () => {})
+
+  expect(run('open-:flex', { utilities, variants })).toMatchInlineSnapshot(`[]`)
+  expect(run('data-:flex', { utilities, variants })).toMatchInlineSnapshot(`[]`)
 })
 
 it('should parse a static variant starting with @', () => {

--- a/packages/tailwindcss/src/candidate.ts
+++ b/packages/tailwindcss/src/candidate.ts
@@ -620,7 +620,10 @@ export function parseVariant(variant: string, designSystem: DesignSystem): Varia
             }
           }
 
-          if (value[0] === '[' && value[value.length - 1] === ']') {
+          if (value[value.length - 1] === ']') {
+            // Discard values like `foo-[#bar]`
+            if (value[0] !== '[') continue
+
             let arbitraryValue = decodeArbitraryValue(value.slice(1, -1))
 
             // Empty arbitrary values are invalid. E.g.: `data-[]:`
@@ -638,12 +641,10 @@ export function parseVariant(variant: string, designSystem: DesignSystem): Varia
             }
           }
 
-          // Discard values like `foo-[#bar]` or `foo-(#bar)`
-          if (value[0] !== '[' && value[value.length - 1] === ']') {
-            continue
-          }
+          if (value[value.length - 1] === ')') {
+            // Discard values like `foo-(--bar)`
+            if (value[0] !== '(') continue
 
-          if (value[0] === '(' && value[value.length - 1] === ')') {
             let arbitraryValue = decodeArbitraryValue(value.slice(1, -1))
 
             // Empty arbitrary values are invalid. E.g.: `data-():`
@@ -659,11 +660,6 @@ export function parseVariant(variant: string, designSystem: DesignSystem): Varia
                 value: `var(${arbitraryValue})`,
               },
             }
-          }
-
-          // Discard values like `foo-[#bar]` or `foo-(#bar)`
-          if (value[0] !== '(' && value[value.length - 1] === ')') {
-            continue
           }
 
           return {

--- a/packages/tailwindcss/src/candidate.ts
+++ b/packages/tailwindcss/src/candidate.ts
@@ -413,7 +413,7 @@ export function* parseCandidate(input: string, designSystem: DesignSystem): Iter
   // Not an arbitrary value
   else {
     roots = findRoots(baseWithoutModifier, (root: string) => {
-      return designSystem.utilities.has(root, 'functional')
+      return designSystem.utilities.has(root, 'functional') ? 'functional' : null
     })
   }
 
@@ -587,7 +587,7 @@ export function parseVariant(variant: string, designSystem: DesignSystem): Varia
     if (additionalModifier) return null
 
     let roots = findRoots(variantWithoutModifier, (root) => {
-      return designSystem.variants.has(root)
+      return designSystem.variants.has(root) ? designSystem.variants.kind(root) : null
     })
 
     for (let [root, value] of roots) {
@@ -702,9 +702,12 @@ type Root = [
   value: string | null,
 ]
 
-function* findRoots(input: string, exists: (input: string) => boolean): Iterable<Root> {
+function* findRoots(
+  input: string,
+  kind: (input: string) => 'static' | 'functional' | 'compound' | 'arbitrary' | null,
+): Iterable<Root> {
   // If there is an exact match, then that's the root.
-  if (exists(input)) {
+  if (kind(input)) {
     yield [input, null]
   }
 
@@ -714,7 +717,7 @@ function* findRoots(input: string, exists: (input: string) => boolean): Iterable
   if (idx === -1) {
     // Variants starting with `@` are special because they don't need a `-`
     // after the `@` (E.g.: `@-lg` should be written as `@lg`).
-    if (input[0] === '@' && exists('@')) {
+    if (input[0] === '@' && kind('@')) {
       yield ['@', input.slice(1)]
     }
     return
@@ -729,9 +732,28 @@ function* findRoots(input: string, exists: (input: string) => boolean): Iterable
   // `bg`         -> Match
   do {
     let maybeRoot = input.slice(0, idx)
+    let rootKind = kind(maybeRoot)
 
-    if (exists(maybeRoot)) {
-      let root: Root = [maybeRoot, input.slice(idx + 1)]
+    if (rootKind) {
+      let value = input.slice(idx + 1)
+
+      // Compound variants e.g. not-in-[#foo] are ultimately split like so:
+      // - root: not
+      // - value: in-[#foo]
+      //  - root: in
+      //  - value: [#foo]
+      //
+      // However, other variants don't have this behavior, so we can skip
+      // over this possible variant if the root is not a compound variant
+      // and it contains an arbitrary value _after_ some other value
+      // e.g. `supports-display-[color:red]` is invalid
+      if (rootKind !== 'compound') {
+        if (value[value.length - 1] === ']' && value[0] !== '[') {
+          break
+        }
+      }
+
+      let root: Root = [maybeRoot, value]
 
       // If the leftover value is an empty string, it means that the value is an
       // invalid named value, e.g.: `bg-`. This makes the candidate invalid and we


### PR DESCRIPTION
This is basically #13970 but for variants

cc @RobinMalfait 