### PR TITLE
fix: remove unused braces dependencies

### DIFF
--- a/packages/@tailwindcss-upgrade/package.json
+++ b/packages/@tailwindcss-upgrade/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "@tailwindcss/node": "workspace:*",
     "@tailwindcss/oxide": "workspace:*",
-    "braces": "^3.0.3",
     "dedent": "1.7.1",
     "enhanced-resolve": "^5.19.0",
     "globby": "^15.0.0",
@@ -46,7 +45,6 @@
     "tree-sitter-typescript": "^0.23.2"
   },
   "devDependencies": {
-    "@types/braces": "^3.0.5",
     "@types/node": "catalog:",
     "@types/postcss-import": "^14.0.3",
     "@types/semver": "^7.7.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,9 +370,6 @@ importers:
       '@tailwindcss/oxide':
         specifier: workspace:*
         version: link:../../crates/node
-      braces:
-        specifier: ^3.0.3
-        version: 3.0.3
       dedent:
         specifier: 1.7.1
         version: 1.7.1
@@ -416,9 +413,6 @@ importers:
         specifier: ^0.23.2
         version: 0.23.2(tree-sitter@0.22.4)
     devDependencies:
-      '@types/braces':
-        specifier: ^3.0.5
-        version: 3.0.5
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.1
@@ -2540,9 +2534,6 @@ packages:
 
   '@types/babel__traverse@7.20.6':
     resolution: {integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==}
-
-  '@types/braces@3.0.5':
-    resolution: {integrity: sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==}
 
   '@types/bun@1.3.9':
     resolution: {integrity: sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw==}
@@ -6615,8 +6606,6 @@ snapshots:
   '@types/babel__traverse@7.20.6':
     dependencies:
       '@babel/types': 7.29.0
-
-  '@types/braces@3.0.5': {}
 
   '@types/bun@1.3.9':
     dependencies:


### PR DESCRIPTION
Removes unused braces and @types/braces from @tailwindcss/upgrade package.json as reported in issue #19794