### PR TITLE
Ensure `outline-hidden` behaves like `outline-none` in non-`forced-colors` mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure `not-*` does not remove `:is(…)` from variants ([#16825](https://github.com/tailwindlabs/tailwindcss/pull/16825))
 - Ensure `@keyframes` are correctly emitted when using a prefixed setup ([#16850](https://github.com/tailwindlabs/tailwindcss/pull/16850))
+- Ensure `outline-hidden` behaves like `outline-none` in non-`forced-colors` mode ([#](https://github.com/tailwindlabs/tailwindcss/pull/))
 
 ## [4.0.9] - 2025-02-25
 

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -14623,6 +14623,7 @@ test('outline', async () => {
     }
 
     .outline-hidden {
+      --tw-outline-style: none;
       outline-style: none;
     }
 

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -3901,6 +3901,7 @@ export function createUtilities(theme: Theme) {
 
     utilities.static('outline-hidden', () => {
       return [
+        decl('--tw-outline-style', 'none'),
         decl('outline-style', 'none'),
         atRule('@media', '(forced-colors: active)', [
           decl('outline', '2px solid transparent'),


### PR DESCRIPTION
Part-of #16926

I noticed that `outline-hidden` would not set `--tw-outline-style` (contrary to `outline-none`), thus stacking it with other outline classes won't work as expected: https://play.tailwindcss.com/Y0lPGgekYh



