### PR TITLE
fix: default package exports

### DIFF
--- a/packages/tailwindcss/fix-default-cjs-exports.mjs
+++ b/packages/tailwindcss/fix-default-cjs-exports.mjs
@@ -12,8 +12,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 /**
  * This function will replace `export { type X, Y, Z as default }` with:
  * ```js
- * export = X;
- * export { Y, Z }; // <== this line will be only added if there are additional named exports
+ * export = Z;
+ * export { type X, Y }; // <== this line will be only added if there are additional named exports
  * ```
  * @param dtsPath {string}
  */

--- a/packages/tailwindcss/fix-default-cjs-exports.mjs
+++ b/packages/tailwindcss/fix-default-cjs-exports.mjs
@@ -1,0 +1,65 @@
+import { readdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// regex to find export {} in a d.ts file
+const regexp = /export\s*\{([^}]*)\}/
+// regex to find the default export in previous export {} expression
+const defaultExportRegexp = /\s*as\s+default\s*/
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+/**
+ * This function will replace `export { type X, Y, Z as default }` with:
+ * ```js
+ * export = X;
+ * export { Y, Z }; // <== this line will be only added if there are additional named exports
+ * ```
+ * @param dtsPath {string}
+ */
+function fixDefaultCjsExport(dtsPath) {
+  return readFile(dtsPath, { encoding: 'utf-8' })
+    .then((content) => {
+      let match = content.match(regexp)
+      if (!match) return undefined
+      const fullExport = match[0]
+      /**@type {string | undefined}*/
+      let defaultExport = undefined
+      /**@type {string[]} */
+      const namedExports = []
+      for (const exp of match[1].split(',').map((e) => e.trim())) {
+        match = exp.match(defaultExportRegexp)
+        if (match) {
+          defaultExport = exp.replace(match[0], '').trim()
+        } else {
+          namedExports.push(exp)
+        }
+      }
+      if (!defaultExport) return undefined
+      return namedExports.length === 0
+        ? content.replace(fullExport, `export = ${defaultExport}`)
+        : content.replace(
+            fullExport,
+            `export = ${defaultExport};\nexport { ${namedExports.join(', ')} }`,
+          )
+    })
+    .then((content) => {
+      return content ? writeFile(dtsPath, content, 'utf-8') : Promise.resolve()
+    })
+}
+
+/**
+ * List all `.d.ts` files in the `dist` directory and fix the default export.
+ *
+ * @returns {Promise<void>}
+ */
+async function fixDefaultCjsExports() {
+  const files = await readdir(resolve(__dirname, 'dist')).then((f) => {
+    return f
+      .filter((file) => file.endsWith('.d.ts'))
+      .map((file) => resolve(__dirname, 'dist', file))
+  })
+  await Promise.all(files.map((file) => fixDefaultCjsExport(file)))
+}
+
+fixDefaultCjsExports()

--- a/packages/tailwindcss/package.json
+++ b/packages/tailwindcss/package.json
@@ -1,5 +1,6 @@
 {
   "name": "tailwindcss",
+  "type": "commonjs",
   "version": "4.0.0",
   "description": "A utility-first CSS framework for rapidly building custom user interfaces.",
   "license": "MIT",
@@ -137,6 +138,16 @@
         }
       },
       "./lib/util/flattenColorPalette": {
+        "import": {
+          "types": "./dist/flatten-color-palette.d.mts",
+          "default": "./dist/flatten-color-palette.mjs"
+        },
+        "require": {
+          "types": "./dist/flatten-color-palette.d.ts",
+          "default": "./dist/flatten-color-palette.js"
+        }
+      },
+      "./lib/util/flattenColorPalette.js": {
         "import": {
           "types": "./dist/flatten-color-palette.d.mts",
           "default": "./dist/flatten-color-palette.mjs"

--- a/packages/tailwindcss/package.json
+++ b/packages/tailwindcss/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://tailwindcss.com",
   "scripts": {
     "lint": "tsc --noEmit",
-    "build": "tsup-node --env.NODE_ENV production",
+    "build": "tsup-node --env.NODE_ENV production && node fix-default-cjs-exports.mjs",
     "dev": "tsup-node --env.NODE_ENV development --watch",
     "test:ui": "playwright test"
   },
@@ -66,38 +66,85 @@
     "access": "public",
     "exports": {
       ".": {
-        "types": "./dist/lib.d.mts",
         "style": "./index.css",
-        "require": "./dist/lib.js",
-        "import": "./dist/lib.mjs"
+        "import": {
+          "types": "./dist/lib.d.mts",
+          "default": "./dist/lib.mjs"
+        },
+        "require": {
+          "types": "./dist/lib.d.ts",
+          "default": "./dist/lib.js"
+        }
       },
       "./plugin": {
-        "require": "./dist/plugin.js",
-        "import": "./dist/plugin.mjs"
+        "import": {
+          "types": "./dist/plugin.d.mts",
+          "default": "./dist/plugin.mjs"
+        },
+        "require": {
+          "types": "./dist/plugin.d.ts",
+          "default": "./dist/plugin.js"
+        }
       },
       "./plugin.js": {
-        "require": "./dist/plugin.js",
-        "import": "./dist/plugin.mjs"
+        "import": {
+          "types": "./dist/plugin.d.mts",
+          "default": "./dist/plugin.mjs"
+        },
+        "require": {
+          "types": "./dist/plugin.d.ts",
+          "default": "./dist/plugin.js"
+        }
       },
       "./defaultTheme": {
-        "require": "./dist/default-theme.js",
-        "import": "./dist/default-theme.mjs"
+        "import": {
+          "types": "./dist/default-theme.d.mts",
+          "default": "./dist/default-theme.mjs"
+        },
+        "require": {
+          "types": "./dist/default-theme.d.ts",
+          "default": "./dist/default-theme.js"
+        }
       },
       "./defaultTheme.js": {
-        "require": "./dist/default-theme.js",
-        "import": "./dist/default-theme.mjs"
+        "import": {
+          "types": "./dist/default-theme.d.mts",
+          "default": "./dist/default-theme.mjs"
+        },
+        "require": {
+          "types": "./dist/default-theme.d.ts",
+          "default": "./dist/default-theme.js"
+        }
       },
       "./colors": {
-        "require": "./dist/colors.js",
-        "import": "./dist/colors.mjs"
+        "import": {
+          "types": "./dist/colors.d.mts",
+          "default": "./dist/colors.mjs"
+        },
+        "require": {
+          "types": "./dist/colors.d.ts",
+          "default": "./dist/colors.js"
+        }
       },
       "./colors.js": {
-        "require": "./dist/colors.js",
-        "import": "./dist/colors.mjs"
+        "import": {
+          "types": "./dist/colors.d.mts",
+          "default": "./dist/colors.mjs"
+        },
+        "require": {
+          "types": "./dist/colors.d.ts",
+          "default": "./dist/colors.js"
+        }
       },
       "./lib/util/flattenColorPalette": {
-        "require": "./dist/flatten-color-palette.js",
-        "import": "./dist/flatten-color-palette.mjs"
+        "import": {
+          "types": "./dist/flatten-color-palette.d.mts",
+          "default": "./dist/flatten-color-palette.mjs"
+        },
+        "require": {
+          "types": "./dist/flatten-color-palette.d.ts",
+          "default": "./dist/flatten-color-palette.js"
+        }
       },
       "./package.json": "./package.json",
       "./index.css": "./index.css",
@@ -111,6 +158,37 @@
     }
   },
   "style": "index.css",
+  "main": "dist/lib.js",
+  "module": "dist/lib.mjs",
+  "types": "dist/lib.d.ts",
+  "typesVersions": {
+    "*": {
+      "plugin": [
+        "./dist/plugin.d.ts"
+      ],
+      "plugin.js": [
+        "./dist/plugin.d.ts"
+      ],
+      "colors": [
+        "./dist/colors.d.ts"
+      ],
+      "colors.js": [
+        "./dist/colors.d.ts"
+      ],
+      "defaultTheme": [
+        "./dist/default-theme.d.ts"
+      ],
+      "defaultTheme.js": [
+        "./dist/default-theme.d.ts"
+      ],
+      "lib/util/flattenColorPalette": [
+        "./dist/flatten-color-palette.d.ts"
+      ],
+      "lib/util/flattenColorPalette.js": [
+        "./dist/flatten-color-palette.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist",
     "index.css",

--- a/packages/tailwindcss/src/plugin.ts
+++ b/packages/tailwindcss/src/plugin.ts
@@ -1,5 +1,7 @@
 import type { Config, PluginFn, PluginWithConfig, PluginWithOptions } from './compat/plugin-api'
 
+export type { Config, PluginFn, PluginWithConfig, PluginWithOptions }
+
 function createPlugin(handler: PluginFn, config?: Partial<Config>): PluginWithConfig {
   return {
     handler,

--- a/packages/tailwindcss/tsup.config.ts
+++ b/packages/tailwindcss/tsup.config.ts
@@ -1,28 +1,15 @@
 import { defineConfig } from 'tsup'
 
-export default defineConfig([
-  {
-    format: ['esm'],
-    minify: true,
-    dts: true,
-    entry: {
-      lib: 'src/index.ts',
-      plugin: 'src/plugin.ts',
-      colors: 'src/compat/colors.ts',
-      'default-theme': 'src/compat/default-theme.ts',
-      'flatten-color-palette': 'src/compat/flatten-color-palette.ts',
-    },
+export default defineConfig({
+  format: ['cjs', 'esm'],
+  clean: true,
+  minify: true,
+  dts: true,
+  entry: {
+    plugin: 'src/plugin.ts',
+    lib: 'src/index.ts',
+    colors: 'src/compat/colors.ts',
+    'default-theme': 'src/compat/default-theme.ts',
+    'flatten-color-palette': 'src/compat/flatten-color-palette.ts',
   },
-  {
-    format: ['cjs'],
-    minify: true,
-    dts: true,
-    entry: {
-      plugin: 'src/plugin.cts',
-      lib: 'src/index.cts',
-      colors: 'src/compat/colors.cts',
-      'default-theme': 'src/compat/default-theme.cts',
-      'flatten-color-palette': 'src/compat/flatten-color-palette.cts',
-    },
-  },
-])
+})


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->

This PR includes the following changes to the `packages/tailwindcss` package (check **Context**):
- fixes the default packages exports for node10 and node16 cjs types
- export types in `plugin.ts` module, cannot be used with Typescript 5.7
- add `"type": "commonjs"` to package.json
- add `./lib/util/flattenColorPalette.js` variant to package.json exports (`publishConfig`)

**Context**
The current version at npm registry has all types broken for all packages exports. The problem seems to be with tsup since it is not applying the `.cts` hack, all `d.ts` files using `export { X as default };`, check https://arethetypeswrong.github.io/?p=tailwindcss%404.0.0 .

With this PR (for context check this PR https://github.com/unjs/unbuild/pull/475 and this md file https://github.com/unjs/unbuild/blob/a011a7831e2004688bf44716f5e9c9377d08ebec/src/builders/rollup/plugins/cjs.md):

![image](https://github.com/user-attachments/assets/1cbfcdf7-a573-4465-8191-95dea9fabd56)


This PR includes a new script module that runs after tsup finish building the dist, extracting the default export and applying some replacements in the files including the default `export` correclty: `export = X;` and remaining named exports in the default export statement.

About exporting the types in the `plugin.ts` module, when using TypeScript 5.7 there is an error. Using the following code with any module resolution

```ts
import plugin from 'tailwindcss/plugin'

const exportedPlugin = plugin.withOptions(() => {
	return ({ matchComponents }) => {
		matchComponents({
			test: (content: string) => {
				return {
					color: content,
				};
			},
		});
	};
});

export default exportedPlugin;
```

and building it via `tsc -b`, there is an error about required annotation:

![image](https://github.com/user-attachments/assets/dc092554-6467-4c50-b18c-7b0d8dd40274)

Using a local tgz from this PR, TypeScript is fine when building the module:

![image](https://github.com/user-attachments/assets/625ea542-6ac4-41ee-9aa6-670f08d6ca4c)

You can generate the local tgz using this PR in the following repository (use packages/plugin): https://github.com/iconify/iconify-tailwind
