### PR TITLE
Allow decimal values in aspect ratio utilities

### DIFF
--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -3156,7 +3156,7 @@ test('aspect-ratio', async () => {
         }
         @tailwind utilities;
       `,
-      ['aspect-video', 'aspect-[10/9]', 'aspect-4/3'],
+      ['aspect-video', 'aspect-[10/9]', 'aspect-4/3', 'aspect-8.5/11'],
     ),
   ).toMatchInlineSnapshot(`
     ":root, :host {
@@ -3165,6 +3165,10 @@ test('aspect-ratio', async () => {
 
     .aspect-4\\/3 {
       aspect-ratio: 4 / 3;
+    }
+
+    .aspect-8\\.5\\/11 {
+      aspect-ratio: 8.5 / 11;
     }
 
     .aspect-\\[10\\/9\\] {

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -19,6 +19,7 @@ import { DefaultMap } from './utils/default-map'
 import {
   inferDataType,
   isPositiveInteger,
+  isPositiveNumber,
   isStrictPositiveInteger,
   isValidOpacityValue,
   isValidSpacingMultiplier,
@@ -981,7 +982,7 @@ export function createUtilities(theme: Theme) {
     handleBareValue: ({ fraction }) => {
       if (fraction === null) return null
       let [lhs, rhs] = segment(fraction, '/')
-      if (!isPositiveInteger(lhs) || !isPositiveInteger(rhs)) return null
+      if (!isPositiveNumber(lhs) || !isPositiveNumber(rhs)) return null
       return fraction
     },
     handle: (value) => [decl('aspect-ratio', value)],

--- a/packages/tailwindcss/src/utils/infer-data-type.ts
+++ b/packages/tailwindcss/src/utils/infer-data-type.ts
@@ -353,6 +353,11 @@ export function isStrictPositiveInteger(value: any) {
   return Number.isInteger(num) && num > 0 && String(num) === String(value)
 }
 
+export function isPositiveNumber(value: any) {
+  let num = Number(value)
+  return Number.isFinite(num) && num > 0 && String(num) === String(value)
+}
+
 export function isValidSpacingMultiplier(value: any) {
   return isMultipleOf(value, 0.25)
 }


### PR DESCRIPTION
Fixes #19663

The `aspect-*` utility currently only accepts integer ratios (e.g. `aspect-4/3`) because `handleBareValue` validates both sides of the fraction with `isPositiveInteger`. This means perfectly valid ratios like `aspect-8.5/11` are silently dropped from the stylesheet.

CSS `aspect-ratio` supports any positive number ratio, so there's no reason to restrict it to integers. This PR adds an `isPositiveNumber` check and uses it for the aspect utility, so `aspect-8.5/11` now correctly generates:

```css
.aspect-8\.5\/11 {
  aspect-ratio: 8.5 / 11;
}
```

Tested by adding `aspect-8.5/11` to the existing aspect-ratio test case and confirming the output. All 382 utility tests pass, no regressions.