### PR TITLE
Ensure classes containing number followed by dash or underscore are extracted correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Ensure classes containing `--` are extracted correctly ([#16972](https://github.com/tailwindlabs/tailwindcss/pull/16972))
+- Ensure classes containing number followed by dash or underscore are extracted correctly ([#16980](https://github.com/tailwindlabs/tailwindcss/pull/16980))
 
 ## [4.0.10] - 2025-03-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Ensure classes containing `--` are extracted correctly ([#16972](https://github.com/tailwindlabs/tailwindcss/pull/16972))
-- Ensure classes containing number followed by dash or underscore are extracted correctly ([#16980](https://github.com/tailwindlabs/tailwindcss/pull/16980))
+- Ensure classes containing numbers followed by dash or underscore are extracted correctly ([#16980](https://github.com/tailwindlabs/tailwindcss/pull/16980))
 
 ## [4.0.10] - 2025-03-05
 

--- a/crates/oxide/src/extractor/mod.rs
+++ b/crates/oxide/src/extractor/mod.rs
@@ -300,9 +300,6 @@ mod tests {
             ("items--center", vec!["items--center"]),
             // Simple utility with numbers
             ("px-2.5", vec!["px-2.5"]),
-            // Simple utility with number followed by dash or underscore
-            ("text-title1-strong", vec!["text-title1-strong"]),
-            ("text-title1_strong", vec!["text-title1_strong"]),
             // Arbitrary properties
             ("[color:red]", vec!["[color:red]"]),
             ("![color:red]", vec!["![color:red]"]),
@@ -833,6 +830,15 @@ mod tests {
         assert_extract_sorted_candidates(
             &pre_process_input(r#"<div class:px-4='condition'></div>"#, "svelte"),
             vec!["class", "px-4", "condition"],
+        );
+    }
+
+    // https://github.com/tailwindlabs/tailwindcss/issues/16978
+    #[test]
+    fn test_classes_containing_number_followed_by_dash_or_underscore() {
+        assert_extract_sorted_candidates(
+            r#"<div class="text-Title1_Strong"></div>"#,
+            vec!["text-Title1_Strong"],
         );
     }
 

--- a/crates/oxide/src/extractor/mod.rs
+++ b/crates/oxide/src/extractor/mod.rs
@@ -300,6 +300,9 @@ mod tests {
             ("items--center", vec!["items--center"]),
             // Simple utility with numbers
             ("px-2.5", vec!["px-2.5"]),
+            // Simple utility with number followed by dash or underscore
+            ("text-title1-strong", vec!["text-title1-strong"]),
+            ("text-title1_strong", vec!["text-title1_strong"]),
             // Arbitrary properties
             ("[color:red]", vec!["[color:red]"]),
             ("![color:red]", vec!["![color:red]"]),

--- a/crates/oxide/src/extractor/named_utility_machine.rs
+++ b/crates/oxide/src/extractor/named_utility_machine.rs
@@ -243,7 +243,8 @@ impl Machine for NamedUtilityMachine {
                         }
 
                         // A number must be preceded by a `-`, `.` or another alphanumeric
-                        // character, and can be followed by a `.` or an alphanumeric character or dash or underscore.
+                        // character, and can be followed by a `.` or an alphanumeric character or
+                        // dash or underscore.
                         //
                         // E.g.: `text-2xs`
                         //            ^^

--- a/crates/oxide/src/extractor/named_utility_machine.rs
+++ b/crates/oxide/src/extractor/named_utility_machine.rs
@@ -243,7 +243,7 @@ impl Machine for NamedUtilityMachine {
                         }
 
                         // A number must be preceded by a `-`, `.` or another alphanumeric
-                        // character, and can be followed by a `.` or an alphanumeric character.
+                        // character, and can be followed by a `.` or an alphanumeric character or dash or underscore.
                         //
                         // E.g.: `text-2xs`
                         //            ^^
@@ -272,6 +272,8 @@ impl Machine for NamedUtilityMachine {
                                     | Class::AlphaLower
                                     | Class::AlphaUpper
                                     | Class::Percent
+                                    | Class::Underscore
+                                    | Class::Dash
                             ) {
                                 return self.done(self.start_pos, cursor);
                             }
@@ -395,6 +397,9 @@ mod tests {
             // With numbers
             ("px-5", vec!["px-5"]),
             ("px-2.5", vec!["px-2.5"]),
+            // With number followed by dash or underscore
+            ("text-title1-strong", vec!["text-title1-strong"]),
+            ("text-title1_strong", vec!["text-title1_strong"]),
             // With trailing % sign
             ("from-15%", vec!["from-15%"]),
             // Arbitrary value with bracket notation

--- a/crates/oxide/src/extractor/utility_machine.rs
+++ b/crates/oxide/src/extractor/utility_machine.rs
@@ -220,9 +220,6 @@ mod tests {
             // With dashes
             ("items-center", vec!["items-center"]),
             ("items--center", vec!["items--center"]),
-            // With number followed by dash or underscore
-            ("text-title1-strong", vec!["text-title1-strong"]),
-            ("text-title1_strong", vec!["text-title1_strong"]),
             // Inside a string
             ("'flex'", vec!["flex"]),
             // Multiple utilities

--- a/crates/oxide/src/extractor/utility_machine.rs
+++ b/crates/oxide/src/extractor/utility_machine.rs
@@ -220,6 +220,9 @@ mod tests {
             // With dashes
             ("items-center", vec!["items-center"]),
             ("items--center", vec!["items--center"]),
+            // With number followed by dash or underscore
+            ("text-title1-strong", vec!["text-title1-strong"]),
+            ("text-title1_strong", vec!["text-title1_strong"]),
             // Inside a string
             ("'flex'", vec!["flex"]),
             // Multiple utilities


### PR DESCRIPTION
Fixes #16978, and also added support for dash.
Classes like `text-theme1-primary` or `text-theme1_primary` should be treated as valid.

If this approach is not aligned with the project’s direction or there are any concerns, please feel free to close or edit this PR 😃

<br/>

### As is

Classes conatining number followed by dash or underscore (e.g. `bg-theme1-primary`, `text-title1_strong`) are ignored, and utility classes are not generated.

### To be

Classes conatining number followed by dash or underscore (e.g. `bg-theme1-primary`, `text-title1_strong`) are treated as valid tailwindcss classes