### PR TITLE
Do not wrap `color-mix` in a `@supports` rule if one already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Do not wrap `color-mix` in a `@supports` rule if one already exists ([#19450](https://github.com/tailwindlabs/tailwindcss/pull/19450))
+
 ### Added
 
 - _Experimental_: Add `@container-size` utility ([#18901](https://github.com/tailwindlabs/tailwindcss/pull/18901))

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -240,18 +240,6 @@ export function optimizeAst(
     context: Record<string, string | boolean> = {},
     depth = 0,
   ) {
-    // Already checking for color-mix support. No need to do it again.
-    if (
-      node.kind === 'at-rule' &&
-      node.name === '@supports' &&
-      node.params.includes('color-mix(')
-    ) {
-      for (const child of node.nodes) {
-        transform(child, node.nodes, { ...context, supportsColorMix: true }, depth + 1)
-      }
-      return
-    }
-
     // Declaration
     if (node.kind === 'declaration') {
       if (node.property === '--tw-sort' || node.value === undefined || node.value === null) {
@@ -395,6 +383,8 @@ export function optimizeAst(
     else if (node.kind === 'at-rule') {
       if (node.name === '@keyframes') {
         context = { ...context, keyframes: true }
+      } else if (node.name === '@supports' && node.params.includes('color-mix(')) {
+        context = { ...context, supportsColorMix: true }
       }
 
       let copy = { ...node, nodes: [] }

--- a/packages/tailwindcss/src/ast.ts
+++ b/packages/tailwindcss/src/ast.ts
@@ -240,6 +240,18 @@ export function optimizeAst(
     context: Record<string, string | boolean> = {},
     depth = 0,
   ) {
+    // Already checking for color-mix support. No need to do it again.
+    if (
+      node.kind === 'at-rule' &&
+      node.name === '@supports' &&
+      node.params.includes('color-mix(')
+    ) {
+      for (const child of node.nodes) {
+        transform(child, node.nodes, { ...context, supportsColorMix: true }, depth + 1)
+      }
+      return
+    }
+
     // Declaration
     if (node.kind === 'declaration') {
       if (node.property === '--tw-sort' || node.value === undefined || node.value === null) {
@@ -285,6 +297,7 @@ export function optimizeAst(
       if (
         polyfills & Polyfills.ColorMix &&
         node.value.includes('color-mix(') &&
+        !context.supportsColorMix &&
         !context.keyframes
       ) {
         colorMixDeclarations.get(parent).add(node)

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -5818,15 +5818,19 @@ describe('`color-mix(…)` polyfill', () => {
       compileCss(
         css`
           @tailwind utilities;
-          @utility unresolvable-color-mix {
-            background: color-mix(in oklab, var(--tw-gradient-from), var(--tw-gradient-to) 0%);
+          @utility color-mix-in-supports-block {
+            @supports (color: color-mix(in lab, red, red)) {
+              background: color-mix(in oklab, var(--tw-gradient-from), var(--tw-gradient-to) 0%);
+            }
           }
         `,
-        ['unresolvable-color-mix'],
+        ['color-mix-in-supports-block'],
       ),
     ).resolves.toMatchInlineSnapshot(`
-      ".unresolvable-color-mix {
-        background: color-mix(in oklab, var(--tw-gradient-from), var(--tw-gradient-to) 0%);
+      ".color-mix-in-supports-block {
+        @supports (color: color-mix(in lab, red, red)) {
+          background: color-mix(in oklab, var(--tw-gradient-from), var(--tw-gradient-to) 0%);
+        }
       }"
     `)
   })

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -5820,7 +5820,7 @@ describe('`color-mix(…)` polyfill', () => {
           @tailwind utilities;
           @utility color-mix-in-supports-block {
             @supports (color: color-mix(in lab, red, red)) {
-              background: color-mix(in oklab, var(--tw-gradient-from), var(--tw-gradient-to) 0%);
+              background: color-mix(in oklab, var(--color-1), var(--color-2) 0%);
             }
           }
         `,
@@ -5829,7 +5829,7 @@ describe('`color-mix(…)` polyfill', () => {
     ).resolves.toMatchInlineSnapshot(`
       ".color-mix-in-supports-block {
         @supports (color: color-mix(in lab, red, red)) {
-          background: color-mix(in oklab, var(--tw-gradient-from), var(--tw-gradient-to) 0%);
+          background: color-mix(in oklab, var(--color-1), var(--color-2) 0%);
         }
       }"
     `)

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -5812,6 +5812,24 @@ describe('`color-mix(…)` polyfill', () => {
       }"
     `)
   })
+
+  it('should not create a fallback when color-mix contains only CSS variables that cannot be resolved', async () => {
+    await expect(
+      compileCss(
+        css`
+          @tailwind utilities;
+          @utility unresolvable-color-mix {
+            background: color-mix(in oklab, var(--tw-gradient-from), var(--tw-gradient-to) 0%);
+          }
+        `,
+        ['unresolvable-color-mix'],
+      ),
+    ).resolves.toMatchInlineSnapshot(`
+      ".unresolvable-color-mix {
+        background: color-mix(in oklab, var(--tw-gradient-from), var(--tw-gradient-to) 0%);
+      }"
+    `)
+  })
 })
 
 describe('`@property` polyfill', async () => {

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -5813,22 +5813,22 @@ describe('`color-mix(…)` polyfill', () => {
     `)
   })
 
-  it('should not apply color-mix optimizations when already inside a @supports at-rule that checks for color-mix', async () => {
+  it('does not apply optimizations when already inside a @supports (color: color-mix... block', async () => {
     await expect(
       compileCss(
         css`
           @tailwind utilities;
-          @utility mixed-color {
+          @utility mixed {
             @supports (color: color-mix(in lab, red, red)) {
               background: color-mix(in oklab, var(--color-1), var(--color-2) 0%);
             }
           }
         `,
-        ['mixed-color'],
+        ['mixed'],
       ),
     ).resolves.toMatchInlineSnapshot(`
       "@supports (color: color-mix(in lab, red, red)) {
-        .mixed-color {
+        .mixed {
           background: color-mix(in oklab, var(--color-1), var(--color-2) 0%);
         }
       }"

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -5813,7 +5813,7 @@ describe('`color-mix(…)` polyfill', () => {
     `)
   })
 
-  it('should not create a fallback when color-mix contains only CSS variables that cannot be resolved', async () => {
+  it('should not apply color-mix optimizations when already inside a @supports at-rule that checks for color-mix', async () => {
     await expect(
       compileCss(
         css`

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -5818,17 +5818,17 @@ describe('`color-mix(…)` polyfill', () => {
       compileCss(
         css`
           @tailwind utilities;
-          @utility color-mix-in-supports-block {
+          @utility mixed-color {
             @supports (color: color-mix(in lab, red, red)) {
               background: color-mix(in oklab, var(--color-1), var(--color-2) 0%);
             }
           }
         `,
-        ['color-mix-in-supports-block'],
+        ['mixed-color'],
       ),
     ).resolves.toMatchInlineSnapshot(`
-      ".color-mix-in-supports-block {
-        @supports (color: color-mix(in lab, red, red)) {
+      "@supports (color: color-mix(in lab, red, red)) {
+        .mixed-color {
           background: color-mix(in oklab, var(--color-1), var(--color-2) 0%);
         }
       }"

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -189,7 +189,19 @@ export function withAlpha(value: string, alpha: string): string {
     return value
   }
 
+  // prefix the color-mix function with an internal /* tw:optimize */ comment so that
+  // only this will be optimized later
   return `color-mix(in oklab, ${value} ${alpha}, transparent)`
+}
+
+export const optimizeCommentPattern = /^\s*\/\*\s*tw:optimize\s*\*\/\s/;
+
+export function containsOptimizeComment(value: string): boolean {
+  return optimizeCommentPattern.test(value);
+}
+
+export function removeOptimizeComment(value: string): string {
+  return value.replace(optimizeCommentPattern, '');
 }
 
 /**

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -189,19 +189,7 @@ export function withAlpha(value: string, alpha: string): string {
     return value
   }
 
-  // prefix the color-mix function with an internal /* tw:optimize */ comment so that
-  // only this will be optimized later
   return `color-mix(in oklab, ${value} ${alpha}, transparent)`
-}
-
-export const optimizeCommentPattern = /^\s*\/\*\s*tw:optimize\s*\*\/\s/;
-
-export function containsOptimizeComment(value: string): boolean {
-  return optimizeCommentPattern.test(value);
-}
-
-export function removeOptimizeComment(value: string): string {
-  return value.replace(optimizeCommentPattern, '');
 }
 
 /**


### PR DESCRIPTION
Related issue: #19445 

## Summary

Fixes an issue where tailwindcss wraps `color-mix` inside a `@supports` block even if the original code already checks for support.

Uncompiled Code:

```css
@utility foo {
  @supports (color: color-mix(in lab, red, red)) {
    background: color-mix(in lab, var(--color-1), var(--color-2));
  }
}
```

### Compiled code: Current behavior

https://play.tailwindcss.com/KSvR7wefdh?file=css

```css
@layer utilities {
  .foo {
    @supports (color: color-mix(in lab, red, red)) {
      background: var(--color-1);
      @supports (color: color-mix(in lab, red, red)) {
        background: color-mix(in lab, var(--color-1), var(--color-2));
      }
    }
}
```

### Compiled code: Fixed behavior

```css
@layer utilities {
  @supports (color: color-mix(in lab, red, red)) {
    .foo {
      background: color-mix(in lab, var(--color-1), var(--color-2));
    }
}
```

## Test plan

I have tested this by writing a new test that was at first failing. Now it passes.