### PR TITLE
Fix `@import url()` being stripped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Fix `@import url()` being stripped ([#16144](https://github.com/tailwindlabs/tailwindcss/pull/16144))
 
 ## [4.0.2] - 2025-01-31
 

--- a/packages/tailwindcss/src/ast.test.ts
+++ b/packages/tailwindcss/src/ast.test.ts
@@ -142,6 +142,7 @@ it('should not emit empty rules once optimized', () => {
     @layer foo, bar, baz;
     @custom-media --modern (color), (hover);
     @namespace 'http://www.w3.org/1999/xhtml';
+    @import url('https://fonts.googleapis.com/css2?family=Cedarville+Cursive&display=swap');
   `)
 
   expect(toCss(ast)).toMatchInlineSnapshot(`
@@ -174,6 +175,7 @@ it('should not emit empty rules once optimized', () => {
     @layer foo, bar, baz;
     @custom-media --modern (color), (hover);
     @namespace 'http://www.w3.org/1999/xhtml';
+    @import url('https://fonts.googleapis.com/css2?family=Cedarville+Cursive&display=swap');
     "
   `)
 
@@ -182,6 +184,7 @@ it('should not emit empty rules once optimized', () => {
     @layer foo, bar, baz;
     @custom-media --modern (color), (hover);
     @namespace 'http://www.w3.org/1999/xhtml';
+    @import url('https://fonts.googleapis.com/css2?family=Cedarville+Cursive&display=swap');
     "
   `)
 })

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -306,7 +306,8 @@ export function optimizeAst(ast: AstNode[]) {
         copy.name === '@layer' ||
         copy.name === '@charset' ||
         copy.name === '@custom-media' ||
-        copy.name === '@namespace'
+        copy.name === '@namespace' ||
+        copy.name === '@import'
       ) {
         parent.push(copy)
       }


### PR DESCRIPTION
Regression from #16121, where empty at-rules are stripped from output. There are some exceptions made (like `@layer`) but it seems `@import` was missed. This PR assumes that the non-`url()` `@import`s have already been dealt with up to this point.

Fixes #16136.
