### PR TITLE
fix: don't break CSS keywords when formatting math expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade: migrate CSS variable shorthand if fallback value contains function call ([#18184](https://github.com/tailwindlabs/tailwindcss/pull/18184))
 - Upgrade: Migrate negative arbitrary values to negative bare values, e.g.: `mb-[-32rem]` → `-mb-128` ([#18212](https://github.com/tailwindlabs/tailwindcss/pull/18212))
 - Upgrade: Do not migrate `blur` in `wire:model.blur` ([#18216](https://github.com/tailwindlabs/tailwindcss/pull/18216))
+- Don't add spaces around CSS dashed idents when formatting math expressions ([#18220](https://github.com/tailwindlabs/tailwindcss/pull/18220))
 
 ## [4.1.8] - 2025-05-27
 

--- a/packages/tailwindcss/src/utils/decode-arbitrary-value.test.ts
+++ b/packages/tailwindcss/src/utils/decode-arbitrary-value.test.ts
@@ -84,6 +84,11 @@ describe('adds spaces around math operators', () => {
     ['calc(theme(spacing.foo-2))', 'calc(theme(spacing.foo-2))'],
     ['calc(theme(spacing.foo-bar))', 'calc(theme(spacing.foo-bar))'],
 
+    // Preserving CSS keyword tokens like fit-content without splitting around hyphens in complex expressions
+    ['min(fit-content,calc(100dvh-4rem))', 'min(fit-content, calc(100dvh - 4rem))'],
+    ['min(theme(spacing.foo-bar),fit-content,calc(20*calc(40-30)))', 'min(theme(spacing.foo-bar), fit-content, calc(20 * calc(40 - 30)))'],
+    ['min(fit-content,calc(100dvh-4rem)-calc(50dvh-2px))', 'min(fit-content, calc(100dvh - 4rem) - calc(50dvh - 2px))'],
+
     // A negative number immediately after a `,` should not have spaces inserted
     ['clamp(-3px+4px,-3px+4px,-3px+4px)', 'clamp(-3px + 4px, -3px + 4px, -3px + 4px)'],
 

--- a/packages/tailwindcss/src/utils/decode-arbitrary-value.test.ts
+++ b/packages/tailwindcss/src/utils/decode-arbitrary-value.test.ts
@@ -109,6 +109,12 @@ describe('adds spaces around math operators', () => {
     // Prevent formatting inside `env()` functions
     ['calc(env(safe-area-inset-bottom)*2)', 'calc(env(safe-area-inset-bottom) * 2)'],
 
+    // Handle dashed functions that look like known dashed idents
+    [
+      'fit-content(min(max-content,max(min-content,calc(20px+1em))))',
+      'fit-content(min(max-content, max(min-content, calc(20px + 1em))))',
+    ],
+
     // Should format inside `calc()` nested in `env()`
     [
       'env(safe-area-inset-bottom,calc(10px+20px))',

--- a/packages/tailwindcss/src/utils/decode-arbitrary-value.test.ts
+++ b/packages/tailwindcss/src/utils/decode-arbitrary-value.test.ts
@@ -87,7 +87,7 @@ describe('adds spaces around math operators', () => {
     // Preserving CSS keyword tokens like fit-content without splitting around hyphens in complex expressions
     ['min(fit-content,calc(100dvh-4rem))', 'min(fit-content, calc(100dvh - 4rem))'],
     ['min(theme(spacing.foo-bar),fit-content,calc(20*calc(40-30)))', 'min(theme(spacing.foo-bar), fit-content, calc(20 * calc(40 - 30)))'],
-    ['min(fit-content,calc(100dvh-4rem)-calc(50dvh-2px))', 'min(fit-content, calc(100dvh - 4rem) - calc(50dvh - 2px))'],
+    ['min(fit-content,calc(100dvh-4rem)-calc(50dvh--2px))', 'min(fit-content, calc(100dvh - 4rem) - calc(50dvh - -2px))'],
 
     // A negative number immediately after a `,` should not have spaces inserted
     ['clamp(-3px+4px,-3px+4px,-3px+4px)', 'clamp(-3px + 4px, -3px + 4px, -3px + 4px)'],

--- a/packages/tailwindcss/src/utils/decode-arbitrary-value.test.ts
+++ b/packages/tailwindcss/src/utils/decode-arbitrary-value.test.ts
@@ -86,8 +86,19 @@ describe('adds spaces around math operators', () => {
 
     // Preserving CSS keyword tokens like fit-content without splitting around hyphens in complex expressions
     ['min(fit-content,calc(100dvh-4rem))', 'min(fit-content, calc(100dvh - 4rem))'],
-    ['min(theme(spacing.foo-bar),fit-content,calc(20*calc(40-30)))', 'min(theme(spacing.foo-bar), fit-content, calc(20 * calc(40 - 30)))'],
-    ['min(fit-content,calc(100dvh-4rem)-calc(50dvh--2px))', 'min(fit-content, calc(100dvh - 4rem) - calc(50dvh - -2px))'],
+    [
+      'min(theme(spacing.foo-bar),fit-content,calc(20*calc(40-30)))',
+      'min(theme(spacing.foo-bar), fit-content, calc(20 * calc(40 - 30)))',
+    ],
+    [
+      'min(fit-content,calc(100dvh-4rem)-calc(50dvh--2px))',
+      'min(fit-content, calc(100dvh - 4rem) - calc(50dvh - -2px))',
+    ],
+    ['min(-3.4e-2-var(--foo),calc-size(auto))', 'min(-3.4e-2 - var(--foo), calc-size(auto))'],
+    [
+      'clamp(-10e3-var(--foo),calc-size(max-content),var(--foo)+-10e3)',
+      'clamp(-10e3 - var(--foo), calc-size(max-content), var(--foo) + -10e3)',
+    ],
 
     // A negative number immediately after a `,` should not have spaces inserted
     ['clamp(-3px+4px,-3px+4px,-3px+4px)', 'clamp(-3px + 4px, -3px + 4px, -3px + 4px)'],
@@ -127,7 +138,7 @@ describe('adds spaces around math operators', () => {
 
     // round(…) function
     ['round(1+2,1+3)', 'round(1 + 2, 1 + 3)'],
-    ['round(to-zero,1+2,1+3)', 'round(to-zero,1 + 2, 1 + 3)'],
+    ['round(to-zero,1+2,1+3)', 'round(to-zero, 1 + 2, 1 + 3)'],
 
     // Nested parens in non-math functions don't format their contents
     ['env((safe-area-inset-bottom))', 'env((safe-area-inset-bottom))'],

--- a/packages/tailwindcss/src/utils/math-operators.ts
+++ b/packages/tailwindcss/src/utils/math-operators.ts
@@ -111,7 +111,6 @@ export function addWhitespaceAroundMathOperators(input: string) {
     else if ((char === '+' || char === '*' || char === '/' || char === '-') && formattable[0]) {
       let trimmed = result.trimEnd()
       let prev = trimmed[trimmed.length - 1]
-      let rest = input.slice(i + 1) || ''
       let next = input[i + 1] || ''
 
       // If we're preceded by an operator don't add spaces
@@ -127,7 +126,7 @@ export function addWhitespaceAroundMathOperators(input: string) {
       }
 
       // If there's no number before or after it and it's not followed by a math function, don't add spaces.
-      else if (next.length > 0 && !/\d/.test(prev + next) && !MATH_FUNCTIONS.some(fn => rest.startsWith(`${fn}(`))) {
+      else if (next.length > 0 && !/\d/.test(prev + next) && !MATH_FUNCTIONS.some(fn => input.slice(i + 1).startsWith(`${fn}(`))) {
         result += char
         continue
       }

--- a/packages/tailwindcss/src/utils/math-operators.ts
+++ b/packages/tailwindcss/src/utils/math-operators.ts
@@ -126,7 +126,7 @@ export function addWhitespaceAroundMathOperators(input: string) {
       }
 
       // If there's no number before or after it and it's not followed by a math function, don't add spaces.
-      else if (!/\d/.test(prev + next) && !MATH_FUNCTIONS.some(fn => input.slice(i + 1).startsWith(`${fn}(`))) {
+      else if (!/\d/.test(prev + next) && !/^[a-zA-Z_$][a-zA-Z0-9_$]*\(/.test(input.slice(i + 1)) && next !== '(' && next !== '+' && next !== '-') {
         result += char
         continue
       }

--- a/packages/tailwindcss/src/utils/math-operators.ts
+++ b/packages/tailwindcss/src/utils/math-operators.ts
@@ -111,7 +111,8 @@ export function addWhitespaceAroundMathOperators(input: string) {
     else if ((char === '+' || char === '*' || char === '/' || char === '-') && formattable[0]) {
       let trimmed = result.trimEnd()
       let prev = trimmed[trimmed.length - 1]
-      let next = input[trimmed.length]
+      let rest = input.slice(i + 1) || ''
+      let next = input[i + 1] || ''
 
       // If we're preceded by an operator don't add spaces
       if (prev === '+' || prev === '*' || prev === '/' || prev === '-') {
@@ -125,8 +126,8 @@ export function addWhitespaceAroundMathOperators(input: string) {
         continue
       }
 
-      // If there was a letter both before and after, don't add spaces
-      else if (!/\d/.test(prev + next)) {
+      // If there's no number before or after it and it's not followed by a math function, don't add spaces.
+      else if (next.length > 0 && !/\d/.test(prev + next) && !MATH_FUNCTIONS.some(fn => rest.startsWith(`${fn}(`))) {
         result += char
         continue
       }

--- a/packages/tailwindcss/src/utils/math-operators.ts
+++ b/packages/tailwindcss/src/utils/math-operators.ts
@@ -111,9 +111,16 @@ export function addWhitespaceAroundMathOperators(input: string) {
     else if ((char === '+' || char === '*' || char === '/' || char === '-') && formattable[0]) {
       let trimmed = result.trimEnd()
       let prev = trimmed[trimmed.length - 1]
+      let prevprevCode = trimmed.charCodeAt(trimmed.length - 2)
+
+      // Do not add spaces for scientific notation, e.g.: `-3.4e-2`
+      if ((prev === 'e' || prev === 'E') && prevprevCode >= 48 && prevprevCode <= 57) {
+        result += char
+        continue
+      }
 
       // If we're preceded by an operator don't add spaces
-      if (prev === '+' || prev === '*' || prev === '/' || prev === '-') {
+      else if (prev === '+' || prev === '*' || prev === '/' || prev === '-') {
         result += char
         continue
       }

--- a/packages/tailwindcss/src/utils/math-operators.ts
+++ b/packages/tailwindcss/src/utils/math-operators.ts
@@ -121,13 +121,13 @@ export function addWhitespaceAroundMathOperators(input: string) {
       let trimmed = result.trimEnd()
       let prev = trimmed[trimmed.length - 1]
       let prevCode = prev.charCodeAt(0)
-      let prevprevCode = trimmed.charCodeAt(trimmed.length - 2)
+      let prevPrevCode = trimmed.charCodeAt(trimmed.length - 2)
 
       let next = input[i + 1]
       let nextCode = next?.charCodeAt(0)
 
       // Do not add spaces for scientific notation, e.g.: `-3.4e-2`
-      if ((prev === 'e' || prev === 'E') && prevprevCode >= 48 && prevprevCode <= 57) {
+      if ((prev === 'e' || prev === 'E') && prevPrevCode >= 48 && prevPrevCode <= 57) {
         result += char
         continue
       }

--- a/packages/tailwindcss/src/utils/math-operators.ts
+++ b/packages/tailwindcss/src/utils/math-operators.ts
@@ -111,7 +111,7 @@ export function addWhitespaceAroundMathOperators(input: string) {
     else if ((char === '+' || char === '*' || char === '/' || char === '-') && formattable[0]) {
       let trimmed = result.trimEnd()
       let prev = trimmed[trimmed.length - 1]
-      let next = input[i + 1] || ''
+      let next = input[i + 1]
 
       // If we're preceded by an operator don't add spaces
       if (prev === '+' || prev === '*' || prev === '/' || prev === '-') {
@@ -126,7 +126,7 @@ export function addWhitespaceAroundMathOperators(input: string) {
       }
 
       // If there's no number before or after it and it's not followed by a math function, don't add spaces.
-      else if (next.length > 0 && !/\d/.test(prev + next) && !MATH_FUNCTIONS.some(fn => input.slice(i + 1).startsWith(`${fn}(`))) {
+      else if (!/\d/.test(prev + next) && !MATH_FUNCTIONS.some(fn => input.slice(i + 1).startsWith(`${fn}(`))) {
         result += char
         continue
       }

--- a/packages/tailwindcss/src/utils/math-operators.ts
+++ b/packages/tailwindcss/src/utils/math-operators.ts
@@ -111,7 +111,6 @@ export function addWhitespaceAroundMathOperators(input: string) {
     else if ((char === '+' || char === '*' || char === '/' || char === '-') && formattable[0]) {
       let trimmed = result.trimEnd()
       let prev = trimmed[trimmed.length - 1]
-      let next = input[i + 1]
 
       // If we're preceded by an operator don't add spaces
       if (prev === '+' || prev === '*' || prev === '/' || prev === '-') {
@@ -121,12 +120,6 @@ export function addWhitespaceAroundMathOperators(input: string) {
 
       // If we're at the beginning of an argument don't add spaces
       else if (prev === '(' || prev === ',') {
-        result += char
-        continue
-      }
-
-      // If there's no number/operator before or after it and it's not followed by a math function, don't add spaces
-      else if (!/\d/.test(prev + next) && !/^[a-zA-Z_$][a-zA-Z0-9_$]*\(/.test(input.slice(i + 1)) && next !== '(' && next !== '+' && next !== '-') {
         result += char
         continue
       }

--- a/packages/tailwindcss/src/utils/math-operators.ts
+++ b/packages/tailwindcss/src/utils/math-operators.ts
@@ -125,7 +125,7 @@ export function addWhitespaceAroundMathOperators(input: string) {
         continue
       }
 
-      // If there's no number before or after it and it's not followed by a math function, don't add spaces.
+      // If there's no number/operator before or after it and it's not followed by a math function, don't add spaces
       else if (!/\d/.test(prev + next) && !/^[a-zA-Z_$][a-zA-Z0-9_$]*\(/.test(input.slice(i + 1)) && next !== '(' && next !== '+' && next !== '-') {
         result += char
         continue

--- a/packages/tailwindcss/src/utils/math-operators.ts
+++ b/packages/tailwindcss/src/utils/math-operators.ts
@@ -124,6 +124,12 @@ export function addWhitespaceAroundMathOperators(input: string) {
         continue
       }
 
+      // If there was a letter both before and after, don't add spaces
+      else if (!/\d/.test(prev + next)) {
+        result += char
+        continue
+      }
+
       // Add spaces only after the operator if we already have spaces before it
       else if (input[i - 1] === ' ') {
         result += `${char} `

--- a/packages/tailwindcss/src/utils/math-operators.ts
+++ b/packages/tailwindcss/src/utils/math-operators.ts
@@ -111,6 +111,7 @@ export function addWhitespaceAroundMathOperators(input: string) {
     else if ((char === '+' || char === '*' || char === '/' || char === '-') && formattable[0]) {
       let trimmed = result.trimEnd()
       let prev = trimmed[trimmed.length - 1]
+      let next = input[trimmed.length]
 
       // If we're preceded by an operator don't add spaces
       if (prev === '+' || prev === '*' || prev === '/' || prev === '-') {

--- a/packages/tailwindcss/src/utils/math-operators.ts
+++ b/packages/tailwindcss/src/utils/math-operators.ts
@@ -74,7 +74,7 @@ export function addWhitespaceAroundMathOperators(input: string) {
 
     // Determine if we're inside a math function
     if (char === OPEN_PAREN) {
-      result += String.fromCharCode(char)
+      result += input[i]
 
       // Scan backwards to determine the function name. This assumes math
       // functions are named with lowercase alphanumeric characters.
@@ -115,7 +115,7 @@ export function addWhitespaceAroundMathOperators(input: string) {
     // We've exited the function so format according to the parent function's
     // type.
     else if (char === CLOSE_PAREN) {
-      result += String.fromCharCode(char)
+      result += input[i]
       formattable.shift()
     }
 
@@ -139,25 +139,25 @@ export function addWhitespaceAroundMathOperators(input: string) {
 
       // Do not add spaces for scientific notation, e.g.: `-3.4e-2`
       if ((prev === LOWER_E || prev === UPPER_E) && prevPrev >= ZERO && prevPrev <= NINE) {
-        result += String.fromCharCode(char)
+        result += input[i]
         continue
       }
 
       // If we're preceded by an operator don't add spaces
       else if (prev === ADD || prev === MUL || prev === DIV || prev === SUB) {
-        result += String.fromCharCode(char)
+        result += input[i]
         continue
       }
 
       // If we're at the beginning of an argument don't add spaces
       else if (prev === OPEN_PAREN || prev === COMMA) {
-        result += String.fromCharCode(char)
+        result += input[i]
         continue
       }
 
       // Add spaces only after the operator if we already have spaces before it
       else if (input.charCodeAt(i - 1) === SPACE) {
-        result += `${String.fromCharCode(char)} `
+        result += `${input[i]} `
       }
 
       // Add spaces around the operator, if...
@@ -178,18 +178,18 @@ export function addWhitespaceAroundMathOperators(input: string) {
         // Previous position was a value (+ unit)
         (lastValuePos !== null && lastValuePos === i - 1)
       ) {
-        result += ` ${String.fromCharCode(char)} `
+        result += ` ${input[i]} `
       }
 
       // Everything else
       else {
-        result += String.fromCharCode(char)
+        result += input[i]
       }
     }
 
     // Handle all other characters
     else {
-      result += String.fromCharCode(char)
+      result += input[i]
     }
   }
 


### PR DESCRIPTION
Fixes #18219

## Summary

In an arbitrary value, if there's a non-numeric character both before and after a hyphen, there's no need for a space.

## Test plan

`decodeArbitraryValue` will correctly format special CSS values like `fit-content`. I believe spaces are only necessary if there's a digit either before or after the hyphen.

```js
decodeArbitraryValue('min(fit-content,calc(100dvh-4rem))')
```

This way, the result of the following arbitrary value will also be correct:

```html
<div class="min-h-[min(fit-content,calc(100dvh-4rem))]"></div>
```

```css
.min-h-\[min\(fit-content\,calc\(100dvh-4rem\)\)\] {
  min-height: min(fit-content, calc(100dvh - 4rem));
}
```
