### PR TITLE
A bit of internal cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +394,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +575,7 @@ dependencies = [
  "globwalk",
  "ignore 0.4.23",
  "log",
+ "pretty_assertions",
  "rayon",
  "regex",
  "rustc-hash",
@@ -792,3 +809,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"

--- a/crates/oxide/Cargo.toml
+++ b/crates/oxide/Cargo.toml
@@ -22,3 +22,4 @@ regex = "1.11.1"
 
 [dev-dependencies]
 tempfile = "3.13.0"
+pretty_assertions = "1.4.1"

--- a/crates/oxide/src/cursor.rs
+++ b/crates/oxide/src/cursor.rs
@@ -119,6 +119,7 @@ impl Display for Cursor<'_> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn test_cursor() {

--- a/crates/oxide/src/extractor/arbitrary_property_machine.rs
+++ b/crates/oxide/src/extractor/arbitrary_property_machine.rs
@@ -307,6 +307,7 @@ enum Class {
 mod tests {
     use super::{ArbitraryPropertyMachine, IdleState};
     use crate::extractor::machine::Machine;
+    use pretty_assertions::assert_eq;
 
     #[test]
     #[ignore]

--- a/crates/oxide/src/extractor/arbitrary_property_machine.rs
+++ b/crates/oxide/src/extractor/arbitrary_property_machine.rs
@@ -414,7 +414,7 @@ mod tests {
                 let actual = ArbitraryPropertyMachine::<IdleState>::test_extract_all(&input);
 
                 if actual != expected {
-                    dbg!(&input, &actual, &expected);
+                    dbg!(&input);
                 }
                 assert_eq!(actual, expected);
             }

--- a/crates/oxide/src/extractor/arbitrary_value_machine.rs
+++ b/crates/oxide/src/extractor/arbitrary_value_machine.rs
@@ -149,6 +149,7 @@ enum Class {
 mod tests {
     use super::ArbitraryValueMachine;
     use crate::extractor::machine::Machine;
+    use pretty_assertions::assert_eq;
 
     #[test]
     #[ignore]

--- a/crates/oxide/src/extractor/arbitrary_variable_machine.rs
+++ b/crates/oxide/src/extractor/arbitrary_variable_machine.rs
@@ -336,6 +336,7 @@ enum Class {
 mod tests {
     use super::ArbitraryVariableMachine;
     use crate::extractor::{arbitrary_variable_machine::IdleState, machine::Machine};
+    use pretty_assertions::assert_eq;
 
     #[test]
     #[ignore]

--- a/crates/oxide/src/extractor/candidate_machine.rs
+++ b/crates/oxide/src/extractor/candidate_machine.rs
@@ -308,7 +308,7 @@ mod tests {
                 actual.sort();
 
                 if actual != expected {
-                    dbg!(&input, &expected, &actual);
+                    dbg!(&input);
                 }
 
                 assert_eq!(actual, expected);

--- a/crates/oxide/src/extractor/candidate_machine.rs
+++ b/crates/oxide/src/extractor/candidate_machine.rs
@@ -181,6 +181,7 @@ impl CandidateMachine {
 mod tests {
     use super::CandidateMachine;
     use crate::extractor::machine::Machine;
+    use pretty_assertions::assert_eq;
 
     #[test]
     #[ignore]

--- a/crates/oxide/src/extractor/css_variable_machine.rs
+++ b/crates/oxide/src/extractor/css_variable_machine.rs
@@ -116,6 +116,7 @@ enum Class {
 mod tests {
     use super::CssVariableMachine;
     use crate::extractor::machine::Machine;
+    use pretty_assertions::assert_eq;
 
     #[test]
     #[ignore]

--- a/crates/oxide/src/extractor/css_variable_machine.rs
+++ b/crates/oxide/src/extractor/css_variable_machine.rs
@@ -204,7 +204,7 @@ mod tests {
                 let actual = CssVariableMachine::test_extract_all(&input);
 
                 if actual != expected {
-                    dbg!(&input, &actual, &expected);
+                    dbg!(&input);
                 }
 
                 assert_eq!(actual, expected);

--- a/crates/oxide/src/extractor/mod.rs
+++ b/crates/oxide/src/extractor/mod.rs
@@ -245,7 +245,7 @@ mod tests {
         expected.dedup();
 
         if actual != expected {
-            dbg!(&input, &actual, &expected);
+            dbg!(&input);
         }
         assert_eq!(actual, expected);
     }
@@ -273,7 +273,7 @@ mod tests {
         expected.sort();
 
         if actual != expected {
-            dbg!(&input, &actual, &expected);
+            dbg!(&input);
         }
         assert_eq!(actual, expected);
     }

--- a/crates/oxide/src/extractor/mod.rs
+++ b/crates/oxide/src/extractor/mod.rs
@@ -199,6 +199,7 @@ fn drop_covered_spans(mut spans: Vec<Span>) -> Vec<Span> {
 mod tests {
     use super::{Extracted, Extractor};
     use crate::throughput::Throughput;
+    use pretty_assertions::assert_eq;
     use std::hint::black_box;
 
     fn pre_process_input(input: &str, extension: &str) -> String {

--- a/crates/oxide/src/extractor/modifier_machine.rs
+++ b/crates/oxide/src/extractor/modifier_machine.rs
@@ -121,6 +121,7 @@ enum Class {
 mod tests {
     use super::ModifierMachine;
     use crate::extractor::machine::Machine;
+    use pretty_assertions::assert_eq;
 
     #[test]
     #[ignore]

--- a/crates/oxide/src/extractor/named_utility_machine.rs
+++ b/crates/oxide/src/extractor/named_utility_machine.rs
@@ -386,6 +386,7 @@ enum Class {
 mod tests {
     use super::{IdleState, NamedUtilityMachine};
     use crate::extractor::machine::Machine;
+    use pretty_assertions::assert_eq;
 
     #[test]
     #[ignore]

--- a/crates/oxide/src/extractor/named_utility_machine.rs
+++ b/crates/oxide/src/extractor/named_utility_machine.rs
@@ -516,7 +516,7 @@ mod tests {
                 actual.sort();
 
                 if actual != expected {
-                    dbg!(&input, &expected, &actual);
+                    dbg!(&input);
                 }
                 assert_eq!(actual, expected);
             }

--- a/crates/oxide/src/extractor/named_variant_machine.rs
+++ b/crates/oxide/src/extractor/named_variant_machine.rs
@@ -367,6 +367,7 @@ enum Class {
 mod tests {
     use super::{IdleState, NamedVariantMachine};
     use crate::extractor::machine::Machine;
+    use pretty_assertions::assert_eq;
 
     #[test]
     #[ignore]

--- a/crates/oxide/src/extractor/named_variant_machine.rs
+++ b/crates/oxide/src/extractor/named_variant_machine.rs
@@ -414,7 +414,7 @@ mod tests {
         ] {
             let actual = NamedVariantMachine::<IdleState>::test_extract_all(input);
             if actual != expected {
-                dbg!(&input, &actual, &expected);
+                dbg!(&input);
             }
             assert_eq!(actual, expected);
         }

--- a/crates/oxide/src/extractor/pre_processors/haml.rs
+++ b/crates/oxide/src/extractor/pre_processors/haml.rs
@@ -93,6 +93,7 @@ impl PreProcessor for Haml {
 mod tests {
     use super::Haml;
     use crate::extractor::pre_processors::pre_processor::PreProcessor;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn test_haml_pre_processor() {

--- a/crates/oxide/src/extractor/pre_processors/pre_processor.rs
+++ b/crates/oxide/src/extractor/pre_processors/pre_processor.rs
@@ -17,10 +17,6 @@ pub trait PreProcessor: Sized + Default {
         let actual = String::from_utf8_lossy(&actual);
         let expected = String::from_utf8_lossy(expected);
 
-        if actual != expected {
-            dbg!((&input, &actual, &expected));
-        }
-
         // The input and output should have the exact same length.
         assert_eq!(input.len(), actual.len());
         assert_eq!(actual.len(), expected.len());

--- a/crates/oxide/src/extractor/pre_processors/pre_processor.rs
+++ b/crates/oxide/src/extractor/pre_processors/pre_processor.rs
@@ -3,6 +3,8 @@ pub trait PreProcessor: Sized + Default {
 
     #[cfg(test)]
     fn test(input: &str, expected: &str) {
+        use pretty_assertions::assert_eq;
+
         let input = input.as_bytes();
         let expected = expected.as_bytes();
 

--- a/crates/oxide/src/extractor/string_machine.rs
+++ b/crates/oxide/src/extractor/string_machine.rs
@@ -87,6 +87,7 @@ enum Class {
 mod tests {
     use super::StringMachine;
     use crate::extractor::machine::Machine;
+    use pretty_assertions::assert_eq;
 
     #[test]
     #[ignore]

--- a/crates/oxide/src/extractor/utility_machine.rs
+++ b/crates/oxide/src/extractor/utility_machine.rs
@@ -192,6 +192,7 @@ enum Class {
 mod tests {
     use super::UtilityMachine;
     use crate::extractor::machine::Machine;
+    use pretty_assertions::assert_eq;
 
     #[test]
     #[ignore]

--- a/crates/oxide/src/extractor/utility_machine.rs
+++ b/crates/oxide/src/extractor/utility_machine.rs
@@ -337,7 +337,7 @@ mod tests {
                 actual.sort();
 
                 if actual != expected {
-                    dbg!(&input, &expected, &actual);
+                    dbg!(&input);
                 }
                 assert_eq!(actual, expected);
             }

--- a/crates/oxide/src/extractor/variant_machine.rs
+++ b/crates/oxide/src/extractor/variant_machine.rs
@@ -80,6 +80,7 @@ enum Class {
 mod tests {
     use super::VariantMachine;
     use crate::extractor::machine::Machine;
+    use pretty_assertions::assert_eq;
 
     #[test]
     #[ignore]

--- a/crates/oxide/src/glob.rs
+++ b/crates/oxide/src/glob.rs
@@ -191,6 +191,7 @@ mod tests {
     use super::optimize_patterns;
     use crate::GlobEntry;
     use bexpand::Expression;
+    use pretty_assertions::assert_eq;
     use std::process::Command;
     use std::{fs, path};
     use tempfile::tempdir;

--- a/crates/oxide/src/scanner/mod.rs
+++ b/crates/oxide/src/scanner/mod.rs
@@ -664,6 +664,7 @@ fn create_walker(sources: Sources) -> Option<WalkBuilder> {
 #[cfg(test)]
 mod tests {
     use super::{ChangedContent, Scanner};
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn test_positions() {

--- a/crates/oxide/src/scanner/sources.rs
+++ b/crates/oxide/src/scanner/sources.rs
@@ -128,13 +128,8 @@ impl PublicSourceEntry {
                         .to_string_lossy()
                         .to_string();
                     // Ensure leading slash, otherwise it will match against all files in all folders/
-                    self.pattern = format!(
-                        "/{}",
-                        resolved_path
-                            .file_name()
-                            .unwrap()
-                            .to_string_lossy()
-                    );
+                    self.pattern =
+                        format!("/{}", resolved_path.file_name().unwrap().to_string_lossy());
                 }
                 _ => {}
             }

--- a/crates/oxide/src/scanner/sources.rs
+++ b/crates/oxide/src/scanner/sources.rs
@@ -134,7 +134,6 @@ impl PublicSourceEntry {
                             .file_name()
                             .unwrap()
                             .to_string_lossy()
-                            .to_string()
                     );
                 }
                 _ => {}

--- a/crates/oxide/tests/scanner.rs
+++ b/crates/oxide/tests/scanner.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod scanner {
+    use pretty_assertions::assert_eq;
     use std::path::{Path, PathBuf};
     use std::process::Command;
     use std::thread::sleep;


### PR DESCRIPTION
Was working on another issue and noticed that I wanted these but they aren't related to any of the issues. So opening a separate PR to do some internal cleanup.

Essentially what happens here is:

1. Run `cargo --clippy` and `cargo fmt` to format everything nicely.
2. Added `pretty_assertions` to get better diffs when working on Rust tests if `assert_eq!(…)` fails.

This is just some internal cleanup, nothing changes for end users so no changelog entry was added.