### PR TITLE
Fix parsing issue when `\t` is used in at-rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow named groups in combination with `not-*`, `has-*`, and `in-*` ([#19100](https://github.com/tailwindlabs/tailwindcss/pull/19100))
 - Prevent important utilities from affecting other utilities ([#19110](https://github.com/tailwindlabs/tailwindcss/pull/19110))
 - Don’t index into strings with the `theme(…)` function ([#19111](https://github.com/tailwindlabs/tailwindcss/pull/19111))
+- Fix parsing issue when `\t` is used in at-rules ([#19130](https://github.com/tailwindlabs/tailwindcss/pull/19130))
 - Upgrade: Canonicalize utilities containing `0` values ([#19095](https://github.com/tailwindlabs/tailwindcss/pull/19095))
 
 ## [4.1.14] - 2025-10-01

--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -723,14 +723,22 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
       ).toEqual([{ kind: 'at-rule', name: '@charset', params: '"UTF-8"', nodes: [] }])
     })
 
-    it('should parse an at-rule with tabs in the params', () => {
-      expect(parse('@apply\tbg-red-500;')).toEqual([
-        { kind: 'at-rule', name: '@apply', params: 'bg-red-500', nodes: [] },
-      ])
-    })
-
-    it('should parse an at-rule with tabs and newlines in the params', () => {
-      expect(parse('@apply\n\tbg-red-500;')).toEqual([
+    it.each([
+      [' '], // space
+      ['  '], // multiple spaces
+      ['\t'], // tab
+      [' \t'], // space + tab
+      ['\t '], // tab + space
+      ['\t\t'], // multiple tabs
+      ['\n'], // newline
+      [' \n'], // space + newline
+      ['\n '], // newline + space
+      ['\n\n'], // multiple newlines
+      ['\r\n'], // windows newline
+      [' \r\n'], // space + windows newline
+      ['\r\n '], // windows newline + space
+    ])('should parse an at-rule with whitespace %s in the params', (whitespace) => {
+      expect(parse(`@apply${whitespace}bg-red-500;`)).toEqual([
         { kind: 'at-rule', name: '@apply', params: 'bg-red-500', nodes: [] },
       ])
     })

--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -723,6 +723,18 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
       ).toEqual([{ kind: 'at-rule', name: '@charset', params: '"UTF-8"', nodes: [] }])
     })
 
+    it('should parse an at-rule with tabs in the params', () => {
+      expect(parse('@apply\tbg-red-500;')).toEqual([
+        { kind: 'at-rule', name: '@apply', params: 'bg-red-500', nodes: [] },
+      ])
+    })
+
+    it('should parse an at-rule with tabs and newlines in the params', () => {
+      expect(parse('@apply\n\tbg-red-500;')).toEqual([
+        { kind: 'at-rule', name: '@apply', params: 'bg-red-500', nodes: [] },
+      ])
+    })
+
     it('should parse an at-rule without a block or semicolon', () => {
       expect(
         parse(`

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -571,7 +571,7 @@ export function parseAtRule(buffer: string, nodes: AstNode[] = []): AtRule {
   // behavior if necessary.
   for (let i = 5 /* '@page'.length */; i < buffer.length; i++) {
     let currentChar = buffer.charCodeAt(i)
-    if (currentChar === SPACE || currentChar === OPEN_PAREN) {
+    if (currentChar === SPACE || currentChar === TAB || currentChar === OPEN_PAREN) {
       name = buffer.slice(0, i)
       params = buffer.slice(i)
       break


### PR DESCRIPTION
This PR fixes an issue where an at-rule that used `@name\tparams` didn't properly parse because we didn't properly handle `\t`.

## Test plan

1. Added failing tests
2. Made them pass

Fixes: #19127
