### PR TITLE
fix(ring-utility): remove extra comma after --tw-ring-inset (fixes #18923)"

### DIFF
--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -5571,7 +5571,7 @@ export function createUtilities(theme: Theme) {
 
     let defaultRingColor = theme.get(['--default-ring-color']) ?? 'currentcolor'
     function ringShadowValue(value: string) {
-      return `var(--tw-ring-inset,) 0 0 0 calc(${value} + var(--tw-ring-offset-width)) var(--tw-ring-color, ${defaultRingColor})`
+      return `var(--tw-ring-inset) 0 0 0 calc(${value} + var(--tw-ring-offset-width)) var(--tw-ring-color, ${defaultRingColor})`
     }
     utilities.functional('ring', (candidate) => {
       if (!candidate.value) {


### PR DESCRIPTION
This PR fixes issue #18923 by removing the extra comma after `--tw-ring-inset` in the ring utility.

### Changes Made
- Removed the trailing comma after `--tw-ring-inset` in the ring utility definition

### Testing
- [x] Tested the changes locally
- [x] Verified that the ring utility works as expected

Fixes #18923