### PR TITLE
Use `default` export condition for `@tailwindcss/vite`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent duplicate CSS when overwriting a static utility with a theme key ([#18056](https://github.com/tailwindlabs/tailwindcss/pull/18056))
 - Do not migrate `variant = 'outline'` during upgrades ([#18922](https://github.com/tailwindlabs/tailwindcss/pull/18922))
 - Show Lightning CSS warnings (if any) when optimizing/minifying ([#18918](https://github.com/tailwindlabs/tailwindcss/pull/18918))
+- Use `default` export condition for `@tailwindcss/vite` ([#18948](https://github.com/tailwindlabs/tailwindcss/pull/18948))
 
 ## [4.1.13] - 2025-09-03
 

--- a/packages/@tailwindcss-vite/package.json
+++ b/packages/@tailwindcss-vite/package.json
@@ -24,7 +24,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",
-      "import": "./dist/index.mjs"
+      "default": "./dist/index.mjs"
     }
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

In `@tailwindcss/vite` 's `package.json`, change the `exports` key from `include` to `default` since there is no `require` case.

Ran into an issue using the `tsx` package to run a script that has a sub-dependency that imports from `@tailwindcss/vite`, where `tsx` converts things to cjs to run, and since there is no `require` case for this package, it can't find the file. Changing to `default` covers the cases for both `import` and `require`.

## Test plan

No testing needed. Functionality is the same.
