### PR TITLE
Upgrade: Migrate `outline` class

### DIFF
--- a/integrations/upgrade/index.test.ts
+++ b/integrations/upgrade/index.test.ts
@@ -81,6 +81,9 @@ test(
 
         <!-- Migrate to -3 -->
         <div class="ring"></div>
+
+        <!-- Migrate to -solid -->
+        <div class="outline"></div>
       `,
       'src/input.css': css`
         @tailwind base;
@@ -116,6 +119,9 @@ test(
 
       <!-- Migrate to -3 -->
       <div class="ring-3"></div>
+
+      <!-- Migrate to -solid -->
+      <div class="outline-solid"></div>
 
       --- ./src/input.css ---
       @import 'tailwindcss';

--- a/packages/@tailwindcss-upgrade/src/codemods/template/migrate-legacy-classes.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/template/migrate-legacy-classes.test.ts
@@ -27,6 +27,8 @@ test.each([
 
   ['ring', 'ring-3'],
 
+  ['outline', 'outline-solid'],
+
   ['blur!', 'blur-sm!'],
   ['hover:blur', 'hover:blur-sm'],
   ['hover:blur!', 'hover:blur-sm!'],

--- a/packages/@tailwindcss-upgrade/src/codemods/template/migrate-legacy-classes.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/template/migrate-legacy-classes.ts
@@ -33,6 +33,8 @@ const LEGACY_CLASS_MAP = new Map([
   ['backdrop-blur-sm', 'backdrop-blur-xs'],
 
   ['ring', 'ring-3'],
+
+  ['outline', 'outline-solid'],
 ])
 
 const THEME_KEYS = new Map([


### PR DESCRIPTION
This PR adds a migration from `outline` to `outline-solid` for the v3 -> v4 upgrade tool.

## Test plan

- Added integration test