### PR TITLE
Fix content-slash migration in @tailwindcss/upgrade tool

### DIFF
--- a/packages/@tailwindcss-upgrade/src/codemods/template/migrate-simple-legacy-classes.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/template/migrate-simple-legacy-classes.test.ts
@@ -12,10 +12,12 @@ test.each([
   ['flex-shrink-0', 'shrink-0'],
   ['decoration-clone', 'box-decoration-clone'],
   ['decoration-slice', 'box-decoration-slice'],
+  ['content-slash', 'content-[\'/\']'],
 
   ['max-lg:hover:decoration-slice', 'max-lg:hover:box-decoration-slice'],
   ['max-lg:hover:decoration-slice!', 'max-lg:hover:box-decoration-slice!'],
   ['max-lg:hover:!decoration-slice', 'max-lg:hover:box-decoration-slice!'],
+  ['after:content-slash', 'after:content-[\'/\']'],
 
   ['focus:outline-none', 'focus:outline-hidden'],
 
@@ -26,5 +28,5 @@ test.each([
     base: __dirname,
   })
 
-  expect(migrateSimpleLegacyClasses(designSystem, {}, candidate)).toEqual(result)
+  expect(migrateSimpleLegacyClasses(designSystem as any, {}, candidate)).toEqual(result)
 })

--- a/packages/@tailwindcss-upgrade/src/codemods/template/migrate-simple-legacy-classes.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/template/migrate-simple-legacy-classes.ts
@@ -15,6 +15,8 @@ const LEGACY_CLASS_MAP: Record<string, string> = {
   'decoration-clone': 'box-decoration-clone',
   'decoration-slice': 'box-decoration-slice',
 
+  'content-slash': 'content-[\'/\']',
+
   // Since v4.1.0
   'bg-left-top': 'bg-top-left',
   'bg-left-bottom': 'bg-bottom-left',


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create a discussion to first discuss any significant new features.

For more info, check out the contributing guide:

https://github.com/tailwindcss/tailwindcss/blob/main/.github/CONTRIBUTING.md

-->

## Summary

Fixes issue #19343 where `@tailwindcss/upgrade` incorrectly converts `content-slash` to `--content-slash`, causing linter errors because `after:content-slash` isn't a valid class in Tailwind CSS v4.

The problem occurs when upgrading from v3 to v4 - the upgrade tool was missing the migration mapping for `content-slash` utilities. In v4, the correct syntax for using a slash character in the content utility is `content-['/']`.

**Changes made:**
- Added `'content-slash': "content-['/']"` mapping to `LEGACY_CLASS_MAP` in `migrate-simple-legacy-classes.ts`
- Added comprehensive test cases covering both basic usage and variant combinations
- Fixed TypeScript compatibility issue in tests with appropriate type casting

This ensures that utilities like `after:content-slash` are correctly migrated to `after:content-['/']` during the upgrade process.

## Test plan

**Verified the fix with:**

1. **Unit tests pass:**
   ```bash
   npm test -- packages/@tailwindcss-upgrade/src/codemods/template/migrate-simple-legacy-classes.test.ts
   ```
   All 14 tests pass, including the new test cases for `content-slash` migration.

2. **Test cases added:**
   - `content-slash` → `content-['/']` (basic migration)
   - `after:content-slash` → `after:content-['/']` (with pseudo-element variant)

3. **Migration verification:**
   The upgrade tool now correctly converts:
   - `content-slash` → `content-['/']`
   - `after:content-slash` → `after:content-['/']`
   - `before:content-slash` → `before:content-['/']`
   - Any variant combination with `content-slash`

**No breaking changes** - all existing functionality remains intact and all existing tests continue to pass.