### PR TITLE
Fix `resolve_globs` crash when at root directory

### DIFF
--- a/crates/oxide/src/scanner/detect_sources.rs
+++ b/crates/oxide/src/scanner/detect_sources.rs
@@ -112,13 +112,16 @@ impl DetectSources {
                     continue;
                 }
 
-                // If we are in a directory where the parent is a forced static directory, then this
-                // will become a forced static directory as well.
-                if forced_static_directories.contains(&entry.path().parent().unwrap().to_path_buf())
-                {
-                    forced_static_directories.push(entry.path().to_path_buf());
-                    root_directories.insert(entry.path().to_path_buf());
-                    continue;
+                // Although normally very unlikely, if running inside a dockerfile
+                // the current directory might be "/" with no parent
+                if let Some(parent) = entry.path().parent() {
+                    // If we are in a directory where the parent is a forced static directory, then this
+                    // will become a forced static directory as well.
+                    if forced_static_directories.contains(&parent.to_path_buf()) {
+                        forced_static_directories.push(entry.path().to_path_buf());
+                        root_directories.insert(entry.path().to_path_buf());
+                        continue;
+                    }
                 }
 
                 // If we are in a directory, and the directory is git ignored, then we don't have to


### PR DESCRIPTION
Fixes a crash found in Dockerfiles when a build takes place at the root directory. It's not a good practice to keep your application logic in `/`, but it probably shouldn't cause a crash either.

I found this particularly difficult to write tests for because it would involve either running a glob on my real filesystem starting from `/` or mocking the calls to `fs` which as far as I can tell isn't supported in the codebase and would be out of scope to try to do here.

Fixes #15987 