### PR TITLE
docs(postcss): remove duplicated optimize example from README

### DIFF
--- a/packages/@tailwindcss-postcss/README.md
+++ b/packages/@tailwindcss-postcss/README.md
@@ -110,17 +110,3 @@ export default {
 }
 ```
 
-You may also pass options to `optimize` to enable Lightning CSS but prevent minification:
-
-```js
-import tailwindcss from '@tailwindcss/postcss'
-
-export default {
-  plugins: [
-    tailwindcss({
-      // Enables Lightning CSS but disables minification
-      optimize: { minify: false },
-    }),
-  ],
-}
-```


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create a discussion to first discuss any significant new features.

For more info, check out the contributing guide:

https://github.com/tailwindlabs/tailwindcss/blob/main/.github/CONTRIBUTING.md

-->

## Summary

<!--

Provide a summary of the issue and the changes you're making. How does your change solve the problem?

-->
Removed a duplicated optimize: { minify: false } example from @tailwindcss/postcss README (doc-only, one file).

## Test plan

<!--

Explain how you tested your changes. Include the exact commands that you used to verify the change works and include screenshots/screen recordings of the update behavior in the browser if applicable.

-->
Check the duplicate block is removed, the earlier optimize example still exists, and only packages/@tailwindcss-postcss/README.md changed.
