### PR TITLE
Add word-break: break-word to Tailwindcss

### DIFF
--- a/packages/tailwindcss/src/__snapshots__/intellisense.test.ts.snap
+++ b/packages/tailwindcss/src/__snapshots__/intellisense.test.ts.snap
@@ -3591,6 +3591,7 @@ exports[`getClassList 1`] = `
   "break-after-left",
   "break-after-page",
   "break-after-right",
+  "break-word",
   "break-all",
   "break-before-all",
   "break-before-auto",

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -9514,7 +9514,7 @@ test('text-wrap', async () => {
 })
 
 test('word-break', async () => {
-  expect(await run(['break-normal', 'break-words', 'break-all', 'break-keep']))
+  expect(await run(['break-normal', 'break-words', 'break-word', 'break-all', 'break-keep']))
     .toMatchInlineSnapshot(`
       ".break-normal {
         overflow-wrap: normal;
@@ -9523,6 +9523,10 @@ test('word-break', async () => {
 
       .break-words {
         overflow-wrap: break-word;
+      }
+      
+      .break-word {
+        word-break: break-word;
       }
 
       .break-all {
@@ -9537,10 +9541,12 @@ test('word-break', async () => {
     await run([
       '-break-normal',
       '-break-words',
+      '-break-word',
       '-break-all',
       '-break-keep',
       'break-normal/foo',
       'break-words/foo',
+      'break-word/foo',
       'break-all/foo',
       'break-keep/foo',
     ]),

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -2076,6 +2076,7 @@ export function createUtilities(theme: Theme) {
     ['word-break', 'normal'],
   ])
   staticUtility('break-words', [['overflow-wrap', 'break-word']])
+  staticUtility('break-word', [['word-break', 'break-word']])
   staticUtility('break-all', [['word-break', 'break-all']])
   staticUtility('break-keep', [['word-break', 'keep-all']])
 


### PR DESCRIPTION
# Add word-break: break-word to Tailwindcss
Hi, 

I've noticed that there is no class for word-break: break-word;. 

With this PR a new class called `break-word` will be added that allows text to be wrapped by word.
This is an improvement on the already existing `break-all` class.

The difference is that break-all will not take words into account when slicing content on multiple lines, while break-word does. See [Mozilla docs on work break](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break)

# Break-all
![image](https://github.com/user-attachments/assets/ad3f7189-2b7c-449c-b86d-60c0be484920)

# Break-word
![image](https://github.com/user-attachments/assets/6e3a4327-e0de-476f-88c9-22e3a054aef4)


### Please let me know if anything needs to be added or changed, i'll be happy to help 😊. Also if this gets approved, I'll make a PR for the docs
