### PR TITLE
Include filename and line numbers in CSS parse errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Ensure validation of `source(…)` happens relative to the file it is in ([#19274](https://github.com/tailwindlabs/tailwindcss/pull/19274))
+- Include filename and line numbers in CSS parse errors ([#19282](https://github.com/tailwindlabs/tailwindcss/pull/19282))
 
 ### Added
 

--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -2104,10 +2104,6 @@ test(
   },
 )
 
-function withBOM(text: string): string {
-  return '\uFEFF' + text
-}
-
 test(
   'CSS parse errors should include filename and line number',
   {
@@ -2120,8 +2116,7 @@ test(
           }
         }
       `,
-      'broken.css': css`
-        /* Test file to reproduce the CSS parsing error */
+      'input.css': css`
         .test {
           color: red;
           */
@@ -2130,8 +2125,12 @@ test(
     },
   },
   async ({ exec, expect }) => {
-    await expect(exec('pnpm tailwindcss --input broken.css --output dist/out.css')).rejects.toThrow(
-      /Invalid declaration.*at.*broken\.css:4:/,
+    await expect(exec('pnpm tailwindcss --input input.css --output dist/out.css')).rejects.toThrow(
+      /CssSyntaxError: .*input.css: 3:2: Invalid declaration: `\*\/`/,
     )
   },
 )
+
+function withBOM(text: string): string {
+  return '\uFEFF' + text
+}

--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -2126,7 +2126,7 @@ test(
   },
   async ({ exec, expect }) => {
     await expect(exec('pnpm tailwindcss --input input.css --output dist/out.css')).rejects.toThrow(
-      /CssSyntaxError: .*input.css:3:2: Invalid declaration: `\*\/`/,
+      /CssSyntaxError: .*input.css:3:3: Invalid declaration: `\*\/`/,
     )
   },
 )

--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -2126,7 +2126,7 @@ test(
   },
   async ({ exec, expect }) => {
     await expect(exec('pnpm tailwindcss --input input.css --output dist/out.css')).rejects.toThrow(
-      /CssSyntaxError: .*input.css: 3:2: Invalid declaration: `\*\/`/,
+      /CssSyntaxError: .*input.css:3:2: Invalid declaration: `\*\/`/,
     )
   },
 )

--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -1,8 +1,11 @@
 import dedent from 'dedent'
 import os from 'node:os'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe } from 'vitest'
 import { candidate, css, html, js, json, test, ts, yaml } from '../utils'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const STANDALONE_BINARY = (() => {
   switch (os.platform()) {
@@ -2121,14 +2124,14 @@ test(
         /* Test file to reproduce the CSS parsing error */
         .test {
           color: red;
-          /* margin-bottom: calc(var(--spacing) * 5); */ */
+          */
         }
       `,
     },
   },
   async ({ exec, expect }) => {
     await expect(exec('pnpm tailwindcss --input broken.css --output dist/out.css')).rejects.toThrow(
-      /Invalid declaration.*at.*broken\.css:5:49/,
+      /Invalid declaration.*at.*broken\.css:4:/,
     )
   },
 )

--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -2104,3 +2104,31 @@ test(
 function withBOM(text: string): string {
   return '\uFEFF' + text
 }
+
+test(
+  'CSS parse errors should include filename and line number',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "dependencies": {
+            "tailwindcss": "workspace:^",
+            "@tailwindcss/cli": "workspace:^"
+          }
+        }
+      `,
+      'broken.css': css`
+        /* Test file to reproduce the CSS parsing error */
+        .test {
+          color: red;
+          /* margin-bottom: calc(var(--spacing) * 5); */ */
+        }
+      `,
+    },
+  },
+  async ({ exec, expect }) => {
+    await expect(exec('pnpm tailwindcss --input broken.css --output dist/out.css')).rejects.toThrow(
+      /Invalid declaration.*at.*broken\.css:5:49/,
+    )
+  },
+)

--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -1193,7 +1193,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
        /* ^ Missing closing } */
         `),
       ).toThrowErrorMatchingInlineSnapshot(
-        `[CssSyntaxError: input.css: 7:12: Missing closing } at .bar]`,
+        `[CssSyntaxError: input.css: 6:10: Missing closing } at .bar]`,
       )
     })
 

--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -1215,6 +1215,54 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         `[Error: Invalid declaration: \`bar\`]`,
       )
     })
+
+    it('should include filename and line number in error messages when from option is provided', () => {
+      expect(() => {
+        CSS.parse('/* margin-bottom: calc(var(--spacing) * 5); */ */', { from: 'test.css' })
+      }).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invalid declaration: \`*/\` at test.css:1:49]`,
+      )
+    })
+
+    it('should include filename and line number for multi-line CSS errors', () => {
+      const multiLineCss = `/* Test file */
+.test {
+  color: red;
+  /* margin-bottom: calc(var(--spacing) * 5); */ */
+}`
+      expect(() => {
+        CSS.parse(multiLineCss, { from: 'styles.css' })
+      }).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invalid declaration: \`*/\` at styles.css:4:49]`,
+      )
+    })
+
+    it('should include filename and line number for missing opening brace errors', () => {
+      const cssWithMissingBrace = `.foo {
+  color: red;
+}
+
+.bar
+  color: blue;
+}`
+      expect(() => {
+        CSS.parse(cssWithMissingBrace, { from: 'broken.css' })
+      }).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Missing opening { at broken.css:7:1]`,
+      )
+    })
+
+    it('should include filename and line number for unterminated string errors', () => {
+      const cssWithUnterminatedString = `.foo {
+  content: "Hello world!
+  font-weight: bold;
+}`
+      expect(() => {
+        CSS.parse(cssWithUnterminatedString, { from: 'string-error.css' })
+      }).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Unterminated string: "Hello world! at string-error.css:2:12]`,
+      )
+    })
   })
 
   it('ignores BOM at the beginning of a file', () => {
@@ -1226,5 +1274,13 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         params: "'tailwindcss'",
       },
     ])
+  })
+
+  it('should not include filename when from option is not provided', () => {
+    expect(() => {
+      CSS.parse('/* margin-bottom: calc(var(--spacing) * 5); */ */')
+    }).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Invalid declaration: \`*/\`]`,
+    )
   })
 })

--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -1218,23 +1218,19 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
 
     it('should include filename and line number in error messages when from option is provided', () => {
       expect(() => {
-        CSS.parse('/* margin-bottom: calc(var(--spacing) * 5); */ */', { from: 'test.css' })
-      }).toThrowErrorMatchingInlineSnapshot(
-        `[Error: Invalid declaration: \`*/\` at test.css:1:49]`,
-      )
+        CSS.parse('.test { */ }', { from: 'test.css' })
+      }).toThrow(/CssSyntaxError: Invalid declaration: `\*\/` at test\.css:1:9/)
     })
 
     it('should include filename and line number for multi-line CSS errors', () => {
       const multiLineCss = `/* Test file */
 .test {
   color: red;
-  /* margin-bottom: calc(var(--spacing) * 5); */ */
+  */
 }`
       expect(() => {
         CSS.parse(multiLineCss, { from: 'styles.css' })
-      }).toThrowErrorMatchingInlineSnapshot(
-        `[Error: Invalid declaration: \`*/\` at styles.css:4:49]`,
-      )
+      }).toThrow(/CssSyntaxError: Invalid declaration: `\*\/` at styles\.css:4:3/)
     })
 
     it('should include filename and line number for missing opening brace errors', () => {
@@ -1247,9 +1243,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
 }`
       expect(() => {
         CSS.parse(cssWithMissingBrace, { from: 'broken.css' })
-      }).toThrowErrorMatchingInlineSnapshot(
-        `[Error: Missing opening { at broken.css:7:1]`,
-      )
+      }).toThrow(/CssSyntaxError: Missing opening \{ at broken\.css:7:1/)
     })
 
     it('should include filename and line number for unterminated string errors', () => {
@@ -1259,9 +1253,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
 }`
       expect(() => {
         CSS.parse(cssWithUnterminatedString, { from: 'string-error.css' })
-      }).toThrowErrorMatchingInlineSnapshot(
-        `[Error: Unterminated string: "Hello world! at string-error.css:2:12]`,
-      )
+      }).toThrow(/CssSyntaxError: Unterminated string: "Hello world!" at string-error\.css:2:12/)
     })
   })
 
@@ -1278,9 +1270,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
 
   it('should not include filename when from option is not provided', () => {
     expect(() => {
-      CSS.parse('/* margin-bottom: calc(var(--spacing) * 5); */ */')
-    }).toThrowErrorMatchingInlineSnapshot(
-      `[Error: Invalid declaration: \`*/\`]`,
-    )
+      CSS.parse('.test { */ }')
+    }).toThrow(/CssSyntaxError: Invalid declaration: `\*\/`$/)
   })
 })

--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -1164,7 +1164,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
             color: blue;
           }
         `),
-      ).toThrowErrorMatchingInlineSnapshot(`[CssSyntaxError: input.css: 9:10: Missing opening {]`)
+      ).toThrowErrorMatchingInlineSnapshot(`[CssSyntaxError: input.css:9:11: Missing opening {]`)
     })
 
     it('should error when curly brackets are unbalanced (closing)', () => {
@@ -1193,7 +1193,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
        /* ^ Missing closing } */
         `),
       ).toThrowErrorMatchingInlineSnapshot(
-        `[CssSyntaxError: input.css: 6:10: Missing closing } at .bar]`,
+        `[CssSyntaxError: input.css:6:11: Missing closing } at .bar]`,
       )
     })
 
@@ -1217,7 +1217,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
           }
         `),
       ).toThrowErrorMatchingInlineSnapshot(
-        `[CssSyntaxError: input.css: 3:21: Unterminated string: "Hello world!"]`,
+        `[CssSyntaxError: input.css:3:22: Unterminated string: "Hello world!"]`,
       )
     })
 
@@ -1241,7 +1241,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
           }
         `),
       ).toThrowErrorMatchingInlineSnapshot(
-        `[CssSyntaxError: input.css: 3:21: Unterminated string: "Hello world!;"]`,
+        `[CssSyntaxError: input.css:3:22: Unterminated string: "Hello world!;"]`,
       )
     })
 
@@ -1251,7 +1251,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
       )
 
       expect(() => parseWithLoc('--foo')).toThrowErrorMatchingInlineSnapshot(
-        `[CssSyntaxError: input.css: 1:0: Invalid custom property, expected a value]`,
+        `[CssSyntaxError: input.css:1:1: Invalid custom property, expected a value]`,
       )
     })
 
@@ -1261,7 +1261,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
       )
 
       expect(() => parseWithLoc('.foo { --bar }')).toThrowErrorMatchingInlineSnapshot(
-        `[CssSyntaxError: input.css: 1:7: Invalid custom property, expected a value]`,
+        `[CssSyntaxError: input.css:1:8: Invalid custom property, expected a value]`,
       )
     })
 
@@ -1283,7 +1283,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
           }
         `),
       ).toThrowErrorMatchingInlineSnapshot(
-        `[CssSyntaxError: input.css: 3:19: Unterminated string: 'Hello world!']`,
+        `[CssSyntaxError: input.css:3:20: Unterminated string: 'Hello world!']`,
       )
     })
 
@@ -1293,7 +1293,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
       )
 
       expect(() => parseWithLoc('.foo { bar }')).toThrowErrorMatchingInlineSnapshot(
-        `[CssSyntaxError: input.css: 1:7: Invalid declaration: \`bar\`]`,
+        `[CssSyntaxError: input.css:1:8: Invalid declaration: \`bar\`]`,
       )
     })
   })

--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -1219,7 +1219,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
     it('should include filename and line number in error messages when from option is provided', () => {
       expect(() => {
         CSS.parse('.test { */ }', { from: 'test.css' })
-      }).toThrow(/CssSyntaxError: Invalid declaration: `\*\/` at test\.css:1:9/)
+      }).toThrow(/CssSyntaxError: Invalid declaration: `\*\/` at test\.css:1:10/)
     })
 
     it('should include filename and line number for multi-line CSS errors', () => {
@@ -1230,7 +1230,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
 }`
       expect(() => {
         CSS.parse(multiLineCss, { from: 'styles.css' })
-      }).toThrow(/CssSyntaxError: Invalid declaration: `\*\/` at styles\.css:4:3/)
+      }).toThrow(/CssSyntaxError: Invalid declaration: `\*\/` at styles\.css:4:4/)
     })
 
     it('should include filename and line number for missing opening brace errors', () => {
@@ -1243,7 +1243,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
 }`
       expect(() => {
         CSS.parse(cssWithMissingBrace, { from: 'broken.css' })
-      }).toThrow(/CssSyntaxError: Missing opening \{ at broken\.css:7:1/)
+      }).toThrow(/CssSyntaxError: Missing opening \{ at broken\.css:7:2/)
     })
 
     it('should include filename and line number for unterminated string errors', () => {
@@ -1253,7 +1253,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
 }`
       expect(() => {
         CSS.parse(cssWithUnterminatedString, { from: 'string-error.css' })
-      }).toThrow(/CssSyntaxError: Unterminated string: "Hello world!" at string-error\.css:2:12/)
+      }).toThrow(/CssSyntaxError: Unterminated string: "Hello world!" at string-error\.css:2:13/)
     })
   })
 

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -47,7 +47,7 @@ export class CssSyntaxError extends Error {
     if (loc) {
       let source = loc[0]
       let start = createLineTable(source.code).find(loc[1])
-      message = `${source.file}: ${start.line}:${start.column}: ${message}`
+      message = `${source.file}:${start.line}:${start.column + 1}: ${message}`
     }
 
     super(message)

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -43,7 +43,7 @@ export class CssSyntaxError extends Error {
       super(message)
     } else {
       const { line, column } = createLineTable(source.code).find(position)
-      super(`${message} at ${source.file}:${line}:${column}`)
+      super(`${message} at ${source.file}:${line}:${column + 1}`)
     }
     this.name = 'CssSyntaxError'
   }

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -574,14 +574,14 @@ export function parse(input: string, opts?: ParseOptions) {
     if (parent.kind === 'rule') {
       throw new CssSyntaxError(
         `Missing closing } at ${parent.selector}`,
-        source ? [source, bufferStart, bufferStart] : null,
+        parent.src ? [parent.src[0], parent.src[1], parent.src[1]] : null,
       )
     }
 
     if (parent.kind === 'at-rule') {
       throw new CssSyntaxError(
         `Missing closing } at ${parent.name} ${parent.params}`,
-        source ? [source, bufferStart, bufferStart] : null,
+        parent.src ? [parent.src[0], parent.src[1], parent.src[1]] : null,
       )
     }
   }

--- a/packages/tailwindcss/src/css-parser.ts
+++ b/packages/tailwindcss/src/css-parser.ts
@@ -37,6 +37,9 @@ export interface ParseOptions {
   from?: string
 }
 
+/**
+ * CSS syntax error with source location information.
+ */
 export class CssSyntaxError extends Error {
   constructor(message: string, source: Source | null, position: number) {
     if (!source) {


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

Please ask first before starting work on any significant new features.

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create a discussion to first discuss any significant new features.

For more info, check out the contributing guide:

https://github.com/tailwindcss/tailwindcss/blob/main/.github/CONTRIBUTING.md

-->

**Summary**  
<!--

Provide a summary of the issue and the changes you're making. How does your change solve the problem?

-->
Fixes CSS parse errors to include filename and line numbers, making debugging much easier for developers.  

Currently, CSS parsing errors only show generic messages like:


This gives no clue about the file or line causing the issue.  
This change adds filename and line/column info to error messages, allowing developers to quickly locate and fix syntax problems.  

Key updates include:  
- Added `getLineAndColumn()` helper to calculate line and column positions  
- Implemented `formatError()` for standardized error output  
- Updated CSS parser to attach filename and position details  
- Improved `parseString()` to pass source metadata  
- Added comprehensive test coverage for various error cases  

Example output improvement:  

**Before:**

**After:**

---

**Test plan**  
<!--

Explain how you tested your changes. Include the exact commands that you used to verify the change works and include screenshots/screen recordings of the update behavior in the browser if applicable.

-->
- ✅ Added unit tests for all new error formats  
- ✅ Added CLI integration tests  
- ✅ Verified backward compatibility when filename is not provided  
- ✅ All existing tests pass successfully  

No breaking changes.  
Fixes #19236
