### PR TITLE
Ignore consecutive semicolons in the CSS parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Detect classes inside Elixir charlist, word list, and string sigils ([#18432](https://github.com/tailwindlabs/tailwindcss/pull/18432))
 - Track source locations through `@plugin` and `@config` ([#18345](https://github.com/tailwindlabs/tailwindcss/pull/18345))
 - Handle when `process.env.DEBUG` is a boolean in `@tailwindcss/node` ([#18485](https://github.com/tailwindlabs/tailwindcss/pull/18485))
+- Ignore consecutive semicolons in the CSS parser ([#18532](https://github.com/tailwindlabs/tailwindcss/pull/18532))
 
 ## [4.1.11] - 2025-06-26
 

--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -1078,6 +1078,38 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         },
       ])
     })
+
+    it('should ignore consecutive semicolons', () => {
+      expect(parse(';;;')).toEqual([])
+    })
+
+    it('should ignore semicolons after an at-rule with a body', () => {
+      expect(parse('@plugin "foo" {} ;')).toEqual([
+        {
+          kind: 'at-rule',
+          name: '@plugin',
+          params: '"foo"',
+          nodes: [],
+        },
+      ])
+    })
+
+    it('should ignore consecutive semicolons a declaration', () => {
+      expect(parse('.foo { color: red;;; }')).toEqual([
+        {
+          kind: 'rule',
+          selector: '.foo',
+          nodes: [
+            {
+              kind: 'declaration',
+              property: 'color',
+              value: 'red',
+              important: false,
+            },
+          ],
+        },
+      ])
+    })
   })
 
   describe('errors', () => {
@@ -1161,22 +1193,6 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
     it('should error when a declaration is incomplete', () => {
       expect(() => parse('.foo { bar }')).toThrowErrorMatchingInlineSnapshot(
         `[Error: Invalid declaration: \`bar\`]`,
-      )
-    })
-
-    it('should error when a semicolon exists after an at-rule with a body', () => {
-      expect(() => parse('@plugin "foo" {} ;')).toThrowErrorMatchingInlineSnapshot(
-        `[Error: Unexpected semicolon]`,
-      )
-    })
-
-    it('should error when consecutive semicolons exist', () => {
-      expect(() => parse(';;;')).toThrowErrorMatchingInlineSnapshot(`[Error: Unexpected semicolon]`)
-    })
-
-    it('should error when consecutive semicolons exist after a declaration', () => {
-      expect(() => parse('.foo { color: red;;; }')).toThrowErrorMatchingInlineSnapshot(
-        `[Error: Unexpected semicolon]`,
       )
     })
   })

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -333,7 +333,7 @@ export function parse(input: string, opts?: ParseOptions) {
     ) {
       let declaration = parseDeclaration(buffer)
       if (!declaration) {
-        if (buffer.length === 0) throw new Error('Unexpected semicolon')
+        if (buffer.length === 0) continue
         throw new Error(`Invalid declaration: \`${buffer.trim()}\``)
       }
 


### PR DESCRIPTION
Fixes #18523

I swear I'd already landed this but apparently not.