### PR TITLE
Fix variants with `<digit>.</digit>` are extracted correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Do not extract candidates with JS string interpolation `${` ([#17142](https://github.com/tailwindlabs/tailwindcss/pull/17142))
+- Fix extraction of variants containing `.` character ([#17153](https://github.com/tailwindlabs/tailwindcss/pull/17153))
 
 ## [4.0.13] - 2025-03-11
 

--- a/crates/oxide/src/extractor/named_variant_machine.rs
+++ b/crates/oxide/src/extractor/named_variant_machine.rs
@@ -391,6 +391,8 @@ mod tests {
                 vec!["group-[data-state=pending]/name:"],
             ),
             ("supports-(--foo)/name:flex", vec!["supports-(--foo)/name:"]),
+            // Odd media queries
+            ("1.5xl:flex", vec!["1.5xl:"]),
             // Container queries
             ("@md:flex", vec!["@md:"]),
             ("@max-md:flex", vec!["@max-md:"]),

--- a/crates/oxide/src/extractor/named_variant_machine.rs
+++ b/crates/oxide/src/extractor/named_variant_machine.rs
@@ -237,8 +237,8 @@ impl Machine for NamedVariantMachine<ParsingState> {
 
                 // A dot must be surrounded by numbers
                 //
-                // E.g.: `px-2.5`
-                //           ^^^
+                // E.g.: `2.5xl:flex`
+                //        ^^^
                 Class::Dot => {
                     if !matches!(cursor.prev.into(), Class::Number) {
                         return self.restart();

--- a/crates/oxide/src/extractor/named_variant_machine.rs
+++ b/crates/oxide/src/extractor/named_variant_machine.rs
@@ -235,6 +235,22 @@ impl Machine for NamedVariantMachine<ParsingState> {
                 //             ^
                 Class::Colon => return self.done(self.start_pos, cursor),
 
+                // A dot must be surrounded by numbers
+                //
+                // E.g.: `px-2.5`
+                //           ^^^
+                Class::Dot => {
+                    if !matches!(cursor.prev.into(), Class::Number) {
+                        return self.restart();
+                    }
+
+                    if !matches!(cursor.next.into(), Class::Number) {
+                        return self.restart();
+                    }
+
+                    cursor.advance();
+                }
+
                 // Everything else is invalid
                 _ => return self.restart(),
             };

--- a/crates/oxide/src/extractor/named_variant_machine.rs
+++ b/crates/oxide/src/extractor/named_variant_machine.rs
@@ -341,23 +341,14 @@ enum Class {
     #[bytes(b'.')]
     Dot,
 
-    #[bytes(b'\0')]
-    End,
-
     #[bytes_range(b'0'..=b'9')]
     Number,
 
     #[bytes(b'[')]
     OpenBracket,
 
-    #[bytes(b']')]
-    CloseBracket,
-
     #[bytes(b'(')]
     OpenParen,
-
-    #[bytes(b'\'', b'"', b'`')]
-    Quote,
 
     #[bytes(b'*')]
     Star,
@@ -367,9 +358,6 @@ enum Class {
 
     #[bytes(b'_')]
     Underscore,
-
-    #[bytes(b' ', b'\t', b'\n', b'\r', b'\x0C')]
-    Whitespace,
 
     #[fallback]
     Other,


### PR DESCRIPTION
This PR fixes an issue where if you use a number with a decimal in a variant then it wasn't picked up correctly.

E.g.:
```
<div class="2xl:flex 1.5xl:flex"></div>
            ^^^^^^^^                        Picked up
                     ^^^^^^^^^^             Not picket up
```

This PR fixes that behavior by applying the same rules for utilities where a `.` is valid if it is surrounded by numbers.

# Test plan

1. Added test to ensure this is picked up
2. Existing tests pass
3. Ran the extractor on a real example with the following results:

| Before | After |
| --- | --- |
| <img width="821" alt="image" src="https://github.com/user-attachments/assets/a77ed5e4-6848-4fe3-8cbf-cf61ff8db41d" /> | <img width="821" alt="image" src="https://github.com/user-attachments/assets/61aca66a-e38d-4b61-bf86-e6286a89a3d9" /> |

They are crossed out just because it's not a default value we know in the system, but you can see that the `1.` part is also extracted now.

Fixes: #17148
