### PR TITLE
fix: allow `process.env.DEBUG` to be a boolean in `@tailwindcss/node`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix trailing `)` from interfering with extraction in Clojure keywords ([#18345](https://github.com/tailwindlabs/tailwindcss/pull/18345))
 - Detect classes inside Elixir charlist, word list, and string sigils ([#18432](https://github.com/tailwindlabs/tailwindcss/pull/18432))
 - Track source locations through `@plugin` and `@config` ([#18345](https://github.com/tailwindlabs/tailwindcss/pull/18345))
+- Handle when `process.env.DEBUG` is a boolean in `@tailwindcss/node` ([#18485](https://github.com/tailwindlabs/tailwindcss/pull/18485))
 
 ## [4.1.11] - 2025-06-26
 

--- a/packages/@tailwindcss-node/src/env.ts
+++ b/packages/@tailwindcss-node/src/env.ts
@@ -1,6 +1,10 @@
 export const DEBUG = resolveDebug(process.env.DEBUG)
 
 function resolveDebug(debug: typeof process.env.DEBUG) {
+  if (typeof debug === 'boolean') {
+    return debug
+  }
+
   if (debug === undefined) {
     return false
   }


### PR DESCRIPTION
TanStack Start build to `cloudflare-module`, `debug` value type is boolean.
reference: https://developers.cloudflare.com/workers/framework-guides/web-apps/tanstack/

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create a discussion to first discuss any significant new features.

For more info, check out the contributing guide:

https://github.com/tailwindcss/tailwindcss/blob/main/.github/CONTRIBUTING.md

-->

## Summary

<img width="1327" alt="image" src="https://github.com/user-attachments/assets/9f9247af-c9ab-43e8-8e5d-db0a2d206d4b" />

## Test plan

<!--

Explain how you tested your changes. Include the exact commands that you used to verify the change works and include screenshots/screen recordings of the update behavior in the browser if applicable.

-->
