### PR TITLE
Canonicalize dimensions

### DIFF
--- a/packages/@tailwindcss-upgrade/src/codemods/template/migrate-arbitrary-variants.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/template/migrate-arbitrary-variants.ts
@@ -1,4 +1,5 @@
 import { cloneCandidate } from '../../../../tailwindcss/src/candidate'
+import { createSignatureOptions } from '../../../../tailwindcss/src/canonicalize-candidates'
 import type { Config } from '../../../../tailwindcss/src/compat/plugin-api'
 import type { DesignSystem } from '../../../../tailwindcss/src/design-system'
 import {
@@ -14,8 +15,9 @@ export function migrateArbitraryVariants(
   _userConfig: Config | null,
   rawCandidate: string,
 ): string {
-  let signatures = computeVariantSignature.get(designSystem)
-  let variants = preComputedVariants.get(designSystem)
+  let signatureOptions = createSignatureOptions(designSystem)
+  let signatures = computeVariantSignature.get(signatureOptions)
+  let variants = preComputedVariants.get(signatureOptions)
 
   for (let readonlyCandidate of designSystem.parseCandidate(rawCandidate)) {
     // We are only interested in the variants

--- a/packages/@tailwindcss-upgrade/src/codemods/template/migrate-modernize-arbitrary-values.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/template/migrate-modernize-arbitrary-values.test.ts
@@ -17,7 +17,7 @@ function migrate(designSystem: DesignSystem, userConfig: UserConfig | null, rawC
     migratePrefix,
     migrateModernizeArbitraryValues,
     migrateArbitraryVariants,
-    (designSystem: DesignSystem, _, rawCandidate: string) => {
+    (designSystem: DesignSystem, _: UserConfig | null, rawCandidate: string) => {
       return designSystem.canonicalizeCandidates([rawCandidate]).pop() ?? rawCandidate
     },
   ]) {

--- a/packages/@tailwindcss-upgrade/src/codemods/template/migrate.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/template/migrate.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises'
 import path, { extname } from 'node:path'
+import { createSignatureOptions } from '../../../../tailwindcss/src/canonicalize-candidates'
 import type { Config } from '../../../../tailwindcss/src/compat/plugin-api'
 import type { DesignSystem } from '../../../../tailwindcss/src/design-system'
 import { computeUtilitySignature } from '../../../../tailwindcss/src/signatures'
@@ -39,11 +40,10 @@ export const DEFAULT_MIGRATIONS: Migration[] = [
   migrateModernizeArbitraryValues,
 ]
 
-let migrateCached = new DefaultMap<
-  DesignSystem,
-  DefaultMap<Config | null, DefaultMap<string, Promise<string>>>
->((designSystem) => {
-  return new DefaultMap((userConfig) => {
+let migrateCached = new DefaultMap((designSystem: DesignSystem) => {
+  let options = createSignatureOptions(designSystem)
+
+  return new DefaultMap((userConfig: Config | null) => {
     return new DefaultMap(async (rawCandidate) => {
       let original = rawCandidate
 
@@ -57,7 +57,7 @@ let migrateCached = new DefaultMap<
       // Verify that the candidate actually makes sense at all. E.g.: `duration`
       // is not a valid candidate, but it will parse because `duration-<number>`
       // exists.
-      let signature = computeUtilitySignature.get(designSystem).get(rawCandidate)
+      let signature = computeUtilitySignature.get(options).get(rawCandidate)
       if (typeof signature !== 'string') return original
 
       return rawCandidate

--- a/packages/tailwindcss/src/canonicalize-candidates.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.ts
@@ -26,6 +26,16 @@ import { segment } from './utils/segment'
 import { toKeyPath } from './utils/to-key-path'
 import * as ValueParser from './value-parser'
 
+export interface CanonicalizeOptions {
+  /**
+   * The root font size in pixels. If provided, `rem` values will be normalized
+   * to `px` values.
+   *
+   * E.g.: `mt-[16px]` with `rem: 16` will become `mt-4` (assuming `--spacing: 0.25rem`).
+   */
+  rem?: number
+}
+
 export function canonicalizeCandidates(ds: DesignSystem, candidates: string[]): string[] {
   let result = new Set<string>()
   let cache = canonicalizeCandidateCache.get(ds)

--- a/packages/tailwindcss/src/constant-fold-declaration.test.ts
+++ b/packages/tailwindcss/src/constant-fold-declaration.test.ts
@@ -72,18 +72,18 @@ it.each([
 
 it.each([
   ['0deg', '0deg'],
-  ['0rad', '0rad'],
+  ['0rad', '0deg'],
   ['0%', '0%'],
-  ['0turn', '0turn'],
+  ['0turn', '0deg'],
   ['0fr', '0fr'],
-  ['0ms', '0ms'],
+  ['0ms', '0s'],
   ['0s', '0s'],
   ['-0.0deg', '0deg'],
-  ['-0.0rad', '0rad'],
+  ['-0.0rad', '0deg'],
   ['-0.0%', '0%'],
-  ['-0.0turn', '0turn'],
+  ['-0.0turn', '0deg'],
   ['-0.0fr', '0fr'],
-  ['-0.0ms', '0ms'],
+  ['-0.0ms', '0s'],
   ['-0.0s', '0s'],
 ])('should not fold non-foldable units to `0`. Constant fold `%s` into `%s`', (input, expected) => {
   expect(constantFoldDeclaration(input)).toBe(expected)

--- a/packages/tailwindcss/src/constant-fold-declaration.ts
+++ b/packages/tailwindcss/src/constant-fold-declaration.ts
@@ -4,7 +4,7 @@ import * as ValueParser from './value-parser'
 
 // Assumption: We already assume that we receive somewhat valid `calc()`
 // expressions. So we will see `calc(1 + 1)` and not `calc(1+1)`
-export function constantFoldDeclaration(input: string): string {
+export function constantFoldDeclaration(input: string, rem: number | null): string {
   let folded = false
   let valueAst = ValueParser.parse(input)
 
@@ -17,7 +17,7 @@ export function constantFoldDeclaration(input: string): string {
       valueNode.kind === 'word' &&
       valueNode.value !== '0' // Already `0`, nothing to do
     ) {
-      let canonical = canonicalizeDimension(valueNode.value)
+      let canonical = canonicalizeDimension(valueNode.value, rem)
       if (canonical === null) return // Couldn't be canonicalized, nothing to do
       if (canonical === valueNode.value) return // Already in canonical form, nothing to do
 
@@ -113,7 +113,7 @@ export function constantFoldDeclaration(input: string): string {
   return folded ? ValueParser.toCss(valueAst) : input
 }
 
-function canonicalizeDimension(input: string, rem?: number): string | null {
+function canonicalizeDimension(input: string, rem: number | null = null): string | null {
   let dimension = dimensions.get(input)
   if (dimension === null) return null // This shouldn't happen
 
@@ -132,7 +132,7 @@ function canonicalizeDimension(input: string, rem?: number): string | null {
     case 'q':   return `${value * 96 / 2.54 / 10 / 4}px`  //  1q  =  0.945px
     case 'pc':  return `${value * 96 / 6}px`              // 1pc  = 16.000px
     case 'pt':  return `${value * 96 / 72}px`             // 1pt  =  1.333px
-    case 'rem': return rem ? `${value * rem}px` : null    // 1rem = 16.000px (Assuming root font-size is 16px)
+    case 'rem': return rem !== null ? `${value * rem}px` : null    // 1rem = 16.000px (Assuming root font-size is 16px)
 
     // <angle> to deg, https://developer.mozilla.org/en-US/docs/Web/CSS/angle
     case 'grad': return `${value * 0.9}deg`               // 1grad =   0.900deg

--- a/packages/tailwindcss/src/constant-fold-declaration.ts
+++ b/packages/tailwindcss/src/constant-fold-declaration.ts
@@ -9,33 +9,21 @@ export function constantFoldDeclaration(input: string): string {
   let valueAst = ValueParser.parse(input)
 
   ValueParser.walkDepth(valueAst, (valueNode, { replaceWith }) => {
-    // Convert `-0`, `+0`, `0.0`, … to `0`
-    // Convert `-0px`, `+0em`, `0.0rem`, … to `0`
+    // Canonicalize dimensions to their simplest form. This includes:
+    // - Convert `-0`, `+0`, `0.0`, … to `0`
+    // - Convert `-0px`, `+0em`, `0.0rem`, … to `0`
+    // - Convert units to an equivalent unit
     if (
       valueNode.kind === 'word' &&
-      valueNode.value !== '0' && // Already `0`, nothing to do
-      ((valueNode.value[0] === '-' && valueNode.value[1] === '0') || // `-0…`
-        (valueNode.value[0] === '+' && valueNode.value[1] === '0') || // `+0…`
-        valueNode.value[0] === '0') // `0…`
+      valueNode.value !== '0' // Already `0`, nothing to do
     ) {
-      let dimension = dimensions.get(valueNode.value)
-      if (dimension === null) return // This shouldn't happen
+      let canonical = canonicalizeDimension(valueNode.value)
+      if (canonical === null) return // Couldn't be canonicalized, nothing to do
+      if (canonical === valueNode.value) return // Already in canonical form, nothing to do
 
-      if (dimension[0] !== 0) return // Not a zero value, nothing to do
-
-      // Replace length units with just `0`
-      if (dimension[1] === null || isLength(valueNode.value)) {
-        folded = true
-        replaceWith(ValueParser.word('0'))
-        return
-      }
-
-      // Replace other units with `0<unit>`, e.g. `0%`, `0fr`, `0s`, …
-      else if (valueNode.value !== `0${dimension[1]}`) {
-        folded = true
-        replaceWith(ValueParser.word(`0${dimension[1]}`))
-        return
-      }
+      folded = true
+      replaceWith(ValueParser.word(canonical))
+      return
     }
 
     // Constant fold `calc()` expressions with two operands and one operator
@@ -123,4 +111,40 @@ export function constantFoldDeclaration(input: string): string {
   })
 
   return folded ? ValueParser.toCss(valueAst) : input
+}
+
+function canonicalizeDimension(input: string, rem?: number): string | null {
+  let dimension = dimensions.get(input)
+  if (dimension === null) return null // This shouldn't happen
+
+  let [value, unit] = dimension
+  if (unit === null) return `${value}` // Already unitless, nothing to do
+
+  // Replace `0<length>` units with just `0`
+  if (value === 0 && isLength(input)) return '0'
+
+  // prettier-ignore
+  switch (unit.toLowerCase()) {
+    // <length> to px, https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Styling_basics/Values_and_units#lengths
+    case 'in':  return `${value * 96}px`                  // 1in  = 96.000px
+    case 'cm':  return `${value * 96 / 2.54}px`           // 1cm  = 37.795px
+    case 'mm':  return `${value * 96 / 2.54 / 10}px`      // 1mm  =  3.779px
+    case 'q':   return `${value * 96 / 2.54 / 10 / 4}px`  //  1q  =  0.945px
+    case 'pc':  return `${value * 96 / 6}px`              // 1pc  = 16.000px
+    case 'pt':  return `${value * 96 / 72}px`             // 1pt  =  1.333px
+    case 'rem': return rem ? `${value * rem}px` : null    // 1rem = 16.000px (Assuming root font-size is 16px)
+
+    // <angle> to deg, https://developer.mozilla.org/en-US/docs/Web/CSS/angle
+    case 'grad': return `${value * 0.9}deg`               // 1grad =   0.900deg
+    case 'rad':  return `${value * 180 / Math.PI}deg`     //  1rad =  57.296deg
+    case 'turn': return `${value * 360}deg`               // 1turn = 360.000deg
+
+    // <time> to s, https://developer.mozilla.org/en-US/docs/Web/CSS/time
+    case 'ms':   return `${value / 1000}s`                // 1ms = 0.001s
+
+    // <frequency> to hz, https://developer.mozilla.org/en-US/docs/Web/CSS/frequency
+    case 'khz':  return `${value * 1000}hz`               // 1kHz = 1000Hz
+
+    default: return `${value}${unit}` // No canonicalization possible, return as-is
+  }
 }

--- a/packages/tailwindcss/src/design-system.ts
+++ b/packages/tailwindcss/src/design-system.ts
@@ -14,6 +14,7 @@ import {
   canonicalizeCandidates,
   getClassList,
   getVariants,
+  type CanonicalizeOptions,
   type ClassEntry,
   type VariantEntry,
 } from './intellisense'
@@ -54,7 +55,7 @@ export type DesignSystem = {
   resolveThemeValue(path: string, forceInline?: boolean): string | undefined
 
   trackUsedVariables(raw: string): void
-  canonicalizeCandidates(candidates: string[]): string[]
+  canonicalizeCandidates(candidates: string[], options?: CanonicalizeOptions): string[]
 
   // Used by IntelliSense
   candidatesToCss(classes: string[]): (string | null)[]
@@ -210,8 +211,8 @@ export function buildDesignSystem(theme: Theme): DesignSystem {
       trackUsedVariables.get(raw)
     },
 
-    canonicalizeCandidates(candidates: string[]) {
-      return canonicalizeCandidates(this, candidates)
+    canonicalizeCandidates(candidates: string[], options?: CanonicalizeOptions) {
+      return canonicalizeCandidates(this, candidates, options)
     },
   }
 

--- a/packages/tailwindcss/src/intellisense.ts
+++ b/packages/tailwindcss/src/intellisense.ts
@@ -3,7 +3,7 @@ import { applyVariant } from './compile'
 import type { DesignSystem } from './design-system'
 import { compare } from './utils/compare'
 import { DefaultMap } from './utils/default-map'
-export { canonicalizeCandidates } from './canonicalize-candidates'
+export { canonicalizeCandidates, type CanonicalizeOptions } from './canonicalize-candidates'
 
 interface ClassMetadata {
   modifiers: string[]


### PR DESCRIPTION
This PR further improves the canonicalization of units in Tailwind CSS to increase the amount of similar candidates that can be converted to their canonical form.

This also introduces a `rem` option to the `canonicalizeCandidates([…], { rem: 16 })`. If this is passed with a pixel value, then `rem` units will be converted to `px` values. This is not enabled by default while running upgrades, but this can be used (e.g.: in intellisense).

This allows us to migrate `mt-[16px]` to `mt-4` (assuming `--spacing: 0.25rem` is defined). Rem to px value migrations are not safe by default (because it depends on the root font size), but Intellisense can use them to provide a suggestion because in most cases that _is_ what you want.

Internally this required a refactor because we now need the `rem` value as well. This introduced a `SignatureOptions` interface to make sure that we have a single stable object that can be passed around and that all the caches exist per `SignatureOptions` object. This means that you can call `canonicalizeCandidates` with different `rem` values without influencing other options.

As a user, you don't have to worry about making this second object stable, that will happen internally already.

### Usage example:

```ts
designSystem.canonicalizeCandidates(['m-[16px]'])              // m-[16px]
designSystem.canonicalizeCandidates(['m-[16px]'], { rem: 16 }) // m-4 
designSystem.canonicalizeCandidates(['m-[16px]'], { rem: 64 }) // m-1
```

## Test plan

1. Made sure that existing tests pass
2. Added new tests for when you pass in a `rem` value
3. Also made sure that calling without `rem` value or a different value after the previous calls don't touch shared caches.


