### PR TITLE
Incorporate changes from latest `ignore` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -200,9 +200,9 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "globset"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+checksum = "eab69130804d941f8075cfd713bf8848a2c3b3f201a9457a11e6f87e1ab62305"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -218,18 +218,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
  "bitflags",
- "ignore 0.4.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ignore 0.4.23",
  "walkdir",
 ]
 
 [[package]]
 name = "ignore"
 version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
 dependencies = [
- "bstr",
- "crossbeam-channel",
  "crossbeam-deque",
- "dunce",
  "globset",
  "log",
  "memchr",
@@ -241,11 +240,12 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
+version = "0.4.24"
 dependencies = [
+ "bstr",
+ "crossbeam-channel",
  "crossbeam-deque",
+ "dunce",
  "globset",
  "log",
  "memchr",
@@ -599,7 +599,7 @@ dependencies = [
  "dunce",
  "fast-glob",
  "globwalk",
- "ignore 0.4.23",
+ "ignore 0.4.24",
  "log",
  "pretty_assertions",
  "rayon",

--- a/crates/ignore/Cargo.toml
+++ b/crates/ignore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ignore"
-version = "0.4.23"  #:version
+version = "0.4.24"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = """
 A fast library for efficiently matching ignore files such as `.gitignore`
@@ -12,7 +12,7 @@ repository = "https://github.com/BurntSushi/ripgrep/tree/master/crates/ignore"
 readme = "README.md"
 keywords = ["glob", "ignore", "gitignore", "pattern", "file"]
 license = "Unlicense OR MIT"
-edition = "2021"
+edition = "2024"
 
 [lib]
 name = "ignore"
@@ -20,7 +20,7 @@ bench = false
 
 [dependencies]
 crossbeam-deque = "0.8.3"
-globset = "0.4.16"
+globset = "0.4.17"
 log = "0.4.20"
 memchr = "2.6.3"
 same-file = "1.0.6"
@@ -37,7 +37,7 @@ version = "0.1.2"
 
 [dev-dependencies]
 bstr = { version = "1.6.2", default-features = false, features = ["std"] }
-crossbeam-channel = "0.5.8"
+crossbeam-channel = "0.5.15"
 
 [features]
 # DEPRECATED. It is a no-op. SIMD is done automatically through runtime

--- a/crates/ignore/README.md
+++ b/crates/ignore/README.md
@@ -1,5 +1,5 @@
-# ignore
-
+ignore
+======
 The ignore crate provides a fast recursive directory iterator that respects
 various filters such as globs, file types and `.gitignore` files. This crate
 also provides lower level direct access to gitignore and file type matchers.
@@ -28,6 +28,7 @@ This example shows the most basic usage of this crate. This code will
 recursively traverse the current directory while automatically filtering out
 files and directories according to ignore globs found in files like
 `.ignore` and `.gitignore`:
+
 
 ```rust,no_run
 use ignore::Walk;

--- a/crates/ignore/examples/walk.rs
+++ b/crates/ignore/examples/walk.rs
@@ -18,8 +18,10 @@ fn main() {
     let stdout_thread = std::thread::spawn(move || {
         let mut stdout = std::io::BufWriter::new(std::io::stdout());
         for dent in rx {
-            stdout.write(&*Vec::from_path_lossy(dent.path())).unwrap();
-            stdout.write(b"\n").unwrap();
+            stdout
+                .write_all(&Vec::from_path_lossy(dent.path()))
+                .unwrap();
+            stdout.write_all(b"\n").unwrap();
         }
     });
 

--- a/crates/ignore/src/default_types.rs
+++ b/crates/ignore/src/default_types.rs
@@ -27,9 +27,10 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["bat", "batch"], &["*.bat"]),
     (&["bazel"], &[
         "*.bazel", "*.bzl", "*.BUILD", "*.bazelrc", "BUILD", "MODULE.bazel",
-        "WORKSPACE", "WORKSPACE.bazel",
+        "WORKSPACE", "WORKSPACE.bazel", "WORKSPACE.bzlmod",
     ]),
     (&["bitbake"], &["*.bb", "*.bbappend", "*.bbclass", "*.conf", "*.inc"]),
+    (&["boxlang"], &["*.bx", "*.bxm", "*.bxs"]),
     (&["brotli"], &["*.br"]),
     (&["buildstream"], &["*.bst"]),
     (&["bzip2"], &["*.bz2", "*.tbz2"]),
@@ -39,6 +40,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["carp"], &["*.carp"]),
     (&["cbor"], &["*.cbor"]),
     (&["ceylon"], &["*.ceylon"]),
+    (&["cfml"], &["*.cfc", "*.cfm"]),
     (&["clojure"], &["*.clj", "*.cljc", "*.cljs", "*.cljx"]),
     (&["cmake"], &["*.cmake", "CMakeLists.txt"]),
     (&["cmd"], &["*.bat", "*.cmd"]),
@@ -62,7 +64,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["cython"], &["*.pyx", "*.pxi", "*.pxd"]),
     (&["d"], &["*.d"]),
     (&["dart"], &["*.dart"]),
-    (&["devicetree"], &["*.dts", "*.dtsi"]),
+    (&["devicetree"], &["*.dts", "*.dtsi", "*.dtso"]),
     (&["dhall"], &["*.dhall"]),
     (&["diff"], &["*.patch", "*.diff"]),
     (&["dita"], &["*.dita", "*.ditamap", "*.ditaval"]),
@@ -88,6 +90,8 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["fsharp"], &["*.fs", "*.fsx", "*.fsi"]),
     (&["fut"], &["*.fut"]),
     (&["gap"], &["*.g", "*.gap", "*.gi", "*.gd", "*.tst"]),
+    (&["gdscript"], &["*.gd"]),
+    (&["gleam"], &["*.gleam"]),
     (&["gn"], &["*.gn", "*.gni"]),
     (&["go"], &["*.go"]),
     (&["gprbuild"], &["*.gpr"]),
@@ -117,6 +121,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["julia"], &["*.jl"]),
     (&["jupyter"], &["*.ipynb", "*.jpynb"]),
     (&["k"], &["*.k"]),
+    (&["kconfig"], &["Kconfig", "Kconfig.*"]),
     (&["kotlin"], &["*.kt", "*.kts"]),
     (&["lean"], &["*.lean"]),
     (&["less"], &["*.less"]),
@@ -149,6 +154,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     ]),
     (&["lilypond"], &["*.ly", "*.ily"]),
     (&["lisp"], &["*.el", "*.jl", "*.lisp", "*.lsp", "*.sc", "*.scm"]),
+    (&["llvm"], &["*.ll"]),
     (&["lock"], &["*.lock", "package-lock.json"]),
     (&["log"], &["*.log"]),
     (&["lua"], &["*.lua"]),
@@ -159,6 +165,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
         "[Gg][Nn][Uu]makefile", "[Mm]akefile",
         "[Gg][Nn][Uu]makefile.am", "[Mm]akefile.am",
         "[Gg][Nn][Uu]makefile.in", "[Mm]akefile.in",
+        "Makefile.*",
         "*.mk", "*.mak"
     ]),
     (&["mako"], &["*.mako", "*.mao"]),
@@ -181,7 +188,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["motoko"], &["*.mo"]),
     (&["msbuild"], &[
         "*.csproj", "*.fsproj", "*.vcxproj", "*.proj", "*.props", "*.targets",
-        "*.sln",
+        "*.sln", "*.slnf"
     ]),
     (&["nim"], &["*.nim", "*.nimf", "*.nimble", "*.nims"]),
     (&["nix"], &["*.nix"]),
@@ -210,7 +217,9 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["py", "python"], &["*.py", "*.pyi"]),
     (&["qmake"], &["*.pro", "*.pri", "*.prf"]),
     (&["qml"], &["*.qml"]),
-    (&["r"], &["*.R", "*.r", "*.Rmd", "*.Rnw"]),
+    (&["qrc"], &["*.qrc"]),
+    (&["qui"], &["*.ui"]),
+    (&["r"], &["*.R", "*.r", "*.Rmd", "*.rmd", "*.Rnw", "*.rnw"]),
     (&["racket"], &["*.rkt"]),
     (&["raku"], &[
         "*.raku", "*.rakumod", "*.rakudoc", "*.rakutest",
@@ -227,14 +236,16 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
         // Idiomatic files
         "config.ru", "Gemfile", ".irbrc", "Rakefile",
         // Extensions
-        "*.gemspec", "*.rb", "*.rbw"
+        "*.gemspec", "*.rb", "*.rbw", "*.rake"
     ]),
     (&["rust"], &["*.rs"]),
     (&["sass"], &["*.sass", "*.scss"]),
     (&["scala"], &["*.scala", "*.sbt"]),
+    (&["scdoc"], &["*.scd", "*.scdoc"]),
+    (&["seed7"], &["*.sd7", "*.s7i"]),
     (&["sh"], &[
         // Portable/misc. init files
-        ".login", ".logout", ".profile", "profile",
+        ".env", ".login", ".logout", ".profile", "profile",
         // bash-specific init files
         ".bash_login", "bash_login",
         ".bash_logout", "bash_logout",
@@ -253,7 +264,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
         ".zprofile", "zprofile",
         ".zshrc", "zshrc",
         // Extensions
-        "*.bash", "*.csh", "*.ksh", "*.sh", "*.tcsh", "*.zsh",
+        "*.bash", "*.csh", "*.env", "*.ksh", "*.sh", "*.tcsh", "*.zsh",
     ]),
     (&["slim"], &["*.skim", "*.slim", "*.slime"]),
     (&["smarty"], &["*.tpl"]),
@@ -265,7 +276,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["sql"], &["*.sql", "*.psql"]),
     (&["stylus"], &["*.styl"]),
     (&["sv"], &["*.v", "*.vg", "*.sv", "*.svh", "*.h"]),
-    (&["svelte"], &["*.svelte"]),
+    (&["svelte"], &["*.svelte", "*.svelte.ts"]),
     (&["svg"], &["*.svg"]),
     (&["swift"], &["*.swift"]),
     (&["swig"], &["*.def", "*.i"]),
@@ -280,9 +291,8 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["texinfo"], &["*.texi"]),
     (&["textile"], &["*.textile"]),
     (&["tf"], &[
-        "*.tf", "*.auto.tfvars", "terraform.tfvars", "*.tf.json",
-        "*.auto.tfvars.json", "terraform.tfvars.json", "*.terraformrc",
-        "terraform.rc", "*.tfrc", "*.terraform.lock.hcl",
+        "*.tf", "*.tf.json", "*.tfvars", "*.tfvars.json",
+        "*.terraformrc", "terraform.rc", "*.tfrc", "*.terraform.lock.hcl",
     ]),
     (&["thrift"], &["*.thrift"]),
     (&["toml"], &["*.toml", "Cargo.lock"]),
@@ -290,6 +300,7 @@ pub(crate) const DEFAULT_TYPES: &[(&[&str], &[&str])] = &[
     (&["twig"], &["*.twig"]),
     (&["txt"], &["*.txt"]),
     (&["typoscript"], &["*.typoscript", "*.ts"]),
+    (&["typst"], &["*.typ"]),
     (&["usd"], &["*.usd", "*.usda", "*.usdc"]),
     (&["v"], &["*.v", "*.vsh"]),
     (&["vala"], &["*.vala"]),

--- a/crates/ignore/src/lib.rs
+++ b/crates/ignore/src/lib.rs
@@ -495,11 +495,7 @@ impl<T> Match<T> {
 
     /// Return the match if it is not none. Otherwise, return other.
     pub fn or(self, other: Self) -> Self {
-        if self.is_none() {
-            other
-        } else {
-            self
-        }
+        if self.is_none() { other } else { self }
     }
 }
 
@@ -544,7 +540,7 @@ mod tests {
 
             let tmpdir = env::temp_dir();
             for _ in 0..TRIES {
-                let count = COUNTER.fetch_add(1, Ordering::SeqCst);
+                let count = COUNTER.fetch_add(1, Ordering::Relaxed);
                 let path = tmpdir.join("rust-ignore").join(count.to_string());
                 if path.is_dir() {
                     continue;

--- a/crates/ignore/src/types.rs
+++ b/crates/ignore/src/types.rs
@@ -91,7 +91,7 @@ use {
     regex_automata::util::pool::Pool,
 };
 
-use crate::{default_types::DEFAULT_TYPES, pathutil::file_name, Error, Match};
+use crate::{Error, Match, default_types::DEFAULT_TYPES, pathutil::file_name};
 
 /// Glob represents a single glob in a set of file type definitions.
 ///

--- a/crates/ignore/tests/gitignore_skip_bom.gitignore
+++ b/crates/ignore/tests/gitignore_skip_bom.gitignore
@@ -1,0 +1,2 @@
+﻿ignore/this/path
+# This file begins with a BOM (U+FEFF)

--- a/crates/ignore/tests/gitignore_skip_bom.rs
+++ b/crates/ignore/tests/gitignore_skip_bom.rs
@@ -1,0 +1,17 @@
+use ignore::gitignore::GitignoreBuilder;
+
+const IGNORE_FILE: &'static str = "tests/gitignore_skip_bom.gitignore";
+
+/// Skip a Byte-Order Mark (BOM) at the beginning of the file, matching Git's
+/// behavior.
+///
+/// Ref: <https://github.com/BurntSushi/ripgrep/issues/2177>
+#[test]
+fn gitignore_skip_bom() {
+    let mut builder = GitignoreBuilder::new("ROOT");
+    let error = builder.add(IGNORE_FILE);
+    assert!(error.is_none(), "failed to open gitignore file");
+    let g = builder.build().unwrap();
+
+    assert!(g.matched("ignore/this/path", false).is_ignore());
+}


### PR DESCRIPTION
This updates our internal fork of the `ignore` crate to incorporate changes from the latest release [v0.4.24](https://github.com/BurntSushi/ripgrep/compare/ignore-0.4.23...ignore-0.4.24).

Aside: We should look into opening issues about the changes we had to make to see if they could be addressed in the crate itself so we can get rid of our fork.