### PR TITLE
Never publish v3 as `latest` on npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           echo "TAILWINDCSS_VERSION=$(node -e 'console.log(require(`./package.json`).version);')" >> $GITHUB_ENV
 
       - name: Publish
-        run: npm publish --provenance
+        run: npm publish --provenance --tag v3-lts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
This PR ensures that if we release v3 in the future, that we don't use `latest` as the npm tag, but `v3-lts` instead.

Unfortunately we can't just use `3` or `v3` because they are not valid and you will get an error when trying to publish.

Angular uses `v{n}-lts` for the versions they still support: https://www.npmjs.com/package/@angular/core?activeTab=versions

Adding a tag is important, because omitting the `--tag` is the same as `--tag latest`
