### PR TITLE
docs: fix typo ("a arbitrary" -> "an arbitrary")

### DIFF
--- a/packages/@tailwindcss-upgrade/src/codemods/template/migrate-arbitrary-utilities.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/template/migrate-arbitrary-utilities.test.ts
@@ -277,7 +277,7 @@ describe.each([['@theme'], ['@theme inline']])('%s', (theme) => {
   })
 })
 
-test('migrate a arbitrary property without spaces, to a theme value with spaces (canonicalization)', async () => {
+test('migrate an arbitrary property without spaces, to a theme value with spaces (canonicalization)', async () => {
   let candidate = 'font-[foo,bar,baz]'
   let expected = 'font-example'
   let input = css`


### PR DESCRIPTION
## Summary
- Fixes a typo: "a arbitrary" → "an arbitrary" in a comment/description.

## Details
- This is a documentation-only change. No code logic is affected.

## Test Plan
- N/A (doc-only)