### PR TITLE
refactor[integrations/test]: change `let` to `const` for those references doesn't change

### DIFF
--- a/integrations/cli/config.test.ts
+++ b/integrations/cli/config.test.ts
@@ -161,7 +161,7 @@ test(
     },
   },
   async ({ fs, spawn }) => {
-    let process = await spawn(
+    const process = await spawn(
       'pnpm tailwindcss --input src/index.css --output dist/out.css --watch',
     )
     await process.onStderr((m) => m.includes('Done in'))
@@ -217,7 +217,7 @@ test(
     },
   },
   async ({ fs, spawn }) => {
-    let process = await spawn(
+    const process = await spawn(
       'pnpm tailwindcss --input src/index.css --output dist/out.css --watch',
     )
     await process.onStderr((m) => m.includes('Done in'))
@@ -273,7 +273,7 @@ test(
     },
   },
   async ({ fs, spawn }) => {
-    let process = await spawn(
+    const process = await spawn(
       'pnpm tailwindcss --input src/index.css --output dist/out.css --watch',
     )
     await process.onStderr((m) => m.includes('Done in'))

--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -223,7 +223,7 @@ describe.each([
       },
     },
     async ({ root, expect, exec }) => {
-      let stdout = await exec(`${command} --input src/index.css --output -`, {
+      const stdout = await exec(`${command} --input src/index.css --output -`, {
         cwd: path.join(root, 'project-a'),
       })
 
@@ -299,9 +299,12 @@ describe.each([
       },
     },
     async ({ root, fs, spawn }) => {
-      let process = await spawn(`${command} --input src/index.css --output dist/out.css --watch`, {
-        cwd: path.join(root, 'project-a'),
-      })
+      const process = await spawn(
+        `${command} --input src/index.css --output dist/out.css --watch`,
+        {
+          cwd: path.join(root, 'project-a'),
+        },
+      )
       await process.onStderr((m) => m.includes('Done in'))
 
       await fs.expectFileToContain('project-a/dist/out.css', [
@@ -1017,7 +1020,7 @@ test(
     `)
 
     // Watch mode tests
-    let process = await spawn(
+    const process = await spawn(
       'pnpm tailwindcss --input src/index.css --output dist/out.css --watch',
       {
         cwd: path.join(root, 'project-a'),
@@ -1249,7 +1252,7 @@ test(
     },
   },
   async ({ fs, spawn, expect }) => {
-    let process = await spawn(
+    const process = await spawn(
       `pnpm tailwindcss --input src/index.css --output dist/out.css --watch`,
     )
     await process.onStderr((m) => m.includes('Done in'))
@@ -1315,7 +1318,7 @@ test(
     },
   },
   async ({ fs, spawn, expect }) => {
-    let process = await spawn(
+    const process = await spawn(
       'pnpm tailwindcss --input src/index.css --output dist/out.css --watch',
     )
     await process.onStderr((m) => m.includes('Done in'))
@@ -1523,7 +1526,7 @@ test(
     // NOTE: We are writing to an output CSS file which is not being ignored by
     // `.gitignore` nor marked with `@source not`. This should not result in an
     // infinite loop.
-    let process = await spawn(
+    const process = await spawn(
       'pnpm tailwindcss --input ./index.css --output ./dist/out.css --watch',
     )
     await process.onStderr((m) => m.includes('Done in'))

--- a/integrations/cli/plugins.test.ts
+++ b/integrations/cli/plugins.test.ts
@@ -33,9 +33,9 @@ test(
 
     // Verify that `prose-stone` is defined before `prose-invert`
     {
-      let contents = await fs.read('dist/out.css')
-      let proseInvertIdx = contents.indexOf('.prose-invert')
-      let proseStoneIdx = contents.indexOf('.prose-stone')
+      const contents = await fs.read('dist/out.css')
+      const proseInvertIdx = contents.indexOf('.prose-invert')
+      const proseStoneIdx = contents.indexOf('.prose-stone')
 
       expect(proseStoneIdx).toBeLessThan(proseInvertIdx)
     }

--- a/integrations/postcss/config.test.ts
+++ b/integrations/postcss/config.test.ts
@@ -148,7 +148,9 @@ test(
     },
   },
   async ({ fs, spawn }) => {
-    let process = await spawn('pnpm postcss src/index.css --output dist/out.css --watch --verbose')
+    const process = await spawn(
+      'pnpm postcss src/index.css --output dist/out.css --watch --verbose',
+    )
     await process.onStderr((m) => m.includes('Waiting for file changes'))
 
     await fs.expectFileToContain('dist/out.css', [
@@ -219,7 +221,9 @@ test(
     },
   },
   async ({ fs, spawn }) => {
-    let process = await spawn('pnpm postcss src/index.css --output dist/out.css --watch --verbose')
+    const process = await spawn(
+      'pnpm postcss src/index.css --output dist/out.css --watch --verbose',
+    )
     await process.onStderr((m) => m.includes('Waiting for file changes'))
 
     await fs.expectFileToContain('dist/out.css', [

--- a/integrations/postcss/index.test.ts
+++ b/integrations/postcss/index.test.ts
@@ -558,7 +558,7 @@ test(
     },
   },
   async ({ root, fs, spawn }) => {
-    let process = await spawn(
+    const process = await spawn(
       'pnpm postcss src/index.css --output dist/out.css --watch --verbose',
       { cwd: path.join(root, 'project-a') },
     )

--- a/integrations/postcss/next.test.ts
+++ b/integrations/postcss/next.test.ts
@@ -60,12 +60,12 @@ test(
   async ({ fs, exec, expect }) => {
     await exec('pnpm next build')
 
-    let files = await fs.glob('.next/static/css/**/*.css')
+    const files = await fs.glob('.next/static/css/**/*.css')
     expect(files).toHaveLength(2)
 
     let globalCss: string | null = null
     let moduleCss: string | null = null
-    for (let [filename, content] of files) {
+    for (const [filename, content] of files) {
       if (content.includes('@keyframes page_ping')) moduleCss = filename
       else globalCss = filename
     }
@@ -141,11 +141,11 @@ describe.each(['turbo', 'webpack'])('%s', (bundler) => {
       },
     },
     async ({ fs, spawn, expect }) => {
-      let process = await spawn(`pnpm next dev ${bundler === 'turbo' ? '--turbo' : ''}`)
+      const process = await spawn(`pnpm next dev ${bundler === 'turbo' ? '--turbo' : ''}`)
 
       let url = ''
       await process.onStdout((m) => {
-        let match = /Local:\s*(http.*)/.exec(m)
+        const match = /Local:\s*(http.*)/.exec(m)
         if (match) url = match[1]
         return Boolean(url)
       })
@@ -153,7 +153,7 @@ describe.each(['turbo', 'webpack'])('%s', (bundler) => {
       await process.onStdout((m) => m.includes('Ready in'))
 
       await retryAssertion(async () => {
-        let css = await fetchStyles(url)
+        const css = await fetchStyles(url)
         expect(css).toContain(candidate`underline`)
         expect(css).toContain('content: var(--tw-content)')
         expect(css).toContain('@keyframes')
@@ -171,7 +171,7 @@ describe.each(['turbo', 'webpack'])('%s', (bundler) => {
       await process.onStdout((m) => m.includes('Compiled in'))
 
       await retryAssertion(async () => {
-        let css = await fetchStyles(url)
+        const css = await fetchStyles(url)
         expect(css).toContain(candidate`underline`)
         expect(css).toContain(candidate`bg-red-500`)
         expect(css).toContain('--tw-skew-x: skewX(7deg);')
@@ -247,9 +247,9 @@ test(
   async ({ fs, exec, expect }) => {
     await exec('pnpm next build')
 
-    let files = await fs.glob('.next/static/css/**/*.css')
+    const files = await fs.glob('.next/static/css/**/*.css')
     expect(files).toHaveLength(1)
-    let [filename] = files[0]
+    const [filename] = files[0]
 
     await fs.expectFileToContain(filename, [
       candidate`content-['[slug]']`,
@@ -319,11 +319,11 @@ test(
     // NOTE: We are writing to an output CSS file which is not being ignored by
     // `.gitignore` nor marked with `@source not`. This should not result in an
     // infinite loop.
-    let process = await spawn(`pnpm next dev`)
+    const process = await spawn(`pnpm next dev`)
 
     let url = ''
     await process.onStdout((m) => {
-      let match = /Local:\s*(http.*)/.exec(m)
+      const match = /Local:\s*(http.*)/.exec(m)
       if (match) url = match[1]
       return Boolean(url)
     })
@@ -331,7 +331,7 @@ test(
     await process.onStdout((m) => m.includes('Ready in'))
 
     await retryAssertion(async () => {
-      let css = await fetchStyles(url)
+      const css = await fetchStyles(url)
       expect(css).toContain(candidate`flex`)
       expect(css).toContain('--color-blue-500:')
       expect(css).not.toContain('--color-red-500:')
@@ -349,7 +349,7 @@ test(
     await process.onStdout((m) => m.includes('Compiled in'))
 
     await retryAssertion(async () => {
-      let css = await fetchStyles(url)
+      const css = await fetchStyles(url)
       expect(css).toContain(candidate`flex`)
       expect(css).toContain('--color-blue-500:')
       expect(css).toContain('--color-red-500:')
@@ -429,11 +429,11 @@ test(
     },
   },
   async ({ spawn, fs, expect }) => {
-    let process = await spawn('pnpm next dev')
+    const process = await spawn('pnpm next dev')
 
     let url = ''
     await process.onStdout((m) => {
-      let match = /Local:\s*(http.*)/.exec(m)
+      const match = /Local:\s*(http.*)/.exec(m)
       if (match) url = match[1]
       return Boolean(url)
     })
@@ -441,7 +441,7 @@ test(
     await process.onStdout((m) => m.includes('Ready in'))
 
     await retryAssertion(async () => {
-      let css = await fetchStyles(url)
+      const css = await fetchStyles(url)
       expect(css).toContain(candidate`flex`)
       expect(css).not.toContain(candidate`underline`)
     })
@@ -457,7 +457,7 @@ test(
     await process.onStdout((m) => m.includes('Compiled in'))
 
     await retryAssertion(async () => {
-      let css = await fetchStyles(url)
+      const css = await fetchStyles(url)
       expect(css).toContain(candidate`flex`)
       expect(css).toContain(candidate`underline`)
     })
@@ -473,7 +473,7 @@ test(
     // files to disk.
     //
     // Ensure there are no more changes in stdout (signaling no infinite loop)
-    let result = await Promise.race([
+    const result = await Promise.race([
       // If this succeeds, it means that it saw another change which indicates
       // an infinite loop.
       process.onStdout((m) => m.includes('Compiled in')).then(() => 'infinite loop detected'),

--- a/integrations/postcss/source.test.ts
+++ b/integrations/postcss/source.test.ts
@@ -389,7 +389,7 @@ test(
     `)
 
     // Watch mode tests
-    let process = await spawn(
+    const process = await spawn(
       'pnpm postcss src/index.css --output dist/out.css --watch --verbose',
       {
         cwd: path.join(root, 'project-a'),
@@ -732,7 +732,7 @@ test(
     `)
 
     // Watch mode tests
-    let process = await spawn(
+    const process = await spawn(
       'pnpm postcss src/index.css --output dist/out.css --watch --verbose',
       {
         cwd: path.join(root, 'project-a'),

--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -26,7 +26,7 @@ test(
     },
   },
   async ({ fs, exec, expect }) => {
-    let output = await exec('npx @tailwindcss/upgrade')
+    const output = await exec('npx @tailwindcss/upgrade')
     expect(output).toContain('Cannot find any CSS files that reference Tailwind CSS.')
 
     // Files should not be modified
@@ -143,8 +143,8 @@ test(
       "
     `)
 
-    let packageJsonContent = await fs.read('package.json')
-    let packageJson = JSON.parse(packageJsonContent)
+    const packageJsonContent = await fs.read('package.json')
+    const packageJson = JSON.parse(packageJsonContent)
     expect(packageJson.dependencies).toMatchObject({
       tailwindcss: expect.stringMatching(/^\^4/),
     })
@@ -654,8 +654,8 @@ test(
       `,
     )
 
-    let packageJsonContent = await fs.read('package.json')
-    let packageJson = JSON.parse(packageJsonContent)
+    const packageJsonContent = await fs.read('package.json')
+    const packageJson = JSON.parse(packageJsonContent)
     expect(packageJson.dependencies).toMatchObject({
       tailwindcss: expect.stringMatching(/^\^4/),
     })
@@ -706,8 +706,8 @@ test(
   async ({ exec, fs, expect }) => {
     await exec('npx @tailwindcss/upgrade')
 
-    let packageJsonContent = await fs.read('package.json')
-    let packageJson = JSON.parse(packageJsonContent)
+    const packageJsonContent = await fs.read('package.json')
+    const packageJson = JSON.parse(packageJsonContent)
     expect(packageJson.dependencies).toMatchObject({
       '@tailwindcss/postcss': expect.stringMatching(/^\^4/),
     })
@@ -753,8 +753,8 @@ test(
   async ({ exec, fs, expect }) => {
     await exec('npx @tailwindcss/upgrade')
 
-    let packageJsonContent = await fs.read('package.json')
-    let packageJson = JSON.parse(packageJsonContent)
+    const packageJsonContent = await fs.read('package.json')
+    const packageJson = JSON.parse(packageJsonContent)
     expect(packageJson.devDependencies).toMatchObject({
       '@tailwindcss/postcss': expect.stringMatching(/^\^4/),
     })
@@ -813,8 +813,8 @@ test(
       `,
     )
 
-    let packageJsonContent = await fs.read('package.json')
-    let packageJson = JSON.parse(packageJsonContent)
+    const packageJsonContent = await fs.read('package.json')
+    const packageJson = JSON.parse(packageJsonContent)
     expect(packageJson.postcss).toMatchInlineSnapshot(`
       {
         "plugins": {
@@ -888,8 +888,8 @@ test(
       `,
     )
 
-    let jsonConfigContent = await fs.read('.postcssrc.json')
-    let jsonConfig = JSON.parse(jsonConfigContent)
+    const jsonConfigContent = await fs.read('.postcssrc.json')
+    const jsonConfig = JSON.parse(jsonConfigContent)
     expect(jsonConfig).toMatchInlineSnapshot(`
       {
         "plugins": {
@@ -898,8 +898,8 @@ test(
       }
     `)
 
-    let packageJsonContent = await fs.read('package.json')
-    let packageJson = JSON.parse(packageJsonContent)
+    const packageJsonContent = await fs.read('package.json')
+    const packageJson = JSON.parse(packageJsonContent)
     expect(packageJson.dependencies).toMatchObject({
       tailwindcss: expect.stringMatching(/^\^4/),
     })
@@ -1352,7 +1352,7 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    let output = await exec('npx @tailwindcss/upgrade --force')
+    const output = await exec('npx @tailwindcss/upgrade --force')
 
     expect(output).toMatch(
       /You have one or more stylesheets that are imported into a utility layer and non-utility layer./,
@@ -1701,7 +1701,7 @@ test(
     },
   },
   async ({ exec, expect }) => {
-    let output = await exec('npx @tailwindcss/upgrade --force', {}, { ignoreStdErr: true }).catch(
+    const output = await exec('npx @tailwindcss/upgrade --force', {}, { ignoreStdErr: true }).catch(
       (e) => e.toString(),
     )
 
@@ -2249,7 +2249,7 @@ test(
   async ({ exec, fs, expect }) => {
     await exec('npx @tailwindcss/upgrade --force')
 
-    let pkg = JSON.parse(await fs.read('package.json'))
+    const pkg = JSON.parse(await fs.read('package.json'))
 
     expect(pkg.devDependencies).toMatchObject({
       'prettier-plugin-tailwindcss': expect.any(String),
@@ -2619,7 +2619,7 @@ test(
     },
   },
   async ({ exec, expect }) => {
-    let output = await exec('npx @tailwindcss/upgrade', {}, { ignoreStdErr: true }).catch((e) =>
+    const output = await exec('npx @tailwindcss/upgrade', {}, { ignoreStdErr: true }).catch((e) =>
       e.toString(),
     )
 

--- a/integrations/vite/astro.test.ts
+++ b/integrations/vite/astro.test.ts
@@ -34,12 +34,12 @@ test(
     },
   },
   async ({ fs, spawn, expect }) => {
-    let process = await spawn('pnpm astro dev')
+    const process = await spawn('pnpm astro dev')
     await process.onStdout((m) => m.includes('ready in'))
 
     let url = ''
     await process.onStdout((m) => {
-      let match = /Local\s*(http.*)\//.exec(m)
+      const match = /Local\s*(http.*)\//.exec(m)
       if (match) url = match[1]
       return Boolean(url)
     })
@@ -47,7 +47,7 @@ test(
     await process.onStdout((m) => m.includes('watching for file changes'))
 
     await retryAssertion(async () => {
-      let css = await fetchStyles(url)
+      const css = await fetchStyles(url)
       expect(css).toContain(candidate`underline`)
     })
 
@@ -63,7 +63,7 @@ test(
       `,
       )
 
-      let css = await fetchStyles(url)
+      const css = await fetchStyles(url)
       expect(css).toContain(candidate`underline`)
       expect(css).toContain(candidate`font-bold`)
     })
@@ -123,7 +123,7 @@ test(
   async ({ fs, exec, expect }) => {
     await exec('pnpm astro build')
 
-    let files = await fs.glob('dist/**/*.css')
+    const files = await fs.glob('dist/**/*.css')
     expect(files).toHaveLength(1)
 
     await fs.expectFileToContain(files[0][0], [candidate`underline`, candidate`overline`])

--- a/integrations/vite/config.test.ts
+++ b/integrations/vite/config.test.ts
@@ -53,9 +53,9 @@ test(
   async ({ fs, exec, expect }) => {
     await exec('pnpm vite build')
 
-    let files = await fs.glob('dist/**/*.css')
+    const files = await fs.glob('dist/**/*.css')
     expect(files).toHaveLength(1)
-    let [filename] = files[0]
+    const [filename] = files[0]
 
     await fs.expectFileToContain(filename, [
       //
@@ -117,9 +117,9 @@ test(
   async ({ fs, exec, expect }) => {
     await exec('pnpm vite build')
 
-    let files = await fs.glob('dist/**/*.css')
+    const files = await fs.glob('dist/**/*.css')
     expect(files).toHaveLength(1)
-    let [filename] = files[0]
+    const [filename] = files[0]
 
     await fs.expectFileToContain(filename, [
       //
@@ -181,18 +181,18 @@ test(
     },
   },
   async ({ fs, spawn, expect }) => {
-    let process = await spawn('pnpm vite dev')
+    const process = await spawn('pnpm vite dev')
     await process.onStdout((m) => m.includes('ready in'))
 
     let url = ''
     await process.onStdout((m) => {
-      let match = /Local:\s*(http.*)\//.exec(m)
+      const match = /Local:\s*(http.*)\//.exec(m)
       if (match) url = match[1]
       return Boolean(url)
     })
 
     await retryAssertion(async () => {
-      let css = await fetchStyles(url, '/index.html')
+      const css = await fetchStyles(url, '/index.html')
       expect(css).toContain(candidate`text-primary`)
       expect(css).toContain('color: blue')
     })
@@ -200,7 +200,7 @@ test(
     await retryAssertion(async () => {
       await fs.write('my-color.cjs', js`module.exports = 'red'`)
 
-      let css = await fetchStyles(url, '/index.html')
+      const css = await fetchStyles(url, '/index.html')
       expect(css).toContain(candidate`text-primary`)
       expect(css).toContain('color: red')
     })
@@ -260,18 +260,18 @@ test(
     },
   },
   async ({ fs, spawn, expect }) => {
-    let process = await spawn('pnpm vite dev')
+    const process = await spawn('pnpm vite dev')
     await process.onStdout((m) => m.includes('ready in'))
 
     let url = ''
     await process.onStdout((m) => {
-      let match = /Local:\s*(http.*)\//.exec(m)
+      const match = /Local:\s*(http.*)\//.exec(m)
       if (match) url = match[1]
       return Boolean(url)
     })
 
     await retryAssertion(async () => {
-      let css = await fetchStyles(url, '/index.html')
+      const css = await fetchStyles(url, '/index.html')
       expect(css).toContain(candidate`text-primary`)
       expect(css).toContain('color: blue')
     })
@@ -279,7 +279,7 @@ test(
     await retryAssertion(async () => {
       await fs.write('my-color.mjs', js`export default 'red'`)
 
-      let css = await fetchStyles(url, '/index.html')
+      const css = await fetchStyles(url, '/index.html')
       expect(css).toContain(candidate`text-primary`)
       expect(css).toContain('color: red')
     })

--- a/integrations/vite/css-modules.test.ts
+++ b/integrations/vite/css-modules.test.ts
@@ -55,9 +55,9 @@ describe.each(['postcss', 'lightningcss'])('%s', (transformer) => {
     async ({ exec, fs, expect }) => {
       await exec(`pnpm vite build`)
 
-      let files = await fs.glob('dist/**/*.css')
+      const files = await fs.glob('dist/**/*.css')
       expect(files).toHaveLength(1)
-      let [filename] = files[0]
+      const [filename] = files[0]
 
       await fs.expectFileToContain(filename, [/text-decoration-line: underline;/gi])
     },

--- a/integrations/vite/ignored-packages.test.ts
+++ b/integrations/vite/ignored-packages.test.ts
@@ -47,9 +47,9 @@ test(
   async ({ fs, exec, expect }) => {
     await exec('pnpm vite build')
 
-    let files = await fs.glob('dist/**/*.css')
+    const files = await fs.glob('dist/**/*.css')
     expect(files).toHaveLength(1)
-    let [, content] = files[0]
+    const [, content] = files[0]
 
     expect(content).toMatchInlineSnapshot(`
       "@layer utilities {
@@ -63,18 +63,18 @@ test(
 )
 
 test('does not scan tailwind-merge in dev builds', WORKSPACE, async ({ spawn, expect }) => {
-  let process = await spawn('pnpm vite dev')
+  const process = await spawn('pnpm vite dev')
   await process.onStdout((m) => m.includes('ready in'))
 
   let url = ''
   await process.onStdout((m) => {
-    let match = /Local:\s*(http.*)\//.exec(m)
+    const match = /Local:\s*(http.*)\//.exec(m)
     if (match) url = match[1]
     return Boolean(url)
   })
 
   await retryAssertion(async () => {
-    let styles = await fetchStyles(url, '/index.html')
+    const styles = await fetchStyles(url, '/index.html')
 
     expect(styles).not.toContain(candidate`flex`)
   })

--- a/integrations/vite/index.test.ts
+++ b/integrations/vite/index.test.ts
@@ -79,9 +79,9 @@ describe.each(['postcss', 'lightningcss'])('%s', (transformer) => {
     async ({ root, fs, exec, expect }) => {
       await exec('pnpm vite build', { cwd: path.join(root, 'project-a') })
 
-      let files = await fs.glob('project-a/dist/**/*.css')
+      const files = await fs.glob('project-a/dist/**/*.css')
       expect(files).toHaveLength(1)
-      let [filename] = files[0]
+      const [filename] = files[0]
 
       await fs.expectFileToContain(filename, [
         candidate`underline`,
@@ -168,20 +168,20 @@ describe.each(['postcss', 'lightningcss'])('%s', (transformer) => {
       },
     },
     async ({ root, spawn, fs, expect }) => {
-      let process = await spawn('pnpm vite dev', {
+      const process = await spawn('pnpm vite dev', {
         cwd: path.join(root, 'project-a'),
       })
       await process.onStdout((m) => m.includes('ready in'))
 
       let url = ''
       await process.onStdout((m) => {
-        let match = /Local:\s*(http.*)\//.exec(m)
+        const match = /Local:\s*(http.*)\//.exec(m)
         if (match) url = match[1]
         return Boolean(url)
       })
 
       await retryAssertion(async () => {
-        let styles = await fetchStyles(url, '/index.html')
+        const styles = await fetchStyles(url, '/index.html')
         expect(styles).toContain(candidate`underline`)
         expect(styles).toContain(candidate`flex`)
         expect(styles).toContain(candidate`font-bold`)
@@ -202,7 +202,7 @@ describe.each(['postcss', 'lightningcss'])('%s', (transformer) => {
           `,
         )
 
-        let styles = await fetchStyles(url)
+        const styles = await fetchStyles(url)
         expect(styles).toContain(candidate`underline`)
         expect(styles).toContain(candidate`flex`)
         expect(styles).toContain(candidate`font-bold`)
@@ -220,7 +220,7 @@ describe.each(['postcss', 'lightningcss'])('%s', (transformer) => {
           `,
         )
 
-        let styles = await fetchStyles(url)
+        const styles = await fetchStyles(url)
         expect(styles).toContain(candidate`underline`)
         expect(styles).toContain(candidate`flex`)
         expect(styles).toContain(candidate`font-bold`)
@@ -243,7 +243,7 @@ describe.each(['postcss', 'lightningcss'])('%s', (transformer) => {
           `,
         )
 
-        let styles = await fetchStyles(url)
+        const styles = await fetchStyles(url)
         expect(styles).toContain(candidate`red`)
         expect(styles).toContain(candidate`flex`)
         expect(styles).toContain(candidate`imported`)
@@ -266,7 +266,7 @@ describe.each(['postcss', 'lightningcss'])('%s', (transformer) => {
             </body>
           `,
         )
-        let styles = await fetchStyles(url)
+        const styles = await fetchStyles(url)
         expect(styles).toContain(candidate`m-4`)
       })
 
@@ -281,7 +281,7 @@ describe.each(['postcss', 'lightningcss'])('%s', (transformer) => {
           `,
         )
 
-        let styles = await fetchStyles(url)
+        const styles = await fetchStyles(url)
         expect(styles).toContain(candidate`red`)
         expect(styles).toContain(candidate`flex`)
         expect(styles).toContain(candidate`m-2`)
@@ -361,14 +361,14 @@ describe.each(['postcss', 'lightningcss'])('%s', (transformer) => {
       },
     },
     async ({ root, spawn, fs, expect }) => {
-      let process = await spawn('pnpm vite build --watch', {
+      const process = await spawn('pnpm vite build --watch', {
         cwd: path.join(root, 'project-a'),
       })
       await process.onStdout((m) => m.includes('built in'))
 
       let filename = ''
       await retryAssertion(async () => {
-        let files = await fs.glob('project-a/dist/**/*.css')
+        const files = await fs.glob('project-a/dist/**/*.css')
         expect(files).toHaveLength(1)
         filename = files[0][0]
       })
@@ -394,9 +394,9 @@ describe.each(['postcss', 'lightningcss'])('%s', (transformer) => {
           `,
         )
 
-        let files = await fs.glob('project-a/dist/**/*.css')
+        const files = await fs.glob('project-a/dist/**/*.css')
         expect(files).toHaveLength(1)
-        let [, styles] = files[0]
+        const [, styles] = files[0]
 
         expect(styles).toContain(css`
           .text-primary {
@@ -419,9 +419,9 @@ describe.each(['postcss', 'lightningcss'])('%s', (transformer) => {
           `,
         )
 
-        let files = await fs.glob('project-a/dist/**/*.css')
+        const files = await fs.glob('project-a/dist/**/*.css')
         expect(files).toHaveLength(1)
-        let [, styles] = files[0]
+        const [, styles] = files[0]
         expect(styles).toContain(candidate`underline`)
         expect(styles).toContain(candidate`flex`)
         expect(styles).toContain(candidate`m-2`)
@@ -437,9 +437,9 @@ describe.each(['postcss', 'lightningcss'])('%s', (transformer) => {
           `,
         )
 
-        let files = await fs.glob('project-a/dist/**/*.css')
+        const files = await fs.glob('project-a/dist/**/*.css')
         expect(files).toHaveLength(1)
-        let [, styles] = files[0]
+        const [, styles] = files[0]
         expect(styles).toContain(candidate`underline`)
         expect(styles).toContain(candidate`flex`)
         expect(styles).toContain(candidate`m-2`)
@@ -460,9 +460,9 @@ describe.each(['postcss', 'lightningcss'])('%s', (transformer) => {
           `,
         )
 
-        let files = await fs.glob('project-a/dist/**/*.css')
+        const files = await fs.glob('project-a/dist/**/*.css')
         expect(files).toHaveLength(1)
-        let [, styles] = files[0]
+        const [, styles] = files[0]
         expect(styles).toContain(candidate`underline`)
         expect(styles).toContain(candidate`flex`)
         expect(styles).toContain(candidate`m-2`)
@@ -529,9 +529,9 @@ describe.each(['postcss', 'lightningcss'])('%s', (transformer) => {
     async ({ root, fs, exec, expect }) => {
       await exec('pnpm vite build', { cwd: path.join(root, 'project-a') })
 
-      let files = await fs.glob('project-a/dist/**/*.css')
+      const files = await fs.glob('project-a/dist/**/*.css')
       expect(files).toHaveLength(1)
-      let [filename] = files[0]
+      const [filename] = files[0]
 
       // `underline` and `m-2` are only present from files in the module graph
       // which we've explicitly disabled with source(none) so they should not
@@ -622,9 +622,9 @@ describe.each(['postcss', 'lightningcss'])('%s', (transformer) => {
     async ({ root, fs, exec, expect }) => {
       await exec('pnpm vite build', { cwd: path.join(root, 'project-a') })
 
-      let files = await fs.glob('project-a/dist/**/*.css')
+      const files = await fs.glob('project-a/dist/**/*.css')
       expect(files).toHaveLength(1)
-      let [filename] = files[0]
+      const [filename] = files[0]
 
       // `underline` and `m-2` are present in files in the module graph but
       // we've filtered the module graph such that we only look in
@@ -726,7 +726,7 @@ describe.each(['postcss', 'lightningcss'])('%s', (transformer) => {
         exec('pnpm vite build', { cwd: path.join(root, 'project-a') }, { ignoreStdErr: true }),
       ).rejects.toThrowError('The `source(../i-do-not-exist)` does not exist')
 
-      let files = await fs.glob('project-a/dist/**/*.css')
+      const files = await fs.glob('project-a/dist/**/*.css')
       expect(files).toHaveLength(0)
     },
   )
@@ -777,18 +777,18 @@ test(
     },
   },
   async ({ spawn, fs, expect }) => {
-    let process = await spawn('pnpm vite dev')
+    const process = await spawn('pnpm vite dev')
     await process.onStdout((m) => m.includes('ready in'))
 
     let url = ''
     await process.onStdout((m) => {
-      let match = /Local:\s*(http.*)\//.exec(m)
+      const match = /Local:\s*(http.*)\//.exec(m)
       if (match) url = match[1]
       return Boolean(url)
     })
 
     await retryAssertion(async () => {
-      let styles = await fetchStyles(url, '/index.html')
+      const styles = await fetchStyles(url, '/index.html')
       expect(styles).toContain(candidate`underline`)
       expect(styles).toContain(candidate`font-bold`)
     })
@@ -797,7 +797,7 @@ test(
       // We change the CSS file so it is no longer a valid Tailwind root.
       await fs.write('src/index.css', css`@import 'tailwindcss';`)
 
-      let styles = await fetchStyles(url)
+      const styles = await fetchStyles(url)
       expect(styles).toContain(candidate`underline`)
       expect(styles).toContain(candidate`font-bold`)
     })
@@ -842,12 +842,12 @@ test(
     },
   },
   async ({ spawn, expect }) => {
-    let process = await spawn('pnpm vite dev')
+    const process = await spawn('pnpm vite dev')
     await process.onStdout((m) => m.includes('ready in'))
 
     let baseUrl = ''
     await process.onStdout((m) => {
-      let match = /Local:\s*(http.*)\//.exec(m)
+      const match = /Local:\s*(http.*)\//.exec(m)
       if (match) baseUrl = match[1]
       return Boolean(baseUrl)
     })
@@ -857,7 +857,7 @@ test(
       // resolved
       await fetch(`${baseUrl}/src/index.js`).then((r) => r.text())
 
-      let [raw, url] = await Promise.all([
+      const [raw, url] = await Promise.all([
         fetch(`${baseUrl}/src/index.css?raw`).then((r) => r.text()),
         fetch(`${baseUrl}/src/index.css?url`).then((r) => r.text()),
       ])
@@ -903,9 +903,9 @@ test(
   async ({ exec, expect, fs }) => {
     await exec('pnpm vite build')
 
-    let files = await fs.glob('dist/**/*.css')
+    const files = await fs.glob('dist/**/*.css')
     expect(files).toHaveLength(1)
-    let [filename] = files[0]
+    const [filename] = files[0]
 
     await fs.expectFileToContain(filename, [candidate`maplibregl-map`])
   },

--- a/integrations/vite/multi-root.test.ts
+++ b/integrations/vite/multi-root.test.ts
@@ -67,11 +67,11 @@ test(
   async ({ fs, exec, expect }) => {
     await exec('pnpm vite build')
 
-    let files = await fs.glob('dist/**/*.css')
+    const files = await fs.glob('dist/**/*.css')
     expect(files).toHaveLength(2)
 
-    let root1 = files.find(([filename]) => filename.includes('root1'))
-    let root2 = files.find(([filename]) => filename.includes('root2'))
+    const root1 = files.find(([filename]) => filename.includes('root1'))
+    const root2 = files.find(([filename]) => filename.includes('root2'))
 
     expect(root1).toBeDefined()
     expect(root2).toBeDefined()
@@ -141,12 +141,12 @@ test(
     },
   },
   async ({ spawn, expect }) => {
-    let process = await spawn('pnpm vite dev')
+    const process = await spawn('pnpm vite dev')
     await process.onStdout((m) => m.includes('ready in'))
 
     let url = ''
     await process.onStdout((m) => {
-      let match = /Local:\s*(http.*)\//.exec(m)
+      const match = /Local:\s*(http.*)\//.exec(m)
       if (match) url = match[1]
       return Boolean(url)
     })
@@ -154,7 +154,7 @@ test(
     // Candidates are resolved lazily, so the first visit of index.html
     // will only have candidates from this file.
     await retryAssertion(async () => {
-      let styles = await fetchStyles(url, '/root1.html')
+      const styles = await fetchStyles(url, '/root1.html')
       expect(styles).toContain(candidate`one:underline`)
       expect(styles).not.toContain(candidate`two:underline`)
     })
@@ -162,7 +162,7 @@ test(
     // Going to about.html will extend the candidate list to include
     // candidates from about.html.
     await retryAssertion(async () => {
-      let styles = await fetchStyles(url, '/root2.html')
+      const styles = await fetchStyles(url, '/root2.html')
       expect(styles).not.toContain(candidate`one:underline`)
       expect(styles).toContain(candidate`two:underline`)
     })

--- a/integrations/vite/nuxt.test.ts
+++ b/integrations/vite/nuxt.test.ts
@@ -37,7 +37,7 @@ const SETUP = {
 }
 
 test('dev mode', SETUP, async ({ fs, spawn, expect }) => {
-  let process = await spawn('pnpm nuxt dev', {
+  const process = await spawn('pnpm nuxt dev', {
     env: {
       TEST: 'false', // VERY IMPORTANT OTHERWISE YOU WON'T GET OUTPUT
       NODE_ENV: 'development',
@@ -46,7 +46,7 @@ test('dev mode', SETUP, async ({ fs, spawn, expect }) => {
 
   let url = ''
   await process.onStdout((m) => {
-    let match = /Local:\s*(http.*)\//.exec(m)
+    const match = /Local:\s*(http.*)\//.exec(m)
     if (match) url = match[1]
     return Boolean(url)
   })
@@ -54,7 +54,7 @@ test('dev mode', SETUP, async ({ fs, spawn, expect }) => {
   await process.onStdout((m) => m.includes('server warmed up in'))
 
   await retryAssertion(async () => {
-    let css = await fetchStyles(url)
+    const css = await fetchStyles(url)
     expect(css).toContain(candidate`underline`)
   })
 
@@ -68,7 +68,7 @@ test('dev mode', SETUP, async ({ fs, spawn, expect }) => {
       `,
     )
 
-    let css = await fetchStyles(url)
+    const css = await fetchStyles(url)
     expect(css).toContain(candidate`underline`)
     expect(css).toContain(candidate`font-bold`)
   })
@@ -78,7 +78,7 @@ test('build', SETUP, async ({ spawn, exec, expect }) => {
   await exec('pnpm nuxt build')
   // The Nuxt preview server does not automatically assign a free port if 3000
   // is taken, so we use a random port instead.
-  let process = await spawn(`pnpm nuxt preview --port 8724`, {
+  const process = await spawn(`pnpm nuxt preview --port 8724`, {
     env: {
       TEST: 'false',
       NODE_ENV: 'development',
@@ -87,13 +87,13 @@ test('build', SETUP, async ({ spawn, exec, expect }) => {
 
   let url = ''
   await process.onStdout((m) => {
-    let match = /Listening on\s*(http.*)\/?/.exec(m)
+    const match = /Listening on\s*(http.*)\/?/.exec(m)
     if (match) url = match[1].replace('http://[::]', 'http://127.0.0.1')
     return m.includes('Listening on')
   })
 
   await retryAssertion(async () => {
-    let css = await fetchStyles(url)
+    const css = await fetchStyles(url)
     expect(css).toContain(candidate`underline`)
   })
 })

--- a/integrations/vite/other-transforms.test.ts
+++ b/integrations/vite/other-transforms.test.ts
@@ -62,9 +62,9 @@ describe.each(['postcss', 'lightningcss'] as const)('%s', (transformer) => {
   test(`production build`, createSetup(transformer), async ({ fs, exec, expect }) => {
     await exec('pnpm vite build')
 
-    let files = await fs.glob('dist/**/*.css')
+    const files = await fs.glob('dist/**/*.css')
     expect(files).toHaveLength(1)
-    let [filename] = files[0]
+    const [filename] = files[0]
 
     await fs.expectFileToContain(filename, [
       css`
@@ -82,18 +82,18 @@ describe.each(['postcss', 'lightningcss'] as const)('%s', (transformer) => {
   })
 
   test('dev mode', createSetup(transformer), async ({ spawn, fs, expect }) => {
-    let process = await spawn('pnpm vite dev')
+    const process = await spawn('pnpm vite dev')
     await process.onStdout((m) => m.includes('ready in'))
 
     let url = ''
     await process.onStdout((m) => {
-      let match = /Local:\s*(http.*)\//.exec(m)
+      const match = /Local:\s*(http.*)\//.exec(m)
       if (match) url = match[1]
       return Boolean(url)
     })
 
     await retryAssertion(async () => {
-      let styles = await fetchStyles(url, '/index.html')
+      const styles = await fetchStyles(url, '/index.html')
       expect(styles).toContain(css`
         .foo {
           color: blue;
@@ -120,7 +120,7 @@ describe.each(['postcss', 'lightningcss'] as const)('%s', (transformer) => {
         `,
       )
 
-      let styles = await fetchStyles(url)
+      const styles = await fetchStyles(url)
       expect(styles).toContain(css`
         .foo {
           background-color: blue;
@@ -130,13 +130,13 @@ describe.each(['postcss', 'lightningcss'] as const)('%s', (transformer) => {
   })
 
   test('watch mode', createSetup(transformer), async ({ spawn, fs, expect }) => {
-    let process = await spawn('pnpm vite build --watch')
+    const process = await spawn('pnpm vite build --watch')
     await process.onStdout((m) => m.includes('built in'))
 
     await retryAssertion(async () => {
-      let files = await fs.glob('dist/**/*.css')
+      const files = await fs.glob('dist/**/*.css')
       expect(files).toHaveLength(1)
-      let [, styles] = files[0]
+      const [, styles] = files[0]
 
       expect(styles).toContain(css`
         .foo {
@@ -164,9 +164,9 @@ describe.each(['postcss', 'lightningcss'] as const)('%s', (transformer) => {
         `,
       )
 
-      let files = await fs.glob('dist/**/*.css')
+      const files = await fs.glob('dist/**/*.css')
       expect(files).toHaveLength(1)
-      let [, styles] = files[0]
+      const [, styles] = files[0]
 
       expect(styles).toContain(css`
         .foo {

--- a/integrations/vite/qwik.test.ts
+++ b/integrations/vite/qwik.test.ts
@@ -64,19 +64,19 @@ test(
     },
   },
   async ({ fs, spawn, expect }) => {
-    let process = await spawn('pnpm vite --mode ssr')
+    const process = await spawn('pnpm vite --mode ssr')
     await process.onStdout((m) => m.includes('ready in'))
 
     let url = ''
     await process.onStdout((m) => {
       console.log(m)
-      let match = /Local:\s*(http.*)\//.exec(m)
+      const match = /Local:\s*(http.*)\//.exec(m)
       if (match) url = match[1]
       return Boolean(url)
     })
 
     await retryAssertion(async () => {
-      let css = await fetchStyles(url)
+      const css = await fetchStyles(url)
       expect(css).toContain(candidate`underline`)
     })
 
@@ -92,7 +92,7 @@ test(
         `,
       )
 
-      let css = await fetchStyles(url)
+      const css = await fetchStyles(url)
       expect(css).toContain(candidate`underline`)
       expect(css).toContain(candidate`flex`)
     })

--- a/integrations/vite/react-router.test.ts
+++ b/integrations/vite/react-router.test.ts
@@ -72,17 +72,17 @@ const WORKSPACE = {
 }
 
 test('dev mode', { fs: WORKSPACE }, async ({ fs, spawn, expect }) => {
-  let process = await spawn('pnpm react-router dev')
+  const process = await spawn('pnpm react-router dev')
 
   let url = ''
   await process.onStdout((m) => {
-    let match = /Local:\s*(http.*)\//.exec(m)
+    const match = /Local:\s*(http.*)\//.exec(m)
     if (match) url = match[1]
     return Boolean(url)
   })
 
   await retryAssertion(async () => {
-    let css = await fetchStyles(url)
+    const css = await fetchStyles(url)
     expect(css).toContain(candidate`font-bold`)
   })
 
@@ -96,7 +96,7 @@ test('dev mode', { fs: WORKSPACE }, async ({ fs, spawn, expect }) => {
       `,
     )
 
-    let css = await fetchStyles(url)
+    const css = await fetchStyles(url)
     expect(css).toContain(candidate`underline`)
     expect(css).toContain(candidate`font-bold`)
   })
@@ -104,17 +104,17 @@ test('dev mode', { fs: WORKSPACE }, async ({ fs, spawn, expect }) => {
 
 test('build mode', { fs: WORKSPACE }, async ({ spawn, exec, expect }) => {
   await exec('pnpm react-router build')
-  let process = await spawn('pnpm react-router-serve ./build/server/index.js')
+  const process = await spawn('pnpm react-router-serve ./build/server/index.js')
 
   let url = ''
   await process.onStdout((m) => {
-    let match = /\[react-router-serve\]\s*(http.*)\ \/?/.exec(m)
+    const match = /\[react-router-serve\]\s*(http.*)\ \/?/.exec(m)
     if (match) url = match[1]
     return url != ''
   })
 
   await retryAssertion(async () => {
-    let css = await fetchStyles(url)
+    const css = await fetchStyles(url)
     expect(css).toContain(candidate`font-bold`)
   })
 })
@@ -168,10 +168,10 @@ test(
   async ({ fs, exec, expect }) => {
     await exec('pnpm react-router build')
 
-    let files = await fs.glob('build/client/assets/**/*.css')
+    const files = await fs.glob('build/client/assets/**/*.css')
 
     expect(files).toHaveLength(1)
-    let [filename] = files[0]
+    const [filename] = files[0]
 
     await fs.expectFileToContain(filename, [candidate`font-bold`])
   },

--- a/integrations/vite/resolvers.test.ts
+++ b/integrations/vite/resolvers.test.ts
@@ -62,9 +62,9 @@ describe.each(['postcss', 'lightningcss'])('%s', (transformer) => {
     async ({ fs, exec, expect }) => {
       await exec('pnpm vite build')
 
-      let files = await fs.glob('dist/**/*.css')
+      const files = await fs.glob('dist/**/*.css')
       expect(files).toHaveLength(1)
-      let [filename] = files[0]
+      const [filename] = files[0]
 
       await fs.expectFileToContain(filename, [candidate`underline`, candidate`custom-underline`])
     },
@@ -128,18 +128,18 @@ describe.each(['postcss', 'lightningcss'])('%s', (transformer) => {
       },
     },
     async ({ spawn, expect }) => {
-      let process = await spawn('pnpm vite dev')
+      const process = await spawn('pnpm vite dev')
       await process.onStdout((m) => m.includes('ready in'))
 
       let url = ''
       await process.onStdout((m) => {
-        let match = /Local:\s*(http.*)\//.exec(m)
+        const match = /Local:\s*(http.*)\//.exec(m)
         if (match) url = match[1]
         return Boolean(url)
       })
 
       await retryAssertion(async () => {
-        let styles = await fetchStyles(url, '/index.html')
+        const styles = await fetchStyles(url, '/index.html')
         expect(styles).toContain(candidate`underline`)
         expect(styles).toContain(candidate`custom-underline`)
       })

--- a/integrations/vite/solidstart.test.ts
+++ b/integrations/vite/solidstart.test.ts
@@ -70,7 +70,7 @@ test(
     fs: WORKSPACE,
   },
   async ({ fs, spawn, expect }) => {
-    let process = await spawn('pnpm vinxi dev', {
+    const process = await spawn('pnpm vinxi dev', {
       env: {
         TEST: 'false', // VERY IMPORTANT OTHERWISE YOU WON'T GET OUTPUT
         NODE_ENV: 'development',
@@ -79,13 +79,13 @@ test(
 
     let url = ''
     await process.onStdout((m) => {
-      let match = /Local:\s*(http.*)\//.exec(m)
+      const match = /Local:\s*(http.*)\//.exec(m)
       if (match) url = match[1]
       return Boolean(url)
     })
 
     await retryAssertion(async () => {
-      let css = await fetchStyles(url)
+      const css = await fetchStyles(url)
       expect(css).toContain(candidate`underline`)
     })
 
@@ -100,7 +100,7 @@ test(
         `,
       )
 
-      let css = await fetchStyles(url)
+      const css = await fetchStyles(url)
       expect(css).toContain(candidate`underline`)
       expect(css).toContain(candidate`font-bold`)
     })

--- a/integrations/vite/ssr.test.ts
+++ b/integrations/vite/ssr.test.ts
@@ -60,9 +60,9 @@ test(
   async ({ fs, exec, expect }) => {
     await exec('pnpm vite build --ssr server.ts')
 
-    let files = await fs.glob('dist/**/*.css')
+    const files = await fs.glob('dist/**/*.css')
     expect(files).toHaveLength(1)
-    let [filename] = files[0]
+    const [filename] = files[0]
 
     await fs.expectFileToContain(filename, [
       candidate`underline`,
@@ -107,9 +107,9 @@ test(
   async ({ fs, exec, expect }) => {
     await exec('pnpm vite build --ssr server.ts')
 
-    let files = await fs.glob('dist/**/*.css')
+    const files = await fs.glob('dist/**/*.css')
     expect(files).toHaveLength(1)
-    let [filename] = files[0]
+    const [filename] = files[0]
 
     await fs.expectFileToContain(filename, [
       candidate`underline`,

--- a/integrations/vite/svelte.test.ts
+++ b/integrations/vite/svelte.test.ts
@@ -51,7 +51,7 @@ test(
       'src/App.svelte': html`
         <script>
           import './index.css'
-          let name = 'world'
+          const name = 'world'
         </script>
 
         <h1 class="global local underline">Hello {name}!</h1>
@@ -93,9 +93,9 @@ test(
     },
   },
   async ({ exec, fs, expect }) => {
-    let output = await exec('pnpm vite build')
+    const output = await exec('pnpm vite build')
 
-    let files = await fs.glob('dist/**/*.css')
+    const files = await fs.glob('dist/**/*.css')
     expect(files).toHaveLength(1)
 
     await fs.expectFileToContain(files[0][0], [
@@ -161,7 +161,7 @@ test(
       'src/App.svelte': html`
         <script>
           import './index.css'
-          let name = 'world'
+          const name = 'world'
         </script>
 
         <h1 class="local global underline">Hello {name}!</h1>
@@ -204,13 +204,13 @@ test(
     },
   },
   async ({ fs, spawn, expect }) => {
-    let process = await spawn(`pnpm vite build --watch`)
+    const process = await spawn(`pnpm vite build --watch`)
     await process.onStdout((m) => m.includes('built in'))
 
     await retryAssertion(async () => {
-      let files = await fs.glob('dist/**/*.css')
+      const files = await fs.glob('dist/**/*.css')
       expect(files).toHaveLength(1)
-      let [, css] = files[0]
+      const [, css] = files[0]
       expect(css).toContain(candidate`underline`)
       expect(css).toContain(
         '.global{color:var(--color-green-500,oklch(72.3% .219 149.579));animation:2s ease-in-out infinite globalKeyframes}',
@@ -233,9 +233,9 @@ test(
     )
 
     await retryAssertion(async () => {
-      let files = await fs.glob('dist/**/*.css')
+      const files = await fs.glob('dist/**/*.css')
       expect(files).toHaveLength(1)
-      let [, css] = files[0]
+      const [, css] = files[0]
       expect(css).toContain(candidate`font-bold`)
       expect(css).toContain(
         '.global{color:var(--color-green-500,oklch(72.3% .219 149.579));animation:2s ease-in-out infinite globalKeyframes}',

--- a/integrations/vite/url-rewriting.test.ts
+++ b/integrations/vite/url-rewriting.test.ts
@@ -94,12 +94,12 @@ describe.each(['postcss', 'lightningcss'])('%s', (transformer) => {
     async ({ fs, exec, expect }) => {
       await exec('pnpm vite build')
 
-      let files = await fs.glob('dist/**/*.css')
+      const files = await fs.glob('dist/**/*.css')
       expect(files).toHaveLength(1)
 
       await fs.expectFileToContain(files[0][0], [SIMPLE_IMAGE])
 
-      let images = await fs.glob('dist/**/*.svg')
+      const images = await fs.glob('dist/**/*.svg')
       expect(images).toHaveLength(2)
 
       await fs.expectFileToContain(files[0][0], [/\/assets\/vector-.*?\.svg/])

--- a/integrations/vite/vue.test.ts
+++ b/integrations/vite/vue.test.ts
@@ -64,7 +64,7 @@ test(
   async ({ fs, exec, expect }) => {
     await exec('pnpm vite build')
 
-    let files = await fs.glob('dist/**/*.css')
+    const files = await fs.glob('dist/**/*.css')
     expect(files).toHaveLength(1)
 
     await fs.expectFileToContain(files[0][0], [candidate`underline`, candidate`foo`])

--- a/integrations/webpack/index.test.ts
+++ b/integrations/webpack/index.test.ts
@@ -29,7 +29,7 @@ test(
         }
       `,
       'webpack.config.js': js`
-        let MiniCssExtractPlugin = require('mini-css-extract-plugin')
+        const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 
         module.exports = {
           output: {
@@ -68,7 +68,7 @@ test(
     // NOTE: We are writing to an output CSS file which is not being ignored by
     // `.gitignore` nor marked with `@source not`. This should not result in an
     // infinite loop.
-    let process = await spawn('pnpm webpack --mode=development --watch')
+    const process = await spawn('pnpm webpack --mode=development --watch')
     await process.onStdout((m) => m.includes('compiled successfully in'))
 
     expect(await fs.dumpFiles('./dist/*.css')).toMatchInlineSnapshot(`

--- a/integrations/workers/index.test.ts
+++ b/integrations/workers/index.test.ts
@@ -12,7 +12,7 @@ test(
         }
       `,
       'start.js': js`
-        let { Worker } = require('worker_threads')
+        const { Worker } = require('worker_threads')
         new Worker('./worker.js')
       `,
       'worker.js': js`
@@ -22,7 +22,7 @@ test(
     },
   },
   async ({ exec, expect }) => {
-    let output = await exec('node ./start.js').then(
+    const output = await exec('node ./start.js').then(
       (out) => out.trim(),
       (err) => `${err}`,
     )


### PR DESCRIPTION
Some variables were declared with the `let` keyword but never reassigned. For the reasons below, it would be a better practice to change to `const`.

1. Prevents accidental reassignment
2. Signals intent clearly to other developers
3. Improves code readability
4. Enables potential compiler optimizations
5. Simplifies debugging
6. Promotes immutability
7. Reduces bugs from mutable state