### PR TITLE
Add CSS content-visibility utilities

### DIFF
--- a/src/corePlugins.js
+++ b/src/corePlugins.js
@@ -2919,6 +2919,14 @@ export let corePlugins = {
     })
   },
 
+  contentVisibility: ({ addUtilities }) => {
+    addUtilities({
+      '.content-visibility-visible': { 'content-visibility': 'visible' },
+      '.content-visibility-hidden': { 'content-visibility': 'hidden' },
+      '.content-visibility-auto': { 'content-visibility': 'auto' },
+    })
+  },
+
   transitionProperty: ({ matchUtilities, theme }) => {
     let defaultTimingFunction = theme('transitionTimingFunction.DEFAULT')
     let defaultDuration = theme('transitionDuration.DEFAULT')

--- a/tests/raw-content.test.css
+++ b/tests/raw-content.test.css
@@ -760,6 +760,15 @@
 .backdrop-filter-none {
   backdrop-filter: none;
 }
+.content-visibility-visible {
+  content-visibility: visible;
+}
+.content-visibility-hidden {
+  content-visibility: hidden;
+}
+.content-visibility-auto {
+  content-visibility: auto;
+}
 .transition {
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke,
     opacity, box-shadow, transform, filter, backdrop-filter;

--- a/tests/raw-content.test.js
+++ b/tests/raw-content.test.js
@@ -145,6 +145,9 @@ it('raw content', () => {
           <div class="w-12"></div>
           <div class="break-words"></div>
           <div class="z-30"></div>
+          <div class="content-visibility-visible"></div>
+          <div class="content-visibility-hidden"></div>
+          <div class="content-visibility-auto"></div>
         `,
       },
     ],


### PR DESCRIPTION
This PR here was declined because the lack of browser support: https://github.com/tailwindlabs/tailwindcss/pull/7955. 
The browser support is now much better as you can see: https://developer.mozilla.org/en-US/docs/Web/CSS/content-visibility#browser_compatibility

So again this PR adds [content-visibility](https://developer.mozilla.org/en-US/docs/Web/CSS/content-visibility) utilities.
