### PR TITLE
Add `ring-initial` utility

### DIFF
--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -5486,6 +5486,7 @@ export function createUtilities(theme: Theme) {
     ])
 
     staticUtility('ring-inset', [boxShadowProperties, ['--tw-ring-inset', 'inset']])
+    staticUtility('ring-initial', [boxShadowProperties, ['--tw-ring-inset', 'initial']])
 
     let defaultRingColor = theme.get(['--default-ring-color']) ?? 'currentcolor'
     function ringShadowValue(value: string) {


### PR DESCRIPTION
## Summary
There is no way to undo a `ring-inset` at the moment. This PR adds utility `ring-initial` to do that. Has been discussed at #3016 

