### PR TITLE
Fix lowercase+uppercase keys (camelCase/PascalCase) unexpectedly treated to kebab-case when using JavaScript config file

### DIFF
--- a/packages/tailwindcss/src/compat/apply-config-to-theme.test.ts
+++ b/packages/tailwindcss/src/compat/apply-config-to-theme.test.ts
@@ -55,6 +55,7 @@ test('config values can be merged into the theme', () => {
             lg: ['1.125rem', '2'],
             xl: ['1.5rem', '3rem', 'invalid'],
             '2xl': ['2rem'],
+            LargeTitle: ['28px', { fontWeight: 700, lineHeight: '36px' }],
           },
 
           letterSpacing: {
@@ -117,6 +118,7 @@ test('config values can be merged into the theme', () => {
   ])
   expect(theme.resolve('2xl', ['--text'])).toEqual('2rem')
   expect(theme.resolveWith('2xl', ['--text'], ['--line-height'])).toEqual(['2rem', {}])
+  expect(theme.resolve('LargeTitle', ['--text'])).toEqual('28px')
   expect(theme.resolve('super-wide', ['--tracking'])).toEqual('0.25em')
   expect(theme.resolve('super-loose', ['--leading'])).toEqual('3')
   expect(theme.resolve('1/2', ['--width'])).toEqual('60%')

--- a/packages/tailwindcss/src/theme.ts
+++ b/packages/tailwindcss/src/theme.ts
@@ -165,10 +165,12 @@ export class Theme {
         candidateValue !== null ? (`${namespace}-${candidateValue}` as ThemeKey) : namespace
 
       if (!this.values.has(themeKey)) {
-        // If the exact theme key is not found, we might be trying to resolve a key containing a dot
-        // that was registered with an underscore instead:
-        if (candidateValue !== null && candidateValue.includes('.')) {
-          themeKey = `${namespace}-${candidateValue.replaceAll('.', '_')}` as ThemeKey
+        if (candidateValue !== null) {
+          // If the exact theme key is not found, we might be trying to resolve a key:
+          // - containing a dot that was registered with an underscore instead
+          // - containing a lowercase alphabet followed by an uppercase one that was replaced to kebab case
+          themeKey =
+            `${namespace}-${candidateValue.replaceAll('.', '_').replace(/([a-z])([A-Z])/g, (_, a, b) => `${a}-${b.toLowerCase()}`)}` as ThemeKey
 
           if (!this.values.has(themeKey)) continue
         } else {


### PR DESCRIPTION
## Summary

Fixes #18114.

It Seems in `apply-config-to-theme.ts#keyPathToCssProperty` function the theme key is transformed as:
- `.` is replaced with `-`
- `/([a-z])([A-Z])/` is replaced with `$1-$2.toLowerCase()`

However in `theme.ts#resolve`, when failed to find exact key, it only replaces
- `.` is replaced with `-`

It seems the second transformation step is missing in theme.ts#resolve, causing inconsistencies when using camelCase or PascalCase theme keys.

## Test plan

All unit tests pass, including the new test case covering this behavior.
