### PR TITLE
Use viewport units for both width and height

### DIFF
--- a/packages/tailwindcss/preflight.css
+++ b/packages/tailwindcss/preflight.css
@@ -224,7 +224,8 @@ object {
 
 img,
 video {
-  max-width: 100%;
+  max-width: 100vw;
+  max-height: 100vh;
   height: auto;
 }
 


### PR DESCRIPTION
img and video should not exceed viewport size.