### PR TITLE
docs: fix typo in arbitrary description ("a arbitrary" -> "an arbitrary")

### DIFF
--- a/packages/@tailwindcss-upgrade/src/codemods/template/migrate-arbitrary-utilities.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/template/migrate-arbitrary-utilities.test.ts
@@ -277,7 +277,7 @@ describe.each([['@theme'], ['@theme inline']])('%s', (theme) => {
   })
 })
 
-test('migrate a arbitrary property without spaces, to a theme value with spaces (canonicalization)', async () => {
+test('migrate an arbitrary property without spaces, to a theme value with spaces (canonicalization)', async () => {
   let candidate = 'font-[foo,bar,baz]'
   let expected = 'font-example'
   let input = css`

--- a/packages/tailwindcss/src/compat/container.ts
+++ b/packages/tailwindcss/src/compat/container.ts
@@ -50,7 +50,7 @@ export function buildCustomContainerUtilityRules(
   if (typeof screens === 'object' && screens !== null) {
     breakpointOverwrites = new Map()
 
-    // When setting a the `screens` in v3, you were overwriting the default
+    // When setting the `screens` in v3, you were overwriting the default
     // screens config. To do this in v4, you have to manually unset all core
     // screens.
 


### PR DESCRIPTION
## Description
This PR fixes a typo in the test description where "a arbitrary" was incorrectly used instead of "an arbitrary". This is a documentation-only change that improves readability.

## Test Plan
- [x] No functional changes, only documentation update
- [x] The test description now correctly uses "an" before "arbitrary"

## Changes Made
- Changed "a arbitrary" to "an arbitrary" in the test description for better grammar