### PR TITLE
docs: clarify that PRs are also for documentation fixes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -100,4 +100,4 @@ When a pull request is created, Tailwind CSS maintainers will be notified automa
 
 - **GitHub discussions**: For feature ideas and general questions
 - **GitHub issues**: For bug reports
-- **GitHub pull requests**: For code contributions
+- **GitHub pull requests**: For code contributions and documentation fixes


### PR DESCRIPTION
Added "and documentation fixes" to the communication section to encourage users to contribute to docs as well.