### PR TITLE
Allow whitespace around `@source inline()` arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Do not wrap `color-mix` in a `@supports` rule if one already exists ([#19450](https://github.com/tailwindlabs/tailwindcss/pull/19450))
+- Allow whitespace around `@source inline()` argument ([#19461](https://github.com/tailwindlabs/tailwindcss/pull/19461))
 
 ### Added
 

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -3806,6 +3806,7 @@ describe('@source', () => {
     test('works with whitespace around the argument', async () => {
       let { build } = await compile(
         css`
+          /* prettier-ignore */
           @source inline( "underline" );
           @tailwind utilities;
         `,
@@ -3823,6 +3824,7 @@ describe('@source', () => {
     test('works with newlines around the argument', async () => {
       let { build } = await compile(
         css`
+          /* prettier-ignore */
           @source inline(
             "underline"
           );

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -3802,6 +3802,42 @@ describe('@source', () => {
 
       expect(build(['bg-red-500', 'bg-red-700'])).toMatchInlineSnapshot(`""`)
     })
+
+    test('works with whitespace around the argument', async () => {
+      let { build } = await compile(
+        css`
+          @source inline( "underline" );
+          @tailwind utilities;
+        `,
+        { base: '/root' },
+      )
+
+      expect(build([])).toMatchInlineSnapshot(`
+        ".underline {
+          text-decoration-line: underline;
+        }
+        "
+      `)
+    });
+
+    test('works with newlines around the argument', async () => {
+      let { build } = await compile(
+        css`
+          @source inline(
+            "underline"
+          );
+          @tailwind utilities;
+        `,
+        { base: '/root' },
+      )
+
+      expect(build([])).toMatchInlineSnapshot(`
+        ".underline {
+          text-decoration-line: underline;
+        }
+        "
+      `)
+    });
   })
 })
 

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -3818,7 +3818,7 @@ describe('@source', () => {
         }
         "
       `)
-    });
+    })
 
     test('works with newlines around the argument', async () => {
       let { build } = await compile(
@@ -3837,7 +3837,7 @@ describe('@source', () => {
         }
         "
       `)
-    });
+    })
   })
 })
 

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -274,7 +274,7 @@ async function parseCss(
 
       if (path[0] === 'i' && path.startsWith('inline(')) {
         inline = true
-        path = path.slice(7, -1).trim();
+        path = path.slice(7, -1).trim()
       }
 
       if (

--- a/packages/tailwindcss/src/index.ts
+++ b/packages/tailwindcss/src/index.ts
@@ -274,7 +274,7 @@ async function parseCss(
 
       if (path[0] === 'i' && path.startsWith('inline(')) {
         inline = true
-        path = path.slice(7, -1)
+        path = path.slice(7, -1).trim();
       }
 
       if (


### PR DESCRIPTION
## Summary

Inspired by #19460, relaxes whitespace syntax around `@source inline(…):`

### Before

```css
/* ❌ Error: `@source` paths must be quoted. */
@source inline( "underline" );
@source inline(
  "underline"
);
```

### After

```css
/* ✅ Generates the class names as normal. */
@source inline( "underline" );
@source inline(
  "underline"
);
```

## Test plan

Added tests to `packages/tailwindcss/src/index.test.ts`.
