### PR TITLE
Handle utilities with `1` keys in a JS config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Handle utilities with `1` keys in a JS config  ([#19254](https://github.com/tailwindlabs/tailwindcss/pull/19254))
+
 ### Added
 
 - _Experimental_: Add `@container-size` utility ([#18901](https://github.com/tailwindlabs/tailwindcss/pull/18901))

--- a/packages/tailwindcss/src/compat/config.test.ts
+++ b/packages/tailwindcss/src/compat/config.test.ts
@@ -297,6 +297,74 @@ test('Variants in CSS overwrite variants from plugins', async () => {
   `)
 })
 
+test('A `1` key is treated like a nested theme key *and* a normal theme key', async () => {
+  let input = css`
+    @tailwind utilities;
+    @config "./config.js";
+  `
+
+  let compiler = await compile(input, {
+    loadModule: async () => ({
+      module: {
+        theme: {
+          fontSize: {
+            xs: ['0.5rem', { lineHeight: '0.25rem' }],
+          },
+          colors: {
+            a: {
+              1: { DEFAULT: '#ffffff', hovered: '#000000' },
+              2: { DEFAULT: '#000000', hovered: '#c0ffee' },
+            },
+            b: {
+              1: '#ffffff',
+              2: '#000000',
+            },
+          },
+        },
+      },
+      base: '/root',
+      path: '',
+    }),
+  })
+
+  expect(
+    compiler.build([
+      'text-xs',
+
+      'text-a-1',
+      'text-a-2',
+      'text-a-1-hovered',
+      'text-a-2-hovered',
+      'text-b-1',
+      'text-b-2',
+    ]),
+  ).toMatchInlineSnapshot(`
+    ".text-xs {
+      font-size: 0.5rem;
+      line-height: var(--tw-leading, 0.25rem);
+    }
+    .text-a-1 {
+      color: #ffffff;
+    }
+    .text-a-1-hovered {
+      color: #000000;
+    }
+    .text-a-2 {
+      color: #000000;
+    }
+    .text-a-2-hovered {
+      color: #c0ffee;
+    }
+    .text-b-1 {
+      color: #ffffff;
+    }
+    .text-b-2 {
+      color: #000000;
+    }
+    "
+  `)
+})
+
 describe('theme callbacks', () => {
   test('tuple values from the config overwrite `@theme default` tuple-ish values from the CSS theme', async ({
     expect,


### PR DESCRIPTION
Fixes #19250

When converting a JS config to a series of theme keys we special case a key of `1`, treat it as if it were tuple access, and turn that into nested theme keys.

This isn't 100% correct though because a user can use `1` in an object instead of an array — in which case we should generate normal theme keys with a `1` in the variable name instead of one with a nested theme key separator (`--`).

Because the conversion works based on key paths we need to treat a path like `colors.a.1.b` as both `--color-a-1-b` *and* `--color-a--b`. This ensures a utility like `text-a-1-b` works as expected.