### PR TITLE
Add `Upgrading from Tailwind CSS v…` when running upgrade tool

### DIFF
--- a/crates/node/scripts/move-artifacts.mjs
+++ b/crates/node/scripts/move-artifacts.mjs
@@ -35,4 +35,3 @@ for (let file of await fs.readdir(tailwindcssOxideRoot)) {
   )
   console.log(`Moved ${file} to npm/wasm32-wasi`)
 }
-

--- a/packages/@tailwindcss-postcss/README.md
+++ b/packages/@tailwindcss-postcss/README.md
@@ -62,29 +62,29 @@ By default, this plugin detects whether or not the CSS is being built for produc
 If you want to always enable or disable Lightning CSS the `optimize` option may be used:
 
 ```js
-import tailwindcss from "@tailwindcss/postcss"
+import tailwindcss from '@tailwindcss/postcss'
 
 export default {
- plugins: [
-  tailwindcss({
-    // Enable or disable Lightning CSS
-    optimize: false,
-  })
- ]
+  plugins: [
+    tailwindcss({
+      // Enable or disable Lightning CSS
+      optimize: false,
+    }),
+  ],
 }
 ```
 
 It's also possible to keep Lightning CSS enabled but disable minification:
 
 ```js
-import tailwindcss from "@tailwindcss/postcss"
+import tailwindcss from '@tailwindcss/postcss'
 
 export default {
- plugins: [
-  tailwindcss({
-    optimize: { minify: false },
-  })
- ]
+  plugins: [
+    tailwindcss({
+      optimize: { minify: false },
+    }),
+  ],
 }
 ```
 
@@ -95,32 +95,32 @@ Our PostCSS plugin can rewrite `url(…)`s for you since it also handles `@impor
 In some situations the bundler or framework you're using may provide this feature itself. In this case you can set `transformAssetUrls` to `false` to disable this feature:
 
 ```js
-import tailwindcss from "@tailwindcss/postcss"
+import tailwindcss from '@tailwindcss/postcss'
 
 export default {
- plugins: [
-  tailwindcss({
-    // Disable `url(…)` rewriting
-    transformAssetUrls: false,
+  plugins: [
+    tailwindcss({
+      // Disable `url(…)` rewriting
+      transformAssetUrls: false,
 
-    // Enable `url(…)` rewriting (the default)
-    transformAssetUrls: true,
-  })
- ]
+      // Enable `url(…)` rewriting (the default)
+      transformAssetUrls: true,
+    }),
+  ],
 }
 ```
 
 You may also pass options to `optimize` to enable Lighting CSS but prevent minification:
 
 ```js
-import tailwindcss from "@tailwindcss/postcss"
+import tailwindcss from '@tailwindcss/postcss'
 
 export default {
- plugins: [
-  tailwindcss({
-    // Enables Lightning CSS but disables minification
-    optimize: { minify: false },
-  })
- ]
+  plugins: [
+    tailwindcss({
+      // Enables Lightning CSS but disables minification
+      optimize: { minify: false },
+    }),
+  ],
 }
 ```

--- a/packages/@tailwindcss-upgrade/src/index.ts
+++ b/packages/@tailwindcss-upgrade/src/index.ts
@@ -58,6 +58,10 @@ async function run() {
     }
   }
 
+  info(`Upgrading from Tailwind CSS ${highlight(`v${version.installedTailwindVersion(base)}`)}`, {
+    prefix: '↳ ',
+  })
+
   {
     // Stylesheet migrations
 

--- a/packages/@tailwindcss-upgrade/src/utils/version.ts
+++ b/packages/@tailwindcss-upgrade/src/utils/version.ts
@@ -26,6 +26,6 @@ let cache = new DefaultMap((base) => {
   return tailwindVersion
 })
 
-function installedTailwindVersion(base = process.cwd()): string {
+export function installedTailwindVersion(base = process.cwd()): string {
   return cache.get(base)
 }


### PR DESCRIPTION
This PR adds a bit more information when running the upgrade tool to know what version of Tailwind CSS you're upgrading from. This will help users and maintainers when things go wrong.

Will have another PR up soon that errors when the Tailwind CSS version in package.json and node_modules don't match.

### Test plan

Ran this one one of our older projects and saw the version logged correctly.

<img width="1055" height="363" alt="image" src="https://github.com/user-attachments/assets/5cbf4c52-ea0f-42c8-bd55-5bae2ed511de" />

