### PR TITLE
Fix  conditional check for vite config css configuration

### DIFF
--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -6,12 +6,12 @@ import {
   normalizePath,
   optimize,
   toSourceMap,
-} from '@tailwindcss/node';
-import { clearRequireCache } from '@tailwindcss/node/require-cache';
-import { Scanner } from '@tailwindcss/oxide';
-import fs from 'node:fs/promises';
-import path from 'node:path';
-import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite';
+} from '@tailwindcss/node'
+import { clearRequireCache } from '@tailwindcss/node/require-cache'
+import { Scanner } from '@tailwindcss/oxide'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite'
 
 const DEBUG = env.DEBUG
 const SPECIAL_QUERY_RE = /[?&](?:worker|sharedworker|raw|url)\b/

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -6,12 +6,12 @@ import {
   normalizePath,
   optimize,
   toSourceMap,
-} from '@tailwindcss/node'
-import { clearRequireCache } from '@tailwindcss/node/require-cache'
-import { Scanner } from '@tailwindcss/oxide'
-import fs from 'node:fs/promises'
-import path from 'node:path'
-import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite'
+} from '@tailwindcss/node';
+import { clearRequireCache } from '@tailwindcss/node/require-cache';
+import { Scanner } from '@tailwindcss/oxide';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite';
 
 const DEBUG = env.DEBUG
 const SPECIAL_QUERY_RE = /[?&](?:worker|sharedworker|raw|url)\b/
@@ -47,7 +47,7 @@ export default function tailwindcss(): Plugin[] {
       config!.root,
       // Currently, Vite only supports CSS source maps in development and they
       // are off by default. Check to see if we need them or not.
-      config?.css.devSourcemap ?? false,
+      config?.css?.devSourcemap ?? false,
       customCssResolver,
       customJsResolver,
     )


### PR DESCRIPTION
## Summary

The tailwindcss vite implementation is not checking for the conditional existence of the optional `css` options in the vite config.

See: https://github.com/vitejs/vite/blob/0d60667e03d91cc0d48dd2cdbd8154d94e0aba74/packages/vite/src/node/config.ts#L355
```typescript
  css?: CSSOptions
```

In 99% of the cases this works because I think vite normally always fills this in.

> Updated description - orginally mentioned vite preview when meaning vitest-preview

But in the case of [vitest-preview](https://www.vitest-preview.com/) it is not setting this optional field. Which is valid.
The correct fix is for tailwindcss vite to handle this optional field since it is marked as optional.

This should fix vitest-preview with the latest tailwindcss.

## Test plan

There is no functional change as this just adds the extra needed optional chain check.