### PR TITLE
Put components into an extra layer when using the legacy JS API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix incorrectly replacing `_` with ` ` in arbitrary modifier shorthand `bg-red-500/(--my_opacity)` ([#17889](https://github.com/tailwindlabs/tailwindcss/pull/17889))
 - Upgrade: Bump dependencies in parallel and make the upgrade faster ([#17898](https://github.com/tailwindlabs/tailwindcss/pull/17898))
 - Don't scan `.log` files for classes by default ([#17906](https://github.com/tailwindlabs/tailwindcss/pull/17906))
+- Ensure that components added via the JS API are put into a layer so they can always be overwritten by utilities ([#17918](https://github.com/tailwindlabs/tailwindcss/pull/17918))
 
 ## [4.1.5] - 2025-04-30
 

--- a/packages/tailwindcss/src/compat/plugin-api.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.ts
@@ -448,11 +448,35 @@ export function buildPluginApi({
     },
 
     addComponents(components, options) {
-      this.addUtilities(components, options)
+      function wrapRecord(record: Record<string, CssInJs>) {
+        return Object.fromEntries(
+          Object.entries(record).map(([key, value]) => [
+            key,
+            {
+              '@layer components': value,
+            },
+          ]),
+        )
+      }
+
+      this.addUtilities(
+        Array.isArray(components) ? components.map(wrapRecord) : wrapRecord(components),
+        options,
+      )
     },
 
     matchComponents(components, options) {
-      this.matchUtilities(components, options)
+      this.matchUtilities(
+        Object.fromEntries(
+          Object.entries(components).map(([key, fn]) => [
+            key,
+            (value, extra) => ({
+              '@layer components': fn(value, extra),
+            }),
+          ]),
+        ),
+        options,
+      )
     },
 
     theme: createThemeFn(

--- a/packages/tailwindcss/tests/fixtures/example-plugin.ts
+++ b/packages/tailwindcss/tests/fixtures/example-plugin.ts
@@ -1,0 +1,23 @@
+import type { PluginAPI } from '../../src/compat/plugin-api'
+
+export function plugin({ addComponents, addUtilities }: PluginAPI) {
+  addUtilities({
+    '.btn-utility': {
+      padding: '1rem 2rem',
+      borderRadius: '1rem',
+    },
+  })
+  addComponents({
+    '.btn': {
+      padding: '.5rem 1rem',
+      borderRadius: '.25rem',
+    },
+    '.btn-blue': {
+      backgroundColor: '#3490dc',
+      color: '#fff',
+      '&:hover': {
+        backgroundColor: '#2779bd',
+      },
+    },
+  })
+}


### PR DESCRIPTION
This PR changes the way how legacy JS `addComponents()` and `matchComponents()` CSS is handled. In v3, these were conceptually added to the `@layer components` so that each utility defined in `@layer utility` is able to overwrite it.

In order to improve backwards compatibility, this PR tries to recreate the same behavior by relying on [layer nesting](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer#nesting_layers). This means that as far as core is concerned, there is still only one `utility` layer, however utilities added via these APIs will now create a nested `@layer components`. Since all utilities that are in the `@layer utilities` alone will have have a higher presedenc than the components defined in `@layer utilities.components`, this will emulate the legacy behavior. 

## Test plan

- Added unit tests
- Added a UI test to ensure the layers are resolved correctly 