### PR TITLE
Update upgrade CLI to handle `containers` config correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Nothing yet!
 
+### Fixed
+
+- Ensure that the `containers` JS theme key is added to the `--container-*` namespace. ([#16169](https://github.com/tailwindlabs/tailwindcss/pull/16169))
+
 ## [4.0.3] - 2025-02-01
 
 ### Fixed

--- a/packages/tailwindcss/src/compat/apply-config-to-theme.ts
+++ b/packages/tailwindcss/src/compat/apply-config-to-theme.ts
@@ -151,6 +151,7 @@ export function keyPathToCssProperty(path: string[]) {
   if (path[0] === 'borderRadius') path[0] = 'radius'
   if (path[0] === 'boxShadow') path[0] = 'shadow'
   if (path[0] === 'colors') path[0] = 'color'
+  if (path[0] === 'containers') path[0] = 'container'
   if (path[0] === 'fontFamily') path[0] = 'font'
   if (path[0] === 'fontSize') path[0] = 'text'
   if (path[0] === 'letterSpacing') path[0] = 'tracking'


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->

Right now, if you have

```js
{
  containers: {
    foo: "1rem",
  },
}
```

the generated CSS will be

```css
@theme {
  --containers-*: initial;
  --containers-foo: 1rem;
}
```

which is incorrect – it should be `container` not `containers`. Yes I spent a while thinking the Tailwind IntelliSense extension is not working, but in fact the extension is working fine and it's my CSS file that is invalid.