### PR TITLE
Add legacy type exports to `tailwindcss/plugin` export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don’t replace `_` in suggested theme keys ([#16433](https://github.com/tailwindlabs/tailwindcss/pull/16433))
 - Ensure `--default-outline-width` can be used to change the `outline-width` value of the `outline` utility
 - Ensure drop shadow utilities don't inherit unexpectedly ([#16471](https://github.com/tailwindlabs/tailwindcss/pull/16471))
+- Export backwards compatible config and plugin types from `tailwindcss/plugin` ([#16505](https://github.com/tailwindlabs/tailwindcss/pull/16505))
 
 ## [4.0.6] - 2025-02-10
 

--- a/packages/tailwindcss/src/plugin.ts
+++ b/packages/tailwindcss/src/plugin.ts
@@ -1,4 +1,12 @@
-import type { Config, PluginFn, PluginWithConfig, PluginWithOptions } from './compat/plugin-api'
+import type { ThemeConfig } from './compat/config/types'
+import type {
+  Config,
+  Plugin,
+  PluginAPI,
+  PluginFn,
+  PluginWithConfig,
+  PluginWithOptions,
+} from './compat/plugin-api'
 
 function createPlugin(handler: PluginFn, config?: Partial<Config>): PluginWithConfig {
   return {
@@ -24,3 +32,6 @@ createPlugin.withOptions = function <T>(
 }
 
 export default createPlugin
+
+// v3 compatible types previously exported via `tailwindcss/types/config`
+export type { Config, PluginAPI, PluginFn as PluginCreator, Plugin as PluginsConfig, ThemeConfig }


### PR DESCRIPTION
Closes #16209

This PR exposes the following types that were accessible via `tailwindcss/types/config` in v3 now via the `tailwindcss/plugin` export:

```ts
import type {Cofig, PluginAPI, PluginCreator, PluginsConfig, ThemeConfig } from 'tailwindcss/plugin'
```

Note that these types will not be the same as the v3 and just approximations, however it should be enough to upgrade plugins to work with v4.

## Test plan

Tested in a standalone project importing a dev build of tailwindcss: 

<img width="1784" alt="Screenshot 2025-02-13 at 14 50 48" src="https://github.com/user-attachments/assets/27c04666-0106-414d-ba25-1a853f9d53d1" />
