### PR TITLE
Extract candidates with variants in Clojure/ClojureScript keywords

### DIFF
--- a/crates/oxide/src/extractor/pre_processors/clojure.rs
+++ b/crates/oxide/src/extractor/pre_processors/clojure.rs
@@ -54,7 +54,7 @@ impl PreProcessor for Clojure {
                     // Keep the `.` as-is
                 }
 
-                // A `:` surrounded by letters denotes a pseudo-class. Keep as is.
+                // A `:` surrounded by letters denotes a variant. Keep as is.
                 //
                 // E.g.:
                 // ```

--- a/crates/oxide/src/extractor/pre_processors/clojure.rs
+++ b/crates/oxide/src/extractor/pre_processors/clojure.rs
@@ -61,7 +61,7 @@ impl PreProcessor for Clojure {
                 // lg:pr-6"
                 //   ^
                 // ``
-                b':' if cursor.prev.is_ascii_alphabetic() && cursor.next.is_ascii_alphabetic() => {
+                b':' if cursor.prev.is_ascii_alphanumeric() && cursor.next.is_ascii_alphanumeric() => {
 
                     // Keep the `:` as-is
                 }
@@ -195,11 +195,11 @@ mod tests {
     #[test]
     fn test_extraction_of_pseudoclasses_from_keywords() {
         let input = r#"
-            ($ :div {:class [:flex :first:lg:pr-6]} …)
+            ($ :div {:class [:flex :first:lg:pr-6 :first:2xl:pl-6 :group-hover/2:2xs:pt-6]} …)
 
             :.hover:bg-white
         "#;
 
-        Clojure::test_extract_contains(input, vec!["flex", "first:lg:pr-6", "hover:bg-white"]);
+        Clojure::test_extract_contains(input, vec!["flex", "first:lg:pr-6", "first:2xl:pl-6", "group-hover/2:2xs:pt-6", "hover:bg-white"]);
     }
 }


### PR DESCRIPTION
## Summary

Taking a shot at fixing my own complaint from #18336. 

Added failing test and fix for extracting classes containing a pseudo-class from Clojure keywords. Eg., `:hover:text` -> `"hover:text"`. This would previously produce `["hover", "text"]`.

## Test plan

- Add a failing test. 
- Verify that it fails with `cargo test`. 
- Add fix. 
- Verify that `cargo test` has no further complaints. 

ATT: @RobinMalfait 