### PR TITLE
fix(canonicalize): collapse arbitrary values into shorthand utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve canonicalizations for `tracking-*` utilities ([#19827](https://github.com/tailwindlabs/tailwindcss/pull/19827))
 - Fix crash due to invalid characters in candidate ([#19829](https://github.com/tailwindlabs/tailwindcss/pull/19829))
 - Ensure query params in imports are considered unique resources when using `@tailwindcss/webpack` ([#19723](https://github.com/tailwindlabs/tailwindcss/pull/19723))
+- Collapse arbitrary values into shorthand utilities during canonicalization ([#19837](https://github.com/tailwindlabs/tailwindcss/pull/19837))
 
 ## [4.2.2] - 2026-03-18
 

--- a/packages/tailwindcss/src/canonicalize-candidates.test.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.test.ts
@@ -1311,6 +1311,7 @@ test(
   },
 )
 
+// https://github.com/tailwindlabs/tailwindcss/issues/19835
 test('collapse canonicalization works for arbitrary values', { timeout }, async () => {
   let designSystem = await designSystems.get(__dirname).get(css`
     @import 'tailwindcss';

--- a/packages/tailwindcss/src/canonicalize-candidates.test.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.test.ts
@@ -1319,7 +1319,7 @@ test.each([
     ['text-left', 'p-[1.2rem]'],
   ],
 
-  // Arbitrary values could also be collapsed in a bare value
+  // Arbitrary values could also be collapsed into a bare value
   [
     ['px-[30.75rem]', 'py-[30.75rem]', 'text-left'],
     ['text-left', 'p-123'],

--- a/packages/tailwindcss/src/canonicalize-candidates.test.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.test.ts
@@ -1310,3 +1310,19 @@ test(
     )
   },
 )
+
+test('collapse canonicalization works for arbitrary values', { timeout }, async () => {
+  let designSystem = await designSystems.get(__dirname).get(css`
+    @import 'tailwindcss';
+  `)
+
+  let options: CanonicalizeOptions = {
+    collapse: true,
+    logicalToPhysical: true,
+    rem: 16,
+  }
+
+  expect(
+    designSystem.canonicalizeCandidates(['px-[1.2rem]', 'py-[1.2rem]', 'text-left'], options),
+  ).toEqual(['text-left', 'p-[1.2rem]'])
+})

--- a/packages/tailwindcss/src/canonicalize-candidates.test.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.test.ts
@@ -1312,18 +1312,32 @@ test(
 )
 
 // https://github.com/tailwindlabs/tailwindcss/issues/19835
-test('collapse canonicalization works for arbitrary values', { timeout }, async () => {
-  let designSystem = await designSystems.get(__dirname).get(css`
-    @import 'tailwindcss';
-  `)
+test.each([
+  // Arbitrary values should be collapsed to another arbitrary value
+  [
+    ['px-[1.2rem]', 'py-[1.2rem]', 'text-left'],
+    ['text-left', 'p-[1.2rem]'],
+  ],
 
-  let options: CanonicalizeOptions = {
-    collapse: true,
-    logicalToPhysical: true,
-    rem: 16,
-  }
+  // Arbitrary values could also be collapsed in a bare value
+  [
+    ['px-[30.75rem]', 'py-[30.75rem]', 'text-left'],
+    ['text-left', 'p-123'],
+  ],
+])(
+  'collapse canonicalization works for arbitrary values',
+  { timeout },
+  async (candidates, expected) => {
+    let designSystem = await designSystems.get(__dirname).get(css`
+      @import 'tailwindcss';
+    `)
 
-  expect(
-    designSystem.canonicalizeCandidates(['px-[1.2rem]', 'py-[1.2rem]', 'text-left'], options),
-  ).toEqual(['text-left', 'p-[1.2rem]'])
-})
+    let options: CanonicalizeOptions = {
+      collapse: true,
+      logicalToPhysical: true,
+      rem: 16,
+    }
+
+    expect(designSystem.canonicalizeCandidates(candidates, options)).toEqual(expected)
+  },
+)

--- a/packages/tailwindcss/src/canonicalize-candidates.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.ts
@@ -321,10 +321,7 @@ function collapseCandidates(options: InternalCanonicalizeOptions, candidates: st
       if (relevantProperties.size === 0) return result
 
       for (let parsedCandidate of parseCandidate(designSystem, candidate)) {
-        if (
-          parsedCandidate.kind !== 'functional' ||
-          parsedCandidate.value?.kind !== 'named' // Necessary for bare values
-        ) {
+        if (parsedCandidate.kind !== 'functional' || parsedCandidate.value === null) {
           continue
         }
 


### PR DESCRIPTION
The guard on `dynamicUtilities` restricted root-swapping to named values, so arbitrary values like `px-[1.2rem] py-[1.2rem]` were never collapsed into `p-[1.2rem]`.

This is what caused #19835 — in `--stream` mode, the collapse only happened if an earlier line caused the shorthand to be registered in `STATIC_UTILITIES_KEY` as a side effect, making the output non-deterministic. The underlying issue is that arbitrary value collapse wasn't supported at all.

The fix relaxes the guard from `parsedCandidate.value?.kind !== 'named'` to `parsedCandidate.value === null`. `cloneCandidate` and `printCandidate` already handle arbitrary values, so the root-swapping machinery works without other changes.

The iteration in `dynamicUtilities` is over `designSystem.utilities.keys('functional')` — a fixed set of roots, not input-proportional — so the performance cost of including arbitrary values should be negligible.

Fixes #19835.