### PR TITLE
refactor[packages/test]: change `let` to `const` for those references doesn't change

### DIFF
--- a/packages/@tailwindcss-browser/tests/ui.spec.ts
+++ b/packages/@tailwindcss-browser/tests/ui.spec.ts
@@ -113,7 +113,7 @@ async function createServer() {
   }
 
   async function render({ page, htmlClasses, head, body }: PageOptions) {
-    let content = html`
+    const content = html`
       <!doctype html>
       <html lang="en" class="${htmlClasses ?? ''}">
         <head>
@@ -155,9 +155,9 @@ async function createServer() {
 
   app.use(router)
 
-  let workerIndex = Number(process.env.TEST_WORKER_INDEX ?? 0)
+  const workerIndex = Number(process.env.TEST_WORKER_INDEX ?? 0)
 
-  let listener = await listen(toNodeListener(app), {
+  const listener = await listen(toNodeListener(app), {
     port: 3000 + workerIndex,
     showURL: false,
     open: false,

--- a/packages/@tailwindcss-cli/src/utils/args.test.ts
+++ b/packages/@tailwindcss-cli/src/utils/args.test.ts
@@ -86,7 +86,7 @@ it('should convert the incoming value to the correct type', () => {
 })
 
 it('should be possible to provide multiple types, and convert the value to that type', () => {
-  let options = {
+  const options = {
     '--retries': { type: 'boolean | number | string', description: 'Retries' },
   } satisfies Arg
 

--- a/packages/@tailwindcss-node/src/instrumentation.test.ts
+++ b/packages/@tailwindcss-node/src/instrumentation.test.ts
@@ -3,7 +3,7 @@ import { expect, it } from 'vitest'
 import { Instrumentation } from './instrumentation'
 
 it('should add instrumentation', () => {
-  let I = new Instrumentation()
+  const I = new Instrumentation()
 
   I.start('Foo')
   let x = 1
@@ -36,7 +36,7 @@ it('should add instrumentation', () => {
 })
 
 it('should auto end pending timers when reporting', () => {
-  let I = new Instrumentation()
+  const I = new Instrumentation()
 
   I.start('Foo')
   let x = 1

--- a/packages/@tailwindcss-node/src/urls.test.ts
+++ b/packages/@tailwindcss-node/src/urls.test.ts
@@ -4,9 +4,9 @@ import { rewriteUrls } from './urls'
 const css = String.raw
 
 test('URLs can be rewritten', async () => {
-  let root = '/root'
+  const root = '/root'
 
-  let result = await rewriteUrls({
+  const result = await rewriteUrls({
     root,
     base: '/root/foo/bar',
     // prettier-ignore

--- a/packages/@tailwindcss-postcss/src/index.test.ts
+++ b/packages/@tailwindcss-postcss/src/index.test.ts
@@ -20,11 +20,11 @@ function inputCssFilePath() {
 const css = dedent
 
 test("`@import 'tailwindcss'` is replaced with the generated CSS", async () => {
-  let processor = postcss([
+  const processor = postcss([
     tailwindcss({ base: `${__dirname}/fixtures/example-project`, optimize: { minify: false } }),
   ])
 
-  let result = await processor.process(`@import 'tailwindcss'`, { from: inputCssFilePath() })
+  const result = await processor.process(`@import 'tailwindcss'`, { from: inputCssFilePath() })
 
   expect(result.css.trim()).toMatchSnapshot()
 
@@ -51,11 +51,11 @@ test("`@import 'tailwindcss'` is replaced with the generated CSS", async () => {
 })
 
 test('output is optimized by Lightning CSS', async () => {
-  let processor = postcss([
+  const processor = postcss([
     tailwindcss({ base: `${__dirname}/fixtures/example-project`, optimize: { minify: false } }),
   ])
 
-  let result = await processor.process(
+  const result = await processor.process(
     css`
       @layer utilities {
         .foo {
@@ -86,11 +86,11 @@ test('output is optimized by Lightning CSS', async () => {
 })
 
 test('@apply can be used without emitting the theme in the CSS file', async () => {
-  let processor = postcss([
+  const processor = postcss([
     tailwindcss({ base: `${__dirname}/fixtures/example-project`, optimize: { minify: false } }),
   ])
 
-  let result = await processor.process(
+  const result = await processor.process(
     css`
       @reference 'tailwindcss/theme.css';
       .foo {
@@ -123,9 +123,9 @@ describe('processing without specifying a base path', () => {
     const spy = vi.spyOn(process, 'cwd')
     spy.mockReturnValue(dir)
 
-    let processor = postcss([tailwindcss({ optimize: { minify: false } })])
+    const processor = postcss([tailwindcss({ optimize: { minify: false } })])
 
-    let result = await processor.process(`@import "tailwindcss"`, { from: inputCssFilePath() })
+    const result = await processor.process(`@import "tailwindcss"`, { from: inputCssFilePath() })
 
     expect(result.css).toContain(
       ".md\\:\\[\\&\\:hover\\]\\:content-\\[\\'testing_default_base_path\\'\\]",
@@ -142,11 +142,11 @@ describe('processing without specifying a base path', () => {
 
 describe('plugins', () => {
   test('local CJS plugin', async () => {
-    let processor = postcss([
+    const processor = postcss([
       tailwindcss({ base: `${__dirname}/fixtures/example-project`, optimize: { minify: false } }),
     ])
 
-    let result = await processor.process(
+    const result = await processor.process(
       css`
         @import 'tailwindcss/utilities';
         @plugin './plugin.js';
@@ -172,11 +172,11 @@ describe('plugins', () => {
   })
 
   test('local CJS plugin from `@import`-ed file', async () => {
-    let processor = postcss([
+    const processor = postcss([
       tailwindcss({ base: `${__dirname}/fixtures/example-project`, optimize: { minify: false } }),
     ])
 
-    let result = await processor.process(
+    const result = await processor.process(
       css`
         @import 'tailwindcss/utilities';
         @import '../example-project/src/relative-import.css';
@@ -202,11 +202,11 @@ describe('plugins', () => {
   })
 
   test('published CJS plugin', async () => {
-    let processor = postcss([
+    const processor = postcss([
       tailwindcss({ base: `${__dirname}/fixtures/example-project`, optimize: { minify: false } }),
     ])
 
-    let result = await processor.process(
+    const result = await processor.process(
       css`
         @import 'tailwindcss/utilities';
         @plugin 'internal-example-plugin';
@@ -233,11 +233,11 @@ describe('plugins', () => {
 })
 
 test('bail early when Tailwind is not used', async () => {
-  let processor = postcss([
+  const processor = postcss([
     tailwindcss({ base: `${__dirname}/fixtures/example-project`, optimize: { minify: false } }),
   ])
 
-  let result = await processor.process(
+  const result = await processor.process(
     css`
       .custom-css {
         color: red;
@@ -258,11 +258,11 @@ test('bail early when Tailwind is not used', async () => {
 })
 
 test('handle CSS when only using a `@reference` (we should not bail early)', async () => {
-  let processor = postcss([
+  const processor = postcss([
     tailwindcss({ base: `${__dirname}/fixtures/example-project`, optimize: { minify: false } }),
   ])
 
-  let result = await processor.process(
+  const result = await processor.process(
     css`
       @reference "tailwindcss/theme.css";
 
@@ -285,11 +285,11 @@ test('handle CSS when only using a `@reference` (we should not bail early)', asy
 })
 
 test('handle CSS when using a `@variant` using variants that do not rely on the `@theme`', async () => {
-  let processor = postcss([
+  const processor = postcss([
     tailwindcss({ base: `${__dirname}/fixtures/example-project`, optimize: { minify: false } }),
   ])
 
-  let result = await processor.process(
+  const result = await processor.process(
     css`
       .foo {
         @variant data-is-hoverable {
@@ -310,7 +310,7 @@ test('handle CSS when using a `@variant` using variants that do not rely on the 
 test('runs `Once` plugins in the right order', async () => {
   let before = ''
   let after = ''
-  let processor = postcss([
+  const processor = postcss([
     {
       postcssPlugin: 'before',
       Once(root) {
@@ -326,7 +326,7 @@ test('runs `Once` plugins in the right order', async () => {
     },
   ])
 
-  let result = await processor.process(
+  const result = await processor.process(
     css`
       @theme {
         --color-red-500: red;
@@ -382,14 +382,14 @@ describe('concurrent builds', () => {
     const spy = vi.spyOn(process, 'cwd')
     spy.mockReturnValue(dir)
 
-    let from = path.join(dir, 'index.css')
-    let input = (await readFile(path.join(dir, 'index.css'))).toString()
+    const from = path.join(dir, 'index.css')
+    const input = (await readFile(path.join(dir, 'index.css'))).toString()
 
-    let plugin = tailwindcss({ optimize: { minify: false } })
+    const plugin = tailwindcss({ optimize: { minify: false } })
 
     async function run(input: string): Promise<string> {
-      let ast = postcss.parse(input)
-      for (let runner of (plugin as any).plugins) {
+      const ast = postcss.parse(input)
+      for (const runner of (plugin as any).plugins) {
         if (runner.Once) {
           await runner.Once(ast, { result: { opts: { from }, messages: [] } })
         }
@@ -397,7 +397,7 @@ describe('concurrent builds', () => {
       return ast.toString()
     }
 
-    let result = await run(input)
+    const result = await run(input)
 
     expect(result).toContain('.underline')
 
@@ -413,8 +413,8 @@ describe('concurrent builds', () => {
       `,
     )
 
-    let promise1 = run(input)
-    let promise2 = run(input)
+    const promise1 = run(input)
+    const promise2 = run(input)
 
     expect(await promise1).toContain('.red')
     expect(await promise2).toContain('.red')
@@ -422,11 +422,11 @@ describe('concurrent builds', () => {
 })
 
 test('does not register the input file as a dependency, even if it is passed in as relative path', async () => {
-  let processor = postcss([
+  const processor = postcss([
     tailwindcss({ base: `${__dirname}/fixtures/example-project`, optimize: { minify: false } }),
   ])
 
-  let result = await processor.process(`@tailwind utilities`, { from: './input.css' })
+  const result = await processor.process(`@tailwind utilities`, { from: './input.css' })
 
   expect(result.css.trim()).toMatchInlineSnapshot(`
     ".underline {

--- a/packages/@tailwindcss-postcss/src/postcss-fix-relative-paths/index.test.ts
+++ b/packages/@tailwindcss-postcss/src/postcss-fix-relative-paths/index.test.ts
@@ -7,12 +7,12 @@ import fixRelativePathsPlugin from '.'
 
 describe('fixRelativePathsPlugin', () => {
   test('rewrites @source and @plugin to be relative to the initial css file', async () => {
-    let cssPath = path.join(__dirname, 'fixtures', 'external-import', 'src', 'index.css')
-    let css = fs.readFileSync(cssPath, 'utf-8')
+    const cssPath = path.join(__dirname, 'fixtures', 'external-import', 'src', 'index.css')
+    const css = fs.readFileSync(cssPath, 'utf-8')
 
-    let processor = postcss([atImport(), fixRelativePathsPlugin()])
+    const processor = postcss([atImport(), fixRelativePathsPlugin()])
 
-    let result = await processor.process(css, { from: cssPath })
+    const result = await processor.process(css, { from: cssPath })
 
     expect(result.css.trim()).toMatchInlineSnapshot(`
       "@source "../../example-project/src/**/*.ts";
@@ -23,12 +23,12 @@ describe('fixRelativePathsPlugin', () => {
   })
 
   test('should not rewrite non-relative paths', async () => {
-    let cssPath = path.join(__dirname, 'fixtures', 'external-import', 'src', 'invalid.css')
-    let css = fs.readFileSync(cssPath, 'utf-8')
+    const cssPath = path.join(__dirname, 'fixtures', 'external-import', 'src', 'invalid.css')
+    const css = fs.readFileSync(cssPath, 'utf-8')
 
-    let processor = postcss([atImport(), fixRelativePathsPlugin()])
+    const processor = postcss([atImport(), fixRelativePathsPlugin()])
 
-    let result = await processor.process(css, { from: cssPath })
+    const result = await processor.process(css, { from: cssPath })
 
     expect(result.css.trim()).toMatchInlineSnapshot(`
       "@plugin "/absolute/paths";
@@ -39,12 +39,18 @@ describe('fixRelativePathsPlugin', () => {
   })
 
   test('should return relative paths even if the file is resolved in the same basedir as the root stylesheet', async () => {
-    let cssPath = path.join(__dirname, 'fixtures', 'external-import', 'src', 'plugins-in-root.css')
-    let css = fs.readFileSync(cssPath, 'utf-8')
+    const cssPath = path.join(
+      __dirname,
+      'fixtures',
+      'external-import',
+      'src',
+      'plugins-in-root.css',
+    )
+    const css = fs.readFileSync(cssPath, 'utf-8')
 
-    let processor = postcss([atImport(), fixRelativePathsPlugin()])
+    const processor = postcss([atImport(), fixRelativePathsPlugin()])
 
-    let result = await processor.process(css, { from: cssPath })
+    const result = await processor.process(css, { from: cssPath })
 
     expect(result.css.trim()).toMatchInlineSnapshot(`
       "@plugin './plugin-in-sibling.ts';

--- a/packages/@tailwindcss-upgrade/src/codemods/css/migrate-at-layer-utilities.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/css/migrate-at-layer-utilities.test.ts
@@ -24,8 +24,8 @@ async function migrate(
     stylesheet = await Stylesheet.fromRoot(data.root)
 
     if (data.layers) {
-      let meta = { layers: data.layers }
-      let parent = await Stylesheet.fromString('.placeholder {}')
+      const meta = { layers: data.layers }
+      const parent = await Stylesheet.fromString('.placeholder {}')
 
       stylesheet.parents.add({ item: parent, meta })
       parent.children.add({ item: stylesheet, meta })

--- a/packages/@tailwindcss-upgrade/src/utils/args.test.ts
+++ b/packages/@tailwindcss-upgrade/src/utils/args.test.ts
@@ -86,7 +86,7 @@ it('should convert the incoming value to the correct type', () => {
 })
 
 it('should be possible to provide multiple types, and convert the value to that type', () => {
-  let options = {
+  const options = {
     '--retries': { type: 'boolean | number | string', description: 'Retries' },
   } satisfies Arg
 

--- a/packages/@tailwindcss-upgrade/src/utils/extract-static-plugins.test.ts
+++ b/packages/@tailwindcss-upgrade/src/utils/extract-static-plugins.test.ts
@@ -306,7 +306,7 @@ describe('findStaticPlugins', () => {
 
 describe('extractStaticImportMap', () => {
   test('extracts different kind of imports from an ESM file', () => {
-    let extracted = extractStaticImportMap(js`
+    const extracted = extractStaticImportMap(js`
       import plugin1 from './plugin1'
       import * as plugin2 from './plugin2'
       import plugin6, { plugin3, plugin4, default as plugin5 } from './plugin3'
@@ -326,7 +326,7 @@ describe('extractStaticImportMap', () => {
   })
 
   test('extracts different kind of imports from an CJS file', () => {
-    let extracted = extractStaticImportMap(js`
+    const extracted = extractStaticImportMap(js`
       const plugin1 = require('./plugin1')
       let plugin2 = require('./plugin2')
       var plugin3 = require('./plugin3')

--- a/packages/tailwindcss/src/ast.test.ts
+++ b/packages/tailwindcss/src/ast.test.ts
@@ -82,14 +82,14 @@ it('allows the placement of context nodes', () => {
 })
 
 it('should stop walking when returning `WalkAction.Stop`', () => {
-  let ast = [
+  const ast = [
     styleRule('.foo', [styleRule('.nested', [styleRule('.bail', [decl('color', 'red')])])]),
     styleRule('.bar'),
     styleRule('.baz'),
     styleRule('.qux'),
   ]
 
-  let seen = new Set()
+  const seen = new Set()
 
   walk(ast, (node) => {
     if (node.kind === 'rule') {
@@ -112,7 +112,7 @@ it('should stop walking when returning `WalkAction.Stop`', () => {
 })
 
 it('should not emit empty rules once optimized', () => {
-  let ast = CSS.parse(css`
+  const ast = CSS.parse(css`
     /* Empty rule */
     .foo {
     }
@@ -203,9 +203,9 @@ it('should not emit empty rules once optimized', () => {
 })
 
 it('should only visit children once when calling `replaceWith` with single element array', () => {
-  let visited = new Set()
+  const visited = new Set()
 
-  let ast = [
+  const ast = [
     atRule('@media', '', [styleRule('.foo', [decl('color', 'blue')])]),
     styleRule('.bar', [decl('color', 'blue')]),
   ]
@@ -221,9 +221,9 @@ it('should only visit children once when calling `replaceWith` with single eleme
 })
 
 it('should only visit children once when calling `replaceWith` with multi-element array', () => {
-  let visited = new Set()
+  const visited = new Set()
 
-  let ast = [
+  const ast = [
     atRule('@media', '', [
       context({}, [
         styleRule('.foo', [decl('color', 'red')]),
@@ -234,7 +234,7 @@ it('should only visit children once when calling `replaceWith` with multi-elemen
   ]
 
   walk(ast, (node, { replaceWith }) => {
-    let key = id(node)
+    const key = id(node)
     if (visited.has(key)) {
       throw new Error('Visited node twice')
     }
@@ -257,11 +257,11 @@ it('should only visit children once when calling `replaceWith` with multi-elemen
 })
 
 it('should never visit children when calling `replaceWith` with `WalkAction.Skip`', () => {
-  let visited = new Set()
+  const visited = new Set()
 
-  let inner = styleRule('.foo', [decl('color', 'blue')])
+  const inner = styleRule('.foo', [decl('color', 'blue')])
 
-  let ast = [atRule('@media', '', [inner]), styleRule('.bar', [decl('color', 'blue')])]
+  const ast = [atRule('@media', '', [inner]), styleRule('.bar', [decl('color', 'blue')])]
 
   walk(ast, (node, { replaceWith }) => {
     visited.add(node)
@@ -318,14 +318,14 @@ it('should never visit children when calling `replaceWith` with `WalkAction.Skip
 
 it('should skip the correct number of children based on the the replaced children nodes', () => {
   {
-    let ast = [
+    const ast = [
       decl('--index', '0'),
       decl('--index', '1'),
       decl('--index', '2'),
       decl('--index', '3'),
       decl('--index', '4'),
     ]
-    let visited: string[] = []
+    const visited: string[] = []
     walk(ast, (node, { replaceWith }) => {
       visited.push(id(node))
       if (node.kind === 'declaration' && node.value === '2') {
@@ -346,14 +346,14 @@ it('should skip the correct number of children based on the the replaced childre
   }
 
   {
-    let ast = [
+    const ast = [
       decl('--index', '0'),
       decl('--index', '1'),
       decl('--index', '2'),
       decl('--index', '3'),
       decl('--index', '4'),
     ]
-    let visited: string[] = []
+    const visited: string[] = []
     walk(ast, (node, { replaceWith }) => {
       visited.push(id(node))
       if (node.kind === 'declaration' && node.value === '2') {
@@ -374,14 +374,14 @@ it('should skip the correct number of children based on the the replaced childre
   }
 
   {
-    let ast = [
+    const ast = [
       decl('--index', '0'),
       decl('--index', '1'),
       decl('--index', '2'),
       decl('--index', '3'),
       decl('--index', '4'),
     ]
-    let visited: string[] = []
+    const visited: string[] = []
     walk(ast, (node, { replaceWith }) => {
       visited.push(id(node))
       if (node.kind === 'declaration' && node.value === '2') {
@@ -402,14 +402,14 @@ it('should skip the correct number of children based on the the replaced childre
   }
 
   {
-    let ast = [
+    const ast = [
       decl('--index', '0'),
       decl('--index', '1'),
       decl('--index', '2'),
       decl('--index', '3'),
       decl('--index', '4'),
     ]
-    let visited: string[] = []
+    const visited: string[] = []
     walk(ast, (node, { replaceWith }) => {
       visited.push(id(node))
       if (node.kind === 'declaration' && node.value === '2') {
@@ -431,14 +431,14 @@ it('should skip the correct number of children based on the the replaced childre
   }
 
   {
-    let ast = [
+    const ast = [
       decl('--index', '0'),
       decl('--index', '1'),
       decl('--index', '2'),
       decl('--index', '3'),
       decl('--index', '4'),
     ]
-    let visited: string[] = []
+    const visited: string[] = []
     walk(ast, (node, { replaceWith }) => {
       visited.push(id(node))
       if (node.kind === 'declaration' && node.value === '2') {
@@ -459,14 +459,14 @@ it('should skip the correct number of children based on the the replaced childre
   }
 
   {
-    let ast = [
+    const ast = [
       decl('--index', '0'),
       decl('--index', '1'),
       decl('--index', '2'),
       decl('--index', '3'),
       decl('--index', '4'),
     ]
-    let visited: string[] = []
+    const visited: string[] = []
     walk(ast, (node, { replaceWith }) => {
       visited.push(id(node))
       if (node.kind === 'declaration' && node.value === '2') {

--- a/packages/tailwindcss/src/at-import.test.ts
+++ b/packages/tailwindcss/src/at-import.test.ts
@@ -25,13 +25,13 @@ async function run(
     optimize?: boolean
   },
 ) {
-  let compiler = await compile(css, { base: '/root', loadStylesheet, loadModule })
-  let result = compiler.build(candidates)
+  const compiler = await compile(css, { base: '/root', loadStylesheet, loadModule })
+  const result = compiler.build(candidates)
   return optimize ? optimizeCss(result) : result
 }
 
 test('can resolve relative @imports', async () => {
-  let loadStylesheet = async (id: string, base: string) => {
+  const loadStylesheet = async (id: string, base: string) => {
     expect(base).toBe('/root')
     expect(id).toBe('./foo/bar.css')
     return {
@@ -60,7 +60,7 @@ test('can resolve relative @imports', async () => {
 })
 
 test('can recursively resolve relative @imports', async () => {
-  let loadStylesheet = async (id: string, base: string) => {
+  const loadStylesheet = async (id: string, base: string) => {
     if (base === '/root' && id === './foo/bar.css') {
       return {
         content: css`
@@ -97,12 +97,12 @@ test('can recursively resolve relative @imports', async () => {
   `)
 })
 
-let exampleCSS = css`
+const exampleCSS = css`
   a {
     color: red;
   }
 `
-let loadStylesheet = async (id: string) => {
+const loadStylesheet = async (id: string) => {
   if (!id.endsWith('example.css')) throw new Error('Unexpected import: ' + id)
   return {
     content: exampleCSS,
@@ -428,7 +428,7 @@ test('supports theme(reference) imports', async () => {
 })
 
 test('updates the base when loading modules inside nested files', async () => {
-  let loadStylesheet = () =>
+  const loadStylesheet = () =>
     Promise.resolve({
       content: css`
         @config './nested-config.js';
@@ -436,7 +436,7 @@ test('updates the base when loading modules inside nested files', async () => {
       `,
       base: '/root/foo',
     })
-  let loadModule = vi.fn().mockResolvedValue({ base: '', module: () => {} })
+  const loadModule = vi.fn().mockResolvedValue({ base: '', module: () => {} })
 
   expect(
     (
@@ -458,7 +458,7 @@ test('updates the base when loading modules inside nested files', async () => {
 })
 
 test('emits the right base for @source directives inside nested files', async () => {
-  let loadStylesheet = () =>
+  const loadStylesheet = () =>
     Promise.resolve({
       content: css`
         @source './nested/**/*.css';
@@ -466,7 +466,7 @@ test('emits the right base for @source directives inside nested files', async ()
       base: '/root/foo',
     })
 
-  let compiler = await compile(
+  const compiler = await compile(
     css`
       @import './foo/bar.css';
       @source './root/**/*.css';
@@ -481,7 +481,7 @@ test('emits the right base for @source directives inside nested files', async ()
 })
 
 test('emits the right base for @source found inside JS configs and plugins from nested imports', async () => {
-  let loadStylesheet = () =>
+  const loadStylesheet = () =>
     Promise.resolve({
       content: css`
         @config './nested-config.js';
@@ -489,11 +489,11 @@ test('emits the right base for @source found inside JS configs and plugins from 
       `,
       base: '/root/foo',
     })
-  let loadModule = vi.fn().mockImplementation((id: string) => {
-    let base = id.includes('nested') ? '/root/foo' : '/root'
+  const loadModule = vi.fn().mockImplementation((id: string) => {
+    const base = id.includes('nested') ? '/root/foo' : '/root'
     if (id.includes('config')) {
-      let glob = id.includes('nested') ? './nested-config/*.html' : './root-config/*.html'
-      let pluginGlob = id.includes('nested')
+      const glob = id.includes('nested') ? './nested-config/*.html' : './root-config/*.html'
+      const pluginGlob = id.includes('nested')
         ? './nested-config-plugin/*.html'
         : './root-config-plugin/*.html'
       return {
@@ -504,7 +504,7 @@ test('emits the right base for @source found inside JS configs and plugins from 
         base: base + '-config',
       }
     } else {
-      let glob = id.includes('nested') ? './nested-plugin/*.html' : './root-plugin/*.html'
+      const glob = id.includes('nested') ? './nested-plugin/*.html' : './root-plugin/*.html'
       return {
         module: plugin(() => {}, { content: [glob] }),
         base: base + '-plugin',
@@ -512,7 +512,7 @@ test('emits the right base for @source found inside JS configs and plugins from 
     }
   })
 
-  let compiler = await compile(
+  const compiler = await compile(
     css`
       @import './foo/bar.css';
       @config './root-config.js';
@@ -534,7 +534,7 @@ test('emits the right base for @source found inside JS configs and plugins from 
 })
 
 test('it crashes when inside a cycle', async () => {
-  let loadStylesheet = () =>
+  const loadStylesheet = () =>
     Promise.resolve({
       content: css`
         @import 'foo.css';
@@ -555,7 +555,7 @@ test('it crashes when inside a cycle', async () => {
 })
 
 test('resolves @reference as `@import "…" reference`', async () => {
-  let loadStylesheet = async (id: string, base: string) => {
+  const loadStylesheet = async (id: string, base: string) => {
     expect(base).toBe('/root')
     expect(id).toBe('./foo/bar.css')
     return {
@@ -588,7 +588,7 @@ test('resolves @reference as `@import "…" reference`', async () => {
 })
 
 test('resolves `@variant` used as `@custom-variant` inside `@reference`', async () => {
-  let loadStylesheet = async (id: string, base: string) => {
+  const loadStylesheet = async (id: string, base: string) => {
     expect(base).toBe('/root')
     expect(id).toBe('./foo/bar.css')
     return {

--- a/packages/tailwindcss/src/candidate.test.ts
+++ b/packages/tailwindcss/src/candidate.test.ts
@@ -15,7 +15,7 @@ function run(
   utilities ??= new Utilities()
   variants ??= new Variants()
 
-  let designSystem = buildDesignSystem(new Theme())
+  const designSystem = buildDesignSystem(new Theme())
   designSystem.theme.prefix = prefix ?? null
 
   designSystem.utilities = utilities
@@ -33,7 +33,7 @@ it('should skip unknown variants', () => {
 })
 
 it('should parse a simple utility', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
 
   expect(run('flex', { utilities })).toMatchInlineSnapshot(`
@@ -50,7 +50,7 @@ it('should parse a simple utility', () => {
 })
 
 it('should parse a simple utility that should be important', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
 
   expect(run('flex!', { utilities })).toMatchInlineSnapshot(`
@@ -67,7 +67,7 @@ it('should parse a simple utility that should be important', () => {
 })
 
 it('should parse a simple utility that can be negative', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('-translate-x', () => [])
 
   expect(run('-translate-x-4', { utilities })).toMatchInlineSnapshot(`
@@ -90,10 +90,10 @@ it('should parse a simple utility that can be negative', () => {
 })
 
 it('should parse a simple utility with a variant', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
 
-  let variants = new Variants()
+  const variants = new Variants()
   variants.static('hover', () => {})
 
   expect(run('hover:flex', { utilities, variants })).toMatchInlineSnapshot(`
@@ -115,10 +115,10 @@ it('should parse a simple utility with a variant', () => {
 })
 
 it('should parse a simple utility with stacked variants', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
 
-  let variants = new Variants()
+  const variants = new Variants()
   variants.static('hover', () => {})
   variants.static('focus', () => {})
 
@@ -145,7 +145,7 @@ it('should parse a simple utility with stacked variants', () => {
 })
 
 it('should parse a simple utility with an arbitrary variant', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
 
   expect(run('[&_p]:flex', { utilities })).toMatchInlineSnapshot(`
@@ -168,9 +168,9 @@ it('should parse a simple utility with an arbitrary variant', () => {
 })
 
 it('should parse an arbitrary variant using the automatic var shorthand', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
-  let variants = new Variants()
+  const variants = new Variants()
   variants.functional('supports', () => {})
 
   expect(run('supports-(--test):flex', { utilities, variants })).toMatchInlineSnapshot(`
@@ -197,10 +197,10 @@ it('should parse an arbitrary variant using the automatic var shorthand', () => 
 })
 
 it('should parse a simple utility with a parameterized variant', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
 
-  let variants = new Variants()
+  const variants = new Variants()
   variants.functional('data', () => {})
 
   expect(run('data-[disabled]:flex', { utilities, variants })).toMatchInlineSnapshot(`
@@ -227,10 +227,10 @@ it('should parse a simple utility with a parameterized variant', () => {
 })
 
 it('should parse compound variants with an arbitrary value as an arbitrary variant', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
 
-  let variants = new Variants()
+  const variants = new Variants()
   variants.compound('group', Compounds.StyleRules, () => {})
 
   expect(run('group-[&_p]/parent-name:flex', { utilities, variants })).toMatchInlineSnapshot(`
@@ -261,10 +261,10 @@ it('should parse compound variants with an arbitrary value as an arbitrary varia
 })
 
 it('should parse a simple utility with a parameterized variant and a modifier', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
 
-  let variants = new Variants()
+  const variants = new Variants()
   variants.compound('group', Compounds.StyleRules, () => {})
   variants.functional('aria', () => {})
 
@@ -301,10 +301,10 @@ it('should parse a simple utility with a parameterized variant and a modifier', 
 })
 
 it('should parse compound group with itself group-group-*', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
 
-  let variants = new Variants()
+  const variants = new Variants()
   variants.static('hover', () => {})
   variants.compound('group', Compounds.StyleRules, () => {})
 
@@ -346,7 +346,7 @@ it('should parse compound group with itself group-group-*', () => {
 })
 
 it('should parse a simple utility with an arbitrary media variant', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
 
   expect(run('[@media(width>=123px)]:flex', { utilities })).toMatchInlineSnapshot(`
@@ -369,14 +369,14 @@ it('should parse a simple utility with an arbitrary media variant', () => {
 })
 
 it('should skip arbitrary variants where @media and other arbitrary variants are combined', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
 
   expect(run('[@media(width>=123px){&:hover}]:flex', { utilities })).toMatchInlineSnapshot(`[]`)
 })
 
 it('should parse a utility with a modifier', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-red-500/50', { utilities })).toMatchInlineSnapshot(`
@@ -402,7 +402,7 @@ it('should parse a utility with a modifier', () => {
 })
 
 it('should parse a utility with an arbitrary modifier', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-red-500/[50%]', { utilities })).toMatchInlineSnapshot(`
@@ -428,7 +428,7 @@ it('should parse a utility with an arbitrary modifier', () => {
 })
 
 it('should parse a utility with a modifier that is important', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-red-500/50!', { utilities })).toMatchInlineSnapshot(`
@@ -454,10 +454,10 @@ it('should parse a utility with a modifier that is important', () => {
 })
 
 it('should parse a utility with a modifier and a variant', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
-  let variants = new Variants()
+  const variants = new Variants()
   variants.static('hover', () => {})
 
   expect(run('hover:bg-red-500/50', { utilities, variants })).toMatchInlineSnapshot(`
@@ -488,7 +488,7 @@ it('should parse a utility with a modifier and a variant', () => {
 })
 
 it('should not parse a partial utility', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
   utilities.functional('bg', () => [])
 
@@ -497,28 +497,28 @@ it('should not parse a partial utility', () => {
 })
 
 it('should not parse static utilities with a modifier', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
 
   expect(run('flex/foo', { utilities })).toMatchInlineSnapshot(`[]`)
 })
 
 it('should not parse static utilities with multiple modifiers', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
 
   expect(run('flex/foo/bar', { utilities })).toMatchInlineSnapshot(`[]`)
 })
 
 it('should not parse functional utilities with multiple modifiers', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-red-1/2/3', { utilities })).toMatchInlineSnapshot(`[]`)
 })
 
 it('should parse a utility with an arbitrary value', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-[#0088cc]', { utilities })).toMatchInlineSnapshot(`
@@ -541,14 +541,14 @@ it('should parse a utility with an arbitrary value', () => {
 })
 
 it('should not parse a utility with an incomplete arbitrary value', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-[#0088cc', { utilities })).toMatchInlineSnapshot(`[]`)
 })
 
 it('should parse a utility with an arbitrary value with parens', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-(--my-color)', { utilities })).toMatchInlineSnapshot(`
@@ -571,14 +571,14 @@ it('should parse a utility with an arbitrary value with parens', () => {
 })
 
 it('should not parse a utility with an arbitrary value with parens that does not start with --', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-(my-color)', { utilities })).toMatchInlineSnapshot(`[]`)
 })
 
 it('should parse a utility with an arbitrary value including a typehint', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-[color:var(--value)]', { utilities })).toMatchInlineSnapshot(`
@@ -601,7 +601,7 @@ it('should parse a utility with an arbitrary value including a typehint', () => 
 })
 
 it('should parse a utility with an arbitrary value with parens including a typehint', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-(color:--my-color)', { utilities })).toMatchInlineSnapshot(`
@@ -624,14 +624,14 @@ it('should parse a utility with an arbitrary value with parens including a typeh
 })
 
 it('should not parse a utility with an arbitrary value with parens including a typehint that does not start with --', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-(color:my-color)', { utilities })).toMatchInlineSnapshot(`[]`)
 })
 
 it('should parse a utility with an arbitrary value with parens and a fallback', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-(color:--my-color,#0088cc)', { utilities })).toMatchInlineSnapshot(`
@@ -654,7 +654,7 @@ it('should parse a utility with an arbitrary value with parens and a fallback', 
 })
 
 it('should parse a utility with an arbitrary value with a modifier', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-[#0088cc]/50', { utilities })).toMatchInlineSnapshot(`
@@ -680,7 +680,7 @@ it('should parse a utility with an arbitrary value with a modifier', () => {
 })
 
 it('should parse a utility with an arbitrary value with an arbitrary modifier', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-[#0088cc]/[50%]', { utilities })).toMatchInlineSnapshot(`
@@ -706,7 +706,7 @@ it('should parse a utility with an arbitrary value with an arbitrary modifier', 
 })
 
 it('should parse a utility with an arbitrary value that is important', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-[#0088cc]!', { utilities })).toMatchInlineSnapshot(`
@@ -729,7 +729,7 @@ it('should parse a utility with an arbitrary value that is important', () => {
 })
 
 it('should parse a utility with an implicit variable as the arbitrary value', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-[var(--value)]', { utilities })).toMatchInlineSnapshot(`
@@ -752,7 +752,7 @@ it('should parse a utility with an implicit variable as the arbitrary value', ()
 })
 
 it('should parse a utility with an implicit variable as the arbitrary value that is important', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-[var(--value)]!', { utilities })).toMatchInlineSnapshot(`
@@ -775,7 +775,7 @@ it('should parse a utility with an implicit variable as the arbitrary value that
 })
 
 it('should parse a utility with an explicit variable as the arbitrary value', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-[var(--value)]', { utilities })).toMatchInlineSnapshot(`
@@ -798,7 +798,7 @@ it('should parse a utility with an explicit variable as the arbitrary value', ()
 })
 
 it('should parse a utility with an explicit variable as the arbitrary value that is important', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-[var(--value)]!', { utilities })).toMatchInlineSnapshot(`
@@ -821,10 +821,10 @@ it('should parse a utility with an explicit variable as the arbitrary value that
 })
 
 it('should not parse invalid arbitrary values', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
-  for (let candidate of [
+  for (const candidate of [
     'bg-red-[#0088cc]',
     'bg-red[#0088cc]',
 
@@ -851,13 +851,13 @@ it('should not parse invalid arbitrary values', () => {
 })
 
 it('should not parse invalid arbitrary values in variants', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
 
-  let variants = new Variants()
+  const variants = new Variants()
   variants.functional('data', () => {})
 
-  for (let candidate of [
+  for (const candidate of [
     'data-foo-[#0088cc]:flex',
     'data-foo[#0088cc]:flex',
 
@@ -910,7 +910,7 @@ it('should not parse invalid arbitrary values in variants', () => {
 })
 
 it('should parse a utility with an implicit variable as the modifier', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-red-500/[var(--value)]', { utilities })).toMatchInlineSnapshot(`
@@ -936,9 +936,9 @@ it('should parse a utility with an implicit variable as the modifier', () => {
 })
 
 it('should properly decode escaped underscores but not convert underscores to spaces for CSS variables in arbitrary positions', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('flex', () => [])
-  let variants = new Variants()
+  const variants = new Variants()
   variants.functional('supports', () => {})
 
   expect(run('flex-(--\\_foo)', { utilities, variants })).toMatchInlineSnapshot(`
@@ -1084,7 +1084,7 @@ it('should properly decode escaped underscores but not convert underscores to sp
 })
 
 it('should parse a utility with an implicit variable as the modifier using the shorthand', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-red-500/(--value)', { utilities })).toMatchInlineSnapshot(`
@@ -1110,14 +1110,14 @@ it('should parse a utility with an implicit variable as the modifier using the s
 })
 
 it('should not parse a utility with an implicit invalid variable as the modifier using the shorthand', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-red-500/(value)', { utilities })).toMatchInlineSnapshot(`[]`)
 })
 
 it('should parse a utility with an implicit variable as the modifier that is important', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-red-500/[var(--value)]!', { utilities })).toMatchInlineSnapshot(`
@@ -1143,7 +1143,7 @@ it('should parse a utility with an implicit variable as the modifier that is imp
 })
 
 it('should parse a utility with an explicit variable as the modifier', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-red-500/[var(--value)]', { utilities })).toMatchInlineSnapshot(`
@@ -1169,7 +1169,7 @@ it('should parse a utility with an explicit variable as the modifier', () => {
 })
 
 it('should parse a utility with an explicit variable as the modifier that is important', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-red-500/[var(--value)]!', { utilities })).toMatchInlineSnapshot(`
@@ -1195,10 +1195,10 @@ it('should parse a utility with an explicit variable as the modifier that is imp
 })
 
 it('should not parse a partial variant', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
 
-  let variants = new Variants()
+  const variants = new Variants()
   variants.static('open', () => {})
   variants.functional('data', () => {})
 
@@ -1207,10 +1207,10 @@ it('should not parse a partial variant', () => {
 })
 
 it('should parse a static variant starting with @', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
 
-  let variants = new Variants()
+  const variants = new Variants()
   variants.static('@lg', () => {})
 
   expect(run('@lg:flex', { utilities, variants })).toMatchInlineSnapshot(`
@@ -1232,10 +1232,10 @@ it('should parse a static variant starting with @', () => {
 })
 
 it('should parse a functional variant with a modifier', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
 
-  let variants = new Variants()
+  const variants = new Variants()
   variants.functional('foo', () => {})
 
   expect(run('foo-bar/50:flex', { utilities, variants })).toMatchInlineSnapshot(`
@@ -1265,10 +1265,10 @@ it('should parse a functional variant with a modifier', () => {
 })
 
 it('should parse a functional variant starting with @', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
 
-  let variants = new Variants()
+  const variants = new Variants()
   variants.functional('@', () => {})
 
   expect(run('@lg:flex', { utilities, variants })).toMatchInlineSnapshot(`
@@ -1295,10 +1295,10 @@ it('should parse a functional variant starting with @', () => {
 })
 
 it('should parse a functional variant starting with @ and a modifier', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
 
-  let variants = new Variants()
+  const variants = new Variants()
   variants.functional('@', () => {})
 
   expect(run('@lg/name:flex', { utilities, variants })).toMatchInlineSnapshot(`
@@ -1328,7 +1328,7 @@ it('should parse a functional variant starting with @ and a modifier', () => {
 })
 
 it('should replace `_` with ` `', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('content', () => [])
 
   expect(run('content-["hello_world"]', { utilities })).toMatchInlineSnapshot(`
@@ -1351,7 +1351,7 @@ it('should replace `_` with ` `', () => {
 })
 
 it('should not replace `\\_` with ` ` (when it is escaped)', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('content', () => [])
 
   expect(run('content-["hello\\_world"]', { utilities })).toMatchInlineSnapshot(`
@@ -1374,7 +1374,7 @@ it('should not replace `\\_` with ` ` (when it is escaped)', () => {
 })
 
 it('should not replace `_` inside of `url()`', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('bg', () => [])
 
   expect(run('bg-[no-repeat_url(https://example.com/some_page)]', { utilities }))
@@ -1398,7 +1398,7 @@ it('should not replace `_` inside of `url()`', () => {
 })
 
 it('should not replace `_` in the first argument to `var()`', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('ml', () => [])
 
   expect(run('ml-[var(--spacing-1_5,_var(--spacing-2_5,_1rem))]', { utilities }))
@@ -1422,7 +1422,7 @@ it('should not replace `_` in the first argument to `var()`', () => {
 })
 
 it('should not replace `_` in the first argument to `theme()`', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.functional('ml', () => [])
 
   expect(run('ml-[theme(--spacing-1_5,_theme(--spacing-2_5,_1rem))]', { utilities }))
@@ -1505,7 +1505,7 @@ it('should parse arbitrary properties that are important', () => {
 })
 
 it('should parse arbitrary properties with a variant', () => {
-  let variants = new Variants()
+  const variants = new Variants()
   variants.static('hover', () => {})
 
   expect(run('hover:[color:red]', { variants })).toMatchInlineSnapshot(`
@@ -1529,7 +1529,7 @@ it('should parse arbitrary properties with a variant', () => {
 })
 
 it('should parse arbitrary properties with stacked variants', () => {
-  let variants = new Variants()
+  const variants = new Variants()
   variants.static('hover', () => {})
   variants.static('focus', () => {})
 
@@ -1585,20 +1585,20 @@ it('should parse arbitrary properties that are important and using stacked arbit
 })
 
 it('should not parse compound group with a non-compoundable variant', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
 
-  let variants = new Variants()
+  const variants = new Variants()
   variants.compound('group', Compounds.StyleRules, () => {})
 
   expect(run('group-*:flex', { utilities, variants })).toMatchInlineSnapshot(`[]`)
 })
 
 it('should parse a variant containing an arbitrary string with unbalanced parens, brackets, curlies and other quotes', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
 
-  let variants = new Variants()
+  const variants = new Variants()
   variants.functional('string', () => {})
 
   expect(run(`string-['}[("\\'']:flex`, { utilities, variants })).toMatchInlineSnapshot(`
@@ -1625,10 +1625,10 @@ it('should parse a variant containing an arbitrary string with unbalanced parens
 })
 
 it('should parse candidates with a prefix', () => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
 
-  let variants = new Variants()
+  const variants = new Variants()
   variants.static('hover', () => {})
 
   // A prefix is required
@@ -1780,11 +1780,11 @@ it.each([
   'group-data-[_]/(_):flex',
   'group-data-(_)/(_):flex',
 ])('should not parse invalid empty arbitrary values: %s', (rawCandidate) => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
   utilities.functional('bg', () => [])
 
-  let variants = new Variants()
+  const variants = new Variants()
   variants.functional('data', () => {})
   variants.compound('group', Compounds.StyleRules, () => {})
 
@@ -1808,11 +1808,11 @@ it.each([
   // Arbitrary variant values that end the block
   'data-[a]{color:red}foo[a]:flex',
 ])('should not parse invalid arbitrary values: %s', (rawCandidate) => {
-  let utilities = new Utilities()
+  const utilities = new Utilities()
   utilities.static('flex', () => [])
   utilities.functional('bg', () => [])
 
-  let variants = new Variants()
+  const variants = new Variants()
   variants.functional('data', () => {})
   variants.compound('group', Compounds.StyleRules, () => {})
 

--- a/packages/tailwindcss/src/compat/config.test.ts
+++ b/packages/tailwindcss/src/compat/config.test.ts
@@ -6,12 +6,12 @@ import flattenColorPalette from './flatten-color-palette'
 const css = String.raw
 
 test('Config files can add content', async () => {
-  let input = css`
+  const input = css`
     @tailwind utilities;
     @config "./config.js";
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({ module: { content: ['./file.txt'] }, base: '/root' }),
   })
 
@@ -19,12 +19,12 @@ test('Config files can add content', async () => {
 })
 
 test('Config files can change dark mode (media)', async () => {
-  let input = css`
+  const input = css`
     @tailwind utilities;
     @config "./config.js";
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({ module: { darkMode: 'media' }, base: '/root' }),
   })
 
@@ -39,12 +39,12 @@ test('Config files can change dark mode (media)', async () => {
 })
 
 test('Config files can change dark mode (selector)', async () => {
-  let input = css`
+  const input = css`
     @tailwind utilities;
     @config "./config.js";
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({ module: { darkMode: 'selector' }, base: '/root' }),
   })
 
@@ -59,12 +59,12 @@ test('Config files can change dark mode (selector)', async () => {
 })
 
 test('Config files can change dark mode (variant)', async () => {
-  let input = css`
+  const input = css`
     @tailwind utilities;
     @config "./config.js";
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: { darkMode: ['variant', '&:where(:not(.light))'] },
       base: '/root',
@@ -82,12 +82,12 @@ test('Config files can change dark mode (variant)', async () => {
 })
 
 test('Config files can add plugins', async () => {
-  let input = css`
+  const input = css`
     @tailwind utilities;
     @config "./config.js";
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: {
         plugins: [
@@ -113,12 +113,12 @@ test('Config files can add plugins', async () => {
 })
 
 test('Plugins loaded from config files can contribute to the config', async () => {
-  let input = css`
+  const input = css`
     @tailwind utilities;
     @config "./config.js";
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: {
         plugins: [
@@ -142,12 +142,12 @@ test('Plugins loaded from config files can contribute to the config', async () =
 })
 
 test('Config file presets can contribute to the config', async () => {
-  let input = css`
+  const input = css`
     @tailwind utilities;
     @config "./config.js";
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: {
         presets: [
@@ -171,12 +171,12 @@ test('Config file presets can contribute to the config', async () => {
 })
 
 test('Config files can affect the theme', async () => {
-  let input = css`
+  const input = css`
     @tailwind utilities;
     @config "./config.js";
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: {
         theme: {
@@ -213,14 +213,14 @@ test('Config files can affect the theme', async () => {
 })
 
 test('Variants in CSS overwrite variants from plugins', async () => {
-  let input = css`
+  const input = css`
     @tailwind utilities;
     @config "./config.js";
     @custom-variant dark (&:is(.my-dark));
     @custom-variant light (&:is(.my-light));
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: {
         darkMode: ['variant', '&:is(.dark)'],
@@ -253,7 +253,7 @@ describe('theme callbacks', () => {
   test('tuple values from the config overwrite `@theme default` tuple-ish values from the CSS theme', async ({
     expect,
   }) => {
-    let input = css`
+    const input = css`
       @theme default {
         --text-base: 0rem;
         --text-base--line-height: 1rem;
@@ -270,7 +270,7 @@ describe('theme callbacks', () => {
       @config "./config.js";
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async () => ({
         module: {
           theme: {
@@ -367,7 +367,7 @@ describe('theme callbacks', () => {
 
 describe('theme overrides order', () => {
   test('user theme > js config > default theme', async () => {
-    let input = css`
+    const input = css`
       @theme default {
         --color-red: red;
       }
@@ -378,7 +378,7 @@ describe('theme overrides order', () => {
       @config "./config.js";
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async () => ({
         module: {
           theme: {
@@ -409,7 +409,7 @@ describe('theme overrides order', () => {
   })
 
   test('user theme > js config > default theme (with nested object)', async () => {
-    let input = css`
+    const input = css`
       @theme default {
         --color-slate-100: #000100;
         --color-slate-200: #000200;
@@ -424,7 +424,7 @@ describe('theme overrides order', () => {
       @plugin "./plugin.js";
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async (id) => {
         if (id.includes('config.js')) {
           return {
@@ -542,7 +542,7 @@ describe('theme overrides order', () => {
 
 describe('default font family compatibility', () => {
   test('overriding `fontFamily.sans` sets `--default-font-family`', async () => {
-    let input = css`
+    const input = css`
       @theme default {
         --default-font-family: var(--font-family-sans);
         --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
@@ -552,7 +552,7 @@ describe('default font family compatibility', () => {
       @tailwind utilities;
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async () => ({
         module: {
           theme: {
@@ -576,7 +576,7 @@ describe('default font family compatibility', () => {
   test('overriding `fontFamily.sans[1].fontFeatureSettings` sets `--default-font-feature-settings`', async ({
     expect,
   }) => {
-    let input = css`
+    const input = css`
       @theme default {
         --default-font-family: var(--font-family-sans);
         --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
@@ -586,7 +586,7 @@ describe('default font family compatibility', () => {
       @tailwind utilities;
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async () => ({
         module: {
           theme: {
@@ -611,7 +611,7 @@ describe('default font family compatibility', () => {
   test('overriding `fontFamily.sans[1].fontVariationSettings` sets `--default-font-variation-settings`', async ({
     expect,
   }) => {
-    let input = css`
+    const input = css`
       @theme default {
         --default-font-family: var(--font-family-sans);
         --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
@@ -621,7 +621,7 @@ describe('default font family compatibility', () => {
       @tailwind utilities;
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async () => ({
         module: {
           theme: {
@@ -646,7 +646,7 @@ describe('default font family compatibility', () => {
   test('overriding `fontFeatureSettings` and `fontVariationSettings` for `fontFamily.sans` sets `--default-font-feature-settings` and `--default-font-variation-settings`', async ({
     expect,
   }) => {
-    let input = css`
+    const input = css`
       @theme default {
         --default-font-family: var(--font-family-sans);
         --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
@@ -656,7 +656,7 @@ describe('default font family compatibility', () => {
       @tailwind utilities;
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async () => ({
         module: {
           theme: {
@@ -685,7 +685,7 @@ describe('default font family compatibility', () => {
   test('overriding `--font-family-sans` in `@theme` without `default` preserves the original `--default-font-*` values', async ({
     expect,
   }) => {
-    let input = css`
+    const input = css`
       @theme default {
         --default-font-family: var(--font-family-sans);
         --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
@@ -698,7 +698,7 @@ describe('default font family compatibility', () => {
       @tailwind utilities;
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async () => ({
         module: {
           theme: {
@@ -725,7 +725,7 @@ describe('default font family compatibility', () => {
   test('overriding `fontFamily.sans` in a config file with an array sets `--default-font-family`', async ({
     expect,
   }) => {
-    let input = css`
+    const input = css`
       @theme default {
         --default-font-family: var(--font-family-sans);
         --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
@@ -735,7 +735,7 @@ describe('default font family compatibility', () => {
       @tailwind utilities;
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async () => ({
         module: {
           theme: {
@@ -759,7 +759,7 @@ describe('default font family compatibility', () => {
   test('overriding `fontFamily.sans` in a config file with an unexpected type is ignored', async ({
     expect,
   }) => {
-    let input = css`
+    const input = css`
       @theme default {
         --default-font-family: var(--font-family-sans);
         --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
@@ -769,7 +769,7 @@ describe('default font family compatibility', () => {
       @tailwind utilities;
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async () => ({
         module: {
           theme: {
@@ -786,7 +786,7 @@ describe('default font family compatibility', () => {
   })
 
   test('overriding `fontFamily.mono` sets `--default-mono-font-family`', async () => {
-    let input = css`
+    const input = css`
       @theme default {
         --default-mono-font-family: var(--font-family-mono);
         --default-mono-font-feature-settings: var(--font-family-mono--font-feature-settings);
@@ -796,7 +796,7 @@ describe('default font family compatibility', () => {
       @tailwind utilities;
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async () => ({
         module: {
           theme: {
@@ -820,7 +820,7 @@ describe('default font family compatibility', () => {
   test('overriding `fontFamily.mono[1].fontFeatureSettings` sets `--default-mono-font-feature-settings`', async ({
     expect,
   }) => {
-    let input = css`
+    const input = css`
       @theme default {
         --default-mono-font-family: var(--font-family-mono);
         --default-mono-font-feature-settings: var(--font-family-mono--font-feature-settings);
@@ -830,7 +830,7 @@ describe('default font family compatibility', () => {
       @tailwind utilities;
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async () => ({
         module: {
           theme: {
@@ -855,7 +855,7 @@ describe('default font family compatibility', () => {
   test('overriding `fontFamily.mono[1].fontVariationSettings` sets `--default-mono-font-variation-settings`', async ({
     expect,
   }) => {
-    let input = css`
+    const input = css`
       @theme default {
         --default-mono-font-family: var(--font-family-mono);
         --default-mono-font-feature-settings: var(--font-family-mono--font-feature-settings);
@@ -865,7 +865,7 @@ describe('default font family compatibility', () => {
       @tailwind utilities;
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async () => ({
         module: {
           theme: {
@@ -890,7 +890,7 @@ describe('default font family compatibility', () => {
   test('overriding `fontFeatureSettings` and `fontVariationSettings` for `fontFamily.mono` sets `--default-mono-font-feature-settings` and `--default-mono-font-variation-settings`', async ({
     expect,
   }) => {
-    let input = css`
+    const input = css`
       @theme default {
         --default-mono-font-family: var(--font-mono);
         --default-mono-font-feature-settings: var(--font-mono--font-feature-settings);
@@ -900,7 +900,7 @@ describe('default font family compatibility', () => {
       @tailwind utilities;
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async () => ({
         module: {
           theme: {
@@ -929,7 +929,7 @@ describe('default font family compatibility', () => {
   test('overriding `--font-family-mono` in `@theme` without `default` preserves the original `--default-mono-font-*` values', async ({
     expect,
   }) => {
-    let input = css`
+    const input = css`
       @theme default {
         --default-mono-font-family: var(--font-mono);
         --default-mono-font-feature-settings: var(--font-mono--font-feature-settings);
@@ -942,7 +942,7 @@ describe('default font family compatibility', () => {
       @tailwind utilities;
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async () => ({
         module: {
           theme: {
@@ -969,7 +969,7 @@ describe('default font family compatibility', () => {
   test('overriding `fontFamily.mono` in a config file with an unexpected type is ignored', async ({
     expect,
   }) => {
-    let input = css`
+    const input = css`
       @theme default {
         --default-mono-font-family: var(--font-family-mono);
         --default-mono-font-feature-settings: var(--font-family-mono--font-feature-settings);
@@ -979,7 +979,7 @@ describe('default font family compatibility', () => {
       @tailwind utilities;
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async () => ({
         module: {
           theme: {
@@ -997,12 +997,12 @@ describe('default font family compatibility', () => {
 })
 
 test('creates variants for `data`, `supports`, and `aria` theme options at the same level as the core utility ', async () => {
-  let input = css`
+  const input = css`
     @tailwind utilities;
     @config "./config.js";
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: {
         theme: {
@@ -1086,7 +1086,7 @@ test('creates variants for `data`, `supports`, and `aria` theme options at the s
 })
 
 test('merges css breakpoints with js config screens', async () => {
-  let input = css`
+  const input = css`
     @theme default {
       --breakpoint-sm: 40rem;
       --breakpoint-md: 48rem;
@@ -1101,7 +1101,7 @@ test('merges css breakpoints with js config screens', async () => {
     @tailwind utilities;
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: {
         theme: {
@@ -1145,7 +1145,7 @@ test('merges css breakpoints with js config screens', async () => {
 })
 
 test('utilities must be prefixed', async () => {
-  let input = css`
+  const input = css`
     @tailwind utilities;
     @config "./config.js";
 
@@ -1192,7 +1192,7 @@ test('utilities must be prefixed', async () => {
 })
 
 test('utilities used in @apply must be prefixed', async () => {
-  let compiler = await compile(
+  const compiler = await compile(
     css`
       @config "./config.js";
 
@@ -1239,7 +1239,7 @@ test('utilities used in @apply must be prefixed', async () => {
 })
 
 test('Prefixes configured in CSS take precedence over those defined in JS configs', async () => {
-  let compiler = await compile(
+  const compiler = await compile(
     css`
       @theme prefix(wat) {
         --color-red: #f00;
@@ -1294,7 +1294,7 @@ test('a prefix must be letters only', async () => {
 })
 
 test('important: `#app`', async () => {
-  let input = css`
+  const input = css`
     @tailwind utilities;
     @config "./config.js";
 
@@ -1303,7 +1303,7 @@ test('important: `#app`', async () => {
     }
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async (_, base) => ({
       base,
       module: { important: '#app' },
@@ -1331,7 +1331,7 @@ test('important: `#app`', async () => {
 })
 
 test('important: true', async () => {
-  let input = css`
+  const input = css`
     @tailwind utilities;
     @config "./config.js";
 
@@ -1340,7 +1340,7 @@ test('important: true', async () => {
     }
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async (_, base) => ({
       base,
       module: { important: true },
@@ -1366,7 +1366,7 @@ test('important: true', async () => {
 })
 
 test('blocklisted candidates are not generated', async () => {
-  let compiler = await compile(
+  const compiler = await compile(
     css`
       @theme reference {
         --color-white: #fff;
@@ -1435,7 +1435,7 @@ test('blocklisted candidates cannot be used with `@apply`', async () => {
 })
 
 test('old theme values are merged with their renamed counterparts in the CSS theme', async () => {
-  let didCallPluginFn = vi.fn()
+  const didCallPluginFn = vi.fn()
 
   await compile(
     css`
@@ -1558,7 +1558,7 @@ test('old theme values are merged with their renamed counterparts in the CSS the
 })
 
 test('handles setting theme keys to null', async () => {
-  let compiler = await compile(
+  const compiler = await compile(
     css`
       @theme default {
         --color-red-50: oklch(0.971 0.013 17.38);

--- a/packages/tailwindcss/src/compat/container-config.test.ts
+++ b/packages/tailwindcss/src/compat/container-config.test.ts
@@ -4,7 +4,7 @@ import { compile } from '..'
 const css = String.raw
 
 test('creates a custom utility to extend the built-in container', async () => {
-  let input = css`
+  const input = css`
     @theme default {
       --breakpoint-sm: 40rem;
       --breakpoint-md: 48rem;
@@ -16,7 +16,7 @@ test('creates a custom utility to extend the built-in container', async () => {
     @tailwind utilities;
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: {
         theme: {
@@ -58,7 +58,7 @@ test('creates a custom utility to extend the built-in container', async () => {
 })
 
 test('allows padding to be defined at custom breakpoints', async () => {
-  let input = css`
+  const input = css`
     @theme default {
       --breakpoint-sm: 40rem;
       --breakpoint-md: 48rem;
@@ -70,7 +70,7 @@ test('allows padding to be defined at custom breakpoints', async () => {
     @tailwind utilities;
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: {
         theme: {
@@ -121,7 +121,7 @@ test('allows padding to be defined at custom breakpoints', async () => {
 })
 
 test('allows breakpoints to be overwritten', async () => {
-  let input = css`
+  const input = css`
     @theme default {
       --breakpoint-sm: 40rem;
       --breakpoint-md: 48rem;
@@ -133,7 +133,7 @@ test('allows breakpoints to be overwritten', async () => {
     @tailwind utilities;
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: {
         theme: {
@@ -184,7 +184,7 @@ test('allows breakpoints to be overwritten', async () => {
 })
 
 test('padding applies to custom `container` screens', async () => {
-  let input = css`
+  const input = css`
     @theme default {
       --breakpoint-sm: 40rem;
       --breakpoint-md: 48rem;
@@ -196,7 +196,7 @@ test('padding applies to custom `container` screens', async () => {
     @tailwind utilities;
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: {
         theme: {
@@ -248,7 +248,7 @@ test('padding applies to custom `container` screens', async () => {
 })
 
 test("an empty `screen` config will undo all custom media screens and won't apply any breakpoint-specific padding", async () => {
-  let input = css`
+  const input = css`
     @theme default {
       --breakpoint-sm: 40rem;
       --breakpoint-md: 48rem;
@@ -260,7 +260,7 @@ test("an empty `screen` config will undo all custom media screens and won't appl
     @tailwind utilities;
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: {
         theme: {
@@ -308,7 +308,7 @@ test("an empty `screen` config will undo all custom media screens and won't appl
 })
 
 test('legacy container component does not interfere with new --container variables', async () => {
-  let input = css`
+  const input = css`
     @theme default {
       --container-3xs: 16rem;
       --container-2xs: 18rem;
@@ -329,7 +329,7 @@ test('legacy container component does not interfere with new --container variabl
     @tailwind utilities;
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: {
         theme: {
@@ -355,7 +355,7 @@ test('legacy container component does not interfere with new --container variabl
 })
 
 test('combines custom padding and screen overwrites', async () => {
-  let input = css`
+  const input = css`
     @theme default {
       --breakpoint-sm: 40rem;
       --breakpoint-md: 48rem;
@@ -367,7 +367,7 @@ test('combines custom padding and screen overwrites', async () => {
     @tailwind utilities;
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: {
         theme: {
@@ -465,7 +465,7 @@ test('combines custom padding and screen overwrites', async () => {
 })
 
 test('filters out complex breakpoints', async () => {
-  let input = css`
+  const input = css`
     @theme default {
       --breakpoint-sm: 40rem;
       --breakpoint-md: 48rem;
@@ -477,7 +477,7 @@ test('filters out complex breakpoints', async () => {
     @tailwind utilities;
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: {
         theme: {

--- a/packages/tailwindcss/src/compat/plugin-api.test.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.test.ts
@@ -9,12 +9,12 @@ const css = String.raw
 
 describe('theme', async () => {
   test('plugin theme can contain objects', async () => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @plugin "my-plugin";
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
           base,
@@ -72,12 +72,12 @@ describe('theme', async () => {
   })
 
   test('keyframes added via addUtilities are appended to the AST', async () => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @plugin "my-plugin";
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
           base,
@@ -105,7 +105,7 @@ describe('theme', async () => {
   })
 
   test('plugin theme can extend colors', async () => {
-    let input = css`
+    const input = css`
       @theme reference {
         --color-red-500: #ef4444;
       }
@@ -113,7 +113,7 @@ describe('theme', async () => {
       @plugin "my-plugin";
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
           base,
@@ -156,12 +156,12 @@ describe('theme', async () => {
   test('plugin theme values can reference legacy theme keys that have been replaced with bare value support', async ({
     expect,
   }) => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @plugin "my-plugin";
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
           base,
@@ -203,12 +203,12 @@ describe('theme', async () => {
   test('plugin theme values that support bare values are merged with other values for that theme key', async ({
     expect,
   }) => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @plugin "my-plugin";
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
           base,
@@ -254,7 +254,7 @@ describe('theme', async () => {
   })
 
   test('plugin theme can have opacity modifiers', async () => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @theme {
         --color-red-500: #ef4444;
@@ -262,7 +262,7 @@ describe('theme', async () => {
       @plugin "my-plugin";
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
           base,
@@ -301,7 +301,7 @@ describe('theme', async () => {
   })
 
   test('plugin theme colors can use <alpha-value>', async () => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @theme {
         /* This should not work */
@@ -310,7 +310,7 @@ describe('theme', async () => {
       @plugin "my-plugin";
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
           base,
@@ -390,12 +390,12 @@ describe('theme', async () => {
   })
 
   test('theme value functions are resolved correctly regardless of order', async () => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @plugin "my-plugin";
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
           base,
@@ -444,12 +444,12 @@ describe('theme', async () => {
   })
 
   test('plugins can override the default key', async () => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @plugin "my-plugin";
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
           base,
@@ -487,7 +487,7 @@ describe('theme', async () => {
   })
 
   test('plugins can read CSS theme keys using the old theme key notation', async () => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @plugin "my-plugin";
       @theme reference {
@@ -496,7 +496,7 @@ describe('theme', async () => {
       }
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
           base,
@@ -545,7 +545,7 @@ describe('theme', async () => {
   })
 
   test('CSS theme values are merged with JS theme values', async () => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @plugin "my-plugin";
       @theme reference {
@@ -554,7 +554,7 @@ describe('theme', async () => {
       }
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
           base,
@@ -599,7 +599,7 @@ describe('theme', async () => {
   })
 
   test('CSS theme defaults take precedence over JS theme defaults', async () => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @plugin "my-plugin";
       @theme reference {
@@ -608,7 +608,7 @@ describe('theme', async () => {
       }
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
           base,
@@ -646,7 +646,7 @@ describe('theme', async () => {
   })
 
   test('CSS theme values take precedence even over non-object JS values', async () => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @plugin "my-plugin";
       @theme reference {
@@ -655,7 +655,7 @@ describe('theme', async () => {
       }
     `
 
-    let fn = vi.fn()
+    const fn = vi.fn()
 
     await compile(input, {
       loadModule: async (id, base) => {
@@ -687,12 +687,12 @@ describe('theme', async () => {
   })
 
   test('all necessary theme keys support bare values', async () => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @plugin "my-plugin";
     `
 
-    let { build } = await compile(input, {
+    const { build } = await compile(input, {
       loadModule: async (id, base) => {
         return {
           base,
@@ -751,7 +751,7 @@ describe('theme', async () => {
       },
     })
 
-    let output = build([
+    const output = build([
       'my-aspect-2/5',
       'my-backdrop-brightness-1',
       'my-backdrop-contrast-1',
@@ -928,7 +928,7 @@ describe('theme', async () => {
   })
 
   test('theme keys can derive from other theme keys', async () => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @plugin "my-plugin";
       @theme {
@@ -937,7 +937,7 @@ describe('theme', async () => {
       }
     `
 
-    let fn = vi.fn()
+    const fn = vi.fn()
 
     await compile(input, {
       loadModule: async (id, base) => {
@@ -970,7 +970,7 @@ describe('theme', async () => {
   test("`theme('*.DEFAULT')` resolves to `undefined` when all theme keys in that namespace have a suffix", async ({
     expect,
   }) => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @plugin "my-plugin";
       @theme {
@@ -979,7 +979,7 @@ describe('theme', async () => {
       }
     `
 
-    let fn = vi.fn()
+    const fn = vi.fn()
 
     await compile(input, {
       loadModule: async (id, base) => {
@@ -1000,7 +1000,7 @@ describe('theme', async () => {
   })
 
   test('nested theme key lookups work even for flattened keys', async () => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @plugin "my-plugin";
       @theme {
@@ -1010,7 +1010,7 @@ describe('theme', async () => {
       }
     `
 
-    let fn = vi.fn()
+    const fn = vi.fn()
 
     await compile(input, {
       loadModule: async (id, base) => {
@@ -1033,12 +1033,12 @@ describe('theme', async () => {
   test('keys that do not exist return the default value (or undefined if none)', async ({
     expect,
   }) => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @plugin "my-plugin";
     `
 
-    let fn = vi.fn()
+    const fn = vi.fn()
 
     await compile(input, {
       loadModule: async (id, base) => {
@@ -1061,12 +1061,12 @@ describe('theme', async () => {
   })
 
   test('Candidates can match multiple utility definitions', async () => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @plugin "my-plugin";
     `
 
-    let { build } = await compile(input, {
+    const { build } = await compile(input, {
       loadModule: async (id, base) => {
         return {
           base,
@@ -1116,12 +1116,12 @@ describe('theme', async () => {
   })
 
   test('spreading `tailwindcss/defaultTheme` exports keeps bare values', async () => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @plugin "my-plugin";
     `
 
-    let { build } = await compile(input, {
+    const { build } = await compile(input, {
       loadModule: async (id, base) => {
         return {
           base,
@@ -1184,7 +1184,7 @@ describe('theme', async () => {
       },
     })
 
-    let output = build([
+    const output = build([
       'my-aspect-2/5',
       // 'my-backdrop-brightness-1',
       // 'my-backdrop-contrast-1',
@@ -1334,12 +1334,12 @@ describe('theme', async () => {
   })
 
   test('can use escaped JS variables in theme values', async () => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @plugin "my-plugin";
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
           base,
@@ -1384,7 +1384,7 @@ describe('theme', async () => {
   })
 
   test('can use escaped CSS variables in theme values', async () => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @plugin "my-plugin";
 
@@ -1397,7 +1397,7 @@ describe('theme', async () => {
       }
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
           base,
@@ -1430,7 +1430,7 @@ describe('theme', async () => {
   })
 
   test('can use escaped CSS variables in referenced theme namespace', async () => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @plugin "my-plugin";
 
@@ -1443,7 +1443,7 @@ describe('theme', async () => {
       }
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
           base,
@@ -1483,13 +1483,13 @@ describe('theme', async () => {
 
 describe('addBase', () => {
   test('does not create rules when imported via `@import "…" reference`', async () => {
-    let input = css`
+    const input = css`
       @tailwind utilities;
       @plugin "outside";
       @import './inside.css' reference;
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async (id, base) => {
         if (id === 'inside') {
           return {
@@ -1527,11 +1527,11 @@ describe('addBase', () => {
   })
 
   test('does not modify CSS variables', async () => {
-    let input = css`
+    const input = css`
       @plugin "my-plugin";
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async () => ({
         module: plugin(function ({ addBase }) {
           addBase({
@@ -1561,7 +1561,7 @@ describe('addBase', () => {
 
 describe('addVariant', () => {
   test('addVariant with string selector', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -1579,7 +1579,7 @@ describe('addVariant', () => {
         },
       },
     )
-    let compiled = build(['hocus:underline', 'group-hocus:flex'])
+    const compiled = build(['hocus:underline', 'group-hocus:flex'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
@@ -1595,7 +1595,7 @@ describe('addVariant', () => {
   })
 
   test('addVariant with array of selectors', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -1614,7 +1614,7 @@ describe('addVariant', () => {
       },
     )
 
-    let compiled = build(['hocus:underline', 'group-hocus:flex'])
+    const compiled = build(['hocus:underline', 'group-hocus:flex'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
@@ -1630,7 +1630,7 @@ describe('addVariant', () => {
   })
 
   test('addVariant with object syntax and @slot', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -1651,7 +1651,7 @@ describe('addVariant', () => {
         },
       },
     )
-    let compiled = build(['hocus:underline', 'group-hocus:flex'])
+    const compiled = build(['hocus:underline', 'group-hocus:flex'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
@@ -1667,7 +1667,7 @@ describe('addVariant', () => {
   })
 
   test('addVariant with object syntax, media, nesting and multiple @slot', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -1690,7 +1690,7 @@ describe('addVariant', () => {
         },
       },
     )
-    let compiled = build(['hocus:underline', 'group-hocus:flex'])
+    const compiled = build(['hocus:underline', 'group-hocus:flex'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
@@ -1718,7 +1718,7 @@ describe('addVariant', () => {
   })
 
   test('addVariant with at-rules and placeholder', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -1739,7 +1739,7 @@ describe('addVariant', () => {
         },
       },
     )
-    let compiled = build(['potato:underline', 'potato:flex'])
+    const compiled = build(['potato:underline', 'potato:flex'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
@@ -1759,7 +1759,7 @@ describe('addVariant', () => {
   })
 
   test('@slot is preserved when used as a custom property value', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -1783,7 +1783,7 @@ describe('addVariant', () => {
         },
       },
     )
-    let compiled = build(['hocus:underline'])
+    const compiled = build(['hocus:underline'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
@@ -1801,7 +1801,7 @@ describe('addVariant', () => {
 
 describe('matchVariant', () => {
   test('partial arbitrary variants', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -1819,7 +1819,7 @@ describe('matchVariant', () => {
         },
       },
     )
-    let compiled = build(['potato-[yellow]:underline', 'potato-[baked]:flex'])
+    const compiled = build(['potato-[yellow]:underline', 'potato-[baked]:flex'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
@@ -1835,7 +1835,7 @@ describe('matchVariant', () => {
   })
 
   test('partial arbitrary variants with at-rules', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -1853,7 +1853,7 @@ describe('matchVariant', () => {
         },
       },
     )
-    let compiled = build(['potato-[yellow]:underline', 'potato-[baked]:flex'])
+    const compiled = build(['potato-[yellow]:underline', 'potato-[baked]:flex'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
@@ -1873,7 +1873,7 @@ describe('matchVariant', () => {
   })
 
   test('partial arbitrary variants with at-rules and placeholder', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -1895,7 +1895,7 @@ describe('matchVariant', () => {
         },
       },
     )
-    let compiled = build(['potato-[yellow]:underline', 'potato-[baked]:flex'])
+    const compiled = build(['potato-[yellow]:underline', 'potato-[baked]:flex'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
@@ -1919,7 +1919,7 @@ describe('matchVariant', () => {
   })
 
   test('partial arbitrary variants with default values', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -1942,7 +1942,7 @@ describe('matchVariant', () => {
         },
       },
     )
-    let compiled = build(['tooltip-bottom:underline', 'tooltip-top:flex'])
+    const compiled = build(['tooltip-bottom:underline', 'tooltip-top:flex'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
@@ -1958,7 +1958,7 @@ describe('matchVariant', () => {
   })
 
   test('matched variant values maintain the sort order they are registered in', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -1983,7 +1983,7 @@ describe('matchVariant', () => {
         },
       },
     )
-    let compiled = build([
+    const compiled = build([
       'alphabet-c:underline',
       'alphabet-a:underline',
       'alphabet-d:underline',
@@ -2000,7 +2000,7 @@ describe('matchVariant', () => {
   })
 
   test('matchVariant can return an array of format strings from the function', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -2020,7 +2020,7 @@ describe('matchVariant', () => {
         },
       },
     )
-    let compiled = build(['test-[a,b,c]:underline'])
+    const compiled = build(['test-[a,b,c]:underline'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
@@ -2032,7 +2032,7 @@ describe('matchVariant', () => {
   })
 
   test('should be possible to sort variants', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -2054,7 +2054,7 @@ describe('matchVariant', () => {
         },
       },
     )
-    let compiled = build([
+    const compiled = build([
       'testmin-[600px]:flex',
       'testmin-[500px]:underline',
       'testmin-[700px]:italic',
@@ -2084,7 +2084,7 @@ describe('matchVariant', () => {
   })
 
   test('should be possible to compare arbitrary variants and hardcoded variants', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -2109,7 +2109,7 @@ describe('matchVariant', () => {
         },
       },
     )
-    let compiled = build([
+    const compiled = build([
       'testmin-[700px]:italic',
       'testmin-example:italic',
       'testmin-[500px]:italic',
@@ -2139,7 +2139,7 @@ describe('matchVariant', () => {
   })
 
   test('should be possible to sort stacked arbitrary variants correctly', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -2168,7 +2168,7 @@ describe('matchVariant', () => {
       },
     )
 
-    let compiled = build([
+    const compiled = build([
       'testmin-[150px]:testmax-[400px]:order-2',
       'testmin-[100px]:testmax-[350px]:order-3',
       'testmin-[100px]:testmax-[300px]:order-4',
@@ -2211,7 +2211,7 @@ describe('matchVariant', () => {
   })
 
   test('should maintain sort from other variants, if sort functions of arbitrary variants return 0', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -2239,7 +2239,7 @@ describe('matchVariant', () => {
         },
       },
     )
-    let compiled = build([
+    const compiled = build([
       'testmin-[100px]:testmax-[200px]:focus:underline',
       'testmin-[100px]:testmax-[200px]:hover:underline',
     ])
@@ -2265,7 +2265,7 @@ describe('matchVariant', () => {
   })
 
   test('should sort arbitrary variants left to right (1)', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -2292,7 +2292,7 @@ describe('matchVariant', () => {
         },
       },
     )
-    let compiled = build([
+    const compiled = build([
       'testmin-[200px]:testmax-[400px]:order-2',
       'testmin-[200px]:testmax-[300px]:order-4',
       'testmin-[100px]:testmax-[400px]:order-1',
@@ -2337,7 +2337,7 @@ describe('matchVariant', () => {
   })
 
   test('should sort arbitrary variants left to right (2)', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -2364,7 +2364,7 @@ describe('matchVariant', () => {
         },
       },
     )
-    let compiled = build([
+    const compiled = build([
       'testmax-[400px]:testmin-[200px]:underline',
       'testmax-[300px]:testmin-[200px]:underline',
       'testmax-[400px]:testmin-[100px]:underline',
@@ -2405,7 +2405,7 @@ describe('matchVariant', () => {
   })
 
   test('should guarantee that we are not passing values from other variants to the wrong function', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -2419,7 +2419,7 @@ describe('matchVariant', () => {
             module: ({ matchVariant }: PluginAPI) => {
               matchVariant('testmin', (value) => `@media (min-width: ${value})`, {
                 sort(a, z) {
-                  let lookup = ['100px', '200px']
+                  const lookup = ['100px', '200px']
                   if (lookup.indexOf(a.value) === -1 || lookup.indexOf(z.value) === -1) {
                     throw new Error('We are seeing values that should not be there!')
                   }
@@ -2428,7 +2428,7 @@ describe('matchVariant', () => {
               })
               matchVariant('testmax', (value) => `@media (max-width: ${value})`, {
                 sort(a, z) {
-                  let lookup = ['300px', '400px']
+                  const lookup = ['300px', '400px']
                   if (lookup.indexOf(a.value) === -1 || lookup.indexOf(z.value) === -1) {
                     throw new Error('We are seeing values that should not be there!')
                   }
@@ -2440,7 +2440,7 @@ describe('matchVariant', () => {
         },
       },
     )
-    let compiled = build([
+    const compiled = build([
       'testmin-[200px]:testmax-[400px]:order-2',
       'testmin-[200px]:testmax-[300px]:order-4',
       'testmin-[100px]:testmax-[400px]:order-1',
@@ -2485,7 +2485,7 @@ describe('matchVariant', () => {
   })
 
   test('should default to the DEFAULT value for variants', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -2507,7 +2507,7 @@ describe('matchVariant', () => {
         },
       },
     )
-    let compiled = build(['foo:underline'])
+    const compiled = build(['foo:underline'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
@@ -2519,7 +2519,7 @@ describe('matchVariant', () => {
   })
 
   test('should not generate anything if the matchVariant does not have a DEFAULT value configured', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -2537,13 +2537,13 @@ describe('matchVariant', () => {
         },
       },
     )
-    let compiled = build(['foo:underline'])
+    const compiled = build(['foo:underline'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`"@layer utilities;"`)
   })
 
   test('should be possible to use `null` as a DEFAULT value', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -2563,7 +2563,7 @@ describe('matchVariant', () => {
         },
       },
     )
-    let compiled = build(['foo:underline'])
+    const compiled = build(['foo:underline'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
@@ -2575,7 +2575,7 @@ describe('matchVariant', () => {
   })
 
   test('should be possible to use `undefined` as a DEFAULT value', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -2595,7 +2595,7 @@ describe('matchVariant', () => {
         },
       },
     )
-    let compiled = build(['foo:underline'])
+    const compiled = build(['foo:underline'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
@@ -2607,7 +2607,7 @@ describe('matchVariant', () => {
   })
 
   test('should be called with eventual modifiers', async () => {
-    let { build } = await compile(
+    const { build } = await compile(
       css`
         @plugin "my-plugin";
         @tailwind utilities;
@@ -2633,7 +2633,7 @@ describe('matchVariant', () => {
         },
       },
     )
-    let compiled = build([
+    const compiled = build([
       'my-container-[250px]:underline',
       'my-container-[250px]/placement:underline',
     ])
@@ -2655,7 +2655,7 @@ describe('matchVariant', () => {
 
 describe('addUtilities()', () => {
   test('custom static utility', async () => {
-    let compiled = await compile(
+    const compiled = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -2702,7 +2702,7 @@ describe('addUtilities()', () => {
   })
 
   test('return multiple rule objects from a custom utility', async () => {
-    let compiled = await compile(
+    const compiled = await compile(
       css`
         @plugin "my-plugin";
         @tailwind utilities;
@@ -2735,7 +2735,7 @@ describe('addUtilities()', () => {
   })
 
   test('define multiple utilities with array syntax', async () => {
-    let compiled = await compile(
+    const compiled = await compile(
       css`
         @plugin "my-plugin";
         @tailwind utilities;
@@ -2774,7 +2774,7 @@ describe('addUtilities()', () => {
   })
 
   test('utilities can use arrays for fallback declaration values', async () => {
-    let compiled = await compile(
+    const compiled = await compile(
       css`
         @plugin "my-plugin";
         @tailwind utilities;
@@ -2806,7 +2806,7 @@ describe('addUtilities()', () => {
   })
 
   test('camel case properties are converted to kebab-case', async () => {
-    let compiled = await compile(
+    const compiled = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -2843,7 +2843,7 @@ describe('addUtilities()', () => {
   })
 
   test('custom static utilities support `@apply`', async () => {
-    let compiled = await compile(
+    const compiled = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -2930,7 +2930,7 @@ describe('addUtilities()', () => {
   })
 
   test('supports multiple selector names', async () => {
-    let compiled = await compile(
+    const compiled = await compile(
       css`
         @plugin "my-plugin";
         @tailwind utilities;
@@ -2973,7 +2973,7 @@ describe('addUtilities()', () => {
   })
 
   test('supports pseudo classes and pseudo elements', async () => {
-    let compiled = await compile(
+    const compiled = await compile(
       css`
         @plugin "my-plugin";
         @tailwind utilities;
@@ -3016,7 +3016,7 @@ describe('addUtilities()', () => {
   })
 
   test('nests complex utility names', async () => {
-    let compiled = await compile(
+    const compiled = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -3110,7 +3110,7 @@ describe('addUtilities()', () => {
   })
 
   test('prefixes nested class names with the configured theme prefix', async () => {
-    let compiled = await compile(
+    const compiled = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -3164,7 +3164,7 @@ describe('addUtilities()', () => {
   })
 
   test('replaces the class name with variants in nested selectors', async () => {
-    let compiled = await compile(
+    const compiled = await compile(
       css`
         @plugin "my-plugin";
         @theme {
@@ -3226,7 +3226,7 @@ describe('addUtilities()', () => {
 describe('matchUtilities()', () => {
   test('custom functional utility', async () => {
     async function run(candidates: string[]) {
-      let compiled = await compile(
+      const compiled = await compile(
         css`
           @plugin "my-plugin";
 
@@ -3311,7 +3311,7 @@ describe('matchUtilities()', () => {
 
   test('custom functional utilities can start with @', async () => {
     async function run(candidates: string[]) {
-      let compiled = await compile(
+      const compiled = await compile(
         css`
           @plugin "my-plugin";
           @tailwind utilities;
@@ -3353,7 +3353,7 @@ describe('matchUtilities()', () => {
   })
 
   test('custom functional utilities can return an array of rules', async () => {
-    let compiled = await compile(
+    const compiled = await compile(
       css`
         @plugin "my-plugin";
         @tailwind utilities;
@@ -3396,7 +3396,7 @@ describe('matchUtilities()', () => {
 
   test('custom functional utility with any modifier', async () => {
     async function run(candidates: string[]) {
-      let compiled = await compile(
+      const compiled = await compile(
         css`
           @plugin "my-plugin";
 
@@ -3466,7 +3466,7 @@ describe('matchUtilities()', () => {
 
   test('custom functional utility with known modifier', async () => {
     async function run(candidates: string[]) {
-      let compiled = await compile(
+      const compiled = await compile(
         css`
           @plugin "my-plugin";
 
@@ -3545,7 +3545,7 @@ describe('matchUtilities()', () => {
   describe('plugins that handle a specific arbitrary value type prevent falling through to other plugins if the result is invalid for that plugin', () => {
     test('implicit color modifier', async () => {
       async function run(candidates: string[]) {
-        let compiled = await compile(
+        const compiled = await compile(
           css`
             @tailwind utilities;
             @plugin "my-plugin";
@@ -3600,7 +3600,7 @@ describe('matchUtilities()', () => {
 
     test('no modifiers are supported by the plugins', async () => {
       async function run(candidates: string[]) {
-        let compiled = await compile(
+        const compiled = await compile(
           css`
             @tailwind utilities;
             @plugin "my-plugin";
@@ -3638,7 +3638,7 @@ describe('matchUtilities()', () => {
 
     test('invalid named modifier', async () => {
       async function run(candidates: string[]) {
-        let compiled = await compile(
+        const compiled = await compile(
           css`
             @tailwind utilities;
             @plugin "my-plugin";
@@ -3677,7 +3677,7 @@ describe('matchUtilities()', () => {
 
   test('custom functional utilities with different types', async () => {
     async function run(candidates: string[]) {
-      let compiled = await compile(
+      const compiled = await compile(
         css`
           @plugin "my-plugin";
 
@@ -3804,7 +3804,7 @@ describe('matchUtilities()', () => {
 
   test('functional utilities with `type: color` automatically support opacity', async () => {
     async function run(candidates: string[]) {
-      let compiled = await compile(
+      const compiled = await compile(
         css`
           @plugin "my-plugin";
 
@@ -3888,7 +3888,7 @@ describe('matchUtilities()', () => {
 
   test('functional utilities with explicit modifiers', async () => {
     async function run(candidates: string[]) {
-      let compiled = await compile(
+      const compiled = await compile(
         css`
           @plugin "my-plugin";
 
@@ -3947,7 +3947,7 @@ describe('matchUtilities()', () => {
   })
 
   test('functional utilities support `@apply`', async () => {
-    let compiled = await compile(
+    const compiled = await compile(
       css`
         @plugin "my-plugin";
         @layer utilities {
@@ -4045,7 +4045,7 @@ describe('matchUtilities()', () => {
   })
 
   test('replaces the class name with variants in nested selectors', async () => {
-    let compiled = await compile(
+    const compiled = await compile(
       css`
         @plugin "my-plugin";
         @theme {
@@ -4114,7 +4114,7 @@ describe('matchUtilities()', () => {
 
 describe('addComponents()', () => {
   test('is an alias for addUtilities', async () => {
-    let compiled = await compile(
+    const compiled = await compile(
       css`
         @plugin "my-plugin";
         @tailwind utilities;
@@ -4182,7 +4182,7 @@ describe('addComponents()', () => {
 
 describe('matchComponents()', () => {
   test('is an alias for matchUtilities', async () => {
-    let compiled = await compile(
+    const compiled = await compile(
       css`
         @plugin "my-plugin";
         @tailwind utilities;
@@ -4227,7 +4227,7 @@ describe('matchComponents()', () => {
 
 describe('prefix()', () => {
   test('is an identity function', async () => {
-    let fn = vi.fn()
+    const fn = vi.fn()
     await compile(
       css`
         @plugin "my-plugin";
@@ -4250,7 +4250,7 @@ describe('prefix()', () => {
 
 describe('config()', () => {
   test('can return the resolved config when passed no arguments', async () => {
-    let fn = vi.fn()
+    const fn = vi.fn()
     await compile(
       css`
         @plugin "my-plugin";
@@ -4277,7 +4277,7 @@ describe('config()', () => {
   })
 
   test('can return part of the config', async () => {
-    let fn = vi.fn()
+    const fn = vi.fn()
     await compile(
       css`
         @plugin "my-plugin";
@@ -4302,7 +4302,7 @@ describe('config()', () => {
   })
 
   test('falls back to default value if requested path does not exist', async () => {
-    let fn = vi.fn()
+    const fn = vi.fn()
     await compile(
       css`
         @plugin "my-plugin";

--- a/packages/tailwindcss/src/compat/screens-config.test.ts
+++ b/packages/tailwindcss/src/compat/screens-config.test.ts
@@ -4,7 +4,7 @@ import { compile } from '..'
 const css = String.raw
 
 test('CSS `--breakpoint-*` merge with JS config `screens`', async () => {
-  let input = css`
+  const input = css`
     @theme default {
       --breakpoint-sm: 40rem;
       --breakpoint-md: 48rem;
@@ -19,7 +19,7 @@ test('CSS `--breakpoint-*` merge with JS config `screens`', async () => {
     @tailwind utilities;
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: {
         theme: {
@@ -88,7 +88,7 @@ test('CSS `--breakpoint-*` merge with JS config `screens`', async () => {
 })
 
 test('JS config `screens` extend CSS `--breakpoint-*`', async () => {
-  let input = css`
+  const input = css`
     @theme default {
       --breakpoint-xs: 39rem;
       --breakpoint-md: 49rem;
@@ -100,7 +100,7 @@ test('JS config `screens` extend CSS `--breakpoint-*`', async () => {
     @tailwind utilities;
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: {
         theme: {
@@ -190,12 +190,12 @@ test('JS config `screens` extend CSS `--breakpoint-*`', async () => {
 })
 
 test('JS config `screens` only setup, even if those match the default-theme export', async () => {
-  let input = css`
+  const input = css`
     @config "./config.js";
     @tailwind utilities;
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: {
         theme: {
@@ -262,7 +262,7 @@ test('JS config `screens` only setup, even if those match the default-theme expo
 })
 
 test('JS config `screens` overwrite CSS `--breakpoint-*`', async () => {
-  let input = css`
+  const input = css`
     @theme default {
       --breakpoint-sm: 40rem;
       --breakpoint-md: 48rem;
@@ -274,7 +274,7 @@ test('JS config `screens` overwrite CSS `--breakpoint-*`', async () => {
     @tailwind utilities;
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: {
         theme: {
@@ -370,12 +370,12 @@ test('JS config `screens` overwrite CSS `--breakpoint-*`', async () => {
 })
 
 test('JS config with `theme: { extends }` should not include the `default-config` values', async () => {
-  let input = css`
+  const input = css`
     @config "./config.js";
     @tailwind utilities;
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: {
         theme: {
@@ -448,12 +448,12 @@ test('JS config with `theme: { extends }` should not include the `default-config
 
 describe('complex screen configs', () => {
   test('generates utilities', async () => {
-    let input = css`
+    const input = css`
       @config "./config.js";
       @tailwind utilities;
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async () => ({
         module: {
           theme: {
@@ -531,7 +531,7 @@ describe('complex screen configs', () => {
   })
 
   test("don't interfere with `min-*` and `max-*` variants of non-complex screen configs", async () => {
-    let input = css`
+    const input = css`
       @theme default {
         --breakpoint-sm: 39rem;
         --breakpoint-md: 48rem;
@@ -540,7 +540,7 @@ describe('complex screen configs', () => {
       @tailwind utilities;
     `
 
-    let compiler = await compile(input, {
+    const compiler = await compile(input, {
       loadModule: async () => ({
         module: {
           theme: {
@@ -604,7 +604,7 @@ describe('complex screen configs', () => {
 })
 
 test('JS config `screens` can overwrite default CSS `--breakpoint-*`', async () => {
-  let input = css`
+  const input = css`
     @theme default {
       --breakpoint-sm: 40rem;
       --breakpoint-md: 48rem;
@@ -616,7 +616,7 @@ test('JS config `screens` can overwrite default CSS `--breakpoint-*`', async () 
     @tailwind utilities;
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: {
         theme: {

--- a/packages/tailwindcss/src/css-functions.test.ts
+++ b/packages/tailwindcss/src/css-functions.test.ts
@@ -763,7 +763,7 @@ describe('theme(…)', () => {
         })
 
         test('theme(fontFamily.sans) (config)', async () => {
-          let compiled = await compile(
+          const compiled = await compile(
             css`
               @config "./my-config.js";
               .fam {
@@ -984,18 +984,18 @@ describe('theme(…)', () => {
         ['lineHeight.tight', '1.25'],
         ['backgroundColor.red.500', 'oklch(63.7% .237 25.331)'],
       ])('theme(%s) → %s', async (value, result) => {
-        let defaultTheme = await fs.readFile(path.join(__dirname, '..', 'theme.css'), 'utf8')
-        let compiled = await compileCss(css`
+        const defaultTheme = await fs.readFile(path.join(__dirname, '..', 'theme.css'), 'utf8')
+        const compiled = await compileCss(css`
           ${defaultTheme}
           .custom {
             --custom-value: theme(${value});
           }
         `)
 
-        let startOfCustomClass = compiled.indexOf('.custom {\n')
-        let endOfCustomClass = compiled.indexOf('}', startOfCustomClass)
+        const startOfCustomClass = compiled.indexOf('.custom {\n')
+        const endOfCustomClass = compiled.indexOf('}', startOfCustomClass)
 
-        let customClassRule = compiled
+        const customClassRule = compiled
           .slice(startOfCustomClass + '.custom {\n'.length, endOfCustomClass)
           .replace('--custom-value:', '')
           .trim()
@@ -1179,7 +1179,7 @@ describe('theme(…)', () => {
 
 describe('in plugins', () => {
   test('CSS theme functions in plugins are properly evaluated', async () => {
-    let compiled = await compile(
+    const compiled = await compile(
       css`
         @layer base, utilities;
         @plugin "my-plugin";
@@ -1239,7 +1239,7 @@ describe('in plugins', () => {
 
 describe('in JS config files', () => {
   test('CSS theme functions in config files are properly evaluated', async () => {
-    let compiled = await compile(
+    const compiled = await compile(
       css`
         @layer base, utilities;
         @config "./my-config.js";

--- a/packages/tailwindcss/src/important.test.ts
+++ b/packages/tailwindcss/src/important.test.ts
@@ -6,13 +6,13 @@ const css = String.raw
 
 test('Utilities can be wrapped in a selector', async () => {
   // This is the v4 equivalent of `important: "#app"` from v3
-  let input = css`
+  const input = css`
     #app {
       @tailwind utilities;
     }
   `
 
-  let compiler = await compile(input)
+  const compiler = await compile(input)
 
   expect(compiler.build(['underline', 'hover:line-through'])).toMatchInlineSnapshot(`
     "#app {
@@ -33,11 +33,11 @@ test('Utilities can be wrapped in a selector', async () => {
 
 test('Utilities can be marked with important', async () => {
   // This is the v4 equivalent of `important: true` from v3
-  let input = css`
+  const input = css`
     @import 'tailwindcss/utilities' important;
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadStylesheet: async (id: string, base: string) => ({
       base,
       content: '@tailwind utilities;',
@@ -62,7 +62,7 @@ test('Utilities can be marked with important', async () => {
 test('Utilities can be wrapped with a selector and marked as important', async () => {
   // This does not have a direct equivalent in v3 but works as a consequence of
   // the new APIs
-  let input = css`
+  const input = css`
     @media important {
       #app {
         @tailwind utilities;
@@ -70,7 +70,7 @@ test('Utilities can be wrapped with a selector and marked as important', async (
     }
   `
 
-  let compiler = await compile(input)
+  const compiler = await compile(input)
 
   expect(compiler.build(['underline', 'hover:line-through'])).toMatchInlineSnapshot(`
     "#app {

--- a/packages/tailwindcss/src/intellisense.test.ts
+++ b/packages/tailwindcss/src/intellisense.test.ts
@@ -7,7 +7,7 @@ import { Theme, ThemeOptions } from './theme'
 const css = String.raw
 
 function loadDesignSystem() {
-  let theme = new Theme()
+  const theme = new Theme()
   theme.add('--spacing', '0.25rem')
   theme.add('--colors-red-500', 'red')
   theme.add('--colors-blue-500', 'blue')
@@ -29,9 +29,9 @@ function loadDesignSystem() {
 }
 
 test('getClassList', () => {
-  let design = loadDesignSystem()
-  let classList = design.getClassList()
-  let classNames = classList.flatMap(([name, meta]) => [
+  const design = loadDesignSystem()
+  const classList = design.getClassList()
+  const classNames = classList.flatMap(([name, meta]) => [
     name,
     ...meta.modifiers.map((m) => `${name}/${m}`),
   ])
@@ -40,13 +40,13 @@ test('getClassList', () => {
 })
 
 test('Spacing utilities do not suggest bare values when not using the multiplier-based spacing scale', () => {
-  let design = loadDesignSystem()
+  const design = loadDesignSystem()
 
   // Remove spacing scale
   design.theme.clearNamespace('--spacing', ThemeOptions.NONE)
 
-  let classList = design.getClassList()
-  let classNames = classList.flatMap(([name, meta]) => [
+  const classList = design.getClassList()
+  const classNames = classList.flatMap(([name, meta]) => [
     name,
     ...meta.modifiers.map((m) => `${name}/${m}`),
   ])
@@ -59,25 +59,25 @@ test('Spacing utilities do not suggest bare values when not using the multiplier
 })
 
 test('Theme values with underscores are converted back to decimal points', () => {
-  let design = loadDesignSystem()
-  let classes = design.getClassList()
+  const design = loadDesignSystem()
+  const classes = design.getClassList()
 
   expect(classes).toContainEqual(['inset-0.5', { modifiers: [] }])
 })
 
 test('getVariants', () => {
-  let design = loadDesignSystem()
-  let variants = design.getVariants()
+  const design = loadDesignSystem()
+  const variants = design.getVariants()
 
   expect(variants).toMatchSnapshot()
 })
 
 test('getVariants compound', () => {
-  let design = loadDesignSystem()
-  let variants = design.getVariants()
-  let group = variants.find((v) => v.name === 'group')!
+  const design = loadDesignSystem()
+  const variants = design.getVariants()
+  const group = variants.find((v) => v.name === 'group')!
 
-  let list = [
+  const list = [
     // A selector-based variant
     group.selectors({ value: 'hover' }),
 
@@ -104,7 +104,7 @@ test('getVariants compound', () => {
 })
 
 test('variant selectors are in the correct order', async () => {
-  let input = css`
+  const input = css`
     @custom-variant overactive {
       &:hover {
         @media (hover: hover) {
@@ -118,9 +118,9 @@ test('variant selectors are in the correct order', async () => {
     }
   `
 
-  let design = await __unstable__loadDesignSystem(input)
-  let variants = design.getVariants()
-  let overactive = variants.find((v) => v.name === 'overactive')!
+  const design = await __unstable__loadDesignSystem(input)
+  const variants = design.getVariants()
+  const overactive = variants.find((v) => v.name === 'overactive')!
 
   expect(overactive).toBeTruthy()
   expect(overactive.selectors({})).toMatchInlineSnapshot(`
@@ -131,15 +131,15 @@ test('variant selectors are in the correct order', async () => {
 })
 
 test('The variant `has-force` does not crash', () => {
-  let design = loadDesignSystem()
-  let variants = design.getVariants()
-  let has = variants.find((v) => v.name === 'has')!
+  const design = loadDesignSystem()
+  const variants = design.getVariants()
+  const has = variants.find((v) => v.name === 'has')!
 
   expect(has.selectors({ value: 'force' })).toMatchInlineSnapshot(`[]`)
 })
 
 test('Can produce CSS per candidate using `candidatesToCss`', () => {
-  let design = loadDesignSystem()
+  const design = loadDesignSystem()
   design.invalidCandidates = new Set(['bg-[#fff]'])
 
   expect(design.candidatesToCss(['underline', 'i-dont-exist', 'bg-[#fff]', 'bg-[#000]', 'text-xs']))
@@ -165,12 +165,12 @@ test('Can produce CSS per candidate using `candidatesToCss`', () => {
 })
 
 test('Utilities do not show wrapping selector in intellisense', async () => {
-  let input = css`
+  const input = css`
     @import 'tailwindcss/utilities';
     @config './config.js';
   `
 
-  let design = await __unstable__loadDesignSystem(input, {
+  const design = await __unstable__loadDesignSystem(input, {
     loadStylesheet: async (_, base) => ({
       base,
       content: '@tailwind utilities;',
@@ -202,11 +202,11 @@ test('Utilities do not show wrapping selector in intellisense', async () => {
 })
 
 test('Utilities, when marked as important, show as important in intellisense', async () => {
-  let input = css`
+  const input = css`
     @import 'tailwindcss/utilities' important;
   `
 
-  let design = await __unstable__loadDesignSystem(input, {
+  const design = await __unstable__loadDesignSystem(input, {
     loadStylesheet: async (_, base) => ({
       base,
       content: '@tailwind utilities;',
@@ -232,12 +232,12 @@ test('Utilities, when marked as important, show as important in intellisense', a
 })
 
 test('Static utilities from plugins are listed in hovers and completions', async () => {
-  let input = css`
+  const input = css`
     @import 'tailwindcss/utilities';
     @plugin "./plugin.js"l;
   `
 
-  let design = await __unstable__loadDesignSystem(input, {
+  const design = await __unstable__loadDesignSystem(input, {
     loadStylesheet: async (_, base) => ({
       base,
       content: '@tailwind utilities;',
@@ -267,12 +267,12 @@ test('Static utilities from plugins are listed in hovers and completions', async
 })
 
 test('Functional utilities from plugins are listed in hovers and completions', async () => {
-  let input = css`
+  const input = css`
     @import 'tailwindcss/utilities';
     @plugin "./plugin.js"l;
   `
 
-  let design = await __unstable__loadDesignSystem(input, {
+  const design = await __unstable__loadDesignSystem(input, {
     loadStylesheet: async (_, base) => ({
       base,
       content: '@tailwind utilities;',
@@ -375,8 +375,8 @@ test('Functional utilities from plugins are listed in hovers and completions', a
     ]
   `)
 
-  let classMap = new Map(design.getClassList())
-  let classNames = Array.from(classMap.keys())
+  const classMap = new Map(design.getClassList())
+  const classNames = Array.from(classMap.keys())
 
   // matchUtilities without modifiers
   expect(classNames).toContain('custom-1-red')
@@ -407,7 +407,7 @@ test('Functional utilities from plugins are listed in hovers and completions', a
 })
 
 test('Custom at-rule variants do not show up as a value under `group`', async () => {
-  let input = css`
+  const input = css`
     @import 'tailwindcss/utilities';
     @custom-variant variant-1 (@media foo);
     @custom-variant variant-2 {
@@ -418,7 +418,7 @@ test('Custom at-rule variants do not show up as a value under `group`', async ()
     @plugin "./plugin.js";
   `
 
-  let design = await __unstable__loadDesignSystem(input, {
+  const design = await __unstable__loadDesignSystem(input, {
     loadStylesheet: async (_, base) => ({
       base,
       content: '@tailwind utilities;',
@@ -432,13 +432,13 @@ test('Custom at-rule variants do not show up as a value under `group`', async ()
     }),
   })
 
-  let variants = design.getVariants()
-  let v1 = variants.find((v) => v.name === 'variant-1')!
-  let v2 = variants.find((v) => v.name === 'variant-2')!
-  let v3 = variants.find((v) => v.name === 'variant-3')!
-  let v4 = variants.find((v) => v.name === 'variant-4')!
-  let group = variants.find((v) => v.name === 'group')!
-  let not = variants.find((v) => v.name === 'not')!
+  const variants = design.getVariants()
+  const v1 = variants.find((v) => v.name === 'variant-1')!
+  const v2 = variants.find((v) => v.name === 'variant-2')!
+  const v3 = variants.find((v) => v.name === 'variant-3')!
+  const v4 = variants.find((v) => v.name === 'variant-4')!
+  const group = variants.find((v) => v.name === 'group')!
+  const not = variants.find((v) => v.name === 'not')!
 
   // All the variants should exist
   expect(v1).not.toBeUndefined()
@@ -462,7 +462,7 @@ test('Custom at-rule variants do not show up as a value under `group`', async ()
 })
 
 test('Custom functional @utility', async () => {
-  let input = css`
+  const input = css`
     @import 'tailwindcss/utilities';
 
     @theme reference {
@@ -508,15 +508,15 @@ test('Custom functional @utility', async () => {
     }
   `
 
-  let design = await __unstable__loadDesignSystem(input, {
+  const design = await __unstable__loadDesignSystem(input, {
     loadStylesheet: async (_, base) => ({
       base,
       content: '@tailwind utilities;',
     }),
   })
 
-  let classMap = new Map(design.getClassList())
-  let classNames = Array.from(classMap.keys())
+  const classMap = new Map(design.getClassList())
+  const classNames = Array.from(classMap.keys())
 
   expect(classNames).toContain('tab-1')
   expect(classNames).toContain('tab-2')
@@ -563,7 +563,7 @@ test('Custom functional @utility', async () => {
 })
 
 test('Theme keys with underscores are suggested with underscores', async () => {
-  let input = css`
+  const input = css`
     @import 'tailwindcss/utilities';
 
     @theme {
@@ -581,14 +581,14 @@ test('Theme keys with underscores are suggested with underscores', async () => {
     }
   `
 
-  let design = await __unstable__loadDesignSystem(input, {
+  const design = await __unstable__loadDesignSystem(input, {
     loadStylesheet: async (_, base) => ({
       base,
       content: '@tailwind utilities;',
     }),
   })
 
-  let entries = design.getClassList().filter(([name]) => name.startsWith('p-'))
+  const entries = design.getClassList().filter(([name]) => name.startsWith('p-'))
 
   expect(entries).toContainEqual(['p-1.5', { modifiers: [] }])
   expect(entries).toContainEqual(['p-2.5', { modifiers: [] }])

--- a/packages/tailwindcss/src/plugin.test.ts
+++ b/packages/tailwindcss/src/plugin.test.ts
@@ -5,11 +5,11 @@ import plugin from './plugin'
 const css = String.raw
 
 test('plugin', async () => {
-  let input = css`
+  const input = css`
     @plugin "my-plugin";
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: plugin(function ({ addBase }) {
         addBase({
@@ -33,11 +33,11 @@ test('plugin', async () => {
 })
 
 test('plugin.withOptions', async () => {
-  let input = css`
+  const input = css`
     @plugin "my-plugin";
   `
 
-  let compiler = await compile(input, {
+  const compiler = await compile(input, {
     loadModule: async () => ({
       module: plugin.withOptions(function (opts = { foo: '1px' }) {
         return function ({ addBase }) {

--- a/packages/tailwindcss/src/prefix.test.ts
+++ b/packages/tailwindcss/src/prefix.test.ts
@@ -5,7 +5,7 @@ import plugin from './plugin'
 const css = String.raw
 
 test('utilities must be prefixed', async () => {
-  let input = css`
+  const input = css`
     @theme reference prefix(tw);
     @tailwind utilities;
 
@@ -63,7 +63,7 @@ test('utilities must be prefixed', async () => {
 })
 
 test('utilities used in @apply must be prefixed', async () => {
-  let compiler = await compile(css`
+  const compiler = await compile(css`
     @theme reference prefix(tw);
 
     .my-underline {
@@ -94,7 +94,7 @@ test('utilities used in @apply must be prefixed', async () => {
 })
 
 test('CSS variables output by the theme are prefixed', async () => {
-  let compiler = await compile(css`
+  const compiler = await compile(css`
     @theme prefix(tw) {
       --color-red: #f00;
       --color-green: #0f0;
@@ -154,7 +154,7 @@ test('CSS theme functions do not use the prefix', async () => {
 })
 
 test('JS theme functions do not use the prefix', async () => {
-  let compiler = await compile(
+  const compiler = await compile(
     css`
       @theme prefix(tw) {
         --color-red: #f00;
@@ -194,7 +194,7 @@ test('JS theme functions do not use the prefix', async () => {
 })
 
 test('a prefix can be configured via @import theme(…)', async () => {
-  let input = css`
+  const input = css`
     @import 'tailwindcss/theme' theme(reference prefix(tw));
     @tailwind utilities;
 
@@ -264,7 +264,7 @@ test('a prefix can be configured via @import theme(…)', async () => {
 })
 
 test('a prefix can be configured via @import prefix(…)', async () => {
-  let input = css`
+  const input = css`
     @import 'tailwindcss' prefix(tw);
 
     @utility custom {
@@ -329,7 +329,7 @@ test('a prefix can be configured via @import prefix(…)', async () => {
 })
 
 test('a prefix must be letters only', async () => {
-  let input = css`
+  const input = css`
     @theme reference prefix(__);
   `
 
@@ -339,12 +339,12 @@ test('a prefix must be letters only', async () => {
 })
 
 test('a candidate matching the prefix does not crash', async () => {
-  let input = css`
+  const input = css`
     @theme reference prefix(tomato);
     @tailwind utilities;
   `
 
-  let compiler = await compile(input)
+  const compiler = await compile(input)
 
   expect(compiler.build(['tomato', 'tomato:flex'])).toMatchInlineSnapshot(`
     ".tomato\\:flex {

--- a/packages/tailwindcss/src/sort.test.ts
+++ b/packages/tailwindcss/src/sort.test.ts
@@ -40,12 +40,12 @@ test.each(table)('sorts classes: "%s" -> "%s"', async (input, expected) => {
 })
 
 test.skip('group, peer, and dark have their own order', async () => {
-  let input = shuffle(['group', 'peer', 'dark']).join(' ')
+  const input = shuffle(['group', 'peer', 'dark']).join(' ')
   expect(sortClasses(input, await loadDesign())).toEqual('dark group peer')
 })
 
 test('can sort classes deterministically across multiple class lists', async () => {
-  let classes = [
+  const classes = [
     [
       'a-class px-3 p-1 b-class py-3 bg-red-500 bg-blue-500',
       'a-class b-class bg-blue-500 bg-red-500 p-1 px-3 py-3',
@@ -57,7 +57,7 @@ test('can sort classes deterministically across multiple class lists', async () 
   ]
 
   // Shared design
-  let design = await loadDesign()
+  const design = await loadDesign()
   for (const [input, output] of classes) {
     expect(sortClasses(input, design)).toEqual(output)
   }
@@ -69,13 +69,13 @@ test('can sort classes deterministically across multiple class lists', async () 
 })
 
 test('sorts arbitrary values across one or more class lists consistently', async () => {
-  let classes = [
+  const classes = [
     ['[--fg:#fff]', '[--fg:#fff]'],
     ['[--bg:#111] [--bg_hover:#000] [--fg:#fff]', '[--bg:#111] [--bg_hover:#000] [--fg:#fff]'],
   ]
 
   // Shared design
-  let design = await loadDesign()
+  const design = await loadDesign()
   for (const [input, output] of classes) {
     expect(sortClasses(input, design)).toEqual(output)
   }
@@ -121,7 +121,7 @@ function bigSign(value: bigint) {
 
 function shuffle<T>(arr: T[]): T[] {
   for (let i = arr.length - 1; i > 0; i--) {
-    let j = Math.round(Math.random() * i)
+    const j = Math.round(Math.random() * i)
     ;[arr[i], arr[j]] = [arr[j], arr[i]]
   }
 

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -10566,9 +10566,9 @@ const prefixes = [
   'border-l',
 ]
 
-for (let prefix of prefixes) {
+for (const prefix of prefixes) {
   test(`${prefix}-*`, async () => {
-    let classes = []
+    const classes = []
 
     // Width
     classes.push(prefix)
@@ -25851,14 +25851,14 @@ test('@container', async () => {
 
 describe('spacing utilities', () => {
   test('`--spacing: initial` disables the spacing multiplier', async () => {
-    let { build } = await compile(css`
+    const { build } = await compile(css`
       @theme {
         --spacing: initial;
         --spacing-4: 1rem;
       }
       @tailwind utilities;
     `)
-    let compiled = build(['px-1', 'px-4'])
+    const compiled = build(['px-1', 'px-4'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       ":root, :host {
@@ -25872,14 +25872,14 @@ describe('spacing utilities', () => {
   })
 
   test('`--spacing-*: initial` disables the spacing multiplier', async () => {
-    let { build } = await compile(css`
+    const { build } = await compile(css`
       @theme {
         --spacing-*: initial;
         --spacing-4: 1rem;
       }
       @tailwind utilities;
     `)
-    let compiled = build(['px-1', 'px-4'])
+    const compiled = build(['px-1', 'px-4'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       ":root, :host {
@@ -25893,13 +25893,13 @@ describe('spacing utilities', () => {
   })
 
   test('only multiples of 0.25 with no trailing zeroes are supported with the spacing multiplier', async () => {
-    let { build } = await compile(css`
+    const { build } = await compile(css`
       @theme {
         --spacing: 4px;
       }
       @tailwind utilities;
     `)
-    let compiled = build(['px-0.25', 'px-1.5', 'px-2.75', 'px-0.375', 'px-2.50', 'px-.75'])
+    const compiled = build(['px-0.25', 'px-1.5', 'px-2.75', 'px-0.375', 'px-2.50', 'px-.75'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       ":root, :host {
@@ -25921,26 +25921,26 @@ describe('spacing utilities', () => {
   })
 
   test('spacing utilities must have a value', async () => {
-    let { build } = await compile(css`
+    const { build } = await compile(css`
       @theme reference {
         --spacing: 4px;
       }
       @tailwind utilities;
     `)
-    let compiled = build(['px'])
+    const compiled = build(['px'])
 
     expect(optimizeCss(compiled).trim()).toEqual('')
   })
 
   test('--spacing-* variables take precedence over --container-* variables', async () => {
-    let { build } = await compile(css`
+    const { build } = await compile(css`
       @theme {
         --spacing-sm: 8px;
         --container-sm: 256px;
       }
       @tailwind utilities;
     `)
-    let compiled = build(['w-sm', 'max-w-sm', 'min-w-sm', 'basis-sm'])
+    const compiled = build(['w-sm', 'max-w-sm', 'min-w-sm', 'basis-sm'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       ":root, :host {
@@ -25968,7 +25968,7 @@ describe('spacing utilities', () => {
 
 describe('custom utilities', () => {
   test('custom static utility', async () => {
-    let { build } = await compile(css`
+    const { build } = await compile(css`
       @layer utilities {
         @tailwind utilities;
       }
@@ -25982,7 +25982,7 @@ describe('custom utilities', () => {
         text-box-edge: cap alphabetic;
       }
     `)
-    let compiled = build(['text-trim', 'lg:text-trim'])
+    const compiled = build(['text-trim', 'lg:text-trim'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
@@ -26002,7 +26002,7 @@ describe('custom utilities', () => {
   })
 
   test('custom static utility emit CSS variables if the utility is used', async () => {
-    let { build } = await compile(css`
+    const { build } = await compile(css`
       @layer utilities {
         @tailwind utilities;
       }
@@ -26036,7 +26036,7 @@ describe('custom utilities', () => {
   })
 
   test('custom static utility (negative)', async () => {
-    let { build } = await compile(css`
+    const { build } = await compile(css`
       @layer utilities {
         @tailwind utilities;
       }
@@ -26045,7 +26045,7 @@ describe('custom utilities', () => {
         value: -1;
       }
     `)
-    let compiled = build(['-example', 'lg:-example'])
+    const compiled = build(['-example', 'lg:-example'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
@@ -26057,7 +26057,7 @@ describe('custom utilities', () => {
   })
 
   test('Multiple static utilities are merged', async () => {
-    let { build } = await compile(css`
+    const { build } = await compile(css`
       @layer utilities {
         @tailwind utilities;
       }
@@ -26071,7 +26071,7 @@ describe('custom utilities', () => {
         border-radius: 30rem;
       }
     `)
-    let compiled = build(['really-round'])
+    const compiled = build(['really-round'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
@@ -26084,7 +26084,7 @@ describe('custom utilities', () => {
   })
 
   test('custom utilities support some special characters', async () => {
-    let { build } = await compile(css`
+    const { build } = await compile(css`
       @layer utilities {
         @tailwind utilities;
       }
@@ -26097,7 +26097,7 @@ describe('custom utilities', () => {
         right: 50%;
       }
     `)
-    let compiled = build(['push-1/2', 'push-50%'])
+    const compiled = build(['push-1/2', 'push-50%'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
@@ -26109,7 +26109,7 @@ describe('custom utilities', () => {
   })
 
   test('can override specific versions of a functional utility with a static utility', async () => {
-    let { build } = await compile(css`
+    const { build } = await compile(css`
       @layer utilities {
         @tailwind utilities;
       }
@@ -26125,7 +26125,7 @@ describe('custom utilities', () => {
         text-rendering: optimizeLegibility;
       }
     `)
-    let compiled = build(['text-sm'])
+    const compiled = build(['text-sm'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
@@ -26141,7 +26141,7 @@ describe('custom utilities', () => {
   })
 
   test('can override the default value of a functional utility', async () => {
-    let { build } = await compile(css`
+    const { build } = await compile(css`
       @layer utilities {
         @tailwind utilities;
       }
@@ -26154,7 +26154,7 @@ describe('custom utilities', () => {
         border-radius: 50rem;
       }
     `)
-    let compiled = build(['rounded', 'rounded-xl', 'rounded-[33px]'])
+    const compiled = build(['rounded', 'rounded-xl', 'rounded-[33px]'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
@@ -26174,7 +26174,7 @@ describe('custom utilities', () => {
   })
 
   test('custom utilities are sorted by used properties', async () => {
-    let { build } = await compile(css`
+    const { build } = await compile(css`
       @layer utilities {
         @tailwind utilities;
       }
@@ -26183,7 +26183,7 @@ describe('custom utilities', () => {
         right: 100%;
       }
     `)
-    let compiled = build(['top-[100px]', 'push-left', 'right-[100px]', 'bottom-[100px]'])
+    const compiled = build(['top-[100px]', 'push-left', 'right-[100px]', 'bottom-[100px]'])
 
     expect(optimizeCss(compiled).trim()).toMatchInlineSnapshot(`
       "@layer utilities {
@@ -26391,7 +26391,7 @@ describe('custom utilities', () => {
 
   describe('functional utilities', () => {
     test('resolving values from `@theme`', async () => {
-      let input = css`
+      const input = css`
         @theme reference {
           --tab-size-1: 1;
           --tab-size-2: 2;
@@ -26428,7 +26428,7 @@ describe('custom utilities', () => {
     })
 
     test('resolving values from `@theme`, with `--tab-size-*` syntax', async () => {
-      let input =
+      const input =
         // Explicitly not using the css tagged template literal so that
         // Prettier doesn't format the `value(--tab-size-*)` as
         // `value(--tab-size- *)`
@@ -26469,7 +26469,7 @@ describe('custom utilities', () => {
     })
 
     test('resolving values from `@theme`, with `--tab-size-\\*` syntax (prettier friendly)', async () => {
-      let input = css`
+      const input = css`
         @theme reference {
           --tab-size-1: 1;
           --tab-size-2: 2;
@@ -26506,7 +26506,7 @@ describe('custom utilities', () => {
     })
 
     test('resolving bare values', async () => {
-      let input = css`
+      const input = css`
         @utility tab-* {
           tab-size: --value(integer);
         }
@@ -26531,8 +26531,8 @@ describe('custom utilities', () => {
     })
 
     test('bare values with unsupported data types should result in a warning', async () => {
-      let spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-      let input = css`
+      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const input = css`
         @utility paint-* {
           paint: --value([color], color);
         }
@@ -26559,7 +26559,7 @@ describe('custom utilities', () => {
     })
 
     test('resolve literal values', async () => {
-      let input = css`
+      const input = css`
         @utility tab-* {
           tab-size: --value('revert');
         }
@@ -26576,7 +26576,7 @@ describe('custom utilities', () => {
     })
 
     test('resolving bare values with constraints for integer, percentage, and ratio', async () => {
-      let input = css`
+      const input = css`
         @utility example-* {
           --value-as-number: --value(number);
           --value-as-percentage: --value(percentage);
@@ -26616,7 +26616,7 @@ describe('custom utilities', () => {
     })
 
     test('resolving unsupported bare values', async () => {
-      let input = css`
+      const input = css`
         @utility tab-* {
           tab-size: --value(color);
         }
@@ -26628,7 +26628,7 @@ describe('custom utilities', () => {
     })
 
     test('resolving arbitrary values', async () => {
-      let input = css`
+      const input = css`
         @utility tab-* {
           tab-size: --value([integer]);
         }
@@ -26674,7 +26674,7 @@ describe('custom utilities', () => {
     })
 
     test('resolving any arbitrary values', async () => {
-      let input = css`
+      const input = css`
         @utility tab-* {
           tab-size: --value([ *]);
         }
@@ -26714,7 +26714,7 @@ describe('custom utilities', () => {
     })
 
     test('resolving any arbitrary values (without space)', async () => {
-      let input = `
+      const input = `
         @utility tab-* {
           tab-size: --value([*]);
         }
@@ -26754,7 +26754,7 @@ describe('custom utilities', () => {
     })
 
     test('resolving any arbitrary values (with escaped `*`)', async () => {
-      let input = css`
+      const input = css`
         @utility tab-* {
           tab-size: --value([\*]);
         }
@@ -26794,7 +26794,7 @@ describe('custom utilities', () => {
     })
 
     test('resolving theme, bare and arbitrary values all at once', async () => {
-      let input = css`
+      const input = css`
         @theme reference {
           --tab-size-github: 8;
         }
@@ -26825,7 +26825,7 @@ describe('custom utilities', () => {
     })
 
     test('in combination with calc to produce different data types of values', async () => {
-      let input = css`
+      const input = css`
         @theme reference {
           --example-full: 100%;
         }
@@ -26857,7 +26857,7 @@ describe('custom utilities', () => {
     })
 
     test('shorthand if resulting values are of the same type', async () => {
-      let input = css`
+      const input = css`
         @theme reference {
           --tab-size-github: 8;
           --example-full: 100%;
@@ -26915,7 +26915,7 @@ describe('custom utilities', () => {
     })
 
     test('negative values', async () => {
-      let input = css`
+      const input = css`
         @theme reference {
           --example-full: 100%;
         }
@@ -26969,7 +26969,7 @@ describe('custom utilities', () => {
     })
 
     test('using the same value multiple times', async () => {
-      let input = css`
+      const input = css`
         @utility example-* {
           --value: calc(var(--spacing) * --value(number)) calc(var(--spacing) * --value(number));
         }
@@ -26985,7 +26985,7 @@ describe('custom utilities', () => {
     })
 
     test('using `--spacing(…)` shorthand', async () => {
-      let input = css`
+      const input = css`
         @theme {
           --spacing: 4px;
         }
@@ -27009,7 +27009,7 @@ describe('custom utilities', () => {
     })
 
     test('using `--spacing(…)` shorthand (inline theme)', async () => {
-      let input = css`
+      const input = css`
         @theme inline reference {
           --spacing: 4px;
         }
@@ -27029,7 +27029,7 @@ describe('custom utilities', () => {
     })
 
     test('modifiers', async () => {
-      let input = css`
+      const input = css`
         @theme reference {
           --value-sm: 14px;
           --modifier-7: 28px;
@@ -27096,7 +27096,7 @@ describe('custom utilities', () => {
     })
 
     test('fractions', async () => {
-      let input = css`
+      const input = css`
         @theme reference {
           --example-video: 16 / 9;
         }
@@ -27126,7 +27126,7 @@ describe('custom utilities', () => {
     })
 
     test('resolve theme values with sub-namespace (--text- * --line-height)', async () => {
-      let input = css`
+      const input = css`
         @theme reference {
           --text-xs: 0.75rem;
           --text-xs--line-height: calc(1 / 0.75);
@@ -27157,7 +27157,7 @@ describe('custom utilities', () => {
     })
 
     test('resolve theme values with sub-namespace (--text-\\* --line-height)', async () => {
-      let input = css`
+      const input = css`
         @theme reference {
           --text-xs: 0.75rem;
           --text-xs--line-height: calc(1 / 0.75);
@@ -27188,7 +27188,7 @@ describe('custom utilities', () => {
     })
 
     test('resolve theme values with sub-namespace (--value(--text --line-height))', async () => {
-      let input = css`
+      const input = css`
         @theme reference {
           --text-xs: 0.75rem;
           --text-xs--line-height: calc(1 / 0.75);
@@ -27219,7 +27219,7 @@ describe('custom utilities', () => {
     })
 
     test('resolve theme values with sub-namespace (--value(--text-*--line-height))', async () => {
-      let input = `
+      const input = `
         @theme reference {
           --text-xs: 0.75rem;
           --text-xs--line-height: calc(1 / 0.75);
@@ -27250,7 +27250,7 @@ describe('custom utilities', () => {
     })
 
     test('variables used in `@utility` will not be emitted if the utility is not used', async () => {
-      let input = css`
+      const input = css`
         @theme {
           --example-foo: red;
           --color-red-500: #f00;
@@ -27272,7 +27272,7 @@ describe('custom utilities', () => {
     })
 
     test('variables used in `@utility` will be emitted if the utility is used', async () => {
-      let input = css`
+      const input = css`
         @theme {
           --example-foo: red;
           --color-red-500: #f00;
@@ -27307,7 +27307,7 @@ describe('custom utilities', () => {
     //
     // This test now ensures that we only remove/replace a declaration once.
     test('declaration nodes are only replaced/removed once', async () => {
-      let input = css`
+      const input = css`
         @utility mask-r-* {
           --mask-right: linear-gradient(to left, transparent, black --value(percentage));
           --mask-right: linear-gradient(
@@ -27333,7 +27333,7 @@ describe('custom utilities', () => {
   })
 
   test('resolve value based on `@theme`', async () => {
-    let input = css`
+    const input = css`
       @theme {
         --tab-size-github: 8;
       }
@@ -27357,7 +27357,7 @@ describe('custom utilities', () => {
   })
 
   test('resolve value based on `@theme reference`', async () => {
-    let input = css`
+    const input = css`
       @theme reference {
         --tab-size-github: 8;
       }
@@ -27377,7 +27377,7 @@ describe('custom utilities', () => {
   })
 
   test('resolve value based on `@theme inline`', async () => {
-    let input = css`
+    const input = css`
       @theme inline {
         --tab-size-github: 8;
       }
@@ -27397,7 +27397,7 @@ describe('custom utilities', () => {
   })
 
   test('resolve value based on `@theme inline reference`', async () => {
-    let input = css`
+    const input = css`
       @theme inline reference {
         --tab-size-github: 8;
       }
@@ -27417,7 +27417,7 @@ describe('custom utilities', () => {
   })
 
   test('sub namespaces can live in different @theme blocks (1)', async () => {
-    let input = `
+    const input = `
       @theme reference {
         --text-xs: 0.75rem;
       }
@@ -27443,7 +27443,7 @@ describe('custom utilities', () => {
   })
 
   test('sub namespaces can live in different @theme blocks (2)', async () => {
-    let input = `
+    const input = `
       @theme inline reference {
         --text-xs: 0.75rem;
       }

--- a/packages/tailwindcss/src/utils/compare.test.ts
+++ b/packages/tailwindcss/src/utils/compare.test.ts
@@ -135,13 +135,13 @@ it('sort is stable', () => {
   // Heap's algorithm for permutations
   function* permutations<T>(input: T[]) {
     let pos = 1
-    let stack = input.map(() => 0)
+    const stack = input.map(() => 0)
 
     yield input.slice()
 
     while (pos < input.length) {
       if (stack[pos] < pos) {
-        let k = pos % 2 == 0 ? 0 : stack[pos]
+        const k = pos % 2 == 0 ? 0 : stack[pos]
         ;[input[k], input[pos]] = [input[pos], input[k]]
         yield input.slice()
         ++stack[pos]
@@ -153,10 +153,16 @@ it('sort is stable', () => {
     }
   }
 
-  let classes = ['duration-initial', 'duration-75', 'duration-150', 'duration-700', 'duration-1000']
+  const classes = [
+    'duration-initial',
+    'duration-75',
+    'duration-150',
+    'duration-700',
+    'duration-1000',
+  ]
 
-  for (let permutation of permutations(classes)) {
-    let sorted = [...permutation].sort(compare)
+  for (const permutation of permutations(classes)) {
+    const sorted = [...permutation].sort(compare)
     expect(sorted).toEqual([
       'duration-75',
       'duration-150',

--- a/packages/tailwindcss/src/utils/decode-arbitrary-value.test.ts
+++ b/packages/tailwindcss/src/utils/decode-arbitrary-value.test.ts
@@ -44,7 +44,7 @@ describe('decoding arbitrary values', () => {
 })
 
 describe('adds spaces around math operators', () => {
-  let table = [
+  const table = [
     // math functions like calc(…) get spaces around operators
     ['calc(1+2)', 'calc(1 + 2)'],
     ['calc(100%+1rem)', 'calc(100% + 1rem)'],

--- a/packages/tailwindcss/src/utils/replace-shadow-colors.test.ts
+++ b/packages/tailwindcss/src/utils/replace-shadow-colors.test.ts
@@ -3,45 +3,45 @@ import { replaceAlpha } from '../utilities'
 import { replaceShadowColors } from './replace-shadow-colors'
 
 describe('without replacer', () => {
-  let replacer = (color: string) => `var(--tw-shadow-color, ${color})`
+  const replacer = (color: string) => `var(--tw-shadow-color, ${color})`
 
   it('should handle var shadow', () => {
-    let parsed = replaceShadowColors('var(--my-shadow)', replacer)
+    const parsed = replaceShadowColors('var(--my-shadow)', replacer)
     expect(parsed).toMatchInlineSnapshot(`"var(--my-shadow)"`)
   })
 
   it('should handle var shadow with offset', () => {
-    let parsed = replaceShadowColors('1px var(--my-shadow)', replacer)
+    const parsed = replaceShadowColors('1px var(--my-shadow)', replacer)
     expect(parsed).toMatchInlineSnapshot(`"1px var(--my-shadow)"`)
   })
 
   it('should handle var color with offsets', () => {
-    let parsed = replaceShadowColors('1px 1px var(--my-color)', replacer)
+    const parsed = replaceShadowColors('1px 1px var(--my-color)', replacer)
     expect(parsed).toMatchInlineSnapshot(`"1px 1px var(--tw-shadow-color, var(--my-color))"`)
   })
 
   it('should handle var color with zero offsets', () => {
-    let parsed = replaceShadowColors('0 0 0 var(--my-color)', replacer)
+    const parsed = replaceShadowColors('0 0 0 var(--my-color)', replacer)
     expect(parsed).toMatchInlineSnapshot(`"0 0 0 var(--tw-shadow-color, var(--my-color))"`)
   })
 
   it('should handle two values with currentcolor', () => {
-    let parsed = replaceShadowColors('1px 2px', replacer)
+    const parsed = replaceShadowColors('1px 2px', replacer)
     expect(parsed).toMatchInlineSnapshot(`"1px 2px var(--tw-shadow-color, currentcolor)"`)
   })
 
   it('should handle three values with currentcolor', () => {
-    let parsed = replaceShadowColors('1px 2px 3px', replacer)
+    const parsed = replaceShadowColors('1px 2px 3px', replacer)
     expect(parsed).toMatchInlineSnapshot(`"1px 2px 3px var(--tw-shadow-color, currentcolor)"`)
   })
 
   it('should handle four values with currentcolor', () => {
-    let parsed = replaceShadowColors('1px 2px 3px 4px', replacer)
+    const parsed = replaceShadowColors('1px 2px 3px 4px', replacer)
     expect(parsed).toMatchInlineSnapshot(`"1px 2px 3px 4px var(--tw-shadow-color, currentcolor)"`)
   })
 
   it('should handle multiple shadows', () => {
-    let parsed = replaceShadowColors(
+    const parsed = replaceShadowColors(
       ['var(--my-shadow)', '1px 1px var(--my-color)', '0 0 1px var(--my-color)'].join(', '),
       replacer,
     )
@@ -52,31 +52,31 @@ describe('without replacer', () => {
 })
 
 describe('with replacer', () => {
-  let replacer = (color: string) => `var(--tw-shadow-color, ${replaceAlpha(color, '50%')})`
+  const replacer = (color: string) => `var(--tw-shadow-color, ${replaceAlpha(color, '50%')})`
 
   it('should handle var color with intensity', () => {
-    let parsed = replaceShadowColors('1px 1px var(--my-color)', replacer)
+    const parsed = replaceShadowColors('1px 1px var(--my-color)', replacer)
     expect(parsed).toMatchInlineSnapshot(
       `"1px 1px var(--tw-shadow-color, oklab(from var(--my-color) l a b / 50%))"`,
     )
   })
 
   it('should handle box-shadow with intensity', () => {
-    let parsed = replaceShadowColors('1px 1px var(--my-color)', replacer)
+    const parsed = replaceShadowColors('1px 1px var(--my-color)', replacer)
     expect(parsed).toMatchInlineSnapshot(
       `"1px 1px var(--tw-shadow-color, oklab(from var(--my-color) l a b / 50%))"`,
     )
   })
 
   it('should handle four values with intensity and no color value', () => {
-    let parsed = replaceShadowColors('1px 2px 3px 4px', replacer)
+    const parsed = replaceShadowColors('1px 2px 3px 4px', replacer)
     expect(parsed).toMatchInlineSnapshot(
       `"1px 2px 3px 4px var(--tw-shadow-color, oklab(from currentcolor l a b / 50%))"`,
     )
   })
 
   it('should handle multiple shadows with intensity', () => {
-    let parsed = replaceShadowColors(
+    const parsed = replaceShadowColors(
       ['var(--my-shadow)', '1px 1px var(--my-color)', '0 0 1px var(--my-color)'].join(', '),
       replacer,
     )


### PR DESCRIPTION
Some variables were declared with the `let` keyword but never reassigned. For the reasons below, it would be a better practice to change to `const`.

1. Prevents accidental reassignment
2. Signals intent clearly to other developers
3. Improves code readability
4. Enables potential compiler optimizations
5. Simplifies debugging
6. Promotes immutability
7. Reduces bugs from mutable state