### PR TITLE
fix(upgrade): use v3 config content patterns when no @source is set

### DIFF
--- a/packages/@tailwindcss-upgrade/src/codemods/template/migrate.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/template/migrate.ts
@@ -123,8 +123,8 @@ export async function migrate(designSystem: DesignSystem, userConfig: Config | n
   let fullPath = path.isAbsolute(file) ? file : path.resolve(process.cwd(), file)
   let contents = await fs.readFile(fullPath, 'utf-8')
 
-  await fs.writeFile(
-    fullPath,
-    await migrateContents(designSystem, userConfig, contents, extname(file)),
-  )
+  let migrated = await migrateContents(designSystem, userConfig, contents, extname(file))
+  if (migrated !== contents) {
+    await fs.writeFile(fullPath, migrated)
+  }
 }

--- a/packages/@tailwindcss-upgrade/src/index.ts
+++ b/packages/@tailwindcss-upgrade/src/index.ts
@@ -293,6 +293,8 @@ async function run() {
         let designSystem = await sheet.designSystem()
         if (!designSystem) continue
 
+        let config = configBySheet.get(sheet)
+
         // Figure out the source files to migrate
         let sources = (() => {
           // Disable auto source detection
@@ -300,16 +302,20 @@ async function run() {
             return []
           }
 
-          // No root specified, use the base directory
+          // No root specified — during a v3→v4 migration the CSS entrypoint won't
+          // have an @source directive yet. Use the content patterns from the v3 JS
+          // config if available, rather than falling back to '**/*' which would
+          // scan every file in the project (including migrations, vendor files, etc.).
           if (compiler.root === null) {
+            if (config?.sources && config.sources.length > 0) {
+              return config.sources
+            }
             return [{ base, pattern: '**/*', negated: false }]
           }
 
           // Use the specified root
           return [{ ...compiler.root, negated: false }]
         })().concat(compiler.sources)
-
-        let config = configBySheet.get(sheet)
         let scanner = new Scanner({ sources })
         let filesToMigrate = []
         for (let file of scanner.files) {


### PR DESCRIPTION
## Summary

Fixes two main problems I've come across on every project i try tp upgrade from v3 to v4:

1. It ignores my tailwind.config.js's content and tries to go through every single file in the project.
2. It wipes out files, and since it goes through every single file, it just wipes out all files.

When migrating from v3 to v4, the CSS entrypoint has no `@source` directive yet, leaving compiler.root as null. The fallback to '**/*' caused the tool to scan every file in the project (PHP migrations, config files, etc.) and unconditionally write them all back to disk.

Proposed solution:

- Use the v3 JS config's content patterns (config.sources) as the scan scope when compiler.root is null, falling back to '**/*' only when no config sources are available
- Skip fs.writeFile when the migrated content is identical to the original

This is likely a bug introduced from allowing the upgrade tool to also run on tailwind v4 projects.

https://github.com/tailwindlabs/tailwindcss/commit/8e826b18f3997970503508817ef2fd2b249d3009

