### PR TITLE
Improve `@utility` name validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI: Emit comment when source maps are saved to files ([#19447](https://github.com/tailwindlabs/tailwindcss/pull/19447))
 - Detect utilities when containing capital letters followed by numbers ([#19465](https://github.com/tailwindlabs/tailwindcss/pull/19465))
 - Fix class extraction for Rails' strict locals ([#19525](https://github.com/tailwindlabs/tailwindcss/pull/19525))
+- Align `@utility` name validation with Oxide scanner rules ([#19524](https://github.com/tailwindlabs/tailwindcss/pull/19524))
 
 ### Added
 

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -4660,6 +4660,41 @@ describe('@utility', () => {
       `[Error: \`@utility my-*-utility\` defines an invalid utility name. The dynamic portion marked by \`-*\` must appear once at the end.]`,
     )
   })
+
+  // https://github.com/tailwindlabs/tailwindcss/issues/19505
+  test('@utility name cannot contain multiple `/` characters', async () => {
+    await expect(
+      compileCss(
+        css`
+          @utility ui/button {
+            display: inline-flex;
+            background: blue;
+          }
+          @tailwind utilities;
+        `,
+        ['ui/button'],
+      ),
+    ).resolves.toMatchInlineSnapshot(
+      `
+      ".ui\\/button {
+        background: #00f;
+        display: inline-flex;
+      }"
+    `,
+    )
+
+    await expect(
+      compileCss(css`
+        @utility ui/button/sm {
+          display: inline-flex;
+          background: blue;
+          font-size: 12px;
+        }
+      `),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: \`@utility ui/button/sm\` defines an invalid utility name. Utilities should be alphanumeric and start with a lowercase letter.]`,
+    )
+  })
 })
 
 test('addBase', async () => {

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from 'vitest'
 import { compile } from '.'
 import { compileCss, optimizeCss, run } from './test-utils/run'
+import { isValidFunctionalUtilityName, isValidStaticUtilityName } from './utilities'
 
 const css = String.raw
 
@@ -27207,6 +27208,46 @@ describe('spacing utilities', () => {
 })
 
 describe('custom utilities', () => {
+  test.each([
+    ['foo', true], // Simple name
+    ['foo-123', true], // Ending with a number is valid
+    ['foo-2.5', true], // Dots are valid when surrounded by numbers
+    ['-foo', true], // Simple name with negative sign
+    ['foo-bar', true], // With dashes
+    ['foo_bar', true], // With underscores
+    ['foo-50%', true], // Bare value with percentage
+    ['foo-1/2', true], // Bare value with fraction
+    ['foo-sm/8', true], // Bare value with number modifier
+    ['foo-4/snug', true], // Bare value with named modifier
+    ['foo_', true], // This is supported today, so let's not break it
+
+    ['Foo', false], // Starting with uppercase letter is invalid
+    ['-Foo', false], // Starting with uppercase letter is invalid (negative)
+    ['foo-', false], // Should not end with a dash
+    ['foo-1/', false], // Invalid fraction/modifier
+    ['foo-p%', false], // Invalid percentage
+    ['foo.bar', false], // Dots are only valid when surrounded by numbers
+    ['foo-1..5', false], // Double dots are invalid
+    ['foo..bar', false], // Double dots are invalid definitely without numbers
+  ])('valid static utility name "%s" (%s)', (name, valid) => {
+    expect(isValidStaticUtilityName(name)).toBe(valid)
+  })
+
+  test.each([
+    ['foo', false], // Simple name, missing '-*' suffix
+    ['foo-*', true], // Simple name
+    ['foo--*', false], // Root should not end in `-`
+    ['-foo-*', true], // Simple name (negative)
+    ['foo-bar-*', true], // With dashes
+    ['foo_bar-*', true], // With underscores
+    ['Foo-*', false], // Starting with uppercase letter is invalid
+    ['-Foo-*', false], // Starting with uppercase letter is invalid
+    ['foo!-*', false], // Invalid special character
+    ['foo-[…]', false], // Invalid special character
+  ])('valid functional name "%s" (%s)', (name, valid) => {
+    expect(isValidFunctionalUtilityName(name)).toBe(valid)
+  })
+
   test('custom static utility', async () => {
     let { build } = await compile(css`
       @layer utilities {

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -27220,6 +27220,7 @@ describe('custom utilities', () => {
     ['foo-sm/8', true], // Bare value with number modifier
     ['foo-4/snug', true], // Bare value with named modifier
     ['foo_', true], // This is supported today, so let's not break it
+    ['foo/bar', true], // A slash to separate the modifier is valid.
 
     ['Foo', false], // Starting with uppercase letter is invalid
     ['-Foo', false], // Starting with uppercase letter is invalid (negative)
@@ -27229,6 +27230,7 @@ describe('custom utilities', () => {
     ['foo.bar', false], // Dots are only valid when surrounded by numbers
     ['foo-1..5', false], // Double dots are invalid
     ['foo..bar', false], // Double dots are invalid definitely without numbers
+    ['foo/bar/baz', false], // Multiple slashes are invalid
   ])('valid static utility name "%s" (%s)', (name, valid) => {
     expect(isValidStaticUtilityName(name)).toBe(valid)
   })


### PR DESCRIPTION
This PR improves the validation of allowed `@utility …` names.

Each `@utility` name should be a valid Tailwind CSS class, so new syntaxes should not be allowed, e.g. `foo/bar/baz` would be invalid.

We already enforce this behavior but not consistently. The Oxide scanner that scans all your source files for potential Tailwind CSS classes does enforce all of these rules already. So if you used `@utility foo/bar/baz {}`, the Oxide scanner would not pick up `foo/bar/baz` as a valid class name, so for that reason it's not a breaking change.

Where we didn't enforce it is in places where you use the development-only CDN or Tailwind Play. That's because those environments don't use the Oxide at all, and get the classes from the DOM directly and pass it to Tailwind's compiler.

This PR moves some of these validation rules into Tailwind's core when defining custom `@utility` utilities.

Fixes: #19505

### Test plan

1. Existing tests still pass
2. Added a regression test for the linked issue
3. Added new tests with valid / invalid `@utility` names

I also confirmed with Oxide to know which classes were actually valid and which ones are invalid.

Given this input CSS:
```css
@utility foo { color: red }
@utility foo_ { color: red }     /* This one looks invalid to me, but it works today */
                                 /* and I don't want to introduce unnecessary breaking changes. */
@utility foo-1.5 { color: red }
@utility foo-123 { color: red }
@utility -foo { color: red }
@utility foo-bar { color: red }
@utility foo_bar { color: red }
@utility foo-50% { color: red }
@utility foo-1/2 { color: red }
```

And this HTML:
```html
<!-- Extracted: -->
<div class="foo foo_ foo-123 -foo foo-bar foo_bar foo-50% foo-1/2 foo-1.5"></div>

<!-- Not Extracted: -->
<div class="Foo -Foo foo-1/ foo- foo-p% foo-1..5 foo.bar foo..bar "></div>
```

Then all classes in the `Extracted` section are found. One funny thing in the not extracted section is that the `bar` in `foo.bar` and `foo..bar` is also extracted. Feels like a potential bug, but out of scope for this PR.

<img width="766" height="164" alt="image" src="https://github.com/user-attachments/assets/fafbaa35-2730-4f61-9b15-6690b02ec686" />

