### PR TITLE
Add --radius-full variable

### DIFF
--- a/packages/tailwindcss/theme.css
+++ b/packages/tailwindcss/theme.css
@@ -354,6 +354,7 @@
   --radius-2xl: 1rem;
   --radius-3xl: 1.5rem;
   --radius-4xl: 2rem;
+  --radius-full: calc(infinity * 1px)
 
   --shadow-2xs: 0 1px rgb(0 0 0 / 0.05);
   --shadow-xs: 0 1px 2px 0 rgb(0 0 0 / 0.05);


### PR DESCRIPTION
The `rounded-full` classname doesn't match the pattern of the other radius classnames:
```
rounded-xl: border-radius: var(--radius-xl)
rounded-2xl: border-radius: var(--radius-2xl)
rounded-3xl: border-radius: var(--radius-3xl)
rounded-full: border-radius: calc(infinity * 1px)
```
This PR makes `var(--rounded-full)` available to use like all the others in the theme.css.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create an issue to first discuss any significant new features. This includes things like adding new utilities, creating new at-rules, or adding new component examples to the documentation.

https://github.com/tailwindcss/tailwindcss/blob/master/.github/CONTRIBUTING.md

-->
