### PR TITLE
Skip `.css` files when migrating templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Upgrade: Automatically convert candidates with arbitrary values to their utilities ([#17831](https://github.com/tailwindlabs/tailwindcss/pull/17831))
+- Upgrade: Automatically convert candidates with arbitrary values to their utilities ([#17831](https://github.com/tailwindlabs/tailwindcss/pull/17831), [#17854](https://github.com/tailwindlabs/tailwindcss/pull/17854))
 
 ### Fixed
 

--- a/packages/@tailwindcss-upgrade/src/index.ts
+++ b/packages/@tailwindcss-upgrade/src/index.ts
@@ -283,6 +283,7 @@ async function run() {
         let scanner = new Scanner({ sources })
         let filesToMigrate = []
         for (let file of scanner.files) {
+          if (file.endsWith('.css')) continue
           if (seenFiles.has(file)) continue
           seenFiles.add(file)
           filesToMigrate.push(file)


### PR DESCRIPTION
This PR fixes an issue where the upgrade tool also migrates `.css` files as-if they are content files. This is not the intended behavior.

## Test plan

Ran this on my personal website. 

Before:
<img width="1316" alt="image" src="https://github.com/user-attachments/assets/2b7337c6-7b88-4811-911f-139ab2e31b3b" />

After: 
<img width="1046" alt="image" src="https://github.com/user-attachments/assets/55f09355-37cb-419b-9924-973cf2681c1d" />
