### PR TITLE
Vite: Add option to disable module-graph based scanning and turn it on for Astro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - _Experimental_: Add `user-valid` and `user-invalid` variants ([#12370](https://github.com/tailwindlabs/tailwindcss/pull/12370))
+- Vite: Add a new `scanner` option to disable module-graph based scanning ([#16425](https://github.com/tailwindlabs/tailwindcss/pull/16425))
 
 ### Fixed
 
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Export backwards compatible config and plugin types from `tailwindcss/plugin` ([#16505](https://github.com/tailwindlabs/tailwindcss/pull/16505))
 - Upgrade: Report errors when updating dependencies ([#16504](https://github.com/tailwindlabs/tailwindcss/pull/16504))
 - Upgrade: Ensure a `darkMode` JS config setting with block syntax converts to use `@slot` ([#16507](https://github.com/tailwindlabs/tailwindcss/pull/16507))
+- Vite: Ensure that Astro builds with client-only components are always scanned ([#16425](https://github.com/tailwindlabs/tailwindcss/pull/16425))
 
 ## [4.0.6] - 2025-02-10
 

--- a/integrations/vite/astro.test.ts
+++ b/integrations/vite/astro.test.ts
@@ -1,4 +1,4 @@
-import { candidate, fetchStyles, html, json, retryAssertion, test, ts } from '../utils'
+import { candidate, fetchStyles, html, js, json, retryAssertion, test, ts } from '../utils'
 
 test(
   'dev mode',
@@ -19,11 +19,7 @@ test(
         import { defineConfig } from 'astro/config'
 
         // https://astro.build/config
-        export default defineConfig({
-          vite: {
-            plugins: [tailwindcss()],
-          },
-        })
+        export default defineConfig({ vite: { plugins: [tailwindcss()] } })
       `,
       'src/pages/index.astro': html`
        <div class="underline">Hello, world!</div>
@@ -68,5 +64,60 @@ test(
       expect(css).toContain(candidate`underline`)
       expect(css).toContain(candidate`font-bold`)
     })
+  },
+)
+
+test(
+  'build mode',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "type": "module",
+          "dependencies": {
+            "astro": "^4.15.2",
+            "react": "^19",
+            "react-dom": "^19",
+            "@astrojs/react": "^4",
+            "@tailwindcss/vite": "workspace:^",
+            "tailwindcss": "workspace:^"
+          }
+        }
+      `,
+      'astro.config.mjs': ts`
+        import tailwindcss from '@tailwindcss/vite'
+        import react from '@astrojs/react'
+        import { defineConfig } from 'astro/config'
+
+        // https://astro.build/config
+        export default defineConfig({ vite: { plugins: [tailwindcss()] }, integrations: [react()] })
+      `,
+      'src/pages/index.astro': html`
+        ---
+        import ClientOnly from './client-only';
+        ---
+
+        <div class="underline">Hello, world!</div>
+
+        <ClientOnly client:only="react" />
+
+        <style is:global>
+          @import 'tailwindcss';
+        </style>
+      `,
+      'src/pages/client-only.jsx': js`
+        export default function ClientOnly() {
+          return <div className="overline">Hello, world!</div>
+        }
+      `,
+    },
+  },
+  async ({ fs, exec, expect }) => {
+    await exec('pnpm astro build')
+
+    let files = await fs.glob('dist/**/*.css')
+    expect(files).toHaveLength(1)
+
+    await fs.expectFileToContain(files[0][0], [candidate`underline`, candidate`overline`])
   },
 )

--- a/integrations/vite/astro.test.ts
+++ b/integrations/vite/astro.test.ts
@@ -92,9 +92,10 @@ test(
         // https://astro.build/config
         export default defineConfig({ vite: { plugins: [tailwindcss()] }, integrations: [react()] })
       `,
+      // prettier-ignore
       'src/pages/index.astro': html`
         ---
-        import ClientOnly from './client-only';
+        import ClientOnly from '../components/client-only';
         ---
 
         <div class="underline">Hello, world!</div>
@@ -105,7 +106,7 @@ test(
           @import 'tailwindcss';
         </style>
       `,
-      'src/pages/client-only.jsx': js`
+      'src/components/client-only.jsx': js`
         export default function ClientOnly() {
           return <div className="overline">Hello, world!</div>
         }

--- a/integrations/vite/astro.test.ts
+++ b/integrations/vite/astro.test.ts
@@ -92,10 +92,9 @@ test(
         // https://astro.build/config
         export default defineConfig({ vite: { plugins: [tailwindcss()] }, integrations: [react()] })
       `,
-      // prettier-ignore
       'src/pages/index.astro': html`
         ---
-        import ClientOnly from '../components/client-only';
+        import ClientOnly from './client-only';
         ---
 
         <div class="underline">Hello, world!</div>
@@ -106,7 +105,7 @@ test(
           @import 'tailwindcss';
         </style>
       `,
-      'src/components/client-only.jsx': js`
+      'src/pages/client-only.jsx': js`
         export default function ClientOnly() {
           return <div className="overline">Hello, world!</div>
         }

--- a/integrations/vite/react-router.test.ts
+++ b/integrations/vite/react-router.test.ts
@@ -1,0 +1,178 @@
+import { candidate, css, fetchStyles, json, retryAssertion, test, ts, txt } from '../utils'
+
+const WORKSPACE = {
+  'package.json': json`
+    {
+      "type": "module",
+      "dependencies": {
+        "@react-router/dev": "^7",
+        "@react-router/node": "^7",
+        "@react-router/serve": "^7",
+        "@tailwindcss/vite": "workspace:^",
+        "@types/node": "^20",
+        "@types/react-dom": "^19",
+        "@types/react": "^19",
+        "isbot": "^5",
+        "react-dom": "^19",
+        "react-router": "^7",
+        "react": "^19",
+        "tailwindcss": "workspace:^",
+        "vite": "^5"
+      }
+    }
+  `,
+  'react-router.config.ts': ts`
+    import type { Config } from '@react-router/dev/config'
+    export default { ssr: true } satisfies Config
+  `,
+  'vite.config.ts': ts`
+    import { defineConfig } from 'vite'
+    import { reactRouter } from '@react-router/dev/vite'
+    import tailwindcss from '@tailwindcss/vite'
+
+    export default defineConfig({
+      plugins: [tailwindcss(), reactRouter()],
+    })
+  `,
+  'app/routes/home.tsx': ts`
+    export default function Home() {
+      return <h1 className="font-bold">Welcome to React Router</h1>
+    }
+  `,
+  'app/app.css': css`@import 'tailwindcss';`,
+  'app/routes.ts': ts`
+    import { type RouteConfig, index } from '@react-router/dev/routes'
+    export default [index('routes/home.tsx')] satisfies RouteConfig
+  `,
+  'app/root.tsx': ts`
+    import { Links, Meta, Outlet, Scripts, ScrollRestoration } from 'react-router'
+    import './app.css'
+    export function Layout({ children }: { children: React.ReactNode }) {
+      return (
+        <html lang="en">
+          <head>
+            <meta charSet="utf-8" />
+            <meta name="viewport" content="width=device-width, initial-scale=1" />
+            <Meta />
+            <Links />
+          </head>
+          <body>
+            {children}
+            <ScrollRestoration />
+            <Scripts />
+          </body>
+        </html>
+      )
+    }
+
+    export default function App() {
+      return <Outlet />
+    }
+  `,
+}
+
+test('dev mode', { fs: WORKSPACE }, async ({ fs, spawn, expect }) => {
+  let process = await spawn('pnpm react-router dev')
+
+  let url = ''
+  await process.onStdout((m) => {
+    let match = /Local:\s*(http.*)\//.exec(m)
+    if (match) url = match[1]
+    return Boolean(url)
+  })
+
+  await retryAssertion(async () => {
+    let css = await fetchStyles(url)
+    expect(css).toContain(candidate`font-bold`)
+  })
+
+  await retryAssertion(async () => {
+    await fs.write(
+      'app/routes/home.tsx',
+      ts`
+        export default function Home() {
+          return <h1 className="font-bold underline">Welcome to React Router</h1>
+        }
+      `,
+    )
+
+    let css = await fetchStyles(url)
+    expect(css).toContain(candidate`underline`)
+    expect(css).toContain(candidate`font-bold`)
+  })
+})
+
+test('build mode', { fs: WORKSPACE }, async ({ spawn, exec, expect }) => {
+  await exec('pnpm react-router build')
+  let process = await spawn('pnpm react-router-serve ./build/server/index.js')
+
+  let url = ''
+  await process.onStdout((m) => {
+    let match = /\[react-router-serve\]\s*(http.*)\ \/?/.exec(m)
+    if (match) url = match[1]
+    return url != ''
+  })
+
+  await retryAssertion(async () => {
+    let css = await fetchStyles(url)
+    expect(css).toContain(candidate`font-bold`)
+  })
+})
+
+test(
+  'build mode using ?url stylesheet imports should only build one stylesheet (requires `file-system` scanner)',
+  {
+    fs: {
+      ...WORKSPACE,
+      'app/root.tsx': ts`
+        import { Links, Meta, Outlet, Scripts, ScrollRestoration } from 'react-router'
+        import styles from './app.css?url'
+        export const links: Route.LinksFunction = () => [{ rel: 'stylesheet', href: styles }]
+        export function Layout({ children }: { children: React.ReactNode }) {
+          return (
+            <html lang="en">
+              <head>
+                <meta charSet="utf-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1" />
+                <Meta />
+                <Links />
+              </head>
+              <body class="dark">
+                {children}
+                <ScrollRestoration />
+                <Scripts />
+              </body>
+            </html>
+          )
+        }
+
+        export default function App() {
+          return <Outlet />
+        }
+      `,
+      'vite.config.ts': ts`
+        import { defineConfig } from 'vite'
+        import { reactRouter } from '@react-router/dev/vite'
+        import tailwindcss from '@tailwindcss/vite'
+
+        export default defineConfig({
+          plugins: [tailwindcss({ scanner: 'file-system' }), reactRouter()],
+        })
+      `,
+      '.gitignore': txt`
+        node_modules/
+        build/
+      `,
+    },
+  },
+  async ({ fs, exec, expect }) => {
+    await exec('pnpm react-router build')
+
+    let files = await fs.glob('build/client/assets/**/*.css')
+
+    expect(files).toHaveLength(1)
+    let [filename] = files[0]
+
+    await fs.expectFileToContain(filename, [candidate`font-bold`])
+  },
+)

--- a/integrations/vite/ssr.test.ts
+++ b/integrations/vite/ssr.test.ts
@@ -1,5 +1,30 @@
 import { candidate, css, html, json, test, ts } from '../utils'
 
+const WORKSPACE = {
+  'index.html': html`
+    <body>
+      <div id="app"></div>
+      <script type="module" src="./src/index.ts"></script>
+    </body>
+  `,
+  'src/index.css': css`@import 'tailwindcss';`,
+  'src/index.ts': ts`
+    import './index.css'
+
+    document.querySelector('#app').innerHTML = \`
+      <div class="underline m-2">Hello, world!</div>
+    \`
+  `,
+  'server.ts': ts`
+    import css from './src/index.css?url'
+
+    document.querySelector('#app').innerHTML = \`
+      <link rel="stylesheet" href="\${css}">
+      <div class="overline m-3">Hello, world!</div>
+    \`
+  `,
+}
+
 test(
   'Vite 5',
   {
@@ -26,32 +51,10 @@ test(
             cssMinify: false,
             ssrEmitAssets: true,
           },
-          plugins: [tailwindcss()],
-          ssr: { resolve: { conditions: [] } },
+          plugins: [tailwindcss({ scanner: 'file-system' })],
         })
       `,
-      'index.html': html`
-        <body>
-          <div id="app"></div>
-          <script type="module" src="./src/index.ts"></script>
-        </body>
-      `,
-      'src/index.css': css`@import 'tailwindcss';`,
-      'src/index.ts': ts`
-        import './index.css'
-
-        document.querySelector('#app').innerHTML = \`
-          <div class="underline m-2">Hello, world!</div>
-        \`
-      `,
-      'server.ts': ts`
-        import css from './src/index.css?url'
-
-        document.querySelector('#app').innerHTML = \`
-          <link rel="stylesheet" href="\${css}">
-          <div class="underline m-2">Hello, world!</div>
-        \`
-      `,
+      ...WORKSPACE,
     },
   },
   async ({ fs, exec, expect }) => {
@@ -62,9 +65,10 @@ test(
     let [filename] = files[0]
 
     await fs.expectFileToContain(filename, [
-      //
       candidate`underline`,
       candidate`m-2`,
+      candidate`overline`,
+      candidate`m-3`,
     ])
   },
 )
@@ -94,32 +98,10 @@ test(
             cssMinify: false,
             ssrEmitAssets: true,
           },
-          plugins: [tailwindcss()],
-          ssr: { resolve: { conditions: [] } },
+          plugins: [tailwindcss({ scanner: 'file-system' })],
         })
       `,
-      'index.html': html`
-        <body>
-          <div id="app"></div>
-          <script type="module" src="./src/index.ts"></script>
-        </body>
-      `,
-      'src/index.css': css`@import 'tailwindcss';`,
-      'src/index.ts': ts`
-        import './index.css'
-
-        document.querySelector('#app').innerHTML = \`
-          <div class="underline m-2">Hello, world!</div>
-        \`
-      `,
-      'server.ts': ts`
-        import css from './src/index.css?url'
-
-        document.querySelector('#app').innerHTML = \`
-          <link rel="stylesheet" href="\${css}">
-          <div class="underline m-2">Hello, world!</div>
-        \`
-      `,
+      ...WORKSPACE,
     },
   },
   async ({ fs, exec, expect }) => {
@@ -130,9 +112,10 @@ test(
     let [filename] = files[0]
 
     await fs.expectFileToContain(filename, [
-      //
       candidate`underline`,
       candidate`m-2`,
+      candidate`overline`,
+      candidate`m-3`,
     ])
   },
 )

--- a/packages/@tailwindcss-vite/README.md
+++ b/packages/@tailwindcss-vite/README.md
@@ -21,9 +21,42 @@
 
 ---
 
+# `@tailwindcss/vite`
+
 ## Documentation
 
 For full documentation, visit [tailwindcss.com](https://tailwindcss.com).
+
+---
+
+## Advanced topics
+
+### API reference
+
+The Vite plugin can be configured by passing an object to the `tailwindcss()`. Here is a full list of available options:
+
+| Property                                      | Values                                    |
+| --------------------------------------------- | ----------------------------------------- |
+| [`scanner`](#disabling-module-graph-scanning) | `module-graph` _(default)_, `file-system` |
+
+### Disabling module-graph scanning
+
+Our Vite plugin is designed to take the Vite module graph into account when scanning for utilities used in your project. This will work well in most cases since the module graph contains all markup that will be in your final build.
+
+However, sometimes your Vite setup is split across different build steps (e.g. when using SSR builds). If that is the case, you might find that the client build might contain more utilities since it traverses all components while the server build doesn't.
+
+To ensure that both builds read all components from your project, set the `scanner` option to `file-system`:
+
+```js
+import { defineConfig } from 'vite'
+import tailwindcss from '@tailwindcss/vite'
+
+export default defineConfig({
+  plugins: [tailwindcss({ scanner: 'file-system' })],
+})
+```
+
+---
 
 ## Community
 

--- a/packages/@tailwindcss-vite/README.md
+++ b/packages/@tailwindcss-vite/README.md
@@ -35,9 +35,9 @@ For full documentation, visit [tailwindcss.com](https://tailwindcss.com).
 
 The Vite plugin can be configured by passing an object to the `tailwindcss()`. Here is a full list of available options:
 
-| Property                                      | Values                                    |
-| --------------------------------------------- | ----------------------------------------- |
-| [`scanner`](#disabling-module-graph-scanning) | `module-graph` _(default)_, `file-system` |
+| Property                                      | Values                                                 |
+| --------------------------------------------- | ------------------------------------------------------ |
+| [`scanner`](#disabling-module-graph-scanning) | `automatic` _(default)_, `module-graph`, `file-system` |
 
 ### Disabling module-graph scanning
 
@@ -45,7 +45,9 @@ Our Vite plugin is designed to take the Vite module graph into account when scan
 
 However, sometimes your Vite setup is split across different build steps (e.g. when using SSR builds). If that is the case, you might find that the client build might contain more utilities since it traverses all components while the server build doesn't.
 
-To ensure that both builds read all components from your project, set the `scanner` option to `file-system`:
+When the `scanner` is set to `automatic`, we will automatically use the `file-system` scanner for Astro builds.
+
+To ensure that both builds read all components from your project in other cases, set the `scanner` option to `file-system`:
 
 ```js
 import { defineConfig } from 'vite'

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -209,9 +209,13 @@ export default function tailwindcss(
         minify = config.build.cssMinify !== false
         isSSR = config.build.ssr !== false && config.build.ssr !== undefined
 
-        if (shouldDisableModuleGraph(config) && scannerMode === 'automatic') {
-          console.warn('Detected an Astro.js build and opted-out of using the Vite module graph.')
-          scannerMode = 'file-system'
+        if (scannerMode === 'automatic') {
+          if (shouldDisableModuleGraph(config)) {
+            console.warn('Detected an Astro.js build and opted-out of using the Vite module graph.')
+            scannerMode = 'file-system'
+            return
+          }
+          scannerMode = 'module-graph'
         }
       },
 

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -211,7 +211,6 @@ export default function tailwindcss(
 
         if (scannerMode === 'automatic') {
           if (shouldDisableModuleGraph(config)) {
-            console.warn('Detected an Astro.js build and opted-out of using the Vite module graph.')
             scannerMode = 'file-system'
             return
           }

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -13,11 +13,11 @@ const INLINE_STYLE_ID_RE = /[?&]index\=\d+\.css$/
 
 const IGNORED_DEPENDENCIES = ['tailwind-merge']
 
-type ScannerMode = 'module-graph' | 'file-system'
+type ScannerMode = 'automatic' | 'module-graph' | 'file-system'
 
 export default function tailwindcss(
-  { scanner: scannerMode = 'module-graph' }: { scanner: ScannerMode } = {
-    scanner: 'module-graph',
+  { scanner: scannerMode = 'automatic' }: { scanner: ScannerMode } = {
+    scanner: 'automatic',
   },
 ): Plugin[] {
   let servers: ViteDevServer[] = []
@@ -25,8 +25,6 @@ export default function tailwindcss(
 
   let isSSR = false
   let minify = false
-
-  let additionalFileSystemSources: string[] = []
 
   // The Vite extension has two types of sources for candidates:
   //
@@ -69,7 +67,6 @@ export default function tailwindcss(
       () => moduleGraphCandidates,
       scannerMode,
       config!.root,
-      additionalFileSystemSources,
       customCssResolver,
       customJsResolver,
     )
@@ -212,8 +209,13 @@ export default function tailwindcss(
         minify = config.build.cssMinify !== false
         isSSR = config.build.ssr !== false && config.build.ssr !== undefined
 
-        if (isAstro(config)) {
-          additionalFileSystemSources.push(path.join(config.root, 'src', 'components'))
+        if (scannerMode === 'automatic') {
+          if (shouldDisableModuleGraph(config)) {
+            console.warn('Detected an Astro.js build and opted-out of using the Vite module graph.')
+            scannerMode = 'file-system'
+            return
+          }
+          scannerMode = 'module-graph'
         }
       },
 
@@ -436,7 +438,6 @@ class Root {
     private getSharedCandidates: () => Map<string, Set<string>>,
     private scannerMode: ScannerMode,
     private base: string,
-    private additionalFileSystemSources: string[],
 
     private customCssResolver: (id: string, base: string) => Promise<string | false | undefined>,
     private customJsResolver: (id: string, base: string) => Promise<string | false | undefined>,
@@ -490,15 +491,6 @@ class Root {
         // Use the specified root
         return [this.compiler.root]
       })().concat(this.compiler.globs)
-
-      if (this.additionalFileSystemSources) {
-        sources = sources.concat(
-          this.additionalFileSystemSources.map((source) => ({
-            base: source,
-            pattern: '**/*',
-          })),
-        )
-      }
 
       this.scanner = new Scanner({ sources })
     }
@@ -616,6 +608,6 @@ class Root {
   }
 }
 
-function isAstro(config: ResolvedConfig) {
+function shouldDisableModuleGraph(config: ResolvedConfig) {
   return config.plugins.some((p) => p.name === 'astro:scripts:page-ssr')
 }


### PR DESCRIPTION
This PR adds an option to the Vite plugin to control wether or not the module-graph based dependency scanner is used. 

The main motivation for doing this is a number of SSR specific build issues where differences in the dependency graphs for SSR and client builds would cause unexpected production builds. Some specific examples:

- #16389
- #16252
- #15794

The new option has a way to force `module-graph` and `file-system` based candidate scanning but will default to an `automatic` mode that will detect Astro and change the default behavior there to immediately fix the most prominent issue (#15794). 

It is configured like this:

```js
import { defineConfig } from 'vite'
import tailwindcss from '@tailwindcss/vite'

export default defineConfig({
  plugins: [tailwindcss({ scanner: 'file-system' })],
})
```

## Test plan

- I updated the Astro integration test to include an example using the `client:only` directive that was able to reproduce the issue #15794
- I also added an example that was able to reproduce the issue with React Router as outlined in #16252
- The existing SSR tests were also able to reproduce the issues form #16389 by having both entry points use different class names.

I ensured that the new option turns-on automatically for Astro and that enabling it manually fixes the other cases.
