### PR TITLE
Canonicalization: combine `text-*` and `leading-*` classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve backwards compatibility for `content` theme key from JS configs ([#19381](https://github.com/tailwindlabs/tailwindcss/pull/19381))
 - Upgrade: Handle `future` and `experimental` config keys ([#19344](https://github.com/tailwindlabs/tailwindcss/pull/19344))
 - Try to canonicalize any arbitrary utility to a bare value ([#19379](https://github.com/tailwindlabs/tailwindcss/pull/19379))
+- Canonicalization: combine `text-*` and `leading-*` classes ([#19396](https://github.com/tailwindlabs/tailwindcss/pull/19396))
 
 ### Added
 

--- a/packages/tailwindcss/src/canonicalize-candidates.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.ts
@@ -262,17 +262,20 @@ function collapseCandidates(options: InternalCanonicalizeOptions, candidates: st
     // E.g.: `margin-top` → `mt-1`, `my-1`, `m-1`
     let otherUtilities = candidatePropertiesValues.map((propertyValues) => {
       let result: Set<string> | null = null
-      for (let [property, values] of propertyValues) {
-        for (let value of values) {
-          let otherUtilities = staticUtilities.get(property).get(value)
-
-          if (result === null) result = new Set(otherUtilities)
-          else result = intersection(result, otherUtilities)
-
-          // The moment no other utilities match, we can stop searching because
-          // all intersections with an empty set will remain empty.
-          if (result!.size === 0) return result!
+      for (let property of propertyValues.keys()) {
+        let otherUtilities = new Set<string>()
+        for (let group of staticUtilities.get(property).values()) {
+          for (let candidate of group) {
+            otherUtilities.add(candidate)
+          }
         }
+
+        if (result === null) result = otherUtilities
+        else result = intersection(result, otherUtilities)
+
+        // The moment no other utilities match, we can stop searching because
+        // all intersections with an empty set will remain empty.
+        if (result!.size === 0) return result!
       }
       return result!
     })

--- a/packages/tailwindcss/src/canonicalize-candidates.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.ts
@@ -286,11 +286,10 @@ function collapseCandidates(options: InternalCanonicalizeOptions, candidates: st
     // E.g.: `mt-1` and `text-red-500` cannot be collapsed because there is no 3rd
     // utility with overlapping property/value combinations.
     let linked = new DefaultMap<number, Set<number>>((key) => new Set<number>([key]))
-    let otherUtilitiesArray = Array.from(otherUtilities)
-    for (let i = 0; i < otherUtilitiesArray.length; i++) {
-      let current = otherUtilitiesArray[i]
-      for (let j = i + 1; j < otherUtilitiesArray.length; j++) {
-        let other = otherUtilitiesArray[j]
+    for (let i = 0; i < otherUtilities.length; i++) {
+      let current = otherUtilities[i]
+      for (let j = i + 1; j < otherUtilities.length; j++) {
+        let other = otherUtilities[j]
 
         for (let property of current) {
           if (other.has(property)) {

--- a/packages/tailwindcss/src/canonicalize-candidates.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.ts
@@ -949,6 +949,11 @@ function createSpacingCache(
   let [value, unit] = parsed
 
   return new DefaultMap<string, number | null>((input) => {
+    // If we already know that the spacing multiplier is 0, all spacing
+    // multipliers will also be 0. No need to even try and parse/canonicalize
+    // the input value.
+    if (value === 0) return null
+
     let parsed = dimensions.get(constantFoldDeclaration(input, options?.rem ?? null))
     if (!parsed) return null
 

--- a/packages/tailwindcss/src/cartesian.ts
+++ b/packages/tailwindcss/src/cartesian.ts
@@ -1,0 +1,40 @@
+type CartesianInput = readonly unknown[][]
+
+type CartesianResult<T extends CartesianInput> = T extends [
+  infer Head extends unknown[],
+  ...infer Tail extends CartesianInput,
+]
+  ? [Head[number], ...CartesianResult<Tail>]
+  : []
+
+export function* cartesian<T extends CartesianInput>(...sets: T): Generator<CartesianResult<T>> {
+  let n = sets.length
+  if (n === 0) return
+
+  // Index lookup
+  let idx = Array(n).fill(0)
+
+  while (true) {
+    // Compute current combination
+    let result = [] as CartesianResult<T>
+    for (let i = 0; i < n; i++) {
+      result[i] = sets[i][idx[i]]
+    }
+    yield result
+
+    // Update index vector
+    let k = n - 1
+    while (k >= 0) {
+      idx[k]++
+      if (idx[k] < sets[k].length) {
+        break
+      }
+      idx[k] = 0
+      k--
+    }
+
+    if (k < 0) {
+      return
+    }
+  }
+}

--- a/packages/tailwindcss/src/cartesian.ts
+++ b/packages/tailwindcss/src/cartesian.ts
@@ -11,6 +11,11 @@ export function* cartesian<T extends CartesianInput>(...sets: T): Generator<Cart
   let n = sets.length
   if (n === 0) return
 
+  // If any input set is empty, the Cartesian product is empty.
+  if (sets.some((set) => set.length === 0)) {
+    return
+  }
+
   // Index lookup
   let idx = Array(n).fill(0)
 


### PR DESCRIPTION
This PR improves the canonicalization when using `text-*` and `leading-*` utilities together.

When using classes such as:
```html
<div class="text-sm leading-7"></div>
```

Then the canonical way of writing this is:
```html
<div class="text-sm/7"></div>
```

Similarly, if you already have a modifier applied, and add a new line-height utility. It will also combine them into the canonical form:
```html
<div class="text-sm/6 leading-7"></div>
```
becomes:
```html
<div class="text-sm/7"></div>
```

This is because the final CSS output of `text-sm/6 leading-7` is:
```css
/*! tailwindcss v4.1.16 | MIT License | https://tailwindcss.com */
.text-sm\/6 {
  font-size: var(--text-sm, 0.875rem);
  line-height: calc(var(--spacing, 0.25rem) * 6);
}
.leading-7 {
  --tw-leading: calc(var(--spacing, 0.25rem) * 7);
  line-height: calc(var(--spacing, 0.25rem) * 7);
}
@property --tw-leading {
  syntax: "*";
  inherits: false;
}
```

Where the `line-height` of the `leading-7` class wins over the `line-height` of the `text-sm/6` class.

### Implementation

#### On the fly pre-computation

Right now, we are not using any AST based transformations yet and instead rely on a pre-computed list. However, with arbitrary values we don't have pre-computed values for `text-sm/123` for example.

What we do instead is if we see a utility that sets `line-height` and other utilities set `font-size` then we pre-compute those computations on the fly.

We will prefer named font-sizes (such as `sm`, `lg`, etc). We will also prefer bare values for line-height (such as `7`) over arbitrary values (such as `[123px]`).

#### Canonicalization of the CSS AST

Another thing we had to do is to make sure that when multiple declarations of the same property exist, that we only keep the last one. In the real world, multiple declarations of the same value is typically used for fallback values (e.g.: `background-color: #fff; background-color: oklab(255 255 255 / 1);`).

But for our use case, I believe we can safely remove the earlier declarations to make the most modern and thus the last declaration win.

#### Trying combinations based on `property` only

One small change we had to make is that we try combinations of utilities based on property only instead of property _and_ value. This is important for cases such as `text-sm/6 leading-7`. These 2 classes will set a `lin-height` of `24px` and `28px` respectively so they will never match.

However, once combined together, there will be 2 line-height values, and the last one wins. The signature of `text-sm/6 leading-7` becomes:
```css
.x {
  font-size: 14px;          /* From text-sm/6 */
  line-height: 24px;        /* From text-sm/6 */
  line-height: 28px;        /* From leading-7 */
}
```

↓↓↓↓↓↓↓↓↓

```css
.x {
  font-size: 14px;          /* From text-sm/6 */
  line-height: 28px;        /* From leading-7 */
}
```

This now shows that just `text-sm/7` is the canonical form. Because it produces the same final CSS output.


## Test plan

1. All existing tests pass
2. Added a bunch of new tests where we combine `text-*` and `leading-*` utilities with named, bare and arbitrary values. Even with existing modifiers on the text utilities.

<img width="1010" height="1099" alt="image" src="https://github.com/user-attachments/assets/d2775692-a442-4604-8371-21dacf16ebfc" />
