### PR TITLE
Fix failing integration tests

### DIFF
--- a/integrations/vite/nuxt.test.ts
+++ b/integrations/vite/nuxt.test.ts
@@ -11,6 +11,11 @@ const SETUP = {
           "nitropack": "2.11.0",
           "tailwindcss": "workspace:^",
           "vue": "latest"
+        },
+        "pnpm": {
+          "overrides": {
+            "nuxi": "3.28.0"
+          }
         }
       }
     `,


### PR DESCRIPTION
The vite/nuxt integration tests started failing because one of the internal dependencies (`nuxi`) was updated from `3.28.0` to `3.29.0` which includes a newer version of `undici` which in turn relies on `node:sqlite`.

`node:sqlite` was added in a newer Node version, and we still use Node v20 in CI.

This PR pins `nuxi` to `3.28.0` until we can upgrade our Node version in CI.

[ci-all]
