### PR TITLE
fix(node): use Module.registerHooks instead of deprecated Module.register for Node v26+

### DIFF
--- a/packages/@tailwindcss-node/src/index.ts
+++ b/packages/@tailwindcss-node/src/index.ts
@@ -14,8 +14,14 @@ if (!process.versions.bun) {
   let localRequire = Module.createRequire(import.meta.url)
 
   // `Module#register` was added in Node v18.19.0 and v20.6.0
+  // `Module#registerHooks` was added in Node v26.0.0 and is the preferred API
   //
   // Not calling it means that while ESM dependencies don't get reloaded, the
   // actual included files will because they cache bust directly via `?id=…`
-  Module.register?.(pathToFileURL(localRequire.resolve('@tailwindcss/node/esm-cache-loader')))
+  let loaderUrl = pathToFileURL(localRequire.resolve('@tailwindcss/node/esm-cache-loader'))
+  if (Module.registerHooks) {
+    Module.registerHooks({ resolve: loaderUrl })
+  } else {
+    Module.register?.(loaderUrl)
+  }
 }


### PR DESCRIPTION
## Description

Node.js v26 deprecated `Module.register()` in favor of `Module.registerHooks()`, causing a deprecation warning when using Tailwind CSS with Node v26:

```
[DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
```

This change uses the new `Module.registerHooks()` API when available (Node v26+), falling back to the old `Module.register()` API for older Node versions to maintain backward compatibility.

## Changes

- Check for `Module.registerHooks` first (new API in Node v26+)
- Fall back to `Module.register` for older Node versions
- Added comment explaining the version requirements

## Related Issue

Fixes #19893