### PR TITLE
Feat: Adding a warning in the upgrade CLI when a config file contains non-migratable values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor gradient implementation to work around [prettier/prettier#17058](https://github.com/prettier/prettier/issues/17058) ([#16072](https://github.com/tailwindlabs/tailwindcss/pull/16072))
 - Vite: Ensure hot-reloading works with SolidStart setups ([#16052](https://github.com/tailwindlabs/tailwindcss/pull/16052))
 - Vite: Fix a crash when starting the development server in SolidStart setups ([#16052](https://github.com/tailwindlabs/tailwindcss/pull/16052))
-- Adding a warning when a config file contains non-migratable values ([#16073](https://github.com/tailwindlabs/tailwindcss/pull/16073))
+- Adding a warning when a config file contains non-migratable values in upgrade cli ([#16073](https://github.com/tailwindlabs/tailwindcss/pull/16073))
 
 ## [4.0.1] - 2025-01-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor gradient implementation to work around [prettier/prettier#17058](https://github.com/prettier/prettier/issues/17058) ([#16072](https://github.com/tailwindlabs/tailwindcss/pull/16072))
 - Vite: Ensure hot-reloading works with SolidStart setups ([#16052](https://github.com/tailwindlabs/tailwindcss/pull/16052))
 - Vite: Fix a crash when starting the development server in SolidStart setups ([#16052](https://github.com/tailwindlabs/tailwindcss/pull/16052))
-- Adding a warning when a config file contains non-migratable values in upgrade cli ([#16073](https://github.com/tailwindlabs/tailwindcss/pull/16073))
+- Adding a warning when a config file contains non-migratable values in upgrade cli ([#16113](https://github.com/tailwindlabs/tailwindcss/pull/16113))
 
 ## [4.0.1] - 2025-01-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor gradient implementation to work around [prettier/prettier#17058](https://github.com/prettier/prettier/issues/17058) ([#16072](https://github.com/tailwindlabs/tailwindcss/pull/16072))
 - Vite: Ensure hot-reloading works with SolidStart setups ([#16052](https://github.com/tailwindlabs/tailwindcss/pull/16052))
 - Vite: Fix a crash when starting the development server in SolidStart setups ([#16052](https://github.com/tailwindlabs/tailwindcss/pull/16052))
+- Adding a warning when a config file contains non-migratable values ([#16073](https://github.com/tailwindlabs/tailwindcss/pull/16073))
 
 ## [4.0.1] - 2025-01-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor gradient implementation to work around [prettier/prettier#17058](https://github.com/prettier/prettier/issues/17058) ([#16072](https://github.com/tailwindlabs/tailwindcss/pull/16072))
 - Vite: Ensure hot-reloading works with SolidStart setups ([#16052](https://github.com/tailwindlabs/tailwindcss/pull/16052))
 - Vite: Fix a crash when starting the development server in SolidStart setups ([#16052](https://github.com/tailwindlabs/tailwindcss/pull/16052))
-- Adding a warning when a config file contains non-migratable values in upgrade cli ([#16113](https://github.com/tailwindlabs/tailwindcss/pull/16113))
+- Adding a warning in the upgrade CLI when a config file contains non-migratable values. ([#16113](https://github.com/tailwindlabs/tailwindcss/pull/16113))
 
 ## [4.0.1] - 2025-01-29
 

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -298,8 +298,8 @@ function canMigrateConfig(unresolvedConfig: Config, source: string): boolean {
   ]
 
   if (Object.keys(unresolvedConfig).some((key) => !knownProperties.includes(key))) {
-    let unresolvedConfigExtraKeys = Object.keys(unresolvedConfig).filter(key => !knownProperties.includes(key))
-    info(`We have detected that your configuration file contains non-migratable values : ${highlight(unresolvedConfigExtraKeys.join(', '))}`, { prefix: '↳ ' })
+    let extraKeys = Object.keys(unresolvedConfig).filter(key => !knownProperties.includes(key))
+    info(`We have detected that your configuration file contains non-migratable values : ${highlight(extraKeys.join(', '))}`, { prefix: '↳ ' })
     return false
   }
 

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -298,6 +298,8 @@ function canMigrateConfig(unresolvedConfig: Config, source: string): boolean {
   ]
 
   if (Object.keys(unresolvedConfig).some((key) => !knownProperties.includes(key))) {
+    let unresolvedConfigExtraKeys = Object.keys(unresolvedConfig).filter(key => !knownProperties.includes(key))
+    info(`We have detected that your configuration file contains non-migratable values : ${highlight(unresolvedConfigExtraKeys.join(', '))}`, { prefix: '↳ ' })
     return false
   }
 


### PR DESCRIPTION
I encountered an issue in several of my projects during migration. I was unable to migrate correctly because my config file contained the now-deprecated "safelist" key. I had to reverse-engineer the problem to identify what was blocking me. To help others facing the same issue, I added this warning to inform them that they need to edit their config file for a smooth automatic migration.