### PR TITLE
Fix webpack loader cache key for resource queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - _Experimental_: Add `@container-size` utility ([#18901](https://github.com/tailwindlabs/tailwindcss/pull/18901))
 
+### Fixed
+
+- Ensure query params in imports are considered unique resources when using `@tailwindcss/webpack` ([#19723](https://github.com/tailwindlabs/tailwindcss/pull/19723))
+
 ## [4.2.1] - 2026-02-23
 
 ### Fixed

--- a/integrations/webpack/loader.test.ts
+++ b/integrations/webpack/loader.test.ts
@@ -469,11 +469,11 @@ test(
       'query-loader.js': js`
         module.exports = function (source) {
           if (this.resourceQuery.includes('a')) {
-            return '@import "tailwindcss/utilities";\n\n@utility only-a {\n  color: var(--color-red-500);\n}\n'
+            return '@import "tailwindcss/utilities"; @utility only-a {color: var(--color-red-500);}'
           }
 
           if (this.resourceQuery.includes('b')) {
-            return '@import "tailwindcss/utilities";\n\n@utility only-b {\n  color: var(--color-blue-500);\n}\n'
+            return '@import "tailwindcss/utilities"; @utility only-b {color: var(--color-blue-500);}'
           }
 
           return source


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create a discussion to first discuss any significant new features.

For more info, check out the contributing guide:

https://github.com/tailwindlabs/tailwindcss/blob/main/.github/CONTRIBUTING.md

-->

## Summary

<!--

Provide a summary of the issue and the changes you're making. How does your change solve the problem?

-->

`@tailwindcss/webpack` currently uses `this.resourcePath` as the cache key, which ignores the resource query. When the same CSS file is imported multiple times with different `resourceQuery` values, all of those imports share a single `CacheEntry`. That means the utilities discovered for one entry can leak into the CSS output for another entry.

This PR changes the cache key to use `this.resource` (path + query) instead, while still using `this.resourcePath` for all filesystem work.

## Test plan

<!--

Explain how you tested your changes. Include the exact commands that you used to verify the change works and include screenshots/screen recordings of the update behavior in the browser if applicable.

-->

- `pnpm test:integrations -- webpack/loader.test.ts`  
  - Confirms all existing webpack loader integration tests pass.  
  - Confirms the new `@tailwindcss/webpack loader isolates cache by resource including query` test passes, verifying that two entries importing the same CSS file with different queries produce isolated outputs (`dist/a.css` only contains `only-a` / `--color-red-500`, and `dist/b.css` only contains `only-b` / `--color-blue-500`).
