### PR TITLE
fix error serving with older vite versions when config.css was not defined

### DIFF
--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -122,7 +122,7 @@ export default function tailwindcss(opts: PluginOptions = {}): Plugin[] {
       config!.root,
       // Currently, Vite only supports CSS source maps in development and they
       // are off by default. Check to see if we need them or not.
-      config?.css.devSourcemap ?? false,
+      config?.css?.devSourcemap ?? false,
       customCssResolver,
       customJsResolver,
     )


### PR DESCRIPTION
## Summary
When attempting to serve a Vue app using Vite 4.3.5 with the tailwind/vite plugin, I received the following error:

```
[vite] Internal server error: Cannot read properties of undefined (reading 'devSourcemap')
  Plugin: @tailwindcss/vite:generate:serve
```

The issue was a missing `?.` check. My `vite.config` file did not contain a `css` property and that crashed the plugin.

## Test plan
- In `pnpm-workspace.yaml`, change the vite version to `^4.3.5`.
- Run `pnpm install`
- In `playgrounds/vite`, run `pnpm build && pnpm vite`
- The example app should serve normally. Note that without the change from the PR, it fails to serve.