### PR TITLE
display: none !important; #19538

### DIFF
--- a/packages/tailwindcss/preflight.css
+++ b/packages/tailwindcss/preflight.css
@@ -388,6 +388,6 @@ input:where([type='button'], [type='reset'], [type='submit']),
   Make elements with the HTML hidden attribute stay hidden by default.
 */
 
-[hidden]:where(:not([hidden='until-found'])) {
+:where([hidden]:not([hidden="until-found"])) {
   display: none !important;
 }


### PR DESCRIPTION
Bug  #19538 

This change keeps existing behavior intact while reducing selector impact by moving the :where() wrapper to the full selector.

It does not remove !important or change semantics, but improves composability for component libraries and advanced overrides