### PR TITLE
Ignore .geojson files by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Don't scan `.geojson` files for classes by default ([#17700](https://github.com/tailwindlabs/tailwindcss/pull/17700))
 
 ## [4.1.4] - 2025-04-14
 

--- a/crates/oxide/src/scanner/fixtures/binary-extensions.txt
+++ b/crates/oxide/src/scanner/fixtures/binary-extensions.txt
@@ -77,6 +77,7 @@ fpx
 fst
 fvt
 g3
+geojson
 gh
 gif
 graffle


### PR DESCRIPTION
Resolves https://github.com/tailwindlabs/tailwindcss/issues/17699

GeoJSON files are giant JSON files for geographic data structures and will never contain Tailwind classes, but because they are often huge they will slow down the build a lot if scanned.