### PR TITLE
feat: allow `size` theme namespace in `width` and `height`

### DIFF
--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -1005,12 +1005,12 @@ export function createUtilities(theme: Theme) {
   )
 
   for (let [name, namespaces, property] of [
-    ['w', ['--width', '--spacing', '--container'], 'width'],
-    ['min-w', ['--min-width', '--spacing', '--container'], 'min-width'],
-    ['max-w', ['--max-width', '--spacing', '--container'], 'max-width'],
-    ['h', ['--height', '--spacing'], 'height'],
-    ['min-h', ['--min-height', '--height', '--spacing'], 'min-height'],
-    ['max-h', ['--max-height', '--height', '--spacing'], 'max-height'],
+    ['w', ['--width', '--size', '--spacing', '--container'], 'width'],
+    ['min-w', ['--min-width', '--size', '--spacing', '--container'], 'min-width'],
+    ['max-w', ['--max-width', '--size', '--spacing', '--container'], 'max-width'],
+    ['h', ['--height', '--size', '--spacing'], 'height'],
+    ['min-h', ['--min-height', '--size', '--height', '--spacing'], 'min-height'],
+    ['max-h', ['--max-height', '--size', '--height', '--spacing'], 'max-height'],
   ] as [string, ThemeKey[], string][]) {
     spacingUtility(name, namespaces, (value) => [decl(property, value)], {
       supportsFractions: true,

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -1006,11 +1006,11 @@ export function createUtilities(theme: Theme) {
 
   for (let [name, namespaces, property] of [
     ['w', ['--width', '--size', '--spacing', '--container'], 'width'],
-    ['min-w', ['--min-width', '--size', '--spacing', '--container'], 'min-width'],
-    ['max-w', ['--max-width', '--size', '--spacing', '--container'], 'max-width'],
+    ['min-w', ['--min-width', '--width', '--size', '--spacing', '--container'], 'min-width'],
+    ['max-w', ['--max-width', '--width', '--size', '--spacing', '--container'], 'max-width'],
     ['h', ['--height', '--size', '--spacing'], 'height'],
-    ['min-h', ['--min-height', '--size', '--height', '--spacing'], 'min-height'],
-    ['max-h', ['--max-height', '--size', '--height', '--spacing'], 'max-height'],
+    ['min-h', ['--min-height', '--height', '--size', '--spacing'], 'min-height'],
+    ['max-h', ['--max-height', '--height', '--size', '--spacing'], 'max-height'],
   ] as [string, ThemeKey[], string][]) {
     spacingUtility(name, namespaces, (value) => [decl(property, value)], {
       supportsFractions: true,


### PR DESCRIPTION
I just think it would make sense:

```css
@theme {
  --size-button: 2.5rem; /* should be usable with square buttons and wide buttons */
  --size-bar: 3.5rem; /* should be usable with horizontal and vertical toolbars */
}
```

```html
<!-- vertical toolbar -->
<div class="flex flex-col w-bar">
  <!-- square button with icon -->
  <button class="size-button"><svg>...</svg></button>
</div>

<!-- horizontal toolbar -->
<div class="flex flex-row h-bar">
  <!-- wide button with text -->
  <button class="h-button">Text</button>
</div>
```