### PR TITLE
Add heuristic to skip candidate migrations inside `emit(…)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+- Add heuristic to skip candidate migrations inside `emit(…)` ([#18330](https://github.com/tailwindlabs/tailwindcss/pull/18330))
 
 ## [4.1.10] - 2025-06-11
 

--- a/packages/@tailwindcss-upgrade/src/codemods/template/is-safe-migration.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/template/is-safe-migration.test.ts
@@ -61,4 +61,8 @@ test('does not replace classes in invalid positions', async () => {
 
   // Alpine/Livewire wire:…
   await shouldNotReplace('<x-input.number required="foo" wire:model.blur="coins" />', 'blur')
+
+  // Vue 3 events
+  await shouldNotReplace(`emit('blur', props.modelValue)\n`, 'blur')
+  await shouldNotReplace(`$emit('blur', props.modelValue)\n`, 'blur')
 })

--- a/packages/@tailwindcss-upgrade/src/codemods/template/is-safe-migration.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/template/is-safe-migration.ts
@@ -18,6 +18,7 @@ const CONDITIONAL_TEMPLATE_SYNTAX = [
   /wire:[^\s]*?$/,
 ]
 const NEXT_PLACEHOLDER_PROP = /placeholder=\{?['"]$/
+const VUE_3_EMIT = /\b\$?emit\(['"]$/
 
 export function isSafeMigration(
   rawCandidate: string,
@@ -172,6 +173,11 @@ export function isSafeMigration(
 
   // Heuristic: Disallow Next.js Image `placeholder` prop
   if (NEXT_PLACEHOLDER_PROP.test(currentLineBeforeCandidate)) {
+    return false
+  }
+
+  // Heuristic: Disallow replacements inside `emit('…', …)`
+  if (VUE_3_EMIT.test(currentLineBeforeCandidate)) {
     return false
   }
 


### PR DESCRIPTION
Fixes #18318
