### PR TITLE
Prototype loading `@plugin` and `@config` from non-default exports

### DIFF
--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -61,7 +61,9 @@ type CompileOptions = {
   ) => Promise<{
     path: string
     base: string
-    module: Plugin | Config
+    // TODO: This is *wrong* the export name should be passed in and this should
+    // always be `Plugin | Config`
+    module: Plugin | Config | Record<string, Plugin | Config>
   }>
   loadStylesheet?: (
     id: string,


### PR DESCRIPTION
This will make using `@config` less necessary for plugins which don't use `export default`. Added to `@config` for feature parity.