### PR TITLE
Fix: Remove iOS Safari dialog max-width/max-height constraints in Preflight

### DIFF
--- a/packages/tailwindcss/preflight.css
+++ b/packages/tailwindcss/preflight.css
@@ -385,6 +385,15 @@ input:where([type='button'], [type='reset'], [type='submit']),
 }
 
 /*
+  Remove default max-width and max-height constraints on dialog elements in iOS Safari.
+*/
+
+dialog {
+  max-width: none;
+  max-height: none;
+}
+
+/*
   Make elements with the HTML hidden attribute stay hidden by default.
 */
 

--- a/packages/tailwindcss/tests/ui.spec.ts
+++ b/packages/tailwindcss/tests/ui.spec.ts
@@ -1472,6 +1472,16 @@ test('conic mask color can be changed on hover', async ({ page }) => {
   ]).toContain(await getPropertyValue('#x', 'mask-image'))
 })
 
+test('dialog elements have max-width and max-height reset by Preflight', async ({ page }) => {
+  let { getPropertyValue } = await render(
+    page,
+    html`<dialog id="x">Hello world</dialog>`,
+  )
+
+  expect(await getPropertyValue('#x', 'max-width')).toEqual('none')
+  expect(await getPropertyValue('#x', 'max-height')).toEqual('none')
+})
+
 test("::backdrop can receive a border with just the 'border' utility", async ({ page }) => {
   let { getPropertyValue } = await render(
     page,


### PR DESCRIPTION
Fixes #19363 - Added dialog reset to Preflight CSS to remove iOS Safari's default max-width/max-height constraints on dialog elements.