### PR TITLE
Support setting a default letter spacing for a custom font family

### DIFF
--- a/packages/tailwindcss/src/compat/config.test.ts
+++ b/packages/tailwindcss/src/compat/config.test.ts
@@ -738,6 +738,83 @@ describe('default font family compatibility', () => {
     `)
   })
 
+  test('overriding `fontFamily.sans[1].letterSpacing` sets letter-spacing', async ({ expect }) => {
+    let input = css`
+      @theme default {
+        --default-font-family: var(--font-family-sans);
+        --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
+        --default-font-variation-settings: var(--font-family-sans--font-variation-settings);
+      }
+      @config "./config.js";
+      @tailwind utilities;
+    `
+
+    let compiler = await compile(input, {
+      loadModule: async () => ({
+        module: {
+          theme: {
+            fontFamily: {
+              sans: ['Potato Sans', { letterSpacing: '0.05em' }],
+            },
+          },
+        },
+        base: '/root',
+      }),
+    })
+
+    expect(compiler.build(['font-sans'])).toMatchInlineSnapshot(`
+      ".font-sans {
+        font-family: Potato Sans;
+        letter-spacing: 0.05em;
+      }
+      "
+    `)
+  })
+
+  test('overriding `fontFeatureSettings`, `fontVariationSettings`, and `letterSpacing` for `fontFamily.sans` sets all properties', async ({
+    expect,
+  }) => {
+    let input = css`
+      @theme default {
+        --default-font-family: var(--font-family-sans);
+        --default-font-feature-settings: var(--font-family-sans--font-feature-settings);
+        --default-font-variation-settings: var(--font-family-sans--font-variation-settings);
+      }
+      @config "./config.js";
+      @tailwind utilities;
+    `
+
+    let compiler = await compile(input, {
+      loadModule: async () => ({
+        module: {
+          theme: {
+            fontFamily: {
+              sans: [
+                'Potato Sans',
+                {
+                  fontFeatureSettings: '"cv06"',
+                  fontVariationSettings: '"XHGT" 0.7',
+                  letterSpacing: '0.05em',
+                },
+              ],
+            },
+          },
+        },
+        base: '/root',
+      }),
+    })
+
+    expect(compiler.build(['font-sans'])).toMatchInlineSnapshot(`
+      ".font-sans {
+        font-family: Potato Sans;
+        font-feature-settings: "cv06";
+        font-variation-settings: "XHGT" 0.7;
+        letter-spacing: 0.05em;
+      }
+      "
+    `)
+  })
+
   test('overriding `--font-family-sans` in `@theme` without `default` preserves the original `--default-font-*` values', async ({
     expect,
   }) => {
@@ -984,6 +1061,83 @@ describe('default font family compatibility', () => {
         font-family: Potato Mono;
         font-feature-settings: "cv06";
         font-variation-settings: "XHGT" 0.7;
+      }
+      "
+    `)
+  })
+
+  test('overriding `fontFamily.mono[1].letterSpacing` sets letter-spacing', async ({ expect }) => {
+    let input = css`
+      @theme default {
+        --default-mono-font-family: var(--font-family-mono);
+        --default-mono-font-feature-settings: var(--font-family-mono--font-feature-settings);
+        --default-mono-font-variation-settings: var(--font-family-mono--font-variation-settings);
+      }
+      @config "./config.js";
+      @tailwind utilities;
+    `
+
+    let compiler = await compile(input, {
+      loadModule: async () => ({
+        module: {
+          theme: {
+            fontFamily: {
+              mono: ['Potato Mono', { letterSpacing: '-0.02em' }],
+            },
+          },
+        },
+        base: '/root',
+      }),
+    })
+
+    expect(compiler.build(['font-mono'])).toMatchInlineSnapshot(`
+      ".font-mono {
+        font-family: Potato Mono;
+        letter-spacing: -0.02em;
+      }
+      "
+    `)
+  })
+
+  test('overriding `fontFeatureSettings`, `fontVariationSettings`, and `letterSpacing` for `fontFamily.mono` sets all properties', async ({
+    expect,
+  }) => {
+    let input = css`
+      @theme default {
+        --default-mono-font-family: var(--font-mono);
+        --default-mono-font-feature-settings: var(--font-mono--font-feature-settings);
+        --default-mono-font-variation-settings: var(--font-mono--font-variation-settings);
+      }
+      @config "./config.js";
+      @tailwind utilities;
+    `
+
+    let compiler = await compile(input, {
+      loadModule: async () => ({
+        module: {
+          theme: {
+            fontFamily: {
+              mono: [
+                'Potato Mono',
+                {
+                  fontFeatureSettings: '"cv06"',
+                  fontVariationSettings: '"XHGT" 0.7',
+                  letterSpacing: '-0.02em',
+                },
+              ],
+            },
+          },
+        },
+        base: '/root',
+      }),
+    })
+
+    expect(compiler.build(['font-mono'])).toMatchInlineSnapshot(`
+      ".font-mono {
+        font-family: Potato Mono;
+        font-feature-settings: "cv06";
+        font-variation-settings: "XHGT" 0.7;
+        letter-spacing: -0.02em;
       }
       "
     `)

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -1748,6 +1748,62 @@ describe('Parsing theme values from CSS', () => {
     `)
   })
 
+  test('font families with letter-spacing option', async () => {
+    expect(
+      await compileCss(
+        css`
+          @theme {
+            --font-display: 'Oswald', sans-serif;
+            --font-display--letter-spacing: 0.05em;
+          }
+          @tailwind utilities;
+        `,
+        ['font-display'],
+      ),
+    ).toMatchInlineSnapshot(`
+      ":root, :host {
+        --font-display: "Oswald", sans-serif;
+        --font-display--letter-spacing: .05em;
+      }
+
+      .font-display {
+        font-family: var(--font-display);
+        letter-spacing: var(--font-display--letter-spacing);
+      }"
+    `)
+  })
+
+  test('font families with font-feature-settings, font-variation-settings, and letter-spacing', async () => {
+    expect(
+      await compileCss(
+        css`
+          @theme {
+            --font-display: 'Oswald', sans-serif;
+            --font-display--font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
+            --font-display--font-variation-settings: 'opsz' 32;
+            --font-display--letter-spacing: 0.05em;
+          }
+          @tailwind utilities;
+        `,
+        ['font-display'],
+      ),
+    ).toMatchInlineSnapshot(`
+      ":root, :host {
+        --font-display: "Oswald", sans-serif;
+        --font-display--font-feature-settings: "cv02", "cv03", "cv04", "cv11";
+        --font-display--font-variation-settings: "opsz" 32;
+        --font-display--letter-spacing: .05em;
+      }
+
+      .font-display {
+        font-family: var(--font-display);
+        font-feature-settings: var(--font-display--font-feature-settings);
+        font-variation-settings: var(--font-display--font-variation-settings);
+        letter-spacing: var(--font-display--letter-spacing);
+      }"
+    `)
+  })
+
   test('unsetting `--inset-*` does not unset `--inset-shadow-*`', async () => {
     expect(
       await compileCss(

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -3774,7 +3774,7 @@ export function createUtilities(theme: Theme) {
       let value = theme.resolveWith(
         candidate.value.value,
         ['--font'],
-        ['--font-feature-settings', '--font-variation-settings'],
+        ['--font-feature-settings', '--font-variation-settings', '--letter-spacing'],
       )
       if (value) {
         let [families, options = {}] = value
@@ -3783,6 +3783,7 @@ export function createUtilities(theme: Theme) {
           decl('font-family', families),
           decl('font-feature-settings', options['--font-feature-settings']),
           decl('font-variation-settings', options['--font-variation-settings']),
+          decl('letter-spacing', options['--letter-spacing']),
         ]
       }
     }


### PR DESCRIPTION
This PR makes it possible to set a default letter spacing a given font family, just like how you can set the default `font-feature-settings` and `font-variation-settings`.

The use case is for things like heading fonts, where maybe you want the letter spacing to always be tighter and you don't want to add `tracking-tight` every time you use it.

The letter spacing can still be overridden with explicit tracking utilities.

```css
@theme {
  --font-display: Mona Sans;
  --font-display--letter-spacing: -0.025em;
}
```