### PR TITLE
Fix custom spacing values shadowing leading-none staticValues

### DIFF
--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -24618,6 +24618,38 @@ test('leading', async () => {
   `)
 })
 
+test('leading-none is not shadowed by --spacing-none', async () => {
+  expect(
+    await compileCss(
+      css`
+        @theme {
+          --spacing-none: 0;
+        }
+        @tailwind utilities;
+      `,
+      ['leading-none'],
+    ),
+  ).toMatchInlineSnapshot(`
+    "@layer properties {
+      @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
+        *, :before, :after, ::backdrop {
+          --tw-leading: initial;
+        }
+      }
+    }
+
+    .leading-none {
+      --tw-leading: 1;
+      line-height: 1;
+    }
+
+    @property --tw-leading {
+      syntax: "*";
+      inherits: false
+    }"
+  `)
+})
+
 test('tracking', async () => {
   expect(
     await compileCss(

--- a/packages/tailwindcss/src/utilities.ts
+++ b/packages/tailwindcss/src/utilities.ts
@@ -414,10 +414,24 @@ export function createUtilities(theme: Theme) {
           value = candidate.value.value
           dataType = candidate.value.dataType
         } else {
-          value = theme.resolve(
-            candidate.value.fraction ?? candidate.value.value,
-            desc.themeKeys ?? [],
-          )
+          let resolvedValue = candidate.value.fraction ?? candidate.value.value
+
+          // First try resolving against just the primary theme key.
+          value = theme.resolve(resolvedValue, desc.themeKeys?.slice(0, 1) ?? [])
+
+          // If the primary theme key didn't match, check static values before
+          // falling back to secondary theme keys (like `--spacing`). This
+          // ensures e.g. `leading-none` produces `line-height: 1` even when
+          // `--spacing-none` is defined in the theme.
+          if (value === null && !negative && desc.staticValues && !candidate.modifier) {
+            let fallback = desc.staticValues[candidate.value.value]
+            if (fallback) return fallback.map(cloneAstNode)
+          }
+
+          // Fall back to the full set of theme keys.
+          if (value === null) {
+            value = theme.resolve(resolvedValue, desc.themeKeys ?? [])
+          }
 
           // Automatically handle things like `w-1/2` without requiring `1/2` to
           // exist as a theme value.
@@ -438,11 +452,6 @@ export function createUtilities(theme: Theme) {
           if (value === null && desc.handleBareValue) {
             value = desc.handleBareValue(candidate.value)
             if (!value?.includes('/') && candidate.modifier) return
-          }
-
-          if (value === null && !negative && desc.staticValues && !candidate.modifier) {
-            let fallback = desc.staticValues[candidate.value.value]
-            if (fallback) return fallback.map(cloneAstNode)
           }
         }
 


### PR DESCRIPTION
## Summary

Fixes #19722

When defining `--spacing-none: 0` in `@theme`, the `leading-none` utility incorrectly produces `line-height: 0` instead of `line-height: 1`. This happens because `theme.resolve('none', ['--leading', '--spacing'])` finds `--spacing-none` before checking the `staticValues` fallback where `none` maps to `line-height: 1`.

The fix changes `functionalUtility()` to resolve against only the primary theme key first, check `staticValues` before falling back to secondary theme keys. This preserves the existing behavior where an explicit `--leading-none` in the theme would still override the static value.

## Test plan

- Added test: "leading-none is not shadowed by --spacing-none" that defines `--spacing-none: 0` and verifies `leading-none` still produces `line-height: 1`
- All 4621 existing tests pass
- `pnpm build && pnpm test` passes

This contribution was developed with AI assistance (Claude Code).