### PR TITLE
Fix invalid template tags in tests

### DIFF
--- a/crates/ignore/README.md
+++ b/crates/ignore/README.md
@@ -1,5 +1,5 @@
-ignore
-======
+# ignore
+
 The ignore crate provides a fast recursive directory iterator that respects
 various filters such as globs, file types and `.gitignore` files. This crate
 also provides lower level direct access to gitignore and file type matchers.
@@ -28,7 +28,6 @@ This example shows the most basic usage of this crate. This code will
 recursively traverse the current directory while automatically filtering out
 files and directories according to ignore globs found in files like
 `.ignore` and `.gitignore`:
-
 
 ```rust,no_run
 use ignore::Walk;

--- a/crates/ignore/README.md
+++ b/crates/ignore/README.md
@@ -1,5 +1,5 @@
-# ignore
-
+ignore
+======
 The ignore crate provides a fast recursive directory iterator that respects
 various filters such as globs, file types and `.gitignore` files. This crate
 also provides lower level direct access to gitignore and file type matchers.
@@ -28,6 +28,7 @@ This example shows the most basic usage of this crate. This code will
 recursively traverse the current directory while automatically filtering out
 files and directories according to ignore globs found in files like
 `.ignore` and `.gitignore`:
+
 
 ```rust,no_run
 use ignore::Walk;

--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe } from 'vitest'
-import { candidate, css, html, js, json, retryAssertion, test, ts, yaml } from '../utils'
+import { candidate, css, html, js, json, retryAssertion, test, ts, txt, yaml } from '../utils'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -2591,7 +2591,7 @@ test(
           }
         }
       `,
-      'input.css': css`
+      'input.css': txt`
         .test {
           color: red;
           */

--- a/integrations/cli/standalone.test.ts
+++ b/integrations/cli/standalone.test.ts
@@ -1,6 +1,6 @@
 import os from 'node:os'
 import path from 'node:path'
-import { candidate, css, html, js, json, test } from '../utils'
+import { candidate, css, html, js, json, test, ts } from '../utils'
 
 const STANDALONE_BINARY = (() => {
   switch (os.platform()) {
@@ -122,7 +122,7 @@ test(
           })
         })
       `,
-      'src/plugin.ts': js`
+      'src/plugin.ts': ts`
         import plugin from 'tailwindcss/plugin'
 
         // Make sure all available JS APIs can be imported and used
@@ -132,8 +132,7 @@ test(
         import defaultTheme from 'tailwindcss/defaultTheme'
         import * as pkg from 'tailwindcss/package.json'
 
-        export interface PluginOptions {
-        }
+        export interface PluginOptions {}
 
         export default plugin(function ({ addUtilities }) {
           addUtilities({


### PR DESCRIPTION
## Issues Fixed

### 1. TypeScript incorrectly marked as JavaScript
**File:** `standalone.test.ts` (Line 125)

**Problem:**  
A snippet referencing `src/plugin.ts` used the `js` template tag even though the content included TypeScript syntax (`export interface PluginOptions {}`).  
This caused `prettier-plugin-embed` to attempt parsing TypeScript as JavaScript and fail.

**Fix:**
- Replaced `js` → `ts` template tag  
- Added `ts` to imports from `../utils`

---

### 2. Invalid CSS parsed as actual CSS
**File:** `index.test.ts` (Lines 2595–2599)

**Problem:**  
The test intentionally contains invalid CSS (`*/` without an opening `/*`).  
It was tagged with the `css` template tag, causing Prettier to try formatting it and crash.

**Fix:**
- Replaced `css` → `txt` template tag  
- Added `txt` to imports from `../utils`

---

## Result
-  Prettier lint checks now pass  
-  TypeScript code is formatted correctly  
-  Invalid CSS test no longer breaks formatting  
-  Test suite is more stable and consistent

