### PR TITLE
Rename `next` to `main`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,7 +14,7 @@ If you open a pull request for a new feature, we're likely to close it not becau
 
 ## Coding standards
 
-Our code formatting rules are defined in the `"prettier"` section of [package.json](https://github.com/tailwindcss/tailwindcss/blob/next/package.json). You can check your code against these standards by running:
+Our code formatting rules are defined in the `"prettier"` section of [package.json](https://github.com/tailwindcss/tailwindcss/blob/main/package.json). You can check your code against these standards by running:
 
 ```sh
 pnpm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [next]
+    branches: [main]
   pull_request:
 
 permissions:
@@ -25,13 +25,13 @@ jobs:
             os: macos-14
 
         # Exclude windows and macos from being built on feature branches
-        on-next-branch:
-          - ${{ github.ref == 'refs/heads/next' }}
+        on-main-branch:
+          - ${{ github.ref == 'refs/heads/main' }}
         exclude:
-          - on-next-branch: false
+          - on-main-branch: false
             runner:
               name: Windows
-          - on-next-branch: false
+          - on-main-branch: false
             runner:
               name: macOS
 
@@ -97,8 +97,8 @@ jobs:
         run: npm run test:ui
 
       - name: Notify Discord
-        if: failure() && github.ref == 'refs/heads/next'
+        if: failure() && github.ref == 'refs/heads/main'
         uses: discord-actions/message@v2
         with:
           webhookUrl: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          message: 'The [most recent build](<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>) on the `next` branch has failed.'
+          message: 'The [most recent build](<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>) on the `main` branch has failed.'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,7 +2,7 @@ name: Integration Tests
 
 on:
   push:
-    branches: [next]
+    branches: [main]
   pull_request:
 
 permissions:
@@ -32,13 +32,13 @@ jobs:
           - postcss
 
         # Exclude windows and macos from being built on feature branches
-        on-next-branch:
-          - ${{ github.ref == 'refs/heads/next' }}
+        on-main-branch:
+          - ${{ github.ref == 'refs/heads/main' }}
         exclude:
-          - on-next-branch: false
+          - on-main-branch: false
             runner:
               name: Windows
-          - on-next-branch: false
+          - on-main-branch: false
             runner:
               name: macOS
 
@@ -95,8 +95,8 @@ jobs:
           GITHUB_WORKSPACE: ${{ github.workspace }}
 
       - name: Notify Discord
-        if: failure() && github.ref == 'refs/heads/next'
+        if: failure() && github.ref == 'refs/heads/main'
         uses: discord-actions/message@v2
         with:
           webhookUrl: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          message: 'The [most recent build](<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>) on the `next` branch has failed.'
+          message: 'The [most recent build](<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>) on the `main` branch has failed.'

--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -2,8 +2,7 @@ name: Release Insiders
 
 on:
   push:
-    # TODO: Rename to `main`, once merged
-    branches: [next]
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
This PR renames `next` to `main` in GitHub Action Workflows and the CONTRIBUTING.md file.
