### PR TITLE
Add support for Slang template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handle when `process.env.DEBUG` is a boolean in `@tailwindcss/node` ([#18485](https://github.com/tailwindlabs/tailwindcss/pull/18485))
 - Ignore consecutive semicolons in the CSS parser ([#18532](https://github.com/tailwindlabs/tailwindcss/pull/18532))
 - Center the dropdown icon added to an input with a paired datalist ([#18511](https://github.com/tailwindlabs/tailwindcss/pull/18511))
+- Extract candidates in Slang templates ([#18565](https://github.com/tailwindlabs/tailwindcss/pull/18565))
 
 ## [4.1.11] - 2025-06-26
 

--- a/crates/oxide/src/scanner/mod.rs
+++ b/crates/oxide/src/scanner/mod.rs
@@ -488,7 +488,7 @@ pub fn pre_process_input(content: &[u8], extension: &str) -> Vec<u8> {
         "json" => Json.process(content),
         "pug" => Pug.process(content),
         "rb" | "erb" => Ruby.process(content),
-        "slim" => Slim.process(content),
+        "slim" | "slang" => Slim.process(content),
         "svelte" | "rs" => Svelte.process(content),
         "vue" => Vue.process(content),
         _ => content.to_vec(),


### PR DESCRIPTION
## Summary

Slang is basically a Slim template language for Crystal language, so the very same Slim parser works fine.

Slim template: https://github.com/slim-template/slim
Slang template: https://github.com/jeromegn/slang

## Test plan

Create a simple slang file with some tailwind-css and check if the CSS is being extracted:
```slim
doctype html
html
  head
    title This is a title
  body.min-h-screen
    header.stick.top-0.z-10
      section.max-w-4xl.mx-auto.p-4.flex.items-center.justify-between
        h1.text-3xl.font-medium This is a slang file
``` 
To test it, get any slim template, rename the extension to .slang 

Fixes #17851