### PR TITLE
Don't extract links as arbitrary properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Treat starting single quote as verbatim text in Slim ([#17085](https://github.com/tailwindlabs/tailwindcss/pull/17085))
 - Ensure `.node` and `.wasm` files are not scanned for utilities ([#17123](https://github.com/tailwindlabs/tailwindcss/pull/17123))
 - Improve performance when scanning `JSON` files ([#17125](https://github.com/tailwindlabs/tailwindcss/pull/17125))
+- Don't create invalid CSS when encountering a link wrapped in square brackets ([#17129](https://github.com/tailwindlabs/tailwindcss/pull/17129))
 
 ## [4.0.12] - 2025-03-07
 

--- a/crates/oxide/src/extractor/arbitrary_property_machine.rs
+++ b/crates/oxide/src/extractor/arbitrary_property_machine.rs
@@ -163,7 +163,7 @@ impl Machine for ArbitraryPropertyMachine<ParsingValueState> {
     #[inline]
     fn next(&mut self, cursor: &mut cursor::Cursor<'_>) -> MachineState {
         let len = cursor.input.len();
-        let start_of_value = cursor.pos;
+        let start_of_value_pos = cursor.pos;
         while cursor.pos < len {
             match cursor.curr.into() {
                 Class::Escape => match cursor.next.into() {
@@ -224,7 +224,7 @@ impl Machine for ArbitraryPropertyMachine<ParsingValueState> {
                 Class::Whitespace => return self.restart(),
 
                 // URLs are not allowed
-                Class::Slash if start_of_value == cursor.pos => return self.restart(),
+                Class::Slash if start_of_value_pos == cursor.pos => return self.restart(),
 
                 // Everything else is valid
                 _ => cursor.advance(),


### PR DESCRIPTION
Closes #17128

This PR prevents extraction of links inside square brackets as valid candidate:

```
[https://example/]
```

We do this by throwing out arbitrary properties when the value starts with a slash (`/`).

## Test plan

- Added unit test