### PR TITLE
Ensure `}` and `{` are valid boundary characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure utilities are sorted based on their actual property order ([#16995](https://github.com/tailwindlabs/tailwindcss/pull/16995))
 - Ensure strings in Pug and Slim templates are handled correctly ([#17000](https://github.com/tailwindlabs/tailwindcss/pull/17000))
+- Ensure `}` and `{` are valid boundary characters when extracting candidates ([#17001](https://github.com/tailwindlabs/tailwindcss/pull/17001))
 
 ## [4.0.11] - 2025-03-06
 

--- a/crates/oxide/src/extractor/candidate_machine.rs
+++ b/crates/oxide/src/extractor/candidate_machine.rs
@@ -200,7 +200,7 @@ fn is_valid_before_boundary(c: &u8) -> bool {
 /// E.g.: `<div class:flex="bool">` Svelte
 ///                       ^
 #[inline(always)]
-fn is_valid_after_boundary(c: &u8) -> bool {
+pub fn is_valid_after_boundary(c: &u8) -> bool {
     is_valid_common_boundary(c) || matches!(c, b'}' | b']' | b'=' | b'{')
 }
 

--- a/crates/oxide/src/extractor/candidate_machine.rs
+++ b/crates/oxide/src/extractor/candidate_machine.rs
@@ -191,7 +191,7 @@ fn is_valid_common_boundary(c: &u8) -> bool {
 /// A candidate must be preceded by any of these characters.
 #[inline(always)]
 fn is_valid_before_boundary(c: &u8) -> bool {
-    is_valid_common_boundary(c) || matches!(c, b'.')
+    is_valid_common_boundary(c) || matches!(c, b'.' | b'}')
 }
 
 /// A candidate must be followed by any of these characters.
@@ -201,7 +201,7 @@ fn is_valid_before_boundary(c: &u8) -> bool {
 ///                       ^
 #[inline(always)]
 fn is_valid_after_boundary(c: &u8) -> bool {
-    is_valid_common_boundary(c) || matches!(c, b'}' | b']' | b'=')
+    is_valid_common_boundary(c) || matches!(c, b'}' | b']' | b'=' | b'{')
 }
 
 #[inline(always)]

--- a/crates/oxide/src/extractor/candidate_machine.rs
+++ b/crates/oxide/src/extractor/candidate_machine.rs
@@ -316,13 +316,16 @@ mod tests {
                 //
                 // HTML
                 // Inside a class (on its own)
-                (r#"<div class="{}"></div>"#, vec![]),
+                (r#"<div class="{}"></div>"#, vec!["class"]),
                 // Inside a class (first)
-                (r#"<div class="{} foo"></div>"#, vec!["foo"]),
+                (r#"<div class="{} foo"></div>"#, vec!["class", "foo"]),
                 // Inside a class (second)
-                (r#"<div class="foo {}"></div>"#, vec!["foo"]),
+                (r#"<div class="foo {}"></div>"#, vec!["class", "foo"]),
                 // Inside a class (surrounded)
-                (r#"<div class="foo {} bar"></div>"#, vec!["foo", "bar"]),
+                (
+                    r#"<div class="foo {} bar"></div>"#,
+                    vec!["class", "foo", "bar"],
+                ),
                 // --------------------------
                 //
                 // JavaScript

--- a/crates/oxide/src/extractor/mod.rs
+++ b/crates/oxide/src/extractor/mod.rs
@@ -248,6 +248,22 @@ mod tests {
         assert_eq!(actual, expected);
     }
 
+    fn assert_extract_candidates_contains(input: &str, expected: Vec<&str>) {
+        let actual = extract_sorted_candidates(input);
+
+        let mut missing = vec![];
+        for item in &expected {
+            if !actual.contains(item) {
+                missing.push(item);
+            }
+        }
+
+        if !missing.is_empty() {
+            dbg!(&actual, &missing);
+            panic!("Missing some items");
+        }
+    }
+
     fn assert_extract_sorted_css_variables(input: &str, expected: Vec<&str>) {
         let actual = extract_sorted_css_variables(input);
 

--- a/crates/oxide/src/extractor/mod.rs
+++ b/crates/oxide/src/extractor/mod.rs
@@ -849,11 +849,18 @@ mod tests {
         );
     }
 
+    // https://github.com/tailwindlabs/tailwindcss/issues/16999
     #[test]
     fn test_twig_syntax() {
         assert_extract_candidates_contains(
             r#"<div class="flex items-center mx-4{% if session.isValid %}{% else %} h-4{% endif %}"></div>"#,
             vec!["flex", "items-center", "mx-4", "h-4"],
+        );
+
+        // With touching both `}` and `{`
+        assert_extract_candidates_contains(
+            r#"<div class="{% if true %}flex{% else %}block{% endif %}">"#,
+            vec!["flex", "block"],
         );
     }
 

--- a/crates/oxide/src/extractor/mod.rs
+++ b/crates/oxide/src/extractor/mod.rs
@@ -327,6 +327,7 @@ mod tests {
             (
                 r#"<div class="flex items-center px-2.5 bg-[#0088cc] text-(--my-color)"></div>"#,
                 vec![
+                    "class",
                     "flex",
                     "items-center",
                     "px-2.5",
@@ -379,7 +380,7 @@ mod tests {
             ("{ underline: true }", vec!["underline", "true"]),
             (
                 r#"            <CheckIcon className={clsx('h-4 w-4', { invisible: index !== 0 })} />"#,
-                vec!["h-4", "w-4", "invisible", "index"],
+                vec!["className", "h-4", "w-4", "invisible", "index"],
             ),
             // You can have variants but in a string. Vue example.
             (
@@ -496,13 +497,16 @@ mod tests {
                 //
                 // HTML
                 // Inside a class (on its own)
-                (r#"<div class="{}"></div>"#, vec![]),
+                (r#"<div class="{}"></div>"#, vec!["class"]),
                 // Inside a class (first)
-                (r#"<div class="{} foo"></div>"#, vec!["foo"]),
+                (r#"<div class="{} foo"></div>"#, vec!["class", "foo"]),
                 // Inside a class (second)
-                (r#"<div class="foo {}"></div>"#, vec!["foo"]),
+                (r#"<div class="foo {}"></div>"#, vec!["class", "foo"]),
                 // Inside a class (surrounded)
-                (r#"<div class="foo {} bar"></div>"#, vec!["foo", "bar"]),
+                (
+                    r#"<div class="foo {} bar"></div>"#,
+                    vec!["class", "foo", "bar"],
+                ),
                 // --------------------------
                 //
                 // JavaScript
@@ -606,7 +610,7 @@ mod tests {
             // Quoted attribute
             (
                 r#"input(type="checkbox" class="px-2.5")"#,
-                vec!["checkbox", "px-2.5"],
+                vec!["checkbox", "class", "px-2.5"],
             ),
         ] {
             assert_extract_sorted_candidates(&pre_process_input(input, "pug"), expected);
@@ -627,7 +631,7 @@ mod tests {
                 vec!["bg-blue-100", "2xl:bg-red-100"],
             ),
             // Quoted attribute
-            (r#"div class="px-2.5""#, vec!["div", "px-2.5"]),
+            (r#"div class="px-2.5""#, vec!["div", "class", "px-2.5"]),
         ] {
             assert_extract_sorted_candidates(&pre_process_input(input, "slim"), expected);
         }
@@ -847,6 +851,10 @@ mod tests {
             &pre_process_input(r#"<div class:px-4='condition'></div>"#, "svelte"),
             vec!["class", "px-4", "condition"],
         );
+        assert_extract_sorted_candidates(
+            &pre_process_input(r#"<div class:flex='condition'></div>"#, "svelte"),
+            vec!["class", "flex", "condition"],
+        );
     }
 
     // https://github.com/tailwindlabs/tailwindcss/issues/16999
@@ -870,6 +878,7 @@ mod tests {
         assert_extract_sorted_candidates(
             r#"<div class="@md:flex @max-md:flex @-[36rem]:flex @[36rem]:flex"></div>"#,
             vec![
+                "class",
                 "@md:flex",
                 "@max-md:flex",
                 "@-[36rem]:flex",
@@ -883,7 +892,7 @@ mod tests {
     fn test_classes_containing_number_followed_by_dash_or_underscore() {
         assert_extract_sorted_candidates(
             r#"<div class="text-Title1_Strong"></div>"#,
-            vec!["text-Title1_Strong"],
+            vec!["class", "text-Title1_Strong"],
         );
     }
 
@@ -892,7 +901,11 @@ mod tests {
     fn test_arbitrary_variable_with_data_type() {
         assert_extract_sorted_candidates(
             r#"<div class="bg-(length:--my-length) bg-[color:var(--my-color)]"></div>"#,
-            vec!["bg-(length:--my-length)", "bg-[color:var(--my-color)]"],
+            vec![
+                "class",
+                "bg-(length:--my-length)",
+                "bg-[color:var(--my-color)]",
+            ],
         );
     }
 

--- a/crates/oxide/src/extractor/mod.rs
+++ b/crates/oxide/src/extractor/mod.rs
@@ -849,6 +849,14 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_twig_syntax() {
+        assert_extract_candidates_contains(
+            r#"<div class="flex items-center mx-4{% if session.isValid %}{% else %} h-4{% endif %}"></div>"#,
+            vec!["flex", "items-center", "mx-4", "h-4"],
+        );
+    }
+
     // https://github.com/tailwindlabs/tailwindcss/issues/16982
     #[test]
     fn test_arbitrary_container_queries_syntax() {

--- a/crates/oxide/src/extractor/named_utility_machine.rs
+++ b/crates/oxide/src/extractor/named_utility_machine.rs
@@ -1,6 +1,7 @@
 use crate::cursor;
 use crate::extractor::arbitrary_value_machine::ArbitraryValueMachine;
 use crate::extractor::arbitrary_variable_machine::ArbitraryVariableMachine;
+use crate::extractor::candidate_machine::is_valid_after_boundary;
 use crate::extractor::machine::{Machine, MachineState};
 use classification_macros::ClassifyBytes;
 
@@ -120,19 +121,22 @@ impl Machine for NamedUtilityMachine {
                         // E.g.: `:div="{ flex: true }"` (JavaScript object syntax)
                         //                    ^
                         Class::AlphaLower | Class::AlphaUpper => {
-                            match cursor.next.into() {
-                                Class::Quote
-                                | Class::Whitespace
-                                | Class::CloseBracket
-                                | Class::Dot
-                                | Class::Colon
-                                | Class::End
-                                | Class::Slash
-                                | Class::Exclamation => return self.done(self.start_pos, cursor),
-
-                                // Still valid characters
-                                _ => cursor.advance(),
+                            if is_valid_after_boundary(&cursor.next) || {
+                                // Or any of these characters
+                                //
+                                // - `:`, because of JS object keys
+                                // - `/`, because of modifiers
+                                // - `!`, because of important
+                                matches!(
+                                    cursor.next.into(),
+                                    Class::Colon | Class::Slash | Class::Exclamation
+                                )
+                            } {
+                                return self.done(self.start_pos, cursor);
                             }
+
+                            // Still valid characters
+                            cursor.advance()
                         }
 
                         Class::Dash => match cursor.next.into() {
@@ -213,14 +217,20 @@ impl Machine for NamedUtilityMachine {
                             //                   ^
                             // E.g.: `:div="{ flex: true }"` (JavaScript object syntax)
                             //                    ^
-                            Class::Quote
-                            | Class::Whitespace
-                            | Class::CloseBracket
-                            | Class::Dot
-                            | Class::Colon
-                            | Class::End
-                            | Class::Slash
-                            | Class::Exclamation => return self.done(self.start_pos, cursor),
+                            _ if is_valid_after_boundary(&cursor.next) || {
+                                // Or any of these characters
+                                //
+                                // - `:`, because of JS object keys
+                                // - `/`, because of modifiers
+                                // - `!`, because of important
+                                matches!(
+                                    cursor.next.into(),
+                                    Class::Colon | Class::Slash | Class::Exclamation
+                                )
+                            } =>
+                            {
+                                return self.done(self.start_pos, cursor)
+                            }
 
                             // Everything else is invalid
                             _ => return self.restart(),

--- a/crates/oxide/src/extractor/named_utility_machine.rs
+++ b/crates/oxide/src/extractor/named_utility_machine.rs
@@ -464,15 +464,15 @@ mod tests {
                 //
                 // HTML
                 // Inside a class (on its own)
-                (r#"<div class="{}"></div>"#, vec!["div"]),
+                (r#"<div class="{}"></div>"#, vec!["div", "class"]),
                 // Inside a class (first)
-                (r#"<div class="{} foo"></div>"#, vec!["div", "foo"]),
+                (r#"<div class="{} foo"></div>"#, vec!["div", "class", "foo"]),
                 // Inside a class (second)
-                (r#"<div class="foo {}"></div>"#, vec!["div", "foo"]),
+                (r#"<div class="foo {}"></div>"#, vec!["div", "class", "foo"]),
                 // Inside a class (surrounded)
                 (
                     r#"<div class="foo {} bar"></div>"#,
-                    vec!["div", "foo", "bar"],
+                    vec!["div", "class", "foo", "bar"],
                 ),
                 // --------------------------
                 //
@@ -485,7 +485,10 @@ mod tests {
                     vec!["let", "classes", "true"],
                 ),
                 // Inside an object (no spaces, key)
-                (r#"let classes = {'{}':true};"#, vec!["let", "classes"]),
+                (
+                    r#"let classes = {'{}':true};"#,
+                    vec!["let", "classes", "true"],
+                ),
                 // Inside an object (value)
                 (
                     r#"let classes = { primary: '{}' };"#,

--- a/crates/oxide/src/extractor/utility_machine.rs
+++ b/crates/oxide/src/extractor/utility_machine.rs
@@ -291,15 +291,15 @@ mod tests {
                 //
                 // HTML
                 // Inside a class (on its own)
-                (r#"<div class="{}"></div>"#, vec!["div"]),
+                (r#"<div class="{}"></div>"#, vec!["div", "class"]),
                 // Inside a class (first)
-                (r#"<div class="{} foo"></div>"#, vec!["div", "foo"]),
+                (r#"<div class="{} foo"></div>"#, vec!["div", "class", "foo"]),
                 // Inside a class (second)
-                (r#"<div class="foo {}"></div>"#, vec!["div", "foo"]),
+                (r#"<div class="foo {}"></div>"#, vec!["div", "class", "foo"]),
                 // Inside a class (surrounded)
                 (
                     r#"<div class="foo {} bar"></div>"#,
-                    vec!["div", "foo", "bar"],
+                    vec!["div", "class", "foo", "bar"],
                 ),
                 // --------------------------
                 //
@@ -312,7 +312,10 @@ mod tests {
                     vec!["let", "classes", "true"],
                 ),
                 // Inside an object (no spaces, key)
-                (r#"let classes = {'{}':true};"#, vec!["let", "classes"]),
+                (
+                    r#"let classes = {'{}':true};"#,
+                    vec!["let", "classes", "true"],
+                ),
                 // Inside an object (value)
                 (
                     r#"let classes = { primary: '{}' };"#,

--- a/crates/oxide/src/extractor/utility_machine.rs
+++ b/crates/oxide/src/extractor/utility_machine.rs
@@ -266,8 +266,6 @@ mod tests {
                 "bg-(--my-color) flex px-(--my-padding)",
                 vec!["bg-(--my-color)", "flex", "px-(--my-padding)"],
             ),
-            // Pug syntax
-            (".flex.bg-red-500", vec!["flex", "bg-red-500"]),
             // --------------------------------------------------------
 
             // Exceptions:

--- a/crates/oxide/src/lib.rs
+++ b/crates/oxide/src/lib.rs
@@ -3,7 +3,6 @@ use crate::scanner::allowed_paths::resolve_paths;
 use crate::scanner::detect_sources::DetectSources;
 use bexpand::Expression;
 use bstr::ByteSlice;
-use extractor::string_machine::StringMachine;
 use extractor::{Extracted, Extractor};
 use fast_glob::glob_match;
 use fxhash::{FxHashMap, FxHashSet};

--- a/crates/oxide/src/lib.rs
+++ b/crates/oxide/src/lib.rs
@@ -540,6 +540,7 @@ mod tests {
             (
                 r#"<div class="!tw__flex sm:!tw__block tw__bg-gradient-to-t flex tw:[color:red] group-[]:tw__flex"#,
                 vec![
+                    ("class".to_string(), 5),
                     ("!tw__flex".to_string(), 12),
                     ("sm:!tw__block".to_string(), 22),
                     ("tw__bg-gradient-to-t".to_string(), 36),
@@ -552,6 +553,7 @@ mod tests {
             (
                 r#"<div class="tw:flex! tw:sm:block! tw:bg-linear-to-t flex tw:[color:red] tw:in-[.tw\:group]:flex"></div>"#,
                 vec![
+                    ("class".to_string(), 5),
                     ("tw:flex!".to_string(), 12),
                     ("tw:sm:block!".to_string(), 21),
                     ("tw:bg-linear-to-t".to_string(), 34),


### PR DESCRIPTION
In a lot of templating languages, `{…}` is used to escape the template language to write some code logic, this means that if you have input that looks like this:

```html
<div class="flex items-center mx-4{% if session.isValid %}{% else %} h-4{% endif %}"></div>
```

That the if condition will be gone once it's compiled to HTML, but it also means that the `}` and `{` characters next to `mx-4{` and `h-4` should be valid boundary characters because Tailwind CSS typically operates on the source code, not the compiled code.

I didn't create a pre processor for this because unfortunately this syntax is often embedded in `.html` files, and I would love to not have to create a pre processor for `.html` files.

You might notice that there are other changes in this PR, they are all related to boundary characters, let me explain:

In the named utility machine, we repeated the allowed boundary characters. We will now re-use the shared function so that it's all in one location.
We still check for a few additional characters such as `:` because of JS keys, `/` because it could be a start of a modifier and `!` because the named utility could be important.

This actually exposed a bug where the `class` attribute in `<div class="…">…</div>` was not extracted (which we typically want). However, in languages like Svelte, this is a real thing you can do: `<div class:px-4="condition"></div>`. The pre processor will make sure to convert this input to `<div class px-4="condition"></div>` but that still means that we need to extract the `px-4`.

if a utility ends in an number this worked as expected, but `<div class:flex="condition"></div>` did not work. This PR also fixes that by adding a dedicated test and it's also the reason why you see a bunch of `class` candidates in the tests.

Fixes: #16999

# Test plan

1. Added new test
4. Existing tests pass
