### PR TITLE
Remove the `force` variant

### DIFF
--- a/packages/tailwindcss/src/__snapshots__/intellisense.test.ts.snap
+++ b/packages/tailwindcss/src/__snapshots__/intellisense.test.ts.snap
@@ -7507,13 +7507,6 @@ exports[`getVariants 1`] = `
   {
     "hasDash": true,
     "isArbitrary": false,
-    "name": "force",
-    "selectors": [Function],
-    "values": [],
-  },
-  {
-    "hasDash": true,
-    "isArbitrary": false,
     "name": "*",
     "selectors": [Function],
     "values": [],

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -6,15 +6,6 @@ import { Compounds, compoundsForSelectors } from './variants'
 
 const css = String.raw
 
-test('force', async () => {
-  expect(await run(['force:flex'])).toMatchInlineSnapshot(`
-    ".force\\:flex {
-      display: flex;
-    }"
-  `)
-  expect(await run(['force/foo:flex'])).toEqual('')
-})
-
 test('*', async () => {
   expect(await run(['*:flex'])).toMatchInlineSnapshot(`
     ":is(.\\*\\:flex > *) {

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -365,7 +365,6 @@ export function createVariants(theme: Theme): Variants {
     )
   }
 
-  variants.static('force', () => {}, { compounds: Compounds.Never })
   staticVariant('*', [':is(& > *)'], { compounds: Compounds.Never })
   staticVariant('**', [':is(& *)'], { compounds: Compounds.Never })
 


### PR DESCRIPTION
This PR will remove the `force` variant. This was an experiment that we accidentally shipped, but there is no documentation nor is there any intellisense autocompletion for it.
