### PR TITLE
Fix source map generation during when watching files on the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Skip over arbitrary property utilities with a top-level `!` in the value ([#19243](https://github.com/tailwindlabs/tailwindcss/pull/19243))
 - Support environment API in `@tailwindcss/vite` ([#18970](https://github.com/tailwindlabs/tailwindcss/pull/18970))
 - Preserve case of theme keys from JS configs and plugins ([#19337](https://github.com/tailwindlabs/tailwindcss/pull/19337))
-- Write source maps correctly on the CLI in when using `--watch` ([#19373](https://github.com/tailwindlabs/tailwindcss/pull/19373))
+- Write source maps correctly on the CLI when using `--watch` ([#19373](https://github.com/tailwindlabs/tailwindcss/pull/19373))
 - Upgrade: Handle `future` and `experimental` config keys ([#19344](https://github.com/tailwindlabs/tailwindcss/pull/19344))
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Skip over arbitrary property utilities with a top-level `!` in the value ([#19243](https://github.com/tailwindlabs/tailwindcss/pull/19243))
 - Support environment API in `@tailwindcss/vite` ([#18970](https://github.com/tailwindlabs/tailwindcss/pull/18970))
 - Preserve case of theme keys from JS configs and plugins ([#19337](https://github.com/tailwindlabs/tailwindcss/pull/19337))
+- Write source maps correctly on the CLI in when using `--watch` ([#19373](https://github.com/tailwindlabs/tailwindcss/pull/19373))
 - Upgrade: Handle `future` and `experimental` config keys ([#19344](https://github.com/tailwindlabs/tailwindcss/pull/19344))
 
 ### Added

--- a/packages/@tailwindcss-cli/src/commands/build/index.ts
+++ b/packages/@tailwindcss-cli/src/commands/build/index.ts
@@ -321,7 +321,7 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
 
             if (args['--map']) {
               DEBUG && I.start('Build Source Map')
-              compiledMap = compiler.buildSourceMap() as any
+              compiledMap = toSourceMap(compiler.buildSourceMap())
               DEBUG && I.end('Build Source Map')
             }
           }
@@ -346,7 +346,7 @@ export async function handle(args: Result<ReturnType<typeof options>>) {
 
             if (args['--map']) {
               DEBUG && I.start('Build Source Map')
-              compiledMap = compiler.buildSourceMap() as any
+              compiledMap = toSourceMap(compiler.buildSourceMap())
               DEBUG && I.end('Build Source Map')
             }
           }


### PR DESCRIPTION
Fixes #19362

We were overwriting the source map with the "decoded" map returned by the compiler but didn't wrap it in the helper intended to help inline vs file maps. This resulted in two issues:
1. `undefined` being appended to the CSS file when using `--map`
2. `undefined` being passed to `writeFile(…)` when using `--map <file>`

This PR fixes both.