### PR TITLE
Vite: Work around crash when `.svg` file contains `#` or `?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure `not-*` does not remove `:is(…)` from variants ([#16825](https://github.com/tailwindlabs/tailwindcss/pull/16825))
 - Ensure `@keyframes` are correctly emitted when using a prefixed setup ([#16850](https://github.com/tailwindlabs/tailwindcss/pull/16850))
 - Don't swallow `@utility` declarations when `@apply` is used in nested rules ([#16940](https://github.com/tailwindlabs/tailwindcss/pull/16940))
-- Ensure `outline-hidden` behaves like `outline-none` in non-`forced-colors` mode ([#](https://github.com/tailwindlabs/tailwindcss/pull/))
+- Ensure `outline-hidden` behaves like `outline-none` in non-`forced-colors` mode ([#16943](https://github.com/tailwindlabs/tailwindcss/pull/16943))
 - Allow `!important` on CSS variables again ([#16873](https://github.com/tailwindlabs/tailwindcss/pull/16873))
+- Vite: Do not crash when encountering an `.svg` file with `#` or `?` in the filename ([#16957](https://github.com/tailwindlabs/tailwindcss/pull/16957))
 
 ### Changed
 

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -218,9 +218,20 @@ class Root {
   // not considered a Tailwind root. When this happened, the root can be GCed.
   public async generate(
     content: string,
-    addWatchFile: (file: string) => void,
+    _addWatchFile: (file: string) => void,
     I: Instrumentation,
   ): Promise<string | false> {
+    function addWatchFile(file: string) {
+      // Scanning `.svg` file containing a `#` or `?` in the path will
+      // crash Vite. We work around this for now by ignoring updates to them.
+      //
+      // https://github.com/tailwindlabs/tailwindcss/issues/16877
+      if (/[\#\?].*\.svg$/.test(file)) {
+        return
+      }
+      _addWatchFile(file)
+    }
+
     let requiresBuildPromise = this.requiresBuild()
     let inputPath = idToPath(this.id)
     let inputBase = path.dirname(path.resolve(inputPath))


### PR DESCRIPTION
Closes #16877

This PR works around #16877 by not registering `.svg` files containing a `#` or `?` as a watch dependency for now.

## Test plan

- Add a file to the Vite playground called `src/c#.svg`
- Observe Vite no longer prints errors