### PR TITLE
Cleanup Tailwind Play workflow

### DIFF
--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -285,8 +285,5 @@ jobs:
               owner: 'tailwindlabs',
               repo: 'play.tailwindcss.com',
               ref: 'master',
-              workflow_id: 'upgrade-tailwindcss.yml',
-              inputs: {
-                insidersVersion: '0.0.0-${{ env.RELEASE_CHANNEL }}.${{ env.SHA_SHORT }}'
-              }
+              workflow_id: 'upgrade-tailwindcss.yml'
             })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,8 +283,5 @@ jobs:
               owner: 'tailwindlabs',
               repo: 'play.tailwindcss.com',
               ref: 'master',
-              workflow_id: 'upgrade-tailwindcss.yml',
-              inputs: {
-                version: '${{ env.TAILWINDCSS_VERSION }}'
-              }
+              workflow_id: 'upgrade-tailwindcss.yml'
             })


### PR DESCRIPTION
This PR cleans up the Tailwind Play update by removing unnecessary inputs because Tailwind Play will take care of this.
