### PR TITLE
Prevent duplicate suggestions when using `@theme` and `@utility` together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Allow `_` before numbers during candidate extraction ([#17961](https://github.com/tailwindlabs/tailwindcss/pull/17961))
+- Prevent duplicate suggestions when using `@theme` and `@utility` together ([#17675](https://github.com/tailwindlabs/tailwindcss/pull/17675))
 
 ## [4.1.6] - 2025-05-09
 

--- a/packages/tailwindcss/src/intellisense.test.ts
+++ b/packages/tailwindcss/src/intellisense.test.ts
@@ -653,3 +653,25 @@ test('shadow utility default suggestions', async () => {
   expect(classNames).toContain('inset-shadow')
   expect(classNames).toContain('text-shadow')
 })
+
+test('Custom @utility and existing utility with names matching theme keys dont give duplicate results', async () => {
+  let input = css`
+    @theme reference {
+      --leading-sm: 0.25rem;
+      --text-header: 1.5rem;
+    }
+
+    @utility text-header {
+      text-transform: uppercase;
+    }
+  `
+
+  let design = await __unstable__loadDesignSystem(input)
+
+  let classList = design.getClassList()
+  let classMap = new Map(classList)
+  let matches = classList.filter(([className]) => className === 'text-header')
+
+  expect(matches).toHaveLength(1)
+  expect(classMap.get('text-header')?.modifiers).toEqual(['sm'])
+})


### PR DESCRIPTION
Fixes https://github.com/tailwindlabs/tailwindcss-intellisense/issues/1313

Right now given this CSS:
```css
@theme reference {
  --text-header: 1.5rem;
}

@utility text-header {
  text-transform: uppercase;
}
```

You'll see two entries for `text-header` in IntelliSense completions but we only want you to see one. This PR solves this by merging their modifier lists and de-duping by class name.