### PR TITLE
Implement `@variant`

### DIFF
--- a/integrations/postcss/multi-root.test.ts
+++ b/integrations/postcss/multi-root.test.ts
@@ -30,11 +30,11 @@ test(
       `,
       'src/root1.css': css`
         @import './shared.css';
-        @variant one (&:is([data-root='1']));
+        @custom-variant one (&:is([data-root='1']));
       `,
       'src/root2.css': css`
         @import './shared.css';
-        @variant two (&:is([data-root='2']));
+        @custom-variant two (&:is([data-root='2']));
       `,
     },
   },

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -1433,7 +1433,7 @@ test(
         @tailwind components;
         @tailwind utilities;
 
-        @variant hocus (&:hover, &:focus);
+        @custom-variant hocus (&:hover, &:focus);
 
         @theme {
           --color-red-500: #f00;
@@ -1539,7 +1539,7 @@ test(
 
       @config './tailwind.config.ts';
 
-      @variant hocus (&:hover, &:focus);
+      @custom-variant hocus (&:hover, &:focus);
 
       @theme {
         --color-red-500: #f00;
@@ -1675,7 +1675,7 @@ test(
         @tailwind components;
         @tailwind utilities;
 
-        @variant hocus (&:hover, &:focus);
+        @custom-variant hocus (&:hover, &:focus);
 
         @theme {
           --color-red-500: #f00;

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -167,7 +167,7 @@ test(
 
       @source '../node_modules/my-external-lib/**/*.{html}';
 
-      @variant dark (&:where(.dark, .dark *));
+      @custom-variant dark (&:where(.dark, .dark *));
 
       @theme {
         --shadow-*: initial;

--- a/integrations/vite/multi-root.test.ts
+++ b/integrations/vite/multi-root.test.ts
@@ -48,7 +48,7 @@ test(
       `,
       'src/root1.css': css`
         @import './shared.css';
-        @variant one (&:is([data-root='1']));
+        @custom-variant one (&:is([data-root='1']));
       `,
       'root2.html': html`
         <head>
@@ -60,7 +60,7 @@ test(
       `,
       'src/root2.css': css`
         @import './shared.css';
-        @variant two (&:is([data-root='2']));
+        @custom-variant two (&:is([data-root='2']));
       `,
     },
   },
@@ -124,7 +124,7 @@ test(
       `,
       'src/root1.css': css`
         @import './shared.css';
-        @variant one (&:is([data-root='1']));
+        @custom-variant one (&:is([data-root='1']));
       `,
       'root2.html': html`
         <head>
@@ -136,7 +136,7 @@ test(
       `,
       'src/root2.css': css`
         @import './shared.css';
-        @variant two (&:is([data-root='2']));
+        @custom-variant two (&:is([data-root='2']));
       `,
     },
   },

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-missing-layers.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-missing-layers.ts
@@ -16,6 +16,7 @@ export function migrateMissingLayers(): Plugin {
           node.name === 'source' ||
           node.name === 'theme' ||
           node.name === 'utility' ||
+          node.name === 'custom-variant' ||
           node.name === 'variant'
         ) {
           if (bucket.length > 0) {

--- a/packages/@tailwindcss-upgrade/src/codemods/migrate-preflight.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/migrate-preflight.test.ts
@@ -135,7 +135,7 @@ it('should add the compatibility CSS before the first `@layer base` (if the "tai
     await migrate(css`
       @import 'tailwindcss';
 
-      @variant foo {
+      @custom-variant foo {
       }
 
       @utility bar {
@@ -153,7 +153,7 @@ it('should add the compatibility CSS before the first `@layer base` (if the "tai
   ).toMatchInlineSnapshot(`
     "@import 'tailwindcss';
 
-    @variant foo {
+    @custom-variant foo {
     }
 
     /*
@@ -193,7 +193,7 @@ it('should add the compatibility CSS before the first `@layer base` (if the "tai
     await migrate(css`
       @import 'tailwindcss/preflight';
 
-      @variant foo {
+      @custom-variant foo {
       }
 
       @utility bar {
@@ -211,7 +211,7 @@ it('should add the compatibility CSS before the first `@layer base` (if the "tai
   ).toMatchInlineSnapshot(`
     "@import 'tailwindcss/preflight';
 
-    @variant foo {
+    @custom-variant foo {
     }
 
     /*
@@ -249,7 +249,7 @@ it('should add the compatibility CSS before the first `@layer base` (if the "tai
 it('should not add the backwards compatibility CSS when no `@import "tailwindcss"` or `@import "tailwindcss/preflight"` exists', async () => {
   expect(
     await migrate(css`
-      @variant foo {
+      @custom-variant foo {
       }
 
       @utility bar {
@@ -265,7 +265,7 @@ it('should not add the backwards compatibility CSS when no `@import "tailwindcss
       }
     `),
   ).toMatchInlineSnapshot(`
-    "@variant foo {
+    "@custom-variant foo {
     }
 
     @utility bar {
@@ -287,7 +287,7 @@ it('should not add the backwards compatibility CSS when another `@import "tailwi
     await migrate(css`
       @import 'tailwindcss/theme';
 
-      @variant foo {
+      @custom-variant foo {
       }
 
       @utility bar {
@@ -305,7 +305,7 @@ it('should not add the backwards compatibility CSS when another `@import "tailwi
   ).toMatchInlineSnapshot(`
     "@import 'tailwindcss/theme';
 
-    @variant foo {
+    @custom-variant foo {
     }
 
     @utility bar {

--- a/packages/@tailwindcss-upgrade/src/codemods/sort-buckets.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/sort-buckets.ts
@@ -10,7 +10,7 @@ const BUCKET_ORDER = [
   'config', // @config
   'plugin', // @plugin
   'source', // @source
-  'variant', // @variant
+  'custom-variant', // @custom-variant
   'theme', // @theme
 
   // Styles
@@ -75,7 +75,7 @@ export function sortBuckets(): Plugin {
         // Known at-rules
         else if (
           node.type === 'atrule' &&
-          ['config', 'plugin', 'source', 'theme', 'utility', 'variant'].includes(node.name)
+          ['config', 'plugin', 'source', 'theme', 'utility', 'custom-variant'].includes(node.name)
         ) {
           injectInto(node.name, node)
         }

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -204,7 +204,7 @@ function migrateDarkMode(unresolvedConfig: Config & { darkMode: any }): string {
   if (variant === '') {
     return ''
   }
-  return `\n@tw-bucket variant {\n@variant dark (${variant});\n}\n`
+  return `\n@tw-bucket variant {\n@custom-variant dark (${variant});\n}\n`
 }
 
 // Returns a string identifier used to section theme declarations

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -204,7 +204,7 @@ function migrateDarkMode(unresolvedConfig: Config & { darkMode: any }): string {
   if (variant === '') {
     return ''
   }
-  return `\n@tw-bucket variant {\n@custom-variant dark (${variant});\n}\n`
+  return `\n@tw-bucket custom-variant {\n@custom-variant dark (${variant});\n}\n`
 }
 
 // Returns a string identifier used to section theme declarations

--- a/packages/@tailwindcss-upgrade/src/template/codemods/variant-order.test.ts
+++ b/packages/@tailwindcss-upgrade/src/template/codemods/variant-order.test.ts
@@ -60,19 +60,19 @@ test('it works with custom variants', async () => {
   let designSystem = await __unstable__loadDesignSystem(
     css`
       @import 'tailwindcss';
-      @variant atrule {
+      @custom-variant atrule {
         @media (print) {
           @slot;
         }
       }
 
-      @variant combinator {
+      @custom-variant combinator {
         > * {
           @slot;
         }
       }
 
-      @variant pseudo {
+      @custom-variant pseudo {
         &::before {
           @slot;
         }

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -256,11 +256,23 @@ export function optimizeAst(ast: AstNode[]) {
 
     // Rule
     else if (node.kind === 'rule') {
-      let copy = { ...node, nodes: [] }
-      for (let child of node.nodes) {
-        transform(child, copy.nodes, depth + 1)
+      // Rules with `&` as the selector should be flattened
+      if (node.selector === '&') {
+        for (let child of node.nodes) {
+          let nodes: AstNode[] = []
+          transform(child, nodes, depth + 1)
+          parent.push(...nodes)
+        }
       }
-      parent.push(copy)
+
+      //
+      else {
+        let copy = { ...node, nodes: [] }
+        for (let child of node.nodes) {
+          transform(child, copy.nodes, depth + 1)
+        }
+        parent.push(copy)
+      }
     }
 
     // AtRule `@property`

--- a/packages/tailwindcss/src/compat/config.test.ts
+++ b/packages/tailwindcss/src/compat/config.test.ts
@@ -216,8 +216,8 @@ test('Variants in CSS overwrite variants from plugins', async () => {
   let input = css`
     @tailwind utilities;
     @config "./config.js";
-    @variant dark (&:is(.my-dark));
-    @variant light (&:is(.my-light));
+    @custom-variant dark (&:is(.my-dark));
+    @custom-variant light (&:is(.my-light));
   `
 
   let compiler = await compile(input, {

--- a/packages/tailwindcss/src/compat/plugin-api.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.ts
@@ -10,7 +10,7 @@ import { DefaultMap } from '../utils/default-map'
 import { inferDataType } from '../utils/infer-data-type'
 import { segment } from '../utils/segment'
 import { toKeyPath } from '../utils/to-key-path'
-import { compoundsForSelectors, substituteAtSlot } from '../variants'
+import { compoundsForSelectors, IS_VALID_VARIANT_NAME, substituteAtSlot } from '../variants'
 import type { ResolvedConfig, UserConfig } from './config/types'
 import { createThemeFn } from './plugin-functions'
 import * as SelectorParser from './selector-parser'
@@ -108,6 +108,12 @@ export function buildPluginApi({
     },
 
     addVariant(name, variant) {
+      if (!IS_VALID_VARIANT_NAME.test(name)) {
+        throw new Error(
+          `\`addVariant('${name}')\` defines an invalid variant name. Variants should only contain alphanumeric, dashes or underscore characters.`,
+        )
+      }
+
       // Single selector or multiple parallel selectors
       if (typeof variant === 'string' || Array.isArray(variant)) {
         designSystem.variants.static(

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -3443,33 +3443,6 @@ describe('@variant', () => {
     `)
   })
 
-  it('should be possible to use multiple `@variant` params at once', async () => {
-    await expect(
-      compileCss(
-        css`
-          .btn {
-            background: black;
-
-            @variant hover:focus {
-              background: white;
-            }
-          }
-        `,
-        [],
-      ),
-    ).resolves.toMatchInlineSnapshot(`
-      ".btn {
-        background: #000;
-      }
-
-      @media (hover: hover) {
-        .btn:hover:focus {
-          background: #fff;
-        }
-      }"
-    `)
-  })
-
   it('should be possible to use `@variant` with a funky looking variants', async () => {
     await expect(
       compileCss(
@@ -3481,8 +3454,10 @@ describe('@variant', () => {
           .btn {
             background: black;
 
-            @variant @md:[&.foo] {
-              background: white;
+            @variant @md {
+              @variant [&.foo] {
+                background: white;
+              }
             }
           }
         `,

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -2493,56 +2493,56 @@ describe('@source', () => {
   })
 })
 
-describe('@variant', () => {
-  test('@variant must be top-level and cannot be nested', () => {
+describe('@custom-variant', () => {
+  test('@custom-variant must be top-level and cannot be nested', () => {
     return expect(
       compileCss(css`
         .foo {
-          @variant hocus (&:hover, &:focus);
+          @custom-variant hocus (&:hover, &:focus);
         }
       `),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: \`@variant\` cannot be nested.]`)
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: \`@custom-variant\` cannot be nested.]`)
   })
 
-  test('@variant with no body must include a selector', () => {
+  test('@custom-variant with no body must include a selector', () => {
     return expect(
       compileCss(css`
-        @variant hocus;
+        @custom-variant hocus;
       `),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      '[Error: `@variant hocus` has no selector or body.]',
+      '[Error: `@custom-variant hocus` has no selector or body.]',
     )
   })
 
-  test('@variant with selector must include a body', () => {
+  test('@custom-variant with selector must include a body', () => {
     return expect(
       compileCss(css`
-        @variant hocus {
+        @custom-variant hocus {
         }
       `),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      '[Error: `@variant hocus` has no selector or body.]',
+      '[Error: `@custom-variant hocus` has no selector or body.]',
     )
   })
 
-  test('@variant cannot have both a selector and a body', () => {
+  test('@custom-variant cannot have both a selector and a body', () => {
     return expect(
       compileCss(css`
-        @variant hocus (&:hover, &:focus) {
+        @custom-variant hocus (&:hover, &:focus) {
           &:is(.potato) {
             @slot;
           }
         }
       `),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: \`@variant hocus\` cannot have both a selector and a body.]`,
+      `[Error: \`@custom-variant hocus\` cannot have both a selector and a body.]`,
     )
   })
 
   describe('body-less syntax', () => {
     test('selector variant', async () => {
       let { build } = await compile(css`
-        @variant hocus (&:hover, &:focus);
+        @custom-variant hocus (&:hover, &:focus);
 
         @layer utilities {
           @tailwind utilities;
@@ -2565,7 +2565,7 @@ describe('@variant', () => {
 
     test('at-rule variant', async () => {
       let { build } = await compile(css`
-        @variant any-hover (@media (any-hover: hover));
+        @custom-variant any-hover (@media (any-hover: hover));
 
         @layer utilities {
           @tailwind utilities;
@@ -2588,7 +2588,7 @@ describe('@variant', () => {
 
     test('style-rules and at-rules', async () => {
       let { build } = await compile(css`
-        @variant cant-hover (&:not(:hover), &:not(:active), @media not (any-hover: hover), @media not (pointer: fine));
+        @custom-variant cant-hover (&:not(:hover), &:not(:active), @media not (any-hover: hover), @media not (pointer: fine));
 
         @layer utilities {
           @tailwind utilities;
@@ -2621,7 +2621,7 @@ describe('@variant', () => {
   describe('body with @slot syntax', () => {
     test('selector with @slot', async () => {
       let { build } = await compile(css`
-        @variant selected {
+        @custom-variant selected {
           &[data-selected] {
             @slot;
           }
@@ -2644,7 +2644,7 @@ describe('@variant', () => {
 
     test('grouped selectors with @slot', async () => {
       let { build } = await compile(css`
-        @variant hocus {
+        @custom-variant hocus {
           &:hover,
           &:focus {
             @slot;
@@ -2668,7 +2668,7 @@ describe('@variant', () => {
 
     test('multiple selectors with @slot', async () => {
       let { build } = await compile(css`
-        @variant hocus {
+        @custom-variant hocus {
           &:hover {
             @slot;
           }
@@ -2695,7 +2695,7 @@ describe('@variant', () => {
 
     test('nested selector with @slot', async () => {
       let { build } = await compile(css`
-        @variant custom-before {
+        @custom-variant custom-before {
           & {
             --has-before: 1;
             &::before {
@@ -2725,7 +2725,7 @@ describe('@variant', () => {
 
     test('grouped nested selectors with @slot', async () => {
       let { build } = await compile(css`
-        @variant custom-before {
+        @custom-variant custom-before {
           & {
             --has-before: 1;
             &::before {
@@ -2758,7 +2758,7 @@ describe('@variant', () => {
 
     test('nested multiple selectors with @slot', async () => {
       let { build } = await compile(css`
-        @variant hocus {
+        @custom-variant hocus {
           &:hover {
             @media (hover: hover) {
               @slot;
@@ -2803,7 +2803,7 @@ describe('@variant', () => {
 
     test('selector nested under at-rule with @slot', async () => {
       let { build } = await compile(css`
-        @variant hocus {
+        @custom-variant hocus {
           @media (hover: hover) {
             &:hover {
               @slot;
@@ -2830,7 +2830,7 @@ describe('@variant', () => {
 
     test('at-rule with @slot', async () => {
       let { build } = await compile(css`
-        @variant any-hover {
+        @custom-variant any-hover {
           @media (any-hover: hover) {
             @slot;
           }
@@ -2855,7 +2855,7 @@ describe('@variant', () => {
 
     test('multiple at-rules with @slot', async () => {
       let { build } = await compile(css`
-        @variant desktop {
+        @custom-variant desktop {
           @media (any-hover: hover) {
             @slot;
           }
@@ -2890,7 +2890,7 @@ describe('@variant', () => {
 
     test('nested at-rules with @slot', async () => {
       let { build } = await compile(css`
-        @variant custom-variant {
+        @custom-variant custom-variant {
           @media (orientation: landscape) {
             @media screen {
               @slot;
@@ -2929,7 +2929,7 @@ describe('@variant', () => {
 
     test('at-rule and selector with @slot', async () => {
       let { build } = await compile(css`
-        @variant custom-dark {
+        @custom-variant custom-dark {
           @media (prefers-color-scheme: dark) {
             @slot;
           }
@@ -2964,7 +2964,7 @@ describe('@variant', () => {
     expect(
       await compileCss(
         css`
-          @variant dark (&:is([data-theme='dark'] *));
+          @custom-variant dark (&:is([data-theme='dark'] *));
           @layer utilities {
             @tailwind utilities;
           }
@@ -2993,7 +2993,7 @@ describe('@variant', () => {
     expect(
       await compileCss(
         css`
-          @variant foo (@media foo);
+          @custom-variant foo (@media foo);
 
           @layer utilities {
             @tailwind utilities;
@@ -3137,7 +3137,7 @@ describe('`@import "…" reference`', () => {
             @theme {
               --breakpoint-md: 768px;
             }
-            @variant hocus (&:hover, &:focus);
+            @custom-variant hocus (&:hover, &:focus);
           `,
           base: '/root/foo',
         }
@@ -3217,7 +3217,7 @@ describe('`@import "…" reference`', () => {
             @utility foo {
               color: red;
             }
-            @variant hocus (&:hover, &:focus);
+            @custom-variant hocus (&:hover, &:focus);
           }
 
           .bar {

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -2497,8 +2497,18 @@ describe('@custom-variant', () => {
   test('@custom-variant must be top-level and cannot be nested', () => {
     return expect(
       compileCss(css`
+        @custom-variant foo:bar (&:hover, &:focus);
+      `),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: \`@custom-variant foo:bar\` defines an invalid variant name. Variants should only contain alphanumeric, dashes or underscore characters.]`,
+    )
+  })
+
+  test('@custom-variant must not container special characters', () => {
+    return expect(
+      compileCss(css`
         .foo {
-          @custom-variant hocus (&:hover, &:focus);
+          @custom-variant foo:bar (&:hover, &:focus);
         }
       `),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`[Error: \`@custom-variant\` cannot be nested.]`)

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -547,16 +547,16 @@ async function parseCss(
       // Starting with the `&` rule node
       let node = styleRule('&', variantNode.nodes)
 
-      for (let variant of segment(variantNode.params, ':').reverse()) {
-        let variantAst = designSystem.parseVariant(variant)
-        if (variantAst === null) {
-          throw new Error(`Cannot use \`@variant\` with unknown variant: ${variant}`)
-        }
+      let variant = variantNode.params
 
-        let result = applyVariant(node, variantAst, designSystem.variants)
-        if (result === null) {
-          throw new Error(`Cannot use \`@variant\` with variant: ${variant}`)
-        }
+      let variantAst = designSystem.parseVariant(variant)
+      if (variantAst === null) {
+        throw new Error(`Cannot use \`@variant\` with unknown variant: ${variant}`)
+      }
+
+      let result = applyVariant(node, variantAst, designSystem.variants)
+      if (result === null) {
+        throw new Error(`Cannot use \`@variant\` with variant: ${variant}`)
       }
 
       // Update the variant at-rule node, to be the `&` rule node

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -213,25 +213,25 @@ async function parseCss(
       return
     }
 
-    // Register custom variants from `@variant` at-rules
-    if (node.name === '@variant') {
+    // Register custom variants from `@custom-variant` at-rules
+    if (node.name === '@custom-variant') {
       if (parent !== null) {
-        throw new Error('`@variant` cannot be nested.')
+        throw new Error('`@custom-variant` cannot be nested.')
       }
 
-      // Remove `@variant` at-rule so it's not included in the compiled CSS
+      // Remove `@custom-variant` at-rule so it's not included in the compiled CSS
       replaceWith([])
 
       let [name, selector] = segment(node.params, ' ')
 
       if (node.nodes.length > 0 && selector) {
-        throw new Error(`\`@variant ${name}\` cannot have both a selector and a body.`)
+        throw new Error(`\`@custom-variant ${name}\` cannot have both a selector and a body.`)
       }
 
-      // Variants with a selector, but without a body, e.g.: `@variant hocus (&:hover, &:focus);`
+      // Variants with a selector, but without a body, e.g.: `@custom-variant hocus (&:hover, &:focus);`
       if (node.nodes.length === 0) {
         if (!selector) {
-          throw new Error(`\`@variant ${name}\` has no selector or body.`)
+          throw new Error(`\`@custom-variant ${name}\` has no selector or body.`)
         }
 
         let selectors = segment(selector.slice(1, -1), ',')
@@ -279,7 +279,7 @@ async function parseCss(
       // E.g.:
       //
       // ```css
-      // @variant hocus {
+      // @custom-variant hocus {
       //   &:hover {
       //     @slot;
       //   }

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -28,7 +28,7 @@ import { buildDesignSystem, type DesignSystem } from './design-system'
 import { Theme, ThemeOptions } from './theme'
 import { createCssUtility } from './utilities'
 import { segment } from './utils/segment'
-import { compoundsForSelectors } from './variants'
+import { compoundsForSelectors, IS_VALID_VARIANT_NAME } from './variants'
 export type Config = UserConfig
 
 const IS_VALID_PREFIX = /^[a-z]+$/
@@ -263,6 +263,12 @@ async function parseCss(
       replaceWith([])
 
       let [name, selector] = segment(node.params, ' ')
+
+      if (!IS_VALID_VARIANT_NAME.test(name)) {
+        throw new Error(
+          `\`@custom-variant ${name}\` defines an invalid variant name. Variants should only contain alphanumeric, dashes or underscore characters.`,
+        )
+      }
 
       if (node.nodes.length > 0 && selector) {
         throw new Error(`\`@custom-variant ${name}\` cannot have both a selector and a body.`)

--- a/packages/tailwindcss/src/intellisense.test.ts
+++ b/packages/tailwindcss/src/intellisense.test.ts
@@ -82,7 +82,7 @@ test('getVariants compound', () => {
 
 test('variant selectors are in the correct order', async () => {
   let input = css`
-    @variant overactive {
+    @custom-variant overactive {
       &:hover {
         @media (hover: hover) {
           &:focus {
@@ -386,8 +386,8 @@ test('Functional utilities from plugins are listed in hovers and completions', a
 test('Custom at-rule variants do not show up as a value under `group`', async () => {
   let input = css`
     @import 'tailwindcss/utilities';
-    @variant variant-1 (@media foo);
-    @variant variant-2 {
+    @custom-variant variant-1 (@media foo);
+    @custom-variant variant-2 {
       @media bar {
         @slot;
       }

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -518,7 +518,7 @@ test('group-*', async () => {
   expect(
     await compileCss(
       css`
-        @variant hocus {
+        @custom-variant hocus {
           &:hover,
           &:focus {
             @slot;
@@ -560,8 +560,8 @@ test('group-*', async () => {
   expect(
     await compileCss(
       css`
-        @variant custom-at-rule (@media foo);
-        @variant nested-selectors {
+        @custom-variant custom-at-rule (@media foo);
+        @custom-variant nested-selectors {
           &:hover {
             &:focus {
               @slot;
@@ -610,7 +610,7 @@ test('peer-*', async () => {
   expect(
     await compileCss(
       css`
-        @variant hocus {
+        @custom-variant hocus {
           &:hover,
           &:focus {
             @slot;
@@ -651,8 +651,8 @@ test('peer-*', async () => {
   expect(
     await compileCss(
       css`
-        @variant custom-at-rule (@media foo);
-        @variant nested-selectors {
+        @custom-variant custom-at-rule (@media foo);
+        @custom-variant nested-selectors {
           &:hover {
             &:focus {
               @slot;
@@ -1361,14 +1361,14 @@ test('not', async () => {
   expect(
     await compileCss(
       css`
-        @variant hocus {
+        @custom-variant hocus {
           &:hover,
           &:focus {
             @slot;
           }
         }
 
-        @variant device-hocus {
+        @custom-variant device-hocus {
           @media (hover: hover) {
             &:hover,
             &:focus {
@@ -1625,19 +1625,19 @@ test('not', async () => {
   expect(
     await compileCss(
       css`
-        @variant nested-at-rules {
+        @custom-variant nested-at-rules {
           @media foo {
             @media bar {
               @slot;
             }
           }
         }
-        @variant multiple-media-conditions {
+        @custom-variant multiple-media-conditions {
           @media foo, bar {
             @slot;
           }
         }
-        @variant nested-style-rules {
+        @custom-variant nested-style-rules {
           &:hover {
             &:focus {
               @slot;
@@ -1706,7 +1706,7 @@ test('has', async () => {
   expect(
     await compileCss(
       css`
-        @variant hocus {
+        @custom-variant hocus {
           &:hover,
           &:focus {
             @slot;
@@ -1759,8 +1759,8 @@ test('has', async () => {
   expect(
     await compileCss(
       css`
-        @variant custom-at-rule (@media foo);
-        @variant nested-selectors {
+        @custom-variant custom-at-rule (@media foo);
+        @custom-variant nested-selectors {
           &:hover {
             &:focus {
               @slot;

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -18,6 +18,8 @@ import { DefaultMap } from './utils/default-map'
 import { isPositiveInteger } from './utils/infer-data-type'
 import { segment } from './utils/segment'
 
+export const IS_VALID_VARIANT_NAME = /^@?[a-zA-Z0-9_-]*$/
+
 type VariantFn<T extends Variant['kind']> = (
   rule: Rule,
   variant: Extract<Variant, { kind: T }>,


### PR DESCRIPTION
This PR replaces `@variant` with `@custom-variant` for registering custom variants via your CSS.

In addition, this PR introduces `@variant` that can be used in your CSS to use a variant while writing custom CSS.

E.g.:

```css
.btn {
  background: white;

  @variant dark {
    background: black;
  }
}
```

Compiles to:

```css
.btn {
  background: white;
}

@media (prefers-color-scheme: dark) {
  .btn {
    background: black;
  }
}
```

For backwards compatibility, the `@variant` rules that don't have a body and are
defined inline:

```css
@variant hocus (&:hover, &:focus);
```

And `@variant` rules that are defined with a body and a `@slot`:

```css
@variant hocus {
  &:hover, &:focus {
    @slot;
  }
}
```

Will automatically be upgraded to `@custom-variant` internally, so no breaking changes are introduced with this PR.

---

TODO:
- [x] ~~Decide whether we want to allow multiple variants and if so, what syntax should be used. If not, nesting `@variant <variant> {}` will be the way to go.~~ Only a single `@variant <variant>` can be used, if you want to use multiple, nesting should be used:

```css
.foo {
  @variant hover {
    @variant focus {
      color: red;
    }
  }
}
```
