### PR TITLE
Handle `'` syntax in ClojureScript when extracting classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Handle `'` syntax in ClojureScript when extracting classes ([#18888](https://github.com/tailwindlabs/tailwindcss/pull/18888))
 
 ## [4.1.13] - 2025-09-03
 


### PR DESCRIPTION
This PR fixes an issue where the `'` syntax in ClojureScript was not handled properly, resulting in missing extracted classes.

This PR now supports the following ClojureScript syntaxes:

```cljs
; Keyword
(print 'text-red-500)

; List
(print '(flex flex-col underline))

; Vector
(print '[flex flex-col underline])
```

### Test plan

1. Added regression tests
2. Verified that we extract classes correctly now in various scenarios:

Top is before, bottom is with this PR:

<img width="1335" height="1862" alt="image" src="https://github.com/user-attachments/assets/746aa073-25f8-41f8-b71c-ba83a33065aa" />


Fixes: #18882 
