### PR TITLE
docs: improve contributing commands and playground instructions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -30,10 +30,18 @@ During development, you can run tests in watch mode:
 pnpm tdd
 ```
 
-The `playgrounds` directory contains example projects you can use to test your changes. To start the Vite playground, use:
+The `playgrounds` directory contains example projects you can use to test your changes.
+
+- Start the Vite playground:
 
 ```sh
 pnpm build && pnpm vite
+```
+
+- Start the Next.js playground:
+
+```sh
+pnpm build && pnpm nextjs
 ```
 
 ## Bug fixes
@@ -50,16 +58,18 @@ If you open a pull request for a new feature, we're likely to close it not becau
 
 ## Coding standards
 
-Our code formatting rules are defined in the `"prettier"` section of [package.json](https://github.com/tailwindlabs/tailwindcss/blob/main/package.json). You can check your code against these standards by running:
+Our code formatting rules are defined in the `"prettier"` section of [package.json](https://github.com/tailwindlabs/tailwindcss/blob/main/package.json).
+
+- Check formatting + linting:
 
 ```sh
-pnpm run lint
+pnpm lint
 ```
 
-To automatically fix any style violations in your code, you can run:
+- Fix formatting:
 
 ```sh
-pnpm run format
+pnpm format
 ```
 
 ## Running tests
@@ -98,6 +108,6 @@ When a pull request is created, Tailwind CSS maintainers will be notified automa
 
 ## Communication
 
-- **GitHub discussions**: For feature ideas and general questions
-- **GitHub issues**: For bug reports
-- **GitHub pull requests**: For code contributions
+- **GitHub Discussions**: For feature ideas and general questions
+- **GitHub Issues**: For bug reports
+- **GitHub Pull Requests**: For code contributions


### PR DESCRIPTION
## Summary
Tailwind’s contributing guide currently mixes command styles and omits a useful dev workflow:

- It uses `pnpm run lint` / `pnpm run format`, even though the repo defines the canonical scripts as `pnpm lint` / `pnpm format`.
- It documents how to start the Vite playground, but doesn’t mention the Next.js playground (even though a `nextjs` script exists).

This PR updates `.github/CONTRIBUTING.md` to:
- Prefer the canonical commands (`pnpm lint`, `pnpm format`) for consistency and copy/paste friendliness.
- Add Next.js playground instructions (`pnpm build && pnpm nextjs`) alongside the existing Vite example.
- Normalize capitalization in the “Communication” section (Discussions/Issues/Pull Requests).

## Test plan
- Verified the commands exist by checking the root `package.json` scripts: `lint`, `format`, `vite`, and `nextjs`.
- Ran Prettier check for the edited file: `pnpm prettier --check .github/CONTRIBUTING.md`