### PR TITLE
[tailwindcss-vite] Add Register dependency messages logline

### DIFF
--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -375,6 +375,7 @@ class Root {
     }
 
     if (this.compiler.features & Features.Utilities) {
+      DEBUG && I.start('Register dependency messages')
       // Watch individual files found via custom `@source` paths
       for (let file of this.scanner.files) {
         addWatchFile(file)
@@ -411,6 +412,7 @@ class Root {
           }
         }
       }
+      DEBUG && I.end('Register dependency messages')
     }
 
     DEBUG && I.start('Build CSS')


### PR DESCRIPTION
The PostCSS implementation has a debug logline for registering dependencies but this is missing for @tailwindcss/vite.

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create a discussion to first discuss any significant new features.

For more info, check out the contributing guide:

https://github.com/tailwindcss/tailwindcss/blob/main/.github/CONTRIBUTING.md

-->

## Summary

Adds the "Register dependency messages" instrumentation span to the Vite plugin's dependency registration code, matching the existing implementation in @tailwindcss/postcss.

This ensures consistent debug instrumentation across both bundler integrations when DEBUG is enabled.

<!--

Provide a summary of the issue and the changes you're making. How does your change solve the problem?

-->

## Test plan

<!--

Explain how you tested your changes. Include the exact commands that you used to verify the change works and include screenshots/screen recordings of the update behavior in the browser if applicable.

-->
