### PR TITLE
wip: fix integration tests on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
             os: namespace-profile-default
 
           - name: macOS
-            os: macos-14
+            os: macos-latest
 
         # Exclude windows and macos from being built on feature branches
         run-all:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,7 +23,7 @@ jobs:
             os: namespace-profile-default
 
           - name: macOS
-            os: macos-14
+            os: macos-latest
 
         integration:
           - upgrade


### PR DESCRIPTION
A couple of tests fail in CI with timeouts — only on macOS. This isn't reproducible locally though. Not sure *where* the stall is coming from.

[ci-all]