### PR TITLE
Fix Ruby files causing the CLI to hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - _Experimental_: Add `@source inline(…)` ([#17147](https://github.com/tailwindlabs/tailwindcss/pull/17147))
 - _Experimental_: Add `@source not` ([#17255](https://github.com/tailwindlabs/tailwindcss/pull/17255))
 
+### Fixed
+
+- Fix an issue causing the CLI to hang when processing Ruby files ([#17383](https://github.com/tailwindlabs/tailwindcss/pull/17383))
+
 ## [4.0.16] - 2025-03-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,21 +28,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,17 +154,6 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "fancy-regex"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
-dependencies = [
- "bit-set",
- "regex-automata 0.4.8",
- "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -581,7 +555,6 @@ dependencies = [
  "classification-macros",
  "crossbeam",
  "dunce",
- "fancy-regex",
  "fast-glob",
  "globwalk",
  "ignore 0.4.23",

--- a/crates/oxide/Cargo.toml
+++ b/crates/oxide/Cargo.toml
@@ -19,8 +19,6 @@ fast-glob = "0.4.3"
 classification-macros = { path = "../classification-macros" }
 ignore = { path = "../ignore" }
 regex = "1.11.1"
-fancy-regex = "0.14.0"
 
 [dev-dependencies]
 tempfile = "3.13.0"
-

--- a/crates/oxide/src/extractor/pre_processors/ruby.rs
+++ b/crates/oxide/src/extractor/pre_processors/ruby.rs
@@ -8,10 +8,6 @@ use bstr::ByteVec;
 use regex::{Regex, RegexBuilder};
 use std::sync;
 
-// 1. Find the start of the literal
-// 2. Get the language from the regex
-// 3. Manually scan until we find `^\s+([A-Z]+)`
-
 static TEMPLATE_START_REGEX: sync::LazyLock<Regex> = sync::LazyLock::new(|| {
     RegexBuilder::new(r#"\s*([a-z0-9_-]+)_template\s*<<[-~]?([A-Z]+)$"#)
       .multi_line(true)

--- a/crates/oxide/src/extractor/pre_processors/ruby.rs
+++ b/crates/oxide/src/extractor/pre_processors/ruby.rs
@@ -67,6 +67,7 @@ impl PreProcessor for Ruby {
             let replaced = pre_process_input(body.as_bytes(), &lang.to_ascii_lowercase());
 
             result.replace_range(body_start..body_end, replaced);
+            break;
           }
         }
 


### PR DESCRIPTION
Fixes #17379

The preprocessor we added to detect embedded languages uses a back reference and given a long enough file with certain byte / character patterns it'll cause what appears to be an indefinite hang (might just be catastrophically exponential backtracking but not sure)

This replaces the one regex w/ back references with two, anchored, multi-line regexes

Now we search for all the starting & ending delimiters in the file. We then loop over all the starting delimiters, find the paired ending one, and preprocess the content inside