### PR TITLE
Expose `candidatesToAst` to the language server 

### DIFF
--- a/packages/tailwindcss/src/design-system.ts
+++ b/packages/tailwindcss/src/design-system.ts
@@ -59,6 +59,7 @@ export type DesignSystem = {
 
   // Used by IntelliSense
   candidatesToCss(classes: string[]): (string | null)[]
+  candidatesToAst(classes: string[]): AstNode[][]
 
   // General purpose storage
   storage: Record<symbol, unknown>
@@ -145,6 +146,7 @@ export function buildDesignSystem(theme: Theme): DesignSystem {
     important: false,
 
     candidatesToCss,
+    candidatesToAst,
 
     getClassOrder(classes) {
       return getClassOrder(this, classes)

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -595,7 +595,7 @@ async function parseCss(
     }
   })
 
-  let designSystem = buildDesignSystem(theme)
+  let designSystem = buildDesignSystem(theme, utilitiesNode?.src)
 
   if (important) {
     designSystem.important = important
@@ -855,7 +855,7 @@ export async function compile(
 }
 
 export async function __unstable__loadDesignSystem(css: string, opts: CompileOptions = {}) {
-  let result = await parseCss(CSS.parse(css), opts)
+  let result = await parseCss(CSS.parse(css, { from: opts.from }), opts)
   return result.designSystem
 }
 

--- a/packages/tailwindcss/src/intellisense.test.ts
+++ b/packages/tailwindcss/src/intellisense.test.ts
@@ -259,7 +259,7 @@ test('Utilities, when marked as important, show as important in intellisense', a
 test('Static utilities from plugins are listed in hovers and completions', async () => {
   let input = css`
     @import 'tailwindcss/utilities';
-    @plugin "./plugin.js"l;
+    @plugin "./plugin.js";
   `
 
   let design = await __unstable__loadDesignSystem(input, {
@@ -296,7 +296,7 @@ test('Static utilities from plugins are listed in hovers and completions', async
 test('Functional utilities from plugins are listed in hovers and completions', async () => {
   let input = css`
     @import 'tailwindcss/utilities';
-    @plugin "./plugin.js"l;
+    @plugin "./plugin.js";
   `
 
   let design = await __unstable__loadDesignSystem(input, {

--- a/packages/tailwindcss/src/intellisense.test.ts
+++ b/packages/tailwindcss/src/intellisense.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest'
 import { __unstable__loadDesignSystem } from '.'
+import { decl, rule } from './ast'
 import plugin from './plugin'
 import { ThemeOptions } from './theme'
 
@@ -163,6 +164,26 @@ test('Can produce CSS per candidate using `candidatesToCss`', async () => {
       ",
       ]
     `)
+})
+
+test('Can produce AST per candidate using `candidatesToAst`', async () => {
+  let design = await loadDesignSystem()
+  design.invalidCandidates = new Set(['bg-[#fff]'])
+
+  expect(
+    design.candidatesToAst(['underline', 'i-dont-exist', 'bg-[#fff]', 'bg-[#000]', 'text-xs']),
+  ).toEqual([
+    [rule('.underline', [decl('text-decoration-line', 'underline')])],
+    [],
+    [],
+    [rule('.bg-\\[\\#000\\]', [decl('background-color', '#000')])],
+    [
+      rule('.text-xs', [
+        decl('font-size', 'var(--text-xs)'),
+        decl('line-height', 'var(--tw-leading, var(--text-xs--line-height))'),
+      ]),
+    ],
+  ])
 })
 
 test('Utilities do not show wrapping selector in intellisense', async () => {


### PR DESCRIPTION
This will be used to improve performance and potentially enable future features that require generated CSS source locations.

Note: This is still 100% internal API. You can only access this via `__unstable__loadDesignSystem` for a reason. We may chance the structure of the arguments and/or return values as needed.