### PR TITLE
feat: allow using @variant with stacked variants

### DIFF
--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -5673,8 +5673,8 @@ describe('@variant', () => {
     })
   })
 
-  describe('compound `@variant` rules', () => {
-    it('should handle compound variants', async () => {
+  describe('stacked `@variant` rules', () => {
+    it('should handle stacked variants', async () => {
       await expect(
         compileCss(
           css`
@@ -5702,7 +5702,7 @@ describe('@variant', () => {
       `)
     })
 
-    it('should handle compound variants & comma-separated variants', async () => {
+    it('should handle stacked variants & comma-separated variants', async () => {
       await expect(
         compileCss(
           css`

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -5588,6 +5588,46 @@ describe('@variant', () => {
       `)
     })
 
+    it('should handle missing variants (trailing comma)', async () => {
+      await expect(
+        compileCss(
+          css`
+            .btn {
+              background: black;
+
+              @variant hover,focus, {
+                background: red;
+              }
+            }
+            @tailwind utilities;
+          `,
+          [],
+        ),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[Error: Cannot use \`@variant\` with empty variant]`,
+      )
+    })
+
+    it('should handle missing variants (gap in the middle)', async () => {
+      await expect(
+        compileCss(
+          css`
+            .btn {
+              background: black;
+
+              @variant hover,,focus {
+                background: red;
+              }
+            }
+            @tailwind utilities;
+          `,
+          [],
+        ),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[Error: Cannot use \`@variant\` with empty variant]`,
+      )
+    })
+
     it('should handle nested comma-separated variants', async () => {
       await expect(
         compileCss(
@@ -5628,6 +5668,68 @@ describe('@variant', () => {
 
         .btn:focus:active, .btn:focus:disabled {
           background: #00f;
+        }"
+      `)
+    })
+  })
+
+  describe('compound `@variant` rules', () => {
+    it('should handle compound variants', async () => {
+      await expect(
+        compileCss(
+          css`
+            .btn {
+              background: black;
+
+              @variant hover:focus {
+                background: red;
+              }
+            }
+            @tailwind utilities;
+          `,
+          [],
+        ),
+      ).resolves.toMatchInlineSnapshot(`
+        ".btn {
+          background: #000;
+        }
+
+        @media (hover: hover) {
+          .btn:hover:focus {
+            background: red;
+          }
+        }"
+      `)
+    })
+
+    it('should handle compound variants & comma-separated variants', async () => {
+      await expect(
+        compileCss(
+          css`
+            .btn {
+              background: black;
+
+              @variant hover:focus, disabled {
+                background: red;
+              }
+            }
+            @tailwind utilities;
+          `,
+          [],
+        ),
+      ).resolves.toMatchInlineSnapshot(`
+        ".btn {
+          background: #000;
+        }
+
+        @media (hover: hover) {
+          .btn:hover:focus {
+            background: red;
+          }
+        }
+        
+        .btn:disabled {
+          background: red;
         }"
       `)
     })

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -5459,36 +5459,178 @@ describe('@variant', () => {
     `)
   })
 
-  it('should be possible to use comma-separated `@variant` rules', async () => {
-    await expect(
-      compileCss(
-        css`
-          .btn {
-            background: black;
+  describe('comma-separated `@variant` rules', () => {
+    it('should be possible to use comma-separated `@variant` rules', async () => {
+      await expect(
+        compileCss(
+          css`
+            .btn {
+              background: black;
 
-            @variant hover, focus {
-              background: red;
+              @variant hover, focus {
+                background: red;
+              }
             }
-          }
-          @tailwind utilities;
-        `,
-        [],
-      ),
-    ).resolves.toMatchInlineSnapshot(`
-      ".btn {
-        background: #000;
-      }
+            @tailwind utilities;
+          `,
+          [],
+        ),
+      ).resolves.toMatchInlineSnapshot(`
+        ".btn {
+          background: #000;
+        }
 
-      @media (hover: hover) {
-        .btn:hover {
+        @media (hover: hover) {
+          .btn:hover {
+            background: red;
+          }
+        }
+
+        .btn:focus {
+          background: red;
+        }"
+      `)
+    })
+
+    it('should handle three or more variants', async () => {
+      await expect(
+        compileCss(
+          css`
+            .btn {
+              background: black;
+
+              @variant hover, focus, active {
+                background: red;
+              }
+            }
+            @tailwind utilities;
+          `,
+          [],
+        ),
+      ).resolves.toMatchInlineSnapshot(`
+        ".btn {
+          background: #000;
+        }
+
+        @media (hover: hover) {
+          .btn:hover {
+            background: red;
+          }
+        }
+
+        .btn:focus, .btn:active {
+          background: red;
+        }"
+      `)
+    })
+
+    it('should handle whitespace variations (no space after comma)', async () => {
+      await expect(
+        compileCss(
+          css`
+            .btn {
+              background: black;
+
+              @variant hover,focus {
+                background: red;
+              }
+            }
+            @tailwind utilities;
+          `,
+          [],
+        ),
+      ).resolves.toMatchInlineSnapshot(`
+        ".btn {
+          background: #000;
+        }
+
+        @media (hover: hover) {
+          .btn:hover {
+            background: red;
+          }
+        }
+
+        .btn:focus {
+          background: red;
+        }"
+      `)
+    })
+
+    it('should handle whitespace variations (space before and after comma)', async () => {
+      await expect(
+        compileCss(
+          css`
+            .btn {
+              background: black;
+
+              @variant hover , focus {
+                background: red;
+              }
+            }
+            @tailwind utilities;
+          `,
+          [],
+        ),
+      ).resolves.toMatchInlineSnapshot(`
+        ".btn {
+          background: #000;
+        }
+
+        @media (hover: hover) {
+          .btn:hover {
+            background: red;
+          }
+        }
+
+        .btn:focus {
+          background: red;
+        }"
+      `)
+    })
+
+    it('should handle nested comma-separated variants', async () => {
+      await expect(
+        compileCss(
+          css`
+            .btn {
+              background: black;
+
+              @variant hover, focus {
+                background: red;
+
+                @variant active, disabled {
+                  background: blue;
+                }
+              }
+            }
+            @tailwind utilities;
+          `,
+          [],
+        ),
+      ).resolves.toMatchInlineSnapshot(`
+        ".btn {
+          background: #000;
+        }
+
+        @media (hover: hover) {
+          .btn:hover {
+            background: red;
+          }
+
+          .btn:hover:active, .btn:hover:disabled {
+            background: #00f;
+          }
+        }
+
+        .btn:focus {
           background: red;
         }
-      }
 
-      .btn:focus {
-        background: red;
-      }"
-    `)
+        .btn:focus:active, .btn:focus:disabled {
+          background: #00f;
+        }"
+      `)
+    })
   })
 
   it('should be possible to use `@variant` with a funky looking variants', async () => {

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -5459,6 +5459,38 @@ describe('@variant', () => {
     `)
   })
 
+  it('should be possible to use comma-separated `@variant` rules', async () => {
+    await expect(
+      compileCss(
+        css`
+          .btn {
+            background: black;
+
+            @variant hover, focus {
+              background: red;
+            }
+          }
+          @tailwind utilities;
+        `,
+        [],
+      ),
+    ).resolves.toMatchInlineSnapshot(`
+      ".btn {
+        background: #000;
+      }
+
+      @media (hover: hover) {
+        .btn:hover {
+          background: red;
+        }
+      }
+
+      .btn:focus {
+        background: red;
+      }"
+    `)
+  })
+
   it('should be possible to use `@variant` with a funky looking variants', async () => {
     await expect(
       compileCss(

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -1212,24 +1212,28 @@ export function substituteAtVariant(ast: AstNode[], designSystem: DesignSystem):
   walk(ast, (variantNode) => {
     if (variantNode.kind !== 'at-rule' || variantNode.name !== '@variant') return
 
-    // Starting with the `&` rule node
-    let node = styleRule('&', variantNode.nodes)
+    let variants = segment(variantNode.params, ',').map((variant) => variant.trim())
+    let nodes: AstNode[] = []
+    for (let variant of variants) {
+      // Starting with the `&` rule node
+      let node = styleRule('&', variantNode.nodes)
 
-    let variant = variantNode.params
+      let variantAst = designSystem.parseVariant(variant)
+      if (variantAst === null) {
+        throw new Error(`Cannot use \`@variant\` with unknown variant: ${variant}`)
+      }
 
-    let variantAst = designSystem.parseVariant(variant)
-    if (variantAst === null) {
-      throw new Error(`Cannot use \`@variant\` with unknown variant: ${variant}`)
-    }
+      let result = applyVariant(node, variantAst, designSystem.variants)
+      if (result === null) {
+        throw new Error(`Cannot use \`@variant\` with variant: ${variant}`)
+      }
 
-    let result = applyVariant(node, variantAst, designSystem.variants)
-    if (result === null) {
-      throw new Error(`Cannot use \`@variant\` with variant: ${variant}`)
+      nodes.push(node)
     }
 
     // Update the variant at-rule node, to be the `&` rule node
     features |= Features.Variants
-    return WalkAction.Replace(node)
+    return WalkAction.Replace(nodes)
   })
   return features
 }

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -1216,7 +1216,7 @@ export function substituteAtVariant(ast: AstNode[], designSystem: DesignSystem):
     let nodes: AstNode[] = []
     for (let variant of variants) {
       // Starting with the `&` rule node
-      let node = styleRule('&', variantNode.nodes)
+      let node = styleRule('&', variantNode.nodes.map(cloneAstNode))
 
       let variantAst = designSystem.parseVariant(variant)
       if (variantAst === null) {

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -1212,20 +1212,30 @@ export function substituteAtVariant(ast: AstNode[], designSystem: DesignSystem):
   walk(ast, (variantNode) => {
     if (variantNode.kind !== 'at-rule' || variantNode.name !== '@variant') return
 
-    let variants = segment(variantNode.params, ',').map((variant) => variant.trim())
+    let selectors = segment(variantNode.params, ',').map((variants: string) =>
+      segment(variants, ':')
+        .map((variant) => variant.trim())
+        .reverse(),
+    )
     let nodes: AstNode[] = []
-    for (let variant of variants) {
+    for (let variants of selectors) {
       // Starting with the `&` rule node
       let node = styleRule('&', variantNode.nodes.map(cloneAstNode))
 
-      let variantAst = designSystem.parseVariant(variant)
-      if (variantAst === null) {
-        throw new Error(`Cannot use \`@variant\` with unknown variant: ${variant}`)
-      }
+      for (let variant of variants) {
+        if (!variant) {
+          throw new Error(`Cannot use \`@variant\` with empty variant`)
+        }
 
-      let result = applyVariant(node, variantAst, designSystem.variants)
-      if (result === null) {
-        throw new Error(`Cannot use \`@variant\` with variant: ${variant}`)
+        let variantAst = designSystem.parseVariant(variant)
+        if (variantAst === null) {
+          throw new Error(`Cannot use \`@variant\` with unknown variant: ${variant}`)
+        }
+
+        let result = applyVariant(node, variantAst, designSystem.variants)
+        if (result === null) {
+          throw new Error(`Cannot use \`@variant\` with variant: ${variant}`)
+        }
       }
 
       nodes.push(node)

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -1212,13 +1212,13 @@ export function substituteAtVariant(ast: AstNode[], designSystem: DesignSystem):
   walk(ast, (variantNode) => {
     if (variantNode.kind !== 'at-rule' || variantNode.name !== '@variant') return
 
-    let selectors = segment(variantNode.params, ',').map((variants: string) =>
+    let stacks = segment(variantNode.params, ',').map((variants: string) =>
       segment(variants, ':')
         .map((variant) => variant.trim())
         .reverse(),
     )
     let nodes: AstNode[] = []
-    for (let variants of selectors) {
+    for (let variants of stacks) {
       // Starting with the `&` rule node
       let node = styleRule('&', variantNode.nodes.map(cloneAstNode))
 


### PR DESCRIPTION
Extends: https://github.com/tailwindlabs/tailwindcss/pull/19526
Rationale: https://github.com/tailwindlabs/tailwindcss/discussions/19883 

<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create a discussion to first discuss any significant new features.

For more info, check out the contributing guide:

https://github.com/tailwindlabs/tailwindcss/blob/main/.github/CONTRIBUTING.md

-->

## Summary

<!--

Provide a summary of the issue and the changes you're making. How does your change solve the problem?

-->

in css, you can now apply the same styles to stacked variants (similar to the inline syntax for class names) in one place. e.g.

```css
@variant hover:focus {
    background-color: red;
}
```

## Test plan

<!--

Explain how you tested your changes. Include the exact commands that you used to verify the change works and include screenshots/screen recordings of the update behavior in the browser if applicable.

-->

- all existing unit tests should pass
- created suggested missing tests for @variant with comma-separated values
- created new unit tests to test @variant with stacked variants