### PR TITLE
Cleanup inconsistencies related to (regex) escapes

### DIFF
--- a/integrations/utils.ts
+++ b/integrations/utils.ts
@@ -569,7 +569,7 @@ export async function fetchStyles(base: string, path = '/'): Promise<string> {
   let index = await fetch(`${base}${path}`)
   let html = await index.text()
 
-  let linkRegex = /<link rel="stylesheet" href="([a-zA-Z0-9\/_\.\?=%-]+)"/gi
+  let linkRegex = /<link rel="stylesheet" href="([a-zA-Z0-9/_.?=%-]+)"/gi
   let styleRegex = /<style\b[^>]*>([\s\S]*?)<\/style>/gi
 
   let stylesheets: string[] = []

--- a/integrations/vite/react-router.test.ts
+++ b/integrations/vite/react-router.test.ts
@@ -196,7 +196,7 @@ test('build mode', { fs: WORKSPACE }, async ({ spawn, exec, expect }) => {
 
   let url = ''
   await process.onStdout((m) => {
-    let match = /\[react-router-serve\]\s*(http.*)\ \/?/.exec(m)
+    let match = /\[react-router-serve\]\s*(http.*) \/?/.exec(m)
     if (match) url = match[1]
     return url != ''
   })

--- a/integrations/vite/svelte.test.ts
+++ b/integrations/vite/svelte.test.ts
@@ -101,7 +101,7 @@ test(
     await fs.expectFileToContain(files[0][0], [
       candidate`underline`,
       '.global{color:var(--color-green-500,oklch(72.3% .219 149.579));animation:2s ease-in-out infinite globalKeyframes}',
-      /\.local.svelte-.*\{color:var\(--color-red-500\,oklch\(63\.7% \.237 25\.331\)\);animation:2s ease-in-out infinite svelte-.*-localKeyframes\}/,
+      /\.local.svelte-.*\{color:var\(--color-red-500,oklch\(63\.7% \.237 25\.331\)\);animation:2s ease-in-out infinite svelte-.*-localKeyframes\}/,
       /@keyframes globalKeyframes\{/,
       /@keyframes svelte-.*-localKeyframes\{/,
     ])

--- a/packages/@tailwindcss-node/src/urls.ts
+++ b/packages/@tailwindcss-node/src/urls.ts
@@ -154,7 +154,7 @@ function skipUrlReplacer(rawUrl: string, aliases?: string[]) {
   return (
     isExternalUrl(rawUrl) ||
     isDataUrl(rawUrl) ||
-    !rawUrl[0].match(/[\.a-zA-Z0-9_]/) ||
+    !rawUrl[0].match(/[.a-zA-Z0-9_]/) ||
     functionCallRE.test(rawUrl)
   )
 }

--- a/packages/@tailwindcss-postcss/src/index.test.ts
+++ b/packages/@tailwindcss-postcss/src/index.test.ts
@@ -43,7 +43,7 @@ test("`@import 'tailwindcss'` is replaced with the generated CSS", async () => {
   })
   expect(result.messages).toContainEqual({
     type: 'dir-dependency',
-    dir: expect.stringMatching(/example-project[\/|\\]src$/g),
+    dir: expect.stringMatching(/example-project[/|\\]src$/g),
     glob: expect.stringMatching(/^\*\*\/\*/g),
     parent: expect.any(String),
     plugin: expect.any(String),

--- a/packages/@tailwindcss-upgrade/src/codemods/config/migrate-postcss.ts
+++ b/packages/@tailwindcss-upgrade/src/codemods/config/migrate-postcss.ts
@@ -136,16 +136,16 @@ async function migratePostCSSJSConfig(configPath: string): Promise<{
   didRemovePostCSSImport: boolean
 } | null> {
   function isTailwindCSSPlugin(line: string) {
-    return /['"]?tailwindcss['"]?\: ?\{\}/.test(line)
+    return /['"]?tailwindcss['"]?: ?\{\}/.test(line)
   }
   function isPostCSSImportPlugin(line: string) {
-    return /['"]?postcss-import['"]?\: ?\{\}/.test(line)
+    return /['"]?postcss-import['"]?: ?\{\}/.test(line)
   }
   function isAutoprefixerPlugin(line: string) {
-    return /['"]?autoprefixer['"]?\: ?\{\}/.test(line)
+    return /['"]?autoprefixer['"]?: ?\{\}/.test(line)
   }
   function isTailwindCSSNestingPlugin(line: string) {
-    return /['"]tailwindcss\/nesting['"]\: ?(\{\}|['"]postcss-nesting['"])/.test(line)
+    return /['"]tailwindcss\/nesting['"]: ?(\{\}|['"]postcss-nesting['"])/.test(line)
   }
 
   info('Migrating PostCSS configuration…')

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -24,7 +24,7 @@ import * as vite from 'vite'
 const DEBUG = env.DEBUG
 const SPECIAL_QUERY_RE = /[?&](?:worker|sharedworker|raw|url)\b/
 const COMMON_JS_PROXY_RE = /\?commonjs-proxy/
-const INLINE_STYLE_ID_RE = /[?&]index\=\d+\.css$/
+const INLINE_STYLE_ID_RE = /[?&]index=\d+\.css$/
 
 export type PluginOptions = {
   /**
@@ -415,7 +415,7 @@ class Root {
       // crash Vite. We work around this for now by ignoring updates to them.
       //
       // https://github.com/tailwindlabs/tailwindcss/issues/16877
-      if (/[\#\?].*\.svg$/.test(file)) {
+      if (/[#?].*\.svg$/.test(file)) {
         return
       }
       _addWatchFile(file)

--- a/packages/tailwindcss/src/candidate.test.ts
+++ b/packages/tailwindcss/src/candidate.test.ts
@@ -2043,8 +2043,6 @@ const candidates = [
   ['bg-[var(--spacing)_-_1px]', 'bg-[var(--spacing)-1px]'],
   ['bg-[var(--_spacing)]', 'bg-(--_spacing)'],
   ['bg-(--_spacing)', 'bg-(--_spacing)'],
-  ['bg-[var(--\_spacing)]', 'bg-(--_spacing)'],
-  ['bg-(--\_spacing)', 'bg-(--_spacing)'],
   ['bg-[-1px_-1px]', 'bg-[-1px_-1px]'],
   ['p-[round(to-zero,1px)]', 'p-[round(to-zero,1px)]'],
   ['w-1/2', 'w-1/2'],

--- a/packages/tailwindcss/src/canonicalize-candidates.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.ts
@@ -92,7 +92,7 @@ interface DesignSystem extends BaseDesignSystem {
     [CANONICALIZE_UTILITY_KEY]: DefaultMap<InternalCanonicalizeOptions, DefaultMap<string, string>>
     [CONVERTER_KEY]: (input: string, options?: Convert) => [string, CandidateModifier | null]
     [SPACING_KEY]: DefaultMap<string, number | null> | null
-    [UTILITY_SIGNATURE_KEY]: DefaultMap<SignatureOptions, DefaultMap<string, string | Symbol>>
+    [UTILITY_SIGNATURE_KEY]: DefaultMap<SignatureOptions, DefaultMap<string, string | symbol>>
     [STATIC_UTILITIES_KEY]: DefaultMap<
       SignatureOptions,
       DefaultMap<string, DefaultMap<string, Set<string>>>
@@ -102,7 +102,7 @@ interface DesignSystem extends BaseDesignSystem {
       DefaultMap<string, DefaultMap<string, Set<string>>>
     >
     [PRE_COMPUTED_UTILITIES_KEY]: DefaultMap<SignatureOptions, DefaultMap<string, string[]>>
-    [VARIANT_SIGNATURE_KEY]: DefaultMap<string, string | Symbol>
+    [VARIANT_SIGNATURE_KEY]: DefaultMap<string, string | symbol>
     [PRE_COMPUTED_VARIANTS_KEY]: DefaultMap<string, string[]>
   }
 }
@@ -2095,7 +2095,7 @@ function createUtilitySignatureCache(
   designSystem: DesignSystem,
 ): DesignSystem['storage'][typeof UTILITY_SIGNATURE_KEY] {
   return new DefaultMap((options: SignatureOptions) => {
-    return new DefaultMap<string, string | Symbol>((utility) => {
+    return new DefaultMap<string, string | symbol>((utility) => {
       try {
         // Ensure the prefix is added to the utility if it is not already present.
         utility =
@@ -2463,7 +2463,7 @@ export const VARIANT_SIGNATURE_KEY = Symbol()
 function createVariantSignatureCache(
   designSystem: DesignSystem,
 ): DesignSystem['storage'][typeof VARIANT_SIGNATURE_KEY] {
-  return new DefaultMap<string, string | Symbol>((variant) => {
+  return new DefaultMap<string, string | symbol>((variant) => {
     try {
       // Ensure the prefix is added to the utility if it is not already present.
       variant =

--- a/packages/tailwindcss/src/compat/apply-config-to-theme.ts
+++ b/packages/tailwindcss/src/compat/apply-config-to-theme.ts
@@ -172,7 +172,7 @@ const OLD_TO_NEW_NAMESPACE: Record<string, string> = {
   transitionTimingFunction: 'ease',
 }
 
-const IS_VALID_KEY = /^[a-zA-Z0-9-_%/\.]+$/
+const IS_VALID_KEY = /^[a-zA-Z0-9-_%/.]+$/
 
 export function keyPathToCssProperty(path: string[]) {
   // In some special cases the `DEFAULT` key did not map to a "default" utility

--- a/packages/tailwindcss/src/css-parser.test.ts
+++ b/packages/tailwindcss/src/css-parser.test.ts
@@ -212,7 +212,7 @@ describe.each(['Unix', 'Windows'])('Line endings: %s', (lineEndings) => {
         {
           kind: 'declaration',
           property: 'content',
-          value: `'These are not the end \"\\' of the string'`,
+          value: `'These are not the end "\\' of the string'`,
           important: false,
         },
       ])

--- a/packages/tailwindcss/src/utils/infer-data-type.ts
+++ b/packages/tailwindcss/src/utils/infer-data-type.ts
@@ -184,7 +184,7 @@ function isPercentage(value: string): boolean {
 
 /* -------------------------------------------------------------------------- */
 
-const IS_FRACTION = new RegExp(`^${HAS_NUMBER.source}\s*/\s*${HAS_NUMBER.source}$`)
+const IS_FRACTION = new RegExp(`^${HAS_NUMBER.source}\\s*/\\s*${HAS_NUMBER.source}$`)
 
 function isFraction(value: string): boolean {
   return IS_FRACTION.test(value) || hasMathFn(value)


### PR DESCRIPTION
This PR does some generic cleanup to the codebase.

I'm playing with oxfmt and oxlint and noticed some unnecessary escapes. Might add these dependencies to the project later (and rolldown for building). But baby steps for now.

## Test plan

1. All tests should still pass
