### PR TITLE
perf(vite): add plugin hook filter

### DIFF
--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -134,7 +134,7 @@ export default function tailwindcss(opts: PluginOptions = {}): Plugin[] {
         filter: {
           id: {
             exclude: [/\/\.vite\//, SPECIAL_QUERY_RE, COMMON_JS_PROXY_RE],
-            include: [/css(?:\?.*)?$/, /&lang\.css/, INLINE_STYLE_ID_RE],
+            include: [/\.css(?:\?.*)?$/, /&lang\.css/, INLINE_STYLE_ID_RE],
           },
         },
         async handler(src, id) {

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -101,7 +101,7 @@ export default function tailwindcss(opts: PluginOptions = {}): Plugin[] {
         filter: {
           id: {
             exclude: [/\/\.vite\//, SPECIAL_QUERY_RE, COMMON_JS_PROXY_RE],
-            include: [/css(?:\?.*)?$/, /&lang\.css/, INLINE_STYLE_ID_RE],
+            include: [/\.css(?:\?.*)?$/, /&lang\.css/, INLINE_STYLE_ID_RE],
           },
         },
         async handler(src, id) {

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -134,7 +134,7 @@ export default function tailwindcss(opts: PluginOptions = {}): Plugin[] {
         filter: {
           id: {
             exclude: [/\/\.vite\//, SPECIAL_QUERY_RE, COMMON_JS_PROXY_RE],
-            include: [/css(?:\?.*)?$/, /&lang\.css$/, INLINE_STYLE_ID_RE],
+            include: [/css(?:\?.*)?$/, /&lang\.css/, INLINE_STYLE_ID_RE],
           },
         },
         async handler(src, id) {


### PR DESCRIPTION
## Summary

This PR adds plugin [hook filters](https://vite.dev/guide/api-plugin#hook-filters) to the Vite plugin. They are backwards-compatible, having no impact on older Vite versions as the check for `isPotentialCssRootFile` is still included.

It can be dropped once you don't need to support older Vite versions.

## See also

https://github.com/e18e/ecosystem-issues/issues/171