### PR TITLE
Clone AST nodes used in `staticValues`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Suppress Lightning CSS warnings about `:deep`, `:slotted`, and `:global` ([#19094](https://github.com/tailwindlabs/tailwindcss/pull/19094))
 - Fix resolving theme keys when starting with the name of another theme key in JS configs and plugins ([#19097](https://github.com/tailwindlabs/tailwindcss/pull/19097))
 - Allow named groups in combination with `not-*`, `has-*`, and `in-*` ([#19100](https://github.com/tailwindlabs/tailwindcss/pull/19100))
+- Prevent important utilities from affecting other utilities ([#19110](https://github.com/tailwindlabs/tailwindcss/pull/19110))
 - Upgrade: Canonicalize utilities containing `0` values ([#19095](https://github.com/tailwindlabs/tailwindcss/pull/19095))
 
 ## [4.1.14] - 2025-10-01

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -537,6 +537,50 @@ describe('@apply', () => {
     `)
   })
 
+  it('@apply does not cache important state', async () => {
+    expect(
+      await compileCss(css`
+        .c1 {
+          @apply leading-none;
+        }
+        .c2 {
+          @apply leading-none!;
+        }
+        .c3 {
+          @apply leading-none;
+        }
+      `),
+    ).toMatchInlineSnapshot(`
+      "@layer properties {
+        @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
+          *, :before, :after, ::backdrop {
+            --tw-leading: initial;
+          }
+        }
+      }
+
+      .c1 {
+        --tw-leading: 1;
+        line-height: 1;
+      }
+
+      .c2 {
+        --tw-leading: 1 !important;
+        line-height: 1 !important;
+      }
+
+      .c3 {
+        --tw-leading: 1;
+        line-height: 1;
+      }
+
+      @property --tw-leading {
+        syntax: "*";
+        inherits: false
+      }"
+    `)
+  })
+
   it('should error when using @apply with a utility that does not exist', async () => {
     await expect(
       compile(css`

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -436,7 +436,7 @@ export function createUtilities(theme: Theme) {
 
           if (value === null && !negative && desc.staticValues && !candidate.modifier) {
             let fallback = desc.staticValues[candidate.value.value]
-            if (fallback) return fallback
+            if (fallback) return fallback.map(cloneAstNode)
           }
         }
 


### PR DESCRIPTION
These were getting mutated but they were shared instead of being re-created for new candidates. Cloning the nodes fixes this so mutation of the AST nodes doesn’t stick around.

Fixes #19108