### PR TITLE
Pin `c12` version in Nuxt integration tests

### DIFF
--- a/integrations/vite/nuxt.test.ts
+++ b/integrations/vite/nuxt.test.ts
@@ -10,6 +10,11 @@ const SETUP = {
           "nuxt": "^3.13.1",
           "tailwindcss": "workspace:^",
           "vue": "latest"
+        },
+        "pnpm": {
+          "overrides": {
+            "c12": "2.0.2"
+          }
         }
       }
     `,


### PR DESCRIPTION
Work around https://github.com/unjs/c12/issues/232