### PR TITLE
Fix publish step on CI

### DIFF
--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -298,7 +298,10 @@ jobs:
           path: dist/*.tgz
 
       - name: Publish
-        run: pnpm --recursive publish --tag ${{ env.RELEASE_CHANNEL }} --no-git-checks
+        run: |
+          pnpm --recursive --filter="\!@tailwindcss/oxide-wasm32-wasi" publish --tag ${{ env.RELEASE_CHANNEL }} --no-git-checks
+          # The wasm package needs a special npm config that isn't read when pnpm --recursive is used
+          pushd crates/node/npm/wasm32-wasi; pnpm publish --tag ${{ env.RELEASE_CHANNEL }} --no-git-checks; popd;
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,7 +291,10 @@ jobs:
           echo "TAILWINDCSS_VERSION=$(node -e 'console.log(require(`./packages/tailwindcss/package.json`).version);')" >> $GITHUB_ENV
 
       - name: Publish
-        run: pnpm --recursive publish --tag ${{ env.RELEASE_CHANNEL }} --no-git-checks
+        run: |
+          pnpm --recursive --filter="\!@tailwindcss/oxide-wasm32-wasi" publish --tag ${{ env.RELEASE_CHANNEL }} --no-git-checks
+          # The wasm package needs a special npm config that isn't read when pnpm --recursive is used
+          pushd crates/node/npm/wasm32-wasi; pnpm publish --tag ${{ env.RELEASE_CHANNEL }} --no-git-checks; popd;
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
To publish the newly adde WASM builds, we rely on the `node-linker=hoisted` `.npmrc` flag that isn't read when `pnpm --recursive` is used. To work around it, this PR excludes the wasm package from the `--recursive` part and manually published it afterwards.


## Test Plan

Ensured this does not error now when trying a `--dry run`.

<img width="1273" alt="Screenshot 2025-04-11 at 17 43 38" src="https://github.com/user-attachments/assets/68a28552-0125-4da1-92ff-74e58368abe4" />
