### PR TITLE
Improve error messages when migrating a JS config file goes wrong

### DIFF
--- a/packages/@tailwindcss-upgrade/src/utils/renderer.ts
+++ b/packages/@tailwindcss-upgrade/src/utils/renderer.ts
@@ -44,7 +44,7 @@ export function wordWrap(text: string, width: number): string[] {
   // Handle text with newlines by maintaining the newlines, then splitting
   // each line separately.
   if (text.includes('\n')) {
-    return text.split('\n').flatMap((line) => wordWrap(line, width))
+    return text.split('\n').flatMap((line) => (line ? wordWrap(line, width) : ['']))
   }
 
   let words = text.split(' ')

--- a/packages/tailwindcss/src/compat/config/deep-merge.ts
+++ b/packages/tailwindcss/src/compat/config/deep-merge.ts
@@ -17,7 +17,7 @@ export function deepMerge<T extends object>(
   type Value = T[Key]
 
   for (let source of sources) {
-    if (source === null || source === undefined) {
+    if (source === null || source === undefined || typeof source !== 'object') {
       continue
     }
 

--- a/packages/tailwindcss/src/compat/plugin-api.test.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.test.ts
@@ -4444,6 +4444,43 @@ describe('addComponents()', () => {
         }"
       `)
   })
+
+  test('throws on custom static utilities with an invalid name', async () => {
+    await expect(() => {
+      return compile(
+        css`
+          @plugin "my-plugin";
+          @layer utilities {
+            @tailwind utilities;
+          }
+
+          @theme reference {
+            --breakpoint-lg: 1024px;
+          }
+        `,
+        {
+          async loadModule(id, base) {
+            return {
+              path: '',
+              base,
+              module: ({ addComponents }: PluginAPI) => {
+                addComponents({
+                  ':hover > *': {
+                    'text-box-trim': 'both',
+                    'text-box-edge': 'cap alphabetic',
+                  },
+                })
+              },
+            }
+          },
+        },
+      )
+    }).rejects.toThrowErrorMatchingInlineSnapshot(`
+      [Error: \`addComponents({ ':hover > *': … })\` defines an invalid utility selector. Components must be a single class name and start with a lowercase letter, eg. \`.scrollbar-none\`.
+
+      Note: in Tailwind CSS v4 \`addComponents\` is an alias for \`addUtilities\`.]
+    `)
+  })
 })
 
 describe('matchComponents()', () => {
@@ -4489,6 +4526,37 @@ describe('matchComponents()', () => {
           }
         }"
       `)
+  })
+
+  test('throws on custom utilities with an invalid name', async () => {
+    await expect(() => {
+      return compile(
+        css`
+          @plugin "my-plugin";
+          @tailwind utilities;
+        `,
+        {
+          async loadModule(id, base) {
+            return {
+              path: '',
+              base,
+              module: ({ matchComponents }: PluginAPI) => {
+                matchComponents({
+                  '.text-trim > *': () => ({
+                    'text-box-trim': 'both',
+                    'text-box-edge': 'cap alphabetic',
+                  }),
+                })
+              },
+            }
+          },
+        },
+      )
+    }).rejects.toThrowErrorMatchingInlineSnapshot(`
+      [Error: \`matchComponents({ '.text-trim > *': … })\` defines an invalid utility name. Components should be alphanumeric and start with a lowercase letter, eg. \`scrollbar\`.
+
+      Note: in Tailwind CSS v4 \`matchComponents\` is an alias for \`matchUtilities\`.]
+    `)
   })
 })
 

--- a/packages/tailwindcss/src/compat/plugin-api.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.ts
@@ -307,7 +307,7 @@ export function buildPluginApi({
 
         if (!foundValidUtility) {
           throw new Error(
-            `\`addUtilities({ '${name}' : … })\` defines an invalid utility selector. Utilities must be a single class name and start with a lowercase letter, eg. \`.scrollbar-none\`.`,
+            `\`addUtilities({ '${name}': … })\` defines an invalid utility selector. Utilities must be a single class name and start with a lowercase letter, eg. \`.scrollbar-none\`.`,
           )
         }
       }
@@ -347,7 +347,7 @@ export function buildPluginApi({
       for (let [name, fn] of Object.entries(utilities)) {
         if (!IS_VALID_UTILITY_NAME.test(name)) {
           throw new Error(
-            `\`matchUtilities({ '${name}' : … })\` defines an invalid utility name. Utilities should be alphanumeric and start with a lowercase letter, eg. \`scrollbar\`.`,
+            `\`matchUtilities({ '${name}': … })\` defines an invalid utility name. Utilities should be alphanumeric and start with a lowercase letter, eg. \`scrollbar\`.`,
           )
         }
 
@@ -493,11 +493,31 @@ export function buildPluginApi({
     },
 
     addComponents(components, options) {
-      this.addUtilities(components, options)
+      try {
+        this.addUtilities(components, options)
+      } catch (e) {
+        if (e instanceof Error) {
+          throw new Error(
+            `${e.message.replaceAll('addUtilities', 'addComponents').replaceAll('Utilities', 'Components')}\n\nNote: in Tailwind CSS v4 \`addComponents\` is an alias for \`addUtilities\`.`,
+          )
+        } else {
+          throw e
+        }
+      }
     },
 
     matchComponents(components, options) {
-      this.matchUtilities(components, options)
+      try {
+        this.matchUtilities(components, options)
+      } catch (e) {
+        if (e instanceof Error) {
+          throw new Error(
+            `${e.message.replaceAll('matchUtilities', 'matchComponents').replaceAll('Utilities', 'Components')}\n\nNote: in Tailwind CSS v4 \`matchComponents\` is an alias for \`matchUtilities\`.`,
+          )
+        } else {
+          throw e
+        }
+      }
     },
 
     theme: createThemeFn(


### PR DESCRIPTION
This PR updates some error messages with more insights to know what went wrong or why we didn't migrate the JS config file when going from v3 to v4.


Let's say you have a crazy configuration file like this:
```ts
module.exports = {
  content: ['app/**/*.{ts,tsx}'],
  presets: [require('./preset.config')], // 1. Presets
  somethingHereThatDoesNotExist: {       // 2. Unknown top-level key, but valid value
    darkMode: ['class'],
  },
  unknown: /as-a-regex/g,                // 3. Unknown top-level key, and invalid value
  theme: {
    notSure: {                           // 4. Unknown theme key
      howToMigrate: 'this theme key',
    },
    aria: {                              // 5. Known theme key, but blocked
      busy: 'busy="true"',
    },
    extend: {
      foo: true,                         // 6. Unknown theme key, invalid value
      booleans: {                        // 7. Unknown theme key
        areCool: true,
      },
      notEven: {                         // 7. Unknown theme key
        regexes: /test/i,
      },
      screens: {
        complex: {
          raw: '(min-width: 500px) and (max-width: 700px)'  // 8. Complex screen config
        }
      },
    },
  }
}
```
I know it's made up, but just trying to highlight the different kinds of issue we run into and decide _not_ to migrate.

More than happy to adjust the messages. I also included a bunch of different types to check different categories of issues. But migrating a config like this, will result in:
<img width="2054" height="1012" alt="image" src="https://github.com/user-attachments/assets/b93f441f-d3c3-420d-bfd1-e184fd478378" />

Still a draft, because the category about `data`, `aria` and `supports` variants and also the category about complex screens is something I just want to solve properly.