### PR TITLE
Update vulnerable dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,19 @@
     "patchedDependencies": {
       "lightningcss@1.30.2": "patches/lightningcss@1.30.2.patch",
       "@parcel/watcher@2.5.1": "patches/@parcel__watcher@2.5.1.patch"
+    },
+    "overrides": {
+      "micromatch@<4.0.8": ">=4.0.8",
+      "esbuild@<=0.24.2": ">=0.25.0",
+      "brace-expansion@>=1.0.0 <=1.1.11": ">=1.1.12",
+      "brace-expansion@>=2.0.0 <=2.0.1": ">=2.0.2",
+      "vite@>=7.0.0 <=7.0.6": ">=7.0.7",
+      "vite@>=7.0.0 <=7.0.7": ">=7.0.8",
+      "nanoid@<3.3.8": ">=3.3.8",
+      "js-yaml@>=4.0.0 <4.1.1": ">=4.1.1",
+      "glob@>=10.2.0 <10.5.0": ">=10.5.0",
+      "node-forge@<1.3.2": ">=1.3.2",
+      "h3@<=1.15.4": ">=1.15.5"
     }
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,4 @@
+// configuration file
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({


### PR DESCRIPTION
This update makes the following changes:
  "micromatch@<4.0.8": ">=4.0.8",
  "esbuild@<=0.24.2": ">=0.25.0",
  "brace-expansion@>=1.0.0 <=1.1.11": ">=1.1.12",
  "brace-expansion@>=2.0.0 <=2.0.1": ">=2.0.2",
  "vite@>=7.0.0 <=7.0.6": ">=7.0.7",
  "vite@>=7.0.0 <=7.0.7": ">=7.0.8",
  "nanoid@<3.3.8": ">=3.3.8",
  "js-yaml@>=4.0.0 <4.1.1": ">=4.1.1",
  "glob@>=10.2.0 <10.5.0": ">=10.5.0",
  "node-forge@<1.3.2": ">=1.3.2",
  "h3@<=1.15.4": ">=1.15.5"