### PR TITLE
Fix missing code block delimiters in comment blocks

### DIFF
--- a/packages/@tailwindcss-upgrade/src/codemods/config/migrate-postcss.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/config/migrate-postcss.ts
@@ -15,6 +15,7 @@ import { highlight, info, relative, success, warn } from '../../utils/renderer'
 //     autoprefixer: {},
 //   }
 // }
+// ```
 export async function migratePostCSSConfig(base: string) {
   let ranMigration = false
   let didMigrate = false

--- a/packages/tailwindcss/src/candidate.ts
+++ b/packages/tailwindcss/src/candidate.ts
@@ -385,6 +385,7 @@ export function* parseCandidate(input: string, designSystem: DesignSystem): Iter
   //
   // E.g.:
   //
+  // ```
   // bg-(--my-var)
   // ^^            -> Root
   //    ^^^^^^^^^^ -> Arbitrary value


### PR DESCRIPTION
## Summary

I fixed some code blocks inside comment blocks that were missing delimiters.
