### PR TITLE
Show warning when using unsupported bare value data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PostCSS: Ensure files containing `@tailwind utilities` are processed ([#17514](https://github.com/tailwindlabs/tailwindcss/pull/17514))
 - Ensure the `color-mix(…)` polyfill creates fallbacks even when using colors that cannot be statically analyzed ([#17513](https://github.com/tailwindlabs/tailwindcss/pull/17513))
 - Fix slow incremental builds with `@tailwindcss/vite` and `@tailwindcss/postscss` (especially on Windows) ([#17511](https://github.com/tailwindlabs/tailwindcss/pull/17511))
+- Show warning when using unsupported bare value data type in `--value(…)` ([#17464](https://github.com/tailwindlabs/tailwindcss/pull/17464))
 
 ## [4.1.1] - 2025-04-02
 

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { compile } from '.'
 import { compileCss, optimizeCss, run } from './test-utils/run'
 
@@ -26528,6 +26528,34 @@ describe('custom utilities', () => {
         }"
       `)
       expect(await compileCss(input, ['tab-foo'])).toEqual('')
+    })
+
+    test('bare values with unsupported data types should result in a warning', async () => {
+      let spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      let input = css`
+        @utility paint-* {
+          paint: --value([color], color);
+        }
+
+        @tailwind utilities;
+      `
+
+      expect(await compileCss(input, ['paint-#0088cc', 'paint-red'])).toMatchInlineSnapshot(`""`)
+      expect(spy.mock.calls).toMatchInlineSnapshot(`
+        [
+          [
+            "Unsupported bare value data type: "color".
+        Only valid data types are: "number", "integer", "ratio", "percentage"
+        ",
+          ],
+          [
+            "\`\`\`css
+        --value([color],color)
+                        ^^^^^
+        \`\`\`",
+          ],
+        ]
+      `)
     })
 
     test('resolve literal values', async () => {

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -26545,7 +26545,7 @@ describe('custom utilities', () => {
         [
           [
             "Unsupported bare value data type: "color".
-        Only valid data types are: "number", "integer", "ratio", "percentage"
+        Only valid data types are: "number", "integer", "ratio", "percentage".
         ",
           ],
           [

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -5692,6 +5692,16 @@ export function createUtilities(theme: Theme) {
   return utilities
 }
 
+// Only allowed bare value data types, to prevent creating new syntax that we
+// typically don't support right now. E.g.: `--value(color)` would allow you to
+// use `text-#0088cc` as a valid utility, which is not what we want.
+export const BARE_VALUE_DATA_TYPES = [
+  'number', // 2.5
+  'integer', // 8
+  'ratio', // 2/3
+  'percentage', // 25%
+]
+
 export function createCssUtility(node: AtRule) {
   let name = node.params
 
@@ -6084,12 +6094,7 @@ function resolveValueFunction(
       // Limit the bare value types, to prevent new syntax that we
       // don't want to support. E.g.: `text-#000` is something we
       // don't want to support, but could be built this way.
-      if (
-        arg.value !== 'number' &&
-        arg.value !== 'integer' &&
-        arg.value !== 'ratio' &&
-        arg.value !== 'percentage'
-      ) {
+      if (!BARE_VALUE_DATA_TYPES.includes(arg.value)) {
         continue
       }
 

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -5858,7 +5858,7 @@ export function createCssUtility(node: AtRule) {
               !BARE_VALUE_DATA_TYPES.includes(node.value)
             ) {
               console.warn(
-                `Unsupported bare value data type: "${node.value}".\nOnly valid data types are: ${BARE_VALUE_DATA_TYPES.map((x) => `"${x}"`).join(', ')}\n`,
+                `Unsupported bare value data type: "${node.value}".\nOnly valid data types are: ${BARE_VALUE_DATA_TYPES.map((x) => `"${x}"`).join(', ')}.\n`,
               )
               // TODO: Once we properly track the location of the node, we can
               //       clean this up in a better way.

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -5834,7 +5834,7 @@ export function createCssUtility(node: AtRule) {
           }
           fn.nodes = ValueParser.parse(args.join(','))
 
-          for (let [idx, node] of fn.nodes.entries()) {
+          for (let node of fn.nodes) {
             // Track literal values
             if (
               node.kind === 'word' &&


### PR DESCRIPTION
This PR will show a warning if you are using a bare value data type that is not supported.

Let's say you want to create a new utility that allows `color` to be a bare value data type like this:
```css
@utility paint-* {
  paint: --value([color], color);
}
```

This means that this would enable new syntax that we don't support yet. E.g.: `paint-#0088cc`.

The only supported data types for bare values are:

- `number` — `2.5`
- `integer` — `2`
- `ratio` — `1/2`
- `percentage` — `50%`

All other data types are not supported in this position. This PR will now show a warning:
~~~
Unsupported bare value data type: "color".
Only valid data types are: "number", "integer", "ratio", "percentage".

```css
--value([color],color)
                ^^^^^
```
~~~
Once we have better sourcemap / location tracking support, this warning will point to the exact spot, but for now, only a re-print of the AST can be used.


If you _do_ want to use other data types, then you will have to use arbitrary value syntax with `[…]` instead.


```css
@utility paint-* {
  paint: --value([color]);
}
```

This will allow for `paint-[#0088cc]` for example.

Note: this is not a behavioral change, we already didn't support other data types, but we silently ignored them. This means that we have to do more parsing at runtime when evaluating the utility. 

With this change, a warning is shown when registering the `@utility`, not when using it.
