### PR TITLE
Allow `@custom-variant` to redefine built-in variants with proper `order`.

### DIFF
--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -396,6 +396,7 @@ async function parseCss(
             },
             {
               compounds: compoundsForSelectors([...styleRuleSelectors, ...atRuleParams]),
+              override: true,
             },
           )
         })

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -69,7 +69,11 @@ export class Variants {
   static(
     name: string,
     applyFn: VariantFn<'static'>,
-    { compounds, order }: { compounds?: Compounds; order?: number } = {},
+    {
+      compounds,
+      order,
+      override,
+    }: { compounds?: Compounds; order?: number; override?: boolean } = {},
   ) {
     this.set(name, {
       kind: 'static',
@@ -77,6 +81,7 @@ export class Variants {
       compoundsWith: Compounds.Never,
       compounds: compounds ?? Compounds.StyleRules,
       order,
+      override,
     })
   }
 
@@ -280,26 +285,30 @@ export class Variants {
       compounds,
       compoundsWith,
       order,
+      override,
     }: {
       kind: T
       applyFn: VariantFn<T>
       compoundsWith: Compounds
       compounds: Compounds
       order?: number
+      override?: boolean
     },
   ) {
+    const getNewOrder = () => (this.lastOrder = this.nextOrder())
     let existing = this.variants.get(name)
     if (existing) {
-      Object.assign(existing, { kind, applyFn, compounds })
+      Object.assign(existing, {
+        kind,
+        applyFn,
+        compounds,
+        order: override ? getNewOrder() : existing.order,
+      })
     } else {
-      if (order === undefined) {
-        this.lastOrder = this.nextOrder()
-        order = this.lastOrder
-      }
       this.variants.set(name, {
         kind,
         applyFn,
-        order,
+        order: order ?? getNewOrder(),
         compoundsWith,
         compounds,
       })


### PR DESCRIPTION
## Summary

Adds an "override" property to the object bag passed to `Variants.static` which forces a variant to get a new `order` even if it has already been defined. This property is set in `index.ts:399` for the `@custom-variant` rule to allow custom variants to redefine existing variants like `active:` and have them be properly ordered relative to other custom variants, a.l.a tailwind v3. See #18067 for the motivating regression.

## Test plan

Tested using the playground directory. This is a very insignificant (~17 LOC) change which I don't expect to cause many new issues. I can add more robust testing if necessary, just let me know.