### PR TITLE
Proposal: Allow overwriting static utilities that have a namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure that file system watchers created when using the CLI are always cleaned up ([#18905](https://github.com/tailwindlabs/tailwindcss/pull/18905))
 - Do not generate `grid-column` utilities when configuring `grid-column-start` or `grid-column-end` ([#18907](https://github.com/tailwindlabs/tailwindcss/pull/18907))
 - Do not generate `grid-row` utilities when configuring `grid-row-start` or `grid-row-end` ([#18907](https://github.com/tailwindlabs/tailwindcss/pull/18907))
+- Prevent duplicate CSS when overwriting a static utility with a theme key ([#18056](https://github.com/tailwindlabs/tailwindcss/pull/18056))
 
 ## [4.1.13] - 2025-09-03
 

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -1334,7 +1334,6 @@ test('col-start', async () => {
     }
 
     .col-start-auto {
-      grid-column: var(--grid-column-start-auto);
       grid-column-start: var(--grid-column-start-auto);
     }"
   `)
@@ -1409,7 +1408,6 @@ test('col-end', async () => {
     }
 
     .col-end-auto {
-      grid-column: var(--grid-column-end-auto);
       grid-column-end: var(--grid-column-end-auto);
     }"
   `)
@@ -1573,7 +1571,6 @@ test('row-start', async () => {
     }
 
     .row-start-auto {
-      grid-row: var(--grid-row-start-auto);
       grid-row-start: var(--grid-row-start-auto);
     }"
   `)
@@ -1648,7 +1645,6 @@ test('row-end', async () => {
     }
 
     .row-end-auto {
-      grid-row: var(--grid-row-end-auto);
       grid-row-end: var(--grid-row-end-auto);
     }"
   `)

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -9771,6 +9771,25 @@ test('rounded', async () => {
     }"
   `)
   expect(
+    await compileCss(
+      css`
+        @theme {
+          --radius-full: 99999px;
+        }
+        @tailwind utilities;
+      `,
+      ['rounded-full'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --radius-full: 99999px;
+    }
+
+    .rounded-full {
+      border-radius: var(--radius-full);
+    }"
+  `)
+  expect(
     await run([
       '-rounded',
       '-rounded-full',
@@ -9945,15 +9964,11 @@ test('rounded-t', async () => {
     }
 
     .rounded-t-full {
-      border-top-left-radius: 3.40282e38px;
-      border-top-right-radius: 3.40282e38px;
       border-top-left-radius: var(--radius-full);
       border-top-right-radius: var(--radius-full);
     }
 
     .rounded-t-none {
-      border-top-left-radius: 0;
-      border-top-right-radius: 0;
       border-top-left-radius: var(--radius-none);
       border-top-right-radius: var(--radius-none);
     }
@@ -10012,15 +10027,11 @@ test('rounded-r', async () => {
     }
 
     .rounded-r-full {
-      border-top-right-radius: 3.40282e38px;
-      border-bottom-right-radius: 3.40282e38px;
       border-top-right-radius: var(--radius-full);
       border-bottom-right-radius: var(--radius-full);
     }
 
     .rounded-r-none {
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
       border-top-right-radius: var(--radius-none);
       border-bottom-right-radius: var(--radius-none);
     }
@@ -10079,15 +10090,11 @@ test('rounded-b', async () => {
     }
 
     .rounded-b-full {
-      border-bottom-right-radius: 3.40282e38px;
-      border-bottom-left-radius: 3.40282e38px;
       border-bottom-right-radius: var(--radius-full);
       border-bottom-left-radius: var(--radius-full);
     }
 
     .rounded-b-none {
-      border-bottom-right-radius: 0;
-      border-bottom-left-radius: 0;
       border-bottom-right-radius: var(--radius-none);
       border-bottom-left-radius: var(--radius-none);
     }
@@ -10146,15 +10153,11 @@ test('rounded-l', async () => {
     }
 
     .rounded-l-full {
-      border-top-left-radius: 3.40282e38px;
-      border-bottom-left-radius: 3.40282e38px;
       border-top-left-radius: var(--radius-full);
       border-bottom-left-radius: var(--radius-full);
     }
 
     .rounded-l-none {
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
       border-top-left-radius: var(--radius-none);
       border-bottom-left-radius: var(--radius-none);
     }
@@ -10443,12 +10446,10 @@ test('rounded-tl', async () => {
     }
 
     .rounded-tl-full {
-      border-top-left-radius: 3.40282e38px;
       border-top-left-radius: var(--radius-full);
     }
 
     .rounded-tl-none {
-      border-top-left-radius: 0;
       border-top-left-radius: var(--radius-none);
     }
 
@@ -10503,12 +10504,10 @@ test('rounded-tr', async () => {
     }
 
     .rounded-tr-full {
-      border-top-right-radius: 3.40282e38px;
       border-top-right-radius: var(--radius-full);
     }
 
     .rounded-tr-none {
-      border-top-right-radius: 0;
       border-top-right-radius: var(--radius-none);
     }
 
@@ -10563,12 +10562,10 @@ test('rounded-br', async () => {
     }
 
     .rounded-br-full {
-      border-bottom-right-radius: 3.40282e38px;
       border-bottom-right-radius: var(--radius-full);
     }
 
     .rounded-br-none {
-      border-bottom-right-radius: 0;
       border-bottom-right-radius: var(--radius-none);
     }
 
@@ -10623,12 +10620,10 @@ test('rounded-bl', async () => {
     }
 
     .rounded-bl-full {
-      border-bottom-left-radius: 3.40282e38px;
       border-bottom-left-radius: var(--radius-full);
     }
 
     .rounded-bl-none {
-      border-bottom-left-radius: 0;
       border-bottom-left-radius: var(--radius-none);
     }
 

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -1054,6 +1054,26 @@ test('z-index', async () => {
       '-z-[var(--value)]/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --z-index-auto: 42;
+        }
+        @tailwind utilities;
+      `,
+      ['z-auto'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --z-index-auto: 42;
+    }
+
+    .z-auto {
+      z-index: var(--z-index-auto);
+    }"
+  `)
 })
 
 test('order', async () => {
@@ -1114,6 +1134,46 @@ test('order', async () => {
       'order-none/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --order-first: 1;
+        }
+        @tailwind utilities;
+      `,
+      ['order-first'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --order-first: 1;
+    }
+
+    .order-first {
+      order: var(--order-first);
+    }"
+  `)
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --order-last: -1;
+        }
+        @tailwind utilities;
+      `,
+      ['order-last'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --order-last: -1;
+    }
+
+    .order-last {
+      order: var(--order-last);
+    }"
+  `)
 })
 
 test('col', async () => {
@@ -1176,6 +1236,26 @@ test('col', async () => {
       'col-span-[var(--my-variable)]/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --grid-column-auto: 5;
+        }
+        @tailwind utilities;
+      `,
+      ['col-auto'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --grid-column-auto: 5;
+    }
+
+    .col-auto {
+      grid-column: var(--grid-column-auto);
+    }"
+  `)
 })
 
 test('col-start', async () => {
@@ -1237,6 +1317,27 @@ test('col-start', async () => {
       '-col-start-4/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --grid-column-start-auto: 7;
+        }
+        @tailwind utilities;
+      `,
+      ['col-start-auto'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --grid-column-start-auto: 7;
+    }
+
+    .col-start-auto {
+      grid-column: var(--grid-column-start-auto);
+      grid-column-start: var(--grid-column-start-auto);
+    }"
+  `)
 })
 
 test('col-end', async () => {
@@ -1291,6 +1392,27 @@ test('col-end', async () => {
       '-col-end-4/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --grid-column-end-auto: 3;
+        }
+        @tailwind utilities;
+      `,
+      ['col-end-auto'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --grid-column-end-auto: 3;
+    }
+
+    .col-end-auto {
+      grid-column: var(--grid-column-end-auto);
+      grid-column-end: var(--grid-column-end-auto);
+    }"
+  `)
 })
 
 test('row', async () => {
@@ -1353,6 +1475,26 @@ test('row', async () => {
       'row-span-[var(--my-variable)]/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --grid-row-auto: 9;
+        }
+        @tailwind utilities;
+      `,
+      ['row-auto'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --grid-row-auto: 9;
+    }
+
+    .row-auto {
+      grid-row: var(--grid-row-auto);
+    }"
+  `)
 })
 
 test('row-start', async () => {
@@ -1414,6 +1556,27 @@ test('row-start', async () => {
       '-row-start-4/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --grid-row-start-auto: 11;
+        }
+        @tailwind utilities;
+      `,
+      ['row-start-auto'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --grid-row-start-auto: 11;
+    }
+
+    .row-start-auto {
+      grid-row: var(--grid-row-start-auto);
+      grid-row-start: var(--grid-row-start-auto);
+    }"
+  `)
 })
 
 test('row-end', async () => {
@@ -1468,6 +1631,27 @@ test('row-end', async () => {
       '-row-end-4/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --grid-row-end-auto: 13;
+        }
+        @tailwind utilities;
+      `,
+      ['row-end-auto'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --grid-row-end-auto: 13;
+    }
+
+    .row-end-auto {
+      grid-row: var(--grid-row-end-auto);
+      grid-row-end: var(--grid-row-end-auto);
+    }"
+  `)
 })
 
 test('float', async () => {
@@ -2422,6 +2606,29 @@ test('line-clamp', async () => {
       'line-clamp-none/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --line-clamp-none: 0;
+        }
+        @tailwind utilities;
+      `,
+      ['line-clamp-none'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --line-clamp-none: 0;
+    }
+
+    .line-clamp-none {
+      -webkit-line-clamp: var(--line-clamp-none);
+      -webkit-box-orient: vertical;
+      display: -webkit-box;
+      overflow: hidden;
+    }"
+  `)
 })
 
 test('display', async () => {
@@ -3980,6 +4187,26 @@ test('origin', async () => {
       'origin-[var(--value)]/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --transform-origin-top: 10px 20px;
+        }
+        @tailwind utilities;
+      `,
+      ['origin-top'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --transform-origin-top: 10px 20px;
+    }
+
+    .origin-top {
+      transform-origin: var(--transform-origin-top);
+    }"
+  `)
 })
 
 test('perspective-origin', async () => {
@@ -4059,6 +4286,27 @@ test('perspective-origin', async () => {
       'perspective-origin-[var(--value)]/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --perspective-origin-top: 10px 20px;
+        }
+        @tailwind utilities;
+      `,
+      ['perspective-origin-top'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --perspective-origin-top: 10px 20px;
+    }
+
+    .perspective-origin-top {
+      perspective-origin: var(--perspective-origin-top);
+      perspective: var(--perspective-origin-top);
+    }"
+  `)
 })
 
 test('translate', async () => {
@@ -5560,6 +5808,26 @@ test('perspective', async () => {
       'perspective-[456px]/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --perspective-none: 400px;
+        }
+        @tailwind utilities;
+      `,
+      ['perspective-none'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --perspective-none: 400px;
+    }
+
+    .perspective-none {
+      perspective: var(--perspective-none);
+    }"
+  `)
 })
 
 test('cursor', async () => {
@@ -6937,6 +7205,26 @@ test('list', async () => {
       'list-[var(--value)]/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --list-style-type-none: disc;
+        }
+        @tailwind utilities;
+      `,
+      ['list-none'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --list-style-type-none: disc;
+    }
+
+    .list-none {
+      list-style-type: var(--list-style-type-none);
+    }"
+  `)
 })
 
 test('list-image', async () => {
@@ -6958,6 +7246,26 @@ test('list-image', async () => {
       'list-image-[var(--value)]/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --list-style-image-none: url(../foo.png);
+        }
+        @tailwind utilities;
+      `,
+      ['list-image-none'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --list-style-image-none: url("../foo.png");
+    }
+
+    .list-image-none {
+      list-style-image: var(--list-style-image-none);
+    }"
+  `)
 })
 
 test('appearance', async () => {
@@ -7099,6 +7407,26 @@ test('columns', async () => {
       'columns-[var(--value)]/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --columns-auto: 3;
+        }
+        @tailwind utilities;
+      `,
+      ['columns-auto'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --columns-auto: 3;
+    }
+
+    .columns-auto {
+      columns: var(--columns-auto);
+    }"
+  `)
 })
 
 test('break-before', async () => {
@@ -7319,6 +7647,26 @@ test('auto-cols', async () => {
       'auto-cols-[2fr]/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --grid-auto-columns-auto: 2fr;
+        }
+        @tailwind utilities;
+      `,
+      ['auto-cols-auto'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --grid-auto-columns-auto: 2fr;
+    }
+
+    .auto-cols-auto {
+      grid-auto-columns: var(--grid-auto-columns-auto);
+    }"
+  `)
 })
 
 test('grid-flow', async () => {
@@ -7410,6 +7758,26 @@ test('auto-rows', async () => {
       'auto-rows-[2fr]/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --grid-auto-rows-auto: 2fr;
+        }
+        @tailwind utilities;
+      `,
+      ['auto-rows-auto'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --grid-auto-rows-auto: 2fr;
+    }
+
+    .auto-rows-auto {
+      grid-auto-rows: var(--grid-auto-rows-auto);
+    }"
+  `)
 })
 
 test('grid-cols', async () => {
@@ -7459,6 +7827,26 @@ test('grid-cols', async () => {
       'grid-cols-[123]/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --grid-template-columns-none: 200px 1fr;
+        }
+        @tailwind utilities;
+      `,
+      ['grid-cols-none'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --grid-template-columns-none: 200px 1fr;
+    }
+
+    .grid-cols-none {
+      grid-template-columns: var(--grid-template-columns-none);
+    }"
+  `)
 })
 
 test('grid-rows', async () => {
@@ -7508,6 +7896,26 @@ test('grid-rows', async () => {
       'grid-rows-[123]/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --grid-template-rows-none: 200px 1fr;
+        }
+        @tailwind utilities;
+      `,
+      ['grid-rows-none'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --grid-template-rows-none: 200px 1fr;
+    }
+
+    .grid-rows-none {
+      grid-template-rows: var(--grid-template-rows-none);
+    }"
+  `)
 })
 
 test('flex-direction', async () => {
@@ -20020,6 +20428,26 @@ test('object', async () => {
       'object-top/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --object-position-center: top left;
+        }
+        @tailwind utilities;
+      `,
+      ['object-center'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --object-position-center: top left;
+    }
+
+    .object-center {
+      object-position: var(--object-position-center);
+    }"
+  `)
 })
 
 test('p', async () => {
@@ -21322,6 +21750,26 @@ test('animate', async () => {
       'animate-not-found/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --animate-none: bounce 1s infinite;
+        }
+        @tailwind utilities;
+      `,
+      ['animate-none'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --animate-none: bounce 1s infinite;
+    }
+
+    .animate-none {
+      animation: var(--animate-none);
+    }"
+  `)
 })
 
 test('filter', async () => {
@@ -21751,6 +22199,113 @@ test('filter', async () => {
       'sepia-[var(--value)]/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --blur-none: 2px;
+        }
+        @tailwind utilities;
+      `,
+      ['blur-none'],
+    ),
+  ).toMatchInlineSnapshot(`
+    "@layer properties {
+      @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
+        *, :before, :after, ::backdrop {
+          --tw-blur: initial;
+          --tw-brightness: initial;
+          --tw-contrast: initial;
+          --tw-grayscale: initial;
+          --tw-hue-rotate: initial;
+          --tw-invert: initial;
+          --tw-opacity: initial;
+          --tw-saturate: initial;
+          --tw-sepia: initial;
+          --tw-drop-shadow: initial;
+          --tw-drop-shadow-color: initial;
+          --tw-drop-shadow-alpha: 100%;
+          --tw-drop-shadow-size: initial;
+        }
+      }
+    }
+
+    :root, :host {
+      --blur-none: 2px;
+    }
+
+    .blur-none {
+      --tw-blur: blur(var(--blur-none));
+      filter: var(--tw-blur, ) var(--tw-brightness, ) var(--tw-contrast, ) var(--tw-grayscale, ) var(--tw-hue-rotate, ) var(--tw-invert, ) var(--tw-saturate, ) var(--tw-sepia, ) var(--tw-drop-shadow, );
+    }
+
+    @property --tw-blur {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-brightness {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-contrast {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-grayscale {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-hue-rotate {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-invert {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-opacity {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-saturate {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-sepia {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-drop-shadow {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-drop-shadow-color {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-drop-shadow-alpha {
+      syntax: "<percentage>";
+      inherits: false;
+      initial-value: 100%;
+    }
+
+    @property --tw-drop-shadow-size {
+      syntax: "*";
+      inherits: false
+    }"
+  `)
 })
 
 test('backdrop-filter', async () => {
@@ -22131,6 +22686,89 @@ test('backdrop-filter', async () => {
       'backdrop-sepia-[var(--value)]/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --backdrop-blur-none: 2px;
+        }
+        @tailwind utilities;
+      `,
+      ['backdrop-blur-none'],
+    ),
+  ).toMatchInlineSnapshot(`
+    "@layer properties {
+      @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
+        *, :before, :after, ::backdrop {
+          --tw-backdrop-blur: initial;
+          --tw-backdrop-brightness: initial;
+          --tw-backdrop-contrast: initial;
+          --tw-backdrop-grayscale: initial;
+          --tw-backdrop-hue-rotate: initial;
+          --tw-backdrop-invert: initial;
+          --tw-backdrop-opacity: initial;
+          --tw-backdrop-saturate: initial;
+          --tw-backdrop-sepia: initial;
+        }
+      }
+    }
+
+    :root, :host {
+      --backdrop-blur-none: 2px;
+    }
+
+    .backdrop-blur-none {
+      --tw-backdrop-blur: blur(var(--backdrop-blur-none));
+      -webkit-backdrop-filter: var(--tw-backdrop-blur, ) var(--tw-backdrop-brightness, ) var(--tw-backdrop-contrast, ) var(--tw-backdrop-grayscale, ) var(--tw-backdrop-hue-rotate, ) var(--tw-backdrop-invert, ) var(--tw-backdrop-opacity, ) var(--tw-backdrop-saturate, ) var(--tw-backdrop-sepia, );
+      backdrop-filter: var(--tw-backdrop-blur, ) var(--tw-backdrop-brightness, ) var(--tw-backdrop-contrast, ) var(--tw-backdrop-grayscale, ) var(--tw-backdrop-hue-rotate, ) var(--tw-backdrop-invert, ) var(--tw-backdrop-opacity, ) var(--tw-backdrop-saturate, ) var(--tw-backdrop-sepia, );
+    }
+
+    @property --tw-backdrop-blur {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-backdrop-brightness {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-backdrop-contrast {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-backdrop-grayscale {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-backdrop-hue-rotate {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-backdrop-invert {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-backdrop-opacity {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-backdrop-saturate {
+      syntax: "*";
+      inherits: false
+    }
+
+    @property --tw-backdrop-sepia {
+      syntax: "*";
+      inherits: false
+    }"
+  `)
 })
 
 test('transition', async () => {
@@ -22190,9 +22828,6 @@ test('transition', async () => {
     }
 
     .transition-opacity {
-      transition-property: opacity;
-      transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
-      transition-duration: var(--tw-duration, var(--default-transition-duration));
       transition-property: var(--transition-property-opacity);
       transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
       transition-duration: var(--tw-duration, var(--default-transition-duration));
@@ -22278,6 +22913,28 @@ test('transition', async () => {
       'transition-[var(--value)]/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --transition-property-colors: transform;
+        }
+        @tailwind utilities;
+      `,
+      ['transition-colors'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --transition-property-colors: transform;
+    }
+
+    .transition-colors {
+      transition-property: var(--transition-property-colors);
+      transition-timing-function: var(--tw-ease, ease);
+      transition-duration: var(--tw-duration, 0s);
+    }"
+  `)
 })
 
 test('transition-behavior', async () => {
@@ -22421,6 +23078,40 @@ test('ease', async () => {
       'ease-[var(--value)]/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --ease-linear: steps(4);
+        }
+        @tailwind utilities;
+      `,
+      ['ease-linear'],
+    ),
+  ).toMatchInlineSnapshot(`
+    "@layer properties {
+      @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
+        *, :before, :after, ::backdrop {
+          --tw-ease: initial;
+        }
+      }
+    }
+
+    :root, :host {
+      --ease-linear: steps(4);
+    }
+
+    .ease-linear {
+      --tw-ease: var(--ease-linear);
+      transition-timing-function: var(--ease-linear);
+    }
+
+    @property --tw-ease {
+      syntax: "*";
+      inherits: false
+    }"
+  `)
 })
 
 test('will-change', async () => {
@@ -22678,6 +23369,40 @@ test('leading', async () => {
       'leading-[var(--value)]/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --leading-none: 2;
+        }
+        @tailwind utilities;
+      `,
+      ['leading-none'],
+    ),
+  ).toMatchInlineSnapshot(`
+    "@layer properties {
+      @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
+        *, :before, :after, ::backdrop {
+          --tw-leading: initial;
+        }
+      }
+    }
+
+    :root, :host {
+      --leading-none: 2;
+    }
+
+    .leading-none {
+      --tw-leading: var(--leading-none);
+      line-height: var(--leading-none);
+    }
+
+    @property --tw-leading {
+      syntax: "*";
+      inherits: false
+    }"
+  `)
 })
 
 test('tracking', async () => {
@@ -23405,6 +24130,26 @@ test('underline-offset', async () => {
       '-underline-offset-[var(--value)]/foo',
     ]),
   ).toEqual('')
+
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --text-underline-offset-auto: 4px;
+        }
+        @tailwind utilities;
+      `,
+      ['underline-offset-auto'],
+    ),
+  ).toMatchInlineSnapshot(`
+    ":root, :host {
+      --text-underline-offset-auto: 4px;
+    }
+
+    .underline-offset-auto {
+      text-underline-offset: var(--text-underline-offset-auto);
+    }"
+  `)
 })
 
 test('text', async () => {

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -4761,7 +4761,6 @@ export function createUtilities(theme: Theme) {
           decl('line-height', '1'),
         ],
       },
-      Fv,
     },
   )
 

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -708,8 +708,7 @@ export function createUtilities(theme: Theme) {
       auto: [decl('grid-column', 'auto')],
     },
   })
-  // Ensure discoverability for `col-auto` after converting to fallback
-  suggest('col', () => [{ values: ['auto'], valueThemeKeys: ['--grid-column'] }])
+  
   functionalUtility('col-span', {
     handleBareValue: ({ value }) => {
       if (!isPositiveInteger(value)) return null
@@ -755,13 +754,12 @@ export function createUtilities(theme: Theme) {
 
   suggest('col-span', () => [
     {
-      values: ['full', ...Array.from({ length: 12 }, (_, i) => `${i + 1}`)],
+      values: Array.from({ length: 12 }, (_, i) => `${i + 1}`),
       valueThemeKeys: [],
     },
   ])
 
   suggest('col-start', () => [
-    { values: ['auto'], valueThemeKeys: ['--grid-column-start'] },
     {
       supportsNegative: true,
       values: Array.from({ length: 13 }, (_, i) => `${i + 1}`),
@@ -770,7 +768,6 @@ export function createUtilities(theme: Theme) {
   ])
 
   suggest('col-end', () => [
-    { values: ['auto'], valueThemeKeys: ['--grid-column-end'] },
     {
       supportsNegative: true,
       values: Array.from({ length: 13 }, (_, i) => `${i + 1}`),
@@ -793,8 +790,7 @@ export function createUtilities(theme: Theme) {
       auto: [decl('grid-row', 'auto')],
     },
   })
-  // Ensure discoverability for `row-auto` after converting to fallback
-  suggest('row', () => [{ values: ['auto'], valueThemeKeys: ['--grid-row'] }])
+  
   functionalUtility('row-span', {
     themeKeys: [],
     handleBareValue: ({ value }) => {
@@ -841,13 +837,12 @@ export function createUtilities(theme: Theme) {
 
   suggest('row-span', () => [
     {
-      values: ['full', ...Array.from({ length: 12 }, (_, i) => `${i + 1}`)],
+      values: Array.from({ length: 12 }, (_, i) => `${i + 1}`),
       valueThemeKeys: [],
     },
   ])
 
   suggest('row-start', () => [
-    { values: ['auto'], valueThemeKeys: ['--grid-row-start'] },
     {
       supportsNegative: true,
       values: Array.from({ length: 13 }, (_, i) => `${i + 1}`),
@@ -856,7 +851,6 @@ export function createUtilities(theme: Theme) {
   ])
 
   suggest('row-end', () => [
-    { values: ['auto'], valueThemeKeys: ['--grid-row-end'] },
     {
       supportsNegative: true,
       values: Array.from({ length: 13 }, (_, i) => `${i + 1}`),
@@ -936,7 +930,7 @@ export function createUtilities(theme: Theme) {
 
   suggest('line-clamp', () => [
     {
-      values: ['none', '1', '2', '3', '4', '5', '6'],
+      values: ['1', '2', '3', '4', '5', '6'],
       valueThemeKeys: ['--line-clamp'],
     },
   ])
@@ -991,13 +985,7 @@ export function createUtilities(theme: Theme) {
     },
   })
 
-  // Suggest only the keyword aspect values (no fraction burst)
-  suggest('aspect', () => [
-    {
-      values: ['auto', 'square'],
-      valueThemeKeys: ['--aspect'],
-    },
-  ])
+  
 
   /**
    * @css `size`
@@ -1245,23 +1233,7 @@ export function createUtilities(theme: Theme) {
     },
   })
 
-  // Suggest keyword origin values to match snapshot
-  suggest('origin', () => [
-    {
-      values: [
-        'center',
-        'top',
-        'top-right',
-        'right',
-        'bottom-right',
-        'bottom',
-        'bottom-left',
-        'left',
-        'top-left',
-      ],
-      valueThemeKeys: ['--transform-origin'],
-    },
-  ])
+  
 
   functionalUtility('perspective-origin', {
     themeKeys: ['--perspective-origin'],
@@ -1279,23 +1251,7 @@ export function createUtilities(theme: Theme) {
     },
   })
 
-  // Suggest keyword perspective-origin values to match snapshot
-  suggest('perspective-origin', () => [
-    {
-      values: [
-        'center',
-        'top',
-        'top-right',
-        'right',
-        'bottom-right',
-        'bottom',
-        'bottom-left',
-        'left',
-        'top-left',
-      ],
-      valueThemeKeys: ['--perspective-origin'],
-    },
-  ])
+  
 
   /**
    * @css `perspective`
@@ -1308,13 +1264,7 @@ export function createUtilities(theme: Theme) {
     },
   })
 
-  // Suggest `perspective-none` to match snapshot
-  suggest('perspective', () => [
-    {
-      values: ['none'],
-      valueThemeKeys: ['--perspective'],
-    },
-  ])
+  
 
   let translateProperties = () =>
     atRoot([
@@ -1875,12 +1825,7 @@ export function createUtilities(theme: Theme) {
     },
   })
 
-  suggest('list', () => [
-    {
-      values: ['none', 'disc', 'decimal'],
-      valueThemeKeys: ['--list-style-type'],
-    },
-  ])
+  
 
   // list-image-*
 
@@ -1892,12 +1837,7 @@ export function createUtilities(theme: Theme) {
     },
   })
 
-  suggest('list-image', () => [
-    {
-      values: ['none'],
-      valueThemeKeys: ['--list-style-image'],
-    },
-  ])
+  
 
   staticUtility('appearance-none', [['appearance', 'none']])
   staticUtility('appearance-auto', [['appearance', 'auto']])
@@ -1923,7 +1863,7 @@ export function createUtilities(theme: Theme) {
 
   suggest('columns', () => [
     {
-      values: ['auto', ...Array.from({ length: 12 }, (_, i) => `${i + 1}`)],
+      values: Array.from({ length: 12 }, (_, i) => `${i + 1}`),
       valueThemeKeys: ['--columns', '--container'],
     },
   ])
@@ -1957,12 +1897,7 @@ export function createUtilities(theme: Theme) {
     },
   })
 
-  suggest('auto-cols', () => [
-    {
-      values: ['auto', 'min', 'max', 'fr'],
-      valueThemeKeys: ['--grid-auto-columns'],
-    },
-  ])
+  
 
   functionalUtility('auto-rows', {
     themeKeys: ['--grid-auto-rows'],
@@ -1975,12 +1910,7 @@ export function createUtilities(theme: Theme) {
     },
   })
 
-  suggest('auto-rows', () => [
-    {
-      values: ['auto', 'min', 'max', 'fr'],
-      valueThemeKeys: ['--grid-auto-rows'],
-    },
-  ])
+  
 
   functionalUtility('grid-cols', {
     themeKeys: ['--grid-template-columns'],
@@ -2010,14 +1940,14 @@ export function createUtilities(theme: Theme) {
 
   suggest('grid-cols', () => [
     {
-      values: ['none', 'subgrid', ...Array.from({ length: 12 }, (_, i) => `${i + 1}`)],
+      values: Array.from({ length: 12 }, (_, i) => `${i + 1}`),
       valueThemeKeys: ['--grid-template-columns'],
     },
   ])
 
   suggest('grid-rows', () => [
     {
-      values: ['none', 'subgrid', ...Array.from({ length: 12 }, (_, i) => `${i + 1}`)],
+      values: Array.from({ length: 12 }, (_, i) => `${i + 1}`),
       valueThemeKeys: ['--grid-template-rows'],
     },
   ])
@@ -2280,31 +2210,7 @@ export function createUtilities(theme: Theme) {
       })
     }
 
-    // Ensure IntelliSense continues to suggest `none` and `full` for all rounded-* roots
-    for (let root of [
-      'rounded',
-      'rounded-s',
-      'rounded-e',
-      'rounded-t',
-      'rounded-r',
-      'rounded-b',
-      'rounded-l',
-      'rounded-ss',
-      'rounded-se',
-      'rounded-ee',
-      'rounded-es',
-      'rounded-tl',
-      'rounded-tr',
-      'rounded-br',
-      'rounded-bl',
-    ]) {
-      suggest(root, () => [
-        {
-          values: ['none', 'full'],
-          valueThemeKeys: ['--radius'],
-        },
-      ])
-    }
+    
   }
 
   staticUtility('border-solid', [
@@ -3812,22 +3718,7 @@ export function createUtilities(theme: Theme) {
   })
 
   // Keep keyword object-position values discoverable in IntelliSense
-  suggest('object', () => [
-    {
-      values: [
-        'top',
-        'top-left',
-        'top-right',
-        'bottom',
-        'bottom-left',
-        'bottom-right',
-        'left',
-        'right',
-        'center',
-      ],
-      valueThemeKeys: ['--object-position'],
-    },
-  ])
+  
 
   for (let [name, property] of [
     ['p', 'padding'],
@@ -4062,12 +3953,7 @@ export function createUtilities(theme: Theme) {
     },
   })
 
-  suggest('animate', () => [
-    {
-      values: ['none'],
-      valueThemeKeys: ['--animate'],
-    },
-  ])
+  
 
   {
     let cssFilterValue = [
@@ -4179,12 +4065,7 @@ export function createUtilities(theme: Theme) {
       },
     })
 
-    suggest('blur', () => [
-      {
-        values: ['none'],
-        valueThemeKeys: ['--blur'],
-      },
-    ])
+    
 
     functionalUtility('backdrop-blur', {
       themeKeys: ['--backdrop-blur', '--blur'],
@@ -4204,12 +4085,7 @@ export function createUtilities(theme: Theme) {
       },
     })
 
-    suggest('backdrop-blur', () => [
-      {
-        values: ['none'],
-        valueThemeKeys: ['--backdrop-blur', '--blur'],
-      },
-    ])
+    
 
     functionalUtility('brightness', {
       themeKeys: ['--brightness'],
@@ -4931,13 +4807,7 @@ export function createUtilities(theme: Theme) {
     },
   )
 
-  // Ensure `leading-none` remains suggested
-  suggest('leading', () => [
-    {
-      values: ['none'],
-      valueThemeKeys: ['--leading', '--spacing'],
-    },
-  ])
+  
 
   functionalUtility('tracking', {
     supportsNegative: true,
@@ -5190,7 +5060,6 @@ export function createUtilities(theme: Theme) {
   })
 
   suggest('underline-offset', () => [
-    { values: ['auto'], valueThemeKeys: ['--text-underline-offset'] },
     {
       supportsNegative: true,
       values: ['0', '1', '2', '4', '8'],

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -375,6 +375,7 @@ export function createUtilities(theme: Theme) {
     supportsFractions?: boolean
     themeKeys?: ThemeKey[]
     defaultValue?: string | null
+    fallbacks?: Record<string, AstNode[]>
     handleBareValue?: (value: NamedUtilityValue) => string | null
     handleNegativeBareValue?: (value: NamedUtilityValue) => string | null
     handle: (value: string, dataType: string | null) => AstNode[] | undefined
@@ -430,6 +431,14 @@ export function createUtilities(theme: Theme) {
           if (value === null && desc.handleBareValue) {
             value = desc.handleBareValue(candidate.value)
             if (!value?.includes('/') && candidate.modifier) return
+          }
+
+          if (value === null && desc.fallbacks) {
+            let fallback = desc.fallbacks[candidate.value.value]
+            if (fallback) {
+              if (candidate.modifier) return
+              return fallback
+            }
           }
         }
 
@@ -2125,17 +2134,13 @@ export function createUtilities(theme: Theme) {
       ['rounded-br', ['border-bottom-right-radius']],
       ['rounded-bl', ['border-bottom-left-radius']],
     ] as const) {
-      staticUtility(
-        `${root}-none`,
-        properties.map((property) => [property, '0']),
-      )
-      staticUtility(
-        `${root}-full`,
-        properties.map((property) => [property, 'calc(infinity * 1px)']),
-      )
       functionalUtility(root, {
         themeKeys: ['--radius'],
         handle: (value) => properties.map((property) => decl(property, value)),
+        fallbacks: {
+          none: properties.map((property) => decl(property, '0')),
+          full: properties.map((property) => decl(property, 'calc(infinity * 1px)')),
+        },
       })
     }
   }

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -460,6 +460,13 @@ export function createUtilities(theme: Theme) {
         supportsFractions: desc.supportsFractions,
       },
     ])
+
+    // Also suggest any staticValues automatically so callers don't need to
+    // manually add suggestion groups for e.g. `auto`, `none`, `full`, etc.
+    if (desc.staticValues && Object.keys(desc.staticValues).length > 0) {
+      let values = Object.keys(desc.staticValues)
+      suggest(classRoot, () => [{ values }])
+    }
   }
 
   type ColorUtilityDescription = {

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -433,12 +433,9 @@ export function createUtilities(theme: Theme) {
             if (!value?.includes('/') && candidate.modifier) return
           }
 
-          if (value === null && !negative && desc.staticValues) {
+          if (value === null && !negative && desc.staticValues && !candidate.modifier) {
             let fallback = desc.staticValues[candidate.value.value]
-            if (fallback) {
-              if (candidate.modifier) return
-              return fallback
-            }
+            if (fallback) return fallback
           }
         }
 

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -708,7 +708,7 @@ export function createUtilities(theme: Theme) {
       auto: [decl('grid-column', 'auto')],
     },
   })
-  
+
   functionalUtility('col-span', {
     handleBareValue: ({ value }) => {
       if (!isPositiveInteger(value)) return null
@@ -790,7 +790,7 @@ export function createUtilities(theme: Theme) {
       auto: [decl('grid-row', 'auto')],
     },
   })
-  
+
   functionalUtility('row-span', {
     themeKeys: [],
     handleBareValue: ({ value }) => {
@@ -984,8 +984,6 @@ export function createUtilities(theme: Theme) {
       square: [decl('aspect-ratio', '1 / 1')],
     },
   })
-
-  
 
   /**
    * @css `size`
@@ -1233,8 +1231,6 @@ export function createUtilities(theme: Theme) {
     },
   })
 
-  
-
   functionalUtility('perspective-origin', {
     themeKeys: ['--perspective-origin'],
     handle: (value) => [decl('perspective-origin', value)],
@@ -1251,8 +1247,6 @@ export function createUtilities(theme: Theme) {
     },
   })
 
-  
-
   /**
    * @css `perspective`
    */
@@ -1263,8 +1257,6 @@ export function createUtilities(theme: Theme) {
       none: [decl('perspective', 'none')],
     },
   })
-
-  
 
   let translateProperties = () =>
     atRoot([
@@ -1825,8 +1817,6 @@ export function createUtilities(theme: Theme) {
     },
   })
 
-  
-
   // list-image-*
 
   functionalUtility('list-image', {
@@ -1836,8 +1826,6 @@ export function createUtilities(theme: Theme) {
       none: [decl('list-style-image', 'none')],
     },
   })
-
-  
 
   staticUtility('appearance-none', [['appearance', 'none']])
   staticUtility('appearance-auto', [['appearance', 'auto']])
@@ -1897,8 +1885,6 @@ export function createUtilities(theme: Theme) {
     },
   })
 
-  
-
   functionalUtility('auto-rows', {
     themeKeys: ['--grid-auto-rows'],
     handle: (value) => [decl('grid-auto-rows', value)],
@@ -1909,8 +1895,6 @@ export function createUtilities(theme: Theme) {
       fr: [decl('grid-auto-rows', 'minmax(0, 1fr)')],
     },
   })
-
-  
 
   functionalUtility('grid-cols', {
     themeKeys: ['--grid-template-columns'],
@@ -2209,8 +2193,6 @@ export function createUtilities(theme: Theme) {
         },
       })
     }
-
-    
   }
 
   staticUtility('border-solid', [
@@ -3717,9 +3699,6 @@ export function createUtilities(theme: Theme) {
     },
   })
 
-  // Keep keyword object-position values discoverable in IntelliSense
-  
-
   for (let [name, property] of [
     ['p', 'padding'],
     ['px', 'padding-inline'],
@@ -3953,8 +3932,6 @@ export function createUtilities(theme: Theme) {
     },
   })
 
-  
-
   {
     let cssFilterValue = [
       'var(--tw-blur,)',
@@ -4065,8 +4042,6 @@ export function createUtilities(theme: Theme) {
       },
     })
 
-    
-
     functionalUtility('backdrop-blur', {
       themeKeys: ['--backdrop-blur', '--blur'],
       handle: (value) => [
@@ -4084,8 +4059,6 @@ export function createUtilities(theme: Theme) {
         ],
       },
     })
-
-    
 
     functionalUtility('brightness', {
       themeKeys: ['--brightness'],
@@ -4806,8 +4779,6 @@ export function createUtilities(theme: Theme) {
       },
     },
   )
-
-  
 
   functionalUtility('tracking', {
     supportsNegative: true,

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -659,7 +659,6 @@ export function createUtilities(theme: Theme) {
   })
 
   suggest('z', () => [
-    { values: ['auto'], valueThemeKeys: ['--z-index'] },
     {
       supportsNegative: true,
       values: ['0', '10', '20', '30', '40', '50'],
@@ -685,7 +684,6 @@ export function createUtilities(theme: Theme) {
   })
 
   suggest('order', () => [
-    { values: ['first', 'last'], valueThemeKeys: ['--order'] },
     {
       supportsNegative: true,
       values: Array.from({ length: 12 }, (_, i) => `${i + 1}`),
@@ -4579,13 +4577,6 @@ export function createUtilities(theme: Theme) {
       },
     })
 
-    suggest('transition', () => [
-      {
-        values: ['none', 'all', 'colors', 'opacity', 'shadow', 'transform'],
-        valueThemeKeys: ['--transition-property'],
-      },
-    ])
-
     staticUtility('transition-discrete', [['transition-behavior', 'allow-discrete']])
     staticUtility('transition-normal', [['transition-behavior', 'normal']])
 
@@ -4675,13 +4666,6 @@ export function createUtilities(theme: Theme) {
         ],
       },
     })
-
-    suggest('ease', () => [
-      {
-        values: ['initial', 'linear'],
-        valueThemeKeys: ['--ease'],
-      },
-    ])
   }
 
   staticUtility('will-change-auto', [['will-change', 'auto']])
@@ -4777,6 +4761,7 @@ export function createUtilities(theme: Theme) {
           decl('line-height', '1'),
         ],
       },
+      Fv,
     },
   )
 


### PR DESCRIPTION
This PR attempts to move static utilities that are overwriteable by a theme value to be a fallback rather than a conflicting implementation. The idea is to allow a theme value to take presedence over that static utility _and cause it not to generate_.

For example, when overwriting the `--radius-full` variant, it should ensure that the default `rounded-full` no longer emits the `calc(infinity * 1px)` declaration:

```ts
expect(
  await compileCss(
    css`
      @theme {
        --radius-full: 99999px;
      }
      @tailwind utilities;
    `,
    ['rounded-full'],
  ),
).toMatchInlineSnapshot(`
  ":root, :host {
    --radius-full: 99999px;
  }

  .rounded-full {
    border-radius: var(--radius-full);
  }"
`)
```

This allows anyone who wants `--radius-full` to be a CSS variable to simply define it in their theme:

```css
@theme {
  /* Make `--radius-full` a CSS variable without the utility generating two CSS classes */
  --radius-full: calc(infinity * 1px);
}
```

The idea is to extend this pattern across all functional utilities that also have static utilities that can collide with the namespace. This gives users more control over what they want as CSS variables when the defaults don't work for them, allowing them to resolve #16639 and #15115 in user space.

You may now find yourself thinking "but Philipp, why would someone want to be able to overwrite `--animate-none`. `none` surely always will mean no animation" and I would agree [but it's already possible right now anyways so this is not a new behavior! This PR just cleans up the generated output.](https://play.tailwindcss.com/StnQqm4V2e)