### PR TITLE
Remove unused `crossbeam` dependency in oxide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,19 +69,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,15 +92,6 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -595,7 +573,6 @@ dependencies = [
  "bexpand",
  "bstr",
  "classification-macros",
- "crossbeam",
  "dunce",
  "fast-glob",
  "globwalk",

--- a/crates/oxide/Cargo.toml
+++ b/crates/oxide/Cargo.toml
@@ -9,7 +9,6 @@ globwalk = "0.9.1"
 log = "0.4.22"
 rayon = "1.10.0"
 fxhash = { package = "rustc-hash", version = "2.1.1" }
-crossbeam = "0.8.4"
 tracing = { version = "0.1.40", features = [] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 walkdir = "2.5.0"


### PR DESCRIPTION
## Summary

An unused dependency `crossbeam` was identified in `oxide` rust crate and removed from its Cargo.toml.

## Test plan

```
cargo build
cargo test
```

and also

```
pnpm test
```

[ci-all]