### PR TITLE
Fix upgrade error when using `@import … source(…)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Allow `_` before numbers during candidate extraction ([#17961](https://github.com/tailwindlabs/tailwindcss/pull/17961))
+- Upgrade: Fix error when using `@import … source(…)` ([#17963](https://github.com/tailwindlabs/tailwindcss/pull/17963))
 
 ## [4.1.6] - 2025-05-09
 

--- a/packages/@tailwindcss-upgrade/src/codemods/css/analyze.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/css/analyze.ts
@@ -39,7 +39,7 @@ export async function analyze(stylesheets: Stylesheet[]) {
       AtRule: {
         import(node) {
           // Find what the import points to
-          let id = node.params.match(/['"](.*)['"]/)?.[1]
+          let id = node.params.match(/['"](.*?)['"]/)?.[1]
           if (!id) return
 
           let basePath = node.source?.input.file


### PR DESCRIPTION
This PR fixes an issue when running the upgrade tool and if any of the CSS files has an import that looks like this:

```css
@import "tailwindcss" source("…");
```

This was trying to resolve `tailwindcss" source("…` instead of `tailwindcss`.

This PR fixes that by fixing the regex we used. Made the quantifier lazy to match as few characters as possible and thus only matching `tailwindcss` in this case.

## Test plan

1. Ran it locally on a project

Before:

<img width="1158" alt="image" src="https://github.com/user-attachments/assets/09bf5d69-797c-4330-ade1-edc213f7ce5c" />

After:

<img width="1029" alt="image" src="https://github.com/user-attachments/assets/d1c9e194-30e2-4564-83c5-d9a259a67e90" />
