### PR TITLE
test(upgrade): enable SCSS #{!important} @apply migration test

### DIFF
--- a/packages/@tailwindcss-upgrade/src/codemods/css/migrate-at-apply.test.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/css/migrate-at-apply.test.ts
@@ -61,8 +61,8 @@ it('should append `!` to each utility, when using `!important`', async () => {
   `)
 })
 
-// TODO: Handle SCSS syntax
-it.skip('should append `!` to each utility, when using `#{!important}`', async () => {
+// SCSS: Sass interpolation for !important is supported
+it('should append `!` to each utility, when using `#{!important}`', async () => {
   expect(
     await migrate(css`
       .foo {


### PR DESCRIPTION
## Summary
This PR enables coverage for Sass/SCSS `@apply` usage with interpolation (`#{!important}`) in the `@tailwindcss/upgrade` codemod.

The codemod already handles `#{!important}` in `migrate-at-apply.ts`, but the corresponding test was previously skipped with a TODO. This change removes the skip and updates the comment so CI will catch regressions and the supported behavior stays documented.

## Test plan
- Updated the existing unit test in `packages/@tailwindcss-upgrade/src/codemods/css/migrate-at-apply.test.ts` by un-skipping the `#{!important}` case and verifying the expected output snapshot.
- Local verification (limited in this environment): ensured lint/pre-commit formatting passes and that the change is isolated to tests only.

Recommended CI/local verification in a full dev environment (with Rust toolchain available):
```sh
pnpm install
pnpm test
