### PR TITLE
Add '.vercel' to ignored content directories

### DIFF
--- a/crates/oxide/src/scanner/fixtures/ignored-content-dirs.txt
+++ b/crates/oxide/src/scanner/fixtures/ignored-content-dirs.txt
@@ -11,3 +11,4 @@ venv
 __pycache__
 .svelte-kit
 .pnpm-store
+.vercel


### PR DESCRIPTION
Just like `.next` is ignored, ignore `.vercel` as well.