### PR TITLE
Adds default styles for `[popover]`

### DIFF
--- a/packages/tailwindcss/preflight.css
+++ b/packages/tailwindcss/preflight.css
@@ -15,6 +15,12 @@
   border: 0 solid; /* 3 */
 }
 
+[popover] {
+  margin: auto;
+  background-color: transparent;
+  color: inherit;
+}
+
 /*
   1. Use a consistent sensible line-height in all browsers.
   2. Prevent adjustments of font size after orientation changes in iOS.


### PR DESCRIPTION
This PR addresses existing preflight styles that break the default positioning of popover elements, as well as add some sensible default colors to override those set by the UA by default

-  **Restores default centering**: Implements `margin: auto` to maintain the expected centering for popovers.
-  **Sensible default colors**: 
  - Sets `color: inherit` for more predictable text styles.
  - Sets `background-color: transparent` for easier customization.

The browser's defaults for these colors are `canvastext` and `canvas` color, respectively, which is another option (to allow the UA styles to take precedence), but I think the inherit/transparent styles are more customizable by default, similar to how borders are removed from form controls when Tailwind CSS applies `appearance: none` to form controls, by default.

**Minimal repro:** https://play.tailwindcss.com/jjyvteYH0n