### PR TITLE
chore: move tailwindcss from dependencies to peer dependencies

### DIFF
--- a/packages/@tailwindcss-cli/package.json
+++ b/packages/@tailwindcss-cli/package.json
@@ -35,7 +35,12 @@
     "enhanced-resolve": "^5.18.0",
     "lightningcss": "catalog:",
     "mri": "^1.2.0",
-    "picocolors": "^1.1.1",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "tailwindcss": "workspace:*"
+  },
+  "peerDependencies": {
     "tailwindcss": "workspace:*"
   }
 }

--- a/packages/@tailwindcss-node/package.json
+++ b/packages/@tailwindcss-node/package.json
@@ -38,7 +38,12 @@
   },
   "dependencies": {
     "enhanced-resolve": "^5.18.0",
-    "jiti": "^2.4.2",
+    "jiti": "^2.4.2"
+  },
+  "devDependencies": {
+    "tailwindcss": "workspace:*"
+  },
+  "peerDependencies": {
     "tailwindcss": "workspace:*"
   }
 }

--- a/packages/@tailwindcss-postcss/package.json
+++ b/packages/@tailwindcss-postcss/package.json
@@ -34,14 +34,17 @@
     "@tailwindcss/node": "workspace:^",
     "@tailwindcss/oxide": "workspace:^",
     "lightningcss": "catalog:",
-    "postcss": "^8.4.41",
-    "tailwindcss": "workspace:*"
+    "postcss": "^8.4.41"
   },
   "devDependencies": {
     "@types/node": "catalog:",
     "@types/postcss-import": "14.0.3",
     "dedent": "1.5.3",
     "internal-example-plugin": "workspace:*",
-    "postcss-import": "^16.1.0"
+    "postcss-import": "^16.1.0",
+    "tailwindcss": "workspace:*"
+  },
+  "peerDependencies": {
+    "tailwindcss": "workspace:*"
   }
 }

--- a/packages/@tailwindcss-standalone/package.json
+++ b/packages/@tailwindcss-standalone/package.json
@@ -30,8 +30,7 @@
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/typography": "^0.5.16",
     "detect-libc": "1.0.3",
-    "enhanced-resolve": "^5.18.0",
-    "tailwindcss": "workspace:^"
+    "enhanced-resolve": "^5.18.0"
   },
   "__notes": "These binary packages must be included so Bun can build the CLI for all supported platforms. We also rely on Lightning CSS and Parcel being patched so Bun can statically analyze the executables.",
   "devDependencies": {
@@ -50,6 +49,10 @@
     "lightningcss-linux-arm64-musl": "^1.29.1",
     "lightningcss-linux-x64-gnu": "^1.29.1",
     "lightningcss-linux-x64-musl": "^1.29.1",
-    "lightningcss-win32-x64-msvc": "^1.29.1"
+    "lightningcss-win32-x64-msvc": "^1.29.1",
+    "tailwindcss": "workspace:^"
+  },
+  "peerDependencies": {
+    "tailwindcss": "workspace:*"
   }
 }

--- a/packages/@tailwindcss-upgrade/package.json
+++ b/packages/@tailwindcss-upgrade/package.json
@@ -41,12 +41,15 @@
     "postcss-selector-parser": "^7.0.0",
     "prettier": "^3.4.2",
     "tree-sitter": "^0.22.4",
-    "tree-sitter-typescript": "^0.23.2",
-    "tailwindcss": "workspace:*"
+    "tree-sitter-typescript": "^0.23.2"
   },
   "devDependencies": {
     "@types/braces": "^3.0.5",
     "@types/node": "catalog:",
-    "@types/postcss-import": "^14.0.3"
+    "@types/postcss-import": "^14.0.3",
+    "tailwindcss": "workspace:*"
+  },
+  "peerDependencies": {
+    "tailwindcss": "workspace:*"
   }
 }

--- a/packages/@tailwindcss-vite/package.json
+++ b/packages/@tailwindcss-vite/package.json
@@ -30,14 +30,15 @@
   "dependencies": {
     "@tailwindcss/node": "workspace:^",
     "@tailwindcss/oxide": "workspace:^",
-    "lightningcss": "catalog:",
-    "tailwindcss": "workspace:*"
+    "lightningcss": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "tailwindcss": "workspace:*"
   },
   "peerDependencies": {
+    "tailwindcss": "workspace:*",
     "vite": "^5.2.0 || ^6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,7 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+    devDependencies:
       tailwindcss:
         specifier: workspace:*
         version: link:../tailwindcss
@@ -182,6 +183,7 @@ importers:
       jiti:
         specifier: ^2.4.2
         version: 2.4.2
+    devDependencies:
       tailwindcss:
         specifier: workspace:*
         version: link:../tailwindcss
@@ -203,9 +205,6 @@ importers:
       postcss:
         specifier: ^8.4.41
         version: 8.4.41
-      tailwindcss:
-        specifier: workspace:*
-        version: link:../tailwindcss
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -222,6 +221,9 @@ importers:
       postcss-import:
         specifier: ^16.1.0
         version: 16.1.0(postcss@8.4.41)
+      tailwindcss:
+        specifier: workspace:*
+        version: link:../tailwindcss
 
   packages/@tailwindcss-standalone:
     dependencies:
@@ -243,9 +245,6 @@ importers:
       enhanced-resolve:
         specifier: ^5.18.0
         version: 5.18.0
-      tailwindcss:
-        specifier: workspace:^
-        version: link:../tailwindcss
     devDependencies:
       '@parcel/watcher-darwin-arm64':
         specifier: ^2.5.0
@@ -295,6 +294,9 @@ importers:
       lightningcss-win32-x64-msvc:
         specifier: ^1.29.1
         version: 1.29.1
+      tailwindcss:
+        specifier: workspace:^
+        version: link:../tailwindcss
 
   packages/@tailwindcss-upgrade:
     dependencies:
@@ -337,9 +339,6 @@ importers:
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
-      tailwindcss:
-        specifier: workspace:*
-        version: link:../tailwindcss
       tree-sitter:
         specifier: ^0.22.4
         version: 0.22.4
@@ -356,6 +355,9 @@ importers:
       '@types/postcss-import':
         specifier: ^14.0.3
         version: 14.0.3
+      tailwindcss:
+        specifier: workspace:*
+        version: link:../tailwindcss
 
   packages/@tailwindcss-vite:
     dependencies:
@@ -368,9 +370,6 @@ importers:
       lightningcss:
         specifier: 'catalog:'
         version: 1.29.1(patch_hash=gkqcezdn4goium3e3s43dhy4by)
-      tailwindcss:
-        specifier: workspace:*
-        version: link:../tailwindcss
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -378,6 +377,9 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 6.0.0(@types/node@20.14.13)(jiti@2.4.2)(lightningcss@1.29.1(patch_hash=gkqcezdn4goium3e3s43dhy4by))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0)
+      tailwindcss:
+        specifier: workspace:*
+        version: link:../tailwindcss
 
   packages/internal-example-plugin: {}
 


### PR DESCRIPTION
Follow up of #15751