### PR TITLE
fix: support decimal values in aspect ratio utilities

### DIFF
--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -3156,15 +3156,20 @@ test('aspect-ratio', async () => {
         }
         @tailwind utilities;
       `,
-      ['aspect-video', 'aspect-[10/9]', 'aspect-4/3'],
+      ['aspect-video', 'aspect-[10/9]', 'aspect-4/3', 'aspect-8.5/11'],
     ),
   ).toMatchInlineSnapshot(`
-    ":root, :host {
+    "/*! tailwindcss v4.1.18 | MIT License | https://tailwindcss.com */
+    :root, :host {
       --aspect-video: 16 / 9;
     }
 
     .aspect-4\\/3 {
       aspect-ratio: 4 / 3;
+    }
+
+    .aspect-8\\.5\\/11 {
+      aspect-ratio: 8.5 / 11;
     }
 
     .aspect-\\[10\\/9\\] {

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -19,6 +19,7 @@ import { DefaultMap } from './utils/default-map'
 import {
   inferDataType,
   isPositiveInteger,
+  isPositiveNumber,
   isStrictPositiveInteger,
   isValidOpacityValue,
   isValidSpacingMultiplier,
@@ -981,7 +982,7 @@ export function createUtilities(theme: Theme) {
     handleBareValue: ({ fraction }) => {
       if (fraction === null) return null
       let [lhs, rhs] = segment(fraction, '/')
-      if (!isPositiveInteger(lhs) || !isPositiveInteger(rhs)) return null
+      if (!isPositiveNumber(lhs) || !isPositiveNumber(rhs)) return null
       return fraction
     },
     handle: (value) => [decl('aspect-ratio', value)],

--- a/packages/tailwindcss/src/utils/infer-data-type.ts
+++ b/packages/tailwindcss/src/utils/infer-data-type.ts
@@ -353,6 +353,14 @@ export function isStrictPositiveInteger(value: any) {
   return Number.isInteger(num) && num > 0 && String(num) === String(value)
 }
 
+/**
+ * Returns true if the value can be parsed as a positive number (integer or decimal).
+ */
+export function isPositiveNumber(value: any) {
+  let num = Number(value)
+  return Number.isFinite(num) && num >= 0 && String(num) === String(value)
+}
+
 export function isValidSpacingMultiplier(value: any) {
   return isMultipleOf(value, 0.25)
 }


### PR DESCRIPTION
## Problem

The `aspect-ratio` utility only accepts integer values for bare fractions (e.g. `aspect-4/3`), but the CSS `aspect-ratio` property supports any positive number. Using a decimal like `aspect-8.5/11` silently produces no output.

Reported in #19663.

## Solution

Added an `isPositiveNumber` helper (alongside the existing `isPositiveInteger`) that accepts finite non-negative numbers including decimals. Updated the `aspect` utility's `handleBareValue` to use `isPositiveNumber` instead of `isPositiveInteger`.

### Before
```html
<div class="aspect-8.5/11">  <!-- ❌ No CSS generated -->
```

### After
```html
<div class="aspect-8.5/11">  <!-- ✅ aspect-ratio: 8.5 / 11 -->
```

## Changes

- `packages/tailwindcss/src/utils/infer-data-type.ts` — Added `isPositiveNumber()` utility function
- `packages/tailwindcss/src/utilities.ts` — Changed aspect ratio validation from `isPositiveInteger` to `isPositiveNumber`
- `packages/tailwindcss/src/utilities.test.ts` — Added test case for `aspect-8.5/11`

Fixes #19663