### PR TITLE
Add `tailwindcss/lib/util/flattenColorPalette.js` export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Export `tailwindcss/lib/util/flattenColorPalette.js` for backward compatibility ([#16411](https://github.com/tailwindlabs/tailwindcss/pull/16411))
 
 ## [4.0.6] - 2025-02-10
 

--- a/packages/tailwindcss/package.json
+++ b/packages/tailwindcss/package.json
@@ -103,6 +103,10 @@
         "require": "./dist/flatten-color-palette.js",
         "import": "./dist/flatten-color-palette.mjs"
       },
+      "./lib/util/flattenColorPalette.js": {
+        "require": "./dist/flatten-color-palette.js",
+        "import": "./dist/flatten-color-palette.mjs"
+      },
       "./package.json": "./package.json",
       "./index.css": "./index.css",
       "./index": "./index.css",

--- a/packages/tailwindcss/package.json
+++ b/packages/tailwindcss/package.json
@@ -35,6 +35,10 @@
       "require": "./src/compat/flatten-color-palette.cts",
       "import": "./src/compat/flatten-color-palette.ts"
     },
+    "./lib/util/flattenColorPalette.js": {
+      "require": "./src/compat/flatten-color-palette.cts",
+      "import": "./src/compat/flatten-color-palette.ts"
+    },
     "./defaultTheme": {
       "require": "./src/compat/default-theme.cts",
       "import": "./src/compat/default-theme.ts"


### PR DESCRIPTION
Closes #16401

This adds a `tailwindcss/lib/util/flattenColorPalette.js` (notice the `.js` suffix) inline with our other exports.