### PR TITLE
Do not migrate `blur` in `wire:model.blur`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade: migrate arbitrary modifiers with values without percentage sign to bare values `/[0.16]` -> `/16` ([#18184](https://github.com/tailwindlabs/tailwindcss/pull/18184))
 - Upgrade: migrate CSS variable shorthand if fallback value contains function call ([#18184](https://github.com/tailwindlabs/tailwindcss/pull/18184))
 - Upgrade: Migrate negative arbitrary values to negative bare values, e.g.: `mb-[-32rem]` → `-mb-128` ([#18212](https://github.com/tailwindlabs/tailwindcss/pull/18212))
+- Upgrade: Do not migrate `blur` in `wire:model.blur` ([#18216](https://github.com/tailwindlabs/tailwindcss/pull/18216))
 
 ## [4.1.8] - 2025-05-27
 

--- a/packages/@tailwindcss-upgrade/src/codemods/template/is-safe-migration.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/template/is-safe-migration.test.ts
@@ -58,4 +58,7 @@ test('does not replace classes in invalid positions', async () => {
   await shouldNotReplace('<div v-if="!duration">', '!duration')
   await shouldNotReplace('<div :active="!duration">', '!duration')
   await shouldNotReplace('<div :active="!visible">', '!visible')
+
+  // Alpine/Livewire wire:…
+  await shouldNotReplace('<x-input.number required="foo" wire:model.blur="coins" />', 'blur')
 })

--- a/packages/@tailwindcss-upgrade/src/codemods/template/is-safe-migration.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/template/is-safe-migration.ts
@@ -15,6 +15,7 @@ const CONDITIONAL_TEMPLATE_SYNTAX = [
   // Alpine
   /x-if=['"]$/,
   /x-show=['"]$/,
+  /wire:[^\s]*?$/,
 ]
 const NEXT_PLACEHOLDER_PROP = /placeholder=\{?['"]$/
 


### PR DESCRIPTION
This PR fixes an issue where the `blur` in `wire:model.blur="…"` was incorrectly migrated. We solved it by marking `wire:…` as an unsafe region (`…` can be anything but whitespace).

Fixes: #18187

## Test plan

Added a test with this use case
