### PR TITLE
Add support for `--max-breakpoint-*` theme variables

### DIFF
--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -877,6 +877,109 @@ test('custom breakpoint', async () => {
   `)
 })
 
+test('max-breakpoint (desktop-first)', async () => {
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --max-breakpoint-phone: 501px;
+          --max-breakpoint-tablet: 1001px;
+        }
+        @tailwind utilities;
+      `,
+      ['phone:flex-col', 'tablet:flex-wrap'],
+    ),
+  ).toMatchInlineSnapshot(`
+    "@media not all and (min-width: 1001px) {
+      .tablet\\:flex-wrap {
+        flex-wrap: wrap;
+      }
+    }
+
+    @media not all and (min-width: 501px) {
+      .phone\\:flex-col {
+        flex-direction: column;
+      }
+    }"
+  `)
+})
+
+test('max-breakpoint ordering', async () => {
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          /* Test ordering - larger values should come first in DESC order */
+          --max-breakpoint-mobile: 600px;
+          --max-breakpoint-tablet: 1200px;
+          --max-breakpoint-desktop: 1800px;
+        }
+        @tailwind utilities;
+      `,
+      ['mobile:flex', 'tablet:flex', 'desktop:flex'],
+    ),
+  ).toMatchInlineSnapshot(`
+    "@media not all and (min-width: 1800px) {
+      .desktop\\:flex {
+        display: flex;
+      }
+    }
+
+    @media not all and (min-width: 1200px) {
+      .tablet\\:flex {
+        display: flex;
+      }
+    }
+
+    @media not all and (min-width: 600px) {
+      .mobile\\:flex {
+        display: flex;
+      }
+    }"
+  `)
+})
+
+test('mixed breakpoints and max-breakpoints', async () => {
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --breakpoint-sm: 640px;
+          --breakpoint-md: 768px;
+          --max-breakpoint-phone: 501px;
+          --max-breakpoint-tablet: 1001px;
+        }
+        @tailwind utilities;
+      `,
+      ['sm:flex', 'phone:flex-col', 'md:grid', 'tablet:hidden'],
+    ),
+  ).toMatchInlineSnapshot(`
+    "@media (min-width: 640px) {
+      .sm\\:flex {
+        display: flex;
+      }
+    }
+
+    @media (min-width: 768px) {
+      .md\\:grid {
+        display: grid;
+      }
+    }
+
+    @media not all and (min-width: 1001px) {
+      .tablet\\:hidden {
+        display: none;
+      }
+    }
+
+    @media not all and (min-width: 501px) {
+      .phone\\:flex-col {
+        flex-direction: column;
+      }
+    }"
+  `)
+})
+
 test('max-*', async () => {
   expect(
     await compileCss(


### PR DESCRIPTION
Summary

This PR adds support for `--max-breakpoint-*` theme variables, enabling desktop-first breakpoint workflows similar to Webflow. This complements the existing mobile-first `--breakpoint-*` system by providing max-width media
queries.

Motivation

Currently, Tailwind v4 only supports mobile-first breakpoints via --breakpoint-* variables, which generate min-width media queries. Many designers and teams prefer desktop-first workflows where styles are defined for larger
screens and then overridden for smaller devices.

This is particularly useful for:
- Teams migrating from Webflow or other desktop-first CSS frameworks
- Projects that start with desktop designs and adapt down to mobile
- Situations where max-width queries provide cleaner, more intuitive CSS

Changes

Implementation

- Added --max-breakpoint-* variant support in src/variants.ts
- Creates static variants for each --max-breakpoint-* theme variable
- Generates max-width media queries using the same format as existing max-* variants
- Uses descending sort order (largest breakpoints first) for proper CSS cascade

Usage

Define desktop-first breakpoints in your theme:

```css
@theme {
  --max-breakpoint-phone: 501px;
  --max-breakpoint-tablet: 1001px;
  --max-breakpoint-desktop: 1441px;
}
```

Use them with intuitive, semantic class names:

```html
<!-- Desktop-first: starts as flex-row, becomes flex-col on phones -->
<div class="flex flex-row phone:flex-col">
  <div>Content</div>
  <div>Sidebar</div>
</div>

<!-- Mixed approach: combine with existing min-width breakpoints -->
<div class="md:grid md:grid-cols-2 tablet:block phone:text-center">
  <!-- ... -->  
</div>
```

Generated CSS:

```css
@media not all and (min-width: 1441px) {
  .desktop\:hidden { display: none; }
}

@media not all and (min-width: 1001px) {
  .tablet\:block { display: block; }
}

@media not all and (min-width: 501px) {
  .phone\:flex-col { flex-direction: column; }
}
```

Key Features

- Semantic naming: Allow the use of meaningful breakpoint names like phone, tablet, desktop instead of size-based names
- Desktop-first workflow: Define base styles for large screens, override for smaller devices
- Seamless integration: Works alongside existing `--breakpoint-*` variables
- Consistent behavior: Uses the same media query format and parsing logic as existing `@max-width` variants
- Proper ordering: Automatically sorts breakpoints in descending order for optimal CSS cascade

Testing

Added comprehensive test coverage including:
- Basic functionality with custom breakpoint names
- Breakpoint ordering (descending for max-width queries)
- Mixed usage with existing min-width breakpoints
- Edge cases and proper CSS generation

All existing tests continue to pass, ensuring no breaking changes.

Backward Compatibility

This is a purely additive change that doesn't affect existing functionality:
- Existing `--breakpoint-*` variables continue to work exactly as before
- No changes to existing API or behavior
- Can be used alongside existing breakpoint system

Example Use Cases

Webflow-style migration:
```css
@theme {
  --max-breakpoint-tablet: 991px;
  --max-breakpoint-mobile-landscape: 767px;
  --max-breakpoint-mobile-portrait: 479px;
}
```

Component-specific responsive design:

```html
<nav class="desktop:flex desktop:justify-between tablet:block mobile:text-center">
<!-- Navigation that stacks on smaller screens -->
</nav>

Mixed responsive strategies:
<div class="lg:grid lg:grid-cols-3 tablet:grid tablet:grid-cols-2 mobile:block">
<!-- Hybrid approach using both min and max width breakpoints -->
</div>
```

This feature provides developers with more flexibility in their responsive design workflows while maintaining Tailwind's utility-first philosophy and consistent API patterns.
