### PR TITLE
Fix: Correct typo in comment

### DIFF
--- a/packages/@tailwindcss-upgrade/src/codemods/template/migrate.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/template/migrate.test.ts
@@ -37,7 +37,7 @@ describe.each([['default'], ['with-variant'], ['important'], ['prefix']])('%s', 
   `
 
   test.each([
-    // Arbitrary property to named functional utlity
+    // Arbitrary property to named functional utility
     ['[color:red]', 'text-red-500'],
 
     // Promote data types to more specific utility if it exists

--- a/packages/tailwindcss/src/compat/config/types.ts
+++ b/packages/tailwindcss/src/compat/config/types.ts
@@ -52,7 +52,7 @@ type DarkModeStrategy =
   // Use the `class` strategy with a custom class instead of `.dark`.
   | ['class', string]
 
-  // Use the `selector` strategy — same as `class` but uses `:where()` for more predicable behavior
+  // Use the `selector` strategy — same as `class` but uses `:where()` for more predictable behavior
   | 'selector'
 
   // Use the `selector` strategy with a custom selector instead of `.dark`.


### PR DESCRIPTION
This pull request contains a couple of minor documentation fixes.

- Corrected a typo from `predicable` to `predictable` in a comment for `DarkModeStrategy`.
- Applied minor formatting to a comment in a test file.

These changes help improve code clarity and maintainability.