### PR TITLE
Drop warning from browser build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add configuration to ignore CDN warnings ([#18731](https://github.com/tailwindlabs/tailwindcss/issues/18731))
+- Drop warning from browser build ([#18731](https://github.com/tailwindlabs/tailwindcss/issues/18731))
 
 ## [4.1.12] - 2025-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add configuration to ignore CDN warnings ([#18731](https://github.com/tailwindlabs/tailwindcss/issues/18731))
 - Add suggestions for `flex-<number>` utilities ([#18642](https://github.com/tailwindlabs/tailwindcss/pull/18642))
 
 ### Fixed

--- a/packages/@tailwindcss-browser/src/index.ts
+++ b/packages/@tailwindcss-browser/src/index.ts
@@ -2,14 +2,6 @@ import * as tailwindcss from 'tailwindcss'
 import * as assets from './assets'
 import { Instrumentation } from './instrumentation'
 
-const noWarn = Array.prototype.some.call(document.scripts, (x) => x.hasAttribute("no-warn"))
-
-// Warn users about using the browser build in production as early as possible.
-// It can take time for the script to do its work so this must be at the top.
-if (!noWarn) console.warn(
-  'The browser build of Tailwind CSS should not be used in production. To use Tailwind CSS in production, use the Tailwind CLI, Vite plugin, or PostCSS plugin: https://tailwindcss.com/docs/installation',
-)
-
 /**
  * The type used by `<style>` tags that contain input CSS.
  */

--- a/packages/@tailwindcss-browser/src/index.ts
+++ b/packages/@tailwindcss-browser/src/index.ts
@@ -2,9 +2,11 @@ import * as tailwindcss from 'tailwindcss'
 import * as assets from './assets'
 import { Instrumentation } from './instrumentation'
 
+const noWarn = Array.prototype.some.call(document.scripts, (x) => x.hasAttribute("no-warn"))
+
 // Warn users about using the browser build in production as early as possible.
 // It can take time for the script to do its work so this must be at the top.
-console.warn(
+if (!noWarn) console.warn(
   'The browser build of Tailwind CSS should not be used in production. To use Tailwind CSS in production, use the Tailwind CLI, Vite plugin, or PostCSS plugin: https://tailwindcss.com/docs/installation',
 )
 


### PR DESCRIPTION
To ignore warnings when using the CDN, just add no-warn.
No src check was added since the CDN URL might vary (e.g., not always https://cdn.tailwindcss.com).

```html
<script src="https://cdn.tailwindcss.com" no-warn></script>
```


https://github.com/tailwindlabs/tailwindcss/issues/18731