### PR TITLE
Add funding info to package.json

### DIFF
--- a/packages/@tailwindcss-browser/package.json
+++ b/packages/@tailwindcss-browser/package.json
@@ -12,6 +12,7 @@
   },
   "bugs": "https://github.com/tailwindlabs/tailwindcss/issues",
   "homepage": "https://tailwindcss.com",
+  "funding": "https://tailwindcss.com/sponsor",
   "scripts": {
     "lint": "tsc --noEmit",
     "build": "tsup-node",

--- a/packages/@tailwindcss-cli/package.json
+++ b/packages/@tailwindcss-cli/package.json
@@ -10,6 +10,7 @@
   },
   "bugs": "https://github.com/tailwindlabs/tailwindcss/issues",
   "homepage": "https://tailwindcss.com",
+  "funding": "https://tailwindcss.com/sponsor",
   "scripts": {
     "lint": "tsc --noEmit",
     "build": "tsup-node",

--- a/packages/@tailwindcss-postcss/package.json
+++ b/packages/@tailwindcss-postcss/package.json
@@ -10,6 +10,7 @@
   },
   "bugs": "https://github.com/tailwindlabs/tailwindcss/issues",
   "homepage": "https://tailwindcss.com",
+  "funding": "https://tailwindcss.com/sponsor",
   "scripts": {
     "lint": "tsc --noEmit",
     "build": "tsup-node",

--- a/packages/@tailwindcss-standalone/package.json
+++ b/packages/@tailwindcss-standalone/package.json
@@ -11,6 +11,7 @@
   },
   "bugs": "https://github.com/tailwindlabs/tailwindcss/issues",
   "homepage": "https://tailwindcss.com",
+  "funding": "https://tailwindcss.com/sponsor",
   "scripts": {
     "lint": "tsc --noEmit",
     "build": "bun ./scripts/build.ts"

--- a/packages/@tailwindcss-upgrade/package.json
+++ b/packages/@tailwindcss-upgrade/package.json
@@ -10,6 +10,7 @@
   },
   "bugs": "https://github.com/tailwindlabs/tailwindcss/issues",
   "homepage": "https://tailwindcss.com",
+  "funding": "https://tailwindcss.com/sponsor",
   "scripts": {
     "lint": "tsc --noEmit",
     "build": "tsup-node",

--- a/packages/@tailwindcss-vite/package.json
+++ b/packages/@tailwindcss-vite/package.json
@@ -10,6 +10,7 @@
   },
   "bugs": "https://github.com/tailwindlabs/tailwindcss/issues",
   "homepage": "https://tailwindcss.com",
+  "funding": "https://tailwindcss.com/sponsor",
   "scripts": {
     "build": "tsup-node",
     "dev": "pnpm run build -- --watch"

--- a/packages/tailwindcss/package.json
+++ b/packages/tailwindcss/package.json
@@ -10,6 +10,7 @@
   },
   "bugs": "https://github.com/tailwindlabs/tailwindcss/issues",
   "homepage": "https://tailwindcss.com",
+  "funding": "https://tailwindcss.com/sponsor",
   "scripts": {
     "lint": "tsc --noEmit",
     "build": "tsup-node --env.NODE_ENV production",


### PR DESCRIPTION
Just noticed funding property in `package.json` files had not been set, perhaps by choice, but just in case.

## Summary

Adding funding information to package.json files, such that users of Tailwind CSS might become aware of sponsor opportunities.

<img width="690" height="173" alt="Screenshot 2026-01-08 at 17 28 50" src="https://github.com/user-attachments/assets/7ef9714f-23a1-4e48-954f-fb2a692fccb8" />

## Test plan

NA. Will give funding info upon package installation and running `npm fund`.
