### PR TITLE
Fix plugins with nested rules refering to the utility name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure `--default-outline-width` can be used to change the `outline-width` value of the `outline` utility
 - Ensure drop shadow utilities don't inherit unexpectedly ([#16471](https://github.com/tailwindlabs/tailwindcss/pull/16471))
 - Export backwards compatible config and plugin types from `tailwindcss/plugin` ([#16505](https://github.com/tailwindlabs/tailwindcss/pull/16505))
+- Ensure JavaScript plugins that emit nested rules referencing to the utility name work as expected ([#16539](https://github.com/tailwindlabs/tailwindcss/pull/16539))
 - Upgrade: Report errors when updating dependencies ([#16504](https://github.com/tailwindlabs/tailwindcss/pull/16504))
 
 ## [4.0.6] - 2025-02-10


### PR DESCRIPTION
Closes https://github.com/tailwindlabs/tailwindcss-typography/issues/383

This PR fixes an issue that happened when JavaScript plugins create a nested rule that references to the utility name. The previous behavior looked like this:

![image](https://github.com/user-attachments/assets/93ff869d-c95b-49d0-879c-7c20a852fa09)

I was able to come up with an approach that can be fixed entirely in the compat layer by leveraging the `raw` field on the candidate. 

## Test plan

- Added unit tests
- Verified with the reproduction from https://github.com/tailwindlabs/tailwindcss-typography/issues/383:
      
    <img width="1458" alt="Screenshot 2025-02-14 at 13 21 22" src="https://github.com/user-attachments/assets/50544abc-e98f-48cd-b78c-ad7697387dd8" />
