### PR TITLE
Correct CHANGELOG to mention inset not inline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-- Deprecate `start-*` and `end-*` utilities in favor of `inline-s-*` and `inline-e-*` utilities ([#19613](https://github.com/tailwindlabs/tailwindcss/pull/19613))
+- Deprecate `start-*` and `end-*` utilities in favor of `inset-s-*` and `inset-e-*` utilities ([#19613](https://github.com/tailwindlabs/tailwindcss/pull/19613))
 
 ## [4.1.18] - 2025-12-11
 


### PR DESCRIPTION
I noticed this when reading the changelog to migrate a project to the new version. I'm not sure whether retroactively changing the changelog is considered acceptable behaviour in this project or whether appending a notice in the next changelog would be better.

Funnily this was actually guessed in #19613, though hard to notice among the other many false guesses.