### PR TITLE
Discard invalid declarations when parsing CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Vite: Transform `<style>` blocks in HTML files ([#16069](https://github.com/tailwindlabs/tailwindcss/pull/16069))
 - Prevent camelCasing CSS custom properties added by JavaScript plugins ([#16103](https://github.com/tailwindlabs/tailwindcss/pull/16103))
 - Do not emit `@keyframes` in `@theme reference` ([#16120](https://github.com/tailwindlabs/tailwindcss/pull/16120))
+- Discard invalid declarations when parsing CSS ([#16093](https://github.com/tailwindlabs/tailwindcss/pull/16093))
 
 ## [4.0.1] - 2025-01-29
 

--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -1041,6 +1041,34 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         },
       ])
     })
+
+    // TODO: These should probably be errors in some cases?
+    it('discards invalid declarations', () => {
+      // This shouldn't parse as a custom property declaration
+      expect(parse(`--foo`)).toEqual([])
+
+      // This shouldn't parse as a rule followed by a declaration
+      expect(parse(`@plugin "foo" {};`)).toEqual([
+        {
+          kind: 'at-rule',
+          name: '@plugin',
+          params: '"foo"',
+          nodes: [],
+        },
+      ])
+
+      // This shouldn't parse as consecutive declarations
+      expect(parse(`;;;`)).toEqual([])
+
+      // This shouldn't parse as a rule with a declaration inside of it
+      expect(parse(`.foo { bar }`)).toEqual([
+        {
+          kind: 'rule',
+          selector: '.foo',
+          nodes: [],
+        },
+      ])
+    })
   })
 
   describe('errors', () => {

--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -1145,12 +1145,12 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
     })
 
     it('should error when consecutive semicolons exist', () => {
-      expect(() => parse(';;;')).toThrowErrorMatchingInlineSnapshot(`[Error: Unexpected: \`;;;\`]`)
+      expect(() => parse(';;;')).toThrowErrorMatchingInlineSnapshot(`[Error: Unexpected semicolon]`)
     })
 
     it('should error when consecutive semicolons exist after a declaration', () => {
       expect(() => parse('.foo { color: red;;; }')).toThrowErrorMatchingInlineSnapshot(
-        `[Error: Unexpected: \`;;;\`]`,
+        `[Error: Unexpected semicolon]`,
       )
     })
   })

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -286,10 +286,12 @@ export function parse(input: string) {
       }
 
       let declaration = parseDeclaration(buffer, colonIdx)
-      if (parent) {
-        parent.nodes.push(declaration)
-      } else {
-        ast.push(declaration)
+      if (declaration) {
+        if (parent) {
+          parent.nodes.push(declaration)
+        } else {
+          ast.push(declaration)
+        }
       }
 
       buffer = ''
@@ -337,10 +339,12 @@ export function parse(input: string) {
       closingBracketStack[closingBracketStack.length - 1] !== ')'
     ) {
       let declaration = parseDeclaration(buffer)
-      if (parent) {
-        parent.nodes.push(declaration)
-      } else {
-        ast.push(declaration)
+      if (declaration) {
+        if (parent) {
+          parent.nodes.push(declaration)
+        } else {
+          ast.push(declaration)
+        }
       }
 
       buffer = ''
@@ -435,7 +439,10 @@ export function parse(input: string) {
 
           // Attach the declaration to the parent.
           if (parent) {
-            parent.nodes.push(parseDeclaration(buffer, colonIdx))
+            let node = parseDeclaration(buffer, colonIdx)
+            if (node) {
+              parent.nodes.push(node)
+            }
           }
         }
       }
@@ -543,7 +550,11 @@ export function parseAtRule(buffer: string, nodes: AstNode[] = []): AtRule {
   return atRule(buffer.trim(), '', nodes)
 }
 
-function parseDeclaration(buffer: string, colonIdx: number = buffer.indexOf(':')): Declaration {
+function parseDeclaration(
+  buffer: string,
+  colonIdx: number = buffer.indexOf(':'),
+): Declaration | null {
+  if (colonIdx === -1) return null
   let importantIdx = buffer.indexOf('!important', colonIdx + 1)
   return decl(
     buffer.slice(0, colonIdx).trim(),

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -286,14 +286,12 @@ export function parse(input: string) {
       }
 
       let declaration = parseDeclaration(buffer, colonIdx)
-      if (declaration) {
-        if (parent) {
-          parent.nodes.push(declaration)
-        } else {
-          ast.push(declaration)
-        }
+      if (!declaration) throw new Error(`Invalid custom property, expected a value`)
+
+      if (parent) {
+        parent.nodes.push(declaration)
       } else {
-        throw new Error(`Invalid custom property, expected a value`)
+        ast.push(declaration)
       }
 
       buffer = ''
@@ -341,26 +339,15 @@ export function parse(input: string) {
       closingBracketStack[closingBracketStack.length - 1] !== ')'
     ) {
       let declaration = parseDeclaration(buffer)
-      if (declaration) {
-        if (parent) {
-          parent.nodes.push(declaration)
-        } else {
-          ast.push(declaration)
-        }
-      } else if (input.charCodeAt(i - 1) === SEMICOLON || input.charCodeAt(i + 1) === SEMICOLON) {
-        let startSemiColonIdx = i
-        while (input.charCodeAt(startSemiColonIdx - 1) === SEMICOLON) {
-          startSemiColonIdx--
-        }
-        let endSemiColonIdx = i
-        while (input.charCodeAt(endSemiColonIdx) === SEMICOLON) {
-          endSemiColonIdx++
-        }
-        throw new Error(`Unexpected: \`${input.slice(startSemiColonIdx, endSemiColonIdx)}\``)
-      } else if (buffer.length == 0) {
-        throw new Error('Unexpected semicolon')
-      } else {
+      if (!declaration) {
+        if (buffer.length === 0) throw new Error('Unexpected semicolon')
         throw new Error(`Invalid declaration: \`${buffer.trim()}\``)
+      }
+
+      if (parent) {
+        parent.nodes.push(declaration)
+      } else {
+        ast.push(declaration)
       }
 
       buffer = ''
@@ -456,11 +443,9 @@ export function parse(input: string) {
           // Attach the declaration to the parent.
           if (parent) {
             let node = parseDeclaration(buffer, colonIdx)
-            if (node) {
-              parent.nodes.push(node)
-            } else {
-              throw new Error(`Invalid declaration: \`${buffer.trim()}\``)
-            }
+            if (!node) throw new Error(`Invalid declaration: \`${buffer.trim()}\``)
+
+            parent.nodes.push(node)
           }
         }
       }

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -292,6 +292,8 @@ export function parse(input: string) {
         } else {
           ast.push(declaration)
         }
+      } else {
+        throw new Error(`Invalid custom property, expected a value`)
       }
 
       buffer = ''
@@ -345,6 +347,20 @@ export function parse(input: string) {
         } else {
           ast.push(declaration)
         }
+      } else if (input.charCodeAt(i - 1) === SEMICOLON || input.charCodeAt(i + 1) === SEMICOLON) {
+        let startSemiColonIdx = i
+        while (input.charCodeAt(startSemiColonIdx - 1) === SEMICOLON) {
+          startSemiColonIdx--
+        }
+        let endSemiColonIdx = i
+        while (input.charCodeAt(endSemiColonIdx) === SEMICOLON) {
+          endSemiColonIdx++
+        }
+        throw new Error(`Unexpected: \`${input.slice(startSemiColonIdx, endSemiColonIdx)}\``)
+      } else if (buffer.length == 0) {
+        throw new Error('Unexpected semicolon')
+      } else {
+        throw new Error(`Invalid declaration: \`${buffer.trim()}\``)
       }
 
       buffer = ''
@@ -442,6 +458,8 @@ export function parse(input: string) {
             let node = parseDeclaration(buffer, colonIdx)
             if (node) {
               parent.nodes.push(node)
+            } else {
+              throw new Error(`Invalid declaration: \`${buffer.trim()}\``)
             }
           }
         }


### PR DESCRIPTION
I discovered this when triaging an error someone had on Tailwind Play.

1. When we see a `;` we often assume a valid declaration precedes it but that may not be the case
2. When we see the name of a custom property we assume everything that follows will be a valid declaration but that is not necessarily the case
3. A bare identifier inside of a rule is treated as a declaration which is not the case

This PR fixes all three of these by ignoring these invalid cases. Though some should probably be turned into errors.
