### PR TITLE
Improve error messages when `@apply` fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Improve error messages when `@apply` fails ([#18059](https://github.com/tailwindlabs/tailwindcss/pull/18059))
+
 ### Fixed
 
 - Upgrade: Do not migrate declarations that look like candidates in `<style>` blocks ([#18057](https://github.com/tailwindlabs/tailwindcss/pull/18057), [18068](https://github.com/tailwindlabs/tailwindcss/pull/18068))

--- a/integrations/vite/vue.test.ts
+++ b/integrations/vite/vue.test.ts
@@ -138,10 +138,9 @@ test(
         /error during build:([\s\S]*?)file:/g.exec(
           stripVTControlCharacters(error.message.replace(/\r?\n/g, '\n')),
         ) ?? []
-      expect(message.trim()).toMatchInlineSnapshot(`
-        "[@tailwindcss/vite:generate:build] Cannot apply unknown utility class: \`text-red-500\`.
-        It looks like you are missing a \`@reference "app.css"\` or \`@import "tailwindcss";\`"
-      `)
+      expect(message.trim()).toMatchInlineSnapshot(
+        `"[@tailwindcss/vite:generate:build] Cannot apply unknown utility class \`text-red-500\`. Are you using CSS modules or similar and missing \`@reference\`? https://tailwindcss.com/docs/functions-and-directives#reference-directive"`,
+      )
     }
   },
 )

--- a/integrations/vite/vue.test.ts
+++ b/integrations/vite/vue.test.ts
@@ -133,7 +133,8 @@ test(
     try {
       await exec('pnpm vite build')
     } catch (error) {
-      let [, message] = /error during build:([\s\S]*?)file:/g.exec(error.message) ?? []
+      let [, message] =
+        /error during build:([\s\S]*?)file:/g.exec(error.message.replace(/\r?\n/g, '\n')) ?? []
       expect(message.trim()).toMatchInlineSnapshot(`
         "[@tailwindcss/vite:generate:build] Cannot apply unknown utility class: \`text-red-500\`.
         It looks like you are missing a \`@reference "app.css"\` or \`@import "tailwindcss";\`"

--- a/integrations/vite/vue.test.ts
+++ b/integrations/vite/vue.test.ts
@@ -1,3 +1,4 @@
+import { stripVTControlCharacters } from 'node:util'
 import { candidate, html, json, test, ts } from '../utils'
 
 test(
@@ -134,7 +135,9 @@ test(
       await exec('pnpm vite build')
     } catch (error) {
       let [, message] =
-        /error during build:([\s\S]*?)file:/g.exec(error.message.replace(/\r?\n/g, '\n')) ?? []
+        /error during build:([\s\S]*?)file:/g.exec(
+          stripVTControlCharacters(error.message.replace(/\r?\n/g, '\n')),
+        ) ?? []
       expect(message.trim()).toMatchInlineSnapshot(`
         "[@tailwindcss/vite:generate:build] Cannot apply unknown utility class: \`text-red-500\`.
         It looks like you are missing a \`@reference "app.css"\` or \`@import "tailwindcss";\`"

--- a/packages/tailwindcss/src/apply.ts
+++ b/packages/tailwindcss/src/apply.ts
@@ -197,26 +197,10 @@ export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
               )
             }
 
-            // Verify `@tailwind utilities` or `@reference` is used
-            let hasUtilitiesOrReference = false
-            walk(ast, (node, { context }) => {
-              // Find `@reference`
-              if (context.reference) {
-                hasUtilitiesOrReference = true
-                return WalkAction.Stop
-              }
-
-              // Find `@tailwind utilities`
-              else if (
-                node.kind === 'at-rule' &&
-                node.name === '@tailwind' &&
-                (node.params === 'utilities' || node.params.startsWith('utilities'))
-              ) {
-                hasUtilitiesOrReference = true
-                return WalkAction.Stop
-              }
-            })
-            if (!hasUtilitiesOrReference) {
+            // When the theme is empty, it means that no theme was loaded and
+            // `@import "tailwindcss"`, `@reference "app.css"` or similar is
+            // very likely missing.
+            if (designSystem.theme.size === 0) {
               throw new Error(
                 `Cannot apply unknown utility class: \`${candidate}\`.\nIt looks like you are missing a \`@reference "app.css"\` or \`@import "tailwindcss";\``,
               )

--- a/packages/tailwindcss/src/apply.ts
+++ b/packages/tailwindcss/src/apply.ts
@@ -194,7 +194,7 @@ export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
             // - `@source not inline(…)`
             if (designSystem.invalidCandidates.has(candidate)) {
               throw new Error(
-                `Cannot apply \`${candidate}\`, it seems like the utility was explicitly excluded and cannot be applied.\n\nMore info: https://tailwindcss.com/docs/detecting-classes-in-source-files#explicitly-excluding-classes`,
+                `Cannot apply utility class \`${candidate}\` because it has been explicitly disabled: https://tailwindcss.com/docs/detecting-classes-in-source-files#explicitly-excluding-classes`,
               )
             }
 
@@ -211,11 +211,19 @@ export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
                 )
                 let unknownVariants = parts.filter((_, idx) => compiledVariants[idx] === null)
                 if (unknownVariants.length > 0) {
-                  throw new Error(
-                    `Cannot apply unknown utility class: \`${candidate}\`.\nThe following variants are unknown:\n${unknownVariants
-                      .map((variant) => `- \`${variant}\``)
-                      .join('\n')}\n`,
-                  )
+                  if (unknownVariants.length === 1) {
+                    throw new Error(
+                      `Cannot apply utility class \`${candidate}\` because the ${unknownVariants.map((variant) => `\`${variant}\``)} variant does not exist.`,
+                    )
+                  } else {
+                    let formatter = new Intl.ListFormat('en', {
+                      style: 'long',
+                      type: 'conjunction',
+                    })
+                    throw new Error(
+                      `Cannot apply utility class \`${candidate}\` because the ${formatter.format(unknownVariants.map((variant) => `\`${variant}\``))} variants do not exist.`,
+                    )
+                  }
                 }
               }
             }
@@ -225,7 +233,7 @@ export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
             // very likely missing.
             if (designSystem.theme.size === 0) {
               throw new Error(
-                `Cannot apply unknown utility class: \`${candidate}\`.\nIt looks like you are missing a \`@reference "app.css"\` or \`@import "tailwindcss";\``,
+                `Cannot apply unknown utility class \`${candidate}\`. Are you using CSS modules or similar and missing \`@reference\`? https://tailwindcss.com/docs/functions-and-directives#reference-directive`,
               )
             }
 

--- a/packages/tailwindcss/src/apply.ts
+++ b/packages/tailwindcss/src/apply.ts
@@ -180,7 +180,7 @@ export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
             // When using prefix, make sure prefix is used in candidate
             if (designSystem.theme.prefix && !candidate.startsWith(designSystem.theme.prefix)) {
               throw new Error(
-                `Cannot apply unprefixed utility class: \`${candidate}\`, did you mean \`${designSystem.theme.prefix}:${candidate}\`?`,
+                `Cannot apply unprefixed utility class \`${candidate}\`. Did you mean \`${designSystem.theme.prefix}:${candidate}\`?`,
               )
             }
 
@@ -230,7 +230,7 @@ export function substituteAtApply(ast: AstNode[], designSystem: DesignSystem) {
             }
 
             // Fallback to most generic error message
-            throw new Error(`Cannot apply unknown utility class: \`${candidate}\``)
+            throw new Error(`Cannot apply unknown utility class \`${candidate}\``)
           },
         })
 

--- a/packages/tailwindcss/src/compat/config.test.ts
+++ b/packages/tailwindcss/src/compat/config.test.ts
@@ -1223,6 +1223,7 @@ test('utilities used in @apply must be prefixed', async () => {
   await expect(
     compile(
       css`
+        @tailwind utilities;
         @config "./config.js";
 
         .my-underline {
@@ -1238,7 +1239,7 @@ test('utilities used in @apply must be prefixed', async () => {
       },
     ),
   ).rejects.toThrowErrorMatchingInlineSnapshot(
-    `[Error: Cannot apply unknown utility class: underline]`,
+    `[Error: Cannot apply unprefixed utility class: \`underline\`, did you mean \`tw:underline\`?]`,
   )
 })
 
@@ -1440,7 +1441,11 @@ test('blocklisted candidates cannot be used with `@apply`', async () => {
       },
     ),
   ).rejects.toThrowErrorMatchingInlineSnapshot(
-    `[Error: Cannot apply unknown utility class: bg-white]`,
+    `
+    [Error: Cannot apply \`bg-white\`, it seems like the utility was explicitly excluded and cannot be applied.
+
+    More info: https://tailwindcss.com/docs/detecting-classes-in-source-files#explicitly-excluding-classes]
+  `,
   )
 })
 

--- a/packages/tailwindcss/src/compat/config.test.ts
+++ b/packages/tailwindcss/src/compat/config.test.ts
@@ -1239,7 +1239,7 @@ test('utilities used in @apply must be prefixed', async () => {
       },
     ),
   ).rejects.toThrowErrorMatchingInlineSnapshot(
-    `[Error: Cannot apply unprefixed utility class: \`underline\`, did you mean \`tw:underline\`?]`,
+    `[Error: Cannot apply unprefixed utility class \`underline\`. Did you mean \`tw:underline\`?]`,
   )
 })
 
@@ -1441,11 +1441,7 @@ test('blocklisted candidates cannot be used with `@apply`', async () => {
       },
     ),
   ).rejects.toThrowErrorMatchingInlineSnapshot(
-    `
-    [Error: Cannot apply \`bg-white\`, it seems like the utility was explicitly excluded and cannot be applied.
-
-    More info: https://tailwindcss.com/docs/detecting-classes-in-source-files#explicitly-excluding-classes]
-  `,
+    `[Error: Cannot apply utility class \`bg-white\` because it has been explicitly disabled: https://tailwindcss.com/docs/detecting-classes-in-source-files#explicitly-excluding-classes]`,
   )
 })
 

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -286,6 +286,91 @@ describe('@apply', () => {
     )
   })
 
+  it('@apply referencing theme values without `@tailwind utilities` or `@reference` should error', () => {
+    return expect(() =>
+      compileCss(css`
+        .foo {
+          @apply p-2;
+        }
+      `),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `
+      [Error: Cannot apply unknown utility class: \`p-2\`.
+      It looks like you are missing a \`@reference "app.css"\` or \`@import "tailwindcss";\`]
+    `,
+    )
+  })
+
+  it('@apply referencing theme values with `@tailwind utilities` should work', async () => {
+    return expect(
+      await compileCss(
+        css`
+          @import 'tailwindcss';
+
+          .foo {
+            @apply p-2;
+          }
+        `,
+        [],
+        {
+          async loadStylesheet() {
+            return {
+              path: '',
+              base: '/',
+              content: css`
+                @theme {
+                  --spacing: 0.25rem;
+                }
+                @tailwind utilities;
+              `,
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
+      ":root, :host {
+        --spacing: .25rem;
+      }
+
+      .foo {
+        padding: calc(var(--spacing) * 2);
+      }"
+    `)
+  })
+
+  it('@apply referencing theme values with `@reference` should work', async () => {
+    return expect(
+      await compileCss(
+        css`
+          @reference "style.css";
+
+          .foo {
+            @apply p-2;
+          }
+        `,
+        [],
+        {
+          async loadStylesheet() {
+            return {
+              path: '',
+              base: '/',
+              content: css`
+                @theme {
+                  --spacing: 0.25rem;
+                }
+                @tailwind utilities;
+              `,
+            }
+          },
+        },
+      ),
+    ).toMatchInlineSnapshot(`
+      ".foo {
+        padding: calc(var(--spacing, .25rem) * 2);
+      }"
+    `)
+  })
+
   it('should replace @apply with the correct result', async () => {
     expect(
       await compileCss(css`
@@ -466,7 +551,7 @@ describe('@apply', () => {
         }
       `),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: Cannot apply unknown utility class: bg-not-found]`,
+      `[Error: Cannot apply unknown utility class: \`bg-not-found\`]`,
     )
   })
 
@@ -480,7 +565,7 @@ describe('@apply', () => {
         }
       `),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: Cannot apply unknown utility class: hocus:bg-red-500]`,
+      `[Error: Cannot apply unknown utility class: \`hocus:bg-red-500\`]`,
     )
   })
 

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -551,7 +551,10 @@ describe('@apply', () => {
         }
       `),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: Cannot apply unknown utility class: \`bg-not-found\`]`,
+      `
+      [Error: Cannot apply unknown utility class: \`bg-not-found\`.
+      It looks like you are missing a \`@reference "app.css"\` or \`@import "tailwindcss";\`]
+    `,
     )
   })
 
@@ -565,7 +568,10 @@ describe('@apply', () => {
         }
       `),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: Cannot apply unknown utility class: \`hocus:bg-red-500\`]`,
+      `
+      [Error: Cannot apply unknown utility class: \`hocus:bg-red-500\`.
+      It looks like you are missing a \`@reference "app.css"\` or \`@import "tailwindcss";\`]
+    `,
     )
   })
 

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -294,10 +294,7 @@ describe('@apply', () => {
         }
       `),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `
-      [Error: Cannot apply unknown utility class: \`p-2\`.
-      It looks like you are missing a \`@reference "app.css"\` or \`@import "tailwindcss";\`]
-    `,
+      `[Error: Cannot apply unknown utility class \`p-2\`. Are you using CSS modules or similar and missing \`@reference\`? https://tailwindcss.com/docs/functions-and-directives#reference-directive]`,
     )
   })
 
@@ -551,10 +548,7 @@ describe('@apply', () => {
         }
       `),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `
-      [Error: Cannot apply unknown utility class: \`bg-not-found\`.
-      It looks like you are missing a \`@reference "app.css"\` or \`@import "tailwindcss";\`]
-    `,
+      `[Error: Cannot apply unknown utility class \`bg-not-found\`. Are you using CSS modules or similar and missing \`@reference\`? https://tailwindcss.com/docs/functions-and-directives#reference-directive]`,
     )
   })
 
@@ -571,13 +565,7 @@ describe('@apply', () => {
         }
       `),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `
-      [Error: Cannot apply unknown utility class: \`hocus:hover:pocus:bg-red-500\`.
-      The following variants are unknown:
-      - \`hocus\`
-      - \`pocus\`
-      ]
-    `,
+      `[Error: Cannot apply utility class \`hocus:hover:pocus:bg-red-500\` because the \`hocus\` and \`pocus\` variants do not exist.]`,
     )
   })
 

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -562,15 +562,21 @@ describe('@apply', () => {
     await expect(
       compile(css`
         @tailwind utilities;
+        @theme {
+          --color-red-500: red;
+        }
 
         .foo {
-          @apply hocus:bg-red-500;
+          @apply hocus:hover:pocus:bg-red-500;
         }
       `),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `
-      [Error: Cannot apply unknown utility class: \`hocus:bg-red-500\`.
-      It looks like you are missing a \`@reference "app.css"\` or \`@import "tailwindcss";\`]
+      [Error: Cannot apply unknown utility class: \`hocus:hover:pocus:bg-red-500\`.
+      The following variants are unknown:
+      - \`hocus\`
+      - \`pocus\`
+      ]
     `,
     )
   })

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -624,14 +624,6 @@ async function parseCss(
     firstThemeRule.nodes = [context({ theme: true }, nodes)]
   }
 
-  // Replace the `@tailwind utilities` node with a context since it prints
-  // children directly.
-  if (utilitiesNode) {
-    let node = utilitiesNode as AstNode as Context
-    node.kind = 'context'
-    node.context = {}
-  }
-
   // Replace the `@variant` at-rules with the actual variant rules.
   if (variantNodes.length > 0) {
     for (let variantNode of variantNodes) {
@@ -658,6 +650,14 @@ async function parseCss(
 
   features |= substituteFunctions(ast, designSystem)
   features |= substituteAtApply(ast, designSystem)
+
+  // Replace the `@tailwind utilities` node with a context since it prints
+  // children directly.
+  if (utilitiesNode) {
+    let node = utilitiesNode as AstNode as Context
+    node.kind = 'context'
+    node.context = {}
+  }
 
   // Remove `@utility`, we couldn't replace it before yet because we had to
   // handle the nested `@apply` at-rules first.

--- a/packages/tailwindcss/src/prefix.test.ts
+++ b/packages/tailwindcss/src/prefix.test.ts
@@ -89,7 +89,7 @@ test('utilities used in @apply must be prefixed', async () => {
       }
     `),
   ).rejects.toThrowErrorMatchingInlineSnapshot(
-    `[Error: Cannot apply unknown utility class: underline]`,
+    `[Error: Cannot apply unprefixed utility class: \`underline\`, did you mean \`tw:underline\`?]`,
   )
 })
 

--- a/packages/tailwindcss/src/prefix.test.ts
+++ b/packages/tailwindcss/src/prefix.test.ts
@@ -89,7 +89,7 @@ test('utilities used in @apply must be prefixed', async () => {
       }
     `),
   ).rejects.toThrowErrorMatchingInlineSnapshot(
-    `[Error: Cannot apply unprefixed utility class: \`underline\`, did you mean \`tw:underline\`?]`,
+    `[Error: Cannot apply unprefixed utility class \`underline\`. Did you mean \`tw:underline\`?]`,
   )
 })
 

--- a/packages/tailwindcss/src/theme.ts
+++ b/packages/tailwindcss/src/theme.ts
@@ -51,6 +51,10 @@ export class Theme {
     private keyframes = new Set<AtRule>([]),
   ) {}
 
+  get size() {
+    return this.values.size
+  }
+
   add(key: string, value: string, options = ThemeOptions.NONE, src?: Declaration['src']): void {
     if (key.endsWith('-*')) {
       if (value !== 'initial') {


### PR DESCRIPTION
This PR improves error messages when `@apply` fails. Right now it gives you a generic error message that you cannot apply a certain utility.

```css
.foo {
  @apply bg-red-500;
}
```

Would result in:
```
Cannot apply unknown utility class: bg-red-500
```

However, there are some situations where we can give you more context about what's happening.

### Missing `@import "tailwindcss"` or `@reference`

If you are in a Vue file for example, and you have the following code:
```vue
<template>
  <div class="foo"></div>
</template>

<style>
.foo {
  @apply bg-red-500;
}
</style>
```

Then this will now result in:
```
Cannot apply unknown utility class `bg-white`. Are you using CSS modules or similar and missing `@reference`? https://tailwindcss.com/docs/functions-and-directives#reference-directive
```

We do this by checking if we found a `@tailwind utilities` or `@reference`. If not, we throw this more specific error.

### Explicitly excluded classes via `@source not inline('…')`

Or via the legacy `blocklist` from a JS config.

If you then have the following file:
```css
@import "tailwindcss";

@source not inline('bg-white');

.foo {
  @apply bg-white;
}
```

Then this will now result in:
```
Cannot apply utility class `bg-white` because it has been explicitly disabled: https://tailwindcss.com/docs/detecting-classes-in-source-files#explicitly-excluding-classes
```

We do this by checking if the class was marked as invalid.

### Applying unprefixed class in prefix mode

If you have the prefix option configured, but you are applying a non-prefixed class, then we will show the following error:

Given this input:
```css
@import "tailwindcss" prefix(tw);

.foo {
  @apply underline;
}
```


The following error is thrown:
```
Cannot apply unprefixed utility class `underline`. Did you mean `tw:underline`?
```

### Applying known utilities with unknown variants

If you have unknown variants, then we will list them as well if the base utility does compile correctly.

Given this input:

```css
@import "tailwindcss";

.foo {
  @apply hocus:hover:pocus:bg-red-500;
}
```

The following error is thrown:
```
Cannot apply utility class `hocus:hover:pocus:bg-red-500` because the `hocus` and `pocus` variants do not exist.
```

## Test plan

1. Everything behaves the same, but the error messages give more details.
2. Updated tests with new error messages
3. Added new unit tests to verify the various scenarios
4. Added a Vue specific integration test with a `<style>…</style>` block using `@apply`

[ci-all] There are some newlines here and there, let's verify that they work identically on all platforms.