### PR TITLE
Upgrade `lightningcss` to `1.29.2` in Standalone

### DIFF
--- a/packages/@tailwindcss-standalone/package.json
+++ b/packages/@tailwindcss-standalone/package.json
@@ -44,12 +44,12 @@
     "@parcel/watcher-win32-x64": "^2.5.1",
     "@types/bun": "^1.2.4",
     "bun": "^1.2.4",
-    "lightningcss-darwin-arm64": "^1.29.1",
-    "lightningcss-darwin-x64": "^1.29.1",
-    "lightningcss-linux-arm64-gnu": "^1.29.1",
-    "lightningcss-linux-arm64-musl": "^1.29.1",
-    "lightningcss-linux-x64-gnu": "^1.29.1",
-    "lightningcss-linux-x64-musl": "^1.29.1",
-    "lightningcss-win32-x64-msvc": "^1.29.1"
+    "lightningcss-darwin-arm64": "catalog:",
+    "lightningcss-darwin-x64": "catalog:",
+    "lightningcss-linux-arm64-gnu": "catalog:",
+    "lightningcss-linux-arm64-musl": "catalog:",
+    "lightningcss-linux-x64-gnu": "catalog:",
+    "lightningcss-linux-x64-musl": "catalog:",
+    "lightningcss-win32-x64-msvc": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,27 @@ catalogs:
     lightningcss:
       specifier: 1.29.2
       version: 1.29.2
+    lightningcss-darwin-arm64:
+      specifier: 1.29.2
+      version: 1.29.2
+    lightningcss-darwin-x64:
+      specifier: 1.29.2
+      version: 1.29.2
+    lightningcss-linux-arm64-gnu:
+      specifier: 1.29.2
+      version: 1.29.2
+    lightningcss-linux-arm64-musl:
+      specifier: 1.29.2
+      version: 1.29.2
+    lightningcss-linux-x64-gnu:
+      specifier: 1.29.2
+      version: 1.29.2
+    lightningcss-linux-x64-musl:
+      specifier: 1.29.2
+      version: 1.29.2
+    lightningcss-win32-x64-msvc:
+      specifier: 1.29.2
+      version: 1.29.2
     prettier:
       specifier: 3.5.0
       version: 3.5.0
@@ -278,26 +299,26 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4
       lightningcss-darwin-arm64:
-        specifier: ^1.29.1
-        version: 1.29.1
+        specifier: 'catalog:'
+        version: 1.29.2
       lightningcss-darwin-x64:
-        specifier: ^1.29.1
-        version: 1.29.1
+        specifier: 'catalog:'
+        version: 1.29.2
       lightningcss-linux-arm64-gnu:
-        specifier: ^1.29.1
-        version: 1.29.1
+        specifier: 'catalog:'
+        version: 1.29.2
       lightningcss-linux-arm64-musl:
-        specifier: ^1.29.1
-        version: 1.29.1
+        specifier: 'catalog:'
+        version: 1.29.2
       lightningcss-linux-x64-gnu:
-        specifier: ^1.29.1
-        version: 1.29.1
+        specifier: 'catalog:'
+        version: 1.29.2
       lightningcss-linux-x64-musl:
-        specifier: ^1.29.1
-        version: 1.29.1
+        specifier: 'catalog:'
+        version: 1.29.2
       lightningcss-win32-x64-msvc:
-        specifier: ^1.29.1
-        version: 1.29.1
+        specifier: 'catalog:'
+        version: 1.29.2
 
   packages/@tailwindcss-upgrade:
     dependencies:
@@ -1514,7 +1535,6 @@ packages:
   '@parcel/watcher-darwin-arm64@2.5.1':
     resolution: {integrity: sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==}
     engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
     os: [darwin]
 
   '@parcel/watcher-darwin-x64@2.5.0':
@@ -1526,7 +1546,6 @@ packages:
   '@parcel/watcher-darwin-x64@2.5.1':
     resolution: {integrity: sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==}
     engines: {node: '>= 10.0.0'}
-    cpu: [x64]
     os: [darwin]
 
   '@parcel/watcher-freebsd-x64@2.5.0':
@@ -1574,7 +1593,6 @@ packages:
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
     os: [linux]
 
   '@parcel/watcher-linux-arm64-musl@2.5.0':
@@ -1586,7 +1604,6 @@ packages:
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
     os: [linux]
 
   '@parcel/watcher-linux-x64-glibc@2.5.0':
@@ -1598,7 +1615,6 @@ packages:
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
-    cpu: [x64]
     os: [linux]
 
   '@parcel/watcher-linux-x64-musl@2.5.0':
@@ -1610,7 +1626,6 @@ packages:
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
-    cpu: [x64]
     os: [linux]
 
   '@parcel/watcher-wasm@2.5.0':
@@ -1652,7 +1667,6 @@ packages:
   '@parcel/watcher-win32-x64@2.5.1':
     resolution: {integrity: sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==}
     engines: {node: '>= 10.0.0'}
-    cpu: [x64]
     os: [win32]
 
   '@parcel/watcher@2.5.0':
@@ -2057,7 +2071,6 @@ packages:
 
   bun@1.2.4:
     resolution: {integrity: sha512-ZY0EZ/UKqheaLeAtMsfJA6jWoWvV9HAtfFaOJSmS3LrNpFKs1Sg5fZLSsczN1h3a+Dtheo4O3p3ZYWrf40kRGw==}
-    cpu: [arm64, x64, aarch64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -2888,22 +2901,10 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  lightningcss-darwin-arm64@1.29.1:
-    resolution: {integrity: sha512-HtR5XJ5A0lvCqYAoSv2QdZZyoHNttBpa5EP9aNuzBQeKGfbyH5+UipLWvVzpP4Uml5ej4BYs5I9Lco9u1fECqw==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-
   lightningcss-darwin-arm64@1.29.2:
     resolution: {integrity: sha512-cK/eMabSViKn/PG8U/a7aCorpeKLMlK0bQeNHmdb7qUnBkNPnL+oV5DjJUo0kqWsJUapZsM4jCfYItbqBDvlcA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
-    os: [darwin]
-
-  lightningcss-darwin-x64@1.29.1:
-    resolution: {integrity: sha512-k33G9IzKUpHy/J/3+9MCO4e+PzaFblsgBjSGlpAaFikeBFm8B/CkO3cKU9oI4g+fjS2KlkLM/Bza9K/aw8wsNA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
     os: [darwin]
 
   lightningcss-darwin-x64@1.29.2:
@@ -2924,20 +2925,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  lightningcss-linux-arm64-gnu@1.29.1:
-    resolution: {integrity: sha512-0+vClRIZ6mmJl/dxGuRsE197o1HDEeeRk6nzycSy2GofC2JsY4ifCRnvUWf/CUBQmlrvMzt6SMQNMSEu22csWQ==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-
   lightningcss-linux-arm64-gnu@1.29.2:
     resolution: {integrity: sha512-KKCpOlmhdjvUTX/mBuaKemp0oeDIBBLFiU5Fnqxh1/DZ4JPZi4evEH7TKoSBFOSOV3J7iEmmBaw/8dpiUvRKlQ==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-
-  lightningcss-linux-arm64-musl@1.29.1:
-    resolution: {integrity: sha512-UKMFrG4rL/uHNgelBsDwJcBqVpzNJbzsKkbI3Ja5fg00sgQnHw/VrzUTEc4jhZ+AN2BvQYz/tkHu4vt1kLuJyw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -2948,20 +2937,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  lightningcss-linux-x64-gnu@1.29.1:
-    resolution: {integrity: sha512-u1S+xdODy/eEtjADqirA774y3jLcm8RPtYztwReEXoZKdzgsHYPl0s5V52Tst+GKzqjebkULT86XMSxejzfISw==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-
   lightningcss-linux-x64-gnu@1.29.2:
     resolution: {integrity: sha512-0v6idDCPG6epLXtBH/RPkHvYx74CVziHo6TMYga8O2EiQApnUPZsbR9nFNrg2cgBzk1AYqEd95TlrsL7nYABQg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-
-  lightningcss-linux-x64-musl@1.29.1:
-    resolution: {integrity: sha512-L0Tx0DtaNUTzXv0lbGCLB/c/qEADanHbu4QdcNOXLIe1i8i22rZRpbT3gpWYsCh9aSL9zFujY/WmEXIatWvXbw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -2976,12 +2953,6 @@ packages:
     resolution: {integrity: sha512-nL7zRW6evGQqYVu/bKGK+zShyz8OVzsCotFgc7judbt6wnB2KbiKKJwBE4SGoDBQ1O94RjW4asrCjQL4i8Fhbw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
-    os: [win32]
-
-  lightningcss-win32-x64-msvc@1.29.1:
-    resolution: {integrity: sha512-NygcbThNBe4JElP+olyTI/doBNGJvLs3bFCRPdvuCcxZCcCZ71B858IHpdm7L1btZex0FvCmM17FK98Y9MRy1Q==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
     os: [win32]
 
   lightningcss-win32-x64-msvc@1.29.2:
@@ -6417,15 +6388,9 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  lightningcss-darwin-arm64@1.29.1: {}
+  lightningcss-darwin-arm64@1.29.2: {}
 
-  lightningcss-darwin-arm64@1.29.2:
-    optional: true
-
-  lightningcss-darwin-x64@1.29.1: {}
-
-  lightningcss-darwin-x64@1.29.2:
-    optional: true
+  lightningcss-darwin-x64@1.29.2: {}
 
   lightningcss-freebsd-x64@1.29.2:
     optional: true
@@ -6433,33 +6398,18 @@ snapshots:
   lightningcss-linux-arm-gnueabihf@1.29.2:
     optional: true
 
-  lightningcss-linux-arm64-gnu@1.29.1: {}
+  lightningcss-linux-arm64-gnu@1.29.2: {}
 
-  lightningcss-linux-arm64-gnu@1.29.2:
-    optional: true
+  lightningcss-linux-arm64-musl@1.29.2: {}
 
-  lightningcss-linux-arm64-musl@1.29.1: {}
+  lightningcss-linux-x64-gnu@1.29.2: {}
 
-  lightningcss-linux-arm64-musl@1.29.2:
-    optional: true
-
-  lightningcss-linux-x64-gnu@1.29.1: {}
-
-  lightningcss-linux-x64-gnu@1.29.2:
-    optional: true
-
-  lightningcss-linux-x64-musl@1.29.1: {}
-
-  lightningcss-linux-x64-musl@1.29.2:
-    optional: true
+  lightningcss-linux-x64-musl@1.29.2: {}
 
   lightningcss-win32-arm64-msvc@1.29.2:
     optional: true
 
-  lightningcss-win32-x64-msvc@1.29.1: {}
-
-  lightningcss-win32-x64-msvc@1.29.2:
-    optional: true
+  lightningcss-win32-x64-msvc@1.29.2: {}
 
   lightningcss@1.29.2(patch_hash=tzyxy3asfxcqc7ihrooumyi5fm):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,13 @@ packages:
 
 catalog:
   '@types/node': ^20.14.8
-  lightningcss: 1.29.2
   prettier: 3.5.0
   vite: ^6.0.0
+  lightningcss: 1.29.2
+  lightningcss-darwin-arm64: 1.29.2
+  lightningcss-darwin-x64: 1.29.2
+  lightningcss-linux-arm64-gnu: 1.29.2
+  lightningcss-linux-arm64-musl: 1.29.2
+  lightningcss-linux-x64-gnu: 1.29.2
+  lightningcss-linux-x64-musl: 1.29.2
+  lightningcss-win32-x64-msvc: 1.29.2


### PR DESCRIPTION
Closes #17162
Closes #17163
Closes #17164
Closes #17165
Closes #17166
Closes #17167
Closes #17170

Noticed that there was a second place pulling in the lightningcss version numbers that wasn't covered by the previous upgrade PR. Thankfully the APIs of the node bindings are still compatible.

To avoid this mistake in the future I also exported these sub-packages as a workspace dependency so all the version strings appear right next to each other.