### PR TITLE
Canonicalization: do not canonicalize units in arbitrary values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolve imports relative to `base` when `result.opts.from` is not provided when using `@tailwindcss/postcss` ([#19980](https://github.com/tailwindlabs/tailwindcss/pull/19980))
 - Canonicalization: preserve significant `_` whitespace in arbitrary values ([#19986](https://github.com/tailwindlabs/tailwindcss/pull/19986))
 - Canonicalization: add parentheses when removing whitespace from arbitrary values would hurt readability ([#19986](https://github.com/tailwindlabs/tailwindcss/pull/19986))
+- Canonicalization: preserve the original unit in arbitrary values instead of normalizing to base units (e.g. `-mt-[20in]` → `mt-[-20in]`, not `mt-[-1920px]`) ([#19988](https://github.com/tailwindlabs/tailwindcss/pull/19988))
 
 ## [4.2.4] - 2026-04-21
 

--- a/packages/tailwindcss/src/canonicalize-candidates.test.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.test.ts
@@ -1210,6 +1210,19 @@ describe.each([['default'], ['with-variant'], ['important'], ['prefix']])('%s', 
 
     await expectCanonicalization(input, candidate, expected)
   })
+
+  // https://github.com/tailwindlabs/tailwindcss-intellisense/issues/1573
+  test.each([
+    ['-mt-[0.04in]', 'mt-[-0.04in]'],
+    ['mt-[-0.04in]', 'mt-[-0.04in]'],
+    ['-mt-[-0.04in]', 'mt-[0.04in]'],
+  ])(testName, { timeout }, async (candidate, expected) => {
+    let input = css`
+      @import 'tailwindcss';
+    `
+
+    await expectCanonicalization(input, candidate, expected)
+  })
 })
 
 describe('theme to var', () => {

--- a/packages/tailwindcss/src/canonicalize-candidates.ts
+++ b/packages/tailwindcss/src/canonicalize-candidates.ts
@@ -2117,7 +2117,7 @@ function optimizeArbitraryValueExpressions(
 
   // Start by constant folding the value expression, when dealing with `calc(…)`
   if (valueAst.length === 1 && valueAst[0].kind === 'function' && valueAst[0].value === 'calc') {
-    let [folded, foldedValueAst] = constantFoldDeclarationAst(valueAst)
+    let [folded, foldedValueAst] = constantFoldDeclarationAst(valueAst, null, false)
     if (folded) {
       let replacement = cloneCandidate(candidate)
       replacement.value!.value = ValueParser.toCss(foldedValueAst)
@@ -2139,7 +2139,7 @@ function optimizeArbitraryValueExpressions(
     // Move `* -1` inside, and try to constant fold to see if it's even worth
     // updating the candidate or not.
     let expressionAst = ValueParser.parse(`calc(${candidate.value!.value} * -1)`)
-    let [folded, foldedExpressionAst] = constantFoldDeclarationAst(expressionAst)
+    let [folded, foldedExpressionAst] = constantFoldDeclarationAst(expressionAst, null, false)
     if (folded) {
       let replacement = cloneCandidate(candidate)
 

--- a/packages/tailwindcss/src/constant-fold-declaration.ts
+++ b/packages/tailwindcss/src/constant-fold-declaration.ts
@@ -5,8 +5,12 @@ import { walk, WalkAction } from './walk'
 
 // Assumption: We already assume that we receive somewhat valid `calc()`
 // expressions. So we will see `calc(1 + 1)` and not `calc(1+1)`
-export function constantFoldDeclaration(input: string, rem: number | null = null): string {
-  let [folded, valueAst] = constantFoldDeclarationAst(ValueParser.parse(input), rem)
+export function constantFoldDeclaration(
+  input: string,
+  rem: number | null = null,
+  normalizeUnit = true,
+): string {
+  let [folded, valueAst] = constantFoldDeclarationAst(ValueParser.parse(input), rem, normalizeUnit)
 
   return folded ? ValueParser.toCss(valueAst) : input
 }
@@ -14,6 +18,7 @@ export function constantFoldDeclaration(input: string, rem: number | null = null
 export function constantFoldDeclarationAst(
   ast: ValueParser.ValueAstNode[],
   rem: number | null = null,
+  normalizeUnit = true,
 ): [folded: boolean, ast: ValueParser.ValueAstNode[]] {
   let folded = false
 
@@ -27,7 +32,7 @@ export function constantFoldDeclarationAst(
         valueNode.kind === 'word' &&
         valueNode.value !== '0' // Already `0`, nothing to do
       ) {
-        let canonical = canonicalizeDimension(valueNode.value, rem)
+        let canonical = canonicalizeDimension(valueNode.value, rem, normalizeUnit)
         if (canonical === null) return // Couldn't be canonicalized, nothing to do
         if (canonical === valueNode.value) return // Already in canonical form, nothing to do
 
@@ -256,7 +261,11 @@ export function constantFoldDeclarationAst(
   return [folded, ast]
 }
 
-function canonicalizeDimension(input: string, rem: number | null = null): string | null {
+function canonicalizeDimension(
+  input: string,
+  rem: number | null = null,
+  normalizeUnit = true,
+): string | null {
   let dimension = dimensions.get(input)
   if (dimension === null) return null // This shouldn't happen
 
@@ -265,6 +274,9 @@ function canonicalizeDimension(input: string, rem: number | null = null): string
 
   // Replace `0<length>` units with just `0`
   if (value === 0 && isLength(input)) return '0'
+
+  // Only normalize into base units when necessary
+  if (!normalizeUnit) return `${input}`
 
   // prettier-ignore
   switch (unit.toLowerCase()) {


### PR DESCRIPTION
This PR improves the canonicalization when dealing with arbitrary values.

As part of the canonicalization process we compute a signature for a given utility. This way we can ensure that when we canonicalize a candidate into a simpler candidate that it's still equivalent if the signatures match.

One thing we do during signature computation is normalizing dimensions (value + unit) into the same unit to make comparisons easier.

For example:
```css
.foo { margin-top: 20in; }
.bar { margin-top: 1920px; }
```

Will both get converted to `1920px` and therefore `foo` and `bar` will have the same signature.

Up until this part, everything is fine. However, this normalization also leaks when we try to canonicalize arbitrary values. One of the things we do is try to move the `-` into the arbitrary value:
```diff
- -mt-[20in]
+ mt-[calc(20in_*_-1)]
```

This is obviously not cleaner, but we can perform some canonicalization of the arbitrary value. As part of that we do constant folding _and_ the normalization of base units. That means that we would see this:
```diff
- -mt-[20in]
- mt-[calc(20in_*_-1)]
+ mt-[-1920px]
```

But this might be very confusing because it might not make sense where the `1920px` even came from... the only thing we should have done here is constant fold that calc expression.

That's what this PR does, it only does the constant folding but without the unit normalization:
```diff
- -mt-[20in]
- mt-[calc(20in_*_-1)]
+ mt-[-20in]
```

Which is exactly what we want!

Fixes: https://github.com/tailwindlabs/tailwindcss-intellisense/issues/1573

## Test plan

1. Added a regression test based on the linked issue
2. All other tests still pass
