### PR TITLE
Upgrade: Report errors when updating dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don’t replace `_` in suggested theme keys ([#16433](https://github.com/tailwindlabs/tailwindcss/pull/16433))
 - Ensure `--default-outline-width` can be used to change the `outline-width` value of the `outline` utility
 - Ensure drop shadow utilities don't inherit unexpectedly ([#16471](https://github.com/tailwindlabs/tailwindcss/pull/16471))
+- Upgrade: Report errors when updating dependencies ([#16504](https://github.com/tailwindlabs/tailwindcss/pull/16504))
 
 ## [4.0.6] - 2025-02-10
 

--- a/packages/@tailwindcss-upgrade/src/utils/packages.ts
+++ b/packages/@tailwindcss-upgrade/src/utils/packages.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import { promisify } from 'node:util'
 import { DefaultMap } from '../../../tailwindcss/src/utils/default-map'
-import { warn } from './renderer'
+import { error, warn } from './renderer'
 
 const exec = promisify(execCb)
 
@@ -20,11 +20,28 @@ export function pkg(base: string) {
       if (location === 'devDependencies') {
         args.push(SAVE_DEV[packageManager] || SAVE_DEV.default)
       }
-      return exec(`${packageManager} add ${args.join(' ')}`, { cwd: base })
+
+      let command = `${packageManager} add ${args.join(' ')}`
+      try {
+        return await exec(command, { cwd: base })
+      } catch (e: any) {
+        error(`An error occurred while running \`${command}\`\n\n${e.stdout}\n${e.stderr}`, {
+          prefix: '↳ ',
+        })
+        throw e
+      }
     },
     async remove(packages: string[]) {
       let packageManager = await packageManagerForBase.get(base)
-      return exec(`${packageManager} remove ${packages.join(' ')}`, { cwd: base })
+      let command = `${packageManager} remove ${packages.join(' ')}`
+      try {
+        return await exec(command, { cwd: base })
+      } catch (e: any) {
+        error(`An error occurred while running \`${command}\`\n\n${e.stdout}\n${e.stderr}`, {
+          prefix: '↳ ',
+        })
+        throw e
+      }
     },
   }
 }


### PR DESCRIPTION
Closes #16391

Like the title suggest this PR adds error reporting when the `npm install` or `npm remove` commands fail.

## Test plan

Tested by swapping out the command for `echo "bla"; exit 1` and capturing the output from the integration tests:

<img width="792" alt="Screenshot 2025-02-13 at 14 33 02" src="https://github.com/user-attachments/assets/d1288114-106a-4ac6-a54b-d02b74c98f35" />

<img width="761" alt="Screenshot 2025-02-13 at 14 31 05" src="https://github.com/user-attachments/assets/6d5b9427-457f-4e67-9723-4e340da61749" />

Decided not to add a new test for this since it's unlikely we'll do big changes here and the upgrade integration tests are already quite slow.