### PR TITLE
docs: add contributor guides for local development

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,40 +1,89 @@
 # Contributing
 
+Tailwind is a mixed TypeScript and Rust monorepo. The fastest way to get a change accepted is to keep the scope tight, change the layer that already owns the behavior, and include the smallest convincing test plan.
+
+Before touching core behavior, skim these local repo notes:
+
+- [Architecture overview](../docs/ARCHITECTURE.md)
+- [Build and development](../docs/BUILD.md)
+- [Extending Tailwind in this repository](../docs/EXTENDING.md)
+- [Testing guide](../docs/TESTING.md)
+- [Local runbook](../docs/RUNBOOK.md)
+- [Troubleshooting](../docs/TROUBLESHOOTING.md)
+
 ## Requirements
 
 Before getting started, ensure your system has access to the following tools:
 
-- [Node.js](https://nodejs.org/)
+- [Node.js](https://nodejs.org/) 24 or newer
 - [Rustup](https://rustup.rs/)
-- [pnpm](https://pnpm.io/)
+- [pnpm](https://pnpm.io/) 9.6.0
+- Rust 1.85.0 via the repository toolchain
+- Bun if you want to run the Vite playground
 
 ## Getting started
 
+Run commands from the repository root.
+
 ```sh
-# Install dependencies
+corepack enable
 pnpm install
 
-# Install Rust toolchain and WASM targets
 rustup default stable
 rustup target add wasm32-wasip1-threads
 
-# Build the project
+pnpm run check:env
 pnpm build
+```
+
+If you do not use Corepack, install pnpm manually:
+
+```sh
+npm install -g pnpm@9.6.0
 ```
 
 ## Development workflow
 
-During development, you can run tests in watch mode:
+Most day-to-day work in this repository looks like one of these loops:
+
+- `pnpm tdd` when you are iterating on compiler-level TypeScript tests
+- `pnpm build && pnpm test:integrations` when behavior crosses package boundaries
+- `pnpm build && pnpm vite` or `pnpm build && pnpm nextjs` when you need to see the result inside an app
+
+For watch mode:
 
 ```sh
 pnpm tdd
 ```
 
-The `playgrounds` directory contains example projects you can use to test your changes. To start the Vite playground, use:
+The `playgrounds` directory is useful when a change is easier to judge visually than from snapshots or fixture output alone.
+
+To start the Vite playground:
 
 ```sh
 pnpm build && pnpm vite
 ```
+
+To start the Next.js playground, use:
+
+```sh
+pnpm build && pnpm nextjs
+```
+
+For package-local watch mode, prefer filters:
+
+```sh
+pnpm run --filter=tailwindcss dev
+pnpm run --filter=@tailwindcss/postcss dev
+pnpm run --filter=@tailwindcss/vite dev
+```
+
+## Choosing where to work
+
+- If the bug only shows up in Vite, PostCSS, or Webpack, start in that adapter instead of the core compiler.
+- If the bug is about candidate discovery, roots, ignore rules, or scan performance, start in oxide.
+- If the change affects emitted CSS everywhere, start in `packages/tailwindcss`.
+- If you are not sure, trace the failing integration test first and change the first layer that actually decides the behavior.
 
 ## Bug fixes
 
@@ -47,6 +96,8 @@ If there's a new feature you'd like to see added to Tailwind, [share your idea w
 **Please note that we don't often accept pull requests for new features.** Adding a new feature to Tailwind requires us to think through the entire problem ourselves to make sure we agree with the proposed API, which means the feature needs to be high on our own priority list for us to be able to give it the attention it needs.
 
 If you open a pull request for a new feature, we're likely to close it not because it's a bad idea, but because we aren't ready to prioritize the feature and don't want the PR to sit open for months or even years.
+
+Smaller improvements land more reliably than broad feature pushes. Tight fixes, workflow improvements, platform fixes, adapter-specific correctness work, and missing tests are all much easier to review.
 
 ## Coding standards
 
@@ -64,13 +115,13 @@ pnpm run format
 
 ## Running tests
 
-You can run the TypeScript and Rust test suites using the following command:
+For a normal code change, start with the narrowest check that proves it. These are the most common commands:
 
 ```sh
 pnpm test
 ```
 
-To run the integration tests, use:
+Then widen only if the change crosses package boundaries:
 
 ```sh
 pnpm build && pnpm test:integrations
@@ -82,6 +133,46 @@ Additionally, some features require testing in browsers (i.e. to ensure CSS vari
 pnpm build && pnpm test:ui
 ```
 
+Install Playwright browsers before running UI tests:
+
+```sh
+npx playwright install
+```
+
+### Platform caveats
+
+- The full Windows, Linux, and macOS CI matrix only runs on `main` or when the pull request body contains `[ci-all]`.
+- The WASM integration coverage in [../integrations/oxide/wasm.test.ts](../integrations/oxide/wasm.test.ts) is Linux-only right now.
+- One source-map integration case is intentionally skipped because of an upstream Lightning CSS issue.
+
+If you touch scanner behavior, Rust code, path handling, or source maps, request the full CI matrix.
+
+If your change only fixes one package or one integration path, say that clearly in the PR description. Small, precise claims are easier to verify and easier to merge.
+
+## Debugging tips
+
+The Node-facing packages respect the `DEBUG` environment variable. Useful examples:
+
+macOS/Linux:
+
+```sh
+DEBUG=* pnpm build
+DEBUG=tailwindcss pnpm test
+DEBUG=tailwindcss pnpm build && pnpm test:integrations
+```
+
+Windows PowerShell:
+
+```powershell
+$env:DEBUG='*'
+pnpm build
+$env:DEBUG='tailwindcss'
+pnpm test
+Remove-Item Env:DEBUG
+```
+
+If you need an exact command sequence based on the area you changed, use the [local runbook](../docs/RUNBOOK.md).
+
 Please ensure that all tests are passing when submitting a pull request. If you're adding new features to Tailwind CSS, always include tests.
 
 After a successful build, you can also use the npm package tarballs created inside the `dist/` folder to install your build in other local projects.
@@ -90,9 +181,11 @@ After a successful build, you can also use the npm package tarballs created insi
 
 When submitting a pull request:
 
-- Ensure the pull request title and description explain the changes you made and why you made them.
-- Include a test plan section that outlines how you tested your contributions. We do not accept contributions without tests.
-- Ensure all tests pass. You can add the tag `[ci-all]` in your pull request description to run the test suites across all platforms.
+- Keep the title narrow and factual.
+- Explain the bug, the owning layer, and the behavior change in the summary.
+- Include the exact commands you ran in the test plan.
+- Mention which packages or test suites were intentionally not touched.
+- Add `[ci-all]` in the pull request body if you touched Rust, source maps, path handling, or cross-platform behavior.
 
 When a pull request is created, Tailwind CSS maintainers will be notified automatically.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,13 +28,14 @@ Run commands from the repository root.
 ```sh
 corepack enable
 pnpm install
-
-rustup default stable
-rustup target add wasm32-wasip1-threads
+rustup toolchain install 1.85.0
+rustup target add wasm32-wasip1-threads --toolchain 1.85.0
 
 pnpm run check:env
 pnpm build
 ```
+
+The repository selects Rust 1.85.0 via [rust-toolchain.toml](../rust-toolchain.toml), so contributors do not need to change their global Rust default.
 
 If you do not use Corepack, install pnpm manually:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ It's never a fun experience to have your pull request declined after investing a
 
 For more info, check out the contributing guide:
 
-https://github.com/tailwindlabs/tailwindcss/blob/main/.github/CONTRIBUTING.md
+./CONTRIBUTING.md
 
 -->
 
@@ -17,6 +17,16 @@ https://github.com/tailwindlabs/tailwindcss/blob/main/.github/CONTRIBUTING.md
 <!--
 
 Provide a summary of the issue and the changes you're making. How does your change solve the problem?
+If relevant, mention which package or layer owns the behavior (`tailwindcss`, `@tailwindcss/node`, adapter package, or oxide).
+
+-->
+
+## Impacted areas
+
+<!--
+
+List the packages, integrations, or workflows you intentionally changed.
+If something looks related but was deliberately left alone, call that out too.
 
 -->
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,64 @@
 
 For full documentation, visit [tailwindcss.com](https://tailwindcss.com).
 
+## Working On This Repository
+
+If you are here to change Tailwind itself rather than use it in an app, it helps to think about the repository in three pieces:
+
+- [packages/tailwindcss](packages/tailwindcss) is the compiler and CSS generation core.
+- [packages/@tailwindcss-node](packages/@tailwindcss-node), [packages/@tailwindcss-postcss](packages/@tailwindcss-postcss), [packages/@tailwindcss-vite](packages/@tailwindcss-vite), and [packages/@tailwindcss-webpack](packages/@tailwindcss-webpack) are the adapter layer.
+- [crates/oxide](crates/oxide) and [crates/node](crates/node) are the Rust scanner and Node bridge.
+
+Most accepted changes stay inside one of those layers and come with the smallest test slice that proves the behavior.
+
+The repo-specific guides live here:
+
+- [Architecture overview](docs/ARCHITECTURE.md) for package ownership and request flow.
+- [Build and development](docs/BUILD.md) for setup, daily commands, and local build behavior.
+- [Extending Tailwind in this repository](docs/EXTENDING.md) for deciding whether a change belongs in core, an adapter, or oxide.
+- [Testing guide](docs/TESTING.md) for how the unit, integration, UI, and Rust suites fit together.
+- [Local runbook](docs/RUNBOOK.md) for the shortest command path after a change.
+- [Troubleshooting](docs/TROUBLESHOOTING.md) for common Windows, Bun, Playwright, and Rust setup issues.
+
+## Local Setup
+
+Run commands from the repository root:
+
+```sh
+corepack enable
+pnpm install
+rustup default stable
+rustup target add wasm32-wasip1-threads
+pnpm run check:env
+pnpm build
+pnpm test
+```
+
+If your shell cannot see Rust yet, run `pnpm run check:env` before the full build. That is a fast preflight for Cargo, Rustup, and the required WASM target.
+
+## What To Run After A Change
+
+Common local loops in this repo are:
+
+```sh
+pnpm build && pnpm test:integrations
+pnpm build && pnpm test:ui
+pnpm build && pnpm vite
+pnpm build && pnpm nextjs
+```
+
+The Vite playground requires Bun. If you changed emitted CSS, rebuild first and then open either the Vite or Next.js playground so you can see the output in a real app flow.
+
+If you want the exact minimum command set for a compiler, adapter, scanner, or CLI change, use [docs/RUNBOOK.md](docs/RUNBOOK.md).
+
+## Repository Layout
+
+- [packages/tailwindcss](packages/tailwindcss) contains the compiler, variant handling, utilities, and CSS assets.
+- [packages/@tailwindcss-cli](packages/@tailwindcss-cli) and [packages/@tailwindcss-standalone](packages/@tailwindcss-standalone) cover the command-line entry points.
+- [packages/@tailwindcss-node](packages/@tailwindcss-node) owns config loading, source maps, and the bridge between adapters and core.
+- [integrations](integrations) exercises built packages the way real consumers use them.
+- [playgrounds](playgrounds) is the fastest way to eyeball an actual app after a change.
+
 ## Community
 
 For help, discussion about best practices, or feature ideas:
@@ -33,4 +91,4 @@ For help, discussion about best practices, or feature ideas:
 
 ## Contributing
 
-If you're interested in contributing to Tailwind CSS, please read our [contributing docs](https://github.com/tailwindlabs/tailwindcss/blob/main/.github/CONTRIBUTING.md) **before submitting a pull request**.
+If you're interested in contributing to Tailwind CSS, please read our [contributing docs](.github/CONTRIBUTING.md) **before submitting a pull request**.

--- a/README.md
+++ b/README.md
@@ -51,12 +51,14 @@ Run commands from the repository root:
 ```sh
 corepack enable
 pnpm install
-rustup default stable
-rustup target add wasm32-wasip1-threads
+rustup toolchain install 1.85.0
+rustup target add wasm32-wasip1-threads --toolchain 1.85.0
 pnpm run check:env
 pnpm build
 pnpm test
 ```
+
+The repository pins Rust 1.85.0 in [rust-toolchain.toml](rust-toolchain.toml), so you do not need to change your global Rust default.
 
 If your shell cannot see Rust yet, run `pnpm run check:env` before the full build. That is a fast preflight for Cargo, Rustup, and the required WASM target.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,63 @@
+# Architecture Overview
+
+Tailwind v4 in this repository is not one package. Most behavior crosses at least three layers:
+
+- an adapter or CLI entry point receives a CSS request
+- `@tailwindcss/node` turns that request into compile work
+- the compiler and oxide scanner decide what CSS to emit
+
+That is why a bug that looks like “Tailwind output is wrong” might actually live in a bundler adapter, config loading, source maps, or scanning.
+
+## Repository map
+
+| Path | Role |
+| --- | --- |
+| [packages/tailwindcss](../packages/tailwindcss) | Core compiler, CSS assets, plugin API, theme and utility generation |
+| [packages/@tailwindcss-node](../packages/@tailwindcss-node) | Node runtime helpers, module loading, compile/optimize wrappers, source map helpers |
+| [packages/@tailwindcss-postcss](../packages/@tailwindcss-postcss) | PostCSS adapter and caching layer |
+| [packages/@tailwindcss-vite](../packages/@tailwindcss-vite) | Vite adapter, dev-server integration, HMR-aware generation |
+| [packages/@tailwindcss-webpack](../packages/@tailwindcss-webpack) | Webpack adapter |
+| [packages/@tailwindcss-cli](../packages/@tailwindcss-cli) | CLI entry points |
+| [packages/@tailwindcss-upgrade](../packages/@tailwindcss-upgrade) | Upgrade assistant and codemods |
+| [crates/oxide](../crates/oxide) | Rust scanner and filesystem traversal used to discover class candidates |
+| [crates/node](../crates/node) | N-API bridge that exposes oxide to Node |
+| [integrations](../integrations) | Cross-package integration tests against real toolchains |
+
+## The usual request path
+
+1. An adapter, the CLI, or the standalone binary starts with a CSS entry file.
+   Good entry points: [packages/@tailwindcss-postcss/src/index.ts](../packages/@tailwindcss-postcss/src/index.ts), [packages/@tailwindcss-vite/src/index.ts](../packages/@tailwindcss-vite/src/index.ts), [packages/@tailwindcss-webpack/src/index.ts](../packages/@tailwindcss-webpack/src/index.ts), [packages/@tailwindcss-cli](../packages/@tailwindcss-cli)
+2. `@tailwindcss/node` loads config, resolves modules, prepares source maps, and calls into the compiler.
+   Good entry point: [packages/@tailwindcss-node/src/index.ts](../packages/@tailwindcss-node/src/index.ts)
+3. The compiler parses directives such as `@import`, `@theme`, `@utility`, `@variant`, `@plugin`, and `@config`, then builds the design system and generation plan.
+   Good entry points: [packages/tailwindcss/src/index.ts](../packages/tailwindcss/src/index.ts), [packages/tailwindcss/src/design-system.ts](../packages/tailwindcss/src/design-system.ts), [packages/tailwindcss/src/compile.ts](../packages/tailwindcss/src/compile.ts)
+4. Oxide discovers candidate class names and source files.
+   Good entry points: [crates/oxide](../crates/oxide), [crates/node](../crates/node)
+5. The result comes back through the adapter, which may also optimize output with Lightning CSS and write source maps.
+   Good entry points: [packages/tailwindcss/src/source-maps/source-map.ts](../packages/tailwindcss/src/source-maps/source-map.ts), [packages/@tailwindcss-postcss/src/index.ts](../packages/@tailwindcss-postcss/src/index.ts)
+
+## Where bugs usually live
+
+| If you want to change... | Start here | Then verify in... |
+| --- | --- | --- |
+| CSS directive parsing or utility generation | [packages/tailwindcss/src/index.ts](../packages/tailwindcss/src/index.ts) | [integrations/postcss](../integrations/postcss), [integrations/vite](../integrations/vite), [integrations/webpack](../integrations/webpack) |
+| Plugin API or compatibility behavior | [packages/tailwindcss/src/plugin.ts](../packages/tailwindcss/src/plugin.ts), [packages/tailwindcss/src/compat/plugin-api.ts](../packages/tailwindcss/src/compat/plugin-api.ts) | [integrations/postcss/plugins.test.ts](../integrations/postcss/plugins.test.ts), [packages/internal-example-plugin](../packages/internal-example-plugin) |
+| File scanning, glob behavior, or performance hot paths | [crates/oxide](../crates/oxide), [crates/node](../crates/node) | [crates/oxide/tests](../crates/oxide/tests), [integrations/oxide](../integrations/oxide) |
+| Node resolution, config loading, or source maps | [packages/@tailwindcss-node](../packages/@tailwindcss-node) | [integrations/cli](../integrations/cli), [integrations/postcss](../integrations/postcss), [integrations/vite](../integrations/vite) |
+| Vite-specific behavior or HMR | [packages/@tailwindcss-vite/src/index.ts](../packages/@tailwindcss-vite/src/index.ts) | [integrations/vite](../integrations/vite) |
+| PostCSS-specific behavior or incremental rebuilds | [packages/@tailwindcss-postcss/src/index.ts](../packages/@tailwindcss-postcss/src/index.ts) | [integrations/postcss](../integrations/postcss) |
+| Upgrade logic or migration messages | [packages/@tailwindcss-upgrade](../packages/@tailwindcss-upgrade) | [integrations/upgrade](../integrations/upgrade) |
+
+## Useful mental shortcuts
+
+- If a bug only reproduces through one toolchain, it is often adapter code, not compiler core.
+- If classes are missing entirely, oxide is usually worth checking before touching utility generation.
+- If CSS looks correct but file paths, config loading, or source maps are wrong, start in `@tailwindcss/node`.
+- If a change affects generated CSS semantics, prove it once in a focused test and once through a real adapter path.
+- Avoid moving logic down into shared layers unless multiple entry points genuinely need it.
+
+## Related guides
+
+- [Build and development](BUILD.md)
+- [Extending the repository](EXTENDING.md)
+- [Testing guide](TESTING.md)

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -20,11 +20,13 @@ If you just cloned the repo, start here:
 cd tailwindcss
 corepack enable
 pnpm install
-rustup default stable
-rustup target add wasm32-wasip1-threads
+rustup toolchain install 1.85.0
+rustup target add wasm32-wasip1-threads --toolchain 1.85.0
 pnpm run check:env
 pnpm build
 ```
+
+The repository pins Rust 1.85.0 in [../rust-toolchain.toml](../rust-toolchain.toml), so you do not need to change your global Rust default to match the local build.
 
 `pnpm run check:env` is the fast sanity check. It is cheaper than a full build and catches the most common Rust and WASM setup problems.
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,0 +1,130 @@
+# Build And Development
+
+This repository is a pnpm workspace, a Rust project, and a standalone CLI build at the same time. A normal contributor workflow only needs a subset of that surface, so this guide focuses on the commands you actually use while iterating.
+
+## Prerequisites
+
+You need these tools locally:
+
+- Node.js 24 or newer, matching CI in [../.github/workflows/ci.yml](../.github/workflows/ci.yml)
+- pnpm 9.6.0, matching [../package.json](../package.json)
+- Rust 1.85.0, matching [../rust-toolchain.toml](../rust-toolchain.toml)
+- The `wasm32-wasip1-threads` target
+- Bun, only if you want to run the Vite playground in [../playgrounds/vite/package.json](../playgrounds/vite/package.json)
+
+## First-time setup
+
+If you just cloned the repo, start here:
+
+```sh
+cd tailwindcss
+corepack enable
+pnpm install
+rustup default stable
+rustup target add wasm32-wasip1-threads
+pnpm run check:env
+pnpm build
+```
+
+`pnpm run check:env` is the fast sanity check. It is cheaper than a full build and catches the most common Rust and WASM setup problems.
+
+If you do not use Corepack, install the pinned pnpm version manually:
+
+```sh
+npm install -g pnpm@9.6.0
+```
+
+## Daily commands
+
+| Command | Purpose |
+| --- | --- |
+| `pnpm build` | Build the workspace packages you usually touch during development |
+| `pnpm dev` | Run Turbo dev tasks for packages that expose them |
+| `pnpm test` | Run Rust tests and the main Vitest suite |
+| `pnpm build && pnpm test:integrations` | Verify built packages through real fixture projects |
+| `pnpm build && pnpm test:ui` | Run Playwright coverage for browser-specific behavior |
+| `pnpm bench` | Run committed benchmark files |
+| `pnpm build && pnpm vite` | See a change in the Vite playground |
+| `pnpm build && pnpm nextjs` | See a change in the Next.js playground |
+
+## Working on one package
+
+When you already know which package owns the problem, filtered commands are faster than rebuilding everything:
+
+```sh
+pnpm run --filter=tailwindcss dev
+pnpm run --filter=@tailwindcss/postcss dev
+pnpm run --filter=@tailwindcss/vite dev
+```
+
+That pattern works especially well for adapter work, where the playground or integration suite can consume a single package rebuild.
+
+## Debugging
+
+The Node-facing packages respect the `DEBUG` environment variable through [../packages/@tailwindcss-node/src/env.ts](../packages/@tailwindcss-node/src/env.ts).
+
+Useful examples:
+
+macOS/Linux:
+
+```sh
+DEBUG=* pnpm build
+DEBUG=tailwindcss pnpm test
+DEBUG=tailwindcss pnpm build && pnpm test:integrations
+```
+
+Windows PowerShell:
+
+```powershell
+$env:DEBUG='*'
+pnpm build
+$env:DEBUG='tailwindcss'
+pnpm test
+Remove-Item Env:DEBUG
+```
+
+Adapters such as PostCSS, Vite, and Webpack emit useful rebuild timing and lifecycle logs when debug mode is enabled.
+
+## Common setup mistakes
+
+### Running commands from the wrong directory
+
+The workspace root is the `tailwindcss/` folder. Running `pnpm install` or `npm install` one directory above it will fail because there is no root `package.json` there.
+
+### Missing Rust target
+
+If builds fail around WASM artifacts, confirm the target is installed:
+
+```sh
+rustup target add wasm32-wasip1-threads
+```
+
+### UI tests fail immediately
+
+Playwright browser binaries are not installed automatically. Install them before running browser tests:
+
+```sh
+npx playwright install
+```
+
+On Linux CI, the repository uses `npx playwright install --with-deps`.
+
+### `pnpm vite` fails with Bun errors
+
+The Vite playground uses `bun --bun vite`, so install Bun before using `pnpm vite`. If you do not want Bun locally, validate Vite work through integration tests instead.
+
+## Scenario-based workflow
+
+If you already know which area you changed and want the shortest route back to confidence, go straight to the [local runbook](RUNBOOK.md).
+
+## Consuming local builds in another project
+
+After a successful build, packaged tarballs are placed in `dist/`. You can install those tarballs into another local project to verify behavior outside the monorepo.
+
+## Related guides
+
+- [Architecture overview](ARCHITECTURE.md)
+- [Local runbook](RUNBOOK.md)
+- [Testing guide](TESTING.md)
+- [Troubleshooting](TROUBLESHOOTING.md)
+- [Contributing guide](../.github/CONTRIBUTING.md)

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -1,0 +1,94 @@
+# Extending Tailwind In This Repository
+
+This guide is for changes that add behavior, reshape APIs, or move logic between layers. In Tailwind, those changes are easiest to review when the owning package is obvious.
+
+## Choose the right layer first
+
+The most common mistake in this repo is fixing an adapter bug in core or fixing a core bug in an adapter. Start from the layer that actually decides the behavior.
+
+| Change type | Best starting point |
+| --- | --- |
+| New CSS directive, variant behavior, or utility generation | [../packages/tailwindcss/src/index.ts](../packages/tailwindcss/src/index.ts) |
+| Plugin API additions or compatibility hooks | [../packages/tailwindcss/src/plugin.ts](../packages/tailwindcss/src/plugin.ts), [../packages/tailwindcss/src/compat/plugin-api.ts](../packages/tailwindcss/src/compat/plugin-api.ts) |
+| Config resolution, module loading, or source maps | [../packages/@tailwindcss-node](../packages/@tailwindcss-node) |
+| PostCSS-only behavior | [../packages/@tailwindcss-postcss](../packages/@tailwindcss-postcss) |
+| Vite-only behavior or HMR | [../packages/@tailwindcss-vite](../packages/@tailwindcss-vite) |
+| Candidate scanning or filesystem performance | [../crates/oxide](../crates/oxide), [../crates/node](../crates/node) |
+| Upgrade or migration flows | [../packages/@tailwindcss-upgrade](../packages/@tailwindcss-upgrade) |
+
+## Plugin API basics
+
+The public plugin entry point is exported from [../packages/tailwindcss/src/plugin.ts](../packages/tailwindcss/src/plugin.ts). The underlying API surface is implemented in [../packages/tailwindcss/src/compat/plugin-api.ts](../packages/tailwindcss/src/compat/plugin-api.ts).
+
+That is the place to look when a plugin-facing behavior changes or when compatibility behavior differs from older Tailwind versions.
+
+Supported extension hooks include methods such as `addVariant`, `matchVariant`, `addUtilities`, `matchUtilities`, and `theme`.
+
+Example:
+
+```ts
+import plugin from 'tailwindcss/plugin'
+
+export default plugin.withOptions(
+  function withOptions(options: { prefix?: string } = {}) {
+    let prefix = options.prefix ?? 'app'
+
+    return function ({ addVariant, addUtilities, theme }) {
+      addVariant(`${prefix}-hocus`, ['&:hover', '&:focus'])
+
+      addUtilities({
+        [`.${prefix}-content-auto`]: {
+          contentVisibility: 'auto',
+        },
+        [`.${prefix}-grid-fill`]: {
+          gridTemplateColumns: `repeat(auto-fill, minmax(${theme('spacing.48')}, 1fr))`,
+        },
+      })
+    }
+  },
+)
+```
+
+The internal sample plugin in [../packages/internal-example-plugin](../packages/internal-example-plugin) is deliberately small. It is useful as a smoke-test reference, not as complete API documentation.
+
+## Adding new compiler behavior
+
+When a feature changes how Tailwind interprets CSS directives or generates utilities:
+
+1. Start in [../packages/tailwindcss/src/index.ts](../packages/tailwindcss/src/index.ts) or the nearest focused module.
+2. Keep syntax parsing, design-system state, and CSS emission separate where possible.
+3. Add focused unit coverage near the touched module if the repository already follows that pattern.
+4. Add at least one adapter-level integration test so the feature is exercised through a real package boundary.
+
+## Changing scanning behavior
+
+If your feature affects candidate discovery, roots, ignore behavior, or performance:
+
+1. Inspect [../crates/oxide](../crates/oxide) first.
+2. Update the Node binding in [../crates/node](../crates/node) only when the Rust API surface changes.
+3. Verify behavior in [../integrations/oxide](../integrations/oxide) and then in one adapter integration suite.
+
+Scanner changes often have cross-platform implications, so request a full CI matrix for pull requests that touch Rust or bindings.
+
+## Adapter-specific work
+
+If a change is specific to PostCSS, Vite, or Webpack, avoid patching core first. Tailwind's adapters do real work around caching, rebuilds, module loading, and toolchain conventions.
+
+- PostCSS cache/rebuild logic lives in [../packages/@tailwindcss-postcss/src/index.ts](../packages/@tailwindcss-postcss/src/index.ts)
+- Vite transform and HMR behavior lives in [../packages/@tailwindcss-vite/src/index.ts](../packages/@tailwindcss-vite/src/index.ts)
+- Webpack plugin behavior lives in [../packages/@tailwindcss-webpack/src/index.ts](../packages/@tailwindcss-webpack/src/index.ts)
+
+## Extension checklist
+
+- Update or add tests in the closest relevant suite.
+- Document contributor-facing workflow changes in [../README.md](../README.md) or the docs in this folder.
+- If a feature changes installation or migration messaging, verify [../packages/@tailwindcss-upgrade](../packages/@tailwindcss-upgrade) and [../integrations/upgrade](../integrations/upgrade).
+- If a feature changes emitted CSS or source maps, verify at least one build-tool integration plus CLI behavior.
+
+Before sending a PR, ask whether the change reads like a focused fix or like the start of a larger redesign. Tailwind maintainers are much more likely to merge the former.
+
+## Related guides
+
+- [Architecture overview](ARCHITECTURE.md)
+- [Testing guide](TESTING.md)
+- [Contributing guide](../.github/CONTRIBUTING.md)

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,167 @@
+# Local Runbook
+
+Use this when you already know what you changed and want the shortest route back to confidence.
+
+The goal is simple: run the smallest useful check first, then one real runtime path if the change is easier to judge in an app than in a snapshot.
+
+## Fast decision table
+
+| I changed... | Minimum validation | Best local run path |
+| --- | --- | --- |
+| Core compiler in [../packages/tailwindcss](../packages/tailwindcss) | `pnpm test` | `pnpm build && pnpm vite` or `pnpm build && pnpm nextjs` |
+| PostCSS adapter in [../packages/@tailwindcss-postcss](../packages/@tailwindcss-postcss) | `pnpm build && pnpm test:integrations -- --run integrations/postcss` | `pnpm build && pnpm nextjs` |
+| Vite adapter in [../packages/@tailwindcss-vite](../packages/@tailwindcss-vite) | `pnpm build && pnpm test:integrations -- --run integrations/vite` | `pnpm build && pnpm vite` |
+| Webpack adapter in [../packages/@tailwindcss-webpack](../packages/@tailwindcss-webpack) | `pnpm build && pnpm test:integrations -- --run integrations/webpack` | `pnpm build && pnpm test:integrations -- --run integrations/webpack` |
+| CLI behavior in [../packages/@tailwindcss-cli](../packages/@tailwindcss-cli) | `pnpm build && pnpm test:integrations -- --run integrations/cli` | Use packed tarballs or CLI integration fixtures |
+| Upgrade logic in [../packages/@tailwindcss-upgrade](../packages/@tailwindcss-upgrade) | `pnpm build && pnpm test:integrations -- --run integrations/upgrade` | `pnpm build && pnpm test:integrations -- --run integrations/upgrade` |
+| Rust scanner in [../crates/oxide](../crates/oxide) or [../crates/node](../crates/node) | `cargo test && pnpm build && pnpm test:integrations -- --run integrations/oxide` | `pnpm build && pnpm vite` |
+| Browser-only CSS behavior | `pnpm build && pnpm test:ui` | `pnpm build && pnpm vite` |
+
+## Boot the repository once
+
+From the repository root:
+
+```sh
+corepack enable
+pnpm install
+rustup default stable
+rustup target add wasm32-wasip1-threads
+pnpm build
+```
+
+Optional tools:
+
+- Install Playwright browsers before UI tests: `npx playwright install`
+- Install Bun if you want to run the Vite playground, because [../playgrounds/vite/package.json](../playgrounds/vite/package.json) uses `bun --bun vite`
+
+## Launch local playgrounds
+
+### Vite playground
+
+Use this when changing the core compiler, Vite adapter, or fast feedback CSS generation.
+
+```sh
+pnpm build
+pnpm vite
+```
+
+This is usually the fastest way to eyeball a CSS generation change after `pnpm build`. It requires Bun.
+
+### Next.js playground
+
+Use this when changing the PostCSS path or testing a framework-style app.
+
+```sh
+pnpm build
+pnpm nextjs
+```
+
+### Package-level watch mode
+
+Use this when you only need a package rebuilding while a playground or test suite consumes it.
+
+```sh
+pnpm run --filter=tailwindcss dev
+pnpm run --filter=@tailwindcss/postcss dev
+pnpm run --filter=@tailwindcss/vite dev
+```
+
+Keep one of those running in a terminal, then start the playground or test command in another terminal.
+
+If you are debugging a rebuild issue, this split-terminal setup is often much easier to reason about than rerunning full workspace builds.
+
+## Targeted validation commands
+
+### Core compiler changes
+
+Use this when the change affects variants, utilities, parsing, theme handling, or emitted CSS.
+
+```sh
+pnpm test
+pnpm build && pnpm test:integrations -- --run integrations/postcss
+pnpm build && pnpm test:integrations -- --run integrations/vite
+```
+
+### PostCSS changes
+
+Use this when the bug only reproduces through the PostCSS plugin or through framework integrations that rely on it.
+
+```sh
+pnpm run --filter=@tailwindcss/postcss dev
+pnpm build && pnpm test:integrations -- --run integrations/postcss
+pnpm build && pnpm nextjs
+```
+
+### Vite changes
+
+Use this when the bug involves transforms, HMR, virtual modules, or dev-server behavior.
+
+```sh
+pnpm run --filter=@tailwindcss/vite dev
+pnpm build && pnpm test:integrations -- --run integrations/vite
+pnpm build && pnpm vite
+```
+
+### Rust or scanner changes
+
+Use this when candidates are missing, roots are wrong, ignore behavior changed, or file scanning performance is involved.
+
+```sh
+cargo test
+pnpm build
+pnpm test:integrations -- --run integrations/oxide
+pnpm test:integrations -- --run integrations/vite
+```
+
+### CLI or upgrade changes
+
+Use this when the issue lives in command-line behavior, migration messaging, or upgrade diagnostics.
+
+```sh
+pnpm build && pnpm test:integrations -- --run integrations/cli
+pnpm build && pnpm test:integrations -- --run integrations/upgrade
+```
+
+## Debug logging
+
+### macOS/Linux shells
+
+```sh
+DEBUG=tailwindcss pnpm build
+DEBUG=tailwindcss pnpm test
+```
+
+### Windows PowerShell
+
+```powershell
+$env:DEBUG='tailwindcss'
+pnpm build
+pnpm test
+Remove-Item Env:DEBUG
+```
+
+### Windows Command Prompt
+
+```bat
+set DEBUG=tailwindcss
+pnpm build
+pnpm test
+set DEBUG=
+```
+
+## Before opening a pull request
+
+Use this practical minimum checklist:
+
+1. Run the smallest targeted validation for the area you changed.
+2. Run one local runtime path such as `pnpm vite` or `pnpm nextjs` if your change affects generated CSS, dev-server behavior, or source maps.
+3. If your change touched Rust, source maps, path handling, or scanning, request the full CI matrix with `[ci-all]` in the pull request body.
+4. If your change affected browser behavior, run `pnpm build && pnpm test:ui`.
+
+If you cannot explain why you ran a command, it is probably not the right command for the PR description.
+
+## Related guides
+
+- [Build and development](BUILD.md)
+- [Testing guide](TESTING.md)
+- [Troubleshooting](TROUBLESHOOTING.md)

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -24,10 +24,12 @@ From the repository root:
 ```sh
 corepack enable
 pnpm install
-rustup default stable
-rustup target add wasm32-wasip1-threads
+rustup toolchain install 1.85.0
+rustup target add wasm32-wasip1-threads --toolchain 1.85.0
 pnpm build
 ```
+
+The repository selects Rust 1.85.0 via [../rust-toolchain.toml](../rust-toolchain.toml), so there is no need to change your global Rust default before building.
 
 Optional tools:
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,89 @@
+# Testing Guide
+
+This repository has four useful layers of confidence: focused tests in the touched package, Rust tests for oxide, integration suites that install built packages, and browser tests for CSS behavior that only shows up in a real runtime.
+
+## Test suites
+
+| Command | Scope |
+| --- | --- |
+| `pnpm test` | Rust tests plus the main Vitest suite |
+| `pnpm build && pnpm test:integrations` | End-to-end integration tests under [../integrations](../integrations) |
+| `pnpm build && pnpm test:ui` | Browser tests for packages that depend on Playwright |
+| `pnpm bench` | Benchmark files committed in the repository |
+
+## Where tests live
+
+| Path | Purpose |
+| --- | --- |
+| [../crates/oxide/tests](../crates/oxide/tests) | Rust scanner behavior |
+| [../integrations/cli](../integrations/cli) | CLI behavior and output |
+| [../integrations/postcss](../integrations/postcss) | PostCSS adapter behavior |
+| [../integrations/vite](../integrations/vite) | Vite adapter and dev/build flows |
+| [../integrations/webpack](../integrations/webpack) | Webpack adapter behavior |
+| [../integrations/oxide](../integrations/oxide) | Wasm and oxide integration coverage |
+| [../integrations/upgrade](../integrations/upgrade) | Upgrade assistant and migration errors |
+| [../packages/tailwindcss/src/*.bench.ts](../packages/tailwindcss/src) | Core performance benchmarks |
+
+## Important prerequisites
+
+Integration and UI suites depend on built workspace artifacts. Run `pnpm build` before them.
+
+This matters because the integration harness in [../integrations/utils.ts](../integrations/utils.ts) installs and executes packages the way a consumer would, not by importing your source files directly.
+
+## Platform caveats
+
+- The CI matrix runs Windows, Linux, and macOS on `main`, but feature branches skip Windows and macOS unless a pull request body contains `[ci-all]`. See [../.github/workflows/ci.yml](../.github/workflows/ci.yml).
+- The WASM integration test in [../integrations/oxide/wasm.test.ts](../integrations/oxide/wasm.test.ts) is Linux-only today because of Node WASI limitations on macOS and Windows.
+- The source-map integration case in [../integrations/cli/index.test.ts](../integrations/cli/index.test.ts) is intentionally skipped because of an upstream Lightning CSS bug.
+
+If you touch Rust, scanner behavior, source maps, or path handling, do not rely on a single-platform local run.
+
+## Writing new tests
+
+Prefer the narrowest test that fully proves the behavior:
+
+1. Add focused module tests when the change is internal and deterministic.
+2. Add or update integration coverage when behavior crosses package boundaries.
+3. Add UI tests only when browser behavior or CSS runtime behavior must be verified.
+
+In practice, a good Tailwind PR usually has one focused proof close to the changed code and one broader proof if the behavior crosses package boundaries.
+
+## Debugging integration tests
+
+The integration harness supports debug-oriented behavior in [../integrations/utils.ts](../integrations/utils.ts), including special handling for pnpm workspaces in debug mode.
+
+When an integration test is hard to reason about:
+
+- rebuild first with `pnpm build`
+- rerun the smallest relevant suite
+- enable `DEBUG=tailwindcss`
+- inspect the test fixture setup in [../integrations/utils.ts](../integrations/utils.ts)
+
+That harness is worth reading. Many integration failures make sense once you see how fixture files are written, installed, and executed.
+
+## Benchmarks
+
+Use `pnpm bench` to run committed benchmark files. Candidate-focused benchmarks in [../packages/tailwindcss/src/candidate.bench.ts](../packages/tailwindcss/src/candidate.bench.ts) and compile-focused benchmarks in [../packages/tailwindcss/src/index.bench.ts](../packages/tailwindcss/src/index.bench.ts) are good starting points when you are validating performance-sensitive work.
+
+## What to run before you push
+
+Use this lightweight matrix. It maps closely to how maintainers usually reason about changes during review.
+
+| Change area | Run at minimum |
+| --- | --- |
+| Compiler core | `pnpm test` plus one adapter integration suite |
+| PostCSS adapter | `pnpm build && pnpm test:integrations -- --run integrations/postcss` |
+| Vite adapter | `pnpm build && pnpm test:integrations -- --run integrations/vite` |
+| Webpack adapter | `pnpm build && pnpm test:integrations -- --run integrations/webpack` |
+| CLI or upgrade | `pnpm build && pnpm test:integrations -- --run integrations/cli` or `integrations/upgrade` |
+| Rust scanner | `cargo test`, then `pnpm build && pnpm test:integrations -- --run integrations/oxide` |
+| Browser-visible behavior | `pnpm build && pnpm test:ui` |
+
+For a more operational, step-by-step version of this matrix, see the [local runbook](RUNBOOK.md).
+
+## Related guides
+
+- [Build and development](BUILD.md)
+- [Architecture overview](ARCHITECTURE.md)
+- [Extending the repository](EXTENDING.md)
+- [Local runbook](RUNBOOK.md)

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -29,9 +29,11 @@ npm install -g pnpm@9.6.0
 Confirm the repository toolchain and target are installed:
 
 ```sh
-rustup default stable
-rustup target add wasm32-wasip1-threads
+rustup toolchain install 1.85.0
+rustup target add wasm32-wasip1-threads --toolchain 1.85.0
 ```
+
+The repository uses [../rust-toolchain.toml](../rust-toolchain.toml) to select Rust 1.85.0 locally, so you should not need to change your global Rust default to recover from setup issues.
 
 If the failure is inside the scanner or N-API binding, rerun `cargo test` before the full workspace build so you can isolate the Rust error earlier.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,92 @@
+# Troubleshooting
+
+Most setup problems in this repo come from one of four places: running commands from the wrong directory, a stale Rust PATH on Windows, missing Playwright browsers, or Bun-only local workflows.
+
+## `pnpm install` fails immediately
+
+Make sure you are in the repository root, which is the `tailwindcss/` directory. Running install commands one level above it fails because there is no root [../package.json](../package.json) there.
+
+After installation, run `pnpm run check:env` before `pnpm build` to confirm the toolchain is actually visible in the current terminal session.
+
+That command is especially useful on Windows, where Rust may be installed correctly but not visible in the current shell yet.
+
+## `pnpm` is not recognized
+
+Enable Corepack or install the pinned version manually:
+
+```sh
+corepack enable
+```
+
+or
+
+```sh
+npm install -g pnpm@9.6.0
+```
+
+## Rust or WASM build errors
+
+Confirm the repository toolchain and target are installed:
+
+```sh
+rustup default stable
+rustup target add wasm32-wasip1-threads
+```
+
+If the failure is inside the scanner or N-API binding, rerun `cargo test` before the full workspace build so you can isolate the Rust error earlier.
+
+If the tools are installed but still not visible, reopen the shell and rerun `pnpm run check:env`.
+
+## `pnpm vite` fails with Bun-related errors
+
+The Vite playground in [../playgrounds/vite/package.json](../playgrounds/vite/package.json) runs with `bun --bun vite`. Install Bun before using that playground.
+
+If you do not want to install Bun, validate Vite changes through the integration suite instead:
+
+```sh
+pnpm build && pnpm test:integrations -- --run integrations/vite
+```
+
+## Playwright tests fail before running assertions
+
+Install browser binaries first:
+
+```sh
+npx playwright install
+```
+
+On Linux systems, CI uses `npx playwright install --with-deps`.
+
+## `DEBUG=tailwindcss` does not work on Windows PowerShell
+
+That syntax is for POSIX shells. In PowerShell, use:
+
+```powershell
+$env:DEBUG='tailwindcss'
+pnpm build
+Remove-Item Env:DEBUG
+```
+
+## Integration tests pass on Linux but fail elsewhere
+
+That can happen legitimately. The repository only runs the full platform matrix on `main` or when the pull request body contains `[ci-all]`. Also note that [../integrations/oxide/wasm.test.ts](../integrations/oxide/wasm.test.ts) is Linux-only today.
+
+## Source map behavior seems inconsistent
+
+One CLI source-map integration scenario is intentionally skipped in [../integrations/cli/index.test.ts](../integrations/cli/index.test.ts) due to an upstream Lightning CSS bug. If you are touching source maps, verify the closest non-skipped integration tests and run a local playground in addition to unit coverage.
+
+## I changed code, but the playground does not reflect it
+
+Use one of these approaches:
+
+1. Run `pnpm build` again before starting the playground.
+2. Use package watch mode such as `pnpm run --filter=tailwindcss dev` in one terminal.
+3. If the issue is adapter-specific, run that adapter's package watch mode instead.
+
+If the change only shows up in one toolchain, confirm it in the matching integration suite before widening the investigation.
+
+## Related guides
+
+- [Local runbook](RUNBOOK.md)
+- [Build and development](BUILD.md)
+- [Testing guide](TESTING.md)

--- a/packages/@tailwindcss-browser/README.md
+++ b/packages/@tailwindcss-browser/README.md
@@ -33,4 +33,4 @@ For help, discussion about best practices, or feature ideas:
 
 ## Contributing
 
-If you're interested in contributing to Tailwind CSS, please read our [contributing docs](https://github.com/tailwindlabs/tailwindcss/blob/main/.github/CONTRIBUTING.md) **before submitting a pull request**.
+If you're interested in contributing to Tailwind CSS, please read our [contributing docs](../../.github/CONTRIBUTING.md) **before submitting a pull request**.

--- a/packages/@tailwindcss-cli/README.md
+++ b/packages/@tailwindcss-cli/README.md
@@ -33,4 +33,4 @@ For help, discussion about best practices, or feature ideas:
 
 ## Contributing
 
-If you're interested in contributing to Tailwind CSS, please read our [contributing docs](https://github.com/tailwindlabs/tailwindcss/blob/main/.github/CONTRIBUTING.md) **before submitting a pull request**.
+If you're interested in contributing to Tailwind CSS, please read our [contributing docs](../../.github/CONTRIBUTING.md) **before submitting a pull request**.

--- a/packages/@tailwindcss-node/README.md
+++ b/packages/@tailwindcss-node/README.md
@@ -33,4 +33,4 @@ For help, discussion about best practices, or feature ideas:
 
 ## Contributing
 
-If you're interested in contributing to Tailwind CSS, please read our [contributing docs](https://github.com/tailwindlabs/tailwindcss/blob/main/.github/CONTRIBUTING.md) **before submitting a pull request**.
+If you're interested in contributing to Tailwind CSS, please read our [contributing docs](../../.github/CONTRIBUTING.md) **before submitting a pull request**.

--- a/packages/@tailwindcss-postcss/README.md
+++ b/packages/@tailwindcss-postcss/README.md
@@ -33,7 +33,7 @@ For help, discussion about best practices, or feature ideas:
 
 ## Contributing
 
-If you're interested in contributing to Tailwind CSS, please read our [contributing docs](https://github.com/tailwindlabs/tailwindcss/blob/main/.github/CONTRIBUTING.md) **before submitting a pull request**.
+If you're interested in contributing to Tailwind CSS, please read our [contributing docs](../../.github/CONTRIBUTING.md) **before submitting a pull request**.
 
 ---
 

--- a/packages/@tailwindcss-upgrade/README.md
+++ b/packages/@tailwindcss-upgrade/README.md
@@ -33,4 +33,4 @@ For help, discussion about best practices, or feature ideas:
 
 ## Contributing
 
-If you're interested in contributing to Tailwind CSS, please read our [contributing docs](https://github.com/tailwindlabs/tailwindcss/blob/main/.github/CONTRIBUTING.md) **before submitting a pull request**.
+If you're interested in contributing to Tailwind CSS, please read our [contributing docs](../../.github/CONTRIBUTING.md) **before submitting a pull request**.

--- a/packages/@tailwindcss-vite/README.md
+++ b/packages/@tailwindcss-vite/README.md
@@ -33,7 +33,7 @@ For help, discussion about best practices, or feature ideas:
 
 ## Contributing
 
-If you're interested in contributing to Tailwind CSS, please read our [contributing docs](https://github.com/tailwindlabs/tailwindcss/blob/main/.github/CONTRIBUTING.md) **before submitting a pull request**.
+If you're interested in contributing to Tailwind CSS, please read our [contributing docs](../../.github/CONTRIBUTING.md) **before submitting a pull request**.
 
 ---
 

--- a/packages/@tailwindcss-webpack/README.md
+++ b/packages/@tailwindcss-webpack/README.md
@@ -33,7 +33,7 @@ For help, discussion about best practices, or feature ideas:
 
 ## Contributing
 
-If you're interested in contributing to Tailwind CSS, please read our [contributing docs](https://github.com/tailwindlabs/tailwindcss/blob/main/.github/CONTRIBUTING.md) **before submitting a pull request**.
+If you're interested in contributing to Tailwind CSS, please read our [contributing docs](../../.github/CONTRIBUTING.md) **before submitting a pull request**.
 
 ---
 

--- a/packages/tailwindcss/README.md
+++ b/packages/tailwindcss/README.md
@@ -33,4 +33,4 @@ For help, discussion about best practices, or feature ideas:
 
 ## Contributing
 
-If you're interested in contributing to Tailwind CSS, please read our [contributing docs](https://github.com/tailwindlabs/tailwindcss/blob/main/.github/CONTRIBUTING.md) **before submitting a pull request**.
+If you're interested in contributing to Tailwind CSS, please read our [contributing docs](../../.github/CONTRIBUTING.md) **before submitting a pull request**.


### PR DESCRIPTION
## Summary
Adds contributor-focused documentation for building, testing, and troubleshooting the project locally.

## What changed
- Added ARCHITECTURE.md
- Added BUILD.md
- Added EXTENDING.md
- Added TESTING.md
- Added RUNBOOK.md
- Added TROUBLESHOOTING.md
- Updated README and CONTRIBUTING links to point to fork-specific guides

## Motivation
The project has a complex monorepo + Rust + WASM setup. These docs make onboarding easier for new contributors, especially on Windows.

## Validation
- Verified local build workflow
- Verified test commands
- Confirmed docs match actual project structure

## Notes
This PR focuses only on documentation improvements and does not change runtime behavior.