### PR TITLE
Write to `stdout` when `--output` is omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolve values in functional utilities based on `@theme` options ([#15623](https://github.com/tailwindlabs/tailwindcss/pull/15623))
 - Discard invalid variants such as `data-checked-[selected=1]:*` ([#15629](https://github.com/tailwindlabs/tailwindcss/pull/15629))
 - Ensure `-outline-offset-*` utilities are suggested in IntelliSense ([#15646](https://github.com/tailwindlabs/tailwindcss/pull/15646))
+- Write to `stdout` when `--output` flag is omitted for `@tailwindcss/cli` ([#15656](https://github.com/tailwindlabs/tailwindcss/pull/15656))
+- Write to `stdout` when `--output -` flag is used for `@tailwindcss/cli` ([#15656](https://github.com/tailwindlabs/tailwindcss/pull/15656))
 - _Upgrade (experimental)_: Pretty print `--spacing(…)` to prevent ambiguity ([#15596](https://github.com/tailwindlabs/tailwindcss/pull/15596))
 
 ## [4.0.0-beta.9] - 2025-01-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolve values in functional utilities based on `@theme` options ([#15623](https://github.com/tailwindlabs/tailwindcss/pull/15623))
 - Discard invalid variants such as `data-checked-[selected=1]:*` ([#15629](https://github.com/tailwindlabs/tailwindcss/pull/15629))
 - Ensure `-outline-offset-*` utilities are suggested in IntelliSense ([#15646](https://github.com/tailwindlabs/tailwindcss/pull/15646))
-- Write to `stdout` when `--output` flag is omitted for `@tailwindcss/cli` ([#15656](https://github.com/tailwindlabs/tailwindcss/pull/15656))
+- Write to `stdout` when `--output` is set to `-` or omitted for `@tailwindcss/cli` ([#15656](https://github.com/tailwindlabs/tailwindcss/pull/15656))
 - Write to `stdout` when `--output -` flag is used for `@tailwindcss/cli` ([#15656](https://github.com/tailwindlabs/tailwindcss/pull/15656))
 - _Upgrade (experimental)_: Pretty print `--spacing(…)` to prevent ambiguity ([#15596](https://github.com/tailwindlabs/tailwindcss/pull/15596))
 

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -25,6 +25,7 @@ interface ChildProcessOptions {
 
 interface ExecOptions {
   ignoreStdErr?: boolean
+  stdin?: string
 }
 
 interface TestConfig {
@@ -112,7 +113,7 @@ export function test(
           }
           if (debug) console.log(`> ${command}`)
           return new Promise((resolve, reject) => {
-            exec(
+            let child = exec(
               command,
               {
                 cwd,
@@ -134,6 +135,10 @@ export function test(
                 }
               },
             )
+            if (execOptions.stdin) {
+              child.stdin?.write(execOptions.stdin)
+              child.stdin?.end()
+            }
           })
         },
         async spawn(command: string, childProcessOptions: ChildProcessOptions = {}) {

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -32,6 +32,7 @@ export function options() {
       type: 'string',
       description: 'Output file',
       alias: '-o',
+      default: '-',
     },
     '--watch': {
       type: 'boolean | string',
@@ -72,8 +73,10 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
 
   let base = path.resolve(args['--cwd'])
 
-  // Resolve the output as an absolute path.
-  if (args['--output']) {
+  // Resolve the output as an absolute path. If the output is a `-`, then we
+  // don't need to resolve it because this is a flag to indicate that we want to
+  // use `stdout` instead.
+  if (args['--output'] && args['--output'] !== '-') {
     args['--output'] = path.resolve(base, args['--output'])
   }
 
@@ -129,7 +132,7 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
 
     // Write the output
     DEBUG && I.start('Write output')
-    if (args['--output']) {
+    if (args['--output'] && args['--output'] !== '-') {
       await outputFile(args['--output'], output)
     } else {
       println(output)

--- a/packages/@tailwindcss-cli/src/index.ts
+++ b/packages/@tailwindcss-cli/src/index.ts
@@ -36,7 +36,7 @@ if (command) {
 //
 //   - `tailwindcss -o output.css`  // should run the build command, not show the help message
 //   - `tailwindcss > output.css`   // should run the build command, not show the help message
-if ((process.stdout.isTTY && !flags['--output']) || flags['--help']) {
+if ((process.stdout.isTTY && process.argv[2] === undefined) || flags['--help']) {
   help({
     usage: ['tailwindcss [--input input.css] [--output output.css] [--watch] [options…]'],
     options: { ...build.options(), ...sharedOptions },

--- a/packages/@tailwindcss-cli/src/utils/args.ts
+++ b/packages/@tailwindcss-cli/src/utils/args.ts
@@ -67,7 +67,19 @@ export type Result<T extends Arg> = {
 }
 
 export function args<const T extends Arg>(options: T, argv = process.argv.slice(2)): Result<T> {
+  for (let [idx, value] of argv.entries()) {
+    if (value === '-') {
+      argv[idx] = '__IO_DEFAULT_VALUE__'
+    }
+  }
+
   let parsed = parse(argv)
+
+  for (let key in parsed) {
+    if (parsed[key] === '__IO_DEFAULT_VALUE__') {
+      parsed[key] = '-'
+    }
+  }
 
   let result: { _: string[]; [key: string]: unknown } = {
     _: parsed._,


### PR DESCRIPTION
This PR fixes an issue with the `@tailwindcss/cli`, where omitting the `--output` flag should output to `stdout` but it didn't. This PR fixes that by writing to `stdout` if no `--output` is passed.

That said, if _nothing_ is passed, then the `--help` will show.

In summary: 
- If you want to read from `stdin`, use: `--input -` or `-i -`
- If you want to write to `stdout`, use: `--output -` or `-o -` or omit entirely

Fixes: #15648

### Test plan 

Added integration tests to ensure that reading / writing to stdin / stdout works as expected.

Ran the updated CLI in my terminal to show that the `--help` shows by default, but if you use any arguments (like an `--input`) that the result is printed to `stdout` as expected. 

<img width="1768" alt="image" src="https://github.com/user-attachments/assets/e98bafc6-b372-4ae5-9ece-2966a6600250" />

Note the `tw` command is just a shorthand for running `bun --bun ~/github.com/tailwindlabs/tailwindcss/packages/@tailwindcss-cli/src/index.ts`.