### PR TITLE
Preserve aspect ratio of `svg` elements when changing their width

### DIFF
--- a/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/@tailwindcss-postcss/src/__snapshots__/index.test.ts.snap
@@ -128,7 +128,7 @@ exports[`\`@import 'tailwindcss'\` is replaced with the generated CSS 1`] = `
     display: block;
   }
 
-  img, video {
+  img, svg, video {
     max-width: 100%;
     height: auto;
   }

--- a/packages/tailwindcss/preflight.css
+++ b/packages/tailwindcss/preflight.css
@@ -223,6 +223,7 @@ object {
 */
 
 img,
+svg,
 video {
   max-width: 100%;
   height: auto;

--- a/packages/tailwindcss/src/__snapshots__/index.test.ts.snap
+++ b/packages/tailwindcss/src/__snapshots__/index.test.ts.snap
@@ -242,7 +242,7 @@ exports[`compiling CSS > prefix all CSS variables inside preflight 1`] = `
     display: block;
   }
 
-  img, video {
+  img, svg, video {
     max-width: 100%;
     height: auto;
   }


### PR DESCRIPTION
## Summary

Not sure if there's any reason why the "Constrain images and videos to the parent width and preserve their intrinsic aspect ratio" rule of Preflight doesn't apply to `svg` elements, as they behave pretty much the same as `img`s, in that they also accept `width` and `height` attributes and have an intrinsic aspect ratio. Adding `max-width: 100%` to an `svg` with these attributes ensures that it doesn't overflow its container, and adding `height: auto` ensures that changing its width (either due to the `max-width: 100%`, or to a `w-*` class) also changes the height proportionally, instead of it being locked to the value of the `height` attribute.

## Test plan

"Works ~~on my machine~~ in my projects"
