### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -262,7 +262,7 @@ jobs:
         run: pnpm --filter=!./playgrounds/* install
 
       - name: Download artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           path: ${{ env.OXIDE_LOCATION }}
 

--- a/.github/workflows/release-insiders.yml
+++ b/.github/workflows/release-insiders.yml
@@ -259,7 +259,7 @@ jobs:
         run: pnpm --filter=!./playgrounds/* install
 
       - name: Download artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           path: ${{ env.OXIDE_LOCATION }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,7 +254,7 @@ jobs:
         run: pnpm --filter=!./playgrounds/* install
 
       - name: Download artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           path: ${{ env.OXIDE_LOCATION }}
 


### PR DESCRIPTION
## Summary  
This PR updates outdated GitHub Action versions by migrating `actions/download-artifact` from `v6` to `v7` in the following workflows:  
- `.github/workflows/prepare-release.yml`  
- `.github/workflows/release.yml`  
- `.github/workflows/release-insiders.yml`  

## Test plan  
The changes will be tested in the CI pipeline of the pull request.  

[×] Summary  
[×] Test plan