### PR TITLE
Handle `@variant` inside `@custom-variant`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Handle `@variant` inside `@custom-variant` ([#18885](https://github.com/tailwindlabs/tailwindcss/pull/18885))
 
 ## [4.1.13] - 2025-09-03
 

--- a/packages/tailwindcss/src/compat/plugin-api.ts
+++ b/packages/tailwindcss/src/compat/plugin-api.ts
@@ -154,7 +154,7 @@ export function buildPluginApi({
 
       // CSS-in-JS object
       else if (typeof variant === 'object') {
-        designSystem.variants.fromAst(name, objectToAst(variant))
+        designSystem.variants.fromAst(name, objectToAst(variant), designSystem)
       }
     },
     matchVariant(name, fn, options) {

--- a/packages/tailwindcss/src/utils/topological-sort.ts
+++ b/packages/tailwindcss/src/utils/topological-sort.ts
@@ -1,0 +1,36 @@
+export function topologicalSort<Key>(
+  graph: Map<Key, Set<Key>>,
+  options: { onCircularDependency: (path: Key[], start: Key) => void },
+): Key[] {
+  let seen = new Set<Key>()
+  let wip = new Set<Key>()
+
+  let sorted: Key[] = []
+
+  function visit(node: Key, path: Key[] = []) {
+    if (!graph.has(node)) return
+    if (seen.has(node)) return
+
+    // Circular dependency detected
+    if (wip.has(node)) options.onCircularDependency?.(path, node)
+
+    wip.add(node)
+
+    for (let dependency of graph.get(node) ?? []) {
+      path.push(node)
+      visit(dependency, path)
+      path.pop()
+    }
+
+    seen.add(node)
+    wip.delete(node)
+
+    sorted.push(node)
+  }
+
+  for (let node of graph.keys()) {
+    visit(node)
+  }
+
+  return sorted
+}

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -83,12 +83,15 @@ export class Variants {
     })
   }
 
-  fromAst(name: string, ast: AstNode[]) {
+  fromAst(name: string, ast: AstNode[], designSystem: DesignSystem) {
     let selectors: string[] = []
 
+    let usesAtVariant = false
     walk(ast, (node) => {
       if (node.kind === 'rule') {
         selectors.push(node.selector)
+      } else if (node.kind === 'at-rule' && node.name === '@variant') {
+        usesAtVariant = true
       } else if (node.kind === 'at-rule' && node.name !== '@slot') {
         selectors.push(`${node.name} ${node.params}`)
       }
@@ -98,12 +101,11 @@ export class Variants {
       name,
       (r) => {
         let body = structuredClone(ast)
+        if (usesAtVariant) substituteAtVariant(body, designSystem)
         substituteAtSlot(body, r.nodes)
         r.nodes = body
       },
-      {
-        compounds: compoundsForSelectors(selectors),
-      },
+      { compounds: compoundsForSelectors(selectors) },
     )
   }
 


### PR DESCRIPTION
This PR fixes an issue where you cannot use `@variant` inside a `@custom-variant`. While you can use `@variant` in normal CSS, you cannot inside of `@custom-variant`. Today this silently fails and emits invalid CSS.
```css
@custom-variant dark {
  @variant data-dark {
    @slot;
  }
}
```
```html
<div class="dark:flex"></div>
```

Would result in:
```css
.dark\:flex {
  @variant data-dark {
    display: flex;
  }
}
```

To solve it we have 3 potential solutions:

1. Consider it user error — but since it generates CSS and you don't really get an error you could be shipping broken CSS unknowingly.
1. We could try and detect this and not generate CSS for this and potentially show a warning.
1. We could make it work as expected — which is what this PR does.

Some important notes:

1. The evaluation of the `@custom-variant` only happens when you actually need it. That means that `@variant` inside `@custom-variant` will always have the implementation of the last definition of that variant.

   In other words, if you use `@variant hover` inside a `@custom-variant`, and later you override the `hover` variant, the `@custom-variant` will use the new implementation.
1. If you happen to introduce a circular dependency, then an error will be thrown during the build step.

You can consider it a bug fix or a new feature it's a bit of a gray area. But
one thing that is cool about this is that you can ship a plugin that looks like
this:
```css
@custom-variant hocus {
  @variant hover {
    @slot;
  }

  @variant focus {
    @slot;
  }
}
```

And it will use the implementation of `hover` and `focus` that the user has defined. So if they have a custom `hover` or `focus` variant it will just work.

By default `hocus:underline` would generate:
```css
@media (hover: hover) {
  .hocus\:underline:hover {
    text-decoration-line: underline;
  }
}

.hocus\:underline:focus {
  text-decoration-line: underline;
}
```

But if you have a custom `hover` variant like:
```css
@custom-variant hover (&:hover);
```

Then `hocus:underline` would generate:
```css
.hocus\:underline:hover, .hocus\:underline:focus {
  text-decoration-line: underline;
}
```

### Test plan

1. Existing tests pass
2. Added tests with this new functionality handled
3. Made sure to add a test for circular dependencies + error message
4. Made sure that if you "fix" the circular dependency (by overriding a variant) that everything is generated as expected.

Fixes: https://github.com/tailwindlabs/tailwindcss/issues/18524