### PR TITLE
Fix Windows CI build

### DIFF
--- a/crates/oxide/src/extractor/pre_processors/haml.rs
+++ b/crates/oxide/src/extractor/pre_processors/haml.rs
@@ -425,7 +425,7 @@ mod tests {
         let actual = Haml::extract_annotated(include_bytes!("./test-fixtures/haml/src-17051.haml"));
         let expected = include_str!("./test-fixtures/haml/dst-17051.haml");
 
-        assert_eq!(actual, expected);
+        assert_eq!(actual.replace("\r\n", "\n"), expected.replace("\r\n", "\n"));
     }
 
     // https://github.com/tailwindlabs/tailwindcss/issues/17813
@@ -434,7 +434,7 @@ mod tests {
         let actual = Haml::extract_annotated(include_bytes!("./test-fixtures/haml/src-17813.haml"));
         let expected = include_str!("./test-fixtures/haml/dst-17813.haml");
 
-        assert_eq!(actual, expected);
+        assert_eq!(actual.replace("\r\n", "\n"), expected.replace("\r\n", "\n"));
     }
 
     #[test]


### PR DESCRIPTION
This PR fixes a Windows CI issue due to the recently merged #17846

There might be better ways to solve this, but essentially we want to make sure we are always dealing with `\n` and not `\r\n`. This PR fixes that by replacing all `\r\n` with `\n` in the tests.