### PR TITLE
Add `text-align` and `text-transform` to inherited properties of `button`, `input`, etc.

### DIFF
--- a/packages/tailwindcss/preflight.css
+++ b/packages/tailwindcss/preflight.css
@@ -246,6 +246,8 @@ textarea,
   font-variation-settings: inherit; /* 1 */
   letter-spacing: inherit; /* 1 */
   color: inherit; /* 1 */
+  text-align: inherit; /* 1 */
+  text-transform: inherit; /* 1 */
   border-radius: 0; /* 2 */
   background-color: transparent; /* 3 */
   opacity: 1; /* 4 */


### PR DESCRIPTION
## Summary

This could be considered a bug fix, because `text-align` and `text-transform` usually inherit like those other "font styles" that are reset by Preflight on some elements (`button`, `input`, etc.) due to being set to a fixed value by user agent stylesheets. It seems like an oversight.

## Test plan

Pray this is not a breaking change?