### PR TITLE
Migrate `aria` theme keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Discard matched variants with unknown named values ([#18799](https://github.com/tailwindlabs/tailwindcss/pull/18799))
 - Discard matched variants with non-string values ([#18799](https://github.com/tailwindlabs/tailwindcss/pull/18799))
 - Show suggestions for known `matchVariant` values ([#18798](https://github.com/tailwindlabs/tailwindcss/pull/18798))
+- Migrate `aria` theme keys to `@custom-variant` ([#18815](https://github.com/tailwindlabs/tailwindcss/pull/18815))
 
 ## [4.1.12] - 2025-08-13
 

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -965,6 +965,85 @@ test(
   },
 )
 
+test(
+  'migrate aria theme keys to custom variants',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "dependencies": {
+            "tailwindcss": "^3",
+            "@tailwindcss/upgrade": "workspace:^"
+          }
+        }
+      `,
+      'tailwind.config.ts': ts`
+        export default {
+          content: {
+            relative: true,
+            files: ['./src/**/*.html'],
+          },
+          theme: {
+            extend: {
+              aria: {
+                // Built-in (not really, but visible because of intellisense)
+                busy: 'busy="true"',
+
+                // Automatically handled by bare values
+                foo: 'foo="true"',
+
+                // Not automatically handled by bare values because names differ
+                bar: 'baz="true"',
+
+                // Completely custom
+                asc: 'sort="ascending"',
+                desc: 'sort="descending"',
+              },
+            },
+          },
+        }
+      `,
+      'src/input.css': css`
+        @tailwind base;
+        @tailwind components;
+        @tailwind utilities;
+      `,
+    },
+  },
+  async ({ exec, fs, expect }) => {
+    await exec('npx @tailwindcss/upgrade')
+
+    expect(await fs.dumpFiles('src/*.css')).toMatchInlineSnapshot(`
+      "
+      --- src/input.css ---
+      @import 'tailwindcss';
+
+      @custom-variant aria-bar (&[aria-baz="true"]);
+      @custom-variant aria-asc (&[aria-sort="ascending"]);
+      @custom-variant aria-desc (&[aria-sort="descending"]);
+
+      /*
+        The default border color has changed to \`currentcolor\` in Tailwind CSS v4,
+        so we've added these compatibility styles to make sure everything still
+        looks the same as it did with Tailwind CSS v3.
+
+        If we ever want to remove these styles, we need to add an explicit border
+        color utility to any element that depends on these defaults.
+      */
+      @layer base {
+        *,
+        ::after,
+        ::before,
+        ::backdrop,
+        ::file-selector-button {
+          border-color: var(--color-gray-200, currentcolor);
+        }
+      }
+      "
+    `)
+  },
+)
+
 describe('border compatibility', () => {
   test(
     'migrate border compatibility',

--- a/integrations/upgrade/js-config.test.ts
+++ b/integrations/upgrade/js-config.test.ts
@@ -992,8 +992,12 @@ test(
                 // Automatically handled by bare values
                 foo: 'foo="true"',
 
+                // Quotes are optional in CSS for these kinds of attribute
+                // selectors
+                bar: 'bar=true',
+
                 // Not automatically handled by bare values because names differ
-                bar: 'baz="true"',
+                baz: 'qux="true"',
 
                 // Completely custom
                 asc: 'sort="ascending"',
@@ -1018,7 +1022,7 @@ test(
       --- src/input.css ---
       @import 'tailwindcss';
 
-      @custom-variant aria-bar (&[aria-baz="true"]);
+      @custom-variant aria-baz (&[aria-qux="true"]);
       @custom-variant aria-asc (&[aria-sort="ascending"]);
       @custom-variant aria-desc (&[aria-sort="descending"]);
 

--- a/packages/@tailwindcss-upgrade/src/codemods/config/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/config/migrate-js-config.ts
@@ -145,7 +145,7 @@ async function migrateTheme(
       for (let [key, value] of Object.entries(resolvedConfig.theme.aria ?? {})) {
         // Will be handled by bare values if the names match.
         // E.g.: `aria-foo:flex` should produce `[aria-foo="true"]`
-        if (new RegExp(`^${key}=['"]true['"]$`).test(`${value}`)) continue
+        if (new RegExp(`^${key}=(['"]?)true\\1$`).test(`${value}`)) continue
 
         // Create custom variant
         variants.set(`aria-${key}`, `&[aria-${value}]`)

--- a/packages/@tailwindcss-upgrade/src/codemods/config/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/config/migrate-js-config.ts
@@ -104,6 +104,7 @@ async function migrateTheme(
     base,
     config: { ...unresolvedConfig, plugins: [], presets: undefined },
     reference: false,
+    src: undefined,
   }
   let { resolvedConfig, replacedThemeKeys } = resolveConfig(designSystem, [configToResolve])
 


### PR DESCRIPTION
This PR migrates `aria` theme keys when migrating from Tailwind CSS v3 to v4.

While working on improving some of the error messages to get more insights into why migrating the JS file changed (https://github.com/tailwindlabs/tailwindcss/pull/18808), I ran into an issue where I couldn't think of a good comment to why `aria` theme keys were not being migrated. (Internally we have `aria` "blocked").

So instead of figuring out a good error message..., I just went ahead and added the migration for `aria` theme keys.


Let's imagine you have the following Tailwind CSS v3 configuration:
```ts
export default {
  content: ['./src/**/*.html'],
  theme: {
    extend: {
      aria: {
        // Built-in (not really, but visible because of intellisense)
        busy: 'busy="true"',

        // Automatically handled by bare values
        foo: 'foo="true"',
    //  ^^^   ^^^            ← same names

        // Not automatically handled by bare values because names differ
        bar: 'baz="true"',
    //  ^^^   ^^^            ← different names

        // Completely custom
        asc: 'sort="ascending"',
        desc: 'sort="descending"',
      },
    },
  },
}
```

Then we would generate the following Tailwind CSS v4 CSS:

```css
@custom-variant aria-bar (&[aria-baz="true"]);
@custom-variant aria-asc (&[aria-sort="ascending"]);
@custom-variant aria-desc (&[aria-sort="descending"]);
```

Notice how we didn't generate a custom variant for `aria-busy` or `aria-foo` because those are automatically handled by bare values.

We could also emit a comment near the CSS to warn about the fact that `@custom-variant` will always be sorted _after_ any other built-in variants.

This could result in slightly different behavior, or different order of classes when using `prettier-plugin-tailwindcss`.

I don't know how important this is, because before this PR we would just use `@config './tailwind.config.js';`.
Edit: when using the `@config` we override `aria` and extend it, which means that it would be in the expected order 🤔 

