### PR TITLE
Upgrade: Handle `darkMode` value with block syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don’t replace `_` in suggested theme keys ([#16433](https://github.com/tailwindlabs/tailwindcss/pull/16433))
 - Ensure `--default-outline-width` can be used to change the `outline-width` value of the `outline` utility
 - Ensure drop shadow utilities don't inherit unexpectedly ([#16471](https://github.com/tailwindlabs/tailwindcss/pull/16471))
+- Upgrade: Ensure a `darkMode` JS config setting with block syntax converts to use `@slot` ([#16507](https://github.com/tailwindlabs/tailwindcss/pull/16507))
 
 ## [4.0.6] - 2025-02-10
 

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -318,6 +318,7 @@ test(
         import customPlugin from './custom-plugin'
 
         export default {
+          darkMode: ['variant', '@media not print { .dark & }'],
           plugins: [
             typography,
             customPlugin({

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -380,6 +380,14 @@ test(
         is-arr-mixed: null, true, false, 1234567, 1.35, 'foo', 'bar', 'true';
       }
 
+      @custom-variant dark {
+        @media not print {
+          .dark & {
+            @slot;
+          }
+        }
+      }
+
       /*
         The default border color has changed to \`currentColor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -318,7 +318,14 @@ test(
         import customPlugin from './custom-plugin'
 
         export default {
-          darkMode: ['variant', '@media not print { .dark & }'],
+          darkMode: [
+            'variant',
+            [
+              '@media not print { .dark & }',
+              '@media not eink { .dark & }',
+              '&:where(.dark, .dark *)',
+            ],
+          ],
           plugins: [
             typography,
             customPlugin({
@@ -385,6 +392,14 @@ test(
           .dark & {
             @slot;
           }
+        }
+        @media not eink {
+          .dark & {
+            @slot;
+          }
+        }
+        &:where(.dark, .dark *) {
+          @slot;
         }
       }
 

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -196,7 +196,7 @@ async function migrateTheme(
 }
 
 function migrateDarkMode(unresolvedConfig: Config & { darkMode: any }): string {
-  let variant: string = ''
+  let variant: string | string[] = ''
   let addVariant = (_name: string, _variant: string) => (variant = _variant)
   let config = () => unresolvedConfig.darkMode
   darkModePlugin({ config, addVariant })
@@ -204,7 +204,28 @@ function migrateDarkMode(unresolvedConfig: Config & { darkMode: any }): string {
   if (variant === '') {
     return ''
   }
-  return `\n@tw-bucket custom-variant {\n@custom-variant dark (${variant});\n}\n`
+
+  if (!Array.isArray(variant)) {
+    variant = [variant]
+  }
+
+  let output = ''
+
+  for (let variantName of variant) {
+    if (variantName === 'class') {
+      continue
+    }
+
+    // Convert to the block syntax if a block is used
+    if (variantName.includes('{')) {
+      variantName = variantName.replace('}', '{ @slot }}')
+      output += `\n@tw-bucket custom-variant {\n@custom-variant dark {${variantName}}}\n`
+    } else {
+      output += `\n@tw-bucket custom-variant {\n@custom-variant dark (${variantName});\n}\n`
+    }
+  }
+
+  return output
 }
 
 // Returns a string identifier used to section theme declarations

--- a/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/migrate-js-config.ts
@@ -209,23 +209,25 @@ function migrateDarkMode(unresolvedConfig: Config & { darkMode: any }): string {
     variant = [variant]
   }
 
-  let output = ''
+  if (variant.length === 1 && !variant[0].includes('{')) {
+    return `\n@tw-bucket custom-variant {\n@custom-variant dark (${variant[0]});\n}\n`
+  }
 
+  let customVariant = ''
   for (let variantName of variant) {
-    if (variantName === 'class') {
-      continue
-    }
-
     // Convert to the block syntax if a block is used
     if (variantName.includes('{')) {
-      variantName = variantName.replace('}', '{ @slot }}')
-      output += `\n@tw-bucket custom-variant {\n@custom-variant dark {${variantName}}}\n`
+      customVariant += variantName.replace('}', '{ @slot }}') + '\n'
     } else {
-      output += `\n@tw-bucket custom-variant {\n@custom-variant dark (${variantName});\n}\n`
+      customVariant += variantName + '{ @slot }\n'
     }
   }
 
-  return output
+  if (customVariant !== '') {
+    return `\n@tw-bucket custom-variant {\n@custom-variant dark {${customVariant}};\n}\n`
+  }
+
+  return ''
 }
 
 // Returns a string identifier used to section theme declarations


### PR DESCRIPTION
Closes #16171

This PR handles `darkMode` variant configs containing braces (so creating sub-rules) the same way we handle it in the interop layer. Since the interop layer runs inside the `addVariant` API that we do not run here, I instead oped to copy the one liner.

## Test plan

Updated one of the migration tests to include a rule that wasn't working before. Ensured the new output works via https://play.tailwindcss.com/nR99uhKtv3 