### PR TITLE
Remove useless `console.log` in `@tailwind/vite` package

### DIFF
--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -318,7 +318,6 @@ function isPotentialCssRootFile(id: string) {
     // Don't intercept special static asset resources
     !SPECIAL_QUERY_RE.test(id) &&
     !COMMON_JS_PROXY_RE.test(id)
-  if (isCssFile) console.log(id)
   return isCssFile
 }
 


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->

This PR removes a (seemingly) unwanted `console.log` in the `@tailwind/vite` package.

I discovered this when I updated tailwind in my `astro` project, each `.astro` component log the full path of an imported `.css` file.

It seems that this was the commit that introduced it: https://github.com/tailwindlabs/tailwindcss/commit/e1a85ac260e065c069307deb7f908bc46035a3e5
