### PR TITLE
Add `razor`/`cshtml` pre processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure utilities are sorted based on their actual property order ([#16995](https://github.com/tailwindlabs/tailwindcss/pull/16995))
 - Ensure strings in Pug and Slim templates are handled correctly ([#17000](https://github.com/tailwindlabs/tailwindcss/pull/17000))
 - Ensure `}` and `{` are valid boundary characters when extracting candidates ([#17001](https://github.com/tailwindlabs/tailwindcss/pull/17001))
+- Add `razor`/`cshtml` pre processing ([#17027](https://github.com/tailwindlabs/tailwindcss/pull/17027))
 
 ## [4.0.11] - 2025-03-06
 

--- a/crates/oxide/src/extractor/pre_processors/mod.rs
+++ b/crates/oxide/src/extractor/pre_processors/mod.rs
@@ -1,11 +1,13 @@
 pub mod pre_processor;
 pub mod pug;
+pub mod razor;
 pub mod ruby;
 pub mod slim;
 pub mod svelte;
 
 pub use pre_processor::*;
 pub use pug::*;
+pub use razor::*;
 pub use ruby::*;
 pub use slim::*;
 pub use svelte::*;

--- a/crates/oxide/src/extractor/pre_processors/razor.rs
+++ b/crates/oxide/src/extractor/pre_processors/razor.rs
@@ -1,0 +1,27 @@
+use crate::extractor::pre_processors::pre_processor::PreProcessor;
+use bstr::ByteSlice;
+
+#[derive(Debug, Default)]
+pub struct Razor;
+
+impl PreProcessor for Razor {
+    fn process(&self, content: &[u8]) -> Vec<u8> {
+        content.replace("@@", " @")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Razor;
+    use crate::extractor::pre_processors::pre_processor::PreProcessor;
+
+    #[test]
+    fn test_razor_pre_processor() {
+        let (input, expected) = (
+            r#"<div class="@@sm:text-red-500">"#,
+            r#"<div class=" @sm:text-red-500">"#,
+        );
+        Razor::test(input, expected);
+        Razor::test_extract_contains(input, vec!["@sm:text-red-500"]);
+    }
+}

--- a/crates/oxide/src/lib.rs
+++ b/crates/oxide/src/lib.rs
@@ -468,6 +468,7 @@ pub fn pre_process_input(content: &[u8], extension: &str) -> Vec<u8> {
     use crate::extractor::pre_processors::*;
 
     match extension {
+        "cshtml" | "razor" => Razor.process(content),
         "pug" => Pug.process(content),
         "rb" | "erb" => Ruby.process(content),
         "slim" => Slim.process(content),


### PR DESCRIPTION
This PR fixes an issue in Razor template files where `@sm:flex` doesn't work and `@@sm:flex` is required.

In Tailwind CSS v3, some people used a custom transform to replace `@@` with just `@`. But in Tailwind CSS v4 we don't have this.

However, we can add a pre processor for `.cshtml` and `.razor` files.

Fixes: #17022
