### PR TITLE
Add ignore pattern for node_modules in globby search in upgrade cli

### DIFF
--- a/packages/@tailwindcss-upgrade/src/index.ts
+++ b/packages/@tailwindcss-upgrade/src/index.ts
@@ -71,6 +71,8 @@ async function run() {
       files = await globby(['**/*.css'], {
         absolute: true,
         gitignore: true,
+        // gitignore: true will first search for all .gitignore including node_modules folders, this makes the initial search much faster
+        ignore: ['**/node_modules/**'],
       })
     }
 


### PR DESCRIPTION
When passing `gitignore: true` to globby it will start a search for all .gitignore files, this initial search includes node_modules making it hang forever for large monorepos with many files inside node_modules 