### PR TITLE
Fix internal source map warnings

### DIFF
--- a/packages/@tailwindcss-node/src/source-maps.test.ts
+++ b/packages/@tailwindcss-node/src/source-maps.test.ts
@@ -1,0 +1,8 @@
+import { expect, it } from 'vitest'
+import { toSourceMap } from './source-maps'
+
+it('should emit source maps', () => {
+  let map = toSourceMap('{"version":3,"sources":[],"names":[],"mappings":""}')
+
+  expect(map.comment('app.css.map')).toBe('/*# sourceMappingURL=app.css.map */\n')
+})

--- a/packages/@tailwindcss-node/src/source-maps.ts
+++ b/packages/@tailwindcss-node/src/source-maps.ts
@@ -46,7 +46,7 @@ export function toSourceMap(map: DecodedSourceMap | string): SourceMap {
   let raw = typeof map === 'string' ? map : serializeSourceMap(map)
 
   function comment(url: string) {
-    return `/*# sourceMappingURL=${url} */\n`
+    return `/*# sourceMappingURL\x3d${url} */\n`
   }
 
   return {


### PR DESCRIPTION
This PR fixes an internal source map warning when running tests. To solve this, we encode the `=` as `\x3d` instead. I'm not 100% sure if Vitest was hanging on this but it solved the following warning:

```
 ✓  @tailwindcss/cli  src/utils/format-ns.test.ts (21 tests) 3ms
11:43:59 AM [vite] (ssr) Failed to load source map for /Users/robin/github.com/tailwindlabs/tailwindcss/packages/@tailwindcss-node/dist/index.mjs.
Error: An error occurred while trying to read the map file at ${i}
Error: ENOENT: no such file or directory, open '/Users/robin/github.com/tailwindlabs/tailwindcss/packages/@tailwindcss-node/dist/${i}'
    at open (node:internal/fs/promises:634:25)
    at Object.readFile (node:internal/fs/promises:1238:14)
    at extractSourcemapFromFile (file:///Users/robin/github.com/tailwindlabs/tailwindcss/node_modules/.pnpm/vite@7.0.0_@types+node@20.19.1_jiti@2.6.1_lightningcss@1.31.1_patch_hash=tzyxy3asfxcqc7ihroou_7epcep7uhfc7zidzdmxzgvdzwi/node_modules/vite/dist/node/chunks/dep-Bsx9IwL8.js:8349:65)
    at loadAndTransform (file:///Users/robin/github.com/tailwindlabs/tailwindcss/node_modules/.pnpm/vite@7.0.0_@types+node@20.19.1_jiti@2.6.1_lightningcss@1.31.1_patch_hash=tzyxy3asfxcqc7ihroou_7epcep7uhfc7zidzdmxzgvdzwi/node_modules/vite/dist/node/chunks/dep-Bsx9IwL8.js:26405:22)
```

## Test plan

1. Existing tests pass
2. Added a failing test to ensure that the source maps are emitted correctly
