### PR TITLE
docs/fix-lightning-css-typo-postcss-readme

### DIFF
--- a/packages/@tailwindcss-postcss/README.md
+++ b/packages/@tailwindcss-postcss/README.md
@@ -110,7 +110,7 @@ export default {
 }
 ```
 
-You may also pass options to `optimize` to enable Lighting CSS but prevent minification:
+You may also pass options to `optimize` to enable Lightning CSS but prevent minification:
 
 ```js
 import tailwindcss from '@tailwindcss/postcss'


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create a discussion to first discuss any significant new features.

For more info, check out the contributing guide:

https://github.com/tailwindlabs/tailwindcss/blob/main/.github/CONTRIBUTING.md

-->

## Summary
Fix a typo in the @tailwindcss/postcss README by changing Lighting CSS to Lightning CSS in the optimize option documentation.
<!--

Provide a summary of the issue and the changes you're making. How does your change solve the problem?

-->

## Test plan
Verified the README now says Lightning CSS and that the diff is docs-only.
<!--

Explain how you tested your changes. Include the exact commands that you used to verify the change works and include screenshots/screen recordings of the update behavior in the browser if applicable.

-->
