### PR TITLE
Use `json` preprocessor for new-line delimited JSON files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Canonicalization: migrate `end-full` → `inset-e-full`, `end-auto` → `inset-e-auto`, `end-px` → `inset-e-px`, and `end-<number>` → `inset-e-<number>` as well as negative versions ([#19849](https://github.com/tailwindlabs/tailwindcss/pull/19849))
 - Canonicalization: move the `-` sign inside the arbitrary value `-left-[9rem]` → `left-[-9rem]` ([#19858](https://github.com/tailwindlabs/tailwindcss/pull/19858))
 - Canonicalization: move the `-` sign outside the arbitrary value `ml-[calc(-1*var(--width))]` → `-ml-(--width)` ([#19858](https://github.com/tailwindlabs/tailwindcss/pull/19858))
+- Improve performance when scanning JSONL / NDJSON files ([#19862](https://github.com/tailwindlabs/tailwindcss/pull/19862))
 
 ## [4.2.2] - 2026-03-18
 

--- a/crates/oxide/src/scanner/mod.rs
+++ b/crates/oxide/src/scanner/mod.rs
@@ -474,7 +474,7 @@ pub fn pre_process_input(content: Vec<u8>, extension: &str) -> Vec<u8> {
         "heex" | "eex" | "ex" | "exs" => Elixir.process(&content),
         "cshtml" | "razor" => Razor.process(&content),
         "haml" => Haml.process(&content),
-        "json" => Json.process(&content),
+        "json" | "jsonl" | "ndjson" => Json.process(&content),
         "md" | "mdx" => Markdown.process(&content),
         "pug" => Pug.process(&content),
         "rb" | "erb" => Ruby.process(&content),


### PR DESCRIPTION
## Summary

This specializes the `.jsonl` and `.ndjson` file extensions so they're preprocessed like JSON instead of by the standard scanner. This prevents them from creating thousands of sub machines and reduces scanning time (see #17125 where this was done for `.json` files).

It seems reasonable to handle new-line delimited JSON files as well otherwise scanning these files can take quite a long time.

It's quite unlikely that these will contain classes so, alternatively, these *could* go in the binary extensions list so they get ignored entirely.

## Test plan

I ran manual tests inside the `oxide` crate against some large-ish JSONL files (5MB–15MB). These changes bring down scanning time from 2s–3s on my M3 Max (via `cargo test --release …`) to less than 20ms. 

I also ran tests through a full CLI build pipeline on a low-spec linux box. This change brought scanning time down from ~90s to ~300ms for a single ~15MB file.
