### PR TITLE
Improve boundary classification

### DIFF
--- a/crates/classification-macros/src/lib.rs
+++ b/crates/classification-macros/src/lib.rs
@@ -107,6 +107,12 @@ pub fn classify_bytes_derive(input: TokenStream) -> TokenStream {
                 #enum_name::TABLE[byte as usize]
             }
         }
+
+        impl From<&u8> for #enum_name {
+            fn from(byte: &u8) -> Self {
+                #enum_name::TABLE[*byte as usize]
+            }
+        }
     };
 
     TokenStream::from(expanded)

--- a/crates/oxide/src/extractor/boundary.rs
+++ b/crates/oxide/src/extractor/boundary.rs
@@ -1,0 +1,51 @@
+use crate::extractor::Span;
+
+/// A candidate must be preceded or followed by any of these characters
+/// E.g.: `<div class="flex">`
+///                   ^ Valid for `flex`
+///        ^ Invalid for `div`
+#[inline(always)]
+fn is_valid_common_boundary(c: &u8) -> bool {
+    matches!(
+        c,
+        b'\t' | b'\n' | b'\x0C' | b'\r' | b' ' | b'"' | b'\'' | b'`' | b'\0'
+    )
+}
+
+/// A candidate must be preceded by any of these characters.
+#[inline(always)]
+pub fn is_valid_before_boundary(c: &u8) -> bool {
+    is_valid_common_boundary(c) || matches!(c, b'.' | b'}')
+}
+
+/// A candidate must be followed by any of these characters.
+///
+/// E.g.: `[class.foo]`             Angular
+/// E.g.: `<div class:flex="bool">` Svelte
+///                       ^
+#[inline(always)]
+pub fn is_valid_after_boundary(c: &u8) -> bool {
+    is_valid_common_boundary(c) || matches!(c, b'}' | b']' | b'=' | b'{')
+}
+
+#[inline(always)]
+pub fn has_valid_boundaries(span: &Span, input: &[u8]) -> bool {
+    let before = {
+        if span.start == 0 {
+            b'\0'
+        } else {
+            input[span.start - 1]
+        }
+    };
+
+    let after = {
+        if span.end >= input.len() - 1 {
+            b'\0'
+        } else {
+            input[span.end + 1]
+        }
+    };
+
+    // Ensure the span has valid boundary characters before and after
+    is_valid_before_boundary(&before) && is_valid_after_boundary(&after)
+}

--- a/crates/oxide/src/extractor/boundary.rs
+++ b/crates/oxide/src/extractor/boundary.rs
@@ -66,7 +66,7 @@ enum Class {
     //       ^
     // ```
     #[bytes(b'.')]
-    // Twig like templating languages, e.g.:
+    // Twig-like templating languages, e.g.:
     //
     // ```
     // <div class="{% if true %}flex{% else %}block{% endif %}">

--- a/crates/oxide/src/extractor/boundary.rs
+++ b/crates/oxide/src/extractor/boundary.rs
@@ -50,13 +50,6 @@ enum Class {
     //            ^    ^
     // ```
     #[bytes(b'"', b'\'', b'`')]
-    // Twig like templating languages, e.g.:
-    //
-    // ```
-    // <div class="{% if true %}flex{% else %}block{% endif %}">
-    //                         ^
-    // ```
-    #[bytes(b'}')]
     // End of the input, e.g.:
     //
     // ```
@@ -73,6 +66,13 @@ enum Class {
     //       ^
     // ```
     #[bytes(b'.')]
+    // Twig like templating languages, e.g.:
+    //
+    // ```
+    // <div class="{% if true %}flex{% else %}block{% endif %}">
+    //                         ^
+    // ```
+    #[bytes(b'}')]
     Before,
 
     // Clojure and Angular like languages, e.g.:

--- a/crates/oxide/src/extractor/candidate_machine.rs
+++ b/crates/oxide/src/extractor/candidate_machine.rs
@@ -1,4 +1,5 @@
 use crate::cursor;
+use crate::extractor::boundary::{has_valid_boundaries, is_valid_before_boundary};
 use crate::extractor::machine::{Machine, MachineState};
 use crate::extractor::utility_machine::UtilityMachine;
 use crate::extractor::variant_machine::VariantMachine;
@@ -174,56 +175,6 @@ impl CandidateMachine {
         self.reset();
         MachineState::Done(span)
     }
-}
-
-/// A candidate must be preceded or followed by any of these characters
-/// E.g.: `<div class="flex">`
-///                   ^ Valid for `flex`
-///        ^ Invalid for `div`
-#[inline(always)]
-fn is_valid_common_boundary(c: &u8) -> bool {
-    matches!(
-        c,
-        b'\t' | b'\n' | b'\x0C' | b'\r' | b' ' | b'"' | b'\'' | b'`' | b'\0'
-    )
-}
-
-/// A candidate must be preceded by any of these characters.
-#[inline(always)]
-fn is_valid_before_boundary(c: &u8) -> bool {
-    is_valid_common_boundary(c) || matches!(c, b'.' | b'}')
-}
-
-/// A candidate must be followed by any of these characters.
-///
-/// E.g.: `[class.foo]`             Angular
-/// E.g.: `<div class:flex="bool">` Svelte
-///                       ^
-#[inline(always)]
-pub fn is_valid_after_boundary(c: &u8) -> bool {
-    is_valid_common_boundary(c) || matches!(c, b'}' | b']' | b'=' | b'{')
-}
-
-#[inline(always)]
-fn has_valid_boundaries(span: &Span, input: &[u8]) -> bool {
-    let before = {
-        if span.start == 0 {
-            b'\0'
-        } else {
-            input[span.start - 1]
-        }
-    };
-
-    let after = {
-        if span.end >= input.len() - 1 {
-            b'\0'
-        } else {
-            input[span.end + 1]
-        }
-    };
-
-    // Ensure the span has valid boundary characters before and after
-    is_valid_before_boundary(&before) && is_valid_after_boundary(&after)
 }
 
 #[cfg(test)]

--- a/crates/oxide/src/extractor/mod.rs
+++ b/crates/oxide/src/extractor/mod.rs
@@ -8,6 +8,7 @@ use std::fmt;
 pub mod arbitrary_property_machine;
 pub mod arbitrary_value_machine;
 pub mod arbitrary_variable_machine;
+mod boundary;
 pub mod bracket_stack;
 pub mod candidate_machine;
 pub mod css_variable_machine;

--- a/crates/oxide/src/extractor/named_utility_machine.rs
+++ b/crates/oxide/src/extractor/named_utility_machine.rs
@@ -1,7 +1,7 @@
 use crate::cursor;
 use crate::extractor::arbitrary_value_machine::ArbitraryValueMachine;
 use crate::extractor::arbitrary_variable_machine::ArbitraryVariableMachine;
-use crate::extractor::candidate_machine::is_valid_after_boundary;
+use crate::extractor::boundary::is_valid_after_boundary;
 use crate::extractor::machine::{Machine, MachineState};
 use classification_macros::ClassifyBytes;
 

--- a/crates/oxide/src/extractor/named_utility_machine.rs
+++ b/crates/oxide/src/extractor/named_utility_machine.rs
@@ -485,10 +485,7 @@ mod tests {
                     vec!["let", "classes", "true"],
                 ),
                 // Inside an object (no spaces, key)
-                (
-                    r#"let classes = {'{}':true};"#,
-                    vec!["let", "classes", "true"],
-                ),
+                (r#"let classes = {'{}':true};"#, vec!["let", "classes"]),
                 // Inside an object (value)
                 (
                     r#"let classes = { primary: '{}' };"#,

--- a/crates/oxide/src/extractor/utility_machine.rs
+++ b/crates/oxide/src/extractor/utility_machine.rs
@@ -312,10 +312,7 @@ mod tests {
                     vec!["let", "classes", "true"],
                 ),
                 // Inside an object (no spaces, key)
-                (
-                    r#"let classes = {'{}':true};"#,
-                    vec!["let", "classes", "true"],
-                ),
+                (r#"let classes = {'{}':true};"#, vec!["let", "classes"]),
                 // Inside an object (value)
                 (
                     r#"let classes = { primary: '{}' };"#,


### PR DESCRIPTION
This PR cleans up the boundary character checking by using similar classification techniques as we used for other classification problems.

For starters, this moves the boundary related items to its own file, next we setup the classification enum.

Last but not least, we removed `}` as an _after_ boundary character, and instead handle that situation in the Ruby pre processor where we need it. This means the `%w{flex}` will still work in Ruby files.

---

This PR is a followup for https://github.com/tailwindlabs/tailwindcss/pull/17001, the main goal is to clean up some of the boundary character checking code. The other big improvement is performance. Changing the boundary character checking to use a classification instead results in:

Took the best score of 10 runs each:
```diff
- CandidateMachine: Throughput: 311.96 MB/s
+ CandidateMachine: Throughput: 333.52 MB/s
```

So a ~20MB/s improvement.

# Test plan

1. Existing tests should pass. Due to the removal of `}` as an after boundary character, some tests are updated.
2. Added new tests to ensure the Ruby pre processor still works as expected.
