### PR TITLE
Ensure `@import url(…)` is hoisted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Ensure `@import url(…)` is hoisted ([#16203](https://github.com/tailwindlabs/tailwindcss/pull/16203))
 
 ## [4.0.3] - 2025-02-01
 

--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -1253,3 +1253,44 @@ test(
     `)
   },
 )
+
+test(
+  'external imports are properly hoisted to the top',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "dependencies": {
+            "tailwindcss": "workspace:^",
+            "@tailwindcss/cli": "workspace:^"
+          }
+        }
+      `,
+      'index.html': html`
+          <div class="underline flex"></div>
+        `,
+      'src/index.css': css`
+        @charset "UTF-8";
+        @import 'tailwindcss/utilities';
+        @import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
+      `,
+    },
+  },
+  async ({ fs, exec, expect }) => {
+    await exec('pnpm tailwindcss --input src/index.css --output dist/out.css')
+
+    expect(await fs.dumpFiles('./dist/*.css')).toMatchInlineSnapshot(`
+      "
+      --- ./dist/out.css ---
+      @charset "UTF-8";
+      @import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
+      .flex {
+        display: flex;
+      }
+      .underline {
+        text-decoration-line: underline;
+      }
+      "
+    `)
+  },
+)

--- a/packages/tailwindcss/src/test-utils/run.ts
+++ b/packages/tailwindcss/src/test-utils/run.ts
@@ -1,7 +1,11 @@
 import { Features, transform } from 'lightningcss'
 import { compile } from '..'
 
-export async function compileCss(css: string, candidates: string[] = [], options = {}) {
+export async function compileCss(
+  css: string,
+  candidates: string[] = [],
+  options: Parameters<typeof compile>[1] = {},
+) {
   let { build } = await compile(css, options)
   return optimizeCss(build(candidates)).trim()
 }


### PR DESCRIPTION
This PR fixes an issue where if you use `@import url(…);` _after_ the `@import "tailwindcss";`, then invalid CSS is being generated.

This is because the `@import "tailwindcss";` directive is being replaced with the actual generated CSS variables, utilities, etc. but the `@import url(…);` is kept as-is (Tailwind CSS doesn't handle these). This means that in the final CSS the `@import url(…)` could be in the middle of the generated CSS which is invalid.

```css
/* Invalid: */
@import "tailwindcss";
@import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
```

```css
/* Valid: */
@import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
@import "tailwindcss";
```

While the above examples should both work from a CSS perspective, this PR makes sure to hoist the `@import url(…);` rules. All non-external imports will be inlined already.

Once this PR is merged, both these situations are valid:
```css
/* Valid: */
@import "tailwindcss";
@import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
```

```css
/* Valid: */
@import "tailwindcss";
@import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
```

In order to do this correctly, we also have to make sure that the license comment and `@charset` is in the correct spot.

### Test plan

- Added a simple unit test
- Added an integration test
