### PR TITLE
Use shards when running integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -99,8 +99,18 @@ jobs:
           CARGO_PROFILE_RELEASE_LTO: 'off'
           CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER: 'lld-link'
 
-      - name: Test ${{ matrix.integration }}
-        run: pnpm run test:integrations ./integrations/${{ matrix.integration }}
+      - name: Test ${{ matrix.integration }} 1/3
+        run: pnpm run test:integrations ./integrations/${{ matrix.integration }} --shard 1/3
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Test ${{ matrix.integration }} 2/3
+        run: pnpm run test:integrations ./integrations/${{ matrix.integration }} --shard 2/3
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Test ${{ matrix.integration }} 2/3
+        run: pnpm run test:integrations ./integrations/${{ matrix.integration }} --shard 3/3
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -109,7 +109,7 @@ jobs:
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}
 
-      - name: Test ${{ matrix.integration }} 2/3
+      - name: Test ${{ matrix.integration }} 3/3
         run: pnpm run test:integrations ./integrations/${{ matrix.integration }} --shard 3/3
         env:
           GITHUB_WORKSPACE: ${{ github.workspace }}


### PR DESCRIPTION
This PR splits CI integration tests in 3 shards to reduce the time it takes to run them to hopefully prevent timeouts on a single step.
