### PR TITLE
docs: add community links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ For full documentation, visit [tailwindcss.com](https://tailwindcss.com).
 
 For help, discussion about best practices, or feature ideas:
 
-[Discuss Tailwind CSS on GitHub](https://github.com/tailwindcss/tailwindcss/discussions)
+- [GitHub Discussions](https://github.com/tailwindcss/tailwindcss/discussions) — Ask questions and share ideas
+- [Discord](https://tailwindcss.com/discord) — Chat with the community in real-time
+- [Twitter](https://twitter.com/tailwindcss) — Follow for updates and announcements
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Enhanced the Community section in README.md by adding links to official community channels.

## Changes

Added:
- **Discord** link for real-time chat with the community
- **Twitter** link for official updates and announcements
- Reformatted as a bullet list for better readability

## Before

```markdown
## Community

For help, discussion about best practices, or feature ideas:

[Discuss Tailwind CSS on GitHub](https://github.com/tailwindcss/tailwindcss/discussions)
```

## After

```markdown
## Community

For help, discussion about best practices, or feature ideas:

- [GitHub Discussions](https://github.com/tailwindcss/tailwindcss/discussions) — Ask questions and share ideas
- [Discord](https://tailwindcss.com/discord) — Chat with the community in real-time
- [Twitter](https://twitter.com/tailwindcss) — Follow for updates and announcements
```

## Motivation

New users may not be aware of all the official community channels available. Having these links directly in the README makes it easier for users to find help and stay updated.