### PR TITLE
Handle `future` and `experimental` config keys during upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Skip comments in Ruby files when checking for class names ([#19243](https://github.com/tailwindlabs/tailwindcss/pull/19243))
 - Skip over arbitrary property utilities with a top-level `!` in the value ([#19243](https://github.com/tailwindlabs/tailwindcss/pull/19243))
 - Support environment API in `@tailwindcss/vite` ([#18970](https://github.com/tailwindlabs/tailwindcss/pull/18970))
+- Upgrade: Handle `future` and `experimental` config keys ([#19344](https://github.com/tailwindlabs/tailwindcss/pull/19344))
 
 ### Added
 

--- a/packages/@tailwindcss-upgrade/src/codemods/config/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/config/migrate-js-config.ts
@@ -429,23 +429,23 @@ function canMigrateConfig(unresolvedConfig: Config, source: string): boolean {
 
   // If there are unknown "future" flags we should bail
   if (unresolvedConfig.future && unresolvedConfig.future !== 'all') {
-    let knownFutureFlags = [
+    let knownFlags = [
       'hoverOnlyWhenSupported',
       'respectDefaultRingColorOpacity',
       'disableColorOpacityUtilitiesByDefault',
       'relativeContentPathsByDefault',
     ]
 
-    if (Object.keys(unresolvedConfig.future).some((key) => !knownFutureFlags.includes(key))) {
+    if (Object.keys(unresolvedConfig.future).some((key) => !knownFlags.includes(key))) {
       return false
     }
   }
 
   // If there are unknown "experimental" flags we should bail
   if (unresolvedConfig.experimental && unresolvedConfig.experimental !== 'all') {
-    let knownFutureFlags = ['generalizedModifiers']
+    let knownFlags = ['generalizedModifiers']
 
-    if (Object.keys(unresolvedConfig.experimental).some((key) => !knownFutureFlags.includes(key))) {
+    if (Object.keys(unresolvedConfig.experimental).some((key) => !knownFlags.includes(key))) {
       return false
     }
   }

--- a/packages/@tailwindcss-upgrade/src/codemods/config/migrate-js-config.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/config/migrate-js-config.ts
@@ -411,6 +411,8 @@ function canMigrateConfig(unresolvedConfig: Config, source: string): boolean {
     'presets',
     'prefix', // Prefix is handled in the dedicated prefix migrator
     'corePlugins',
+    'future',
+    'experimental',
   ]
 
   if (Object.keys(unresolvedConfig).some((key) => !knownProperties.includes(key))) {
@@ -423,6 +425,29 @@ function canMigrateConfig(unresolvedConfig: Config, source: string): boolean {
 
   if (unresolvedConfig.presets && unresolvedConfig.presets.length > 0) {
     return false
+  }
+
+  // If there are unknown "future" flags we should bail
+  if (unresolvedConfig.future && unresolvedConfig.future !== 'all') {
+    let knownFutureFlags = [
+      'hoverOnlyWhenSupported',
+      'respectDefaultRingColorOpacity',
+      'disableColorOpacityUtilitiesByDefault',
+      'relativeContentPathsByDefault',
+    ]
+
+    if (Object.keys(unresolvedConfig.future).some((key) => !knownFutureFlags.includes(key))) {
+      return false
+    }
+  }
+
+  // If there are unknown "experimental" flags we should bail
+  if (unresolvedConfig.experimental && unresolvedConfig.experimental !== 'all') {
+    let knownFutureFlags = ['generalizedModifiers']
+
+    if (Object.keys(unresolvedConfig.experimental).some((key) => !knownFutureFlags.includes(key))) {
+      return false
+    }
   }
 
   // Only migrate the config file if all top-level theme keys are allowed to be

--- a/packages/tailwindcss/src/compat/config/resolve-config.ts
+++ b/packages/tailwindcss/src/compat/config/resolve-config.ts
@@ -33,6 +33,7 @@ interface ResolutionContext {
 let minimal: ResolvedConfig = {
   blocklist: [],
   future: {},
+  experimental: {},
   prefix: '',
   important: false,
   darkMode: null,

--- a/packages/tailwindcss/src/compat/config/types.ts
+++ b/packages/tailwindcss/src/compat/config/types.ts
@@ -105,3 +105,12 @@ export interface UserConfig {
 export interface ResolvedConfig {
   future: Record<string, boolean>
 }
+
+// `experimental` key support
+export interface UserConfig {
+  experimental?: 'all' | Record<string, boolean>
+}
+
+export interface ResolvedConfig {
+  experimental: Record<string, boolean>
+}


### PR DESCRIPTION
Fixes #19342