### PR TITLE
Fix slow incremental builds (especially on Windows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix multi-value inset shadow ([#17523](https://github.com/tailwindlabs/tailwindcss/pull/17523))
 - Fix `drop-shadow` utility ([#17515](https://github.com/tailwindlabs/tailwindcss/pull/17515))
 - Fix `drop-shadow-*` utilities that use multiple shadows in `@theme inline` ([#17515](https://github.com/tailwindlabs/tailwindcss/pull/17515))
+- Fix slow incremental builds with `@tailwindcss/vite` and `@tailwindcss/postscss` (especially on Windows) ([#17511](https://github.com/tailwindlabs/tailwindcss/pull/17511))
 
 ## [4.1.1] - 2025-04-02
 

--- a/crates/oxide/src/scanner/detect_sources.rs
+++ b/crates/oxide/src/scanner/detect_sources.rs
@@ -1,3 +1,4 @@
+use crate::scanner::auto_source_detection::IGNORED_CONTENT_DIRS;
 use crate::GlobEntry;
 use fxhash::FxHashSet;
 use globwalk::DirEntry;
@@ -98,6 +99,17 @@ pub fn resolve_globs(
         }
 
         if path == base {
+            continue;
+        }
+
+        if IGNORED_CONTENT_DIRS
+            .iter()
+            .any(|dir| match path.file_name() {
+                Some(name) => name == *dir,
+                None => false,
+            })
+        {
+            it.skip_current_dir();
             continue;
         }
 

--- a/crates/oxide/src/scanner/mod.rs
+++ b/crates/oxide/src/scanner/mod.rs
@@ -321,7 +321,7 @@ impl Scanner {
     }
 
     #[tracing::instrument(skip_all)]
-    pub fn get_normalized_sources(&mut self) -> Vec<GlobEntry> {
+    pub fn get_normalized_sources(&self) -> Vec<GlobEntry> {
         self.sources
             .iter()
             .filter_map(|source| match source {

--- a/crates/oxide/src/scanner/mod.rs
+++ b/crates/oxide/src/scanner/mod.rs
@@ -307,7 +307,7 @@ impl Scanner {
             match source {
                 SourceEntry::Auto { base } | SourceEntry::External { base } => {
                     globs.extend(resolve_globs(
-                        (base).to_path_buf(),
+                        base.to_path_buf(),
                         &self.dirs,
                         &self.extensions,
                     ));

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -15,6 +15,7 @@ const PUBLIC_PACKAGES = (await fs.readdir(path.join(REPO_ROOT, 'dist'))).map((na
 
 interface SpawnedProcess {
   dispose: () => void
+  flush: () => void
   onStdout: (predicate: (message: string) => boolean) => Promise<void>
   onStderr: (predicate: (message: string) => boolean) => Promise<void>
 }
@@ -253,6 +254,13 @@ export function test(
 
           return {
             dispose,
+            flush() {
+              stdoutActors.splice(0)
+              stderrActors.splice(0)
+
+              stdoutMessages.splice(0)
+              stderrMessages.splice(0)
+            },
             onStdout(predicate: (message: string) => boolean) {
               return new Promise<void>((resolve) => {
                 stdoutActors.push({ predicate, resolve })
@@ -504,6 +512,7 @@ export let css = dedent
 export let html = dedent
 export let ts = dedent
 export let js = dedent
+export let jsx = dedent
 export let json = dedent
 export let yaml = dedent
 export let txt = dedent

--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -589,6 +589,8 @@ export async function fetchStyles(base: string, path = '/'): Promise<string> {
 async function gracefullyRemove(dir: string) {
   // Skip removing the directory in CI because it can stall on Windows
   if (!process.env.CI) {
-    await fs.rm(dir, { recursive: true, force: true })
+    await fs.rm(dir, { recursive: true, force: true }).catch((error) => {
+      console.log(`Failed to remove ${dir}`, error)
+    })
   }
 }

--- a/integrations/webpack/index.test.ts
+++ b/integrations/webpack/index.test.ts
@@ -1,7 +1,7 @@
 import { css, html, js, json, test } from '../utils'
 
 test(
-  'Webpack + PostCSS (watch)',
+  'webpack + PostCSS (watch)',
   {
     fs: {
       'package.json': json`


### PR DESCRIPTION
Fixes: #16911
Fixes: #17522

When debugging this issue, we noticed that the `resolve_glob()` function from `detect_sources.rs` was really slow, specifically on Windows. It turns out that we're now computing the list of globs that we use to attach the file system watchers _repeatedly on every change_ instead of doing it only _once per compiler setup_. This changed with the updates we added to support `@source not "…";` in 4.1.

More specifically, we noticed that the way we compute these sources is causing a recursive scan through _all_ folders inside your working directory (including `node_modules/` and `.git/`). This happens because that logic uses a vanilla file-system walker and not our `ignore` crate for this.

When we started investigating it, our first reaction was to change both Vite and PostCSS to use the new `normalized_sources` list instead. This is a list of globs to watch that is computed solely on the input sources and does not require any file-system access and it's what we use in the CLI as well. Think of it as being a `**/*` rule for the current working-directory in the basic auto-content case.

When we made this change, to our surprise, nothing in our existing integration test broke. From memory, though, we remembered that it's important for PostCSS though to _not register a blanket watcher for the current working-directory_. It took us quite a bit of tinkering until we were able to craft an example that would cause an endless re-render loop with this patch applied. We've now [added a new integration test](https://github.com/tailwindlabs/tailwindcss/pull/17511/files#diff-7bc765548a52132ede460508e58dca709c4a00c9c56669bf9954cc4bc3d93c88) to have this context in the repository for the future but also it meant that we have to go back to creating a "smarter" list of globs for the file system watcher again.

To fix the regressions, this PR now does two things:

1. We now cache the list of calculated globs again since it's based only on input form the CSS file. This means that rebuilds are instant as we don't have to compute these globs anymore. This was the same behavior that we had in previous 4.0 releases.
2. Furthermore we also updated the file system walk to include our new globally ignored content directories. By bailing on any subdirectories in `node_modules` and `.git`, that walk is now _much_ faster. We also made sure that you can still add a custom source rule to point _inside_ a `node_modules` folder and it will still pick up changes like you would suggest (e.g. via `@source "../node_modules/my-ui-lib";`). 
 
The results? This PR fixes slow rebuilds on Windows where rebuilds go from ~2s to ~20ms.

We suspect that this issue is more pronounced on Windows because of a slower file system in general.

## Test plan

Tested it on a reproduction with the following results:

**Before:**

https://github.com/user-attachments/assets/10c5e9e0-3c41-4e1d-95f6-ee8d856577ef

**After:**

https://github.com/user-attachments/assets/2c7597e9-3fff-4922-a2da-a8d06eab9047

Zooming in on the times, it looks like this:

| Before    | After |
| -------- | ------- |
| <img width="674" alt="image" src="https://github.com/user-attachments/assets/85eee69c-bbf6-4c28-8ce3-6dcdad74be9c" /> | <img width="719" alt="image" src="https://github.com/user-attachments/assets/d89cefda-0711-4f84-bfaf-2bea11977bf7" /> |

But with these changes:

We also tested this on Windows with the following results:

| Before    | After |
| -------- | ------- |
| <img width="961" alt="image" src="https://github.com/user-attachments/assets/3a42f822-f103-4598-9a91-e659ae09800c" />  | <img width="956" alt="image" src="https://github.com/user-attachments/assets/05b6b6bc-d107-40d1-a207-3638aba3fc3a" /> |


[ci-all]
