### PR TITLE
Trigger updates to the internal `upgrades` repo

### DIFF
--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -312,7 +312,7 @@ jobs:
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: 'tailwindlabs',
-              repo: 'play.tailwindcss.com',
-              ref: 'master',
+              repo: 'upgrades',
+              ref: 'main',
               workflow_id: 'upgrade-tailwindcss.yml'
             })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,7 +306,7 @@ jobs:
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: 'tailwindlabs',
-              repo: 'play.tailwindcss.com',
-              ref: 'master',
+              repo: 'upgrades',
+              ref: 'main',
               workflow_id: 'upgrade-tailwindcss.yml'
             })


### PR DESCRIPTION
This PR updates will now trigger the new internal `upgrades` repo instead of the Tailwind Play repo directly.

We will be updating more internal repos when a new version is published. We will also use that new repo to update our other repos for other published packages in the future.
