### PR TITLE
Upgrade lightningcss to 1.31.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
   "packageManager": "pnpm@9.6.0",
   "pnpm": {
     "patchedDependencies": {
-      "lightningcss@1.30.2": "patches/lightningcss@1.30.2.patch",
       "@parcel/watcher@2.5.1": "patches/@parcel__watcher@2.5.1.patch"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,29 +10,29 @@ catalogs:
       specifier: ^20.19.0
       version: 20.19.1
     lightningcss:
-      specifier: 1.30.2
-      version: 1.30.2
+      specifier: 1.31.0
+      version: 1.31.0
     lightningcss-darwin-arm64:
-      specifier: 1.30.2
-      version: 1.30.2
+      specifier: 1.31.0
+      version: 1.31.0
     lightningcss-darwin-x64:
-      specifier: 1.30.2
-      version: 1.30.2
+      specifier: 1.31.0
+      version: 1.31.0
     lightningcss-linux-arm64-gnu:
-      specifier: 1.30.2
-      version: 1.30.2
+      specifier: 1.31.0
+      version: 1.31.0
     lightningcss-linux-arm64-musl:
-      specifier: 1.30.2
-      version: 1.30.2
+      specifier: 1.31.0
+      version: 1.31.0
     lightningcss-linux-x64-gnu:
-      specifier: 1.30.2
-      version: 1.30.2
+      specifier: 1.31.0
+      version: 1.31.0
     lightningcss-linux-x64-musl:
-      specifier: 1.30.2
-      version: 1.30.2
+      specifier: 1.31.0
+      version: 1.31.0
     lightningcss-win32-x64-msvc:
-      specifier: 1.30.2
-      version: 1.30.2
+      specifier: 1.31.0
+      version: 1.31.0
     prettier:
       specifier: 3.6.2
       version: 3.6.2
@@ -44,9 +44,6 @@ patchedDependencies:
   '@parcel/watcher@2.5.1':
     hash: zs2vvlrje3h42xp5ed2v44fep4
     path: patches/@parcel__watcher@2.5.1.patch
-  lightningcss@1.30.2:
-    hash: tzyxy3asfxcqc7ihrooumyi5fm
-    path: patches/lightningcss@1.30.2.patch
 
 importers:
 
@@ -84,7 +81,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^4.0.3
-        version: 4.0.12(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.30.2(patch_hash=tzyxy3asfxcqc7ihrooumyi5fm))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0)
+        version: 4.0.12(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.31.0)(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0)
 
   crates/node:
     optionalDependencies:
@@ -241,7 +238,7 @@ importers:
         version: 2.6.1
       lightningcss:
         specifier: 'catalog:'
-        version: 1.30.2(patch_hash=tzyxy3asfxcqc7ihrooumyi5fm)
+        version: 1.31.0
       magic-string:
         specifier: ^0.30.21
         version: 0.30.21
@@ -339,25 +336,25 @@ importers:
         version: 1.3.5
       lightningcss-darwin-arm64:
         specifier: 'catalog:'
-        version: 1.30.2
+        version: 1.31.0
       lightningcss-darwin-x64:
         specifier: 'catalog:'
-        version: 1.30.2
+        version: 1.31.0
       lightningcss-linux-arm64-gnu:
         specifier: 'catalog:'
-        version: 1.30.2
+        version: 1.31.0
       lightningcss-linux-arm64-musl:
         specifier: 'catalog:'
-        version: 1.30.2
+        version: 1.31.0
       lightningcss-linux-x64-gnu:
         specifier: 'catalog:'
-        version: 1.30.2
+        version: 1.31.0
       lightningcss-linux-x64-musl:
         specifier: 'catalog:'
-        version: 1.30.2
+        version: 1.31.0
       lightningcss-win32-x64-msvc:
         specifier: 'catalog:'
-        version: 1.30.2
+        version: 1.31.0
 
   packages/@tailwindcss-upgrade:
     dependencies:
@@ -443,7 +440,7 @@ importers:
         version: 20.19.1
       vite:
         specifier: 'catalog:'
-        version: 7.0.0(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.30.2(patch_hash=tzyxy3asfxcqc7ihrooumyi5fm))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0)
+        version: 7.0.0(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.31.0)(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0)
 
   packages/internal-example-plugin: {}
 
@@ -463,7 +460,7 @@ importers:
         version: 1.7.1
       lightningcss:
         specifier: 'catalog:'
-        version: 1.30.2(patch_hash=tzyxy3asfxcqc7ihrooumyi5fm)
+        version: 1.31.0
       magic-string:
         specifier: ^0.30.21
         version: 0.30.21
@@ -555,7 +552,7 @@ importers:
         version: link:../../packages/@tailwindcss-vite
       '@vitejs/plugin-react':
         specifier: ^5.1.2
-        version: 5.1.2(vite@7.0.0(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.30.2(patch_hash=tzyxy3asfxcqc7ihrooumyi5fm))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0))
+        version: 5.1.2(vite@7.0.0(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.31.0)(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0))
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -577,7 +574,7 @@ importers:
         version: 1.3.5
       vite:
         specifier: 'catalog:'
-        version: 7.0.0(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.30.2(patch_hash=tzyxy3asfxcqc7ihrooumyi5fm))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0)
+        version: 7.0.0(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.31.0)(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0)
 
 packages:
 
@@ -2805,10 +2802,6 @@ packages:
     engines: {node: '>=0.10'}
     hasBin: true
 
-  detect-libc@2.0.4:
-    resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
-    engines: {node: '>=8'}
-
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -3494,67 +3487,74 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  lightningcss-android-arm64@1.30.2:
-    resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
+  lightningcss-android-arm64@1.31.0:
+    resolution: {integrity: sha512-qRdhuBXBgGfO3NZ37l/lA1qqjqptBQoa37YiMDeMRpJpv/+0CGKtL4o5+VUFaHzZb9+hS/DOg3XNff3YmwY2ug==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [android]
 
-  lightningcss-darwin-arm64@1.30.2:
-    resolution: {integrity: sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==}
+  lightningcss-darwin-arm64@1.31.0:
+    resolution: {integrity: sha512-ctMERKCPJHgEhkCUvcCT5Z1wB+pCyFO+XskTNFB3uTrE9i3LzQXvrlm2PSuYhOYSExrzfmfD/HVyfqZYnfpjvQ==}
     engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
     os: [darwin]
 
-  lightningcss-darwin-x64@1.30.2:
-    resolution: {integrity: sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==}
+  lightningcss-darwin-x64@1.31.0:
+    resolution: {integrity: sha512-7+8dwpz4qj/IiKxSs210WKWoJg59npBxvEXrpuxAkfZDPSgXiPcNZfaL9HtcaRntd7DbzVSI5SHMsmlsl+NZgA==}
     engines: {node: '>= 12.0.0'}
+    cpu: [x64]
     os: [darwin]
 
-  lightningcss-freebsd-x64@1.30.2:
-    resolution: {integrity: sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==}
+  lightningcss-freebsd-x64@1.31.0:
+    resolution: {integrity: sha512-HZdu0reyMXO0TzJnK3D37dxgijjJsZt9muQRi+df/sr6WnkSZJKHfOufm0amWz+LiWg9X3H+XIBW24s/y3itmQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
 
-  lightningcss-linux-arm-gnueabihf@1.30.2:
-    resolution: {integrity: sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==}
+  lightningcss-linux-arm-gnueabihf@1.31.0:
+    resolution: {integrity: sha512-pqp0rGHc9rebDT7vVtu92JqU6gP5zm19m+zCqvHHMI+cEQrCjbNlMbPqn9UEfPYfRltL4pti9MJQ62558nVHnw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
 
-  lightningcss-linux-arm64-gnu@1.30.2:
-    resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
+  lightningcss-linux-arm64-gnu@1.31.0:
+    resolution: {integrity: sha512-EpAQTq6TXL+200bDNMzhbFpqAJsto01R//xuE8yAWN0l4wmJhmS1r/FxoudIUM9PxHMPEiWeLw+1thdF5ZPg7Q==}
     engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
     os: [linux]
 
-  lightningcss-linux-arm64-musl@1.30.2:
-    resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
+  lightningcss-linux-arm64-musl@1.31.0:
+    resolution: {integrity: sha512-6tuU37nXStA3kxNnjC49z1tPFEoviC9ZLyB34O3X1/VTLXdZX2vmPZ+45XesagvlgoeJQ9r9XVSovUZny41AQA==}
     engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
     os: [linux]
 
-  lightningcss-linux-x64-gnu@1.30.2:
-    resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
+  lightningcss-linux-x64-gnu@1.31.0:
+    resolution: {integrity: sha512-enNePbgDKmJybVz90/8dAGTOulvpn0IwxamHHnIj32gmdbuSPJ9mk+Nob4UmiqLMAdHlH+0c+lpsZkv4TSxi3w==}
     engines: {node: '>= 12.0.0'}
+    cpu: [x64]
     os: [linux]
 
-  lightningcss-linux-x64-musl@1.30.2:
-    resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
+  lightningcss-linux-x64-musl@1.31.0:
+    resolution: {integrity: sha512-EM4jGT+V+PdFkcrIB5m5yiSzfV7z43k0pOtUmODhFSbuay5JvbVChK1uoaMmwPTKGWatwSRbiu90BUzU262B9g==}
     engines: {node: '>= 12.0.0'}
+    cpu: [x64]
     os: [linux]
 
-  lightningcss-win32-arm64-msvc@1.30.2:
-    resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
+  lightningcss-win32-arm64-msvc@1.31.0:
+    resolution: {integrity: sha512-IGvE0eCsWrYWerlkXFitANJ2vdkzs4EVCm1sEttanqVc4lqdRKyZ7ZIapBfo5OckE+zuq/JNaIkbWHdYDpOblQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
 
-  lightningcss-win32-x64-msvc@1.30.2:
-    resolution: {integrity: sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==}
+  lightningcss-win32-x64-msvc@1.31.0:
+    resolution: {integrity: sha512-7V6CPCLNO1Pv5gPPvXWst7V8cvZjbRKgwht1qd4/OH7yacV/kMV5VDq/RDnmdQpXUTnn4ye+vZkU8REXU46iZA==}
     engines: {node: '>= 12.0.0'}
+    cpu: [x64]
     os: [win32]
 
-  lightningcss@1.30.2:
-    resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
+  lightningcss@1.31.0:
+    resolution: {integrity: sha512-mKXR8TIPqVNcs0qQplcnLgDSmyMW5q9Bt5GmcvABpeexaGGPILxDmMNoabSsS9pAPgICYmgzL2wYFPf84/fQ2A==}
     engines: {node: '>= 12.0.0'}
 
   lilconfig@2.1.0:
@@ -6143,7 +6143,7 @@ snapshots:
       '@typescript-eslint/types': 8.47.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react@5.1.2(vite@7.0.0(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.30.2(patch_hash=tzyxy3asfxcqc7ihrooumyi5fm))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0))':
+  '@vitejs/plugin-react@5.1.2(vite@7.0.0(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.31.0)(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -6151,7 +6151,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.53
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.0.0(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.30.2(patch_hash=tzyxy3asfxcqc7ihrooumyi5fm))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0)
+      vite: 7.0.0(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.31.0)(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6164,13 +6164,13 @@ snapshots:
       chai: 6.2.1
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.12(vite@7.0.0(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.30.2(patch_hash=tzyxy3asfxcqc7ihrooumyi5fm))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0))':
+  '@vitest/mocker@4.0.12(vite@7.0.0(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.31.0)(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0))':
     dependencies:
       '@vitest/spy': 4.0.12
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.0.0(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.30.2(patch_hash=tzyxy3asfxcqc7ihrooumyi5fm))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0)
+      vite: 7.0.0(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.31.0)(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0)
 
   '@vitest/pretty-format@4.0.12':
     dependencies:
@@ -6548,10 +6548,7 @@ snapshots:
 
   detect-libc@1.0.3: {}
 
-  detect-libc@2.0.4: {}
-
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   didyoumean@1.2.2: {}
 
@@ -7518,47 +7515,47 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  lightningcss-android-arm64@1.30.2:
+  lightningcss-android-arm64@1.31.0:
     optional: true
 
-  lightningcss-darwin-arm64@1.30.2: {}
+  lightningcss-darwin-arm64@1.31.0: {}
 
-  lightningcss-darwin-x64@1.30.2: {}
+  lightningcss-darwin-x64@1.31.0: {}
 
-  lightningcss-freebsd-x64@1.30.2:
+  lightningcss-freebsd-x64@1.31.0:
     optional: true
 
-  lightningcss-linux-arm-gnueabihf@1.30.2:
+  lightningcss-linux-arm-gnueabihf@1.31.0:
     optional: true
 
-  lightningcss-linux-arm64-gnu@1.30.2: {}
+  lightningcss-linux-arm64-gnu@1.31.0: {}
 
-  lightningcss-linux-arm64-musl@1.30.2: {}
+  lightningcss-linux-arm64-musl@1.31.0: {}
 
-  lightningcss-linux-x64-gnu@1.30.2: {}
+  lightningcss-linux-x64-gnu@1.31.0: {}
 
-  lightningcss-linux-x64-musl@1.30.2: {}
+  lightningcss-linux-x64-musl@1.31.0: {}
 
-  lightningcss-win32-arm64-msvc@1.30.2:
+  lightningcss-win32-arm64-msvc@1.31.0:
     optional: true
 
-  lightningcss-win32-x64-msvc@1.30.2: {}
+  lightningcss-win32-x64-msvc@1.31.0: {}
 
-  lightningcss@1.30.2(patch_hash=tzyxy3asfxcqc7ihrooumyi5fm):
+  lightningcss@1.31.0:
     dependencies:
-      detect-libc: 2.0.4
+      detect-libc: 2.1.2
     optionalDependencies:
-      lightningcss-android-arm64: 1.30.2
-      lightningcss-darwin-arm64: 1.30.2
-      lightningcss-darwin-x64: 1.30.2
-      lightningcss-freebsd-x64: 1.30.2
-      lightningcss-linux-arm-gnueabihf: 1.30.2
-      lightningcss-linux-arm64-gnu: 1.30.2
-      lightningcss-linux-arm64-musl: 1.30.2
-      lightningcss-linux-x64-gnu: 1.30.2
-      lightningcss-linux-x64-musl: 1.30.2
-      lightningcss-win32-arm64-msvc: 1.30.2
-      lightningcss-win32-x64-msvc: 1.30.2
+      lightningcss-android-arm64: 1.31.0
+      lightningcss-darwin-arm64: 1.31.0
+      lightningcss-darwin-x64: 1.31.0
+      lightningcss-freebsd-x64: 1.31.0
+      lightningcss-linux-arm-gnueabihf: 1.31.0
+      lightningcss-linux-arm64-gnu: 1.31.0
+      lightningcss-linux-arm64-musl: 1.31.0
+      lightningcss-linux-x64-gnu: 1.31.0
+      lightningcss-linux-x64-musl: 1.31.0
+      lightningcss-win32-arm64-msvc: 1.31.0
+      lightningcss-win32-x64-msvc: 1.31.0
 
   lilconfig@2.1.0: {}
 
@@ -8595,7 +8592,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@7.0.0(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.30.2(patch_hash=tzyxy3asfxcqc7ihrooumyi5fm))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0):
+  vite@7.0.0(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.31.0)(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0):
     dependencies:
       esbuild: 0.25.0
       fdir: 6.4.6(picomatch@4.0.2)
@@ -8607,15 +8604,15 @@ snapshots:
       '@types/node': 20.19.1
       fsevents: 2.3.3
       jiti: 2.6.1
-      lightningcss: 1.30.2(patch_hash=tzyxy3asfxcqc7ihrooumyi5fm)
+      lightningcss: 1.31.0
       terser: 5.31.6
       tsx: 4.19.1
       yaml: 2.6.0
 
-  vitest@4.0.12(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.30.2(patch_hash=tzyxy3asfxcqc7ihrooumyi5fm))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0):
+  vitest@4.0.12(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.31.0)(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0):
     dependencies:
       '@vitest/expect': 4.0.12
-      '@vitest/mocker': 4.0.12(vite@7.0.0(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.30.2(patch_hash=tzyxy3asfxcqc7ihrooumyi5fm))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0))
+      '@vitest/mocker': 4.0.12(vite@7.0.0(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.31.0)(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0))
       '@vitest/pretty-format': 4.0.12
       '@vitest/runner': 4.0.12
       '@vitest/snapshot': 4.0.12
@@ -8632,7 +8629,7 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.0.0(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.30.2(patch_hash=tzyxy3asfxcqc7ihrooumyi5fm))(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0)
+      vite: 7.0.0(@types/node@20.19.1)(jiti@2.6.1)(lightningcss@1.31.0)(terser@5.31.6)(tsx@4.19.1)(yaml@2.6.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,11 +9,11 @@ catalog:
   '@types/node': ^20.19.0
   prettier: 3.6.2
   vite: ^7.0.0
-  lightningcss: 1.30.2
-  lightningcss-darwin-arm64: 1.30.2
-  lightningcss-darwin-x64: 1.30.2
-  lightningcss-linux-arm64-gnu: 1.30.2
-  lightningcss-linux-arm64-musl: 1.30.2
-  lightningcss-linux-x64-gnu: 1.30.2
-  lightningcss-linux-x64-musl: 1.30.2
-  lightningcss-win32-x64-msvc: 1.30.2
+  lightningcss: 1.31.0
+  lightningcss-darwin-arm64: 1.31.0
+  lightningcss-darwin-x64: 1.31.0
+  lightningcss-linux-arm64-gnu: 1.31.0
+  lightningcss-linux-arm64-musl: 1.31.0
+  lightningcss-linux-x64-gnu: 1.31.0
+  lightningcss-linux-x64-musl: 1.31.0
+  lightningcss-win32-x64-msvc: 1.31.0


### PR DESCRIPTION
## Summary

Upgrade lightningcss to [1.31.0](https://github.com/parcel-bundler/lightningcss/releases/tag/v1.31.0), mainly to [add support for scroll-state container queries](https://github.com/parcel-bundler/lightningcss/issues/887)

## Test plan

I ran `pnpm test` and got 25 failed tests, that's 3 more than there were with lightningcss 1.30.2 Not sure how to proceed.
