### PR TITLE
Extract classes from interpolated expressions in Ruby

### DIFF
--- a/crates/oxide/src/extractor/pre_processors/ruby.rs
+++ b/crates/oxide/src/extractor/pre_processors/ruby.rs
@@ -388,6 +388,20 @@ mod tests {
         Ruby::test_extract_contains(input, vec!["z-1", "z-2", "z-3"]);
     }
 
+    // https://github.com/tailwindlabs/tailwindcss/issues/19728
+    #[test]
+    fn test_heredoc_with_unknown_language() {
+        let input = r#"
+            def width_class(width = nil)
+              <<~STYLE_CLASS
+                #{width || 'w-100'}
+              STYLE_CLASS
+            end
+        "#;
+
+        Ruby::test_extract_contains(input, vec!["w-100"]);
+    }
+
     // https://github.com/tailwindlabs/tailwindcss/issues/19239
     #[test]
     fn test_skip_comments() {

--- a/crates/oxide/src/extractor/pre_processors/ruby.rs
+++ b/crates/oxide/src/extractor/pre_processors/ruby.rs
@@ -124,7 +124,9 @@ impl PreProcessor for Ruby {
                 // Except for strict locals, these are defined in a `<%# locals: … %>`. Checking if
                 // the comment is preceded by a `%` should be enough without having to perform more
                 // parsing logic. Worst case we _do_ scan a few comments.
-                b'#' if !matches!(cursor.prev(), b'%') => {
+                //
+                // We also want to skip interpolation syntax, which look like `#{…}`.
+                b'#' if !matches!(cursor.prev(), b'%') && !matches!(cursor.next(), b'{') => {
                     result[cursor.pos] = b' ';
                     cursor.advance();
 
@@ -390,7 +392,7 @@ mod tests {
 
     // https://github.com/tailwindlabs/tailwindcss/issues/19728
     #[test]
-    fn test_heredoc_with_unknown_language() {
+    fn test_interpolated_expressions() {
         let input = r#"
             def width_class(width = nil)
               <<~STYLE_CLASS


### PR DESCRIPTION
This PR ensures that interpolated expressions in Ruby syntax are correctly extracted.

The issue was that we ignore comments in Ruby syntax (which start with `#`). We already made an exception for locals (`<%# locals: … %>`), but we also need to handle interpolated expressions (`#{ … }`) in the same way because they are not comments.

Fixes: #19728

## Test plan

1. Existing tests pass
2. Added a regression test for this scenario
3. Tested using the extractor on the given code snippet:

<img width="1461" height="1856" alt="image" src="https://github.com/user-attachments/assets/b48f7042-ca9d-4133-87ae-4c37c633c073" />

Notice that the `w-100` gets extracted now.
