### PR TITLE
Handle Ruby `%w` syntax in Slim pre processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Show warning when using unsupported bare value data type in `--value(…)` ([#17464](https://github.com/tailwindlabs/tailwindcss/pull/17464))
 - PostCSS: Resolve an issue where changes to the input CSS file showed outdated content when using Turbopack ([#17554](https://github.com/tailwindlabs/tailwindcss/pull/17554))
+- Handle Ruby `%w` syntax in Slim pre processing ([#17557](https://github.com/tailwindlabs/tailwindcss/pull/17557))
 
 ## [4.1.2] - 2025-04-03
 


### PR DESCRIPTION
This PR fixes an issue where the Ruby `%w[…]` syntax causes utilities to not be properly extracted.

This PR will now ensure that it does get extracted correctly.

Given this input:
```slim
div[
  class=%w[bg-blue-500 w-10 h-10]
]
div[
  class=%w[w-10 bg-green-500 h-10]
]
```

Before this PR, we extracted everything but the `bg-blue-500`. The `w-10` was extracted but not because of the second div, but because of the first one.

Fixes: #17542

## Test plan

1. Added a test to ensure it's working correctly.

Looking at the extractor tool, you can see that it now gets extracted correctly. Top is before, bottom is with this change.

<img width="1199" alt="image" src="https://github.com/user-attachments/assets/028d9abd-8917-438c-a423-88ba887b7f97" />
