### PR TITLE
Skip `color-mix(…)` when opacity is `100%`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace `_` with `.` in theme suggestions for `@utility` if surrounded by digits ([#17743](https://github.com/tailwindlabs/tailwindcss/pull/17743))
 - Upgrade: Bump all Tailwind CSS related dependencies during upgrade ([#17763](https://github.com/tailwindlabs/tailwindcss/pull/17763))
 - PostCSS: Ensure that errors in stylesheet dependencies are recoverable ([#17754](https://github.com/tailwindlabs/tailwindcss/pull/17754))
+- Skip `color-mix(…)` when opacity is `100%` ([#17815](https://github.com/tailwindlabs/tailwindcss/pull/17815))
 
 ## [4.1.4] - 2025-04-14
 

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -10695,6 +10695,8 @@ test('bg', async () => {
         'bg-red-500/2.75',
         'bg-red-500/[0.5]',
         'bg-red-500/[50%]',
+        'bg-red-500/100',
+        'bg-red-500/[100%]',
         'bg-blue-500',
         'bg-current',
         'bg-current/50',
@@ -10992,6 +10994,10 @@ test('bg', async () => {
       }
     }
 
+    .bg-red-500\\/100 {
+      background-color: var(--color-red-500);
+    }
+
     .bg-red-500\\/\\[0\\.5\\] {
       background-color: #ef444480;
     }
@@ -11010,6 +11016,10 @@ test('bg', async () => {
       .bg-red-500\\/\\[50\\%\\] {
         background-color: color-mix(in oklab, var(--color-red-500) 50%, transparent);
       }
+    }
+
+    .bg-red-500\\/\\[100\\%\\] {
+      background-color: var(--color-red-500);
     }
 
     .bg-transparent {

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -173,6 +173,11 @@ export function withAlpha(value: string, alpha: string): string {
     alpha = `${alphaAsNumber * 100}%`
   }
 
+  // No need for `color-mix` if the alpha is `100%`
+  if (alpha === '100%') {
+    return value
+  }
+
   return `color-mix(in oklab, ${value} ${alpha}, transparent)`
 }
 


### PR DESCRIPTION
This PR improves colors with alpha values where the alpha value results in 100%.

Before this change, a class like `bg-red-500/100` would be generated as:

```css
.bg-red-500\/100 {
  background-color: #ef4444;
}

@supports (color: color-mix(in lab, red, red)) {
  .bg-red-500\/100 {
    background-color: color-mix(in oklab, var(--color-red-500) 100%, transparent);
  }
}
```

But we don't need the `color-mix`, or the fallback styles at all in case the alpha value is 100%. 

After this change the `bg-red-500/100` class will generate as:

```css
.bg-red-500\/100 {
  background-color: var(--color-red-500);
}
```

Which is essentially the same as `bg-red-500`, but we can migrate that away in the future. At least the generated CSS is smaller.

## Test plan

1. Added a test to ensure the generated value doesn't include color-mix at all.