### PR TITLE
Export `PluginUtils` from `tailwindcss/plugin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent segfault when loaded in a worker thread on Linux ([#17276](https://github.com/tailwindlabs/tailwindcss/pull/17276))
 - Ensure multiple `--value(…)` or `--modifier(…)` calls don't delete subsequent declarations ([#17273](https://github.com/tailwindlabs/tailwindcss/pull/17273))
 - Fix class extraction followed by `(` in Slim ([#17278](https://github.com/tailwindlabs/tailwindcss/pull/17278))
+- Export `PluginUtils` from `tailwindcss/plugin` for compatibility with v3 ([#17299](https://github.com/tailwindlabs/tailwindcss/pull/17299))
 
 ## [4.0.14] - 2025-03-13
 

--- a/packages/tailwindcss/src/plugin.ts
+++ b/packages/tailwindcss/src/plugin.ts
@@ -1,3 +1,4 @@
+import type { PluginUtils } from './compat/config/resolve-config'
 import type { ThemeConfig } from './compat/config/types'
 import type {
   Config,
@@ -34,4 +35,11 @@ createPlugin.withOptions = function <T>(
 export default createPlugin
 
 // v3 compatible types previously exported via `tailwindcss/types/config`
-export type { Config, PluginAPI, PluginFn as PluginCreator, Plugin as PluginsConfig, ThemeConfig }
+export type {
+  Config,
+  PluginAPI,
+  PluginFn as PluginCreator,
+  Plugin as PluginsConfig,
+  PluginUtils,
+  ThemeConfig,
+}


### PR DESCRIPTION
Closes #17293

We used to export this in v3 so might as well bring it back for the `tailwindcss/plugin` export list.
