### PR TITLE
docs: fix typo in container.ts comment ("a the" -> "the")

### DIFF
--- a/packages/tailwindcss/src/compat/container.ts
+++ b/packages/tailwindcss/src/compat/container.ts
@@ -50,7 +50,7 @@ export function buildCustomContainerUtilityRules(
   if (typeof screens === 'object' && screens !== null) {
     breakpointOverwrites = new Map()
 
-    // When setting a the `screens` in v3, you were overwriting the default
+    // When setting the `screens` in v3, you were overwriting the default
     // screens config. To do this in v4, you have to manually unset all core
     // screens.
 


### PR DESCRIPTION
## Description
Fixed a typo in the container.ts comment where "a the" was incorrectly written as "the" for better readability.

## Test Plan
- [x] Verified the change is purely documentation-related and doesn't affect functionality
- [x] Ensured the comment is more readable and grammatically correct
- [x] No tests needed as this is a documentation-only change

## Changes
- Modified comment in `packages/tailwindcss/src/compat/container.ts`
- Changed "When setting a the `screens` in v3" to "When setting the `screens` in v3"