### PR TITLE
Refactor: use compile time type state pattern

### DIFF
--- a/crates/oxide/src/extractor/arbitrary_variable_machine.rs
+++ b/crates/oxide/src/extractor/arbitrary_variable_machine.rs
@@ -4,6 +4,37 @@ use crate::extractor::css_variable_machine::CssVariableMachine;
 use crate::extractor::machine::{Machine, MachineState};
 use crate::extractor::string_machine::StringMachine;
 use classification_macros::ClassifyBytes;
+use std::marker::PhantomData;
+
+#[derive(Debug, Default)]
+pub struct IdleState;
+
+/// Currently parsing the inside of the arbitrary variable
+///
+/// ```text
+/// (--my-opacity)
+///  ^^^^^^^^^^^^
+/// ```
+#[derive(Debug, Default)]
+pub struct ParsingState;
+
+/// Currently parsing the data type of the arbitrary variable
+///
+/// ```text
+/// (length:--my-opacity)
+///  ^^^^^^^
+/// ```
+#[derive(Debug, Default)]
+pub struct ParsingDataTypeState;
+
+/// Currently parsing the fallback of the arbitrary variable
+///
+/// ```text
+/// (--my-opacity,50%)
+///              ^^^^
+/// ```
+#[derive(Debug, Default)]
+pub struct ParsingFallbackState;
 
 /// Extracts arbitrary variables including the parens.
 ///
@@ -17,226 +48,216 @@ use classification_macros::ClassifyBytes;
 ///            ^^^^^^^^^^^^^^
 /// ```
 #[derive(Debug, Default)]
-pub struct ArbitraryVariableMachine {
+pub struct ArbitraryVariableMachine<State = IdleState> {
     /// Start position of the arbitrary variable
     start_pos: usize,
 
     /// Track brackets to ensure they are balanced
     bracket_stack: BracketStack,
 
-    /// Current state of the machine
-    state: State,
-
     string_machine: StringMachine,
     css_variable_machine: CssVariableMachine,
+
+    _state: PhantomData<State>,
 }
 
-#[derive(Debug, Default)]
-enum State {
-    #[default]
-    Idle,
-
-    /// Currently parsing the data type of the arbitrary variable
-    ///
-    /// ```text
-    /// (length:--my-opacity)
-    ///  ^^^^^^^
-    /// ```
-    ParsingDataType,
-
-    /// Currently parsing the inside of the arbitrary variable
-    ///
-    /// ```text
-    /// (--my-opacity)
-    ///  ^^^^^^^^^^^^
-    /// ```
-    Parsing,
-
-    /// Currently parsing the fallback of the arbitrary variable
-    ///
-    /// ```text
-    /// (--my-opacity,50%)
-    ///              ^^^^
-    /// ```
-    ParsingFallback,
-}
-
-impl Machine for ArbitraryVariableMachine {
+impl<State> ArbitraryVariableMachine<State> {
     #[inline(always)]
-    fn reset(&mut self) {
-        self.start_pos = 0;
-        self.state = State::Idle;
-        self.bracket_stack.reset();
+    fn transition<NextState>(&self) -> ArbitraryVariableMachine<NextState> {
+        ArbitraryVariableMachine {
+            start_pos: self.start_pos,
+            bracket_stack: Default::default(),
+            string_machine: Default::default(),
+            css_variable_machine: Default::default(),
+            _state: PhantomData,
+        }
     }
+}
 
-    #[inline]
+impl Machine for ArbitraryVariableMachine<IdleState> {
+    #[inline(always)]
+    fn reset(&mut self) {}
+
+    #[inline(always)]
     fn next(&mut self, cursor: &mut cursor::Cursor<'_>) -> MachineState {
-        let class_curr = cursor.curr.into();
-        let len = cursor.input.len();
+        match cursor.curr.into() {
+            // Arbitrary variables start with `(` followed by a CSS variable
+            //
+            // E.g.: `(--my-variable)`
+            //        ^^
+            //
+            Class::OpenParen => match cursor.next.into() {
+                Class::Dash => {
+                    self.start_pos = cursor.pos;
+                    cursor.advance();
+                    self.transition::<ParsingState>().next(cursor)
+                }
 
-        match self.state {
-            State::Idle => match class_curr {
-                // Arbitrary variables start with `(` followed by a CSS variable
-                //
-                // E.g.: `(--my-variable)`
-                //        ^^
-                //
-                Class::OpenParen => match cursor.next.into() {
-                    Class::Dash => {
-                        self.start_pos = cursor.pos;
-                        self.state = State::Parsing;
-                        cursor.advance();
-                        self.next(cursor)
-                    }
+                Class::AlphaLower => {
+                    self.start_pos = cursor.pos;
+                    cursor.advance();
+                    self.transition::<ParsingDataTypeState>().next(cursor)
+                }
 
-                    Class::AlphaLower => {
-                        self.start_pos = cursor.pos;
-                        self.state = State::ParsingDataType;
-                        cursor.advance();
-                        self.next(cursor)
-                    }
-
-                    _ => MachineState::Idle,
-                },
-
-                // Everything else, is not a valid start of the arbitrary variable. But the next
-                // character might be a valid start for a new utility.
                 _ => MachineState::Idle,
             },
 
-            State::ParsingDataType => {
-                while cursor.pos < len {
-                    match cursor.curr.into() {
-                        // Valid data type characters
-                        //
-                        // E.g.: `(length:--my-length)`
-                        //         ^
-                        Class::AlphaLower | Class::Dash => {
-                            cursor.advance();
-                        }
-
-                        // End of the data type
-                        //
-                        // E.g.: `(length:--my-length)`
-                        //               ^
-                        Class::Colon => match cursor.next.into() {
-                            Class::Dash => {
-                                self.state = State::Parsing;
-                                cursor.advance();
-                                return self.next(cursor);
-                            }
-
-                            _ => return self.restart(),
-                        },
-
-                        // Anything else is not a valid character
-                        _ => return self.restart(),
-                    };
-                }
-                self.restart()
-            }
-
-            State::Parsing => match self.css_variable_machine.next(cursor) {
-                MachineState::Idle => self.restart(),
-                MachineState::Done(_) => match cursor.next.into() {
-                    // A CSS variable followed by a `,` means that there is a fallback
-                    //
-                    // E.g.: `(--my-color,red)`
-                    //                   ^
-                    Class::Comma => {
-                        self.state = State::ParsingFallback;
-                        cursor.advance_twice(); // Skip the `,`
-                        self.next(cursor)
-                    }
-
-                    // End of the CSS variable
-                    //
-                    // E.g.: `(--my-color)`
-                    //                  ^
-                    _ => {
-                        cursor.advance();
-
-                        match cursor.curr.into() {
-                            // End of an arbitrary variable, must be followed by `)`
-                            Class::CloseParen => self.done(self.start_pos, cursor),
-
-                            // Invalid arbitrary variable, not ending at `)`
-                            _ => self.restart(),
-                        }
-                    }
-                },
-            },
-
-            State::ParsingFallback => {
-                while cursor.pos < len {
-                    match cursor.curr.into() {
-                        Class::Escape => match cursor.next.into() {
-                            // An escaped whitespace character is not allowed
-                            //
-                            // E.g.: `(--my-\ color)`
-                            //              ^^
-                            Class::Whitespace => return self.restart(),
-
-                            // An escaped character, skip the next character, resume after
-                            //
-                            // E.g.: `(--my-\#color)`
-                            //              ^^
-                            _ => cursor.advance_twice(),
-                        },
-
-                        Class::OpenParen | Class::OpenBracket | Class::OpenCurly => {
-                            if !self.bracket_stack.push(cursor.curr) {
-                                return self.restart();
-                            }
-                            cursor.advance();
-                        }
-
-                        Class::CloseParen | Class::CloseBracket | Class::CloseCurly
-                            if !self.bracket_stack.is_empty() =>
-                        {
-                            if !self.bracket_stack.pop(cursor.curr) {
-                                return self.restart();
-                            }
-                            cursor.advance();
-                        }
-
-                        // End of an arbitrary variable
-                        Class::CloseParen => return self.done(self.start_pos, cursor),
-
-                        // Start of a string
-                        Class::Quote => match self.string_machine.next(cursor) {
-                            MachineState::Idle => return self.restart(),
-                            MachineState::Done(_) => {
-                                self.state = State::ParsingFallback;
-                                cursor.advance();
-                                return self.next(cursor);
-                            }
-                        },
-
-                        // A `:` inside of a fallback value is only valid inside of brackets or inside of a
-                        // string. Everywhere else, it's invalid.
-                        //
-                        // E.g.: `(--foo,bar:baz)`
-                        //                  ^ Not valid
-                        //
-                        // E.g.: `(--url,url(https://example.com))`
-                        //                        ^ Valid
-                        //
-                        // E.g.: `(--my-content:'a:b:c:')`
-                        //                        ^ ^ ^ Valid
-                        Class::Colon if self.bracket_stack.is_empty() => return self.restart(),
-
-                        // Any kind of whitespace is not allowed
-                        Class::Whitespace => return self.restart(),
-
-                        // Everything else is valid
-                        _ => cursor.advance(),
-                    };
-                }
-
-                self.restart()
-            }
+            // Everything else, is not a valid start of the arbitrary variable. But the next
+            // character might be a valid start for a new utility.
+            _ => MachineState::Idle,
         }
+    }
+}
+
+impl Machine for ArbitraryVariableMachine<ParsingState> {
+    #[inline(always)]
+    fn reset(&mut self) {}
+
+    #[inline(always)]
+    fn next(&mut self, cursor: &mut cursor::Cursor<'_>) -> MachineState {
+        match self.css_variable_machine.next(cursor) {
+            MachineState::Idle => self.restart(),
+            MachineState::Done(_) => match cursor.next.into() {
+                // A CSS variable followed by a `,` means that there is a fallback
+                //
+                // E.g.: `(--my-color,red)`
+                //                   ^
+                Class::Comma => {
+                    cursor.advance_twice(); // Skip the `,`
+                    self.transition::<ParsingFallbackState>().next(cursor)
+                }
+
+                // End of the CSS variable
+                //
+                // E.g.: `(--my-color)`
+                //                  ^
+                _ => {
+                    cursor.advance();
+
+                    match cursor.curr.into() {
+                        // End of an arbitrary variable, must be followed by `)`
+                        Class::CloseParen => self.done(self.start_pos, cursor),
+
+                        // Invalid arbitrary variable, not ending at `)`
+                        _ => self.restart(),
+                    }
+                }
+            },
+        }
+    }
+}
+
+impl Machine for ArbitraryVariableMachine<ParsingDataTypeState> {
+    #[inline(always)]
+    fn reset(&mut self) {}
+
+    #[inline(always)]
+    fn next(&mut self, cursor: &mut cursor::Cursor<'_>) -> MachineState {
+        let len = cursor.input.len();
+
+        while cursor.pos < len {
+            match cursor.curr.into() {
+                // Valid data type characters
+                //
+                // E.g.: `(length:--my-length)`
+                //         ^
+                Class::AlphaLower | Class::Dash => {
+                    cursor.advance();
+                }
+
+                // End of the data type
+                //
+                // E.g.: `(length:--my-length)`
+                //               ^
+                Class::Colon => match cursor.next.into() {
+                    Class::Dash => {
+                        cursor.advance();
+                        return self.transition::<ParsingState>().next(cursor);
+                    }
+
+                    _ => return self.restart(),
+                },
+
+                // Anything else is not a valid character
+                _ => return self.restart(),
+            };
+        }
+        self.restart()
+    }
+}
+
+impl Machine for ArbitraryVariableMachine<ParsingFallbackState> {
+    #[inline(always)]
+    fn reset(&mut self) {
+        self.bracket_stack.reset();
+    }
+
+    #[inline(always)]
+    fn next(&mut self, cursor: &mut cursor::Cursor<'_>) -> MachineState {
+        let len = cursor.input.len();
+        while cursor.pos < len {
+            match cursor.curr.into() {
+                Class::Escape => match cursor.next.into() {
+                    // An escaped whitespace character is not allowed
+                    //
+                    // E.g.: `(--my-\ color)`
+                    //              ^^
+                    Class::Whitespace => return self.restart(),
+
+                    // An escaped character, skip the next character, resume after
+                    //
+                    // E.g.: `(--my-\#color)`
+                    //              ^^
+                    _ => cursor.advance_twice(),
+                },
+
+                Class::OpenParen | Class::OpenBracket | Class::OpenCurly => {
+                    if !self.bracket_stack.push(cursor.curr) {
+                        return self.restart();
+                    }
+                    cursor.advance();
+                }
+
+                Class::CloseParen | Class::CloseBracket | Class::CloseCurly
+                    if !self.bracket_stack.is_empty() =>
+                {
+                    if !self.bracket_stack.pop(cursor.curr) {
+                        return self.restart();
+                    }
+                    cursor.advance();
+                }
+
+                // End of an arbitrary variable
+                Class::CloseParen => return self.done(self.start_pos, cursor),
+
+                // Start of a string
+                Class::Quote => match self.string_machine.next(cursor) {
+                    MachineState::Idle => return self.restart(),
+                    MachineState::Done(_) => cursor.advance(),
+                },
+
+                // A `:` inside of a fallback value is only valid inside of brackets or inside of a
+                // string. Everywhere else, it's invalid.
+                //
+                // E.g.: `(--foo,bar:baz)`
+                //                  ^ Not valid
+                //
+                // E.g.: `(--url,url(https://example.com))`
+                //                        ^ Valid
+                //
+                // E.g.: `(--my-content:'a:b:c:')`
+                //                        ^ ^ ^ Valid
+                Class::Colon if self.bracket_stack.is_empty() => return self.restart(),
+
+                // Any kind of whitespace is not allowed
+                Class::Whitespace => return self.restart(),
+
+                // Everything else is valid
+                _ => cursor.advance(),
+            };
+        }
+
+        self.restart()
     }
 }
 
@@ -306,15 +327,15 @@ enum Class {
 #[cfg(test)]
 mod tests {
     use super::ArbitraryVariableMachine;
-    use crate::extractor::machine::Machine;
+    use crate::extractor::{arbitrary_variable_machine::IdleState, machine::Machine};
 
     #[test]
     #[ignore]
     fn test_arbitrary_variable_machine_performance() {
         let input = r#"<div class="(--foo) (--my-color,red,blue) (--my-img,url('https://example.com?q=(][)'))"></div>"#.repeat(100);
 
-        ArbitraryVariableMachine::test_throughput(100_000, &input);
-        ArbitraryVariableMachine::test_duration_once(&input);
+        ArbitraryVariableMachine::<IdleState>::test_throughput(100_000, &input);
+        ArbitraryVariableMachine::<IdleState>::test_duration_once(&input);
 
         todo!()
     }
@@ -353,7 +374,10 @@ mod tests {
             (r"(-)", vec![]),
             (r"(-my-color)", vec![]),
         ] {
-            assert_eq!(ArbitraryVariableMachine::test_extract_all(input), expected);
+            assert_eq!(
+                ArbitraryVariableMachine::<IdleState>::test_extract_all(input),
+                expected
+            );
         }
     }
 }


### PR DESCRIPTION
This PR implements the state machines using the type state pattern at compile time (via generic types) instead of a runtime state variable. There is no runtime check to see what state we are in, instead we transition to the new state when it's necessary.

This has some nice performance improvements for some of the state machines, e.g.:

```diff
- ArbitraryVariableMachine: Throughput: 744.92 MB/s
+ ArbitraryVariableMachine: Throughput:   1.21 GB/s
```

We also don't have to store the current state because each machine runs to completion. It's during execution that we can move to a new state if necessary.


Unfortunately the diff is a tiny bit annoying to read, but essentially this is what happened:

### The `enum` is split up in it's individual states as structs:
```rs
enum State {
  A,
  B,
  C,
}
```
Becomes:
```rs
struct A;
struct B;
struct C;
```

### Generics

The current machine will receive a generic `State` that we can default to the `IdleState`. Then we use `PhantomData` to "use" the type because the generic type is otherwise not used as a concrete value, it's just a marker.

```rs
struct MyMachine {}
```
Becomes:
```rs
struct MyMachine<State = Idle> {
  _state: std::marker::PhantomData<State>
}
```

### Split 

Next, the `next` function used to match on the current state, but now each match arm is moved to a dedicated implementation instead:
```rs
impl Machine for MyMachine {
  fn next(&mut self) -> MachineState {
    match self.state {
      State::A => { /* … */ },
      State::B => { /* … */ },
      State::C => { /* … */ },
    }
  }
}
``` 
Becomes:
```rs
impl Machine for MyMachine<A> {
  fn next(&mut self) -> MachineState {
    /* … */
  }
}
impl Machine for MyMachine<B> {
  fn next(&mut self) -> MachineState {
    /* … */
  }
}
impl Machine for MyMachine<C> {
  fn next(&mut self) -> MachineState {
    /* … */
  }
}
```

It's a bit more verbose, but now each state is implemented in its own block. This also removes 2 levels of nesting which is a nice benefit.