### PR TITLE
Vite: Emit build dependencies on partial rebuilds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for literal values in `--value('…')` and `--modifier('…')` ([#17304](https://github.com/tailwindlabs/tailwindcss/pull/17304))
 - Add suggestions when `--spacing(--value(integer, number))` is used ([#17308](https://github.com/tailwindlabs/tailwindcss/pull/17308))
 
+### Fixed
+
+- Vite: Ensure that updates to an imported CSS file are properly propagated after updating templates ([#17347](https://github.com/tailwindlabs/tailwindcss/pull/17347))
+
 ### [4.0.15] - 2025-03-20
 
 ### Fixed

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -277,6 +277,10 @@ class Root {
 
       this.scanner = new Scanner({ sources })
       DEBUG && I.end('Setup scanner')
+    } else {
+      for (let buildDependency of this.buildDependencies.keys()) {
+        addWatchFile(buildDependency)
+      }
     }
 
     if (


### PR DESCRIPTION
Closes #17339

This PR fixes an issue that caused changes to `@import`-ed CSS files to no longer rebuild the stylesheet after a change was made to a template file. 

The change in the template file causes a fast-path in the Vite plugin now after changes in 4.0.8: _partial rebuilds_. For that branch we do not need to re-evaluate your input CSS since we know only the candidate list changed. However, we still need to emit all build dependencies as via `addWatchFile(…)`, otherwise Vite will not correctly register updates for these dependencies anymore.

## Test plan

- Updated the kitchen-sink Vite update tests to ensure that an `@import`-ed CSS file can be updated even after a partial rebuild.
- Ensure this works in our Vite playground