### PR TITLE
Print sources when `DEBUG=*` is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Upgrade: Automatically convert candidates with arbitrary values to their utilities ([#17831](https://github.com/tailwindlabs/tailwindcss/pull/17831), [#17854](https://github.com/tailwindlabs/tailwindcss/pull/17854))
-- Write to log file when using `DEBUG=*` ([#17906](https://github.com/tailwindlabs/tailwindcss/pull/17906))
+- Write to log file when using `DEBUG=*` ([#17906](https://github.com/tailwindlabs/tailwindcss/pull/17906), [#17952](https://github.com/tailwindlabs/tailwindcss/pull/17952))
 - Add support for source maps in development ([#17775](https://github.com/tailwindlabs/tailwindcss/pull/17775))
 
 ### Fixed

--- a/crates/oxide/src/scanner/mod.rs
+++ b/crates/oxide/src/scanner/mod.rs
@@ -153,7 +153,23 @@ pub struct Scanner {
 
 impl Scanner {
     pub fn new(sources: Vec<PublicSourceEntry>) -> Self {
+        init_tracing();
+
+        if *SHOULD_TRACE {
+            event!(tracing::Level::INFO, "Provided sources:");
+            for source in &sources {
+                event!(tracing::Level::INFO, "Source: {:?}", source);
+            }
+        }
+
         let sources = Sources::new(public_source_entries_to_private_source_entries(sources));
+
+        if *SHOULD_TRACE {
+            event!(tracing::Level::INFO, "Optimized sources:");
+            for source in sources.iter() {
+                event!(tracing::Level::INFO, "Source: {:?}", source);
+            }
+        }
 
         Self {
             sources: sources.clone(),
@@ -163,7 +179,6 @@ impl Scanner {
     }
 
     pub fn scan(&mut self) -> Vec<String> {
-        init_tracing();
         self.scan_sources();
 
         // TODO: performance improvement, bail early if we don't have any changed content


### PR DESCRIPTION
This PR improves the debug logging by also adding the provided `@source` to the log file. It will also print the optimized sources (the ones we expand and mark as `Auto` or `Pattern`).


In the logs, this will look like this:

```
2025-05-09T11:03:32.906478Z  INFO tailwindcss_oxide::scanner: Provided sources:
2025-05-09T11:03:32.906544Z  INFO tailwindcss_oxide::scanner: Source: PublicSourceEntry { base: "/Users/robin/github.com/RobinMalfait/spreadsheet", pattern: "**/*", negated: false }
2025-05-09T11:03:32.906589Z  INFO tailwindcss_oxide::scanner: Optimized sources:
2025-05-09T11:03:32.906595Z  INFO tailwindcss_oxide::scanner: Source: Auto { base: "/Users/robin/github.com/RobinMalfait/spreadsheet" }
```

Or if you have more sources:

```
2025-05-09T11:06:54.767546Z  INFO tailwindcss_oxide::scanner: Provided sources:
2025-05-09T11:06:54.767660Z  INFO tailwindcss_oxide::scanner: Source: PublicSourceEntry { base: "/Users/robin/github.com/RobinMalfait/spreadsheet", pattern: "**/*", negated: false }
2025-05-09T11:06:54.767987Z  INFO tailwindcss_oxide::scanner: Source: PublicSourceEntry { base: "/Users/robin/github.com/RobinMalfait/spreadsheet/app", pattern: "./routes/*.{jsx,tsx}", negated: false }
2025-05-09T11:06:54.767992Z  INFO tailwindcss_oxide::scanner: Source: PublicSourceEntry { base: "/Users/robin/github.com/RobinMalfait/spreadsheet/app", pattern: "./utils/*.ts", negated: false }
2025-05-09T11:06:54.768450Z  INFO tailwindcss_oxide::scanner: Optimized sources:
2025-05-09T11:06:54.768455Z  INFO tailwindcss_oxide::scanner: Source: Auto { base: "/Users/robin/github.com/RobinMalfait/spreadsheet" }
2025-05-09T11:06:54.768459Z  INFO tailwindcss_oxide::scanner: Source: Pattern { base: "/Users/robin/github.com/RobinMalfait/spreadsheet/app/routes", pattern: "*.jsx" }
2025-05-09T11:06:54.768462Z  INFO tailwindcss_oxide::scanner: Source: Pattern { base: "/Users/robin/github.com/RobinMalfait/spreadsheet/app/routes", pattern: "*.tsx" }
2025-05-09T11:06:54.768466Z  INFO tailwindcss_oxide::scanner: Source: Pattern { base: "/Users/robin/github.com/RobinMalfait/spreadsheet/app/utils", pattern: "*.ts" }
```

