### PR TITLE
Only use the last value when parsing duplicate cli arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Try to canonicalize any arbitrary utility to a bare value ([#19379](https://github.com/tailwindlabs/tailwindcss/pull/19379))
 - Validate candidates similarly to Oxide ([#19397](https://github.com/tailwindlabs/tailwindcss/pull/19397))
 - Canonicalization: combine `text-*` and `leading-*` classes ([#19396](https://github.com/tailwindlabs/tailwindcss/pull/19396))
+- Correctly handle duplicate CLI arguments ([#19416](https://github.com/tailwindlabs/tailwindcss/pull/19416))
 
 ### Added
 

--- a/packages/@tailwindcss-cli/src/utils/args.test.ts
+++ b/packages/@tailwindcss-cli/src/utils/args.test.ts
@@ -17,6 +17,22 @@ it('should be possible to parse a single argument', () => {
   `)
 })
 
+it('should only return the last value for duplicate arguments', () => {
+  expect(
+    args(
+      {
+        '--output': { type: 'string', description: 'Output file' },
+      },
+      ['--output', 'output.css', '--output', 'override.css'],
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "--output": "override.css",
+      "_": [],
+    }
+  `)
+})
+
 it('should fallback to the default value if no flag is passed', () => {
   expect(
     args(

--- a/packages/@tailwindcss-cli/src/utils/args.test.ts
+++ b/packages/@tailwindcss-cli/src/utils/args.test.ts
@@ -33,6 +33,22 @@ it('should only return the last value for duplicate arguments', () => {
   `)
 })
 
+it('uses last value when flag with "-" is supplied multiple times', () => {
+  let result = args(
+    {
+      '--output': { type: 'string', description: 'Output file', alias: '-o' },
+    },
+    ['--output', 'output.css', '--output', '-'],
+  )
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "--output": "-",
+      "_": [],
+    }
+  `)
+})
+
 it('should fallback to the default value if no flag is passed', () => {
   expect(
     args(

--- a/packages/@tailwindcss-cli/src/utils/args.ts
+++ b/packages/@tailwindcss-cli/src/utils/args.ts
@@ -79,6 +79,8 @@ export function args<const T extends Arg>(options: T, argv = process.argv.slice(
   for (let key in parsed) {
     if (parsed[key] === '__IO_DEFAULT_VALUE__') {
       parsed[key] = '-'
+    } else if (key !== '_' && Array.isArray(parsed[key])) {
+      parsed[key] = parsed[key].at(-1)
     }
   }
 

--- a/packages/@tailwindcss-cli/src/utils/args.ts
+++ b/packages/@tailwindcss-cli/src/utils/args.ts
@@ -80,7 +80,7 @@ export function args<const T extends Arg>(options: T, argv = process.argv.slice(
     let value = parsed[key]
 
     if (key !== '_' && Array.isArray(value)) {
-      value = value.pop()
+      value = value[value.length - 1]
     }
 
     if (value === '__IO_DEFAULT_VALUE__') {

--- a/packages/@tailwindcss-cli/src/utils/args.ts
+++ b/packages/@tailwindcss-cli/src/utils/args.ts
@@ -77,11 +77,17 @@ export function args<const T extends Arg>(options: T, argv = process.argv.slice(
   let parsed = parse(argv)
 
   for (let key in parsed) {
-    if (parsed[key] === '__IO_DEFAULT_VALUE__') {
-      parsed[key] = '-'
-    } else if (key !== '_' && Array.isArray(parsed[key])) {
-      parsed[key] = parsed[key].pop()
+    let value = parsed[key]
+
+    if (key !== '_' && Array.isArray(value)) {
+      value = value.pop()
     }
+
+    if (value === '__IO_DEFAULT_VALUE__') {
+      value = '-'
+    }
+
+    parsed[key] = value
   }
 
   let result: { _: string[]; [key: string]: unknown } = {

--- a/packages/@tailwindcss-cli/src/utils/args.ts
+++ b/packages/@tailwindcss-cli/src/utils/args.ts
@@ -80,7 +80,7 @@ export function args<const T extends Arg>(options: T, argv = process.argv.slice(
     if (parsed[key] === '__IO_DEFAULT_VALUE__') {
       parsed[key] = '-'
     } else if (key !== '_' && Array.isArray(parsed[key])) {
-      parsed[key] = parsed[key].at(-1)
+      parsed[key] = parsed[key].pop()
     }
   }
 


### PR DESCRIPTION
## Summary

When parsing cli args, 'mri' returns an array for duplicate args, which causes unexpected results. All current arguments assume single values only. Tailwind v3 works the same way.

## Test plan

Updated tests.