### PR TITLE
Support Leptos `class:` attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade: Do not migrate declarations that look like candidates in `<style>` blocks ([#18057](https://github.com/tailwindlabs/tailwindcss/pull/18057), [18068](https://github.com/tailwindlabs/tailwindcss/pull/18068))
 - Upgrade: Improve `pnpm` workspaces support ([#18065](https://github.com/tailwindlabs/tailwindcss/pull/18065))
+- Support Leptos `class:` attributes when extracting classes ([#18093](https://github.com/tailwindlabs/tailwindcss/pull/18093))
 
 ## [4.1.7] - 2025-05-15
 

--- a/crates/oxide/src/extractor/mod.rs
+++ b/crates/oxide/src/extractor/mod.rs
@@ -1054,6 +1054,23 @@ mod tests {
         );
     }
 
+    // See: https://github.com/tailwindlabs/tailwindcss/issues/18092
+    #[test]
+    fn test_leptos_rs_view_class_colon_syntax() {
+        for (input, expected) in [
+            (
+                r#"<div class:px-6=true>"#,
+                vec!["class", "px-6"],
+            ),
+            (
+                r#"view! { <div class:px-6=true> }"#,
+                vec!["class", "px-6", "view!"],
+            ),
+        ] {
+            assert_extract_sorted_candidates(&pre_process_input(input, "svelte"), expected);
+        }
+    }
+
     #[test]
     fn test_extract_css_variables() {
         for (input, expected) in [

--- a/crates/oxide/src/scanner/mod.rs
+++ b/crates/oxide/src/scanner/mod.rs
@@ -488,7 +488,7 @@ pub fn pre_process_input(content: &[u8], extension: &str) -> Vec<u8> {
         "pug" => Pug.process(content),
         "rb" | "erb" => Ruby.process(content),
         "slim" => Slim.process(content),
-        "svelte" => Svelte.process(content),
+        "svelte" | "rs" => Svelte.process(content),
         "vue" => Vue.process(content),
         _ => content.to_vec(),
     }


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create a discussion to first discuss any significant new features.

For more info, check out the contributing guide:

https://github.com/tailwindcss/tailwindcss/blob/main/.github/CONTRIBUTING.md

-->

Fixes #18092

## Summary

Using the Svelte preprocessor for Rust files we can support Leptos `class:` attributes syntax.

## Test plan

```
pnpm t
```
