### PR TITLE
Document `--watch=always` in the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Add heuristic to skip candidate migrations inside `emit(…)` ([#18330](https://github.com/tailwindlabs/tailwindcss/pull/18330))
+- Document `--watch=always` in the CLI's usage ([#18337](https://github.com/tailwindlabs/tailwindcss/pull/18337))
 
 ## [4.1.10] - 2025-06-11
 

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -42,8 +42,10 @@ export function options() {
     },
     '--watch': {
       type: 'boolean | string',
-      description: 'Watch for changes and rebuild as needed',
+      description:
+        'Watch for changes and rebuild as needed. Use `always` to keep watching when stdin is closed.',
       alias: '-w',
+      values: ['always'],
     },
     '--minify': {
       type: 'boolean',

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -43,7 +43,7 @@ export function options() {
     '--watch': {
       type: 'boolean | string',
       description:
-        'Watch for changes and rebuild as needed. Use `always` to keep watching when stdin is closed.',
+        'Watch for changes and rebuild as needed, and use `always` to keep watching when stdin is closed',
       alias: '-w',
       values: ['always'],
     },

--- a/packages/@tailwindcss-cli/src/commands/help/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/help/index.ts
@@ -112,7 +112,11 @@ export function help({
     // `alias` followed by `, ` and followed by the `flag`.
     let maxOptionLength = 0
 
-    for (let [flag, { alias }] of Object.entries(options)) {
+    for (let [flag, { alias, values }] of Object.entries(options)) {
+      if (values?.length) {
+        flag += `[=${values.join(', ')}]`
+      }
+
       // The option string, which is the combination of the alias and the flag
       // but already properly indented based on the other aliases to ensure
       // everything is aligned properly.

--- a/packages/@tailwindcss-cli/src/utils/args.ts
+++ b/packages/@tailwindcss-cli/src/utils/args.ts
@@ -7,6 +7,7 @@ export type Arg = {
     description: string
     alias?: `-${string}`
     default?: Types[keyof Types]
+    values?: string[]
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/tailwindlabs/tailwindcss.com/issues/1835

We had this in v3 as an undocumented option. We still have it in v4 but it's not documented under the CLI usage but should be. This PR adds this.

**before**
<img width="803" alt="Screenshot 2025-06-18 at 09 41 40" src="https://github.com/user-attachments/assets/c3becf11-e31d-4355-9d23-bddd0b2fc4a6" />

**after**
<img width="1152" alt="Screenshot 2025-06-18 at 09 41 20" src="https://github.com/user-attachments/assets/4f61a156-680d-4f39-b92d-7f0f63270689" />
