### PR TITLE
Allow `border-*` to match both color and size namesaces at the same time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don’t replace `_` in suggested theme keys ([#16433](https://github.com/tailwindlabs/tailwindcss/pull/16433))
 - Ensure `--default-outline-width` can be used to change the `outline-width` value of the `outline` utility
 - Ensure drop shadow utilities don't inherit unexpectedly ([#16471](https://github.com/tailwindlabs/tailwindcss/pull/16471))
+- Ensure `border` utility creates `border-width` and `border-color` declarations if both namespaces have a match ([#16513](https://github.com/tailwindlabs/tailwindcss/pull/16513))
 
 ## [4.0.6] - 2025-02-10
 

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -9945,7 +9945,38 @@ test('border with custom default border width', async () => {
       initial-value: solid;
     }"
   `)
-  expect(await run(['-border', 'border/foo'])).toEqual('')
+})
+
+test(`border where \`--color-*\` and \`--border-width-*\` matches`, async () => {
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --color-default: #f00;
+          --border-width-default: 2px;
+        }
+        @tailwind utilities;
+      `,
+      ['border-default'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --color-default: red;
+      --border-width-default: 2px;
+    }
+
+    .border-default {
+      border-style: var(--tw-border-style);
+      border-width: var(--border-width-default);
+      border-color: var(--color-default);
+    }
+
+    @property --tw-border-style {
+      syntax: "*";
+      inherits: false;
+      initial-value: solid;
+    }"
+  `)
 })
 
 test('bg', async () => {

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -2141,30 +2141,34 @@ export function createUtilities(theme: Theme) {
           }
         }
 
+        let declarations = []
+
+        // `border-width` property
+        {
+          if (!candidate.modifier) {
+            let value = theme.resolve(candidate.value.value, ['--border-width'])
+            if (value) {
+              let decls = desc.width(value)
+              if (decls) declarations.push(borderProperties(), ...decls)
+            }
+
+            if (isPositiveInteger(candidate.value.value)) {
+              let decls = desc.width(`${candidate.value.value}px`)
+              if (decls) declarations.push(borderProperties(), ...decls)
+            }
+          }
+        }
+
         // `border-color` property
         {
           let value = resolveThemeColor(candidate, theme, ['--border-color', '--color'])
           if (value) {
-            return desc.color(value)
+            let decls = desc.color(value)
+            if (decls) declarations.push(...decls)
           }
         }
 
-        // `border-width` property
-        {
-          if (candidate.modifier) return
-          let value = theme.resolve(candidate.value.value, ['--border-width'])
-          if (value) {
-            let decls = desc.width(value)
-            if (!decls) return
-            return [borderProperties(), ...decls]
-          }
-
-          if (isPositiveInteger(candidate.value.value)) {
-            let decls = desc.width(`${candidate.value.value}px`)
-            if (!decls) return
-            return [borderProperties(), ...decls]
-          }
-        }
+        if (declarations.length > 0) return declarations
       })
 
       suggest(classRoot, () => [


### PR DESCRIPTION
Closes #16343

In v3, if you had a `colors` and `borderWidth` key that resolved to the same value, using the `border-*` utility would actually match create both rules: https://play.tailwindcss.com/Loe4Z1eKky?file=config

In v4, however, it currently only looks at the color and then ends. This PR changes it to be compatible with v3.

My main motivation for fixing this is that this is actually more like the `@utility` API works right now already where this would generate both rules: https://play.tailwindcss.com/bQNe7wXOJb?file=css

```css
@utility border-* {
  color: --value(--color-*);
  border-width: --value(--border-width-*);
}
```