### PR TITLE
Handle backwards compatibility for `content` theme from JS configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Skip over arbitrary property utilities with a top-level `!` in the value ([#19243](https://github.com/tailwindlabs/tailwindcss/pull/19243))
 - Support environment API in `@tailwindcss/vite` ([#18970](https://github.com/tailwindlabs/tailwindcss/pull/18970))
 - Preserve case of theme keys from JS configs and plugins ([#19337](https://github.com/tailwindlabs/tailwindcss/pull/19337))
+- Improve backwards compatibility for `content` theme key from JS configs ([#19381](https://github.com/tailwindlabs/tailwindcss/pull/19381))
 - Upgrade: Handle `future` and `experimental` config keys ([#19344](https://github.com/tailwindlabs/tailwindcss/pull/19344))
 
 ### Added

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -23259,7 +23259,17 @@ test('contain', async () => {
 })
 
 test('content', async () => {
-  expect(await run(['content-["hello_world"]'])).toMatchInlineSnapshot(`
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --content-slash: '/';
+        }
+        @tailwind utilities;
+      `,
+      ['content-slash', 'content-["hello_world"]'],
+    ),
+  ).toMatchInlineSnapshot(`
     "@layer properties {
       @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
         *, :before, :after, ::backdrop {
@@ -23268,8 +23278,17 @@ test('content', async () => {
       }
     }
 
+    :root, :host {
+      --content-slash: "/";
+    }
+
     .content-\\[\\"hello_world\\"\\] {
       --tw-content: "hello world";
+      content: var(--tw-content);
+    }
+
+    .content-slash {
+      --tw-content: var(--content-slash);
       content: var(--tw-content);
     }
 

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -4688,7 +4688,9 @@ export function createUtilities(theme: Theme) {
     ['content', 'none'],
   ])
   functionalUtility('content', {
-    themeKeys: [],
+    // BC: We only read from the `--content` theme key for compatibility reasons. It's recommended
+    // to use the utility with arbitrary values instead.
+    themeKeys: ['--content'],
     handle: (value) => [
       atRoot([property('--tw-content', '""')]),
       decl('--tw-content', value),


### PR DESCRIPTION
Fixes #19343

This PR makes it so the `content-*` utilities read from the `--content-*` theme namespace. This change is **purely for backwards compatibility with Tailwind CSS v3**. It is recommended you use arbitrary values with the `content-*` utility instead.