### PR TITLE
Expose AST scope and parsing methods

### DIFF
--- a/packages/tailwindcss/package.json
+++ b/packages/tailwindcss/package.json
@@ -55,6 +55,14 @@
       "require": "./src/plugin.cts",
       "import": "./src/plugin.ts"
     },
+    "./ast": {
+      "require": "./src/ast.cts",
+      "import": "./src/ast.ts"
+    },
+    "./ast.js": {
+      "require": "./src/ast.cts",
+      "import": "./src/ast.ts"
+    },
     "./package.json": "./package.json",
     "./index.css": "./index.css",
     "./index": "./index.css",
@@ -82,6 +90,14 @@
       "./plugin.js": {
         "require": "./dist/plugin.js",
         "import": "./dist/plugin.mjs"
+      },
+      "./ast": {
+        "require": "./dist/ast.js",
+        "import": "./dist/ast.mjs"
+      },
+      "./ast.js": {
+        "require": "./dist/ast.js",
+        "import": "./dist/ast.mjs"
       },
       "./defaultTheme": {
         "require": "./dist/default-theme.js",

--- a/packages/tailwindcss/src/ast.cts
+++ b/packages/tailwindcss/src/ast.cts
@@ -1,0 +1,8 @@
+import * as ast from './ast.ts'
+
+// This file exists so that `ast.ts` can be written one time but be
+// compatible with both CJS and ESM. Without it we get a `.default` export when
+// using `require` in CJS.
+
+// @ts-ignore
+export = ast

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -33,9 +33,13 @@ import { segment } from './utils/segment'
 import { compoundsForSelectors, IS_VALID_VARIANT_NAME } from './variants'
 export type Config = UserConfig
 
+export {
+  CSS
+}
+
 const IS_VALID_PREFIX = /^[a-z]+$/
 
-type CompileOptions = {
+export type CompileOptions = {
   base?: string
   loadModule?: (
     id: string,
@@ -106,7 +110,7 @@ export const enum Features {
   Variants = 1 << 5,
 }
 
-async function parseCss(
+export async function parseCss(
   ast: AstNode[],
   {
     base = '',

--- a/packages/tailwindcss/tsup.config.ts
+++ b/packages/tailwindcss/tsup.config.ts
@@ -11,6 +11,7 @@ export default defineConfig([
       colors: 'src/compat/colors.ts',
       'default-theme': 'src/compat/default-theme.ts',
       'flatten-color-palette': 'src/compat/flatten-color-palette.ts',
+      'ast': 'src/ast.ts'
     },
     define: {
       'process.env.FEATURES_ENV': JSON.stringify(process.env.FEATURES_ENV ?? 'insiders'),
@@ -26,6 +27,7 @@ export default defineConfig([
       colors: 'src/compat/colors.cts',
       'default-theme': 'src/compat/default-theme.cts',
       'flatten-color-palette': 'src/compat/flatten-color-palette.cts',
+      'ast': 'src/ast.cts'
     },
     define: {
       'process.env.FEATURES_ENV': JSON.stringify(process.env.FEATURES_ENV ?? 'insiders'),


### PR DESCRIPTION
In the current Tailwind CSS functionality, we may need to perform some static analysis on existing projects, including parsing the project's CSS, obtaining the AST, and performing transformations (similar to PostCSS's API). 

However, the currently exposed API does not provide such capabilities. Therefore, the purpose of this PR is to introduce these changes.

```ts
import { CSS, parseCss, CompileOptions } from 'tailwindcss'

function getContext(css: string, opts: CompileOptions = {}) {
  return parseCss(CSS.parse(css), opts)
}

const ctx = await getContext('@import \'tailwindcss\';')
// do stuff
// ...
```