### PR TITLE
Vite: Don't rebase urls that appear to be aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Only generate positive `grid-cols-*` and `grid-rows-*` utilities ([#16020](https://github.com/tailwindlabs/tailwindcss/pull/16020))
 - Ensure we process Tailwind CSS features when only using `@reference` or `@variant` ([#16057](https://github.com/tailwindlabs/tailwindcss/pull/16057))
+- Vite: Don't rebase urls that appear to be aliases ([#16078](https://github.com/tailwindlabs/tailwindcss/pull/16078))
 
 ## [4.0.1] - 2025-01-29
 

--- a/packages/@tailwindcss-node/src/urls.test.ts
+++ b/packages/@tailwindcss-node/src/urls.test.ts
@@ -24,6 +24,20 @@ test('URLs can be rewritten', async () => {
         background: url('/image.jpg');
         background: url("/image.jpg");
 
+        /* Potentially Vite-aliased URLs: ignored */
+        background: url(~/image.jpg);
+        background: url(~/foo/image.jpg);
+        background: url('~/image.jpg');
+        background: url("~/image.jpg");
+        background: url(#/image.jpg);
+        background: url(#/foo/image.jpg);
+        background: url('#/image.jpg');
+        background: url("#/image.jpg");
+        background: url(@/image.jpg);
+        background: url(@/foo/image.jpg);
+        background: url('@/image.jpg');
+        background: url("@/image.jpg");
+
         /* External URL: ignored */
         background: url(http://example.com/image.jpg);
         background: url('http://example.com/image.jpg');
@@ -109,6 +123,18 @@ test('URLs can be rewritten', async () => {
       background: url(/foo/image.jpg);
       background: url('/image.jpg');
       background: url("/image.jpg");
+      background: url(~/image.jpg);
+      background: url(~/foo/image.jpg);
+      background: url('~/image.jpg');
+      background: url("~/image.jpg");
+      background: url(#/image.jpg);
+      background: url(#/foo/image.jpg);
+      background: url('#/image.jpg');
+      background: url("#/image.jpg");
+      background: url(@/image.jpg);
+      background: url(@/foo/image.jpg);
+      background: url('@/image.jpg');
+      background: url("@/image.jpg");
       background: url(http://example.com/image.jpg);
       background: url('http://example.com/image.jpg');
       background: url("http://example.com/image.jpg");

--- a/packages/@tailwindcss-node/src/urls.ts
+++ b/packages/@tailwindcss-node/src/urls.ts
@@ -149,9 +149,12 @@ async function doUrlReplace(
   return `${funcName}(${wrap}${newUrl}${wrap})`
 }
 
-function skipUrlReplacer(rawUrl: string) {
+function skipUrlReplacer(rawUrl: string, aliases?: string[]) {
   return (
-    isExternalUrl(rawUrl) || isDataUrl(rawUrl) || rawUrl[0] === '#' || functionCallRE.test(rawUrl)
+    isExternalUrl(rawUrl) ||
+    isDataUrl(rawUrl) ||
+    !rawUrl[0].match(/[\.a-zA-Z0-9_]/) ||
+    functionCallRE.test(rawUrl)
   )
 }
 


### PR DESCRIPTION
Closes #16039

This PR changes our URL rebasing logic used with Vite so that it does not rebase URLs that look like common alias paths (e.g. urls starting in `~`, `@` or `#`, etc.). Unfortunately this is only an approximation and you can configure an alias for a path that starts with a regular alphabetical character (e.g. `foo` => `./my/foo`) so this isn't a perfect fix, however in practice most aliases will be prefixed with a symbol to make it clear that it's an alias anyways.

One alternative we have considered is to only rebase URLs that we know are relative (so they need to start with a `.`). This, however, will break common CSS use cases where urls are loaded like this:

```css
background: image-set(
  url('image1.jpg') 1x,
  url('image2.jpg') 2x
);
``` 

So making this change felt like we only trade one GitHub issue for another one. 

In a more ideal scenario we try to resolve the URL with the Vite resolver (we have to run the resolver and can't rely on the `resolve` setting alone due to packages like [`vite-tsconfig-paths`](https://www.npmjs.com/package/vite-tsconfig-paths)), however even then we can have relative paths being resolvable to different files based on wether they were rebased or not (e.g. when an image with the same filename exists in two different paths).

So ultimately we settled on extending the already existing blocklist (which we have taken from the Vite implementation) for now.

## Test plan

- Added unit test and it was tested with the Vite playground.