### PR TITLE
Fix test that relies on mtimes

### DIFF
--- a/packages/@tailwindcss-postcss/src/index.test.ts
+++ b/packages/@tailwindcss-postcss/src/index.test.ts
@@ -378,7 +378,7 @@ describe('concurrent builds', () => {
   })
   afterEach(() => rm(dir, { recursive: true, force: true }))
 
-  test('the current working directory is used by default', async () => {
+  test('does experience a race-condition when calling the plugin two times for the same change', async () => {
     const spy = vi.spyOn(process, 'cwd')
     spy.mockReturnValue(dir)
 
@@ -401,6 +401,8 @@ describe('concurrent builds', () => {
 
     expect(result).toContain('.underline')
 
+    // Ensure that the mtime is updated
+    await new Promise((resolve) => setTimeout(resolve, 100))
     await writeFile(
       path.join(dir, 'dependency.css'),
       css`


### PR DESCRIPTION
Fixes a timing issue added to a new unit test on `main`. Going to wait for the `CI / Linux` unit tests to pass 3 times before merging this.

[ci-all]