### PR TITLE
Replace deprecated `clip` with `clip-path` in `sr-only`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show suggestions for known `matchVariant` values ([#18798](https://github.com/tailwindlabs/tailwindcss/pull/18798))
 - Migrate `aria` theme keys to `@custom-variant` ([#18815](https://github.com/tailwindlabs/tailwindcss/pull/18815))
 - Migrate `data` theme keys to `@custom-variant` ([#18816](https://github.com/tailwindlabs/tailwindcss/pull/18816))
+- Replace deprecated `clip` with `clip-path` in `sr-only` ([#18769](https://github.com/tailwindlabs/tailwindcss/pull/18769))
 
 ## [4.1.12] - 2025-08-13
 

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -7,7 +7,7 @@ const css = String.raw
 test('sr-only', async () => {
   expect(await run(['sr-only'])).toMatchInlineSnapshot(`
     ".sr-only {
-      clip: rect(0, 0, 0, 0);
+      clip-path: inset(50%);
       white-space: nowrap;
       border-width: 0;
       width: 1px;
@@ -24,7 +24,7 @@ test('sr-only', async () => {
 test('not-sr-only', async () => {
   expect(await run(['not-sr-only'])).toMatchInlineSnapshot(`
     ".not-sr-only {
-      clip: auto;
+      clip-path: none;
       white-space: normal;
       width: auto;
       height: auto;
@@ -26936,7 +26936,7 @@ describe('custom utilities', () => {
     })
 
     test('bare values with unsupported data types should result in a warning', async () => {
-      let spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      let spy = vi.spyOn(console, 'warn').mockImplementation(() => { })
       let input = css`
         @utility paint-* {
           paint: --value([color], color);

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -26936,7 +26936,7 @@ describe('custom utilities', () => {
     })
 
     test('bare values with unsupported data types should result in a warning', async () => {
-      let spy = vi.spyOn(console, 'warn').mockImplementation(() => { })
+      let spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       let input = css`
         @utility paint-* {
           paint: --value([color], color);

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -79,14 +79,14 @@ interface SuggestionGroup {
 type SuggestionDefinition =
   | string
   | {
-      supportsNegative?: boolean
-      supportsFractions?: boolean
-      values?: string[]
-      modifiers?: string[]
-      valueThemeKeys?: ThemeKey[]
-      modifierThemeKeys?: ThemeKey[]
-      hasDefaultValue?: boolean
-    }
+    supportsNegative?: boolean
+    supportsFractions?: boolean
+    values?: string[]
+    modifiers?: string[]
+    valueThemeKeys?: ThemeKey[]
+    modifierThemeKeys?: ThemeKey[]
+    hasDefaultValue?: boolean
+  }
 
 export type UtilityOptions = {
   types: string[]
@@ -556,7 +556,7 @@ export function createUtilities(theme: Theme) {
     ['padding', '0'],
     ['margin', '-1px'],
     ['overflow', 'hidden'],
-    ['clip', 'rect(0, 0, 0, 0)'],
+    ['clip-path', 'inset(50%)'],
     ['white-space', 'nowrap'],
     ['border-width', '0'],
   ])
@@ -567,7 +567,7 @@ export function createUtilities(theme: Theme) {
     ['padding', '0'],
     ['margin', '0'],
     ['overflow', 'visible'],
-    ['clip', 'auto'],
+    ['clip-path', 'none'],
     ['white-space', 'normal'],
   ])
 
@@ -6326,9 +6326,9 @@ function alphaReplacedDropShadowProperties(
       decl(
         property,
         prefix +
-          segment(value, ',')
-            .map((value) => `drop-shadow(${replaceShadowColors(value, varInjector)})`)
-            .join(' '),
+        segment(value, ',')
+          .map((value) => `drop-shadow(${replaceShadowColors(value, varInjector)})`)
+          .join(' '),
       ),
       rule('@supports (color: lab(from red l a b))', [decl(property, prefix + replacedValue)]),
     ]

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -79,14 +79,14 @@ interface SuggestionGroup {
 type SuggestionDefinition =
   | string
   | {
-    supportsNegative?: boolean
-    supportsFractions?: boolean
-    values?: string[]
-    modifiers?: string[]
-    valueThemeKeys?: ThemeKey[]
-    modifierThemeKeys?: ThemeKey[]
-    hasDefaultValue?: boolean
-  }
+      supportsNegative?: boolean
+      supportsFractions?: boolean
+      values?: string[]
+      modifiers?: string[]
+      valueThemeKeys?: ThemeKey[]
+      modifierThemeKeys?: ThemeKey[]
+      hasDefaultValue?: boolean
+    }
 
 export type UtilityOptions = {
   types: string[]
@@ -6326,9 +6326,9 @@ function alphaReplacedDropShadowProperties(
       decl(
         property,
         prefix +
-        segment(value, ',')
-          .map((value) => `drop-shadow(${replaceShadowColors(value, varInjector)})`)
-          .join(' '),
+          segment(value, ',')
+            .map((value) => `drop-shadow(${replaceShadowColors(value, varInjector)})`)
+            .join(' '),
       ),
       rule('@supports (color: lab(from red l a b))', [decl(property, prefix + replacedValue)]),
     ]


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create a discussion to first discuss any significant new features.

For more info, check out the contributing guide:

https://github.com/tailwindcss/tailwindcss/blob/main/.github/CONTRIBUTING.md

-->

## Summary

This PR replaces the deprecated `clip` property used in the `sr-only` utility with `clip-path`, and updates the corresponding reset in `not-sr-only`.

- Closes [tailwindlabs/tailwindcss#18768](https://github.com/tailwindlabs/tailwindcss/issues/18768)
- Replaces `clip: rect(0, 0, 0, 0);` with `clip-path: inset(50%);` in `sr-only`
- Replaces `clip: auto;` with `clip-path: none;` in `not-sr-only`
- Updates unit test snapshots to reflect the new CSS output

Rationale:

- `clip` is deprecated and flagged by modern linters; `clip-path` is the recommended modern alternative while preserving the intended visually-hidden behavior.

Before:

```css
.sr-only {
  clip: rect(0, 0, 0, 0);
}

.not-sr-only {
  clip: auto;
}
```

After:

```css
.sr-only {
  clip-path: inset(50%);
}

.not-sr-only {
  clip-path: none;
}
```