### PR TITLE
Add Freebsd build target

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -163,8 +163,6 @@ jobs:
           run: |
             sudo pkg install -y -f curl node libnghttp2 npm
             sudo npm install -g pnpm --unsafe-perm=true
-            node --version
-            pnpm --version
             curl https://sh.rustup.rs -sSf --output rustup.sh
             sh rustup.sh -y --profile minimal --default-toolchain beta
             source "$HOME/.cargo/env"
@@ -174,7 +172,7 @@ jobs:
             node -v
             echo "~~~~ pnpm --version ~~~~"
             pnpm --version
-            pnpm install || true
+            pnpm install --ignore-scripts --filter=!./playgrounds/* || true
             pnpm run --filter ${{ env.OXIDE_LOCATION }} build
             strip -x ${{ env.OXIDE_LOCATION }}/*.node
             ls -la ${{ env.OXIDE_LOCATION }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -162,7 +162,7 @@ jobs:
           shell: bash
           run: |
             sudo pkg install -y -f curl node libnghttp2 npm
-            npm install -g pnpm --unsafe-perm=true
+            sudo npm install -g pnpm --unsafe-perm=true
             node --version
             pnpm --version
             curl https://sh.rustup.rs -sSf --output rustup.sh

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -3,6 +3,8 @@ name: Prepare Release
 on:
   workflow_dispatch:
   push:
+    branches:
+      - fix/freebsd
     tags:
       - 'v*'
 
@@ -137,6 +139,51 @@ jobs:
           name: bindings-${{ matrix.target }}
           path: ${{ env.OXIDE_LOCATION }}/*.node
 
+  build-freebsd:
+    name: Build x86_64-unknown-freebsd (OXIDE)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build FreeBSD
+        uses: cross-platform-actions/action@v0.25.0
+        env:
+          DEBUG: napi:*
+          RUSTUP_HOME: /usr/local/rustup
+          CARGO_HOME: /usr/local/cargo
+          RUSTUP_IO_THREADS: 1
+          RUST_TARGET: x86_64-unknown-freebsd
+        with:
+          operating_system: freebsd
+          version: '14.0'
+          memory: 13G
+          cpu_count: 3
+          environment_variables: 'DEBUG RUSTUP_IO_THREADS'
+          shell: bash
+          run: |
+            sudo pkg install -y -f curl node libnghttp2 npm
+            npm install -g pnpm
+            node --version
+            pnpm --version
+            curl https://sh.rustup.rs -sSf --output rustup.sh
+            sh rustup.sh -y --profile minimal --default-toolchain beta
+            source "$HOME/.cargo/env"
+            echo "~~~~ rustc --version ~~~~"
+            rustc --version
+            echo "~~~~ node -v ~~~~"
+            node -v
+            echo "~~~~ pnpm --version ~~~~"
+            pnpm --version
+            pnpm install || true
+            pnpm run --filter ${{ env.OXIDE_LOCATION }} build
+            strip -x ${{ env.OXIDE_LOCATION }}/*.node
+            ls -la ${{ env.OXIDE_LOCATION }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bindings-x86_64-unknown-freebsd
+          path: ${{ env.OXIDE_LOCATION }}/*.node
+
   prepare:
     runs-on: macos-14
     timeout-minutes: 15
@@ -217,6 +264,7 @@ jobs:
           cp bindings-armv7-unknown-linux-gnueabihf/* ./npm/linux-arm-gnueabihf/
           cp bindings-x86_64-unknown-linux-gnu/* ./npm/linux-x64-gnu/
           cp bindings-x86_64-unknown-linux-musl/* ./npm/linux-x64-musl/
+          cp bindings-x86_64-unknown-freebsd/* ./npm/freebsd-x64/
 
       - name: Build Tailwind CSS
         run: pnpm run build
@@ -240,19 +288,19 @@ jobs:
           name: tailwindcss-standalone
           path: packages/@tailwindcss-standalone/dist/
 
-      - name: Prepare GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          draft: true
-          tag_name: ${{ env.TAG_NAME }}
-          body: |
-            ${{ env.RELEASE_NOTES }}
-          files: |
-            packages/@tailwindcss-standalone/dist/sha256sums.txt
-            packages/@tailwindcss-standalone/dist/tailwindcss-linux-arm64
-            packages/@tailwindcss-standalone/dist/tailwindcss-linux-arm64-musl
-            packages/@tailwindcss-standalone/dist/tailwindcss-linux-x64
-            packages/@tailwindcss-standalone/dist/tailwindcss-linux-x64-musl
-            packages/@tailwindcss-standalone/dist/tailwindcss-macos-arm64
-            packages/@tailwindcss-standalone/dist/tailwindcss-macos-x64
-            packages/@tailwindcss-standalone/dist/tailwindcss-windows-x64.exe
+      # - name: Prepare GitHub Release
+      #   uses: softprops/action-gh-release@v2
+      #   with:
+      #     draft: true
+      #     tag_name: ${{ env.TAG_NAME }}
+      #     body: |
+      #       ${{ env.RELEASE_NOTES }}
+      #     files: |
+      #       packages/@tailwindcss-standalone/dist/sha256sums.txt
+      #       packages/@tailwindcss-standalone/dist/tailwindcss-linux-arm64
+      #       packages/@tailwindcss-standalone/dist/tailwindcss-linux-arm64-musl
+      #       packages/@tailwindcss-standalone/dist/tailwindcss-linux-x64
+      #       packages/@tailwindcss-standalone/dist/tailwindcss-linux-x64-musl
+      #       packages/@tailwindcss-standalone/dist/tailwindcss-macos-arm64
+      #       packages/@tailwindcss-standalone/dist/tailwindcss-macos-x64
+      #       packages/@tailwindcss-standalone/dist/tailwindcss-windows-x64.exe

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -162,7 +162,7 @@ jobs:
           shell: bash
           run: |
             sudo pkg install -y -f curl node libnghttp2 npm
-            npm install -g pnpm
+            npm install -g pnpm --unsafe-perm=true
             node --version
             pnpm --version
             curl https://sh.rustup.rs -sSf --output rustup.sh

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -3,8 +3,6 @@ name: Prepare Release
 on:
   workflow_dispatch:
   push:
-    branches:
-      - fix/freebsd
     tags:
       - 'v*'
 
@@ -286,19 +284,19 @@ jobs:
           name: tailwindcss-standalone
           path: packages/@tailwindcss-standalone/dist/
 
-      # - name: Prepare GitHub Release
-      #   uses: softprops/action-gh-release@v2
-      #   with:
-      #     draft: true
-      #     tag_name: ${{ env.TAG_NAME }}
-      #     body: |
-      #       ${{ env.RELEASE_NOTES }}
-      #     files: |
-      #       packages/@tailwindcss-standalone/dist/sha256sums.txt
-      #       packages/@tailwindcss-standalone/dist/tailwindcss-linux-arm64
-      #       packages/@tailwindcss-standalone/dist/tailwindcss-linux-arm64-musl
-      #       packages/@tailwindcss-standalone/dist/tailwindcss-linux-x64
-      #       packages/@tailwindcss-standalone/dist/tailwindcss-linux-x64-musl
-      #       packages/@tailwindcss-standalone/dist/tailwindcss-macos-arm64
-      #       packages/@tailwindcss-standalone/dist/tailwindcss-macos-x64
-      #       packages/@tailwindcss-standalone/dist/tailwindcss-windows-x64.exe
+      - name: Prepare GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          tag_name: ${{ env.TAG_NAME }}
+          body: |
+            ${{ env.RELEASE_NOTES }}
+          files: |
+            packages/@tailwindcss-standalone/dist/sha256sums.txt
+            packages/@tailwindcss-standalone/dist/tailwindcss-linux-arm64
+            packages/@tailwindcss-standalone/dist/tailwindcss-linux-arm64-musl
+            packages/@tailwindcss-standalone/dist/tailwindcss-linux-x64
+            packages/@tailwindcss-standalone/dist/tailwindcss-linux-x64-musl
+            packages/@tailwindcss-standalone/dist/tailwindcss-macos-arm64
+            packages/@tailwindcss-standalone/dist/tailwindcss-macos-x64
+            packages/@tailwindcss-standalone/dist/tailwindcss-windows-x64.exe

--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -136,6 +136,49 @@ jobs:
           name: bindings-${{ matrix.target }}
           path: ${{ env.OXIDE_LOCATION }}/*.node
 
+  build-freebsd:
+    name: Build x86_64-unknown-freebsd (OXIDE)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build FreeBSD
+        uses: cross-platform-actions/action@v0.25.0
+        env:
+          DEBUG: napi:*
+          RUSTUP_HOME: /usr/local/rustup
+          CARGO_HOME: /usr/local/cargo
+          RUSTUP_IO_THREADS: 1
+          RUST_TARGET: x86_64-unknown-freebsd
+        with:
+          operating_system: freebsd
+          version: '14.0'
+          memory: 13G
+          cpu_count: 3
+          environment_variables: 'DEBUG RUSTUP_IO_THREADS'
+          shell: bash
+          run: |
+            sudo pkg install -y -f curl node libnghttp2 npm
+            sudo npm install -g pnpm --unsafe-perm=true
+            curl https://sh.rustup.rs -sSf --output rustup.sh
+            sh rustup.sh -y --profile minimal --default-toolchain beta
+            source "$HOME/.cargo/env"
+            echo "~~~~ rustc --version ~~~~"
+            rustc --version
+            echo "~~~~ node -v ~~~~"
+            node -v
+            echo "~~~~ pnpm --version ~~~~"
+            pnpm --version
+            pnpm install --ignore-scripts --filter=!./playgrounds/* || true
+            pnpm run --filter ${{ env.OXIDE_LOCATION }} build
+            strip -x ${{ env.OXIDE_LOCATION }}/*.node
+            ls -la ${{ env.OXIDE_LOCATION }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bindings-x86_64-unknown-freebsd
+          path: ${{ env.OXIDE_LOCATION }}/*.node
+
   release:
     runs-on: macos-14
     timeout-minutes: 15
@@ -214,6 +257,7 @@ jobs:
           cp bindings-armv7-unknown-linux-gnueabihf/* ./npm/linux-arm-gnueabihf/
           cp bindings-x86_64-unknown-linux-gnu/* ./npm/linux-x64-gnu/
           cp bindings-x86_64-unknown-linux-musl/* ./npm/linux-x64-musl/
+          cp bindings-x86_64-unknown-freebsd/* ./npm/freebsd-x64/
 
       - name: 'Version based on commit: 0.0.0-${{ env.RELEASE_CHANNEL }}.${{ env.SHA_SHORT }}'
         run: pnpm run version-packages 0.0.0-${{ env.RELEASE_CHANNEL }}.${{ env.SHA_SHORT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,49 @@ jobs:
           name: bindings-${{ matrix.target }}
           path: ${{ env.OXIDE_LOCATION }}/*.node
 
+  build-freebsd:
+    name: Build x86_64-unknown-freebsd (OXIDE)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build FreeBSD
+        uses: cross-platform-actions/action@v0.25.0
+        env:
+          DEBUG: napi:*
+          RUSTUP_HOME: /usr/local/rustup
+          CARGO_HOME: /usr/local/cargo
+          RUSTUP_IO_THREADS: 1
+          RUST_TARGET: x86_64-unknown-freebsd
+        with:
+          operating_system: freebsd
+          version: '14.0'
+          memory: 13G
+          cpu_count: 3
+          environment_variables: 'DEBUG RUSTUP_IO_THREADS'
+          shell: bash
+          run: |
+            sudo pkg install -y -f curl node libnghttp2 npm
+            sudo npm install -g pnpm --unsafe-perm=true
+            curl https://sh.rustup.rs -sSf --output rustup.sh
+            sh rustup.sh -y --profile minimal --default-toolchain beta
+            source "$HOME/.cargo/env"
+            echo "~~~~ rustc --version ~~~~"
+            rustc --version
+            echo "~~~~ node -v ~~~~"
+            node -v
+            echo "~~~~ pnpm --version ~~~~"
+            pnpm --version
+            pnpm install --ignore-scripts --filter=!./playgrounds/* || true
+            pnpm run --filter ${{ env.OXIDE_LOCATION }} build
+            strip -x ${{ env.OXIDE_LOCATION }}/*.node
+            ls -la ${{ env.OXIDE_LOCATION }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: bindings-x86_64-unknown-freebsd
+          path: ${{ env.OXIDE_LOCATION }}/*.node
+
   release:
     runs-on: macos-14
     timeout-minutes: 15
@@ -209,6 +252,7 @@ jobs:
           cp bindings-armv7-unknown-linux-gnueabihf/* ./npm/linux-arm-gnueabihf/
           cp bindings-x86_64-unknown-linux-gnu/* ./npm/linux-x64-gnu/
           cp bindings-x86_64-unknown-linux-musl/* ./npm/linux-x64-musl/
+          cp bindings-x86_64-unknown-freebsd/* ./npm/freebsd-x64/
 
       - name: Build Tailwind CSS
         run: pnpm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix missing `@keyframes` definition ([#16237](https://github.com/tailwindlabs/tailwindcss/pull/16237))
 - Vite: Skip parsing stylesheets with the `?commonjs-proxy` flag ([#16238](https://github.com/tailwindlabs/tailwindcss/pull/16238))
 - Fix `order-first` and `order-last` for Firefox ([#16266](https://github.com/tailwindlabs/tailwindcss/pull/16266))
+- Ensure Node addons are packaged correctly with FreeBSD builds ([#16277](https://github.com/tailwindlabs/tailwindcss/pull/16277))
 
 ## [4.0.3] - 2025-02-01
 


### PR DESCRIPTION
Closes #15731

This PR adds a FreeBSD build target to our CI workflows. It was tested on CI: https://github.com/tailwindlabs/tailwindcss/actions/runs/13159185517/job/36723613079

However, due to the build not emitting final npm packages, we don't have a way to actually test the final package before we ship it to an insiders release.