### PR TITLE
feat: add built-in hocus variant

### DIFF
--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -604,11 +604,11 @@ describe('@apply', () => {
         }
 
         .foo {
-          @apply hocus:hover:pocus:bg-red-500;
+          @apply hocus:hover:pocus:mocus:bg-red-500;
         }
       `),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[Error: Cannot apply utility class \`hocus:hover:pocus:bg-red-500\` because the \`hocus\` and \`pocus\` variants do not exist.]`,
+      `[Error: Cannot apply utility class \`hocus:hover:pocus:mocus:bg-red-500\` because the \`pocus\` and \`mocus\` variants do not exist.]`,
     )
   })
 

--- a/packages/tailwindcss/src/variants.test.ts
+++ b/packages/tailwindcss/src/variants.test.ts
@@ -451,6 +451,41 @@ test('hover', async () => {
   expect(await run(['hover/foo:flex'])).toEqual('')
 })
 
+test('hocus', async () => {
+  expect(await run(['hocus:flex', 'group-hocus:flex', 'peer-hocus:flex'])).toMatchInlineSnapshot(`
+    ".group-hocus\\:flex:is(:where(.group):focus *) {
+      display: flex;
+    }
+
+    @media (hover: hover) {
+      .group-hocus\\:flex:is(:where(.group):hover *) {
+        display: flex;
+      }
+    }
+
+    .peer-hocus\\:flex:is(:where(.peer):focus ~ *) {
+      display: flex;
+    }
+
+    @media (hover: hover) {
+      .peer-hocus\\:flex:is(:where(.peer):hover ~ *) {
+        display: flex;
+      }
+    }
+
+    .hocus\\:flex:focus {
+      display: flex;
+    }
+
+    @media (hover: hover) {
+      .hocus\\:flex:hover {
+        display: flex;
+      }
+    }"
+  `)
+  expect(await run(['hocus/foo:flex'])).toEqual('')
+})
+
 test('focus', async () => {
   expect(await run(['focus:flex', 'group-focus:flex', 'peer-focus:flex'])).toMatchInlineSnapshot(`
     ".group-focus\\:flex:is(:where(.group):focus *), .peer-focus\\:flex:is(:where(.peer):focus ~ *), .focus\\:flex:focus {

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -714,6 +714,14 @@ export function createVariants(theme: Theme): Variants {
   variants.static('hover', (r) => {
     r.nodes = [styleRule('&:hover', [atRule('@media', '(hover: hover)', r.nodes)])]
   })
+  variants.static('hocus', (r) => {
+    let nodes = r.nodes
+
+    r.nodes = [
+      styleRule('&:focus', nodes),
+      styleRule('&:hover', [atRule('@media', '(hover: hover)', nodes)]),
+    ]
+  })
   staticVariant('focus', ['&:focus'])
   staticVariant('focus-visible', ['&:focus-visible'])
   staticVariant('active', ['&:active'])


### PR DESCRIPTION
## Summary

This PR adds a built-in `hocus:` variant that applies styles on both focus and hover.

Today this pattern is easy to recreate with a plugin, but it is common enough that having it available as a built-in variant felt like a reasonable quality-of-life improvement. The implementation keeps hover behavior aligned with existing Tailwind behavior by emitting hover selectors inside `@media (hover: hover)`, while still emitting direct focus selectors.

The scope here is intentionally small:
- register `hocus` as a built-in static variant
- add focused coverage for the generated selectors
- update the related `@apply` error expectation now that `hocus` is no longer an unknown variant

## Impacted areas

- Core variant registration
- Variant output tests
- `@apply` unknown-variant error handling expectations

## Test plan

- `pnpm exec vitest run packages/tailwindcss/src/variants.test.ts packages/tailwindcss/src/index.test.ts -t "hocus|variant that does not exist"`

Verified behavior for:
- `hocus:flex`
- `group-hocus:flex`
- `peer-hocus:flex`

Also verified that the related `@apply` error path now treats `hocus` as a built-in variant and only reports the remaining unknown variants.

## Notes

I understand new built-in features are often discussion-first in this repository. If maintainers would prefer this to start as a discussion instead of a direct feature PR, I am happy to re-scope it or move the conversation there first.