### PR TITLE
fix: improve Windows Rust environment setup for build workflows

### DIFF
--- a/crates/node/package.json
+++ b/crates/node/package.json
@@ -50,12 +50,12 @@
   },
   "scripts": {
     "build": "pnpm run build:platform && pnpm run build:wasm",
-    "build:platform": "napi build --platform --release",
+    "build:platform": "node ../../scripts/run-task.mjs build -- napi build --platform --release",
     "postbuild:platform": "node ./scripts/move-artifacts.mjs",
-    "build:wasm": "napi build --release --target wasm32-wasip1-threads",
+    "build:wasm": "node ../../scripts/run-task.mjs build -- napi build --release --target wasm32-wasip1-threads",
     "postbuild:wasm": "node ./scripts/move-artifacts.mjs",
     "dev": "cargo watch --quiet --shell 'npm run build'",
-    "build:debug": "napi build --platform",
+    "build:debug": "node ../../scripts/run-task.mjs build -- napi build --platform",
     "version": "napi version"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,19 +32,20 @@
     ]
   },
   "scripts": {
+    "check:env": "node ./scripts/preflight.mjs doctor",
     "format": "prettier --write .",
     "lint": "prettier --check . && turbo lint",
-    "build": "turbo build --filter=!./playgrounds/*",
+    "build": "node ./scripts/run-task.mjs build",
     "postbuild": "node ./scripts/pack-packages.mjs",
-    "dev": "turbo dev --filter=!./playgrounds/*",
-    "test": "cargo test && vitest run --hideSkippedTests",
-    "test:integrations": "vitest --root=./integrations",
-    "test:ui": "pnpm run --filter=tailwindcss test:ui && pnpm run --filter=@tailwindcss/browser test:ui",
+    "dev": "node ./scripts/run-task.mjs dev",
+    "test": "node ./scripts/run-task.mjs test",
+    "test:integrations": "node ./scripts/run-task.mjs test:integrations",
+    "test:ui": "node ./scripts/run-task.mjs test:ui",
     "tdd": "vitest --hideSkippedTests",
     "bench": "vitest bench",
     "version-packages": "node ./scripts/version-packages.mjs",
-    "vite": "pnpm run --filter=vite-playground dev",
-    "nextjs": "pnpm run --filter=nextjs-playground dev"
+    "vite": "node ./scripts/run-task.mjs vite",
+    "nextjs": "node ./scripts/run-task.mjs nextjs"
   },
   "license": "MIT",
   "devDependencies": {

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -1,0 +1,179 @@
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { commandExists, hasDefaultCargoBin, readInstalledRustTargets, rustEnv } from './rust-env.mjs'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const root = path.resolve(__dirname, '..')
+const command = process.argv[2] ?? 'doctor'
+const wasmTarget = 'wasm32-wasip1-threads'
+
+const contexts = {
+  doctor: {
+    label: 'pnpm run check:env',
+    needsRust: true,
+    needsWasmTarget: true,
+  },
+  build: {
+    label: 'pnpm build',
+    needsRust: true,
+    needsWasmTarget: true,
+  },
+  dev: {
+    label: 'pnpm dev',
+    needsRust: true,
+    needsWasmTarget: true,
+  },
+  test: {
+    label: 'pnpm test',
+    needsRust: true,
+    needsWasmTarget: false,
+  },
+  'test:integrations': {
+    label: 'pnpm test:integrations',
+    needsRust: true,
+    needsWasmTarget: true,
+    needsBuildArtifacts: true,
+  },
+  'test:ui': {
+    label: 'pnpm test:ui',
+    needsRust: true,
+    needsWasmTarget: true,
+    needsBuildArtifacts: true,
+  },
+  vite: {
+    label: 'pnpm vite',
+    needsRust: true,
+    needsWasmTarget: true,
+    needsBuildArtifacts: true,
+    needsBun: true,
+  },
+  nextjs: {
+    label: 'pnpm nextjs',
+    needsRust: true,
+    needsWasmTarget: true,
+    needsBuildArtifacts: true,
+  },
+}
+
+const context = contexts[command] ?? contexts.doctor
+
+const requiredArtifacts = [
+  'crates/node/index.js',
+  'packages/tailwindcss/dist/lib.js',
+]
+
+function run(command, args) {
+  return spawnSync(command, args, {
+    cwd: root,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: rustEnv,
+  })
+}
+
+function formatList(items) {
+  return items.map((item) => `- ${item}`).join('\n')
+}
+
+function relativeArtifact(artifact) {
+  return artifact.replace(/\\/g, '/')
+}
+
+let errors = []
+let warnings = []
+
+if (context.needsRust) {
+  let missingRustTools = ['cargo', 'rustc'].filter((tool) => !commandExists(tool))
+
+  if (missingRustTools.length > 0) {
+    errors.push({
+      title: 'Missing required Rust tools',
+      body: [
+        formatList(missingRustTools),
+        'How to fix:',
+        '1. Install Rustup from https://rustup.rs/',
+        hasDefaultCargoBin()
+          ? '2. Rust appears to be installed in the default cargo directory, so rerun the command through the repo scripts such as `pnpm build` or `pnpm run check:env`.'
+          : '2. If you installed Rustup to a custom location, make sure `CARGO_HOME`, `RUSTUP_HOME`, or your PATH points at the installation.',
+        '3. Run `rustup default stable`.',
+        `4. Run \`rustup target add ${wasmTarget}\`.`,
+      ].join('\n'),
+    })
+  }
+
+  if (!commandExists('rustup')) {
+    warnings.push(
+      'rustup was not found, so the script could not verify the installed WASM targets.',
+    )
+  } else if (context.needsWasmTarget) {
+    let installedTargets = readInstalledRustTargets()
+
+    if (installedTargets === null) {
+      warnings.push('Could not read the installed Rust targets from rustup.')
+    } else if (!installedTargets.has(wasmTarget)) {
+      errors.push({
+        title: 'Missing required Rust target',
+        body: [`- ${wasmTarget}`, `Run \`rustup target add ${wasmTarget}\`.`].join('\n'),
+      })
+    }
+  }
+}
+
+if (context.needsBun && !commandExists('bun')) {
+  errors.push({
+    title: 'Missing required tool for the Vite playground',
+    body: [
+      '- bun',
+      'The Vite playground uses `bun --bun vite`.',
+      'Install Bun, or validate Vite changes with `pnpm build && pnpm test:integrations -- --run integrations/vite`.',
+    ].join('\n'),
+  })
+}
+
+if (context.needsBuildArtifacts) {
+  let missingArtifacts = requiredArtifacts.filter((artifact) => {
+    return !fs.existsSync(path.join(root, artifact))
+  })
+
+  if (missingArtifacts.length > 0) {
+    errors.push({
+      title: 'Missing build artifacts required by this command',
+      body: [
+        formatList(missingArtifacts.map(relativeArtifact)),
+        'Run `pnpm build` first, then retry this command.',
+      ].join('\n'),
+    })
+  }
+}
+
+if (errors.length > 0) {
+  console.error(`Environment preflight failed for ${context.label}.`)
+  console.error('')
+
+  for (let error of errors) {
+    console.error(`${error.title}:`)
+    console.error(error.body)
+    console.error('')
+  }
+
+  if (warnings.length > 0) {
+    console.error('Warnings:')
+    console.error(formatList(warnings))
+    console.error('')
+  }
+
+  process.exit(1)
+}
+
+if (command === 'doctor') {
+  console.log(`Environment preflight passed for ${context.label}.`)
+
+  if (warnings.length > 0) {
+    console.log('')
+    console.log('Warnings:')
+    console.log(formatList(warnings))
+  }
+}

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -3,7 +3,13 @@ import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
-import { commandExists, hasDefaultCargoBin, readInstalledRustTargets, rustEnv } from './rust-env.mjs'
+import {
+  cargoBin,
+  commandExists,
+  hasDetectedCargoBin,
+  readInstalledRustTargets,
+  rustEnv,
+} from './rust-env.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const root = path.resolve(__dirname, '..')
@@ -95,8 +101,8 @@ if (context.needsRust) {
         formatList(missingRustTools),
         'How to fix:',
         '1. Install Rustup from https://rustup.rs/',
-        hasDefaultCargoBin()
-          ? '2. Rust appears to be installed in the default cargo directory, so rerun the command through the repo scripts such as `pnpm build` or `pnpm run check:env`.'
+        hasDetectedCargoBin()
+          ? `2. Rust appears to be installed in the detected Cargo bin directory (${cargoBin}), so rerun the command through the repo scripts such as \`pnpm build\` or \`pnpm run check:env\`.`
           : '2. If you installed Rustup to a custom location, make sure `CARGO_HOME`, `RUSTUP_HOME`, or your PATH points at the installation.',
         '3. Run `rustup default stable`.',
         `4. Run \`rustup target add ${wasmTarget}\`.`,

--- a/scripts/run-task.mjs
+++ b/scripts/run-task.mjs
@@ -27,20 +27,25 @@ const predefinedCommands = {
   nextjs: [['pnpm', ['run', '--filter=nextjs-playground', 'dev']]],
 }
 
+if (!task || !predefinedCommands[task]) {
+  console.error(`Unknown task: ${task ?? '(missing)'}`)
+  process.exit(1)
+}
+
 let commands = predefinedCommands[task]
 
 if (passthrough[0] === '--') {
+  if (!passthrough[1]) {
+    console.error('Missing command after `--`.')
+    process.exit(1)
+  }
+
   commands = [[passthrough[1], passthrough.slice(2)]]
 } else if (commands && passthrough.length > 0) {
   commands = commands.map((entry, index) => {
     if (index !== commands.length - 1) return entry
     return [entry[0], [...entry[1], ...passthrough]]
   })
-}
-
-if (!task || !commands) {
-  console.error(`Unknown task: ${task ?? '(missing)'}`)
-  process.exit(1)
 }
 
 let preflight = spawnSync(process.execPath, [path.join(root, 'scripts', 'preflight.mjs'), task], {

--- a/scripts/run-task.mjs
+++ b/scripts/run-task.mjs
@@ -1,0 +1,67 @@
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { isWindows, rustEnv } from './rust-env.mjs'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const root = path.resolve(__dirname, '..')
+const cwd = process.cwd()
+
+const task = process.argv[2]
+const passthrough = process.argv.slice(3)
+
+const predefinedCommands = {
+  build: [['turbo', ['build', '--filter=!./playgrounds/*']]],
+  dev: [['turbo', ['dev', '--filter=!./playgrounds/*']]],
+  test: [
+    ['cargo', ['test']],
+    ['vitest', ['run', '--hideSkippedTests']],
+  ],
+  'test:integrations': [['vitest', ['--root=./integrations']]],
+  'test:ui': [
+    ['pnpm', ['run', '--filter=tailwindcss', 'test:ui']],
+    ['pnpm', ['run', '--filter=@tailwindcss/browser', 'test:ui']],
+  ],
+  vite: [['pnpm', ['run', '--filter=vite-playground', 'dev']]],
+  nextjs: [['pnpm', ['run', '--filter=nextjs-playground', 'dev']]],
+}
+
+let commands = predefinedCommands[task]
+
+if (passthrough[0] === '--') {
+  commands = [[passthrough[1], passthrough.slice(2)]]
+} else if (commands && passthrough.length > 0) {
+  commands = commands.map((entry, index) => {
+    if (index !== commands.length - 1) return entry
+    return [entry[0], [...entry[1], ...passthrough]]
+  })
+}
+
+if (!task || !commands) {
+  console.error(`Unknown task: ${task ?? '(missing)'}`)
+  process.exit(1)
+}
+
+let preflight = spawnSync(process.execPath, [path.join(root, 'scripts', 'preflight.mjs'), task], {
+  cwd,
+  env: rustEnv,
+  stdio: 'inherit',
+})
+
+if (preflight.status !== 0) {
+  process.exit(preflight.status ?? 1)
+}
+
+for (let [command, args] of commands) {
+  let result = spawnSync(command, args, {
+    cwd,
+    env: rustEnv,
+    stdio: 'inherit',
+    shell: isWindows,
+  })
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1)
+  }
+}

--- a/scripts/rust-env.mjs
+++ b/scripts/rust-env.mjs
@@ -1,0 +1,60 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { spawnSync } from 'node:child_process'
+
+export const isWindows = process.platform === 'win32'
+
+const home = process.env.USERPROFILE ?? process.env.HOME ?? process.env.HOMEPATH ?? ''
+
+export const cargoHome = process.env.CARGO_HOME ?? (home ? path.join(home, '.cargo') : '')
+export const rustupHome = process.env.RUSTUP_HOME ?? (home ? path.join(home, '.rustup') : '')
+export const cargoBin = cargoHome ? path.join(cargoHome, 'bin') : ''
+
+export const mergedPath = cargoBin
+  ? [cargoBin, process.env.PATH ?? ''].filter(Boolean).join(path.delimiter)
+  : process.env.PATH ?? ''
+
+export const rustEnv = {
+  ...process.env,
+  ...(cargoHome ? { CARGO_HOME: cargoHome } : {}),
+  ...(rustupHome ? { RUSTUP_HOME: rustupHome } : {}),
+  PATH: mergedPath,
+  ...(isWindows
+    ? {
+        RUSTUP_TOOLCHAIN:
+          process.env.RUSTUP_TOOLCHAIN ?? 'stable-x86_64-pc-windows-msvc',
+      }
+    : {}),
+}
+
+export function commandExists(command, { cwd = process.cwd() } = {}) {
+  let result = spawnSync(command, ['--version'], {
+    cwd,
+    env: rustEnv,
+    stdio: 'ignore',
+    shell: isWindows,
+  })
+
+  return !result.error && result.status === 0
+}
+
+export function readInstalledRustTargets({ cwd = process.cwd() } = {}) {
+  let result = spawnSync('rustup', ['target', 'list', '--installed'], {
+    cwd,
+    env: rustEnv,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    shell: isWindows,
+  })
+
+  if (result.error || result.status !== 0) {
+    return null
+  }
+
+  return new Set(result.stdout.split(/\r?\n/).filter(Boolean))
+}
+
+export function hasDefaultCargoBin() {
+  return Boolean(cargoBin) && fs.existsSync(cargoBin)
+}

--- a/scripts/rust-env.mjs
+++ b/scripts/rust-env.mjs
@@ -20,12 +20,6 @@ export const rustEnv = {
   ...(cargoHome ? { CARGO_HOME: cargoHome } : {}),
   ...(rustupHome ? { RUSTUP_HOME: rustupHome } : {}),
   PATH: mergedPath,
-  ...(isWindows
-    ? {
-        RUSTUP_TOOLCHAIN:
-          process.env.RUSTUP_TOOLCHAIN ?? 'stable-x86_64-pc-windows-msvc',
-      }
-    : {}),
 }
 
 export function commandExists(command, { cwd = process.cwd() } = {}) {
@@ -55,6 +49,6 @@ export function readInstalledRustTargets({ cwd = process.cwd() } = {}) {
   return new Set(result.stdout.split(/\r?\n/).filter(Boolean))
 }
 
-export function hasDefaultCargoBin() {
+export function hasDetectedCargoBin() {
   return Boolean(cargoBin) && fs.existsSync(cargoBin)
 }


### PR DESCRIPTION
Hello Tailwind CSS team,

I’m submitting this contribution set with a strong focus on reviewability, project fit, and contributor usefulness.

Instead of opening one large pull request, I deliberately split the work into three smaller PRs so each change can be reviewed on its own merits and verified independently:

- fix/windows-rust-env
- feat/hocus-variant
- docs/contributor-guides

I chose that structure intentionally. Since this repository spans the compiler core, multiple adapters, the Node bridge, and the oxide scanner, broad PRs can become difficult to review quickly. I wanted each change to stay close to the layer that actually owns the behavior, and I wanted the validation story for each PR to remain simple and concrete.

The first PR, `fix/windows-rust-env`, is focused on contributor workflows on Windows. The specific problem I addressed was that contributors could still hit `cargo ENOENT` failures during build workflows even when Rust was already installed, simply because the current shell environment did not expose the expected Rust binaries cleanly. To address that, I added environment-aware helper scripts, introduced a contributor-facing preflight check, and routed the relevant build/test commands through the same corrected Rust-aware execution path. I also updated the oxide package build commands to use that path consistently. The purpose of this PR is narrow: make the Windows contributor workflow more reliable without changing the actual compiler behavior.

The second PR, `feat/hocus-variant`, is a small but real product-facing change in Tailwind itself. I added a built-in `hocus:` variant that applies styles on both focus and hover. I kept the implementation aligned with existing variant behavior by preserving the `@media (hover: hover)` guard for hover output while still emitting direct focus selectors. I also updated the relevant focused tests so that the feature is covered both at the variant-output level and in `@apply` error reporting. The goal here was to contribute something user-visible while still keeping the scope compact and easy to reason about.

The third PR, `docs/contributor-guides`, is documentation-focused, but not generic documentation. I rewrote the contributor-facing guidance so it reflects how this repository actually works: the relationship between the core compiler, the adapter layer, `@tailwindcss/node`, the oxide scanner, integration fixtures, and the playground workflows. I specifically tried to avoid boilerplate open-source text and instead wrote the docs around the real workflows a contributor would hit in this monorepo, especially around setup, validation, Windows-specific issues, Rust, Bun, Playwright, and deciding where a change belongs before editing code. My intention was to improve contributor onboarding without adding docs that feel detached from the codebase.

Across the three PRs, I tried to keep a few principles consistent:

- small review surfaces instead of one large mixed change
- behavior changes made at the owning layer instead of through cross-cutting workarounds
- explicit and narrow validation for each PR
- no unrelated refactors mixed into functional fixes
- contributor documentation written specifically for this repository rather than copied generic guidance

Validation for the work included:

- `pnpm run check:env`
- `cd crates/node && pnpm run build`
- `pnpm exec vitest run packages/tailwindcss/src/variants.test.ts packages/tailwindcss/src/index.test.ts -t "hocus|variant that does not exist"`

For the docs work, I also manually reviewed the command paths, local guide links, and contributor flow to make sure the text matched the actual repository structure and workflows.

This is one of my first serious open-source contribution sets at this level of repository complexity, so I approached it conservatively: understand the local code path first, make the change in the nearest owning layer, validate the smallest relevant slice, and split the work into focused PRs instead of asking maintainers to parse one broad patch. If any of these changes should be scoped even more tightly, rewritten in a different style, or moved to a different layer, I’m happy to revise them.

Thank you for your time and review.