### PR TITLE
Fix missing extracted classes containing `.` in Clojure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade: Change casing of utilities with named values to kebab-case to match updated theme variables ([#18017](https://github.com/tailwindlabs/tailwindcss/pull/18017))
 - Upgrade: Fix unsafe migrations in Vue files ([#18025](https://github.com/tailwindlabs/tailwindcss/pull/18025))
 - Ignore custom variants using `:merge(…)` selectors in legacy JS plugins ([#18020](https://github.com/tailwindlabs/tailwindcss/pull/18020))
+- Fix missing extracted classes containing `.` in Clojure ([#18038](https://github.com/tailwindlabs/tailwindcss/pull/18038))
 
 ### Added
 

--- a/crates/oxide/src/extractor/pre_processors/clojure.rs
+++ b/crates/oxide/src/extractor/pre_processors/clojure.rs
@@ -42,6 +42,18 @@ impl PreProcessor for Clojure {
                     }
                 }
 
+                // A `.`  surrounded by digits is a decimal number, so we don't want to replace it.
+                //
+                // E.g.:
+                // ```
+                // gap-1.5
+                //      ^
+                // ``
+                b'.' if cursor.prev.is_ascii_digit() && cursor.next.is_ascii_digit() => {
+
+                    // Keep the `.` as-is
+                }
+
                 b':' | b'.' => {
                     result[cursor.pos] = b' ';
                 }

--- a/crates/oxide/src/extractor/pre_processors/clojure.rs
+++ b/crates/oxide/src/extractor/pre_processors/clojure.rs
@@ -156,4 +156,14 @@ mod tests {
 
         Clojure::test_extract_contains(input, vec!["hover:flex", "px-1.5"]);
     }
+
+    // https://github.com/tailwindlabs/tailwindcss/issues/17760
+    #[test]
+    fn test_extraction_of_classes_with_dots() {
+        let input = r#"
+            ($ :div {:class [:flex :gap-1.5 :p-1]} …)
+        "#;
+
+        Clojure::test_extract_contains(input, vec!["flex", "gap-1.5", "p-1"]);
+    }
 }


### PR DESCRIPTION
This PR fixes an issue in the Clojure pre-processor where candidates including `.` characters were not extracted correctly.

The solution here is to only replace the `.` with a ` ` when the `.` is not surrounded by numbers. This means that:


```
:.foo.bar
```
Becomes
```
: foo bar
```

But
```
:.gap-1.5.flex
```

Becomes
```
: gap-1.5 flex
```

This way the `gap-1.5` is correctly extracted.

## Test plan

1. Added a test for this case
2. Tested this in the extractor tool as well. Notice how the `gap-1.5` is correctly extracted here.

<img width="1247" alt="image" src="https://github.com/user-attachments/assets/f5dd2600-5c5e-4ad8-88af-4e5be44340f5" />


Fixes: #17760
