### PR TITLE
fix: Correctly handle custom variants with @scope

### DIFF
--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -325,7 +325,8 @@ export function compoundsForSelectors(selectors: string[]) {
       if (
         !sel.startsWith('@media') &&
         !sel.startsWith('@supports') &&
-        !sel.startsWith('@container')
+        !sel.startsWith('@container') &&
+        !sel.startsWith('@scope')
       ) {
         return Compounds.Never
       }


### PR DESCRIPTION
Custom variants defined using an @scope rule were not being generated correctly.
This happened because @scope was not being treated as a conditional at-rule, similar to @media, @supports, and @container.

This change updates the compoundsForSelectors function to include @scope in the list of conditional at-rules, ensuring that it is handled correctly during the variant compilation process.

Additionally, an integration test was added to verify that custom variants with @scope rules produce the expected CSS output, preventing future regressions.
issue
#18961 