### PR TITLE
Mark `.hdr` and `.exr` as binary extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix false-positive migrations in `addEventListener` and JavaScript variable names ([#18718](https://github.com/tailwindlabs/tailwindcss/pull/18718))
 - Fix Standalone CLI when run via symlink on Windows ([#18723](https://github.com/tailwindlabs/tailwindcss/pull/18723))
 - Read from `--border-color-*` theme keys in `divide-*` utilities for backwards compatibility ([#18704](https://github.com/tailwindlabs/tailwindcss/pull/18704/))
+- Prevent analysing `.hdr` files by marking it as a binary extension ([#18734](https://github.com/tailwindlabs/tailwindcss/pull/18734))
 
 ## [4.1.11] - 2025-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix false-positive migrations in `addEventListener` and JavaScript variable names ([#18718](https://github.com/tailwindlabs/tailwindcss/pull/18718))
 - Fix Standalone CLI when run via symlink on Windows ([#18723](https://github.com/tailwindlabs/tailwindcss/pull/18723))
 - Read from `--border-color-*` theme keys in `divide-*` utilities for backwards compatibility ([#18704](https://github.com/tailwindlabs/tailwindcss/pull/18704/))
-- Prevent analysing `.hdr` files by marking it as a binary extension ([#18734](https://github.com/tailwindlabs/tailwindcss/pull/18734))
+- Prevent scanning `.hdr` and `.exr` files ([#18734](https://github.com/tailwindlabs/tailwindcss/pull/18734))
 
 ## [4.1.11] - 2025-06-26
 

--- a/crates/oxide/src/scanner/fixtures/binary-extensions.txt
+++ b/crates/oxide/src/scanner/fixtures/binary-extensions.txt
@@ -66,6 +66,7 @@ eol
 eot
 epub
 exe
+exr
 f4v
 fbs
 fh

--- a/crates/oxide/src/scanner/fixtures/binary-extensions.txt
+++ b/crates/oxide/src/scanner/fixtures/binary-extensions.txt
@@ -87,6 +87,7 @@ gzip
 h261
 h263
 h264
+hdr
 icns
 ico
 ief


### PR DESCRIPTION
This PR fixes an issue where `.hdr` files were scanned for candidates even though it's a binary file.

As a workaround today, you could use:

```css
@source not "**/*.hdr";
```

To ignore `.hdr` files, but let's bake it in by default instead.

Fixes: #18733
