### PR TITLE
fix(node): handle character class globs in source() root check

### DIFF
--- a/packages/@tailwindcss-node/src/compile.test.ts
+++ b/packages/@tailwindcss-node/src/compile.test.ts
@@ -1,0 +1,27 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { expect, test } from 'vitest'
+import { compile } from './compile'
+
+test('source() accepts glob patterns with character classes', async () => {
+  let base = await fs.mkdtemp(path.join(process.cwd(), '.tmp-tailwind-source-glob-'))
+
+  try {
+    await fs.mkdir(path.join(base, 'src'), { recursive: true })
+
+    let compiler = await compile('@import "tailwindcss" source("./src/[a-z]/**/*.html");', {
+      base,
+      onDependency() {},
+      customCssResolver(id) {
+        if (id === 'tailwindcss') {
+          return path.join(process.cwd(), 'packages/tailwindcss/index.css')
+        }
+      },
+    })
+
+    let css = compiler.build(['underline'])
+    expect(css).toContain('.underline')
+  } finally {
+    await fs.rm(base, { recursive: true, force: true })
+  }
+})

--- a/packages/@tailwindcss-node/src/compile.ts
+++ b/packages/@tailwindcss-node/src/compile.ts
@@ -68,7 +68,9 @@ async function ensureSourceDetectionRootExists(compiler: {
 }) {
   // Verify if the `source(…)` path exists (until the glob pattern starts)
   if (compiler.root && compiler.root !== 'none') {
-    let globSymbols = /[*{]/
+    // Detect common glob metacharacters so we only verify the static path prefix.
+    // This includes `[]` character classes and `?` wildcards in addition to `*` and `{}`.
+    let globSymbols = /[*{[?]/
     let basePath = []
     for (let segment of compiler.root.pattern.split('/')) {
       if (globSymbols.test(segment)) {


### PR DESCRIPTION
## Summary

Fixes a false-positive validation error when using `source(...)` with glob character classes such as `[a-z]`.

`@tailwindcss/node` validates that the static prefix of the `source(...)` path exists before scanning. The previous implementation only treated `*` and `{` as glob markers, so patterns like `./src/[a-z]/**/*.html` were interpreted as literal directories and failed with:

> The `source(...)` does not exist or is not a directory.

This change updates the static-prefix detection to also stop at `[` and `?`, which are also valid glob metacharacters.

## Changes

- In `ensureSourceDetectionRootExists`, expand glob-symbol detection from `/[*{]/` to `/[*{[?]/`.
- Add `compile.test.ts` in `@tailwindcss/node` to cover `source("./src/[a-z]/**/*.html")` and verify compilation succeeds.

## Test plan

- `pnpm vitest packages/@tailwindcss-node/src/compile.test.ts`
- `pnpm vitest packages/@tailwindcss-node/src/*.test.ts`
