### PR TITLE
Add `.node` and `.wasm` to known binary file list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `haml` pre-processing ([#17051](https://github.com/tailwindlabs/tailwindcss/pull/17051))
 - Ensure classes between `>` and `<` are properly extracted ([#17094](https://github.com/tailwindlabs/tailwindcss/pull/17094))
 - Treat starting single quote as verbatim text in Slim ([#17085](https://github.com/tailwindlabs/tailwindcss/pull/17085))
+- Ensure `.node` and `.wasm` files are not scanned for utilities ([#17123](https://github.com/tailwindlabs/tailwindcss/pull/17123))
 
 ## [4.0.12] - 2025-03-07
 

--- a/crates/oxide/src/scanner/fixtures/binary-extensions.txt
+++ b/crates/oxide/src/scanner/fixtures/binary-extensions.txt
@@ -3,7 +3,6 @@
 3g2
 3gp
 7z
-DS_Store
 a
 aac
 adp
@@ -51,6 +50,7 @@ docx
 dot
 dotm
 dra
+DS_Store
 dsk
 dts
 dtshd
@@ -131,6 +131,7 @@ mpg
 mpga
 mxu
 nef
+node
 npx
 numbers
 nupkg
@@ -229,6 +230,7 @@ uvu
 viv
 vob
 war
+wasm
 wav
 wax
 wbmp


### PR DESCRIPTION
Closes #17092

After a lot of spelunking we found one specific reason for the very slow builds in the repro from #17092: Turns our we are needlessly scanning the binary `.node` extension for class names 😬. This PR adds `.wasm` and `.node` to the list of known binary extensions.

## Test plan

 - Check out the repro from `#17092`
 - Delete the `.gitignore` file
 - Observe that builds are very slow (`527.79s`)
 - Add a _pnpm override_ to load local versions of Oxide
 - `pnpm build` now completes in ~50s