### PR TITLE
Link to upgrade guide in PostCSS compat message

### DIFF
--- a/integrations/postcss/core-as-postcss-plugin.test.ts
+++ b/integrations/postcss/core-as-postcss-plugin.test.ts
@@ -51,7 +51,7 @@ describe.each(Object.keys(variantConfig))('%s', (variant) => {
       expect(
         exec('pnpm postcss src/index.css --output dist/out.css', undefined, { ignoreStdErr: true }),
       ).rejects.toThrowError(
-        `It looks like you're trying to use \`tailwindcss\` directly as a PostCSS plugin. The PostCSS plugin has moved to a separate package, so to continue using Tailwind CSS with PostCSS you'll need to install \`@tailwindcss/postcss\` and update your PostCSS configuration.`,
+        `It looks like you're trying to use \`tailwindcss\` directly as a PostCSS plugin. The PostCSS plugin has moved to a separate package, so to continue using Tailwind CSS with PostCSS you'll need to install \`@tailwindcss/postcss\` and update your PostCSS configuration. Learn more at: https://tailwindcss.com/docs/upgrade-guide#using-postcss`,
       )
     },
   )

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -729,6 +729,6 @@ export async function __unstable__loadDesignSystem(css: string, opts: CompileOpt
 
 export default function postcssPluginWarning() {
   throw new Error(
-    `It looks like you're trying to use \`tailwindcss\` directly as a PostCSS plugin. The PostCSS plugin has moved to a separate package, so to continue using Tailwind CSS with PostCSS you'll need to install \`@tailwindcss/postcss\` and update your PostCSS configuration.`,
+    `It looks like you're trying to use \`tailwindcss\` directly as a PostCSS plugin. The PostCSS plugin has moved to a separate package, so to continue using Tailwind CSS with PostCSS you'll need to install \`@tailwindcss/postcss\` and update your PostCSS configuration. Learn more at: https://tailwindcss.com/docs/upgrade-guide#using-postcss`,
   )
 }


### PR DESCRIPTION
As the title suggests, this adds a link to the upgrade guide in the postcss compat message (= that is the message you see when trying to use `tailwindcss@4` as a PostCSS plugin.