### PR TITLE
Fix missing extracted classes in mdx files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Allow trailing dash in functional utility names for backwards compatibility ([#19696](https://github.com/tailwindlabs/tailwindcss/pull/19696))
+- Fix missing extracted classes in mdx files containing `.` ([#19711](https://github.com/tailwindlabs/tailwindcss/pull/19711))
 
 ## [4.2.0] - 2026-02-18
 


### PR DESCRIPTION
In Tailwind CSS v4.1.14 we released a fix for a bug where we didn't extract classes used in markdown directives (https://github.com/tailwindlabs/tailwindcss/issues/18071). E.g.:

```md
= This can't be extracted

:span[Some Text]{.text-gray-500}

= But this can

text-gray-300
```

The fix was simple, we pre-process classes once we we are inside `{…}`. The pre-processing just replaces `.` with ` ` so the `text-gray-500` from above would be extracted properly.

This fix introduced a bug for mdx files if you use syntax like this:

```mdx
<Example>
{
  <div class="p-2.5"></div>
}
</Example>
```

This is the exact kind of syntax we use in our documentation as well. Because of this fix, we didn't properly extract the `p-2.5` class.

This new PR fixes that by ensuring that classes that are not top-level will stay as-is instead of being pre-processed. 

This fix assumes that when you have `<`, `{`, `[` or `(` somewhere after the initial `{` character then we start nesting. The moment we see `>`, `}`, `]` or `)` we end the current nesting level.

If we are not nesting anymore, only then do we pre-process the class again.

This fix is also a simple implementation (on purpose), there could be even more edge cases that we might run into (order of bracket types, non-matching brackets, strings, escaped values, skipping code blocks, etc.) but I only want to tackle those when we actually run into these issues.

It looks like nobody ran into this (I didn't see a bug report about it). So I don't think it's worth the effort to make it even more robust (and potentially more complex which could result in more bugs).

## Test plan

- Added a regression test for the mdx case
- Ensure the class is correctly extracted now:

Before:
<img width="1361" height="485" alt="image" src="https://github.com/user-attachments/assets/1c79b957-7bdd-40ee-b032-780e35af08ff" />


After:
<img width="1377" height="513" alt="image" src="https://github.com/user-attachments/assets/96bcdc56-d3a5-41f6-8104-0d226e960d55" />

