### PR TITLE
Replace currentColor with currentcolor (lowercase)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3522,7 +3522,7 @@ No release notes
 
 - Lists now have no margins by default
 - `.pin` no longer sets width and height to 100%
-- SVG `fill` no longer defaults to currentColor
+- SVG `fill` no longer defaults to currentcolor
 
 ## [0.2.2] - 2017-11-19
 

--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -1727,7 +1727,7 @@ test(
         }
         @supports (not (-webkit-appearance: -apple-pay-button))  or (contain-intrinsic-size: 1px) {
           ::placeholder {
-            color: color-mix(in oklab, currentColor 50%, transparent);
+            color: color-mix(in oklab, currentcolor 50%, transparent);
           }
         }
         textarea {

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -120,7 +120,7 @@ test(
       @import 'tailwindcss';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -133,7 +133,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
 
@@ -218,7 +218,7 @@ test(
       @import 'tailwindcss' prefix(tw);
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -231,7 +231,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
 
@@ -282,7 +282,7 @@ test(
       @import 'tailwindcss';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -295,7 +295,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
 
@@ -354,7 +354,7 @@ test(
       @import 'tailwindcss';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -367,7 +367,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
 
@@ -431,7 +431,7 @@ test(
       @import 'tailwindcss';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -444,7 +444,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
 
@@ -540,7 +540,7 @@ test(
       @import 'tailwindcss';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -553,7 +553,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
 
@@ -1044,7 +1044,7 @@ test(
       @import './utilities.css';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -1057,7 +1057,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
 
@@ -1492,7 +1492,7 @@ test(
       @config './tailwind.config.ts';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -1505,7 +1505,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
 
@@ -1516,7 +1516,7 @@ test(
       @config "../../tailwind.config.ts";
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -1529,7 +1529,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
 
@@ -1550,7 +1550,7 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -1563,7 +1563,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
 
@@ -1579,7 +1579,7 @@ test(
       @import 'tailwindcss/preflight' layer(base);
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -1592,7 +1592,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
 
@@ -1610,7 +1610,7 @@ test(
       @config '../../tailwind.config.ts';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -1623,7 +1623,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
       "
@@ -1790,7 +1790,7 @@ test(
       @import 'tailwindcss/preflight' layer(base);
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -1803,7 +1803,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
 
@@ -1926,7 +1926,7 @@ test(
       @import 'tailwindcss/preflight' layer(base);
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -1939,7 +1939,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
 
@@ -2043,7 +2043,7 @@ test(
       @import 'tailwindcss/preflight' layer(base);
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -2056,7 +2056,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
 
@@ -2118,7 +2118,7 @@ test(
       @import './styles/components.css' layer(components);
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -2131,7 +2131,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
 
@@ -2349,7 +2349,7 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -2362,7 +2362,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
 
@@ -2434,7 +2434,7 @@ test(
       @import 'tailwindcss';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -2447,7 +2447,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
 
@@ -2547,7 +2547,7 @@ test(
       @import 'tailwindcss/preflight' layer(base);
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -2560,7 +2560,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
 
@@ -2725,7 +2725,7 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -2738,7 +2738,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
       "
@@ -2789,7 +2789,7 @@ test(
       @import 'tailwindcss';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -2802,7 +2802,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
       "

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -270,7 +270,7 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -283,7 +283,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
 
@@ -404,7 +404,7 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -417,7 +417,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
       "
@@ -486,7 +486,7 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -499,7 +499,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
       "
@@ -560,7 +560,7 @@ test(
       @config '../tailwind.config.ts';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -573,7 +573,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
       "
@@ -638,7 +638,7 @@ test(
       @config '../tailwind.config.ts';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -651,7 +651,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
       "
@@ -712,7 +712,7 @@ test(
       @config '../tailwind.config.ts';
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -725,7 +725,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
       "
@@ -824,7 +824,7 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -837,7 +837,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
 
@@ -849,7 +849,7 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -862,7 +862,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
       "
@@ -926,7 +926,7 @@ test(
       }
 
       /*
-        The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
         so we've added these compatibility styles to make sure everything still
         looks the same as it did with Tailwind CSS v3.
 
@@ -939,7 +939,7 @@ test(
         ::before,
         ::backdrop,
         ::file-selector-button {
-          border-color: var(--color-gray-200, currentColor);
+          border-color: var(--color-gray-200, currentcolor);
         }
       }
       "
@@ -986,7 +986,7 @@ describe('border compatibility', () => {
         @import 'tailwindcss';
 
         /*
-          The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+          The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
           so we've added these compatibility styles to make sure everything still
           looks the same as it did with Tailwind CSS v3.
 
@@ -999,7 +999,7 @@ describe('border compatibility', () => {
           ::before,
           ::backdrop,
           ::file-selector-button {
-            border-color: var(--color-gray-200, currentColor);
+            border-color: var(--color-gray-200, currentcolor);
           }
         }
         "
@@ -1048,7 +1048,7 @@ describe('border compatibility', () => {
         @import 'tailwindcss';
 
         /*
-          The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+          The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
           so we've added these compatibility styles to make sure everything still
           looks the same as it did with Tailwind CSS v3.
 
@@ -1088,7 +1088,7 @@ describe('border compatibility', () => {
             theme: {
               extend: {
                 borderColor: ({ colors }) => ({
-                  DEFAULT: 'currentColor',
+                  DEFAULT: 'currentcolor',
                 }),
               },
             },
@@ -1152,7 +1152,7 @@ describe('border compatibility', () => {
         @import 'tailwindcss';
 
         /*
-          The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+          The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
           so we've added these compatibility styles to make sure everything still
           looks the same as it did with Tailwind CSS v3.
 
@@ -1165,7 +1165,7 @@ describe('border compatibility', () => {
           ::before,
           ::backdrop,
           ::file-selector-button {
-            border-color: var(--color-gray-200, currentColor);
+            border-color: var(--color-gray-200, currentcolor);
           }
         }
         "
@@ -1221,7 +1221,7 @@ describe('border compatibility', () => {
         @import 'tailwindcss/preflight' layer(base);
 
         /*
-          The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+          The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
           so we've added these compatibility styles to make sure everything still
           looks the same as it did with Tailwind CSS v3.
 
@@ -1234,7 +1234,7 @@ describe('border compatibility', () => {
           ::before,
           ::backdrop,
           ::file-selector-button {
-            border-color: var(--color-gray-200, currentColor);
+            border-color: var(--color-gray-200, currentcolor);
           }
         }
 
@@ -1339,7 +1339,7 @@ describe('border compatibility', () => {
         }
 
         /*
-          The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+          The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
           so we've added these compatibility styles to make sure everything still
           looks the same as it did with Tailwind CSS v3.
 
@@ -1352,7 +1352,7 @@ describe('border compatibility', () => {
           ::before,
           ::backdrop,
           ::file-selector-button {
-            border-color: var(--color-gray-200, currentColor);
+            border-color: var(--color-gray-200, currentcolor);
           }
         }
 
@@ -1453,7 +1453,7 @@ describe('border compatibility', () => {
         }
 
         /*
-          The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+          The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
           so we've added these compatibility styles to make sure everything still
           looks the same as it did with Tailwind CSS v3.
 
@@ -1466,7 +1466,7 @@ describe('border compatibility', () => {
           ::before,
           ::backdrop,
           ::file-selector-button {
-            border-color: var(--color-gray-200, currentColor);
+            border-color: var(--color-gray-200, currentcolor);
           }
         }
 
@@ -1556,7 +1556,7 @@ describe('border compatibility', () => {
         }
 
         /*
-          The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+          The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
           so we've added these compatibility styles to make sure everything still
           looks the same as it did with Tailwind CSS v3.
 
@@ -1569,7 +1569,7 @@ describe('border compatibility', () => {
           ::before,
           ::backdrop,
           ::file-selector-button {
-            border-color: var(--color-gray-200, currentColor);
+            border-color: var(--color-gray-200, currentcolor);
           }
         }
         "

--- a/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
@@ -165,7 +165,7 @@ exports[`\`@import 'tailwindcss'\` is replaced with the generated CSS 1`] = `
 
   @supports (not ((-webkit-appearance: -apple-pay-button))) or (contain-intrinsic-size: 1px) {
     ::placeholder {
-      color: color-mix(in oklab, currentColor 50%, transparent);
+      color: color-mix(in oklab, currentcolor 50%, transparent);
     }
   }
 

--- a/packages/@tailwindcss-upgrade/src/codemods/css/migrate-preflight.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/css/migrate-preflight.test.ts
@@ -33,7 +33,7 @@ it("should add compatibility CSS after the `@import 'tailwindcss'`", async () =>
     "@import 'tailwindcss';
 
     /*
-      The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+      The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
       so we've added these compatibility styles to make sure everything still
       looks the same as it did with Tailwind CSS v3.
 
@@ -46,7 +46,7 @@ it("should add compatibility CSS after the `@import 'tailwindcss'`", async () =>
       ::before,
       ::backdrop,
       ::file-selector-button {
-        border-color: var(--color-gray-200, currentColor);
+        border-color: var(--color-gray-200, currentcolor);
       }
     }"
   `)
@@ -65,7 +65,7 @@ it('should add the compatibility CSS after the last `@import`', async () => {
     @import './bar.css';
 
     /*
-      The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+      The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
       so we've added these compatibility styles to make sure everything still
       looks the same as it did with Tailwind CSS v3.
 
@@ -78,7 +78,7 @@ it('should add the compatibility CSS after the last `@import`', async () => {
       ::before,
       ::backdrop,
       ::file-selector-button {
-        border-color: var(--color-gray-200, currentColor);
+        border-color: var(--color-gray-200, currentcolor);
       }
     }"
   `)
@@ -111,7 +111,7 @@ it('should add the compatibility CSS after the last import, even if a body-less 
     @import './bar.css';
 
     /*
-      The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+      The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
       so we've added these compatibility styles to make sure everything still
       looks the same as it did with Tailwind CSS v3.
 
@@ -124,7 +124,7 @@ it('should add the compatibility CSS after the last import, even if a body-less 
       ::before,
       ::backdrop,
       ::file-selector-button {
-        border-color: var(--color-gray-200, currentColor);
+        border-color: var(--color-gray-200, currentcolor);
       }
     }"
   `)
@@ -157,7 +157,7 @@ it('should add the compatibility CSS before the first `@layer base` (if the "tai
     }
 
     /*
-      The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+      The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
       so we've added these compatibility styles to make sure everything still
       looks the same as it did with Tailwind CSS v3.
 
@@ -170,7 +170,7 @@ it('should add the compatibility CSS before the first `@layer base` (if the "tai
       ::before,
       ::backdrop,
       ::file-selector-button {
-        border-color: var(--color-gray-200, currentColor);
+        border-color: var(--color-gray-200, currentcolor);
       }
     }
 
@@ -215,7 +215,7 @@ it('should add the compatibility CSS before the first `@layer base` (if the "tai
     }
 
     /*
-      The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+      The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
       so we've added these compatibility styles to make sure everything still
       looks the same as it did with Tailwind CSS v3.
 
@@ -228,7 +228,7 @@ it('should add the compatibility CSS before the first `@layer base` (if the "tai
       ::before,
       ::backdrop,
       ::file-selector-button {
-        border-color: var(--color-gray-200, currentColor);
+        border-color: var(--color-gray-200, currentcolor);
       }
     }
 

--- a/packages/@tailwindcss-upgrade/src/codemods/css/migrate-preflight.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/css/migrate-preflight.ts
@@ -7,12 +7,12 @@ import { toKeyPath } from '../../../../tailwindcss/src/utils/to-key-path'
 import * as ValueParser from '../../../../tailwindcss/src/value-parser'
 
 // Defaults in v4
-const DEFAULT_BORDER_COLOR = 'currentColor'
+const DEFAULT_BORDER_COLOR = 'currentcolor'
 
 const css = dedent
 const BORDER_COLOR_COMPATIBILITY_CSS = css`
   /*
-    The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+    The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
     so we've added these compatibility styles to make sure everything still
     looks the same as it did with Tailwind CSS v3.
 
@@ -78,7 +78,7 @@ export function migratePreflight({
             return defaultBorderColor
           } else {
             if (path === 'borderColor.DEFAULT') {
-              return 'var(--color-gray-200, currentColor)'
+              return 'var(--color-gray-200, currentcolor)'
             }
           }
           return null

--- a/packages/@tailwindcss-upgrade/src/index.test.ts
+++ b/packages/@tailwindcss-upgrade/src/index.test.ts
@@ -97,7 +97,7 @@ it('should migrate a stylesheet', async () => {
     "@import 'tailwindcss';
 
     /*
-      The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+      The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
       so we've added these compatibility styles to make sure everything still
       looks the same as it did with Tailwind CSS v3.
 
@@ -110,7 +110,7 @@ it('should migrate a stylesheet', async () => {
       ::before,
       ::backdrop,
       ::file-selector-button {
-        border-color: var(--color-gray-200, currentColor);
+        border-color: var(--color-gray-200, currentcolor);
       }
     }
 
@@ -168,7 +168,7 @@ it('should migrate a stylesheet (with imports)', async () => {
     @import './my-utilities.css' layer(utilities);
 
     /*
-      The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+      The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
       so we've added these compatibility styles to make sure everything still
       looks the same as it did with Tailwind CSS v3.
 
@@ -181,7 +181,7 @@ it('should migrate a stylesheet (with imports)', async () => {
       ::before,
       ::backdrop,
       ::file-selector-button {
-        border-color: var(--color-gray-200, currentColor);
+        border-color: var(--color-gray-200, currentcolor);
       }
     }"
   `)
@@ -210,7 +210,7 @@ it('should migrate a stylesheet (with preceding rules that should be wrapped in 
     @import 'tailwindcss';
 
     /*
-      The default border color has changed to \`currentColor\` in Tailwind CSS v4,
+      The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
       so we've added these compatibility styles to make sure everything still
       looks the same as it did with Tailwind CSS v3.
 
@@ -223,7 +223,7 @@ it('should migrate a stylesheet (with preceding rules that should be wrapped in 
       ::before,
       ::backdrop,
       ::file-selector-button {
-        border-color: var(--color-gray-200, currentColor);
+        border-color: var(--color-gray-200, currentcolor);
       }
     }
 

--- a/packages/tailwindcss/preflight.css
+++ b/packages/tailwindcss/preflight.css
@@ -285,13 +285,13 @@ textarea,
 
 /*
   Set the default placeholder color to a semi-transparent version of the current text color in browsers that do not
-  crash when using `color-mix(…)` with `currentColor`. (https://github.com/tailwindlabs/tailwindcss/issues/17194)
+  crash when using `color-mix(…)` with `currentcolor`. (https://github.com/tailwindlabs/tailwindcss/issues/17194)
 */
 
 @supports (not (-webkit-appearance: -apple-pay-button)) /* Not Safari */ or
   (contain-intrinsic-size: 1px) /* Safari 17+ */ {
   ::placeholder {
-    color: color-mix(in oklab, currentColor 50%, transparent);
+    color: color-mix(in oklab, currentcolor 50%, transparent);
   }
 }
 

--- a/packages/tailwindcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/tailwindcss/src/__snapshots__/index.test.ts.snap
@@ -287,7 +287,7 @@ exports[`compiling CSS > prefix all CSS variables inside preflight 1`] = `
 
   @supports (not ((-webkit-appearance: -apple-pay-button))) or (contain-intrinsic-size: 1px) {
     ::placeholder {
-      color: color-mix(in oklab, currentColor 50%, transparent);
+      color: color-mix(in oklab, currentcolor 50%, transparent);
     }
   }
 

--- a/packages/tailwindcss/src/__snapshots__/utilities.test.ts.snap
+++ b/packages/tailwindcss/src/__snapshots__/utilities.test.ts.snap
@@ -108,7 +108,7 @@ exports[`border-* 1`] = `
 }
 
 .border-current {
-  border-color: currentcolor;
+  border-color: currentColor;
 }
 
 .border-current\\/50 {
@@ -282,7 +282,7 @@ exports[`border-b-* 1`] = `
 }
 
 .border-b-current {
-  border-bottom-color: currentcolor;
+  border-bottom-color: currentColor;
 }
 
 .border-b-current\\/50 {
@@ -456,7 +456,7 @@ exports[`border-e-* 1`] = `
 }
 
 .border-e-current {
-  border-inline-end-color: currentcolor;
+  border-inline-end-color: currentColor;
 }
 
 .border-e-current\\/50 {
@@ -630,7 +630,7 @@ exports[`border-l-* 1`] = `
 }
 
 .border-l-current {
-  border-left-color: currentcolor;
+  border-left-color: currentColor;
 }
 
 .border-l-current\\/50 {
@@ -804,7 +804,7 @@ exports[`border-r-* 1`] = `
 }
 
 .border-r-current {
-  border-right-color: currentcolor;
+  border-right-color: currentColor;
 }
 
 .border-r-current\\/50 {
@@ -978,7 +978,7 @@ exports[`border-s-* 1`] = `
 }
 
 .border-s-current {
-  border-inline-start-color: currentcolor;
+  border-inline-start-color: currentColor;
 }
 
 .border-s-current\\/50 {
@@ -1152,7 +1152,7 @@ exports[`border-t-* 1`] = `
 }
 
 .border-t-current {
-  border-top-color: currentcolor;
+  border-top-color: currentColor;
 }
 
 .border-t-current\\/50 {
@@ -1326,7 +1326,7 @@ exports[`border-x-* 1`] = `
 }
 
 .border-x-current {
-  border-inline-color: currentcolor;
+  border-inline-color: currentColor;
 }
 
 .border-x-current\\/50 {
@@ -1500,7 +1500,7 @@ exports[`border-y-* 1`] = `
 }
 
 .border-y-current {
-  border-block-color: currentcolor;
+  border-block-color: currentColor;
 }
 
 .border-y-current\\/50 {

--- a/packages/tailwindcss/src/__snapshots__/utilities.test.ts.snap
+++ b/packages/tailwindcss/src/__snapshots__/utilities.test.ts.snap
@@ -108,11 +108,11 @@ exports[`border-* 1`] = `
 }
 
 .border-current {
-  border-color: currentColor;
+  border-color: currentcolor;
 }
 
 .border-current\\/50 {
-  border-color: color-mix(in oklab, currentColor 50%, transparent);
+  border-color: color-mix(in oklab, currentcolor 50%, transparent);
 }
 
 .border-inherit {
@@ -282,11 +282,11 @@ exports[`border-b-* 1`] = `
 }
 
 .border-b-current {
-  border-bottom-color: currentColor;
+  border-bottom-color: currentcolor;
 }
 
 .border-b-current\\/50 {
-  border-bottom-color: color-mix(in oklab, currentColor 50%, transparent);
+  border-bottom-color: color-mix(in oklab, currentcolor 50%, transparent);
 }
 
 .border-b-inherit {
@@ -456,11 +456,11 @@ exports[`border-e-* 1`] = `
 }
 
 .border-e-current {
-  border-inline-end-color: currentColor;
+  border-inline-end-color: currentcolor;
 }
 
 .border-e-current\\/50 {
-  border-inline-end-color: color-mix(in oklab, currentColor 50%, transparent);
+  border-inline-end-color: color-mix(in oklab, currentcolor 50%, transparent);
 }
 
 .border-e-inherit {
@@ -630,11 +630,11 @@ exports[`border-l-* 1`] = `
 }
 
 .border-l-current {
-  border-left-color: currentColor;
+  border-left-color: currentcolor;
 }
 
 .border-l-current\\/50 {
-  border-left-color: color-mix(in oklab, currentColor 50%, transparent);
+  border-left-color: color-mix(in oklab, currentcolor 50%, transparent);
 }
 
 .border-l-inherit {
@@ -804,11 +804,11 @@ exports[`border-r-* 1`] = `
 }
 
 .border-r-current {
-  border-right-color: currentColor;
+  border-right-color: currentcolor;
 }
 
 .border-r-current\\/50 {
-  border-right-color: color-mix(in oklab, currentColor 50%, transparent);
+  border-right-color: color-mix(in oklab, currentcolor 50%, transparent);
 }
 
 .border-r-inherit {
@@ -978,11 +978,11 @@ exports[`border-s-* 1`] = `
 }
 
 .border-s-current {
-  border-inline-start-color: currentColor;
+  border-inline-start-color: currentcolor;
 }
 
 .border-s-current\\/50 {
-  border-inline-start-color: color-mix(in oklab, currentColor 50%, transparent);
+  border-inline-start-color: color-mix(in oklab, currentcolor 50%, transparent);
 }
 
 .border-s-inherit {
@@ -1152,11 +1152,11 @@ exports[`border-t-* 1`] = `
 }
 
 .border-t-current {
-  border-top-color: currentColor;
+  border-top-color: currentcolor;
 }
 
 .border-t-current\\/50 {
-  border-top-color: color-mix(in oklab, currentColor 50%, transparent);
+  border-top-color: color-mix(in oklab, currentcolor 50%, transparent);
 }
 
 .border-t-inherit {
@@ -1326,11 +1326,11 @@ exports[`border-x-* 1`] = `
 }
 
 .border-x-current {
-  border-inline-color: currentColor;
+  border-inline-color: currentcolor;
 }
 
 .border-x-current\\/50 {
-  border-inline-color: color-mix(in oklab, currentColor 50%, transparent);
+  border-inline-color: color-mix(in oklab, currentcolor 50%, transparent);
 }
 
 .border-x-inherit {
@@ -1500,11 +1500,11 @@ exports[`border-y-* 1`] = `
 }
 
 .border-y-current {
-  border-block-color: currentColor;
+  border-block-color: currentcolor;
 }
 
 .border-y-current\\/50 {
-  border-block-color: color-mix(in oklab, currentColor 50%, transparent);
+  border-block-color: color-mix(in oklab, currentcolor 50%, transparent);
 }
 
 .border-y-inherit {

--- a/packages/tailwindcss/src/compat/colors.ts
+++ b/packages/tailwindcss/src/compat/colors.ts
@@ -1,6 +1,6 @@
 export default {
   inherit: 'inherit',
-  current: 'currentColor',
+  current: 'currentcolor',
   transparent: 'transparent',
   black: '#000',
   white: '#fff',

--- a/packages/tailwindcss/src/compat/default-theme.ts
+++ b/packages/tailwindcss/src/compat/default-theme.ts
@@ -156,7 +156,7 @@ export default {
     '3xl': '64px',
   },
   borderColor: ({ theme }) => ({
-    DEFAULT: 'currentColor',
+    DEFAULT: 'currentcolor',
     ...theme('colors'),
   }),
   borderOpacity: ({ theme }) => theme('opacity'),
@@ -825,7 +825,7 @@ export default {
   placeholderColor: ({ theme }) => theme('colors'),
   placeholderOpacity: ({ theme }) => theme('opacity'),
   ringColor: ({ theme }) => ({
-    DEFAULT: 'currentColor',
+    DEFAULT: 'currentcolor',
     ...theme('colors'),
   }),
   ringOffsetColor: ({ theme }) => theme('colors'),

--- a/packages/tailwindcss/src/compat/plugin-api.test.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.test.ts
@@ -3856,11 +3856,11 @@ describe('matchUtilities()', () => {
       }
 
       .scrollbar-current {
-        scrollbar-color: currentColor;
+        scrollbar-color: currentcolor;
       }
 
       .scrollbar-current\\/45 {
-        scrollbar-color: color-mix(in oklab, currentColor 45%, transparent);
+        scrollbar-color: color-mix(in oklab, currentcolor 45%, transparent);
       }"
     `)
   })

--- a/packages/tailwindcss/src/compat/plugin-api.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.ts
@@ -344,13 +344,13 @@ export function buildPluginApi({
               let values = options?.values ?? {}
 
               if (isColor) {
-                // Color utilities implicitly support `inherit`, `transparent`, and `currentColor`
+                // Color utilities implicitly support `inherit`, `transparent`, and `currentcolor`
                 // for backwards compatibility but still allow them to be overridden
                 values = Object.assign(
                   {
                     inherit: 'inherit',
                     transparent: 'transparent',
-                    current: 'currentColor',
+                    current: 'currentcolor',
                   },
                   values,
                 )

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -4896,7 +4896,7 @@ describe('`color-mix(…)` polyfill', () => {
     `)
   })
 
-  it('does not replace `currentColor` inside `color-mix(…)`', async () => {
+  it('does not replace `currentcolor` inside `color-mix(…)`', async () => {
     await expect(
       compileCss(
         css`
@@ -4906,7 +4906,7 @@ describe('`color-mix(…)` polyfill', () => {
       ),
     ).resolves.toMatchInlineSnapshot(`
       ".text-current\\/50 {
-        color: color-mix(in oklab, currentColor 50%, transparent);
+        color: color-mix(in oklab, currentcolor 50%, transparent);
       }"
     `)
   })

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -8448,11 +8448,11 @@ test('accent', async () => {
     }
 
     .accent-current {
-      accent-color: currentColor;
+      accent-color: currentcolor;
     }
 
     .accent-current\\/50, .accent-current\\/\\[0\\.5\\], .accent-current\\/\\[50\\%\\] {
-      accent-color: color-mix(in oklab, currentColor 50%, transparent);
+      accent-color: color-mix(in oklab, currentcolor 50%, transparent);
     }
 
     .accent-inherit {
@@ -8607,11 +8607,11 @@ test('caret', async () => {
     }
 
     .caret-current {
-      caret-color: currentColor;
+      caret-color: currentcolor;
     }
 
     .caret-current\\/50, .caret-current\\/\\[0\\.5\\], .caret-current\\/\\[50\\%\\] {
-      caret-color: color-mix(in oklab, currentColor 50%, transparent);
+      caret-color: color-mix(in oklab, currentcolor 50%, transparent);
     }
 
     .caret-inherit {
@@ -8764,11 +8764,11 @@ test('divide-color', async () => {
     }
 
     :where(.divide-current > :not(:last-child)) {
-      border-color: currentColor;
+      border-color: currentcolor;
     }
 
     :where(.divide-current\\/50 > :not(:last-child)), :where(.divide-current\\/\\[0\\.5\\] > :not(:last-child)), :where(.divide-current\\/\\[50\\%\\] > :not(:last-child)) {
-      border-color: color-mix(in oklab, currentColor 50%, transparent);
+      border-color: color-mix(in oklab, currentcolor 50%, transparent);
     }
 
     :where(.divide-inherit > :not(:last-child)) {
@@ -10789,15 +10789,15 @@ test('bg', async () => {
     }
 
     .bg-current {
-      background-color: currentColor;
+      background-color: currentcolor;
     }
 
     .bg-current\\/50, .bg-current\\/\\[0\\.5\\], .bg-current\\/\\[50\\%\\] {
-      background-color: color-mix(in oklab, currentColor 50%, transparent);
+      background-color: color-mix(in oklab, currentcolor 50%, transparent);
     }
 
     .bg-current\\/\\[var\\(--bg-opacity\\)\\] {
-      background-color: color-mix(in oklab, currentColor var(--bg-opacity), transparent);
+      background-color: color-mix(in oklab, currentcolor var(--bg-opacity), transparent);
     }
 
     .bg-inherit {
@@ -11528,22 +11528,22 @@ test('bg', async () => {
     ),
   ).toMatchInlineSnapshot(`
     ".bg-current\\/custom {
-      background-color: color-mix(in srgb, currentColor var(--custom-opacity), transparent);
+      background-color: color-mix(in srgb, currentcolor var(--custom-opacity), transparent);
     }
 
     @supports (color: color-mix(in lab, red, red)) {
       .bg-current\\/custom {
-        background-color: color-mix(in oklab, currentColor var(--opacity-custom, var(--custom-opacity)), transparent);
+        background-color: color-mix(in oklab, currentcolor var(--opacity-custom, var(--custom-opacity)), transparent);
       }
     }
 
     .bg-current\\/half {
-      background-color: color-mix(in srgb, currentColor .5, transparent);
+      background-color: color-mix(in srgb, currentcolor .5, transparent);
     }
 
     @supports (color: color-mix(in lab, red, red)) {
       .bg-current\\/half {
-        background-color: color-mix(in oklab, currentColor var(--opacity-half, .5), transparent);
+        background-color: color-mix(in oklab, currentcolor var(--opacity-half, .5), transparent);
       }
     }
 
@@ -11733,12 +11733,12 @@ test('from', async () => {
     }
 
     .from-current {
-      --tw-gradient-from: currentColor;
+      --tw-gradient-from: currentcolor;
       --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
     }
 
     .from-current\\/50, .from-current\\/\\[0\\.5\\], .from-current\\/\\[50\\%\\] {
-      --tw-gradient-from: color-mix(in oklab, currentColor 50%, transparent);
+      --tw-gradient-from: color-mix(in oklab, currentcolor 50%, transparent);
       --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
     }
 
@@ -12002,13 +12002,13 @@ test('via', async () => {
     }
 
     .via-current {
-      --tw-gradient-via: currentColor;
+      --tw-gradient-via: currentcolor;
       --tw-gradient-via-stops: var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-via) var(--tw-gradient-via-position), var(--tw-gradient-to) var(--tw-gradient-to-position);
       --tw-gradient-stops: var(--tw-gradient-via-stops);
     }
 
     .via-current\\/50, .via-current\\/\\[0\\.5\\], .via-current\\/\\[50\\%\\] {
-      --tw-gradient-via: color-mix(in oklab, currentColor 50%, transparent);
+      --tw-gradient-via: color-mix(in oklab, currentcolor 50%, transparent);
       --tw-gradient-via-stops: var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-via) var(--tw-gradient-via-position), var(--tw-gradient-to) var(--tw-gradient-to-position);
       --tw-gradient-stops: var(--tw-gradient-via-stops);
     }
@@ -12271,12 +12271,12 @@ test('to', async () => {
     }
 
     .to-current {
-      --tw-gradient-to: currentColor;
+      --tw-gradient-to: currentcolor;
       --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
     }
 
     .to-current\\/50, .to-current\\/\\[0\\.5\\], .to-current\\/\\[50\\%\\] {
-      --tw-gradient-to: color-mix(in oklab, currentColor 50%, transparent);
+      --tw-gradient-to: color-mix(in oklab, currentcolor 50%, transparent);
       --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
     }
 
@@ -18713,11 +18713,11 @@ test('fill', async () => {
     }
 
     .fill-current {
-      fill: currentColor;
+      fill: currentcolor;
     }
 
     .fill-current\\/50, .fill-current\\/\\[0\\.5\\], .fill-current\\/\\[50\\%\\] {
-      fill: color-mix(in oklab, currentColor 50%, transparent);
+      fill: color-mix(in oklab, currentcolor 50%, transparent);
     }
 
     .fill-inherit {
@@ -18894,11 +18894,11 @@ test('stroke', async () => {
     }
 
     .stroke-current {
-      stroke: currentColor;
+      stroke: currentcolor;
     }
 
     .stroke-current\\/50, .stroke-current\\/\\[0\\.5\\], .stroke-current\\/\\[50\\%\\] {
-      stroke: color-mix(in oklab, currentColor 50%, transparent);
+      stroke: color-mix(in oklab, currentcolor 50%, transparent);
     }
 
     .stroke-inherit {
@@ -19944,11 +19944,11 @@ test('placeholder', async () => {
     }
 
     .placeholder-current::placeholder {
-      color: currentColor;
+      color: currentcolor;
     }
 
     .placeholder-current\\/50::placeholder, .placeholder-current\\/\\[0\\.5\\]::placeholder, .placeholder-current\\/\\[50\\%\\]::placeholder {
-      color: color-mix(in oklab, currentColor 50%, transparent);
+      color: color-mix(in oklab, currentcolor 50%, transparent);
     }
 
     .placeholder-inherit::placeholder {
@@ -20137,13 +20137,13 @@ test('decoration', async () => {
     }
 
     .decoration-current {
-      text-decoration-color: currentColor;
+      text-decoration-color: currentcolor;
     }
 
     .decoration-current\\/50, .decoration-current\\/\\[0\\.5\\], .decoration-current\\/\\[50\\%\\] {
-      -webkit-text-decoration-color: color-mix(in oklab, currentColor 50%, transparent);
-      -webkit-text-decoration-color: color-mix(in oklab, currentColor 50%, transparent);
-      text-decoration-color: color-mix(in oklab, currentColor 50%, transparent);
+      -webkit-text-decoration-color: color-mix(in oklab, currentcolor 50%, transparent);
+      -webkit-text-decoration-color: color-mix(in oklab, currentcolor 50%, transparent);
+      text-decoration-color: color-mix(in oklab, currentcolor 50%, transparent);
     }
 
     .decoration-inherit {
@@ -22041,11 +22041,11 @@ test('outline', async () => {
     }
 
     .outline-current {
-      outline-color: currentColor;
+      outline-color: currentcolor;
     }
 
     .outline-current\\/50, .outline-current\\/\\[0\\.5\\], .outline-current\\/\\[50\\%\\] {
-      outline-color: color-mix(in oklab, currentColor 50%, transparent);
+      outline-color: color-mix(in oklab, currentcolor 50%, transparent);
     }
 
     .outline-inherit {
@@ -22525,11 +22525,11 @@ test('text', async () => {
     }
 
     .text-current {
-      color: currentColor;
+      color: currentcolor;
     }
 
     .text-current\\/50, .text-current\\/\\[0\\.5\\], .text-current\\/\\[50\\%\\] {
-      color: color-mix(in oklab, currentColor 50%, transparent);
+      color: color-mix(in oklab, currentcolor 50%, transparent);
     }
 
     .text-inherit {
@@ -22769,11 +22769,11 @@ test('text-shadow', async () => {
     }
 
     .text-shadow-current {
-      --tw-text-shadow-color: color-mix(in oklab, currentColor var(--tw-text-shadow-alpha), transparent);
+      --tw-text-shadow-color: color-mix(in oklab, currentcolor var(--tw-text-shadow-alpha), transparent);
     }
 
     .text-shadow-current\\/50, .text-shadow-current\\/\\[0\\.5\\], .text-shadow-current\\/\\[50\\%\\] {
-      --tw-text-shadow-color: color-mix(in oklab, color-mix(in oklab, currentColor 50%, transparent) var(--tw-text-shadow-alpha), transparent);
+      --tw-text-shadow-color: color-mix(in oklab, color-mix(in oklab, currentcolor 50%, transparent) var(--tw-text-shadow-alpha), transparent);
     }
 
     .text-shadow-inherit {
@@ -23055,11 +23055,11 @@ test('shadow', async () => {
     }
 
     .shadow-current {
-      --tw-shadow-color: color-mix(in oklab, currentColor var(--tw-shadow-alpha), transparent);
+      --tw-shadow-color: color-mix(in oklab, currentcolor var(--tw-shadow-alpha), transparent);
     }
 
     .shadow-current\\/50, .shadow-current\\/\\[0\\.5\\], .shadow-current\\/\\[50\\%\\] {
-      --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, currentColor 50%, transparent) var(--tw-shadow-alpha), transparent);
+      --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, currentcolor 50%, transparent) var(--tw-shadow-alpha), transparent);
     }
 
     .shadow-inherit {
@@ -23401,11 +23401,11 @@ test('inset-shadow', async () => {
     }
 
     .inset-shadow-current {
-      --tw-inset-shadow-color: color-mix(in oklab, currentColor var(--tw-inset-shadow-alpha), transparent);
+      --tw-inset-shadow-color: color-mix(in oklab, currentcolor var(--tw-inset-shadow-alpha), transparent);
     }
 
     .inset-shadow-current\\/50, .inset-shadow-current\\/\\[0\\.5\\], .inset-shadow-current\\/\\[50\\%\\] {
-      --tw-inset-shadow-color: color-mix(in oklab, color-mix(in oklab, currentColor 50%, transparent) var(--tw-inset-shadow-alpha), transparent);
+      --tw-inset-shadow-color: color-mix(in oklab, color-mix(in oklab, currentcolor 50%, transparent) var(--tw-inset-shadow-alpha), transparent);
     }
 
     .inset-shadow-inherit {
@@ -23663,37 +23663,37 @@ test('ring', async () => {
     }
 
     .ring {
-      --tw-ring-shadow: var(--tw-ring-inset, ) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentColor);
+      --tw-ring-shadow: var(--tw-ring-inset, ) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
 
     .ring-0 {
-      --tw-ring-shadow: var(--tw-ring-inset, ) 0 0 0 calc(0px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentColor);
+      --tw-ring-shadow: var(--tw-ring-inset, ) 0 0 0 calc(0px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
 
     .ring-1 {
-      --tw-ring-shadow: var(--tw-ring-inset, ) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentColor);
+      --tw-ring-shadow: var(--tw-ring-inset, ) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
 
     .ring-2 {
-      --tw-ring-shadow: var(--tw-ring-inset, ) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentColor);
+      --tw-ring-shadow: var(--tw-ring-inset, ) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
 
     .ring-4 {
-      --tw-ring-shadow: var(--tw-ring-inset, ) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentColor);
+      --tw-ring-shadow: var(--tw-ring-inset, ) 0 0 0 calc(4px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
 
     .ring-\\[12px\\] {
-      --tw-ring-shadow: var(--tw-ring-inset, ) 0 0 0 calc(12px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentColor);
+      --tw-ring-shadow: var(--tw-ring-inset, ) 0 0 0 calc(12px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
 
     .ring-\\[length\\:var\\(--my-width\\)\\] {
-      --tw-ring-shadow: var(--tw-ring-inset, ) 0 0 0 calc(var(--my-width)  + var(--tw-ring-offset-width)) var(--tw-ring-color, currentColor);
+      --tw-ring-shadow: var(--tw-ring-inset, ) 0 0 0 calc(var(--my-width)  + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
 
@@ -23722,11 +23722,11 @@ test('ring', async () => {
     }
 
     .ring-current {
-      --tw-ring-color: currentColor;
+      --tw-ring-color: currentcolor;
     }
 
     .ring-current\\/50, .ring-current\\/\\[0\\.5\\], .ring-current\\/\\[50\\%\\] {
-      --tw-ring-color: color-mix(in oklab, currentColor 50%, transparent);
+      --tw-ring-color: color-mix(in oklab, currentcolor 50%, transparent);
     }
 
     .ring-inherit {
@@ -23917,7 +23917,7 @@ test('ring', async () => {
     }
 
     .ring {
-      --tw-ring-shadow: var(--tw-ring-inset, ) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentColor);
+      --tw-ring-shadow: var(--tw-ring-inset, ) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
 
@@ -24112,37 +24112,37 @@ test('inset-ring', async () => {
     }
 
     .inset-ring {
-      --tw-inset-ring-shadow: inset 0 0 0 1px var(--tw-inset-ring-color, currentColor);
+      --tw-inset-ring-shadow: inset 0 0 0 1px var(--tw-inset-ring-color, currentcolor);
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
 
     .inset-ring-0 {
-      --tw-inset-ring-shadow: inset 0 0 0 0px var(--tw-inset-ring-color, currentColor);
+      --tw-inset-ring-shadow: inset 0 0 0 0px var(--tw-inset-ring-color, currentcolor);
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
 
     .inset-ring-1 {
-      --tw-inset-ring-shadow: inset 0 0 0 1px var(--tw-inset-ring-color, currentColor);
+      --tw-inset-ring-shadow: inset 0 0 0 1px var(--tw-inset-ring-color, currentcolor);
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
 
     .inset-ring-2 {
-      --tw-inset-ring-shadow: inset 0 0 0 2px var(--tw-inset-ring-color, currentColor);
+      --tw-inset-ring-shadow: inset 0 0 0 2px var(--tw-inset-ring-color, currentcolor);
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
 
     .inset-ring-4 {
-      --tw-inset-ring-shadow: inset 0 0 0 4px var(--tw-inset-ring-color, currentColor);
+      --tw-inset-ring-shadow: inset 0 0 0 4px var(--tw-inset-ring-color, currentcolor);
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
 
     .inset-ring-\\[12px\\] {
-      --tw-inset-ring-shadow: inset 0 0 0 12px var(--tw-inset-ring-color, currentColor);
+      --tw-inset-ring-shadow: inset 0 0 0 12px var(--tw-inset-ring-color, currentcolor);
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
 
     .inset-ring-\\[length\\:var\\(--my-width\\)\\] {
-      --tw-inset-ring-shadow: inset 0 0 0 var(--my-width) var(--tw-inset-ring-color, currentColor);
+      --tw-inset-ring-shadow: inset 0 0 0 var(--my-width) var(--tw-inset-ring-color, currentcolor);
       box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
     }
 
@@ -24171,11 +24171,11 @@ test('inset-ring', async () => {
     }
 
     .inset-ring-current {
-      --tw-inset-ring-color: currentColor;
+      --tw-inset-ring-color: currentcolor;
     }
 
     .inset-ring-current\\/50, .inset-ring-current\\/\\[0\\.5\\], .inset-ring-current\\/\\[50\\%\\] {
-      --tw-inset-ring-color: color-mix(in oklab, currentColor 50%, transparent);
+      --tw-inset-ring-color: color-mix(in oklab, currentcolor 50%, transparent);
     }
 
     .inset-ring-inherit {
@@ -24471,11 +24471,11 @@ test('ring-offset', async () => {
     }
 
     .ring-offset-current {
-      --tw-ring-offset-color: currentColor;
+      --tw-ring-offset-color: currentcolor;
     }
 
     .ring-offset-current\\/50, .ring-offset-current\\/\\[0\\.5\\], .ring-offset-current\\/\\[50\\%\\] {
-      --tw-ring-offset-color: color-mix(in oklab, currentColor 50%, transparent);
+      --tw-ring-offset-color: color-mix(in oklab, currentcolor 50%, transparent);
     }
 
     .ring-offset-inherit {

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -8448,7 +8448,7 @@ test('accent', async () => {
     }
 
     .accent-current {
-      accent-color: currentcolor;
+      accent-color: currentColor;
     }
 
     .accent-current\\/50, .accent-current\\/\\[0\\.5\\], .accent-current\\/\\[50\\%\\] {
@@ -8607,7 +8607,7 @@ test('caret', async () => {
     }
 
     .caret-current {
-      caret-color: currentcolor;
+      caret-color: currentColor;
     }
 
     .caret-current\\/50, .caret-current\\/\\[0\\.5\\], .caret-current\\/\\[50\\%\\] {
@@ -8764,7 +8764,7 @@ test('divide-color', async () => {
     }
 
     :where(.divide-current > :not(:last-child)) {
-      border-color: currentcolor;
+      border-color: currentColor;
     }
 
     :where(.divide-current\\/50 > :not(:last-child)), :where(.divide-current\\/\\[0\\.5\\] > :not(:last-child)), :where(.divide-current\\/\\[50\\%\\] > :not(:last-child)) {
@@ -10789,7 +10789,7 @@ test('bg', async () => {
     }
 
     .bg-current {
-      background-color: currentcolor;
+      background-color: currentColor;
     }
 
     .bg-current\\/50, .bg-current\\/\\[0\\.5\\], .bg-current\\/\\[50\\%\\] {
@@ -18713,7 +18713,7 @@ test('fill', async () => {
     }
 
     .fill-current {
-      fill: currentcolor;
+      fill: currentColor;
     }
 
     .fill-current\\/50, .fill-current\\/\\[0\\.5\\], .fill-current\\/\\[50\\%\\] {
@@ -18894,7 +18894,7 @@ test('stroke', async () => {
     }
 
     .stroke-current {
-      stroke: currentcolor;
+      stroke: currentColor;
     }
 
     .stroke-current\\/50, .stroke-current\\/\\[0\\.5\\], .stroke-current\\/\\[50\\%\\] {
@@ -19944,7 +19944,7 @@ test('placeholder', async () => {
     }
 
     .placeholder-current::placeholder {
-      color: currentcolor;
+      color: currentColor;
     }
 
     .placeholder-current\\/50::placeholder, .placeholder-current\\/\\[0\\.5\\]::placeholder, .placeholder-current\\/\\[50\\%\\]::placeholder {
@@ -20137,7 +20137,7 @@ test('decoration', async () => {
     }
 
     .decoration-current {
-      text-decoration-color: currentcolor;
+      text-decoration-color: currentColor;
     }
 
     .decoration-current\\/50, .decoration-current\\/\\[0\\.5\\], .decoration-current\\/\\[50\\%\\] {
@@ -22041,7 +22041,7 @@ test('outline', async () => {
     }
 
     .outline-current {
-      outline-color: currentcolor;
+      outline-color: currentColor;
     }
 
     .outline-current\\/50, .outline-current\\/\\[0\\.5\\], .outline-current\\/\\[50\\%\\] {
@@ -22525,7 +22525,7 @@ test('text', async () => {
     }
 
     .text-current {
-      color: currentcolor;
+      color: currentColor;
     }
 
     .text-current\\/50, .text-current\\/\\[0\\.5\\], .text-current\\/\\[50\\%\\] {

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -254,7 +254,7 @@ function resolveThemeColor<T extends ThemeKey>(
       break
     }
     case 'current': {
-      value = 'currentColor'
+      value = 'currentcolor'
       break
     }
     default: {
@@ -5439,7 +5439,7 @@ export function createUtilities(theme: Theme) {
 
     staticUtility('ring-inset', [boxShadowProperties, ['--tw-ring-inset', 'inset']])
 
-    let defaultRingColor = theme.get(['--default-ring-color']) ?? 'currentColor'
+    let defaultRingColor = theme.get(['--default-ring-color']) ?? 'currentcolor'
     function ringShadowValue(value: string) {
       return `var(--tw-ring-inset,) 0 0 0 calc(${value} + var(--tw-ring-offset-width)) var(--tw-ring-color, ${defaultRingColor})`
     }
@@ -5515,7 +5515,7 @@ export function createUtilities(theme: Theme) {
     ])
 
     function insetRingShadowValue(value: string) {
-      return `inset 0 0 0 ${value} var(--tw-inset-ring-color, currentColor)`
+      return `inset 0 0 0 ${value} var(--tw-inset-ring-color, currentcolor)`
     }
     utilities.functional('inset-ring', (candidate) => {
       if (!candidate.value) {


### PR DESCRIPTION
Replaces `currentColor` with `currentcolor` (lowercase) to match what's defined in [CSS Color Module Level 4](https://www.w3.org/TR/css-color-4/#currentcolor-color) and [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#currentcolor_keyword) (see: https://github.com/mdn/content/pull/16592).