### PR TITLE
docs: prefer pnpm script shorthand in contributing guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -53,13 +53,13 @@ If you open a pull request for a new feature, we're likely to close it not becau
 Our code formatting rules are defined in the `"prettier"` section of [package.json](https://github.com/tailwindlabs/tailwindcss/blob/main/package.json). You can check your code against these standards by running:
 
 ```sh
-pnpm run lint
+pnpm lint
 ```
 
 To automatically fix any style violations in your code, you can run:
 
 ```sh
-pnpm run format
+pnpm format
 ```
 
 ## Running tests


### PR DESCRIPTION
## Summary
This PR updates the contributing guide to use pnpm’s script shorthand for consistency and copy/paste friendliness:

- `pnpm run lint` → `pnpm lint`
- `pnpm run format` → `pnpm format`

These commands are equivalent, but the shorthand matches the rest of the repo’s script usage and reduces noise in documentation.

## Test plan
- Verified the `lint` and `format` scripts exist in the root `package.json`.
- Ran Prettier formatting check on the edited file:

```sh
pnpm prettier --check .github/CONTRIBUTING.md