### PR TITLE
Fix slow unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ playwright-report/
 blob-report/
 playwright/.cache/
 target/
-.debug
+.debug/


### PR DESCRIPTION
This PR reworks a unit test that created a file in the project root and then proceeded by scanning everything in the git root for candidates. The issue specifically is that with the `.debug/` folder, our project root can grow quite a bit which makes this test slower the more you work on other tests...

To fix this we now simply create a tmp folder with only that one test file. 🚀 