### PR TITLE
Take `NODE_PATH` into account when resolving modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix missing `@keyframes` definition ([#16237](https://github.com/tailwindlabs/tailwindcss/pull/16237))
 - Vite: Skip parsing stylesheets with the `?commonjs-proxy` flag ([#16238](https://github.com/tailwindlabs/tailwindcss/pull/16238))
 - Fix `order-first` and `order-last` for Firefox ([#16266](https://github.com/tailwindlabs/tailwindcss/pull/16266))
+- Ensure `NODE_PATH` is respected when resolving JavaScript and CSS files ([#16274](https://github.com/tailwindlabs/tailwindcss/pull/16274))
 
 ## [4.0.3] - 2025-02-01
 

--- a/packages/@tailwindcss-node/src/compile.ts
+++ b/packages/@tailwindcss-node/src/compile.ts
@@ -193,12 +193,15 @@ async function importModule(path: string): Promise<any> {
   }
 }
 
+const modules = ['node_modules', ...(process.env.NODE_PATH ? [process.env.NODE_PATH] : [])]
+
 const cssResolver = EnhancedResolve.ResolverFactory.createResolver({
   fileSystem: new EnhancedResolve.CachedInputFileSystem(fs, 4000),
   useSyncFileSystemCalls: true,
   extensions: ['.css'],
   mainFields: ['style'],
   conditionNames: ['style'],
+  modules,
 })
 async function resolveCssId(
   id: string,
@@ -227,6 +230,7 @@ const esmResolver = EnhancedResolve.ResolverFactory.createResolver({
   useSyncFileSystemCalls: true,
   extensions: ['.js', '.json', '.node', '.ts'],
   conditionNames: ['node', 'import'],
+  modules,
 })
 
 const cjsResolver = EnhancedResolve.ResolverFactory.createResolver({
@@ -234,6 +238,7 @@ const cjsResolver = EnhancedResolve.ResolverFactory.createResolver({
   useSyncFileSystemCalls: true,
   extensions: ['.js', '.json', '.node', '.ts'],
   conditionNames: ['node', 'require'],
+  modules,
 })
 
 async function resolveJsId(


### PR DESCRIPTION
Fixes #15847

This PR changes the node specific resolver config to takes the eventual `NODE_PATH` env into account.

## Test plan

See #15847

<img width="1273" alt="Screenshot 2025-02-05 at 12 58 20" src="https://github.com/user-attachments/assets/8e1b99d1-608d-437a-a7b2-212feb153da5" />
