### PR TITLE
Always resolve relative files, relative to the current .css file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Ensure `@plugin` resolves package JavaScript entries instead of browser CSS entries when using `@tailwindcss/vite` ([#19949](https://github.com/tailwindlabs/tailwindcss/pull/19949))
+- Fix relative `@import` and `@plugin` paths resolving from the wrong directory when using `@tailwindcss/vite` ([#19965](https://github.com/tailwindlabs/tailwindcss/pull/19965))
 
 ## [4.2.4] - 2026-04-21
 

--- a/integrations/vite/resolvers.test.ts
+++ b/integrations/vite/resolvers.test.ts
@@ -513,6 +513,76 @@ test(
   },
 )
 
+test(
+  'resolve relative CSS files correctly',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "type": "module",
+          "dependencies": {
+            "@tailwindcss/vite": "workspace:^",
+            "tailwindcss": "workspace:^"
+          },
+          "devDependencies": {
+            "vite": "^8"
+          }
+        }
+      `,
+      'vite.config.ts': ts`
+        import tailwindcss from '@tailwindcss/vite'
+        import { defineConfig } from 'vite'
+
+        export default defineConfig({
+          build: { cssMinify: false },
+          plugins: [tailwindcss()],
+        })
+      `,
+      'index.html': html`
+        <html>
+          <head>
+            <link rel="stylesheet" href="./src/index.css" />
+          </head>
+          <body></body>
+        </html>
+      `,
+      'src/index.css': css`
+        @reference 'tailwindcss/theme';
+        @import 'tailwindcss/utilities';
+        @import './themes/glow.css';
+      `,
+      // References a file in the current folder, which names happens to match a
+      // file in the parent folder as well.
+      'src/themes/glow.css': css`@import './entry.css';`,
+      'src/themes/entry.css': css`
+        .do-include-me {
+          color: green;
+        }
+      `,
+
+      // Never rerefenced, so should not be included
+      'src/entry.css': css`
+        .do-not-include-me {
+          color: red;
+        }
+      `,
+    },
+  },
+  async ({ exec, fs, expect }) => {
+    await exec('pnpm vite build')
+
+    expect((await fs.dumpFiles('./dist/**/*.css')).replace(/-([a-zA-Z0-9]*?)\.css/g, '-<hash>.css'))
+      .toMatchInlineSnapshot(`
+      "
+      --- ./dist/assets/index-<hash>.css ---
+      .do-include-me {
+        color: green;
+      }
+      "
+    `)
+  },
+)
+
 describe.each(['postcss', 'lightningcss'])('%s', (transformer) => {
   test(
     'resolves aliases in production build',

--- a/integrations/vite/resolvers.test.ts
+++ b/integrations/vite/resolvers.test.ts
@@ -583,6 +583,78 @@ test(
   },
 )
 
+test(
+  'resolve relative JS files correctly',
+  {
+    fs: {
+      'package.json': json`
+        {
+          "type": "module",
+          "dependencies": {
+            "@tailwindcss/vite": "workspace:^",
+            "tailwindcss": "workspace:^"
+          },
+          "devDependencies": {
+            "vite": "^8"
+          }
+        }
+      `,
+      'vite.config.ts': ts`
+        import tailwindcss from '@tailwindcss/vite'
+        import { defineConfig } from 'vite'
+
+        export default defineConfig({
+          build: { cssMinify: false },
+          plugins: [tailwindcss()],
+        })
+      `,
+      'index.html': html`
+        <html>
+          <head>
+            <link rel="stylesheet" href="./src/index.css" />
+          </head>
+          <body></body>
+        </html>
+      `,
+      'src/index.css': css`
+        @reference 'tailwindcss/theme';
+        @import 'tailwindcss/utilities';
+        @import './themes/glow.css';
+      `,
+      // References a file in the current folder, which names happens to match a
+      // file in the parent folder as well.
+      'src/themes/glow.css': css`@plugin "./my-plugin.js";`,
+      'src/themes/my-plugin.js': ts`
+        export default function ({ addBase }) {
+          addBase({ '.do-include-me': { color: 'green' } })
+        }
+      `,
+
+      // Never rerefenced, so should not be included
+      'src/my-plugin.js': css`
+        export default function ({ addBase }) {
+          addBase({ '.do-not-include-me': { 'color': 'red' } })
+        }
+      `,
+    },
+  },
+  async ({ exec, fs, expect }) => {
+    await exec('pnpm vite build')
+
+    expect((await fs.dumpFiles('./dist/**/*.css')).replace(/-([a-zA-Z0-9]*?)\.css/g, '-<hash>.css'))
+      .toMatchInlineSnapshot(`
+        "
+        --- ./dist/assets/index-<hash>.css ---
+        @layer base {
+          .do-include-me {
+            color: green;
+          }
+        }
+        "
+      `)
+  },
+)
+
 describe.each(['postcss', 'lightningcss'])('%s', (transformer) => {
   test(
     'resolves aliases in production build',

--- a/packages/@tailwindcss-vite/src/index.ts
+++ b/packages/@tailwindcss-vite/src/index.ts
@@ -33,6 +33,44 @@ export type PluginOptions = {
   optimize?: boolean | { minify?: boolean }
 }
 
+function createCustomResolver(
+  resolvers: ((id: string, importer: string) => Promise<string | undefined>)[],
+  filter = (_path: string) => true,
+) {
+  return async (id: string, base: string) => {
+    // The resolver expects an `importer` file. We don't really know where the
+    // current `id` was imported from, but Vite will essentially do a
+    // `path.dirname(importer)` so it doesn't really matter.
+    //
+    // It does matter that this is a file, otherwise we would go up a directory,
+    // which means that we would be resolving files from a parent folder first,
+    // instead of the current folder we are in.
+    let importer = path.resolve(base, '__placeholder__.css')
+
+    for (let resolver of resolvers) {
+      let resolved = await resolver(id, importer)
+
+      // If we didn't resolve, we don't have to bail immediately, but we can try
+      // the next resolver
+      if (!resolved) continue
+
+      if (resolved === id) continue
+
+      // Looks like a relative file, let's resolve it to an absolute path
+      if (resolved[0] === '.') resolved = path.resolve(base, resolved)
+
+      // Must adhere to additional filters (e.g.: must be a .css file)
+      if (!filter(resolved)) continue
+
+      // If it's not an absolute path, then we don't really know how to read
+      // the file from disk.
+      if (!path.isAbsolute(resolved)) continue
+
+      return resolved
+    }
+  }
+}
+
 export default function tailwindcss(opts: PluginOptions = {}): Plugin[] {
   let servers: ViteDevServer[] = []
   let config: ResolvedConfig | null = null
@@ -62,32 +100,20 @@ export default function tailwindcss(opts: PluginOptions = {}): Plugin[] {
 
       let jsResolver = config!.createResolver(config!.resolve)
 
-      customCssResolver = async (id: string, base: string) => {
-        let resolved = await cssResolver(id, base, false, isSSR)
-        if (!resolved) return
-        if (resolved === id) return
-        if (!path.isAbsolute(resolved)) return
-        if (!resolved.endsWith('.css')) return
-        return resolved
-      }
-      customJsResolver = async (id: string, base: string) => {
-        // Resolve Vite aliases first so `@plugin "@/foo"` keeps working, but
-        // let bare package specifiers fall through to Node-style resolution.
-        let resolved = await jsResolver(id, base, true, isSSR)
-        if (resolved && resolved !== id) {
-          if (path.isAbsolute(resolved)) return resolved
-          if (resolved[0] === '.') return path.resolve(base, resolved)
-        }
-
-        // Fall back to Vite's full resolver for features like tsconfigPaths,
-        // but reject CSS results since plugins must resolve to executable code.
-        resolved = await jsResolver(id, base, false, isSSR)
-        if (!resolved) return
-        if (resolved === id) return
-        if (!path.isAbsolute(resolved)) return
-        if (resolved.endsWith('.css')) return
-        return resolved
-      }
+      customCssResolver = createCustomResolver(
+        [
+          (id, importer) => cssResolver(id, importer, true, isSSR),
+          (id, importer) => cssResolver(id, importer, false, isSSR),
+        ],
+        (path) => path.endsWith('.css'),
+      )
+      customJsResolver = createCustomResolver(
+        [
+          (id, importer) => jsResolver(id, importer, true, isSSR),
+          (id, importer) => jsResolver(id, importer, false, isSSR),
+        ],
+        (path) => !path.endsWith('.css'),
+      )
     } else {
       type ResolveIdFn = (
         environment: Environment,
@@ -129,32 +155,20 @@ export default function tailwindcss(opts: PluginOptions = {}): Plugin[] {
 
       let jsResolver = createBackCompatIdResolver(env.config, env.config.resolve)
 
-      customCssResolver = async (id: string, base: string) => {
-        let resolved = await cssResolver(env, id, base, false)
-        if (!resolved) return
-        if (resolved === id) return
-        if (!path.isAbsolute(resolved)) return
-        if (!resolved.endsWith('.css')) return
-        return resolved
-      }
-      customJsResolver = async (id: string, base: string) => {
-        // Resolve Vite aliases first so `@plugin "@/foo"` keeps working, but
-        // let bare package specifiers fall through to Node-style resolution.
-        let resolved = await jsResolver(env, id, base, true)
-        if (resolved && resolved !== id) {
-          if (path.isAbsolute(resolved)) return resolved
-          if (resolved[0] === '.') return path.resolve(base, resolved)
-        }
-
-        // Fall back to Vite's full resolver for features like tsconfigPaths,
-        // but reject CSS results since plugins must resolve to executable code.
-        resolved = await jsResolver(env, id, base, false)
-        if (!resolved) return
-        if (resolved === id) return
-        if (!path.isAbsolute(resolved)) return
-        if (resolved.endsWith('.css')) return
-        return resolved
-      }
+      customCssResolver = createCustomResolver(
+        [
+          (id, importer) => cssResolver(env, id, importer, true),
+          (id, importer) => cssResolver(env, id, importer, false),
+        ],
+        (path) => path.endsWith('.css'),
+      )
+      customJsResolver = createCustomResolver(
+        [
+          (id, importer) => jsResolver(env, id, importer, true),
+          (id, importer) => jsResolver(env, id, importer, false),
+        ],
+        (path) => !path.endsWith('.css'),
+      )
     }
 
     return new Root(


### PR DESCRIPTION
This PR fixes an issue where resolving of certain CSS or JS files results in the wrong paths. The issue happens if you have a setup where a relative file path _also_ exists in the parent folder:

```css
/* src/foo.css */
.foo-in-root {}

/* src/theme/a.css */
@import "./foo.css"; /* This resolved to the file above, instead of the file below */

/* src/theme/foo.css */
.foo-in-theme {}
```

This happened because we resolved relative to a `base` folder, but Vite expects an `importer` instead. The difference is subtle, but they expect a file. On that file they use `let base = path.dirname(importer)` to get a base path out themselves.

This in turn means that if you pass in a folder, you get this:
```js
path.dirname('/path/to/my-project') // /path/to
```

If we gave it a proper file, then we get the proper base path
```js
path.dirname('/path/to/my-project/index.css') // /path/to/my-project
```

I'm actually surprised that this didn't cause issues earlier... but it did result in error since we recently started resolving files using Vite's `aliasOnly: true` feature such taht Vite aliases work as well.

With this change, we now make sure that:

1. We use a proper `importer` instead of the `base` path
2. We refactor the resolving logic such that we try with `aliasOnly: true` first, then `aliasOnly: false`

We also still ensure that in the CSS resolver we expect a `.css` file, and in the JS resolver we _don't_ expect a `.css` file (which can happen if a `"browser": "./dist/index.css"` field in package.json points to a CSS file, daisyUI does this for example).

Fixes: #19956

## Test plan

1. Added additional (failing) integration tests to reproduce the linked issue
2. Existing integration tests pass

While the build still worked, the linked issue resulted in a much bigger file size because the wrong .css files were included. With this fix, the number is correct again:
<img width="1234" height="1037" alt="image" src="https://github.com/user-attachments/assets/fdff803c-0db2-4066-92fa-064c2816b35c" />

Since this is touching code related to previous PRs, I wanted to manually make sure that these still work as expected:

- https://github.com/tailwindlabs/tailwindcss/issues/19950: This one is about daisyUI and the `.css` file referenced in the package.json's `"browser"` field: <img width="782" height="1229" alt="image" src="https://github.com/user-attachments/assets/fb7b9d3b-527b-414b-94b0-2be7e96056f1" />

- https://github.com/tailwindlabs/tailwindcss/issues/19946: This one is about the Vite alias being just a single `@` causing issues with `@plugin "@tailwindcss/typography";` for example: <img width="1694" height="1856" alt="image" src="https://github.com/user-attachments/assets/d1935ecf-e80a-4945-a69a-ec3c5223efab" />


[ci-all]