### PR TITLE
aligning item in display block

### DIFF
--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -2405,7 +2405,7 @@ test(
           list-style: none;
         }
         img, svg, video, canvas, audio, iframe, embed, object {
-          display: block;
+          display: flex;
           align-items: center;
         }
         img, video {

--- a/integrations/cli/index.test.ts
+++ b/integrations/cli/index.test.ts
@@ -2406,7 +2406,7 @@ test(
         }
         img, svg, video, canvas, audio, iframe, embed, object {
           display: block;
-          vertical-align: middle;
+          align-items: center;
         }
         img, video {
           max-width: 100%;


### PR DESCRIPTION
here, the display is set to block and doing the "vertical-align: middle;", while it is not in block.
there should be the "align-items: center; " and take use of flexbox.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create a discussion to first discuss any significant new features.

For more info, check out the contributing guide:

https://github.com/tailwindcss/tailwindcss/blob/main/.github/CONTRIBUTING.md

-->

## Summary

<!--

Provide a summary of the issue and the changes you're making. How does your change solve the problem?

-->

## Test plan

<!--

Explain how you tested your changes. Include the exact commands that you used to verify the change works and include screenshots/screen recordings of the update behavior in the browser if applicable.

-->
