### PR TITLE
Allow `_` before numbers during candidate extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Allow `_` before numbers during candidate extraction ([#17961](https://github.com/tailwindlabs/tailwindcss/pull/17961))
 
 ## [4.1.6] - 2025-05-09
 

--- a/crates/oxide/src/extractor/named_utility_machine.rs
+++ b/crates/oxide/src/extractor/named_utility_machine.rs
@@ -279,7 +279,11 @@ impl Machine for NamedUtilityMachine<ParsingState> {
                 Class::Number => {
                     if !matches!(
                         cursor.prev.into(),
-                        Class::Dash | Class::Dot | Class::Number | Class::AlphaLower
+                        Class::Dash
+                            | Class::Underscore
+                            | Class::Dot
+                            | Class::Number
+                            | Class::AlphaLower
                     ) {
                         return self.restart();
                     }

--- a/crates/oxide/src/extractor/named_utility_machine.rs
+++ b/crates/oxide/src/extractor/named_utility_machine.rs
@@ -415,6 +415,9 @@ mod tests {
             // With numbers
             ("px-5", vec!["px-5"]),
             ("px-2.5", vec!["px-2.5"]),
+            // Underscores followed by numbers
+            ("header_1", vec!["header_1"]),
+            ("header_1_2", vec!["header_1_2"]),
             // With number followed by dash or underscore
             ("text-title1-strong", vec!["text-title1-strong"]),
             ("text-title1_strong", vec!["text-title1_strong"]),


### PR DESCRIPTION
This PR fixes a bug where a class like `header_1` wasn't properly extracted because we didn't allow an `_` before a number.

This PR fixes that by allowing an `_` before a number.

Fixes: #17960


## Test plan

1. Added a test to verify this works
2. Existing tests work

Used the visualizer tool for this to verify that the `header_1` class is being extracted:
<img width="1816" alt="image" src="https://github.com/user-attachments/assets/fdc21602-0e2b-4e4e-92a1-19c4f4f5393f" />

