### PR TITLE
Address No "exports" main defined in package json for vite

### DIFF
--- a/packages/@tailwindcss-vite/package.json
+++ b/packages/@tailwindcss-vite/package.json
@@ -21,6 +21,7 @@
     "provenance": true,
     "access": "public"
   },
+  "main": "./dist/index.mjs",
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",

--- a/packages/@tailwindcss-vite/package.json
+++ b/packages/@tailwindcss-vite/package.json
@@ -21,11 +21,11 @@
     "provenance": true,
     "access": "public"
   },
-  "main": "./dist/index.mjs",
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs",
     }
   },
   "dependencies": {

--- a/packages/@tailwindcss-vite/package.json
+++ b/packages/@tailwindcss-vite/package.json
@@ -25,7 +25,7 @@
     ".": {
       "types": "./dist/index.d.mts",
       "import": "./dist/index.mjs",
-      "default": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
     }
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Package JSON is missing the main property

Fixes: #16751 

Resolves:

<img width="1162" alt="Screenshot 2025-06-11 at 16 34 19" src="https://github.com/user-attachments/assets/7efbf61b-5608-4ede-b395-d26461ed98b4" />

## Test plan

I applied this fix directly in my local node modules and this fixed the error
