### PR TITLE
Add support for source maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade: Automatically convert candidates with arbitrary values to their utilities ([#17831](https://github.com/tailwindlabs/tailwindcss/pull/17831), [#17854](https://github.com/tailwindlabs/tailwindcss/pull/17854))
 - Write to log file when using `DEBUG=*` ([#17906](https://github.com/tailwindlabs/tailwindcss/pull/17906))
+- Add support for source maps in development ([#17775](https://github.com/tailwindlabs/tailwindcss/pull/17775))
 
 ### Fixed
 

--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -653,8 +653,6 @@ describe.each([
     async ({ exec, expect, fs, parseSourceMap }) => {
       await exec(`${command} --input src/index.css --output dist/out.css --map`)
 
-      console.log(await fs.read('dist/out.css'))
-
       await fs.expectFileToContain('dist/out.css', [candidate`flex`])
 
       // Make sure we can find a source map
@@ -783,8 +781,6 @@ describe.each([
       await exec(`${command} --input src/index.css --output dist/out.css --minify --map`)
 
       await fs.expectFileToContain('dist/out.css', [candidate`flex`])
-
-      console.log(await fs.read('dist/out.css'))
 
       // Make sure we can find a source map
       let map = parseSourceMap(await fs.read('dist/out.css'))

--- a/integrations/package.json
+++ b/integrations/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "devDependencies": {
     "dedent": "1.5.3",
-    "fast-glob": "^3.3.3"
+    "fast-glob": "^3.3.3",
+    "source-map-js": "^1.2.1"
   }
 }

--- a/integrations/vite/source-maps.test.ts
+++ b/integrations/vite/source-maps.test.ts
@@ -1,0 +1,96 @@
+import { candidate, css, fetchStyles, html, json, retryAssertion, test, ts } from '../utils'
+
+test(
+  `dev build`,
+  {
+    fs: {
+      'package.json': json`
+        {
+          "type": "module",
+          "dependencies": {
+            "@tailwindcss/vite": "workspace:^",
+            "tailwindcss": "workspace:^"
+          },
+          "devDependencies": {
+            "lightningcss": "^1.26.0",
+            "vite": "^6"
+          }
+        }
+      `,
+      'vite.config.ts': ts`
+        import tailwindcss from '@tailwindcss/vite'
+        import { defineConfig } from 'vite'
+
+        export default defineConfig({
+          plugins: [tailwindcss()],
+          css: {
+            devSourcemap: true,
+          },
+          build: {
+            sourcemap: true,
+          },
+        })
+      `,
+      'index.html': html`
+        <head>
+          <link rel="stylesheet" href="./src/index.css" />
+        </head>
+        <body>
+          <div class="flex">Hello, world!</div>
+        </body>
+      `,
+      'src/index.css': css`
+        @import 'tailwindcss/utilities';
+        /*  */
+      `,
+    },
+  },
+  async ({ fs, spawn, expect, parseSourceMap }) => {
+    // Source maps only work in development mode in Vite
+    let process = await spawn('pnpm vite dev')
+    await process.onStdout((m) => m.includes('ready in'))
+
+    let url = ''
+    await process.onStdout((m) => {
+      let match = /Local:\s*(http.*)\//.exec(m)
+      if (match) url = match[1]
+      return Boolean(url)
+    })
+
+    let styles = await retryAssertion(async () => {
+      let styles = await fetchStyles(url, '/index.html')
+
+      // Wait until we have the right CSS
+      expect(styles).toContain(candidate`flex`)
+
+      return styles
+    })
+
+    // Make sure we can find a source map
+    let map = parseSourceMap(styles)
+
+    expect(map.at(1, 0)).toMatchObject({
+      source: null,
+      original: '(none)',
+      generated: '/*! tailwi...',
+    })
+
+    expect(map.at(2, 0)).toMatchObject({
+      source: expect.stringContaining('node_modules/tailwindcss/utilities.css'),
+      original: '@tailwind...',
+      generated: '.flex {...',
+    })
+
+    expect(map.at(3, 2)).toMatchObject({
+      source: expect.stringContaining('node_modules/tailwindcss/utilities.css'),
+      original: '@tailwind...',
+      generated: 'display: f...',
+    })
+
+    expect(map.at(4, 0)).toMatchObject({
+      source: null,
+      original: '(none)',
+      generated: '}...',
+    })
+  },
+)

--- a/integrations/vite/source-maps.test.ts
+++ b/integrations/vite/source-maps.test.ts
@@ -26,9 +26,6 @@ test(
           css: {
             devSourcemap: true,
           },
-          build: {
-            sourcemap: true,
-          },
         })
       `,
       'index.html': html`

--- a/packages/@tailwindcss-browser/src/index.ts
+++ b/packages/@tailwindcss-browser/src/index.ts
@@ -116,6 +116,7 @@ async function loadStylesheet(id: string, base: string) {
   function load() {
     if (id === 'tailwindcss') {
       return {
+        path: 'virtual:tailwindcss/index.css',
         base,
         content: assets.css.index,
       }
@@ -125,6 +126,7 @@ async function loadStylesheet(id: string, base: string) {
       id === './preflight.css'
     ) {
       return {
+        path: 'virtual:tailwindcss/preflight.css',
         base,
         content: assets.css.preflight,
       }
@@ -134,6 +136,7 @@ async function loadStylesheet(id: string, base: string) {
       id === './theme.css'
     ) {
       return {
+        path: 'virtual:tailwindcss/theme.css',
         base,
         content: assets.css.theme,
       }
@@ -143,6 +146,7 @@ async function loadStylesheet(id: string, base: string) {
       id === './utilities.css'
     ) {
       return {
+        path: 'virtual:tailwindcss/utilities.css',
         base,
         content: assets.css.utilities,
       }

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -126,14 +126,14 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
     if (args['--minify'] || args['--optimize']) {
       if (css !== previous.css) {
         DEBUG && I.start('Optimize CSS')
-        let optimizedCss = optimize(css, {
+        let optimized = optimize(css, {
           file: args['--input'] ?? 'input.css',
           minify: args['--minify'] ?? false,
         })
         DEBUG && I.end('Optimize CSS')
         previous.css = css
-        previous.optimizedCss = optimizedCss
-        output = optimizedCss
+        previous.optimizedCss = optimized.code
+        output = optimized.code
       } else {
         output = previous.optimizedCss
       }

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -119,8 +119,6 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
   // If the user passes `{bin} build --map -` then this likely means they want to output the map inline
   // this is the default behavior of `{bin build} --map` to inform the user of that
   if (args['--map'] === '-') {
-    eprintln(header())
-    eprintln()
     eprintln(`Use --map without a value to inline the source map`)
     process.exit(1)
   }

--- a/packages/@tailwindcss-node/package.json
+++ b/packages/@tailwindcss-node/package.json
@@ -37,9 +37,11 @@
     }
   },
   "dependencies": {
+    "@ampproject/remapping": "^2.3.0",
     "enhanced-resolve": "^5.18.1",
     "jiti": "^2.4.2",
     "lightningcss": "catalog:",
+    "magic-string": "^0.30.17",
     "source-map-js": "^1.2.1",
     "tailwindcss": "workspace:*"
   }

--- a/packages/@tailwindcss-node/package.json
+++ b/packages/@tailwindcss-node/package.json
@@ -40,6 +40,7 @@
     "enhanced-resolve": "^5.18.1",
     "jiti": "^2.4.2",
     "lightningcss": "catalog:",
+    "source-map-js": "^1.2.1",
     "tailwindcss": "workspace:*"
   }
 }

--- a/packages/@tailwindcss-node/package.json
+++ b/packages/@tailwindcss-node/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "enhanced-resolve": "^5.18.1",
     "jiti": "^2.4.2",
-    "tailwindcss": "workspace:*",
-    "lightningcss": "catalog:"
+    "lightningcss": "catalog:",
+    "tailwindcss": "workspace:*"
   }
 }

--- a/packages/@tailwindcss-node/src/compile.ts
+++ b/packages/@tailwindcss-node/src/compile.ts
@@ -125,6 +125,7 @@ export async function loadModule(
 
     let module = await importModule(pathToFileURL(resolvedPath).href)
     return {
+      path: resolvedPath,
       base: path.dirname(resolvedPath),
       module: module.default ?? module,
     }
@@ -144,6 +145,7 @@ export async function loadModule(
     onDependency(file)
   }
   return {
+    path: resolvedPath,
     base: path.dirname(resolvedPath),
     module: module.default ?? module,
   }
@@ -164,6 +166,7 @@ async function loadStylesheet(
     let file = await globalThis.__tw_readFile(resolvedPath, 'utf-8')
     if (file) {
       return {
+        path: resolvedPath,
         base: path.dirname(resolvedPath),
         content: file,
       }
@@ -172,6 +175,7 @@ async function loadStylesheet(
 
   let file = await fsPromises.readFile(resolvedPath, 'utf-8')
   return {
+    path: resolvedPath,
     base: path.dirname(resolvedPath),
     content: file,
   }

--- a/packages/@tailwindcss-node/src/compile.ts
+++ b/packages/@tailwindcss-node/src/compile.ts
@@ -21,6 +21,7 @@ export type Resolver = (id: string, base: string) => Promise<string | false | un
 
 export interface CompileOptions {
   base: string
+  from?: string
   onDependency: (path: string) => void
   shouldRewriteUrls?: boolean
   polyfills?: Polyfills
@@ -31,6 +32,7 @@ export interface CompileOptions {
 
 function createCompileOptions({
   base,
+  from,
   polyfills,
   onDependency,
   shouldRewriteUrls,
@@ -41,6 +43,7 @@ function createCompileOptions({
   return {
     base,
     polyfills,
+    from,
     async loadModule(id: string, base: string) {
       return loadModule(id, base, onDependency, customJsResolver)
     },

--- a/packages/@tailwindcss-node/src/compile.ts
+++ b/packages/@tailwindcss-node/src/compile.ts
@@ -2,7 +2,7 @@ import EnhancedResolve from 'enhanced-resolve'
 import { createJiti, type Jiti } from 'jiti'
 import fs from 'node:fs'
 import fsPromises from 'node:fs/promises'
-import path, { dirname } from 'node:path'
+import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import {
   __unstable__loadDesignSystem as ___unstable__loadDesignSystem,
@@ -125,7 +125,7 @@ export async function loadModule(
 
     let module = await importModule(pathToFileURL(resolvedPath).href)
     return {
-      base: dirname(resolvedPath),
+      base: path.dirname(resolvedPath),
       module: module.default ?? module,
     }
   }
@@ -144,7 +144,7 @@ export async function loadModule(
     onDependency(file)
   }
   return {
-    base: dirname(resolvedPath),
+    base: path.dirname(resolvedPath),
     module: module.default ?? module,
   }
 }

--- a/packages/@tailwindcss-node/src/index.cts
+++ b/packages/@tailwindcss-node/src/index.cts
@@ -5,6 +5,7 @@ export * from './compile'
 export * from './instrumentation'
 export * from './normalize-path'
 export * from './optimize'
+export * from './source-maps'
 export { env }
 
 // In Bun, ESM modules will also populate `require.cache`, so the module hook is

--- a/packages/@tailwindcss-node/src/index.ts
+++ b/packages/@tailwindcss-node/src/index.ts
@@ -5,6 +5,7 @@ export * from './compile'
 export * from './instrumentation'
 export * from './normalize-path'
 export * from './optimize'
+export * from './source-maps'
 export { env }
 
 // In Bun, ESM modules will also populate `require.cache`, so the module hook is

--- a/packages/@tailwindcss-node/src/optimize.ts
+++ b/packages/@tailwindcss-node/src/optimize.ts
@@ -16,7 +16,7 @@ export interface OptimizeOptions {
   /**
    * The output source map before optimization
    *
-   * If omitted an resulting source map will not be available
+   * If omitted a resulting source map will not be available
    */
   map?: string
 }

--- a/packages/@tailwindcss-node/src/optimize.ts
+++ b/packages/@tailwindcss-node/src/optimize.ts
@@ -1,4 +1,6 @@
+import remapping from '@ampproject/remapping'
 import { Features, transform } from 'lightningcss'
+import MagicString from 'magic-string'
 
 export interface OptimizeOptions {
   /**
@@ -10,22 +12,31 @@ export interface OptimizeOptions {
    * Enabled minified output
    */
   minify?: boolean
+
+  /**
+   * The output source map before optimization
+   *
+   * If omitted an resulting source map will not be available
+   */
+  map?: string
 }
 
 export interface TransformResult {
   code: string
+  map: string | undefined
 }
 
 export function optimize(
   input: string,
-  { file = 'input.css', minify = false }: OptimizeOptions = {},
+  { file = 'input.css', minify = false, map }: OptimizeOptions = {},
 ): TransformResult {
-  function optimize(code: Buffer | Uint8Array) {
+  function optimize(code: Buffer | Uint8Array, map: string | undefined) {
     return transform({
       filename: file,
       code,
       minify,
-      sourceMap: false,
+      sourceMap: typeof map !== 'undefined',
+      inputSourceMap: map,
       drafts: {
         customMedia: true,
       },
@@ -46,13 +57,34 @@ export function optimize(
 
   // Running Lightning CSS twice to ensure that adjacent rules are merged after
   // nesting is applied. This creates a more optimized output.
-  let result = optimize(Buffer.from(input))
-  result = optimize(result.code)
+  let result = optimize(Buffer.from(input), map)
+  map = result.map?.toString()
+
+  result = optimize(result.code, map)
+  map = result.map?.toString()
 
   let code = result.code.toString()
-  code = code.replaceAll('@media not (', '@media not all and (')
+
+  // Work around an issue where the media query range syntax transpilation
+  // generates code that is invalid with `@media` queries level 3.
+  let magic = new MagicString(code)
+  magic.replaceAll('@media not (', '@media not all and (')
+
+  // We have to use a source-map-preserving method of replacing the content
+  // which requires the use of Magic String + remapping(…) to make sure
+  // the resulting map is correct
+  if (map !== undefined && magic.hasChanged()) {
+    let magicMap = magic.generateMap({ source: 'original', hires: 'boundary' }).toString()
+
+    let remapped = remapping([magicMap, map], () => null)
+
+    map = remapped.toString()
+  }
+
+  code = magic.toString()
 
   return {
     code,
+    map,
   }
 }

--- a/packages/@tailwindcss-node/src/source-maps.ts
+++ b/packages/@tailwindcss-node/src/source-maps.ts
@@ -1,0 +1,59 @@
+import { SourceMapGenerator } from 'source-map-js'
+import type { DecodedSource, DecodedSourceMap } from '../../tailwindcss/src/source-maps/source-map'
+import { DefaultMap } from '../../tailwindcss/src/utils/default-map'
+
+export type { DecodedSource, DecodedSourceMap }
+export interface SourceMap {
+  readonly raw: string
+  readonly inline: string
+}
+
+function serializeSourceMap(map: DecodedSourceMap): string {
+  let generator = new SourceMapGenerator()
+
+  let id = 1
+  let sourceTable = new DefaultMap<
+    DecodedSource | null,
+    {
+      url: string
+      content: string
+    }
+  >((src) => {
+    return {
+      url: src?.url ?? `<unknown ${id}>`,
+      content: src?.content ?? '<none>',
+    }
+  })
+
+  for (let mapping of map.mappings) {
+    let original = sourceTable.get(mapping.originalPosition?.source ?? null)
+
+    generator.addMapping({
+      generated: mapping.generatedPosition,
+      original: mapping.originalPosition,
+      source: original.url,
+      name: mapping.name,
+    })
+
+    generator.setSourceContent(original.url, original.content)
+  }
+
+  return generator.toString()
+}
+
+export function toSourceMap(map: DecodedSourceMap | string): SourceMap {
+  let raw = typeof map === 'string' ? map : serializeSourceMap(map)
+
+  return {
+    raw,
+    get inline() {
+      let tmp = ''
+
+      tmp += '/*# sourceMappingURL=data:application/json;base64,'
+      tmp += Buffer.from(raw, 'utf-8').toString('base64')
+      tmp += ' */\n'
+
+      return tmp
+    },
+  }
+}

--- a/packages/@tailwindcss-node/src/source-maps.ts
+++ b/packages/@tailwindcss-node/src/source-maps.ts
@@ -20,7 +20,7 @@ function serializeSourceMap(map: DecodedSourceMap): string {
     }
   >((src) => {
     return {
-      url: src?.url ?? `<unknown ${id}>`,
+      url: src?.url ?? `<unknown ${id++}>`,
       content: src?.content ?? '<none>',
     }
   })

--- a/packages/@tailwindcss-postcss/src/ast.ts
+++ b/packages/@tailwindcss-postcss/src/ast.ts
@@ -1,16 +1,53 @@
 import postcss, {
+  Input,
   type ChildNode as PostCssChildNode,
   type Container as PostCssContainerNode,
   type Root as PostCssRoot,
   type Source as PostcssSource,
 } from 'postcss'
 import { atRule, comment, decl, rule, type AstNode } from '../../tailwindcss/src/ast'
+import { createLineTable, type LineTable } from '../../tailwindcss/src/source-maps/line-table'
+import type { Source, SourceLocation } from '../../tailwindcss/src/source-maps/source'
+import { DefaultMap } from '../../tailwindcss/src/utils/default-map'
 
 const EXCLAMATION_MARK = 0x21
 
 export function cssAstToPostCssAst(ast: AstNode[], source: PostcssSource | undefined): PostCssRoot {
+  let inputMap = new DefaultMap<Source, Input>((src) => {
+    return new Input(src.code, {
+      map: source?.input.map,
+      from: src.file ?? undefined,
+    })
+  })
+
+  let lineTables = new DefaultMap<Source, LineTable>((src) => createLineTable(src.code))
+
   let root = postcss.root()
   root.source = source
+
+  function toSource(loc: SourceLocation | undefined): PostcssSource | undefined {
+    // Use the fallback if this node has no location info in the AST
+    if (!loc) return
+    if (!loc[0]) return
+
+    let table = lineTables.get(loc[0])
+    let start = table.find(loc[1])
+    let end = table.find(loc[2])
+
+    return {
+      input: inputMap.get(loc[0]),
+      start: {
+        line: start.line,
+        column: start.column + 1,
+        offset: loc[1],
+      },
+      end: {
+        line: end.line,
+        column: end.column + 1,
+        offset: loc[2],
+      },
+    }
+  }
 
   function transform(node: AstNode, parent: PostCssContainerNode) {
     // Declaration
@@ -20,14 +57,14 @@ export function cssAstToPostCssAst(ast: AstNode[], source: PostcssSource | undef
         value: node.value ?? '',
         important: node.important,
       })
-      astNode.source = source
+      astNode.source = toSource(node.src)
       parent.append(astNode)
     }
 
     // Rule
     else if (node.kind === 'rule') {
       let astNode = postcss.rule({ selector: node.selector })
-      astNode.source = source
+      astNode.source = toSource(node.src)
       astNode.raws.semicolon = true
       parent.append(astNode)
       for (let child of node.nodes) {
@@ -38,7 +75,7 @@ export function cssAstToPostCssAst(ast: AstNode[], source: PostcssSource | undef
     // AtRule
     else if (node.kind === 'at-rule') {
       let astNode = postcss.atRule({ name: node.name.slice(1), params: node.params })
-      astNode.source = source
+      astNode.source = toSource(node.src)
       astNode.raws.semicolon = true
       parent.append(astNode)
       for (let child of node.nodes) {
@@ -53,7 +90,7 @@ export function cssAstToPostCssAst(ast: AstNode[], source: PostcssSource | undef
       // spaces.
       astNode.raws.left = ''
       astNode.raws.right = ''
-      astNode.source = source
+      astNode.source = toSource(node.src)
       parent.append(astNode)
     }
 
@@ -75,18 +112,38 @@ export function cssAstToPostCssAst(ast: AstNode[], source: PostcssSource | undef
 }
 
 export function postCssAstToCssAst(root: PostCssRoot): AstNode[] {
+  let inputMap = new DefaultMap<Input, Source>((input) => ({
+    file: input.file ?? input.id ?? null,
+    code: input.css,
+  }))
+
+  function toSource(node: PostCssChildNode): SourceLocation | undefined {
+    let source = node.source
+    if (!source) return
+
+    let input = source.input
+    if (!input) return
+    if (source.start === undefined) return
+    if (source.end === undefined) return
+
+    return [inputMap.get(input), source.start.offset, source.end.offset]
+  }
+
   function transform(
     node: PostCssChildNode,
     parent: Extract<AstNode, { nodes: AstNode[] }>['nodes'],
   ) {
     // Declaration
     if (node.type === 'decl') {
-      parent.push(decl(node.prop, node.value, node.important))
+      let astNode = decl(node.prop, node.value, node.important)
+      astNode.src = toSource(node)
+      parent.push(astNode)
     }
 
     // Rule
     else if (node.type === 'rule') {
       let astNode = rule(node.selector)
+      astNode.src = toSource(node)
       node.each((child) => transform(child, astNode.nodes))
       parent.push(astNode)
     }
@@ -94,6 +151,7 @@ export function postCssAstToCssAst(root: PostCssRoot): AstNode[] {
     // AtRule
     else if (node.type === 'atrule') {
       let astNode = atRule(`@${node.name}`, node.params)
+      astNode.src = toSource(node)
       node.each((child) => transform(child, astNode.nodes))
       parent.push(astNode)
     }
@@ -101,7 +159,9 @@ export function postCssAstToCssAst(root: PostCssRoot): AstNode[] {
     // Comment
     else if (node.type === 'comment') {
       if (node.text.charCodeAt(0) !== EXCLAMATION_MARK) return
-      parent.push(comment(node.text))
+      let astNode = comment(node.text)
+      astNode.src = toSource(node)
+      parent.push(astNode)
     }
 
     // Unknown

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -282,13 +282,13 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
                 DEBUG && I.end('AST -> CSS')
 
                 DEBUG && I.start('Lightning CSS')
-                let ast = optimizeCss(css, {
+                let optimized = optimizeCss(css, {
                   minify: typeof optimize === 'object' ? optimize.minify : true,
                 })
                 DEBUG && I.end('Lightning CSS')
 
                 DEBUG && I.start('CSS -> PostCSS AST')
-                context.optimizedPostCssAst = postcss.parse(ast, result.opts)
+                context.optimizedPostCssAst = postcss.parse(optimized.code, result.opts)
                 DEBUG && I.end('CSS -> PostCSS AST')
 
                 DEBUG && I.end('Optimization')

--- a/packages/@tailwindcss-postcss/src/index.ts
+++ b/packages/@tailwindcss-postcss/src/index.ts
@@ -121,6 +121,7 @@ function tailwindcss(opts: PluginOptions = {}): AcceptedPlugin {
 
             DEBUG && I.start('Create compiler')
             let compiler = await compileAst(ast, {
+              from: result.opts.from,
               base: inputBasePath,
               shouldRewriteUrls: true,
               onDependency: (path) => context.fullRebuildPaths.push(path),

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -106,7 +106,9 @@ export default function tailwindcss(): Plugin[] {
         DEBUG && I.end('[@tailwindcss/vite] Generate CSS (build)')
 
         DEBUG && I.start('[@tailwindcss/vite] Optimize CSS')
-        result.code = optimize(result.code, { minify })
+        result = optimize(result.code, {
+          minify,
+        })
         DEBUG && I.end('[@tailwindcss/vite] Optimize CSS')
 
         return result

--- a/packages/tailwindcss/package.json
+++ b/packages/tailwindcss/package.json
@@ -127,9 +127,12 @@
     "utilities.css"
   ],
   "devDependencies": {
+    "@ampproject/remapping": "^2.3.0",
     "@tailwindcss/oxide": "workspace:^",
     "@types/node": "catalog:",
+    "dedent": "1.5.3",
     "lightningcss": "catalog:",
-    "dedent": "1.5.3"
+    "magic-string": "^0.30.17",
+    "source-map-js": "^1.2.1"
   }
 }

--- a/packages/tailwindcss/src/apply.ts
+++ b/packages/tailwindcss/src/apply.ts
@@ -2,6 +2,7 @@ import { Features } from '.'
 import { rule, toCss, walk, WalkAction, type AstNode } from './ast'
 import { compileCandidates } from './compile'
 import type { DesignSystem } from './design-system'
+import type { SourceLocation } from './source-maps/source'
 import { DefaultMap } from './utils/default-map'
 
 export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
@@ -159,24 +160,56 @@ export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
     walk(parent.nodes, (child, { replaceWith }) => {
       if (child.kind !== 'at-rule' || child.name !== '@apply') return
 
-      let candidates = child.params.split(/\s+/g)
+      let parts = child.params.split(/(\s+)/g)
+      let candidateOffsets: Record<string, number> = {}
+
+      let offset = 0
+      for (let [idx, part] of parts.entries()) {
+        if (idx % 2 === 0) candidateOffsets[part] = offset
+        offset += part.length
+      }
 
       // Replace the `@apply` rule with the actual utility classes
       {
         // Parse the candidates to an AST that we can replace the `@apply` rule
         // with.
+        let candidates = Object.keys(candidateOffsets)
         let compiled = compileCandidates(candidates, designSystem, {
           onInvalidCandidate: (candidate) => {
             throw new Error(`Cannot apply unknown utility class: ${candidate}`)
           },
         })
 
-        let src = node.src
-        let candidateAst = compiled.astNodes
+        let src = child.src
 
-        walk(candidateAst, (node) => {
-          node.src = src
+        let details = compiled.astNodes.map((node) => {
+          let candidate = compiled.nodeSorting.get(node)?.candidate
+          let candidateOffset = candidate ? candidateOffsets[candidate] : undefined
+
+          node = structuredClone(node)
+
+          if (!src || !candidate || candidateOffset === undefined) {
+            return { node, src }
+          }
+
+          let candidateSrc: SourceLocation = [src[0], src[1], src[2]]
+
+          candidateSrc[1] += 7 + candidateOffset
+          candidateSrc[2] = candidateSrc[1] + candidate.length
+
+          return { node: structuredClone(node), src: candidateSrc }
         })
+
+        for (let { node, src } of details) {
+          // While the original nodes may have come from an `@utility` we still
+          // want to replace the source because the `@apply` is ultimately the
+          // reason the node was emitted into the AST.
+          walk([node], (node) => {
+            node.src = src
+          })
+        }
+
+        let candidateAst = details.map((d) => d.node)
 
         // Collect the nodes to insert in place of the `@apply` rule. When a rule
         // was used, we want to insert its children instead of the rule because we

--- a/packages/tailwindcss/src/apply.ts
+++ b/packages/tailwindcss/src/apply.ts
@@ -165,11 +165,13 @@ export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
       {
         // Parse the candidates to an AST that we can replace the `@apply` rule
         // with.
-        let candidateAst = compileCandidates(candidates, designSystem, {
+        let compiled = compileCandidates(candidates, designSystem, {
           onInvalidCandidate: (candidate) => {
             throw new Error(`Cannot apply unknown utility class: ${candidate}`)
           },
-        }).astNodes
+        })
+
+        let candidateAst = compiled.astNodes
 
         // Collect the nodes to insert in place of the `@apply` rule. When a rule
         // was used, we want to insert its children instead of the rule because we

--- a/packages/tailwindcss/src/apply.ts
+++ b/packages/tailwindcss/src/apply.ts
@@ -171,7 +171,12 @@ export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
           },
         })
 
+        let src = node.src
         let candidateAst = compiled.astNodes
+
+        walk(candidateAst, (node) => {
+          node.src = src
+        })
 
         // Collect the nodes to insert in place of the `@apply` rule. When a rule
         // was used, we want to insert its children instead of the rule because we

--- a/packages/tailwindcss/src/apply.ts
+++ b/packages/tailwindcss/src/apply.ts
@@ -201,7 +201,7 @@ export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
 
           let candidateSrc: SourceLocation = [src[0], src[1], src[2]]
 
-          candidateSrc[1] += 7 + candidateOffset
+          candidateSrc[1] += 7 /* '@apply '.length */ + candidateOffset
           candidateSrc[2] = candidateSrc[1] + candidate.length
 
           // While the original nodes may have come from an `@utility` we still

--- a/packages/tailwindcss/src/apply.ts
+++ b/packages/tailwindcss/src/apply.ts
@@ -197,7 +197,7 @@ export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
           candidateSrc[1] += 7 + candidateOffset
           candidateSrc[2] = candidateSrc[1] + candidate.length
 
-          return { node: structuredClone(node), src: candidateSrc }
+          return { node, src: candidateSrc }
         })
 
         for (let { node, src } of details) {

--- a/packages/tailwindcss/src/ast.bench.ts
+++ b/packages/tailwindcss/src/ast.bench.ts
@@ -1,0 +1,28 @@
+import { bench } from 'vitest'
+import { toCss } from './ast'
+import * as CSS from './css-parser'
+
+const css = String.raw
+const input = css`
+  @theme {
+    --color-primary: #333;
+  }
+  @tailwind utilities;
+  .foo {
+    color: red;
+    /* comment */
+    &:hover {
+      color: blue;
+      @apply font-bold;
+    }
+  }
+`
+const ast = CSS.parse(input)
+
+bench('toCss', () => {
+  toCss(ast)
+})
+
+bench('toCss with source maps', () => {
+  toCss(ast, true)
+})

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -398,6 +398,7 @@ export function optimizeAst(
         }
 
         let fallback = decl(property, initialValue ?? 'initial')
+        fallback.src = node.src
 
         if (inherits) {
           propertyFallbacksRoot.push(fallback)
@@ -644,6 +645,7 @@ export function optimizeAst(
           value: ValueParser.toCss(ast),
         }
         let colorMixQuery = rule('@supports (color: color-mix(in lab, red, red))', [declaration])
+        colorMixQuery.src = declaration.src
         parent.splice(idx, 1, fallback, colorMixQuery)
       }
     }
@@ -654,11 +656,13 @@ export function optimizeAst(
 
     if (propertyFallbacksRoot.length > 0) {
       let wrapper = rule(':root, :host', propertyFallbacksRoot)
+      wrapper.src = propertyFallbacksRoot[0].src
       fallbackAst.push(wrapper)
     }
 
     if (propertyFallbacksUniversal.length > 0) {
       let wrapper = rule('*, ::before, ::after, ::backdrop', propertyFallbacksUniversal)
+      wrapper.src = propertyFallbacksUniversal[0].src
       fallbackAst.push(wrapper)
     }
 
@@ -682,6 +686,7 @@ export function optimizeAst(
       })
 
       let layerPropertiesStatement = atRule('@layer', 'properties', [])
+      layerPropertiesStatement.src = fallbackAst[0].src
 
       newAst.splice(
         firstValidNodeIndex < 0 ? newAst.length : firstValidNodeIndex,
@@ -698,6 +703,9 @@ export function optimizeAst(
           fallbackAst,
         ),
       ])
+
+      block.src = fallbackAst[0].src
+      block.nodes[0].src = fallbackAst[0].src
 
       newAst.push(block)
     }

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -714,7 +714,14 @@ export function optimizeAst(
   return newAst
 }
 
-export function toCss(ast: AstNode[]) {
+export function toCss(ast: AstNode[], track?: boolean) {
+  let pos = 0
+
+  let source: Source = {
+    file: null,
+    code: '',
+  }
+
   function stringify(node: AstNode, depth = 0): string {
     let css = ''
     let indent = '  '.repeat(depth)
@@ -722,15 +729,70 @@ export function toCss(ast: AstNode[]) {
     // Declaration
     if (node.kind === 'declaration') {
       css += `${indent}${node.property}: ${node.value}${node.important ? ' !important' : ''};\n`
+
+      if (track) {
+        // indent
+        pos += indent.length
+
+        // node.property
+        let start = pos
+        pos += node.property.length
+
+        // `: `
+        pos += 2
+
+        // node.value
+        pos += node.value?.length ?? 0
+
+        // !important
+        if (node.important) {
+          pos += 11
+        }
+
+        let end = pos
+
+        // `;\n`
+        pos += 2
+
+        node.dst = [source, start, end]
+      }
     }
 
     // Rule
     else if (node.kind === 'rule') {
       css += `${indent}${node.selector} {\n`
+
+      if (track) {
+        // indent
+        pos += indent.length
+
+        // node.selector
+        let start = pos
+        pos += node.selector.length
+
+        // ` `
+        pos += 1
+
+        let end = pos
+        node.dst = [source, start, end]
+
+        // `{\n`
+        pos += 2
+      }
+
       for (let child of node.nodes) {
         css += stringify(child, depth + 1)
       }
+
       css += `${indent}}\n`
+
+      if (track) {
+        // indent
+        pos += indent.length
+
+        // `}\n`
+        pos += 2
+      }
     }
 
     // AtRule
@@ -744,19 +806,93 @@ export function toCss(ast: AstNode[]) {
       // ```
       if (node.nodes.length === 0) {
         let css = `${indent}${node.name} ${node.params};\n`
+
+        if (track) {
+          // indent
+          pos += indent.length
+
+          // node.name
+          let start = pos
+          pos += node.name.length
+
+          // ` `
+          pos += 1
+
+          // node.params
+          pos += node.params.length
+          let end = pos
+
+          // `;\n`
+          pos += 2
+
+          node.dst = [source, start, end]
+        }
+
         return css
       }
 
       css += `${indent}${node.name}${node.params ? ` ${node.params} ` : ' '}{\n`
+
+      if (track) {
+        // indent
+        pos += indent.length
+
+        // node.name
+        let start = pos
+        pos += node.name.length
+
+        if (node.params) {
+          // ` `
+          pos += 1
+
+          // node.params
+          pos += node.params.length
+        }
+
+        // ` `
+        pos += 1
+
+        let end = pos
+        node.dst = [source, start, end]
+
+        // `{\n`
+        pos += 2
+      }
+
       for (let child of node.nodes) {
         css += stringify(child, depth + 1)
       }
+
       css += `${indent}}\n`
+
+      if (track) {
+        // indent
+        pos += indent.length
+
+        // `}\n`
+        pos += 2
+      }
     }
 
     // Comment
     else if (node.kind === 'comment') {
       css += `${indent}/*${node.value}*/\n`
+
+      if (track) {
+        // indent
+        pos += indent.length
+
+        // The comment itself. We do this instead of just the inside because
+        // it seems more useful to have the entire comment span tracked.
+        let start = pos
+        pos += 2 + node.value.length + 2
+        let end = pos
+
+        node.dst = [source, start, end]
+
+        // `\n`
+        pos += 1
+      }
     }
 
     // These should've been handled already by `optimizeAst` which
@@ -779,6 +915,8 @@ export function toCss(ast: AstNode[]) {
   for (let node of ast) {
     css += stringify(node, 0)
   }
+
+  source.code = css
 
   return css
 }

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -1,6 +1,7 @@
 import { Polyfills } from '.'
 import { parseAtRule } from './css-parser'
 import type { DesignSystem } from './design-system'
+import type { Source, SourceLocation } from './source-maps/source'
 import { Theme, ThemeOptions } from './theme'
 import { DefaultMap } from './utils/default-map'
 import { extractUsedVariables } from './utils/variables'
@@ -12,6 +13,9 @@ export type StyleRule = {
   kind: 'rule'
   selector: string
   nodes: AstNode[]
+
+  src?: SourceLocation
+  dst?: SourceLocation
 }
 
 export type AtRule = {
@@ -19,6 +23,9 @@ export type AtRule = {
   name: string
   params: string
   nodes: AstNode[]
+
+  src?: SourceLocation
+  dst?: SourceLocation
 }
 
 export type Declaration = {
@@ -26,22 +33,34 @@ export type Declaration = {
   property: string
   value: string | undefined
   important: boolean
+
+  src?: SourceLocation
+  dst?: SourceLocation
 }
 
 export type Comment = {
   kind: 'comment'
   value: string
+
+  src?: SourceLocation
+  dst?: SourceLocation
 }
 
 export type Context = {
   kind: 'context'
   context: Record<string, string | boolean>
   nodes: AstNode[]
+
+  src?: undefined
+  dst?: undefined
 }
 
 export type AtRoot = {
   kind: 'at-root'
   nodes: AstNode[]
+
+  src?: undefined
+  dst?: undefined
 }
 
 export type Rule = StyleRule | AtRule

--- a/packages/tailwindcss/src/at-import.ts
+++ b/packages/tailwindcss/src/at-import.ts
@@ -57,6 +57,7 @@ export async function substituteAtImports(
           await substituteAtImports(ast, loaded.base, loadStylesheet, recurseCount + 1, track)
 
           contextNode.nodes = buildImportNodes(
+            node,
             [context({ base: loaded.base }, ast)],
             layer,
             media,
@@ -148,6 +149,7 @@ export function parseImportParams(params: ValueParser.ValueAstNode[]) {
 }
 
 function buildImportNodes(
+  importNode: AstNode,
   importedAst: AstNode[],
   layer: string | null,
   media: string | null,
@@ -157,16 +159,19 @@ function buildImportNodes(
 
   if (layer !== null) {
     let node = atRule('@layer', layer, root)
+    node.src = importNode.src
     root = [node]
   }
 
   if (media !== null) {
     let node = atRule('@media', media, root)
+    node.src = importNode.src
     root = [node]
   }
 
   if (supports !== null) {
     let node = atRule('@supports', supports[0] === '(' ? supports : `(${supports})`, root)
+    node.src = importNode.src
     root = [node]
   }
 

--- a/packages/tailwindcss/src/at-import.ts
+++ b/packages/tailwindcss/src/at-import.ts
@@ -17,6 +17,7 @@ export async function substituteAtImports(
   base: string,
   loadStylesheet: LoadStylesheet,
   recurseCount = 0,
+  track = false,
 ) {
   let features = Features.None
   let promises: Promise<void>[] = []
@@ -52,8 +53,8 @@ export async function substituteAtImports(
           }
 
           let loaded = await loadStylesheet(uri, base)
-          let ast = CSS.parse(loaded.content)
-          await substituteAtImports(ast, loaded.base, loadStylesheet, recurseCount + 1)
+          let ast = CSS.parse(loaded.content, { from: track ? loaded.path : undefined })
+          await substituteAtImports(ast, loaded.base, loadStylesheet, recurseCount + 1, track)
 
           contextNode.nodes = buildImportNodes(
             [context({ base: loaded.base }, ast)],

--- a/packages/tailwindcss/src/at-import.ts
+++ b/packages/tailwindcss/src/at-import.ts
@@ -7,6 +7,7 @@ type LoadStylesheet = (
   id: string,
   basedir: string,
 ) => Promise<{
+  path: string
   base: string
   content: string
 }>

--- a/packages/tailwindcss/src/at-import.ts
+++ b/packages/tailwindcss/src/at-import.ts
@@ -3,7 +3,13 @@ import { atRule, context, walk, WalkAction, type AstNode } from './ast'
 import * as CSS from './css-parser'
 import * as ValueParser from './value-parser'
 
-type LoadStylesheet = (id: string, basedir: string) => Promise<{ base: string; content: string }>
+type LoadStylesheet = (
+  id: string,
+  basedir: string,
+) => Promise<{
+  base: string
+  content: string
+}>
 
 export async function substituteAtImports(
   ast: AstNode[],
@@ -148,15 +154,18 @@ function buildImportNodes(
   let root = importedAst
 
   if (layer !== null) {
-    root = [atRule('@layer', layer, root)]
+    let node = atRule('@layer', layer, root)
+    root = [node]
   }
 
   if (media !== null) {
-    root = [atRule('@media', media, root)]
+    let node = atRule('@media', media, root)
+    root = [node]
   }
 
   if (supports !== null) {
-    root = [atRule('@supports', supports[0] === '(' ? supports : `(${supports})`, root)]
+    let node = atRule('@supports', supports[0] === '(' ? supports : `(${supports})`, root)
+    root = [node]
   }
 
   return root

--- a/packages/tailwindcss/src/compat/apply-compat-hooks.ts
+++ b/packages/tailwindcss/src/compat/apply-compat-hooks.ts
@@ -30,7 +30,10 @@ export async function applyCompatibilityHooks({
     path: string,
     base: string,
     resourceHint: 'plugin' | 'config',
-  ) => Promise<{ module: any; base: string }>
+  ) => Promise<{
+    base: string
+    module: any
+  }>
   sources: { base: string; pattern: string; negated: boolean }[]
 }) {
   let features = Features.None

--- a/packages/tailwindcss/src/compat/apply-compat-hooks.ts
+++ b/packages/tailwindcss/src/compat/apply-compat-hooks.ts
@@ -31,6 +31,7 @@ export async function applyCompatibilityHooks({
     base: string,
     resourceHint: 'plugin' | 'config',
   ) => Promise<{
+    path: string
     base: string
     module: any
   }>

--- a/packages/tailwindcss/src/compat/config.test.ts
+++ b/packages/tailwindcss/src/compat/config.test.ts
@@ -1156,6 +1156,7 @@ test('utilities must be prefixed', async () => {
 
   let compiler = await compile(input, {
     loadModule: async (id, base) => ({
+      path: '',
       base,
       module: { prefix: 'tw' },
     }),
@@ -1183,6 +1184,7 @@ test('utilities must be prefixed', async () => {
   // Non-prefixed utilities are ignored
   compiler = await compile(input, {
     loadModule: async (id, base) => ({
+      path: '',
       base,
       module: { prefix: 'tw' },
     }),
@@ -1202,6 +1204,7 @@ test('utilities used in @apply must be prefixed', async () => {
     `,
     {
       loadModule: async (id, base) => ({
+        path: '',
         base,
         module: { prefix: 'tw' },
       }),
@@ -1228,6 +1231,7 @@ test('utilities used in @apply must be prefixed', async () => {
       `,
       {
         loadModule: async (id, base) => ({
+          path: '',
           base,
           module: { prefix: 'tw' },
         }),
@@ -1258,6 +1262,7 @@ test('Prefixes configured in CSS take precedence over those defined in JS config
     {
       async loadModule(id, base) {
         return {
+          path: '',
           base,
           module: { prefix: 'tw' },
         }
@@ -1282,6 +1287,7 @@ test('a prefix must be letters only', async () => {
       {
         async loadModule(id, base) {
           return {
+            path: '',
             base,
             module: { prefix: '__' },
           }
@@ -1305,6 +1311,7 @@ test('important: `#app`', async () => {
 
   let compiler = await compile(input, {
     loadModule: async (_, base) => ({
+      path: '',
       base,
       module: { important: '#app' },
     }),
@@ -1342,6 +1349,7 @@ test('important: true', async () => {
 
   let compiler = await compile(input, {
     loadModule: async (_, base) => ({
+      path: '',
       base,
       module: { important: true },
     }),
@@ -1378,6 +1386,7 @@ test('blocklisted candidates are not generated', async () => {
     {
       async loadModule(id, base) {
         return {
+          path: '',
           base,
           module: {
             blocklist: ['bg-white'],
@@ -1421,6 +1430,7 @@ test('blocklisted candidates cannot be used with `@apply`', async () => {
       {
         async loadModule(id, base) {
           return {
+            path: '',
             base,
             module: {
               blocklist: ['bg-white'],
@@ -1473,6 +1483,7 @@ test('old theme values are merged with their renamed counterparts in the CSS the
     {
       async loadModule(id, base) {
         return {
+          path: '',
           base,
           module: plugin(function ({ theme }) {
             didCallPluginFn()

--- a/packages/tailwindcss/src/compat/plugin-api.test.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.test.ts
@@ -17,6 +17,7 @@ describe('theme', async () => {
     let compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(
             function ({ addBase, theme }) {
@@ -80,6 +81,7 @@ describe('theme', async () => {
     let compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(function ({ addUtilities, theme }) {
             addUtilities({
@@ -116,6 +118,7 @@ describe('theme', async () => {
     let compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(
             function ({ matchUtilities, theme }) {
@@ -164,6 +167,7 @@ describe('theme', async () => {
     let compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(
             function ({ matchUtilities, theme }) {
@@ -211,6 +215,7 @@ describe('theme', async () => {
     let compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(
             function ({ matchUtilities, theme }) {
@@ -265,6 +270,7 @@ describe('theme', async () => {
     let compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(function ({ addUtilities, theme }) {
             addUtilities({
@@ -313,6 +319,7 @@ describe('theme', async () => {
     let compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(
             function ({ addUtilities, theme }) {
@@ -398,6 +405,7 @@ describe('theme', async () => {
     let compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(
             function ({ matchUtilities, theme }) {
@@ -452,6 +460,7 @@ describe('theme', async () => {
     let compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(
             function ({ matchUtilities, theme }) {
@@ -499,6 +508,7 @@ describe('theme', async () => {
     let compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(function ({ matchUtilities, theme }) {
             matchUtilities(
@@ -557,6 +567,7 @@ describe('theme', async () => {
     let compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(
             function ({ matchUtilities, theme }) {
@@ -611,6 +622,7 @@ describe('theme', async () => {
     let compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(
             function ({ matchUtilities, theme }) {
@@ -660,6 +672,7 @@ describe('theme', async () => {
     await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(
             function ({ theme }) {
@@ -695,6 +708,7 @@ describe('theme', async () => {
     let { build } = await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(function ({ matchUtilities, theme }) {
             function utility(name: string, themeKey: string) {
@@ -942,6 +956,7 @@ describe('theme', async () => {
     await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(
             ({ theme }) => {
@@ -984,6 +999,7 @@ describe('theme', async () => {
     await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(({ theme }) => {
             fn(theme('transitionTimingFunction.DEFAULT'))
@@ -1015,6 +1031,7 @@ describe('theme', async () => {
     await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(({ theme }) => {
             fn(theme('color.red.100'))
@@ -1043,6 +1060,7 @@ describe('theme', async () => {
     await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(({ theme }) => {
             fn(theme('i.do.not.exist'))
@@ -1069,6 +1087,7 @@ describe('theme', async () => {
     let { build } = await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(({ addUtilities, matchUtilities }) => {
             addUtilities({
@@ -1124,6 +1143,7 @@ describe('theme', async () => {
     let { build } = await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(function ({ matchUtilities }) {
             function utility(name: string, themeKey: string) {
@@ -1342,6 +1362,7 @@ describe('theme', async () => {
     let compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(
             function ({ matchUtilities, theme }) {
@@ -1400,6 +1421,7 @@ describe('theme', async () => {
     let compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(function ({ matchUtilities, theme }) {
             matchUtilities(
@@ -1446,6 +1468,7 @@ describe('theme', async () => {
     let compiler = await compile(input, {
       loadModule: async (id, base) => {
         return {
+          path: '',
           base,
           module: plugin(
             function ({ matchUtilities, theme }) {
@@ -1493,6 +1516,7 @@ describe('addBase', () => {
       loadModule: async (id, base) => {
         if (id === 'inside') {
           return {
+            path: '',
             base,
             module: plugin(function ({ addBase }) {
               addBase({ inside: { color: 'red' } })
@@ -1500,6 +1524,7 @@ describe('addBase', () => {
           }
         }
         return {
+          path: '',
           base,
           module: plugin(function ({ addBase }) {
             addBase({ outside: { color: 'red' } })
@@ -1508,6 +1533,7 @@ describe('addBase', () => {
       },
       async loadStylesheet() {
         return {
+          path: '',
           base: '',
           content: css`
             @plugin "inside";
@@ -1533,6 +1559,7 @@ describe('addBase', () => {
 
     let compiler = await compile(input, {
       loadModule: async () => ({
+        path: '',
         base: '/root',
         module: plugin(function ({ addBase }) {
           addBase({
@@ -1571,6 +1598,7 @@ describe('addVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ addVariant }: PluginAPI) => {
               addVariant('hocus', '&:hover, &:focus')
@@ -1605,6 +1633,7 @@ describe('addVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ addVariant }: PluginAPI) => {
               addVariant('hocus', ['&:hover', '&:focus'])
@@ -1640,6 +1669,7 @@ describe('addVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ addVariant }: PluginAPI) => {
               addVariant('hocus', {
@@ -1677,6 +1707,7 @@ describe('addVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ addVariant }: PluginAPI) => {
               addVariant('hocus', {
@@ -1728,6 +1759,7 @@ describe('addVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ addVariant }: PluginAPI) => {
               addVariant(
@@ -1769,6 +1801,7 @@ describe('addVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ addVariant }: PluginAPI) => {
               addVariant('hocus', {
@@ -1811,6 +1844,7 @@ describe('matchVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ matchVariant }: PluginAPI) => {
               matchVariant('potato', (flavor) => `.potato-${flavor} &`)
@@ -1845,6 +1879,7 @@ describe('matchVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ matchVariant }: PluginAPI) => {
               matchVariant('potato', (flavor) => `@media (potato: ${flavor})`)
@@ -1883,6 +1918,7 @@ describe('matchVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ matchVariant }: PluginAPI) => {
               matchVariant(
@@ -1929,6 +1965,7 @@ describe('matchVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ matchVariant }: PluginAPI) => {
               matchVariant('tooltip', (side) => `&${side}`, {
@@ -1968,6 +2005,7 @@ describe('matchVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ matchVariant }: PluginAPI) => {
               matchVariant('alphabet', (side) => `&${side}`, {
@@ -2010,6 +2048,7 @@ describe('matchVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ matchVariant }: PluginAPI) => {
               matchVariant('test', (selector) =>
@@ -2042,6 +2081,7 @@ describe('matchVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ matchVariant }: PluginAPI) => {
               matchVariant('testmin', (value) => `@media (min-width: ${value})`, {
@@ -2094,6 +2134,7 @@ describe('matchVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ matchVariant }: PluginAPI) => {
               matchVariant('testmin', (value) => `@media (min-width: ${value})`, {
@@ -2149,6 +2190,7 @@ describe('matchVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ matchVariant }: PluginAPI) => {
               matchVariant('testmin', (value) => `@media (min-width: ${value})`, {
@@ -2221,6 +2263,7 @@ describe('matchVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ matchVariant }: PluginAPI) => {
               matchVariant('testmin', (value) => `@media (min-width: ${value})`, {
@@ -2275,6 +2318,7 @@ describe('matchVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ matchVariant }: PluginAPI) => {
               matchVariant('testmin', (value) => `@media (min-width: ${value})`, {
@@ -2347,6 +2391,7 @@ describe('matchVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ matchVariant }: PluginAPI) => {
               matchVariant('testmin', (value) => `@media (min-width: ${value})`, {
@@ -2415,6 +2460,7 @@ describe('matchVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ matchVariant }: PluginAPI) => {
               matchVariant('testmin', (value) => `@media (min-width: ${value})`, {
@@ -2495,6 +2541,7 @@ describe('matchVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ matchVariant }: PluginAPI) => {
               matchVariant('foo', (value) => `.foo${value} &`, {
@@ -2529,6 +2576,7 @@ describe('matchVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ matchVariant }: PluginAPI) => {
               matchVariant('foo', (value) => `.foo${value} &`)
@@ -2553,6 +2601,7 @@ describe('matchVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ matchVariant }: PluginAPI) => {
               matchVariant('foo', (value) => `.foo${value === null ? '-good' : '-bad'} &`, {
@@ -2585,6 +2634,7 @@ describe('matchVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ matchVariant }: PluginAPI) => {
               matchVariant('foo', (value) => `.foo${value === undefined ? '-good' : '-bad'} &`, {
@@ -2615,6 +2665,7 @@ describe('matchVariant', () => {
       {
         loadModule: async (id, base) => {
           return {
+            path: '',
             base,
             module: ({ matchVariant }: PluginAPI) => {
               matchVariant('my-container', (value, { modifier }) => {
@@ -2669,6 +2720,7 @@ describe('addUtilities()', () => {
       {
         async loadModule(id, base) {
           return {
+            path: '',
             base,
             module: ({ addUtilities }: PluginAPI) => {
               addUtilities({
@@ -2710,6 +2762,7 @@ describe('addUtilities()', () => {
       {
         async loadModule(id, base) {
           return {
+            path: '',
             base,
             module: ({ addUtilities }: PluginAPI) => {
               addUtilities([
@@ -2743,6 +2796,7 @@ describe('addUtilities()', () => {
       {
         async loadModule(id, base) {
           return {
+            path: '',
             base,
             module: ({ addUtilities }: PluginAPI) => {
               addUtilities([
@@ -2782,6 +2836,7 @@ describe('addUtilities()', () => {
       {
         async loadModule(id, base) {
           return {
+            path: '',
             base,
             module: ({ addUtilities }: PluginAPI) => {
               addUtilities([
@@ -2816,6 +2871,7 @@ describe('addUtilities()', () => {
       {
         async loadModule(id, base) {
           return {
+            path: '',
             base,
             module: ({ addUtilities }: PluginAPI) => {
               addUtilities({
@@ -2857,6 +2913,7 @@ describe('addUtilities()', () => {
       {
         async loadModule(id, base) {
           return {
+            path: '',
             base,
             module: ({ addUtilities }: PluginAPI) => {
               addUtilities({
@@ -2913,6 +2970,7 @@ describe('addUtilities()', () => {
         {
           async loadModule(id, base) {
             return {
+              path: '',
               base,
               module: ({ addUtilities }: PluginAPI) => {
                 addUtilities({
@@ -2942,6 +3000,7 @@ describe('addUtilities()', () => {
       {
         async loadModule(id, base) {
           return {
+            path: '',
             base,
             module: ({ addUtilities }: PluginAPI) => {
               addUtilities({
@@ -2985,6 +3044,7 @@ describe('addUtilities()', () => {
       {
         async loadModule(id, base) {
           return {
+            path: '',
             base,
             module: ({ addUtilities }: PluginAPI) => {
               addUtilities({
@@ -3026,6 +3086,7 @@ describe('addUtilities()', () => {
       {
         async loadModule(id, base) {
           return {
+            path: '',
             base,
             module: ({ addUtilities }: PluginAPI) => {
               addUtilities({
@@ -3122,6 +3183,7 @@ describe('addUtilities()', () => {
       {
         async loadModule(id, base) {
           return {
+            path: '',
             base,
             module: ({ addUtilities }: PluginAPI) => {
               addUtilities({
@@ -3175,6 +3237,7 @@ describe('addUtilities()', () => {
       {
         async loadModule(id, base) {
           return {
+            path: '',
             base,
             module: ({ addUtilities }: PluginAPI) => {
               addUtilities({
@@ -3240,6 +3303,7 @@ describe('matchUtilities()', () => {
         {
           async loadModule(id, base) {
             return {
+              path: '',
               base,
               module: ({ matchUtilities }: PluginAPI) => {
                 matchUtilities(
@@ -3320,6 +3384,7 @@ describe('matchUtilities()', () => {
         {
           async loadModule(id, base) {
             return {
+              path: '',
               base,
               module: ({ matchUtilities }: PluginAPI) => {
                 matchUtilities(
@@ -3361,6 +3426,7 @@ describe('matchUtilities()', () => {
       {
         async loadModule(id, base) {
           return {
+            path: '',
             base,
             module: ({ matchUtilities }: PluginAPI) => {
               matchUtilities(
@@ -3410,6 +3476,7 @@ describe('matchUtilities()', () => {
         {
           async loadModule(id, base) {
             return {
+              path: '',
               base,
               module: ({ matchUtilities }: PluginAPI) => {
                 matchUtilities(
@@ -3480,6 +3547,7 @@ describe('matchUtilities()', () => {
         {
           async loadModule(id, base) {
             return {
+              path: '',
               base,
               module: ({ matchUtilities }: PluginAPI) => {
                 matchUtilities(
@@ -3554,6 +3622,7 @@ describe('matchUtilities()', () => {
           {
             async loadModule(id, base) {
               return {
+                path: '',
                 base,
                 module: ({ matchUtilities }: PluginAPI) => {
                   matchUtilities(
@@ -3609,6 +3678,7 @@ describe('matchUtilities()', () => {
           {
             async loadModule(id, base) {
               return {
+                path: '',
                 base,
                 module: ({ matchUtilities }: PluginAPI) => {
                   matchUtilities(
@@ -3647,6 +3717,7 @@ describe('matchUtilities()', () => {
           {
             async loadModule(id, base) {
               return {
+                path: '',
                 base,
                 module: ({ matchUtilities }: PluginAPI) => {
                   matchUtilities(
@@ -3691,6 +3762,7 @@ describe('matchUtilities()', () => {
         {
           async loadModule(id, base) {
             return {
+              path: '',
               base,
               module: ({ matchUtilities }: PluginAPI) => {
                 matchUtilities(
@@ -3818,6 +3890,7 @@ describe('matchUtilities()', () => {
         {
           async loadModule(id, base) {
             return {
+              path: '',
               base,
               module: ({ matchUtilities }: PluginAPI) => {
                 matchUtilities(
@@ -3903,6 +3976,7 @@ describe('matchUtilities()', () => {
         {
           async loadModule(id, base) {
             return {
+              path: '',
               base,
               module: ({ matchUtilities }: PluginAPI) => {
                 matchUtilities(
@@ -3961,6 +4035,7 @@ describe('matchUtilities()', () => {
       {
         async loadModule(id, base) {
           return {
+            path: '',
             base,
             module: ({ matchUtilities }: PluginAPI) => {
               matchUtilities(
@@ -4028,6 +4103,7 @@ describe('matchUtilities()', () => {
         {
           async loadModule(id, base) {
             return {
+              path: '',
               base,
               module: ({ matchUtilities }: PluginAPI) => {
                 matchUtilities({
@@ -4056,6 +4132,7 @@ describe('matchUtilities()', () => {
       {
         async loadModule(base) {
           return {
+            path: '',
             base,
             module: ({ matchUtilities }: PluginAPI) => {
               matchUtilities(
@@ -4122,6 +4199,7 @@ describe('addComponents()', () => {
       {
         async loadModule(id, base) {
           return {
+            path: '',
             base,
             module: ({ addComponents }: PluginAPI) => {
               addComponents({
@@ -4190,6 +4268,7 @@ describe('matchComponents()', () => {
       {
         async loadModule(id, base) {
           return {
+            path: '',
             base,
             module: ({ matchComponents }: PluginAPI) => {
               matchComponents(
@@ -4235,6 +4314,7 @@ describe('prefix()', () => {
       {
         async loadModule(id, base) {
           return {
+            path: '',
             base,
             module: ({ prefix }: PluginAPI) => {
               fn(prefix('btn'))
@@ -4258,6 +4338,7 @@ describe('config()', () => {
       {
         async loadModule(id, base) {
           return {
+            path: '',
             base,
             module: ({ config }: PluginAPI) => {
               fn(config())
@@ -4285,6 +4366,7 @@ describe('config()', () => {
       {
         async loadModule(id, base) {
           return {
+            path: '',
             base,
             module: ({ config }: PluginAPI) => {
               fn(config('theme'))
@@ -4310,6 +4392,7 @@ describe('config()', () => {
       {
         async loadModule(id, base) {
           return {
+            path: '',
             base,
             module: ({ config }: PluginAPI) => {
               fn(config('somekey', 'defaultvalue'))

--- a/packages/tailwindcss/src/compat/plugin-api.test.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.test.ts
@@ -1508,10 +1508,10 @@ describe('addBase', () => {
       },
       async loadStylesheet() {
         return {
+          base: '',
           content: css`
             @plugin "inside";
           `,
-          base: '',
         }
       },
     })
@@ -1533,6 +1533,7 @@ describe('addBase', () => {
 
     let compiler = await compile(input, {
       loadModule: async () => ({
+        base: '/root',
         module: plugin(function ({ addBase }) {
           addBase({
             ':root': {
@@ -1542,7 +1543,6 @@ describe('addBase', () => {
             },
           })
         }),
-        base: '/root',
       }),
     })
 

--- a/packages/tailwindcss/src/css-functions.test.ts
+++ b/packages/tailwindcss/src/css-functions.test.ts
@@ -412,6 +412,7 @@ describe('--theme(…)', () => {
         [],
         {
           loadModule: async () => ({
+            path: '',
             base: '/root',
             module: () => {},
           }),
@@ -772,6 +773,7 @@ describe('theme(…)', () => {
             `,
             {
               loadModule: async () => ({
+                path: '',
                 base: '/root',
                 module: {},
               }),
@@ -1199,6 +1201,7 @@ describe('in plugins', () => {
       {
         async loadModule() {
           return {
+            path: '',
             base: '/root',
             module: plugin(({ addBase, addUtilities }) => {
               addBase({
@@ -1256,6 +1259,7 @@ describe('in JS config files', () => {
       `,
       {
         loadModule: async () => ({
+          path: '',
           base: '/root',
           module: {
             theme: {
@@ -1317,6 +1321,7 @@ test('replaces CSS theme() function with values inside imported stylesheets', as
       {
         async loadStylesheet() {
           return {
+            path: '',
             base: '/bar.css',
             content: css`
               .red {

--- a/packages/tailwindcss/src/css-functions.test.ts
+++ b/packages/tailwindcss/src/css-functions.test.ts
@@ -412,8 +412,8 @@ describe('--theme(…)', () => {
         [],
         {
           loadModule: async () => ({
-            module: () => {},
             base: '/root',
+            module: () => {},
           }),
         },
       ),
@@ -771,7 +771,10 @@ describe('theme(…)', () => {
               }
             `,
             {
-              loadModule: async () => ({ module: {}, base: '/root' }),
+              loadModule: async () => ({
+                base: '/root',
+                module: {},
+              }),
             },
           )
 
@@ -1196,6 +1199,7 @@ describe('in plugins', () => {
       {
         async loadModule() {
           return {
+            base: '/root',
             module: plugin(({ addBase, addUtilities }) => {
               addBase({
                 '.my-base-rule': {
@@ -1212,7 +1216,6 @@ describe('in plugins', () => {
                 },
               })
             }),
-            base: '/root',
           }
         },
       },
@@ -1253,6 +1256,7 @@ describe('in JS config files', () => {
       `,
       {
         loadModule: async () => ({
+          base: '/root',
           module: {
             theme: {
               extend: {
@@ -1279,7 +1283,6 @@ describe('in JS config files', () => {
               }),
             ],
           },
-          base: '/root',
         }),
       },
     )

--- a/packages/tailwindcss/src/css-parser.bench.ts
+++ b/packages/tailwindcss/src/css-parser.bench.ts
@@ -10,3 +10,7 @@ const cssFile = readFileSync(currentFolder + './preflight.css', 'utf-8')
 bench('css-parser on preflight.css', () => {
   CSS.parse(cssFile)
 })
+
+bench('CSS with sourcemaps', () => {
+  CSS.parse(cssFile, { from: 'input.css' })
+})

--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -86,7 +86,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
           kind: 'comment',
           value: `!
             * License #2
-            `,
+            `.replaceAll(/\r?\n/g, lineEndings === 'Windows' ? '\r\n' : '\n'),
         },
       ])
     })
@@ -368,7 +368,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
               background-color: red;
               /* A comment */
               content: 'Hello, world!';
-            }`,
+            }`.replaceAll(/\r?\n/g, lineEndings === 'Windows' ? '\r\n' : '\n'),
             important: false,
           },
         ])
@@ -396,7 +396,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
               background-color: red;
               /* A comment ; */
               content: 'Hello, world!';
-            }`,
+            }`.replaceAll(/\r?\n/g, lineEndings === 'Windows' ? '\r\n' : '\n'),
             important: false,
           },
           {
@@ -406,7 +406,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
               background-color: red;
               /* A comment } */
               content: 'Hello, world!';
-            }`,
+            }`.replaceAll(/\r?\n/g, lineEndings === 'Windows' ? '\r\n' : '\n'),
             important: false,
           },
         ])

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -36,7 +36,6 @@ export function parse(input: string) {
   // *before* processing do NOT change the length of the string. This
   // would invalidate the mechanism used to track source locations.
   if (input[0] === '\uFEFF') input = ' ' + input.slice(1)
-  input = input.replaceAll('\r\n', ' \n')
 
   let ast: AstNode[] = []
   let licenseComments: Comment[] = []

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -159,7 +159,11 @@ export function parse(input: string) {
         //                                    ^ Missing "
         // }
         // ```
-        else if (peekChar === SEMICOLON && input.charCodeAt(j + 1) === LINE_BREAK) {
+        else if (
+          peekChar === SEMICOLON &&
+          (input.charCodeAt(j + 1) === LINE_BREAK ||
+            (input.charCodeAt(j + 1) === CARRIAGE_RETURN && input.charCodeAt(j + 2) === LINE_BREAK))
+        ) {
           throw new Error(
             `Unterminated string: ${input.slice(start, j + 1) + String.fromCharCode(currentChar)}`,
           )
@@ -175,7 +179,10 @@ export function parse(input: string) {
         //                                    ^ Missing "
         // }
         // ```
-        else if (peekChar === LINE_BREAK) {
+        else if (
+          peekChar === LINE_BREAK ||
+          (peekChar === CARRIAGE_RETURN && input.charCodeAt(j + 1) === LINE_BREAK)
+        ) {
           throw new Error(
             `Unterminated string: ${input.slice(start, j) + String.fromCharCode(currentChar)}`,
           )

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -191,7 +191,12 @@ export function parse(input: string) {
     else if (
       (currentChar === SPACE || currentChar === LINE_BREAK || currentChar === TAB) &&
       (peekChar = input.charCodeAt(i + 1)) &&
-      (peekChar === SPACE || peekChar === LINE_BREAK || peekChar === TAB)
+      (peekChar === SPACE ||
+        peekChar === LINE_BREAK ||
+        peekChar === TAB ||
+        (peekChar === CARRIAGE_RETURN &&
+          (peekChar = input.charCodeAt(i + 2)) &&
+          peekChar == LINE_BREAK))
     ) {
       continue
     }

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -18,6 +18,7 @@ const SINGLE_QUOTE = 0x27
 const COLON = 0x3a
 const SEMICOLON = 0x3b
 const LINE_BREAK = 0x0a
+const CARRIAGE_RETURN = 0xd
 const SPACE = 0x20
 const TAB = 0x09
 const OPEN_CURLY = 0x7b
@@ -52,6 +53,14 @@ export function parse(input: string) {
 
   for (let i = 0; i < input.length; i++) {
     let currentChar = input.charCodeAt(i)
+
+    // Skip over the CR in CRLF. This allows code below to only check for a line
+    // break even if we're looking at a Windows newline. Peeking the input still
+    // has to check for CRLF but that happens less often.
+    if (currentChar === CARRIAGE_RETURN) {
+      peekChar = input.charCodeAt(i + 1)
+      if (peekChar === LINE_BREAK) continue
+    }
 
     // Current character is a `\` therefore the next character is escaped,
     // consume it together with the next character and continue.

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -126,11 +126,11 @@ describe('compiling CSS', () => {
         {
           async loadStylesheet(id) {
             return {
+              base: '',
               content: fs.readFileSync(
                 path.resolve(__dirname, '..', id === 'tailwindcss' ? 'index.css' : id),
                 'utf-8',
               ),
-              base: '',
             }
           },
         },
@@ -2398,6 +2398,7 @@ describe('Parsing theme values from CSS', () => {
         {
           async loadStylesheet() {
             return {
+              base: '',
               content: css`
                 @theme {
                   --color-tomato: #e10c04;
@@ -2407,7 +2408,6 @@ describe('Parsing theme values from CSS', () => {
 
                 @tailwind utilities;
               `,
-              base: '',
             }
           },
         },
@@ -2485,6 +2485,7 @@ describe('Parsing theme values from CSS', () => {
         {
           async loadStylesheet() {
             return {
+              base: '',
               content: css`
                 @theme {
                   --color-tomato: #e10c04;
@@ -2494,7 +2495,6 @@ describe('Parsing theme values from CSS', () => {
 
                 @tailwind utilities;
               `,
-              base: '',
             }
           },
         },
@@ -2782,6 +2782,7 @@ describe('Parsing theme values from CSS', () => {
       {
         loadModule: async () => {
           return {
+            base: '/root',
             module: plugin(({}) => {}, {
               theme: {
                 extend: {
@@ -2792,7 +2793,6 @@ describe('Parsing theme values from CSS', () => {
                 },
               },
             }),
-            base: '/root',
           }
         },
       },
@@ -2828,6 +2828,7 @@ describe('Parsing theme values from CSS', () => {
       {
         loadModule: async () => {
           return {
+            base: '/root',
             module: {
               theme: {
                 extend: {
@@ -2838,7 +2839,6 @@ describe('Parsing theme values from CSS', () => {
                 },
               },
             },
-            base: '/root',
           }
         },
       },
@@ -2917,10 +2917,10 @@ describe('plugins', () => {
         `,
         {
           loadModule: async () => ({
+            base: '/root',
             module: ({ addVariant }: PluginAPI) => {
               addVariant('hocus', '&:hover, &:focus')
             },
-            base: '/root',
           }),
         },
       ),
@@ -2935,10 +2935,10 @@ describe('plugins', () => {
         `,
         {
           loadModule: async () => ({
+            base: '/root',
             module: ({ addVariant }: PluginAPI) => {
               addVariant('hocus', '&:hover, &:focus')
             },
-            base: '/root',
           }),
         },
       ),
@@ -2955,10 +2955,10 @@ describe('plugins', () => {
         `,
         {
           loadModule: async () => ({
+            base: '/root',
             module: ({ addVariant }: PluginAPI) => {
               addVariant('hocus', '&:hover, &:focus')
             },
-            base: '/root',
           }),
         },
       ),
@@ -2977,6 +2977,7 @@ describe('plugins', () => {
       `,
       {
         loadModule: async () => ({
+          base: '/root',
           module: plugin.withOptions((options) => {
             expect(options).toEqual({
               color: 'red',
@@ -2990,7 +2991,6 @@ describe('plugins', () => {
               })
             }
           }),
-          base: '/root',
         }),
       },
     )
@@ -3029,6 +3029,7 @@ describe('plugins', () => {
       `,
       {
         loadModule: async () => ({
+          base: '/root',
           module: plugin.withOptions((options) => {
             expect(options).toEqual({
               'is-null': null,
@@ -3049,7 +3050,6 @@ describe('plugins', () => {
 
             return () => {}
           }),
-          base: '/root',
         }),
       },
     )
@@ -3069,6 +3069,7 @@ describe('plugins', () => {
         `,
         {
           loadModule: async () => ({
+            base: '/root',
             module: plugin.withOptions((options) => {
               return ({ addUtilities }) => {
                 addUtilities({
@@ -3078,7 +3079,6 @@ describe('plugins', () => {
                 })
               }
             }),
-            base: '/root',
           }),
         },
       ),
@@ -3107,6 +3107,7 @@ describe('plugins', () => {
         `,
         {
           loadModule: async () => ({
+            base: '/root',
             module: plugin(({ addUtilities }) => {
               addUtilities({
                 '.text-primary': {
@@ -3114,7 +3115,6 @@ describe('plugins', () => {
                 },
               })
             }),
-            base: '/root',
           }),
         },
       ),
@@ -3132,7 +3132,10 @@ describe('plugins', () => {
           }
         `,
         {
-          loadModule: async () => ({ module: plugin(() => {}), base: '/root' }),
+          loadModule: async () => ({
+            base: '/root',
+            module: plugin(() => {}),
+          }),
         },
       ),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -3153,7 +3156,10 @@ describe('plugins', () => {
           }
         `,
         {
-          loadModule: async () => ({ module: plugin(() => {}), base: '/root' }),
+          loadModule: async () => ({
+            base: '/root',
+            module: plugin(() => {}),
+          }),
         },
       ),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`
@@ -3177,10 +3183,10 @@ describe('plugins', () => {
       `,
       {
         loadModule: async () => ({
+          base: '/root',
           module: ({ addVariant }: PluginAPI) => {
             addVariant('hocus', '&:hover, &:focus')
           },
-          base: '/root',
         }),
       },
     )
@@ -3209,10 +3215,10 @@ describe('plugins', () => {
       `,
       {
         loadModule: async () => ({
+          base: '/root',
           module: ({ addVariant }: PluginAPI) => {
             addVariant('hocus', ['&:hover', '&:focus'])
           },
-          base: '/root',
         }),
       },
     )
@@ -3242,13 +3248,13 @@ describe('plugins', () => {
       `,
       {
         loadModule: async () => ({
+          base: '/root',
           module: ({ addVariant }: PluginAPI) => {
             addVariant('hocus', {
               '&:hover': '@slot',
               '&:focus': '@slot',
             })
           },
-          base: '/root',
         }),
       },
     )
@@ -3277,6 +3283,7 @@ describe('plugins', () => {
       `,
       {
         loadModule: async () => ({
+          base: '/root',
           module: ({ addVariant }: PluginAPI) => {
             addVariant('hocus', {
               '@media (hover: hover)': {
@@ -3285,7 +3292,6 @@ describe('plugins', () => {
               '&:focus': '@slot',
             })
           },
-          base: '/root',
         }),
       },
     )
@@ -3326,6 +3332,7 @@ describe('plugins', () => {
       `,
       {
         loadModule: async () => ({
+          base: '/root',
           module: ({ addVariant }: PluginAPI) => {
             addVariant('hocus', {
               '&': {
@@ -3335,7 +3342,6 @@ describe('plugins', () => {
               },
             })
           },
-          base: '/root',
         }),
       },
     )
@@ -3364,10 +3370,10 @@ describe('plugins', () => {
       `,
       {
         loadModule: async () => ({
+          base: '/root',
           module: ({ addVariant }: PluginAPI) => {
             addVariant('dark', '&:is([data-theme=dark] *)')
           },
-          base: '/root',
         }),
       },
     )
@@ -4220,6 +4226,7 @@ test('addBase', async () => {
     `,
     {
       loadModule: async () => ({
+        base: '/root',
         module: ({ addBase }: PluginAPI) => {
           addBase({
             body: {
@@ -4227,7 +4234,6 @@ test('addBase', async () => {
             },
           })
         },
-        base: '/root',
       }),
     },
   )
@@ -4279,6 +4285,7 @@ describe('`@reference "…" imports`', () => {
     let loadStylesheet = async (id: string, base: string) => {
       if (id === './foo/baz.css') {
         return {
+          base: '/root/foo',
           content: css`
             .foo {
               color: red;
@@ -4291,14 +4298,13 @@ describe('`@reference "…" imports`', () => {
             }
             @custom-variant hocus (&:hover, &:focus);
           `,
-          base: '/root/foo',
         }
       }
       return {
+        base: '/root/foo',
         content: css`
           @import './foo/baz.css';
         `,
-        base: '/root/foo',
       }
     }
 
@@ -4327,19 +4333,19 @@ describe('`@reference "…" imports`', () => {
     let loadStylesheet = async (id: string, base: string) => {
       if (id === './foo/baz.css') {
         return {
+          base: '/root/foo',
           content: css`
             @layer utilities {
               @tailwind utilities;
             }
           `,
-          base: '/root/foo',
         }
       }
       return {
+        base: '/root/foo',
         content: css`
           @import './foo/baz.css';
         `,
-        base: '/root/foo',
       }
     }
 
@@ -4389,6 +4395,7 @@ describe('`@reference "…" imports`', () => {
         ['animate-spin', 'match-utility-initial', 'match-components-initial'],
         {
           loadModule: async () => ({
+            base: '/root',
             module: ({
               addBase,
               addUtilities,
@@ -4422,7 +4429,6 @@ describe('`@reference "…" imports`', () => {
                 { values: { initial: 'initial' } },
               )
             },
-            base: '/root',
           }),
         },
       ),
@@ -4444,22 +4450,23 @@ describe('`@reference "…" imports`', () => {
       switch (id) {
         case './one.css': {
           return {
+            base: '/root',
             content: css`
               @import './two.css' layer(two);
             `,
-            base: '/root',
           }
         }
         case './two.css': {
           return {
+            base: '/root',
             content: css`
               @import './three.css' layer(three);
             `,
-            base: '/root',
           }
         }
         case './three.css': {
           return {
+            base: '/root',
             content: css`
               .foo {
                 color: red;
@@ -4478,10 +4485,11 @@ describe('`@reference "…" imports`', () => {
                 }
               }
             `,
-            base: '/root',
           }
         }
       }
+
+      throw new Error('unreachable')
     }
 
     await expect(
@@ -4516,6 +4524,7 @@ describe('`@reference "…" imports`', () => {
   test('supports `@import "…" reference` syntax', async () => {
     let loadStylesheet = async () => {
       return {
+        base: '/root/foo',
         content: css`
           .foo {
             color: red;
@@ -4528,7 +4537,6 @@ describe('`@reference "…" imports`', () => {
           }
           @custom-variant hocus (&:hover, &:focus);
         `,
-        base: '/root/foo',
       }
     }
 

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -126,6 +126,7 @@ describe('compiling CSS', () => {
         {
           async loadStylesheet(id) {
             return {
+              path: '',
               base: '',
               content: fs.readFileSync(
                 path.resolve(__dirname, '..', id === 'tailwindcss' ? 'index.css' : id),
@@ -401,6 +402,7 @@ describe('@apply', () => {
         {
           async loadStylesheet() {
             return {
+              path: '',
               base: '/bar.css',
               content: css`
                 .foo {
@@ -2398,6 +2400,7 @@ describe('Parsing theme values from CSS', () => {
         {
           async loadStylesheet() {
             return {
+              path: '',
               base: '',
               content: css`
                 @theme {
@@ -2485,6 +2488,7 @@ describe('Parsing theme values from CSS', () => {
         {
           async loadStylesheet() {
             return {
+              path: '',
               base: '',
               content: css`
                 @theme {
@@ -2782,6 +2786,7 @@ describe('Parsing theme values from CSS', () => {
       {
         loadModule: async () => {
           return {
+            path: '',
             base: '/root',
             module: plugin(({}) => {}, {
               theme: {
@@ -2828,6 +2833,7 @@ describe('Parsing theme values from CSS', () => {
       {
         loadModule: async () => {
           return {
+            path: '',
             base: '/root',
             module: {
               theme: {
@@ -2917,6 +2923,7 @@ describe('plugins', () => {
         `,
         {
           loadModule: async () => ({
+            path: '',
             base: '/root',
             module: ({ addVariant }: PluginAPI) => {
               addVariant('hocus', '&:hover, &:focus')
@@ -2935,6 +2942,7 @@ describe('plugins', () => {
         `,
         {
           loadModule: async () => ({
+            path: '',
             base: '/root',
             module: ({ addVariant }: PluginAPI) => {
               addVariant('hocus', '&:hover, &:focus')
@@ -2955,6 +2963,7 @@ describe('plugins', () => {
         `,
         {
           loadModule: async () => ({
+            path: '',
             base: '/root',
             module: ({ addVariant }: PluginAPI) => {
               addVariant('hocus', '&:hover, &:focus')
@@ -2977,6 +2986,7 @@ describe('plugins', () => {
       `,
       {
         loadModule: async () => ({
+          path: '',
           base: '/root',
           module: plugin.withOptions((options) => {
             expect(options).toEqual({
@@ -3029,6 +3039,7 @@ describe('plugins', () => {
       `,
       {
         loadModule: async () => ({
+          path: '',
           base: '/root',
           module: plugin.withOptions((options) => {
             expect(options).toEqual({
@@ -3069,6 +3080,7 @@ describe('plugins', () => {
         `,
         {
           loadModule: async () => ({
+            path: '',
             base: '/root',
             module: plugin.withOptions((options) => {
               return ({ addUtilities }) => {
@@ -3107,6 +3119,7 @@ describe('plugins', () => {
         `,
         {
           loadModule: async () => ({
+            path: '',
             base: '/root',
             module: plugin(({ addUtilities }) => {
               addUtilities({
@@ -3133,6 +3146,7 @@ describe('plugins', () => {
         `,
         {
           loadModule: async () => ({
+            path: '',
             base: '/root',
             module: plugin(() => {}),
           }),
@@ -3157,6 +3171,7 @@ describe('plugins', () => {
         `,
         {
           loadModule: async () => ({
+            path: '',
             base: '/root',
             module: plugin(() => {}),
           }),
@@ -3183,6 +3198,7 @@ describe('plugins', () => {
       `,
       {
         loadModule: async () => ({
+          path: '',
           base: '/root',
           module: ({ addVariant }: PluginAPI) => {
             addVariant('hocus', '&:hover, &:focus')
@@ -3215,6 +3231,7 @@ describe('plugins', () => {
       `,
       {
         loadModule: async () => ({
+          path: '',
           base: '/root',
           module: ({ addVariant }: PluginAPI) => {
             addVariant('hocus', ['&:hover', '&:focus'])
@@ -3248,6 +3265,7 @@ describe('plugins', () => {
       `,
       {
         loadModule: async () => ({
+          path: '',
           base: '/root',
           module: ({ addVariant }: PluginAPI) => {
             addVariant('hocus', {
@@ -3283,6 +3301,7 @@ describe('plugins', () => {
       `,
       {
         loadModule: async () => ({
+          path: '',
           base: '/root',
           module: ({ addVariant }: PluginAPI) => {
             addVariant('hocus', {
@@ -3332,6 +3351,7 @@ describe('plugins', () => {
       `,
       {
         loadModule: async () => ({
+          path: '',
           base: '/root',
           module: ({ addVariant }: PluginAPI) => {
             addVariant('hocus', {
@@ -3370,6 +3390,7 @@ describe('plugins', () => {
       `,
       {
         loadModule: async () => ({
+          path: '',
           base: '/root',
           module: ({ addVariant }: PluginAPI) => {
             addVariant('dark', '&:is([data-theme=dark] *)')
@@ -4226,6 +4247,7 @@ test('addBase', async () => {
     `,
     {
       loadModule: async () => ({
+        path: '',
         base: '/root',
         module: ({ addBase }: PluginAPI) => {
           addBase({
@@ -4265,6 +4287,7 @@ it("should error when `layer(…)` is used, but it's not the first param", async
       {
         async loadStylesheet() {
           return {
+            path: '',
             base: '/bar.css',
             content: css`
               .foo {
@@ -4285,6 +4308,7 @@ describe('`@reference "…" imports`', () => {
     let loadStylesheet = async (id: string, base: string) => {
       if (id === './foo/baz.css') {
         return {
+          path: '',
           base: '/root/foo',
           content: css`
             .foo {
@@ -4301,6 +4325,7 @@ describe('`@reference "…" imports`', () => {
         }
       }
       return {
+        path: '',
         base: '/root/foo',
         content: css`
           @import './foo/baz.css';
@@ -4333,6 +4358,7 @@ describe('`@reference "…" imports`', () => {
     let loadStylesheet = async (id: string, base: string) => {
       if (id === './foo/baz.css') {
         return {
+          path: '',
           base: '/root/foo',
           content: css`
             @layer utilities {
@@ -4342,6 +4368,7 @@ describe('`@reference "…" imports`', () => {
         }
       }
       return {
+        path: '',
         base: '/root/foo',
         content: css`
           @import './foo/baz.css';
@@ -4395,6 +4422,7 @@ describe('`@reference "…" imports`', () => {
         ['animate-spin', 'match-utility-initial', 'match-components-initial'],
         {
           loadModule: async () => ({
+            path: '',
             base: '/root',
             module: ({
               addBase,
@@ -4450,6 +4478,7 @@ describe('`@reference "…" imports`', () => {
       switch (id) {
         case './one.css': {
           return {
+            path: '',
             base: '/root',
             content: css`
               @import './two.css' layer(two);
@@ -4458,6 +4487,7 @@ describe('`@reference "…" imports`', () => {
         }
         case './two.css': {
           return {
+            path: '',
             base: '/root',
             content: css`
               @import './three.css' layer(three);
@@ -4466,6 +4496,7 @@ describe('`@reference "…" imports`', () => {
         }
         case './three.css': {
           return {
+            path: '',
             base: '/root',
             content: css`
               .foo {
@@ -4524,6 +4555,7 @@ describe('`@reference "…" imports`', () => {
   test('supports `@import "…" reference` syntax', async () => {
     let loadStylesheet = async () => {
       return {
+        path: '',
         base: '/root/foo',
         content: css`
           .foo {

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -57,6 +57,7 @@ type CompileOptions = {
     base: string,
     resourceHint: 'plugin' | 'config',
   ) => Promise<{
+    path: string
     base: string
     module: Plugin | Config
   }>
@@ -64,6 +65,7 @@ type CompileOptions = {
     id: string,
     base: string,
   ) => Promise<{
+    path: string
     base: string
     content: string
   }>

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -145,7 +145,7 @@ async function parseCss(
   let features = Features.None
   ast = [contextNode({ base }, ast)] as AstNode[]
 
-  features |= await substituteAtImports(ast, base, loadStylesheet)
+  features |= await substituteAtImports(ast, base, loadStylesheet, 0, from !== undefined)
 
   let important = null as boolean | null
   let theme = new Theme()

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -814,7 +814,7 @@ export async function compile(
         return compiledCss
       }
 
-      compiledCss = toCss(newAst)
+      compiledCss = toCss(newAst, !!opts.from)
       compiledAst = newAst
 
       return compiledCss

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -51,6 +51,7 @@ export const enum Polyfills {
 
 type CompileOptions = {
   base?: string
+  from?: string
   polyfills?: Polyfills
   loadModule?: (
     id: string,
@@ -136,6 +137,7 @@ async function parseCss(
   ast: AstNode[],
   {
     base = '',
+    from,
     loadModule = throwOnLoadModule,
     loadStylesheet = throwOnLoadStylesheet,
   }: CompileOptions = {},
@@ -786,7 +788,7 @@ export async function compile(
   features: Features
   build(candidates: string[]): string
 }> {
-  let ast = CSS.parse(css)
+  let ast = CSS.parse(css, { from: opts.from })
   let api = await compileAst(ast, opts)
   let compiledAst = ast
   let compiledCss = css

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -56,8 +56,17 @@ type CompileOptions = {
     id: string,
     base: string,
     resourceHint: 'plugin' | 'config',
-  ) => Promise<{ module: Plugin | Config; base: string }>
-  loadStylesheet?: (id: string, base: string) => Promise<{ content: string; base: string }>
+  ) => Promise<{
+    base: string
+    module: Plugin | Config
+  }>
+  loadStylesheet?: (
+    id: string,
+    base: string,
+  ) => Promise<{
+    base: string
+    content: string
+  }>
 }
 
 function throwOnLoadModule(): never {
@@ -593,8 +602,8 @@ async function parseCss(
 
     for (let [key, value] of designSystem.theme.entries()) {
       if (value.options & ThemeOptions.REFERENCE) continue
-
-      nodes.push(decl(escape(key), value.value))
+      let node = decl(escape(key), value.value)
+      nodes.push(node)
     }
 
     let keyframesRules = designSystem.theme.getKeyframes()

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -541,7 +541,7 @@ async function parseCss(
 
         if (child.kind === 'comment') return
         if (child.kind === 'declaration' && child.property.startsWith('--')) {
-          theme.add(unescape(child.property), child.value ?? '', themeOptions)
+          theme.add(unescape(child.property), child.value ?? '', themeOptions, child.src)
           return
         }
 
@@ -559,6 +559,7 @@ async function parseCss(
       // theme later, and delete any other `@theme` rules.
       if (!firstThemeRule) {
         firstThemeRule = styleRule(':root, :host', [])
+        firstThemeRule.src = node.src
         replaceWith([firstThemeRule])
       } else {
         replaceWith([])
@@ -607,6 +608,7 @@ async function parseCss(
     for (let [key, value] of designSystem.theme.entries()) {
       if (value.options & ThemeOptions.REFERENCE) continue
       let node = decl(escape(key), value.value)
+      node.src = value.src
       nodes.push(node)
     }
 

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -26,6 +26,7 @@ import { applyVariant, compileCandidates } from './compile'
 import { substituteFunctions } from './css-functions'
 import * as CSS from './css-parser'
 import { buildDesignSystem, type DesignSystem } from './design-system'
+import { createSourceMap, type DecodedSourceMap } from './source-maps/source-map'
 import { Theme, ThemeOptions } from './theme'
 import { createCssUtility } from './utilities'
 import { expand } from './utils/brace-expansion'
@@ -791,6 +792,8 @@ export async function compileAst(
   }
 }
 
+export type { DecodedSourceMap }
+
 export async function compile(
   css: string,
   opts: CompileOptions = {},
@@ -799,6 +802,7 @@ export async function compile(
   root: Root
   features: Features
   build(candidates: string[]): string
+  buildSourceMap(): DecodedSourceMap
 }> {
   let ast = CSS.parse(css, { from: opts.from })
   let api = await compileAst(ast, opts)
@@ -818,6 +822,12 @@ export async function compile(
       compiledAst = newAst
 
       return compiledCss
+    },
+
+    buildSourceMap() {
+      return createSourceMap({
+        ast: compiledAst,
+      })
     },
   }
 }

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -763,6 +763,16 @@ export async function compileAst(
         onInvalidCandidate,
       }).astNodes
 
+      if (opts.from) {
+        walk(newNodes, (node) => {
+          // We do this conditionally to preserve source locations from both
+          // `@utility` and `@custom-variant`. Even though generated nodes are
+          // cached this should be fine because `utilitiesNode.src` should not
+          // change without a full rebuild which destroys the cache.
+          node.src ??= utilitiesNode.src
+        })
+      }
+
       // If no new ast nodes were generated, then we can return the original
       // CSS. This currently assumes that we only add new ast nodes and never
       // remove any.

--- a/packages/tailwindcss/src/intellisense.test.ts
+++ b/packages/tailwindcss/src/intellisense.test.ts
@@ -172,10 +172,12 @@ test('Utilities do not show wrapping selector in intellisense', async () => {
 
   let design = await __unstable__loadDesignSystem(input, {
     loadStylesheet: async (_, base) => ({
+      path: '',
       base,
       content: '@tailwind utilities;',
     }),
     loadModule: async () => ({
+      path: '',
       base: '',
       module: {
         important: '#app',
@@ -208,6 +210,7 @@ test('Utilities, when marked as important, show as important in intellisense', a
 
   let design = await __unstable__loadDesignSystem(input, {
     loadStylesheet: async (_, base) => ({
+      path: '',
       base,
       content: '@tailwind utilities;',
     }),
@@ -239,10 +242,12 @@ test('Static utilities from plugins are listed in hovers and completions', async
 
   let design = await __unstable__loadDesignSystem(input, {
     loadStylesheet: async (_, base) => ({
+      path: '',
       base,
       content: '@tailwind utilities;',
     }),
     loadModule: async () => ({
+      path: '',
       base: '',
       module: plugin(({ addUtilities }) => {
         addUtilities({
@@ -274,10 +279,12 @@ test('Functional utilities from plugins are listed in hovers and completions', a
 
   let design = await __unstable__loadDesignSystem(input, {
     loadStylesheet: async (_, base) => ({
+      path: '',
       base,
       content: '@tailwind utilities;',
     }),
     loadModule: async () => ({
+      path: '',
       base: '',
       module: plugin(({ matchUtilities }) => {
         matchUtilities(
@@ -420,10 +427,12 @@ test('Custom at-rule variants do not show up as a value under `group`', async ()
 
   let design = await __unstable__loadDesignSystem(input, {
     loadStylesheet: async (_, base) => ({
+      path: '',
       base,
       content: '@tailwind utilities;',
     }),
     loadModule: async () => ({
+      path: '',
       base: '',
       module: plugin(({ addVariant }) => {
         addVariant('variant-3', '@media baz')
@@ -510,6 +519,7 @@ test('Custom functional @utility', async () => {
 
   let design = await __unstable__loadDesignSystem(input, {
     loadStylesheet: async (_, base) => ({
+      path: '',
       base,
       content: '@tailwind utilities;',
     }),
@@ -587,6 +597,7 @@ test('Theme keys with underscores are suggested with underscores', async () => {
 
   let design = await __unstable__loadDesignSystem(input, {
     loadStylesheet: async (_, base) => ({
+      path: '',
       base,
       content: '@tailwind utilities;',
     }),

--- a/packages/tailwindcss/src/prefix.test.ts
+++ b/packages/tailwindcss/src/prefix.test.ts
@@ -169,6 +169,7 @@ test('JS theme functions do not use the prefix', async () => {
     {
       async loadModule(id, base) {
         return {
+          path: '',
           base,
           module: plugin(({ addUtilities, theme }) => {
             addUtilities({
@@ -206,6 +207,7 @@ test('a prefix can be configured via @import theme(…)', async () => {
   let compiler = await compile(input, {
     async loadStylesheet(id, base) {
       return {
+        path: '',
         base,
         content: css`
           @theme {
@@ -250,6 +252,7 @@ test('a prefix can be configured via @import theme(…)', async () => {
   compiler = await compile(input, {
     async loadStylesheet(id, base) {
       return {
+        path: '',
         base,
         content: css`
           @theme {
@@ -275,6 +278,7 @@ test('a prefix can be configured via @import prefix(…)', async () => {
   let compiler = await compile(input, {
     async loadStylesheet(id, base) {
       return {
+        path: '',
         base,
         content: css`
           @theme {
@@ -314,6 +318,7 @@ test('a prefix can be configured via @import prefix(…)', async () => {
   compiler = await compile(input, {
     async loadStylesheet(id, base) {
       return {
+        path: '',
         base,
         content: css`
           @theme {

--- a/packages/tailwindcss/src/source-maps/line-table.bench.ts
+++ b/packages/tailwindcss/src/source-maps/line-table.bench.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+import { bench } from 'vitest'
+import { createLineTable } from './line-table'
+
+const currentFolder = fileURLToPath(new URL('..', import.meta.url))
+const cssFile = readFileSync(currentFolder + '../preflight.css', 'utf-8')
+const table = createLineTable(cssFile)
+
+bench('line table lookups', () => {
+  for (let i = 0; i < cssFile.length; ++i) table.find(i)
+})

--- a/packages/tailwindcss/src/source-maps/line-table.test.ts
+++ b/packages/tailwindcss/src/source-maps/line-table.test.ts
@@ -1,0 +1,87 @@
+import dedent from 'dedent'
+import { expect, test } from 'vitest'
+import { createLineTable } from './line-table'
+
+const css = dedent
+
+test('line tables', () => {
+  let text = css`
+    .foo {
+      color: red;
+    }
+  `
+
+  let table = createLineTable(`${text}\n`)
+
+  // Line 1: `.foo {\n`
+  expect(table.find(0)).toEqual({ line: 1, column: 0 })
+  expect(table.find(1)).toEqual({ line: 1, column: 1 })
+  expect(table.find(2)).toEqual({ line: 1, column: 2 })
+  expect(table.find(3)).toEqual({ line: 1, column: 3 })
+  expect(table.find(4)).toEqual({ line: 1, column: 4 })
+  expect(table.find(5)).toEqual({ line: 1, column: 5 })
+  expect(table.find(6)).toEqual({ line: 1, column: 6 })
+
+  // Line 2: `  color: red;\n`
+  expect(table.find(6 + 1)).toEqual({ line: 2, column: 0 })
+  expect(table.find(6 + 2)).toEqual({ line: 2, column: 1 })
+  expect(table.find(6 + 3)).toEqual({ line: 2, column: 2 })
+  expect(table.find(6 + 4)).toEqual({ line: 2, column: 3 })
+  expect(table.find(6 + 5)).toEqual({ line: 2, column: 4 })
+  expect(table.find(6 + 6)).toEqual({ line: 2, column: 5 })
+  expect(table.find(6 + 7)).toEqual({ line: 2, column: 6 })
+  expect(table.find(6 + 8)).toEqual({ line: 2, column: 7 })
+  expect(table.find(6 + 9)).toEqual({ line: 2, column: 8 })
+  expect(table.find(6 + 10)).toEqual({ line: 2, column: 9 })
+  expect(table.find(6 + 11)).toEqual({ line: 2, column: 10 })
+  expect(table.find(6 + 12)).toEqual({ line: 2, column: 11 })
+  expect(table.find(6 + 13)).toEqual({ line: 2, column: 12 })
+
+  // Line 3: `}\n`
+  expect(table.find(20 + 1)).toEqual({ line: 3, column: 0 })
+  expect(table.find(20 + 2)).toEqual({ line: 3, column: 1 })
+
+  // After the new line
+  expect(table.find(22 + 1)).toEqual({ line: 4, column: 0 })
+})
+
+test('line tables findOffset', () => {
+  let text = css`
+    .foo {
+      color: red;
+    }
+  `
+
+  let table = createLineTable(`${text}\n`)
+
+  // Line 1: `.foo {\n`
+  expect(table.findOffset({ line: 1, column: 0 })).toEqual(0)
+  expect(table.findOffset({ line: 1, column: 1 })).toEqual(1)
+  expect(table.findOffset({ line: 1, column: 2 })).toEqual(2)
+  expect(table.findOffset({ line: 1, column: 3 })).toEqual(3)
+  expect(table.findOffset({ line: 1, column: 4 })).toEqual(4)
+  expect(table.findOffset({ line: 1, column: 5 })).toEqual(5)
+  expect(table.findOffset({ line: 1, column: 6 })).toEqual(6)
+
+  // Line 2: `  color: red;\n`
+  expect(table.findOffset({ line: 2, column: 0 })).toEqual(6 + 1)
+  expect(table.findOffset({ line: 2, column: 1 })).toEqual(6 + 2)
+  expect(table.findOffset({ line: 2, column: 2 })).toEqual(6 + 3)
+  expect(table.findOffset({ line: 2, column: 3 })).toEqual(6 + 4)
+  expect(table.findOffset({ line: 2, column: 4 })).toEqual(6 + 5)
+  expect(table.findOffset({ line: 2, column: 5 })).toEqual(6 + 6)
+  expect(table.findOffset({ line: 2, column: 6 })).toEqual(6 + 7)
+  expect(table.findOffset({ line: 2, column: 7 })).toEqual(6 + 8)
+  expect(table.findOffset({ line: 2, column: 8 })).toEqual(6 + 9)
+  expect(table.findOffset({ line: 2, column: 9 })).toEqual(6 + 10)
+  expect(table.findOffset({ line: 2, column: 10 })).toEqual(6 + 11)
+  expect(table.findOffset({ line: 2, column: 11 })).toEqual(6 + 12)
+  expect(table.findOffset({ line: 2, column: 12 })).toEqual(6 + 13)
+
+  // Line 3: `}\n`
+  expect(table.findOffset({ line: 3, column: 0 })).toEqual(20 + 1)
+  expect(table.findOffset({ line: 3, column: 1 })).toEqual(20 + 2)
+
+  // After the new line
+  expect(table.findOffset({ line: 4, column: 0 })).toEqual(22 + 1)
+})

--- a/packages/tailwindcss/src/source-maps/line-table.ts
+++ b/packages/tailwindcss/src/source-maps/line-table.ts
@@ -1,0 +1,100 @@
+/**
+ * Line offset tables are the key to generating our source maps. They allow us
+ * to store indexes with our AST nodes and later convert them into positions as
+ * when given the source that the indexes refer to.
+ */
+
+const LINE_BREAK = 0x0a
+
+/**
+ * A position in source code
+ *
+ * https://tc39.es/ecma426/#sec-position-record-type
+ */
+export interface Position {
+  /** The line number, one-based */
+  line: number
+
+  /** The column/character number, one-based */
+  column: number
+}
+
+/**
+ * A table that lets you turn an offset into a line number and column
+ */
+export interface LineTable {
+  /**
+   * Find the line/column position in the source code for a given offset
+   *
+   * Searching for a given offset takes O(log N) time where N is the number of
+   * lines of code.
+   *
+   * @param offset The index for which to find the position
+   */
+  find(offset: number): Position
+
+  /**
+   * Find the most likely byte offset for given a position
+   *
+   * @param offset The position for which to find the byte offset
+   */
+  findOffset(pos: Position): number
+}
+
+/**
+ * Compute a lookup table to allow for efficient line/column lookups based on
+ * offsets in the source code.
+ *
+ * Creating this table is an O(N) operation where N is the length of the source
+ */
+export function createLineTable(source: string): LineTable {
+  let table: number[] = [0]
+
+  // Compute the offsets for the start of each line
+  for (let i = 0; i < source.length; i++) {
+    if (source.charCodeAt(i) === LINE_BREAK) {
+      table.push(i + 1)
+    }
+  }
+
+  function find(offset: number) {
+    // Based on esbuild's binary search for line numbers
+    let line = 0
+    let count = table.length
+    while (count > 0) {
+      // `| 0` causes integer division
+      let mid = (count / 2) | 0
+      let i = line + mid
+      if (table[i] <= offset) {
+        line = i + 1
+        count = count - mid - 1
+      } else {
+        count = mid
+      }
+    }
+
+    line -= 1
+
+    let column = offset - table[line]
+
+    return {
+      line: line + 1,
+      column: column,
+    }
+  }
+
+  function findOffset({ line, column }: Position) {
+    line -= 1
+    line = Math.min(Math.max(line, 0), table.length - 1)
+
+    let offsetA = table[line]
+    let offsetB = table[line + 1] ?? offsetA
+
+    return Math.min(Math.max(offsetA + column, 0), offsetB)
+  }
+
+  return {
+    find,
+    findOffset,
+  }
+}

--- a/packages/tailwindcss/src/source-maps/line-table.ts
+++ b/packages/tailwindcss/src/source-maps/line-table.ts
@@ -62,8 +62,8 @@ export function createLineTable(source: string): LineTable {
     let line = 0
     let count = table.length
     while (count > 0) {
-      // `| 0` causes integer division
-      let mid = (count / 2) | 0
+      // `| 0` forces integer bytecode generation
+      let mid = (count | 0) >> 1
       let i = line + mid
       if (table[i] <= offset) {
         line = i + 1

--- a/packages/tailwindcss/src/source-maps/line-table.ts
+++ b/packages/tailwindcss/src/source-maps/line-table.ts
@@ -62,7 +62,7 @@ export function createLineTable(source: string): LineTable {
     let line = 0
     let count = table.length
     while (count > 0) {
-      // `| 0` forces integer bytecode generation
+      // `| 0` improves performance (in V8 at least)
       let mid = (count | 0) >> 1
       let i = line + mid
       if (table[i] <= offset) {

--- a/packages/tailwindcss/src/source-maps/source-map.test.ts
+++ b/packages/tailwindcss/src/source-maps/source-map.test.ts
@@ -1,0 +1,421 @@
+import remapping from '@ampproject/remapping'
+import dedent from 'dedent'
+import MagicString from 'magic-string'
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import { SourceMapConsumer, SourceMapGenerator, type RawSourceMap } from 'source-map-js'
+import { test } from 'vitest'
+import { compile } from '..'
+import createPlugin from '../plugin'
+import { DefaultMap } from '../utils/default-map'
+import type { DecodedSource, DecodedSourceMap } from './source-map'
+const css = dedent
+
+interface RunOptions {
+  input: string
+  candidates?: string[]
+  options?: Parameters<typeof compile>[1]
+}
+
+async function run({ input, candidates, options }: RunOptions) {
+  let source = new MagicString(input)
+  let root = path.resolve(__dirname, '../..')
+
+  let compiler = await compile(source.toString(), {
+    from: 'input.css',
+    async loadStylesheet(id, base) {
+      let resolvedPath = path.resolve(root, id === 'tailwindcss' ? 'index.css' : id)
+
+      return {
+        path: path.relative(root, resolvedPath),
+        base,
+        content: await fs.readFile(resolvedPath, 'utf-8'),
+      }
+    },
+    ...options,
+  })
+
+  let css = compiler.build(candidates ?? [])
+  let decoded = compiler.buildSourceMap()
+  let rawMap = toRawSourceMap(decoded)
+  let combined = remapping(rawMap, () => null)
+  let map = JSON.parse(rawMap.toString()) as RawSourceMap
+
+  let sources = combined.sources
+  let annotations = formattedMappings(map)
+
+  return { css, map, sources, annotations }
+}
+
+function toRawSourceMap(map: DecodedSourceMap): string {
+  let generator = new SourceMapGenerator()
+
+  let id = 1
+  let sourceTable = new DefaultMap<
+    DecodedSource | null,
+    {
+      url: string
+      content: string
+    }
+  >((src) => {
+    return {
+      url: src?.url ?? `<unknown ${id}>`,
+      content: src?.content ?? '<none>',
+    }
+  })
+
+  for (let mapping of map.mappings) {
+    let original = sourceTable.get(mapping.originalPosition?.source ?? null)
+
+    generator.addMapping({
+      generated: mapping.generatedPosition,
+      original: mapping.originalPosition,
+      source: original.url,
+      name: mapping.name ?? undefined,
+    })
+
+    generator.setSourceContent(original.url, original.content)
+  }
+
+  return generator.toString()
+}
+
+/**
+ * An string annotation that represents a source map
+ *
+ * It's not meant to be exhaustive just enough to
+ * verify that the source map is working and that
+ * lines are mapped back to the original source
+ *
+ * Including when using @apply with multiple classes
+ */
+function formattedMappings(map: RawSourceMap) {
+  const smc = new SourceMapConsumer(map)
+  const annotations: Record<
+    number,
+    {
+      original: { start: [number, number]; end: [number, number] }
+      generated: { start: [number, number]; end: [number, number] }
+      source: string
+    }
+  > = {}
+
+  smc.eachMapping((mapping) => {
+    let annotation = (annotations[mapping.generatedLine] = annotations[mapping.generatedLine] || {
+      ...mapping,
+
+      original: {
+        start: [mapping.originalLine, mapping.originalColumn],
+        end: [mapping.originalLine, mapping.originalColumn],
+      },
+
+      generated: {
+        start: [mapping.generatedLine, mapping.generatedColumn],
+        end: [mapping.generatedLine, mapping.generatedColumn],
+      },
+
+      source: mapping.source,
+    })
+
+    annotation.generated.end[0] = mapping.generatedLine
+    annotation.generated.end[1] = mapping.generatedColumn
+
+    annotation.original.end[0] = mapping.originalLine!
+    annotation.original.end[1] = mapping.originalColumn!
+  })
+
+  return Object.values(annotations).map((annotation) => {
+    return `${annotation.source}: ${formatRange(annotation.generated)} <- ${formatRange(annotation.original)}`
+  })
+}
+
+function formatRange(range: { start: [number, number]; end: [number, number] }) {
+  if (range.start[0] === range.end[0]) {
+    // This range is on the same line
+    // and the columns are the same
+    if (range.start[1] === range.end[1]) {
+      return `${range.start[0]}:${range.start[1]}`
+    }
+
+    // This range is on the same line
+    // but the columns are different
+    return `${range.start[0]}:${range.start[1]}-${range.end[1]}`
+  }
+
+  // This range spans multiple lines
+  return `${range.start[0]}:${range.start[1]}-${range.end[0]}:${range.end[1]}`
+}
+
+test('source maps trace back to @import location', async ({ expect }) => {
+  let { sources, annotations } = await run({
+    input: css`
+      @import 'tailwindcss';
+
+      .foo {
+        @apply underline;
+      }
+    `,
+  })
+
+  // All CSS should be mapped back to the original source file
+  expect(sources).toEqual([
+    //
+    'index.css',
+    'theme.css',
+    'preflight.css',
+    'input.css',
+  ])
+  expect(sources.length).toBe(4)
+
+  // The output CSS should include annotations linking back to:
+  // 1. The class definition `.foo`
+  // 2. The `@apply underline` line inside of it
+  expect(annotations).toEqual([
+    'index.css: 1:0-41 <- 1:0-41',
+    'index.css: 2:0-13 <- 3:0-34',
+    'theme.css: 3:2-15 <- 1:0-15',
+    'theme.css: 4:4 <- 2:2-4:0',
+    'theme.css: 5:22 <- 4:22',
+    'theme.css: 6:4 <- 6:2-8:0',
+    'theme.css: 7:13 <- 8:13',
+    'theme.css: 8:4-43 <- 446:2-54',
+    'theme.css: 9:4-48 <- 449:2-59',
+    'index.css: 12:0-12 <- 4:0-37',
+    'preflight.css: 13:2-59 <- 7:0-11:23',
+    'preflight.css: 14:4-26 <- 12:2-24',
+    'preflight.css: 15:4-13 <- 13:2-11',
+    'preflight.css: 16:4-14 <- 14:2-12',
+    'preflight.css: 17:4-19 <- 15:2-17',
+    'preflight.css: 19:2-14 <- 28:0-29:6',
+    'preflight.css: 20:4-20 <- 30:2-18',
+    'preflight.css: 21:4-34 <- 31:2-32',
+    'preflight.css: 22:4-15 <- 32:2-13',
+    'preflight.css: 23:4-159 <- 33:2-42:3',
+    'preflight.css: 24:4-71 <- 43:2-73',
+    'preflight.css: 25:4-75 <- 44:2-77',
+    'preflight.css: 26:4-44 <- 45:2-42',
+    'preflight.css: 28:2-5 <- 54:0-3',
+    'preflight.css: 29:4-13 <- 55:2-11',
+    'preflight.css: 30:4-18 <- 56:2-16',
+    'preflight.css: 31:4-25 <- 57:2-23',
+    'preflight.css: 33:2-22 <- 64:0-20',
+    'preflight.css: 34:4-45 <- 65:2-43',
+    'preflight.css: 35:4-37 <- 66:2-35',
+    'preflight.css: 37:2-25 <- 73:0-78:3',
+    'preflight.css: 38:4-22 <- 79:2-20',
+    'preflight.css: 39:4-24 <- 80:2-22',
+    'preflight.css: 41:2-4 <- 87:0-2',
+    'preflight.css: 42:4-18 <- 88:2-16',
+    'preflight.css: 43:4-36 <- 89:2-34',
+    'preflight.css: 44:4-28 <- 90:2-26',
+    'preflight.css: 46:2-12 <- 97:0-98:7',
+    'preflight.css: 47:4-23 <- 99:2-21',
+    'preflight.css: 49:2-23 <- 109:0-112:4',
+    'preflight.css: 50:4-148 <- 113:2-123:3',
+    'preflight.css: 51:4-76 <- 124:2-78',
+    'preflight.css: 52:4-80 <- 125:2-82',
+    'preflight.css: 53:4-18 <- 126:2-16',
+    'preflight.css: 55:2-8 <- 133:0-6',
+    'preflight.css: 56:4-18 <- 134:2-16',
+    'preflight.css: 58:2-11 <- 141:0-142:4',
+    'preflight.css: 59:4-18 <- 143:2-16',
+    'preflight.css: 60:4-18 <- 144:2-16',
+    'preflight.css: 61:4-22 <- 145:2-20',
+    'preflight.css: 62:4-28 <- 146:2-26',
+    'preflight.css: 64:2-6 <- 149:0-4',
+    'preflight.css: 65:4-19 <- 150:2-17',
+    'preflight.css: 67:2-6 <- 153:0-4',
+    'preflight.css: 68:4-15 <- 154:2-13',
+    'preflight.css: 70:2-8 <- 163:0-6',
+    'preflight.css: 71:4-18 <- 164:2-16',
+    'preflight.css: 72:4-25 <- 165:2-23',
+    'preflight.css: 73:4-29 <- 166:2-27',
+    'preflight.css: 75:2-18 <- 173:0-16',
+    'preflight.css: 76:4-17 <- 174:2-15',
+    'preflight.css: 78:2-11 <- 181:0-9',
+    'preflight.css: 79:4-28 <- 182:2-26',
+    'preflight.css: 81:2-10 <- 189:0-8',
+    'preflight.css: 82:4-22 <- 190:2-20',
+    'preflight.css: 84:2-15 <- 197:0-199:5',
+    'preflight.css: 85:4-20 <- 200:2-18',
+    'preflight.css: 87:2-56 <- 209:0-216:7',
+    'preflight.css: 88:4-18 <- 217:2-16',
+    'preflight.css: 89:4-26 <- 218:2-24',
+    'preflight.css: 91:2-13 <- 225:0-226:6',
+    'preflight.css: 92:4-19 <- 227:2-17',
+    'preflight.css: 93:4-16 <- 228:2-14',
+    'preflight.css: 95:2-68 <- 238:0-243:23',
+    'preflight.css: 96:4-17 <- 244:2-15',
+    'preflight.css: 97:4-34 <- 245:2-32',
+    'preflight.css: 98:4-36 <- 246:2-34',
+    'preflight.css: 99:4-27 <- 247:2-25',
+    'preflight.css: 100:4-18 <- 248:2-16',
+    'preflight.css: 101:4-20 <- 249:2-18',
+    'preflight.css: 102:4-33 <- 250:2-31',
+    'preflight.css: 103:4-14 <- 251:2-12',
+    'preflight.css: 105:2-49 <- 258:0-47',
+    'preflight.css: 106:4-23 <- 259:2-21',
+    'preflight.css: 108:2-56 <- 266:0-54',
+    'preflight.css: 109:4-30 <- 267:2-28',
+    'preflight.css: 111:2-25 <- 274:0-23',
+    'preflight.css: 112:4-26 <- 275:2-24',
+    'preflight.css: 114:2-16 <- 282:0-14',
+    'preflight.css: 115:4-14 <- 283:2-12',
+    'preflight.css: 117:2-92 <- 291:0-292:49',
+    'preflight.css: 118:4-18 <- 293:2-16',
+    'preflight.css: 119:6-25 <- 294:4-61',
+    'preflight.css: 120:6-53 <- 294:4-61',
+    'preflight.css: 121:8-65 <- 294:4-61',
+    'preflight.css: 125:2-11 <- 302:0-9',
+    'preflight.css: 126:4-20 <- 303:2-18',
+    'preflight.css: 128:2-30 <- 310:0-28',
+    'preflight.css: 129:4-28 <- 311:2-26',
+    'preflight.css: 131:2-32 <- 319:0-30',
+    'preflight.css: 132:4-19 <- 320:2-17',
+    'preflight.css: 133:4-23 <- 321:2-21',
+    'preflight.css: 135:2-26 <- 328:0-24',
+    'preflight.css: 136:4-24 <- 329:2-22',
+    'preflight.css: 138:2-41 <- 336:0-39',
+    'preflight.css: 139:4-14 <- 337:2-12',
+    'preflight.css: 141:2-329 <- 340:0-348:39',
+    'preflight.css: 142:4-20 <- 349:2-18',
+    'preflight.css: 144:2-19 <- 356:0-17',
+    'preflight.css: 145:4-20 <- 357:2-18',
+    'preflight.css: 147:2-96 <- 364:0-366:23',
+    'preflight.css: 148:4-22 <- 367:2-20',
+    'preflight.css: 150:2-59 <- 374:0-375:28',
+    'preflight.css: 151:4-16 <- 376:2-14',
+    'preflight.css: 153:2-47 <- 383:0-45',
+    'preflight.css: 154:4-28 <- 384:2-26',
+    'index.css: 157:0-16 <- 5:0-42',
+    'input.css: 158:0-5 <- 3:0-5',
+    'input.css: 159:2-33 <- 4:9-18',
+  ])
+})
+
+test('source maps are generated for utilities', async ({ expect }) => {
+  let {
+    sources,
+    css: output,
+    annotations,
+  } = await run({
+    input: css`
+      @import './utilities.css';
+      @plugin "./plugin.js";
+      @utility custom {
+        color: orange;
+      }
+    `,
+    candidates: ['custom', 'custom-js', 'flex'],
+    options: {
+      loadModule: async (_, base) => ({
+        path: '',
+        base,
+        module: createPlugin(({ addUtilities }) => {
+          addUtilities({ '.custom-js': { color: 'blue' } })
+        }),
+      }),
+    },
+  })
+
+  // All CSS should be mapped back to the original source file
+  expect(sources).toEqual(['utilities.css', 'input.css'])
+  expect(sources.length).toBe(2)
+
+  // The output CSS should include annotations linking back to:
+  expect(annotations).toEqual([
+    // @tailwind utilities
+    'utilities.css: 1:0-6 <- 1:0-19',
+    'utilities.css: 2:2-15 <- 1:0-19',
+    'utilities.css: 4:0-8 <- 1:0-19',
+    // color: orange
+    'input.css: 5:2-15 <- 4:2-15',
+    // @tailwind utilities
+    'utilities.css: 7:0-11 <- 1:0-19',
+    'utilities.css: 8:2-13 <- 1:0-19',
+  ])
+
+  expect(output).toMatchInlineSnapshot(`
+    ".flex {
+      display: flex;
+    }
+    .custom {
+      color: orange;
+    }
+    .custom-js {
+      color: blue;
+    }
+    "
+  `)
+})
+
+test('utilities have source maps pointing to the utilities node', async ({ expect }) => {
+  let { sources, annotations } = await run({
+    input: `@tailwind utilities;`,
+    candidates: [
+      //
+      'underline',
+    ],
+  })
+
+  expect(sources).toEqual(['input.css'])
+
+  expect(annotations).toEqual([
+    //
+    'input.css: 1:0-11 <- 1:0-19',
+    'input.css: 2:2-33 <- 1:0-19',
+  ])
+})
+
+test('@apply generates source maps', async ({ expect }) => {
+  let { sources, annotations } = await run({
+    input: css`
+      .foo {
+        color: blue;
+        @apply text-[#000] hover:text-[#f00];
+        @apply underline;
+        color: red;
+      }
+    `,
+  })
+
+  expect(sources).toEqual(['input.css'])
+
+  expect(annotations).toEqual([
+    'input.css: 1:0-5 <- 1:0-5',
+    'input.css: 2:2-13 <- 2:2-13',
+    'input.css: 3:2-13 <- 3:9-20',
+    'input.css: 4:2-10 <- 3:21-38',
+    'input.css: 5:4-26 <- 3:21-38',
+    'input.css: 6:6-17 <- 3:21-38',
+    'input.css: 9:2-33 <- 4:9-18',
+    'input.css: 10:2-12 <- 5:2-12',
+  ])
+})
+
+test('license comments preserve source locations', async ({ expect }) => {
+  let { sources, annotations } = await run({
+    input: `/*! some comment */`,
+  })
+
+  expect(sources).toEqual(['input.css'])
+
+  expect(annotations).toEqual([
+    //
+    'input.css: 1:0-19 <- 1:0-19',
+  ])
+})
+
+test('license comments with new lines preserve source locations', async ({ expect }) => {
+  let { sources, annotations, css } = await run({
+    input: `/*! some \n comment */`,
+  })
+
+  expect(sources).toEqual(['input.css'])
+
+  expect(annotations).toEqual([
+    //
+    'input.css: 1:0 <- 1:0-2:0',
+    'input.css: 2:11 <- 2:11',
+  ])
+})

--- a/packages/tailwindcss/src/source-maps/source-map.test.ts
+++ b/packages/tailwindcss/src/source-maps/source-map.test.ts
@@ -59,7 +59,7 @@ function toRawSourceMap(map: DecodedSourceMap): string {
     }
   >((src) => {
     return {
-      url: src?.url ?? `<unknown ${id}>`,
+      url: src?.url ?? `<unknown ${id++}>`,
       content: src?.content ?? '<none>',
     }
   })

--- a/packages/tailwindcss/src/source-maps/source-map.ts
+++ b/packages/tailwindcss/src/source-maps/source-map.ts
@@ -173,7 +173,12 @@ export function createTranslationMap({
   let originalTable = createLineTable(original)
   let generatedTable = createLineTable(generated)
 
-  type Translation = [Position, Position, Position | null, Position | null]
+  type Translation = [
+    originalStart: Position,
+    originalEnd: Position,
+    generatedStart: Position | null,
+    generatedEnd: Position | null,
+  ]
 
   return (node: AstNode) => {
     if (!node.src) return []

--- a/packages/tailwindcss/src/source-maps/source-map.ts
+++ b/packages/tailwindcss/src/source-maps/source-map.ts
@@ -90,7 +90,7 @@ export function createSourceMap({ ast }: { ast: AstNode[] }) {
   }
 
   // Get all the indexes from the mappings
-  function add(node: AstNode) {
+  walk(ast, (node: AstNode) => {
     if (!node.src || !node.dst) return
 
     let originalSource = sourceTable.get(node.src[0])
@@ -141,9 +141,7 @@ export function createSourceMap({ ast }: { ast: AstNode[] }) {
       },
       generatedPosition: generatedEnd,
     })
-  }
-
-  walk(ast, add)
+  })
 
   // Populate
   for (let source of lineTables.keys()) {

--- a/packages/tailwindcss/src/source-maps/source-map.ts
+++ b/packages/tailwindcss/src/source-maps/source-map.ts
@@ -1,0 +1,194 @@
+import { walk, type AstNode } from '../ast'
+import { DefaultMap } from '../utils/default-map'
+import { createLineTable, type LineTable, type Position } from './line-table'
+import type { Source } from './source'
+
+// https://tc39.es/ecma426/#sec-original-position-record-type
+export interface OriginalPosition extends Position {
+  source: DecodedSource
+}
+
+/**
+ * A "decoded" sourcemap
+ *
+ * @see https://tc39.es/ecma426/#decoded-source-map-record
+ */
+export interface DecodedSourceMap {
+  file: string | null
+  sources: DecodedSource[]
+  mappings: DecodedMapping[]
+}
+
+/**
+ * A "decoded" source
+ *
+ * @see https://tc39.es/ecma426/#decoded-source-record
+ */
+export interface DecodedSource {
+  url: string | null
+  content: string | null
+  ignore: boolean
+}
+
+/**
+ * A "decoded" mapping
+ *
+ * @see https://tc39.es/ecma426/#decoded-mapping-record
+ */
+export interface DecodedMapping {
+  // https://tc39.es/ecma426/#sec-original-position-record-type
+  originalPosition: OriginalPosition | null
+
+  // https://tc39.es/ecma426/#sec-position-record-type
+  generatedPosition: Position
+
+  name: string | null
+}
+
+/**
+ * Build a source map from the given AST.
+ *
+ * Our AST is build from flat CSS strings but there are many because we handle
+ * `@import`. This means that different nodes can have a different source.
+ *
+ * Instead of taking an input source map, we take the input CSS string we were
+ * originally given, as well as the source text for any imported files, and
+ * use that to generate a source map.
+ *
+ * We then require the use of other tools that can translate one or more
+ * "input" source maps into a final output source map. For example,
+ * `@ampproject/remapping` can be used to handle this.
+ *
+ * This also ensures that tools that expect "local" source maps are able to
+ * consume the source map we generate.
+ *
+ * The source map type we generate may be a bit different from "raw" source maps
+ * that the `source-map-js` package uses. It's a "decoded" source map that is
+ * represented by an object graph. It's identical to "decoded" source map from
+ * the ECMA-426 spec for source maps.
+ *
+ * Note that the spec itself is still evolving which means our implementation
+ * may need to evolve to match it.
+ *
+ * This can easily be converted to a "raw" source map by any tool that needs to.
+ **/
+export function createSourceMap({ ast }: { ast: AstNode[] }) {
+  // Compute line tables for both the original and generated source lazily so we
+  // don't have to do it during parsing or printing.
+  let lineTables = new DefaultMap<Source, LineTable>((src) => createLineTable(src.code))
+  let sourceTable = new DefaultMap<Source, DecodedSource>((src) => ({
+    url: src.file,
+    content: src.code,
+    ignore: false,
+  }))
+
+  // Convert each mapping to a set of positions
+  let map: DecodedSourceMap = {
+    file: null,
+    sources: [],
+    mappings: [],
+  }
+
+  // Get all the indexes from the mappings
+  function add(node: AstNode) {
+    if (!node.src || !node.dst) return
+
+    let originalSource = sourceTable.get(node.src[0])
+    if (!originalSource.content) return
+
+    let originalTable = lineTables.get(node.src[0])
+    let generatedTable = lineTables.get(node.dst[0])
+
+    let originalSlice = originalSource.content.slice(node.src[1], node.src[2])
+
+    // Source maps only encode single locations — not multi-line ranges
+    // So to properly emulate this we'll scan the original text for multiple
+    // lines and create mappings for each of those lines that point to the
+    // destination node (whether it spans multiple lines or not)
+    //
+    // This is not 100% accurate if both the source and destination preserve
+    // their newlines but this only happens in the case of custom properties
+    //
+    // This is _good enough_
+    let offset = 0
+    for (let line of originalSlice.split('\n')) {
+      if (line.trim() !== '') {
+        let originalStart = originalTable.find(node.src[1] + offset)
+        let generatedStart = generatedTable.find(node.dst[1])
+
+        map.mappings.push({
+          name: null,
+          originalPosition: {
+            source: originalSource,
+            ...originalStart,
+          },
+          generatedPosition: generatedStart,
+        })
+      }
+
+      offset += line.length
+      offset += 1
+    }
+
+    let originalEnd = originalTable.find(node.src[2])
+    let generatedEnd = generatedTable.find(node.dst[2])
+
+    map.mappings.push({
+      name: null,
+      originalPosition: {
+        source: originalSource,
+        ...originalEnd,
+      },
+      generatedPosition: generatedEnd,
+    })
+  }
+
+  walk(ast, add)
+
+  // Populate
+  for (let source of lineTables.keys()) {
+    map.sources.push(sourceTable.get(source))
+  }
+
+  // Sort the mappings in ascending order
+  map.mappings.sort((a, b) => {
+    return (
+      a.generatedPosition.line - b.generatedPosition.line ||
+      a.generatedPosition.column - b.generatedPosition.column ||
+      (a.originalPosition?.line ?? 0) - (b.originalPosition?.line ?? 0) ||
+      (a.originalPosition?.column ?? 0) - (b.originalPosition?.column ?? 0)
+    )
+  })
+
+  return map
+}
+
+export function createTranslationMap({
+  original,
+  generated,
+}: {
+  original: string
+  generated: string
+}) {
+  // Compute line tables for both the original and generated source lazily so we
+  // don't have to do it during parsing or printing.
+  let originalTable = createLineTable(original)
+  let generatedTable = createLineTable(generated)
+
+  type Translation = [Position, Position, Position | null, Position | null]
+
+  return (node: AstNode) => {
+    if (!node.src) return []
+
+    let translations: Translation[] = []
+
+    translations.push([
+      originalTable.find(node.src[1]),
+      originalTable.find(node.src[2]),
+      node.dst ? generatedTable.find(node.dst[1]) : null,
+      node.dst ? generatedTable.find(node.dst[2]) : null,
+    ])
+
+    return translations
+  }
+}

--- a/packages/tailwindcss/src/source-maps/source.ts
+++ b/packages/tailwindcss/src/source-maps/source.ts
@@ -1,0 +1,27 @@
+/**
+ * The source code for one or more nodes in the AST
+ *
+ * This generally corresponds to a stylesheet
+ */
+export interface Source {
+  /**
+   * The path to the file that contains the referenced source code
+   *
+   * If this references the *output* source code, this is `null`.
+   */
+  file: string | null
+
+  /**
+   * The referenced source code
+   */
+  code: string
+}
+
+/**
+ * The file and offsets within it that this node covers
+ *
+ * This can represent either:
+ * - A location in the original CSS which caused this node to be created
+ * - A location in the output CSS where this node resides
+ */
+export type SourceLocation = [source: Source, start: number, end: number]

--- a/packages/tailwindcss/src/source-maps/translation-map.test.ts
+++ b/packages/tailwindcss/src/source-maps/translation-map.test.ts
@@ -1,0 +1,279 @@
+import dedent from 'dedent'
+import { assert, expect, test } from 'vitest'
+import { toCss, type AstNode } from '../ast'
+import * as CSS from '../css-parser'
+import { createTranslationMap } from './source-map'
+
+async function analyze(input: string) {
+  let ast = CSS.parse(input, { from: 'input.css' })
+  let css = toCss(ast, true)
+  let translate = createTranslationMap({
+    original: input,
+    generated: css,
+  })
+
+  function format(node: AstNode) {
+    let lines: string[] = []
+
+    for (let [oStart, oEnd, gStart, gEnd] of translate(node)) {
+      let src = `${oStart.line}:${oStart.column}-${oEnd.line}:${oEnd.column}`
+
+      let dst = '(none)'
+
+      if (gStart && gEnd) {
+        dst = `${gStart.line}:${gStart.column}-${gEnd.line}:${gEnd.column}`
+      }
+
+      lines.push(`${dst} <- ${src}`)
+    }
+
+    return lines
+  }
+
+  return { ast, css, format }
+}
+
+test('comment, single line', async () => {
+  let { ast, css, format } = await analyze(`/*! foo */`)
+
+  assert(ast[0].kind === 'comment')
+  expect(format(ast[0])).toMatchInlineSnapshot(`
+    [
+      "1:0-1:10 <- 1:0-1:10",
+    ]
+  `)
+
+  expect(css).toMatchInlineSnapshot(`
+    "/*! foo */
+    "
+  `)
+})
+
+test('comment, multi line', async () => {
+  let { ast, css, format } = await analyze(`/*! foo \n bar */`)
+
+  assert(ast[0].kind === 'comment')
+  expect(format(ast[0])).toMatchInlineSnapshot(`
+    [
+      "1:0-2:7 <- 1:0-2:7",
+    ]
+  `)
+
+  expect(css).toMatchInlineSnapshot(`
+    "/*! foo 
+     bar */
+    "
+  `)
+})
+
+test('declaration, normal property, single line', async () => {
+  let { ast, css, format } = await analyze(`.foo { color: red; }`)
+
+  assert(ast[0].kind === 'rule')
+  assert(ast[0].nodes[0].kind === 'declaration')
+  expect(format(ast[0].nodes[0])).toMatchInlineSnapshot(`
+    [
+      "2:2-2:12 <- 1:7-1:17",
+    ]
+  `)
+
+  expect(css).toMatchInlineSnapshot(`
+    ".foo {
+      color: red;
+    }
+    "
+  `)
+})
+
+test('declaration, normal property, multi line', async () => {
+  // Works, no changes needed
+  let { ast, css, format } = await analyze(dedent`
+    .foo {
+      grid-template-areas:
+        "a b c"
+        "d e f"
+        "g h i";
+    }
+  `)
+
+  assert(ast[0].kind === 'rule')
+  assert(ast[0].nodes[0].kind === 'declaration')
+  expect(format(ast[0].nodes[0])).toMatchInlineSnapshot(`
+    [
+      "2:2-2:46 <- 2:2-5:11",
+    ]
+  `)
+
+  expect(css).toMatchInlineSnapshot(`
+    ".foo {
+      grid-template-areas: "a b c" "d e f" "g h i";
+    }
+    "
+  `)
+})
+
+test('declaration, custom property, single line', async () => {
+  let { ast, css, format } = await analyze(`.foo { --foo: bar; }`)
+
+  assert(ast[0].kind === 'rule')
+  assert(ast[0].nodes[0].kind === 'declaration')
+  expect(format(ast[0].nodes[0])).toMatchInlineSnapshot(`
+    [
+      "2:2-2:12 <- 1:7-1:17",
+    ]
+  `)
+
+  expect(css).toMatchInlineSnapshot(`
+    ".foo {
+      --foo: bar;
+    }
+    "
+  `)
+})
+
+test('declaration, custom property, multi line', async () => {
+  let { ast, css, format } = await analyze(dedent`
+    .foo {
+      --foo: bar\nbaz;
+    }
+  `)
+
+  assert(ast[0].kind === 'rule')
+  assert(ast[0].nodes[0].kind === 'declaration')
+  expect(format(ast[0].nodes[0])).toMatchInlineSnapshot(`
+    [
+      "2:2-3:3 <- 2:2-3:3",
+    ]
+  `)
+
+  expect(css).toMatchInlineSnapshot(`
+    ".foo {
+      --foo: bar
+    baz;
+    }
+    "
+  `)
+})
+
+test('at rules, bodyless, single line', async () => {
+  // This intentionally has extra spaces
+  let { ast, css, format } = await analyze(`@layer foo,     bar;`)
+
+  assert(ast[0].kind === 'at-rule')
+  expect(format(ast[0])).toMatchInlineSnapshot(`
+    [
+      "1:0-1:15 <- 1:0-1:19",
+    ]
+  `)
+
+  expect(css).toMatchInlineSnapshot(`
+    "@layer foo, bar;
+    "
+  `)
+})
+
+test('at rules, bodyless, multi line', async () => {
+  let { ast, css, format } = await analyze(dedent`
+    @layer
+      foo,
+      bar
+    ;
+  `)
+
+  assert(ast[0].kind === 'at-rule')
+  expect(format(ast[0])).toMatchInlineSnapshot(`
+    [
+      "1:0-1:15 <- 1:0-4:0",
+    ]
+  `)
+
+  expect(css).toMatchInlineSnapshot(`
+    "@layer foo, bar;
+    "
+  `)
+})
+
+test('at rules, body, single line', async () => {
+  let { ast, css, format } = await analyze(`@layer foo { color: red; }`)
+
+  assert(ast[0].kind === 'at-rule')
+  expect(format(ast[0])).toMatchInlineSnapshot(`
+    [
+      "1:0-1:11 <- 1:0-1:11",
+    ]
+  `)
+
+  expect(css).toMatchInlineSnapshot(`
+    "@layer foo {
+      color: red;
+    }
+    "
+  `)
+})
+
+test('at rules, body, multi line', async () => {
+  let { ast, css, format } = await analyze(dedent`
+    @layer
+      foo
+    {
+      color: baz;
+    }
+  `)
+
+  assert(ast[0].kind === 'at-rule')
+  expect(format(ast[0])).toMatchInlineSnapshot(`
+    [
+      "1:0-1:11 <- 1:0-3:0",
+    ]
+  `)
+
+  expect(css).toMatchInlineSnapshot(`
+    "@layer foo {
+      color: baz;
+    }
+    "
+  `)
+})
+
+test('style rules, body, single line', async () => {
+  let { ast, css, format } = await analyze(`.foo:is(.bar) { color: red; }`)
+
+  assert(ast[0].kind === 'rule')
+  expect(format(ast[0])).toMatchInlineSnapshot(`
+    [
+      "1:0-1:14 <- 1:0-1:14",
+    ]
+  `)
+
+  expect(css).toMatchInlineSnapshot(`
+    ".foo:is(.bar) {
+      color: red;
+    }
+    "
+  `)
+})
+
+test('style rules, body, multi line', async () => {
+  // Works, no changes needed
+  let { ast, css, format } = await analyze(dedent`
+    .foo:is(
+      .bar
+    ) {
+      color: red;
+    }
+  `)
+
+  assert(ast[0].kind === 'rule')
+  expect(format(ast[0])).toMatchInlineSnapshot(`
+    [
+      "1:0-1:16 <- 1:0-3:2",
+    ]
+  `)
+
+  expect(css).toMatchInlineSnapshot(`
+    ".foo:is( .bar ) {
+      color: red;
+    }
+    "
+  `)
+})

--- a/packages/tailwindcss/src/test-utils/run.ts
+++ b/packages/tailwindcss/src/test-utils/run.ts
@@ -7,12 +7,14 @@ export async function compileCss(
   options: Parameters<typeof compile>[1] = {},
 ) {
   let { build } = await compile(css, options)
-  return optimize(build(candidates)).trim()
+  return optimize(build(candidates)).code.trim()
 }
 
 export async function run(candidates: string[]) {
   let { build } = await compile('@tailwind utilities;')
-  return optimize(build(candidates)).trim()
+  return optimize(build(candidates)).code.trim()
 }
 
-export const optimizeCss = optimize
+export function optimizeCss(input: string) {
+  return optimize(input).code
+}

--- a/packages/tailwindcss/src/theme.ts
+++ b/packages/tailwindcss/src/theme.ts
@@ -1,4 +1,4 @@
-import { type AtRule } from './ast'
+import { type AtRule, type Declaration } from './ast'
 import { escape, unescape } from './utils/escape'
 
 export const enum ThemeOptions {
@@ -40,11 +40,18 @@ export class Theme {
   public prefix: string | null = null
 
   constructor(
-    private values = new Map<string, { value: string; options: ThemeOptions }>(),
+    private values = new Map<
+      string,
+      {
+        value: string
+        options: ThemeOptions
+        src: Declaration['src']
+      }
+    >(),
     private keyframes = new Set<AtRule>([]),
   ) {}
 
-  add(key: string, value: string, options = ThemeOptions.NONE): void {
+  add(key: string, value: string, options = ThemeOptions.NONE, src?: Declaration['src']): void {
     if (key.endsWith('-*')) {
       if (value !== 'initial') {
         throw new Error(`Invalid theme value \`${value}\` for namespace \`${key}\``)
@@ -68,7 +75,7 @@ export class Theme {
     if (value === 'initial') {
       this.values.delete(key)
     } else {
-      this.values.set(key, { value, options })
+      this.values.set(key, { value, options, src })
     }
   }
 

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -2528,6 +2528,7 @@ test('matchVariant sorts deterministically', async () => {
     let output = await compileCss('@tailwind utilities; @plugin "./plugin.js";', classList, {
       async loadModule(id: string) {
         return {
+          path: '',
           base: '/',
           module: createPlugin(({ matchVariant }) => {
             matchVariant('is-data', (value) => `&:is([data-${value}])`, {

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -2526,7 +2526,7 @@ test('matchVariant sorts deterministically', async () => {
 
   for (let classList of classLists) {
     let output = await compileCss('@tailwind utilities; @plugin "./plugin.js";', classList, {
-      loadModule(id: string) {
+      async loadModule(id: string) {
         return {
           base: '/',
           module: createPlugin(({ matchVariant }) => {

--- a/packages/tailwindcss/tests/ui.spec.ts
+++ b/packages/tailwindcss/tests/ui.spec.ts
@@ -2216,7 +2216,7 @@ async function render(page: Page, content: string, extraCss: string = '') {
   let scanner = new Scanner({})
   let candidates = scanner.scanFiles([{ content, extension: 'html' }])
 
-  let styles = optimize(build(candidates))
+  let { code: styles } = optimize(build(candidates))
 
   content = `<style type="text/css">${styles}</style>${content}`
   await page.setContent(content)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       fast-glob:
         specifier: ^3.3.3
         version: 3.3.3
+      source-map-js:
+        specifier: ^1.2.1
+        version: 1.2.1
 
   packages/@tailwindcss-browser:
     devDependencies:
@@ -227,6 +230,9 @@ importers:
 
   packages/@tailwindcss-node:
     dependencies:
+      '@ampproject/remapping':
+        specifier: ^2.3.0
+        version: 2.3.0
       enhanced-resolve:
         specifier: ^5.18.1
         version: 5.18.1
@@ -236,6 +242,12 @@ importers:
       lightningcss:
         specifier: 'catalog:'
         version: 1.29.2(patch_hash=tzyxy3asfxcqc7ihrooumyi5fm)
+      magic-string:
+        specifier: ^0.30.17
+        version: 0.30.17
+      source-map-js:
+        specifier: ^1.2.1
+        version: 1.2.1
       tailwindcss:
         specifier: workspace:*
         version: link:../tailwindcss
@@ -437,6 +449,9 @@ importers:
 
   packages/tailwindcss:
     devDependencies:
+      '@ampproject/remapping':
+        specifier: ^2.3.0
+        version: 2.3.0
       '@tailwindcss/oxide':
         specifier: workspace:^
         version: link:../../crates/node
@@ -449,6 +464,12 @@ importers:
       lightningcss:
         specifier: 'catalog:'
         version: 1.29.2(patch_hash=tzyxy3asfxcqc7ihrooumyi5fm)
+      magic-string:
+        specifier: ^0.30.17
+        version: 0.30.17
+      source-map-js:
+        specifier: ^1.2.1
+        version: 1.2.1
 
   playgrounds/nextjs:
     dependencies:
@@ -2068,7 +2089,6 @@ packages:
   '@parcel/watcher-darwin-arm64@2.5.1':
     resolution: {integrity: sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==}
     engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
     os: [darwin]
 
   '@parcel/watcher-darwin-x64@2.5.0':
@@ -2080,7 +2100,6 @@ packages:
   '@parcel/watcher-darwin-x64@2.5.1':
     resolution: {integrity: sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==}
     engines: {node: '>= 10.0.0'}
-    cpu: [x64]
     os: [darwin]
 
   '@parcel/watcher-freebsd-x64@2.5.0':
@@ -2128,7 +2147,6 @@ packages:
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
     os: [linux]
 
   '@parcel/watcher-linux-arm64-musl@2.5.0':
@@ -2140,7 +2158,6 @@ packages:
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
     os: [linux]
 
   '@parcel/watcher-linux-x64-glibc@2.5.0':
@@ -2152,7 +2169,6 @@ packages:
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
-    cpu: [x64]
     os: [linux]
 
   '@parcel/watcher-linux-x64-musl@2.5.0':
@@ -2164,7 +2180,6 @@ packages:
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
-    cpu: [x64]
     os: [linux]
 
   '@parcel/watcher-wasm@2.5.0':
@@ -2206,7 +2221,6 @@ packages:
   '@parcel/watcher-win32-x64@2.5.1':
     resolution: {integrity: sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==}
     engines: {node: '>= 10.0.0'}
-    cpu: [x64]
     os: [win32]
 
   '@parcel/watcher@2.5.0':
@@ -2621,7 +2635,6 @@ packages:
 
   bun@1.2.11:
     resolution: {integrity: sha512-9brVfsp6/TYVsE3lCl1MUxoyKhvljqyL1MNPErgwsOaS9g4Gzi2nY+W5WtRAXGzLrgz5jzsoGHHwyH/rTeRCIg==}
-    cpu: [arm64, x64, aarch64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -3480,13 +3493,11 @@ packages:
   lightningcss-darwin-arm64@1.29.2:
     resolution: {integrity: sha512-cK/eMabSViKn/PG8U/a7aCorpeKLMlK0bQeNHmdb7qUnBkNPnL+oV5DjJUo0kqWsJUapZsM4jCfYItbqBDvlcA==}
     engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
     os: [darwin]
 
   lightningcss-darwin-x64@1.29.2:
     resolution: {integrity: sha512-j5qYxamyQw4kDXX5hnnCKMf3mLlHvG44f24Qyi2965/Ycz829MYqjrVg2H8BidybHBp9kom4D7DR5VqCKDXS0w==}
     engines: {node: '>= 12.0.0'}
-    cpu: [x64]
     os: [darwin]
 
   lightningcss-freebsd-x64@1.29.2:
@@ -3504,25 +3515,21 @@ packages:
   lightningcss-linux-arm64-gnu@1.29.2:
     resolution: {integrity: sha512-KKCpOlmhdjvUTX/mBuaKemp0oeDIBBLFiU5Fnqxh1/DZ4JPZi4evEH7TKoSBFOSOV3J7iEmmBaw/8dpiUvRKlQ==}
     engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
     os: [linux]
 
   lightningcss-linux-arm64-musl@1.29.2:
     resolution: {integrity: sha512-Q64eM1bPlOOUgxFmoPUefqzY1yV3ctFPE6d/Vt7WzLW4rKTv7MyYNky+FWxRpLkNASTnKQUaiMJ87zNODIrrKQ==}
     engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
     os: [linux]
 
   lightningcss-linux-x64-gnu@1.29.2:
     resolution: {integrity: sha512-0v6idDCPG6epLXtBH/RPkHvYx74CVziHo6TMYga8O2EiQApnUPZsbR9nFNrg2cgBzk1AYqEd95TlrsL7nYABQg==}
     engines: {node: '>= 12.0.0'}
-    cpu: [x64]
     os: [linux]
 
   lightningcss-linux-x64-musl@1.29.2:
     resolution: {integrity: sha512-rMpz2yawkgGT8RULc5S4WiZopVMOFWjiItBT7aSfDX4NQav6M44rhn5hjtkKzB+wMTRlLLqxkeYEtQ3dd9696w==}
     engines: {node: '>= 12.0.0'}
-    cpu: [x64]
     os: [linux]
 
   lightningcss-win32-arm64-msvc@1.29.2:
@@ -3534,7 +3541,6 @@ packages:
   lightningcss-win32-x64-msvc@1.29.2:
     resolution: {integrity: sha512-EdIUW3B2vLuHmv7urfzMI/h2fmlnOQBk1xlsDxkN1tCWKjNFjfLhGxYk8C8mzpSfr+A6jFFIi8fU6LbQGsRWjA==}
     engines: {node: '>= 12.0.0'}
-    cpu: [x64]
     os: [win32]
 
   lightningcss@1.29.2:
@@ -3592,8 +3598,8 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  magic-string@0.30.11:
-    resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
+  magic-string@0.30.17:
+    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -4112,10 +4118,6 @@ packages:
   slash@5.1.0:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
-
-  source-map-js@1.2.0:
-    resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
-    engines: {node: '>=0.10.0'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -6156,7 +6158,7 @@ snapshots:
   '@vitest/snapshot@2.0.5':
     dependencies:
       '@vitest/pretty-format': 2.0.5
-      magic-string: 0.30.11
+      magic-string: 0.30.17
       pathe: 1.1.2
 
   '@vitest/spy@2.0.5':
@@ -6817,7 +6819,7 @@ snapshots:
       debug: 4.4.0
       enhanced-resolve: 5.18.1
       eslint: 9.25.1(jiti@2.4.2)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.25.1(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
       fast-glob: 3.3.3
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -6836,7 +6838,7 @@ snapshots:
       debug: 4.4.0
       enhanced-resolve: 5.18.1
       eslint: 9.25.1(jiti@2.4.2)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.25.1(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
       fast-glob: 3.3.3
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -6849,7 +6851,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.25.1(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -6860,7 +6862,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.25.1(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -6882,7 +6884,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.25.1(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.25.1(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -6911,7 +6913,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.25.1(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.25.1(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.11.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.11.0(eslint@9.25.1(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.25.1(jiti@2.4.2)))(eslint@9.25.1(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -7560,7 +7562,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  magic-string@0.30.11:
+  magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
@@ -7865,7 +7867,7 @@ snapshots:
     dependencies:
       nanoid: 3.3.7
       picocolors: 1.1.1
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
 
   postcss@8.4.47:
     dependencies:
@@ -8086,8 +8088,6 @@ snapshots:
     optional: true
 
   slash@5.1.0: {}
-
-  source-map-js@1.2.0: {}
 
   source-map-js@1.2.1: {}
 
@@ -8523,7 +8523,7 @@ snapshots:
       chai: 5.1.1
       debug: 4.3.6
       execa: 8.0.1
-      magic-string: 0.30.11
+      magic-string: 0.30.17
       pathe: 1.1.2
       std-env: 3.7.0
       tinybench: 2.9.0


### PR DESCRIPTION
Closes #13694
Closes #13591

# Source Maps Support for Tailwind CSS

This PR adds support for source maps to Tailwind CSS v4 allowing us to track where styles come from whether that be user CSS, imported stylesheets, or generated utilities. This will improve debuggability in browser dev tools and gives us a good foundation for producing better error messages. I'll go over the details on how end users can enable source maps, any limitations in our implementation, changes to the internal `compile(…)` API, and some details and reasoning around the implementation we chose.

## Usage

### CLI

Source maps can be enabled in the CLI by using the command line argument `--map` which will generate an inline source map comment at the bottom of your CSS. A separate file may be generated by passing a file name to `--map`:

```bash
# Generates an inline source map
npx tailwindcss -i input.css -o output.css --map

# Generates a separate source map file
npx tailwindcss -i input.css -o output.css --map output.css.map
```

### PostCSS

Source maps are supported when using Tailwind as a PostCSS plugin *in development mode only*. They may or may not be enabled by default depending on your build tool. If they are not you may be able to configure them within your PostCSS config:

```jsonc
// package.json
{
  // …
  "postcss": {
    "map": { "inline": true },
    "plugins": {
      "@tailwindcss/postcss": {},
    },
  }
}
```

### Vite

Source maps are supported when using the Tailwind CSS Vite plugin in *development mode only* by enabling the `css.devSourcemap` setting:

```js
import tailwindcss from "@tailwindcss/vite";
import { defineConfig } from "vite";

export default defineConfig({
  plugins: [tailwindcss()],
  css: {
    devSourcemap: true,
  },
})
```

Now when a CSS file is requested by the browser it'll have an inline source map comment that the browser can use.

## Limitations

- Production build source maps are currently disabled due to a bug in Lightning CSS. See https://github.com/parcel-bundler/lightningcss/pull/971 for more details.
- In Vite, minified CSS build source maps are not supported at all. See https://github.com/vitejs/vite/issues/2830 for more details.
- In PostCSS, minified CSS source maps are not supported. This is due to the complexity required around re-associating every AST node with a location in the generated, optimized CSS. This complexity would also have a non-trivial performance impact.

## Testing

Here's how to test the source map functionality in different environments:

### Testing the CLI

1. Setup typical project that the CLI can use and with sources to scan.

```css
@import "tailwindcss";

@utilty my-custom-utility {
  color: red;
}

/* to test `@apply` */
.card {
  @apply bg-white text-center shadow-md;
}
```

2. Build with source maps:
```bash
bun /path/to/tailwindcss/packages/@tailwindcss-cli/src/index.ts --input input.css -o output.css --map
```

3. Open Chrome DevTools, inspect an element with utility classes, and you should see rules pointing to `input.css` or `node_modules/tailwindcss/index.css`

### Testing with Vite

Testing in Vite will require building and installing necessary files under `dist/*.tgz`.

1. Create a Vite project and enable source maps in `vite.config.js`:
```js
import tailwindcss from "@tailwindcss/vite";
import { defineConfig } from "vite";

export default defineConfig({
  plugins: [tailwindcss()],
  css: {
    // This line is required for them to work
    devSourcemap: true,
  },
})
```

2. Add a component that uses Tailwind classes and custom CSS:
```jsx
// ./src/app.jsx
export default function App() {
  return (
    <div className="bg-blue-500 my-custom-class">
      Hello World
    </div>
  )
}
```

```css
/* ./src/styles.css */
@import "tailwindcss";

@utilty my-custom-utility {
  color: red;
}

/* to test `@apply` */
.card {
  @apply bg-white text-center shadow-md;
}
```

3. Run `npm run dev`, open DevTools, and inspect elements to verify source mapping works for both utility classes and custom CSS.

### Testing with PostCSS CLI

1. Create a test file and update your PostCSS config:
```css
/* input.css */
@import "tailwindcss";

@layer components {
  .card {
    @apply p-6 rounded-lg shadow-lg;
  }
}
```

```jsonc
// package.json
{
  // …
  "postcss": {
    "map": {
      "inline": true
    },
    "plugins": {
      "/path/to/tailwindcss/packages/packages/@tailwindcss-postcss/src/index.ts": {}
    }
  }
}
```

2. Run PostCSS through Bun:
```bash
bunx --bun postcss ./src/index.css -o out.css
```

3. Inspect the output CSS - it should include an inline source map comment at the bottom.

### Testing with PostCSS + Next.js

Testing in Next.js will require building and installing necessary files under `dist/*.tgz`. However, I've not been able to get CSS source maps to work in Next.js without this hack:

```js
const nextConfig: NextConfig = {
  // next.js overwrites config.devtool so we prevent it from doing so
  // please don't actually do this…
  webpack: (config) =>
    Object.defineProperty(config, "devtool", {
      get: () => "inline-source-map",
      set: () => {},
    }),
};
```

This is definitely not supported and also doesn't work with turbopack. This can be used to test them temporarily but I suspect that they just don't work there.

### Manual source map analysis

You can analyze source maps using Evan Wallace's  [Source Map Visualization](https://evanw.github.io/source-map-visualization/) tool which will help to verify the accuracy and quality of source maps. This is what I used extensively while developing this implementation.

It'll help verify that custom, user CSS maps back to itself in the input, that generated utilities all map back to `@tailwind utilities;`, that source locations from imported files are also handled correctly, etc… It also highlights the ranges of stuff so it's easy to see if there are off-by-one errors.

It's easiest to use inline source maps with this tool because you can take the CSS file and drop it on the page and it'll analyze it while showing the file content.

If you're using Vite you'll want to access the CSS file with `?direct` at the end so you don't get a JS module back.

## Implementation

The source map implementation follows the ECMA-426 specification and includes several key components to aid in that goal:

### Source Location Tracking

Each emittable AST node in the compilation pipeline tracks two types of source locations:
- `src`: Original source location - [source file, start offset, end offset]
- `dst`: Generated source location - [output file, start offset, end offset]

This dual tracking allows us to maintain mappings between the original source and generated output for things like user CSS, generated utilities, uses of `@apply`, and tracking theme variables.

It is important to note that source locations for nodes _never overlap_ within a file which helps simplify source map generation. As such each type of node tracks a specific piece of itself rather than its entire "block":

| Node        | What a `SourceLocation` represents                               |
| ----------- | ---------------------------------------------------------------- |
| Style Rule  | The selector                                                     |
| At Rule     | Rule name and params, includes the `@`                           |
| Declaration | Property name and value, excludes the semicolon                  |
| Comment     | The entire comment, includes the start `/*` and end `*/` markers |

### Windows line endings when parsing CSS

Because our AST tracks nodes through offsets we must ensure that any mutations to the file do *not* change the lenth of the string. We were previously replacing `\r\n` with `\n` (see [filter code points](https://drafts.csswg.org/css-syntax/#css-filter-code-points) from the spec) — which changes the length of the string and all offsets may end up incorrect. The CSS parser was updated to handle the CRLF token directly by skipping over the `\r` and letting remaining code handle `\n` as it did previously. Some additional tweaks were required when "peeking" the input but those changes were fairly small.

### Tracking of imports

Source maps need paths to the actual imported stylesheets but the resolve step for stylesheets happens inside the call to `loadStylesheet` which make the file path unavailable to us. Because of this the `loadStylesheet` API was augmented such that it has to return a `path` property that we can then use to identify imported sources. I've also made the same change to the `loadModule` API for consistency but nothing currently uses this property.

The `path` property likely makes `base` redundant but elminating that (if we even want to) is a future task.

### Optimizing the AST

Our optimization pass may intoduce some nodes, for example, fallbacks we create for `@property`. These nodes are linked back to `@tailwind utilities` as ultimately that is what is responsible for creating them.

### Line Offset Tables

A key component to our source map generation is the line offset table, which was inspired by some ESBuild internals. It stores a sorted list of offsets for the start of each line allowing us to translate offsets to line/column `Position`s in `O(log N)` time and from `Position`s to offsets in `O(1)` time. Creation of the table takes `O(N)` time.

This means that we can store code point offsets for source locations and not have to worry about computing or tracking line/column numbers during parsing and serialization. Only when a source map is generated do these offsets need to be computed. This ensures the performance penalty when not using source maps is minimal.

### Source Map Generation

The source map returned by `buildSourceMap()` is designed to follow the [ECMA-426 spec](https://tc39.es/ecma426). Because that spec is not completely finalized we consider the result of `buildSourceMap()` to be internal API that may change as the spec chamges.

The produces source map is a "decoded" map such that all sources and mappings are in an object graph. A library like `source-map-js` must be used to convert this to an encoded source map of the right version where mappings are encoded with base 64 VLQs.

Any specific integration (Vite, PostCSS, etc…) can then use `toSourceMap()` from `@tailwindcss/node` to convert from the internal source map to an spec-compliant encoded source map that can be understood by other tools.

### Handling minification in Lightning

Since we use Lightning CSS for optimization, and it takes in an input map, we generate an encoded source map that we then pass to lightning. The output source map *from lighting itself* is then passed back in during the second optimization pass. The final map is then passed from lightning to the CLI (but not Vite or PostCSS — see the limitations section for details).

In some cases we have to "fix up" the output CSS. When this happens we use `magic-string` to do the replacement in a way that is trackable and `@amppproject/remapping` to map that change back onto the original source map. Once the need for these fix ups disappear these dependencies can go away.

Notes:
- The accuracy of source maps run though lightning is reduced as it only tracks on a per-rule level. This is sufficient enough for browser dev tools so should be fine.
- Source maps during optimization do not function properly at this time because of a bug in Lightning CSS regarding license comments. Once this bug is fixed they will start working as expected.

### How source locations flow through the system

1. During initial CSS parsing, source locations are preserved.
2. During parsing these source locations are also mapped to the destinations which supports an optimization for when no utilities are generated.
3. Throughout the compilation process, transformations maintain source location data
4. Generated utilities are explicitly pointed to `@tailwind utilities` unless generated by `@apply`.
5. When optimization is enabled, source maps are remapped through lightningcss
6. Final source maps are written in the requested format (inline or separate file)
