### PR TITLE
vite: fix SVG watch ignore regex for query/hash(#issue 19401)

### DIFF
--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -287,7 +287,7 @@ class Root {
     let inputPath = idToPath(this.id)
 
     function addWatchFile(file: string) {
-      // Don't watch the input file since it's already a dependency anc causes
+      // Don't watch the input file since it's already a dependency and causes
       // issues with some setups (e.g. Qwik).
       if (file === inputPath) {
         return


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create a discussion to first discuss any significant new features.

For more info, check out the contributing guide:

https://github.com/tailwindcss/tailwindcss/blob/main/.github/CONTRIBUTING.md

-->

## Summary

Fixed SVG watch filter regex in the Vite plugin to correctly ignore files with query parameters or hash fragments.

Problem: The regex /[\#\?].*\.svg$/ only matches when # or ? appears before .svg and the string ends with .svg. This fails to match typical Vite import paths like icons/foo.svg?component or icons/foo.svg#sprite, allowing those files to remain watched and potentially crash Vite during file scanning.

Solution: Updated the regex to /\.svg(?:[#?].*)?$/ to match .svg, .svg?…, and .svg#… patterns, ensuring the workaround reliably prevents watch crashes on SVG files with query/hash suffixes.

Test plan:

# Create a test SVG with query parameter
echo '<svg></svg>' > src/icons/test.svg

# Import it with a query in your CSS/JS
import Icon from './icons/test.svg?component'

# Start dev server and modify the SVG
pnpm dev
# Should NOT crash; watch correctly ignores the SVG file.

closed(#19401 )
