### PR TITLE
Simplify `@variant` usage, allow compound and stacked variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - _Experimental_: add `@container-size` utility ([#18901](https://github.com/tailwindlabs/tailwindcss/pull/18901))
+- Allow using `@variant` with stacked variants (e.g. `@variant hover:focus { … }`) ([#19996](https://github.com/tailwindlabs/tailwindcss/pull/19996))
+- Allow using `@variant` with compound variants (e.g. `@variant hover, focus { … }`) ([#19996](https://github.com/tailwindlabs/tailwindcss/pull/19996))
 
 ### Fixed
 

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -5673,8 +5673,8 @@ describe('@variant', () => {
     })
   })
 
-  describe('compound `@variant` rules', () => {
-    it('should handle compound variants', async () => {
+  describe('stacked `@variant` rules', () => {
+    it('should handle stacked variants', async () => {
       await expect(
         compileCss(
           css`
@@ -5702,7 +5702,7 @@ describe('@variant', () => {
       `)
     })
 
-    it('should handle compound variants & comma-separated variants', async () => {
+    it('should handle stacked variants & comma-separated variants', async () => {
       await expect(
         compileCss(
           css`

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -5588,6 +5588,46 @@ describe('@variant', () => {
       `)
     })
 
+    it('should handle missing variants (trailing comma)', async () => {
+      await expect(
+        compileCss(
+          css`
+            .btn {
+              background: black;
+
+              @variant hover,focus, {
+                background: red;
+              }
+            }
+            @tailwind utilities;
+          `,
+          [],
+        ),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[Error: Cannot use \`@variant\` with empty variant]`,
+      )
+    })
+
+    it('should handle missing variants (gap in the middle)', async () => {
+      await expect(
+        compileCss(
+          css`
+            .btn {
+              background: black;
+
+              @variant hover,,focus {
+                background: red;
+              }
+            }
+            @tailwind utilities;
+          `,
+          [],
+        ),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[Error: Cannot use \`@variant\` with empty variant]`,
+      )
+    })
+
     it('should handle nested comma-separated variants', async () => {
       await expect(
         compileCss(
@@ -5628,6 +5668,68 @@ describe('@variant', () => {
 
         .btn:focus:active, .btn:focus:disabled {
           background: #00f;
+        }"
+      `)
+    })
+  })
+
+  describe('compound `@variant` rules', () => {
+    it('should handle compound variants', async () => {
+      await expect(
+        compileCss(
+          css`
+            .btn {
+              background: black;
+
+              @variant hover:focus {
+                background: red;
+              }
+            }
+            @tailwind utilities;
+          `,
+          [],
+        ),
+      ).resolves.toMatchInlineSnapshot(`
+        ".btn {
+          background: #000;
+        }
+
+        @media (hover: hover) {
+          .btn:hover:focus {
+            background: red;
+          }
+        }"
+      `)
+    })
+
+    it('should handle compound variants & comma-separated variants', async () => {
+      await expect(
+        compileCss(
+          css`
+            .btn {
+              background: black;
+
+              @variant hover:focus, disabled {
+                background: red;
+              }
+            }
+            @tailwind utilities;
+          `,
+          [],
+        ),
+      ).resolves.toMatchInlineSnapshot(`
+        ".btn {
+          background: #000;
+        }
+
+        @media (hover: hover) {
+          .btn:hover:focus {
+            background: red;
+          }
+        }
+        
+        .btn:disabled {
+          background: red;
         }"
       `)
     })

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -5459,36 +5459,178 @@ describe('@variant', () => {
     `)
   })
 
-  it('should be possible to use comma-separated `@variant` rules', async () => {
-    await expect(
-      compileCss(
-        css`
-          .btn {
-            background: black;
+  describe('comma-separated `@variant` rules', () => {
+    it('should be possible to use comma-separated `@variant` rules', async () => {
+      await expect(
+        compileCss(
+          css`
+            .btn {
+              background: black;
 
-            @variant hover, focus {
-              background: red;
+              @variant hover, focus {
+                background: red;
+              }
             }
-          }
-          @tailwind utilities;
-        `,
-        [],
-      ),
-    ).resolves.toMatchInlineSnapshot(`
-      ".btn {
-        background: #000;
-      }
+            @tailwind utilities;
+          `,
+          [],
+        ),
+      ).resolves.toMatchInlineSnapshot(`
+        ".btn {
+          background: #000;
+        }
 
-      @media (hover: hover) {
-        .btn:hover {
+        @media (hover: hover) {
+          .btn:hover {
+            background: red;
+          }
+        }
+
+        .btn:focus {
+          background: red;
+        }"
+      `)
+    })
+
+    it('should handle three or more variants', async () => {
+      await expect(
+        compileCss(
+          css`
+            .btn {
+              background: black;
+
+              @variant hover, focus, active {
+                background: red;
+              }
+            }
+            @tailwind utilities;
+          `,
+          [],
+        ),
+      ).resolves.toMatchInlineSnapshot(`
+        ".btn {
+          background: #000;
+        }
+
+        @media (hover: hover) {
+          .btn:hover {
+            background: red;
+          }
+        }
+
+        .btn:focus, .btn:active {
+          background: red;
+        }"
+      `)
+    })
+
+    it('should handle whitespace variations (no space after comma)', async () => {
+      await expect(
+        compileCss(
+          css`
+            .btn {
+              background: black;
+
+              @variant hover,focus {
+                background: red;
+              }
+            }
+            @tailwind utilities;
+          `,
+          [],
+        ),
+      ).resolves.toMatchInlineSnapshot(`
+        ".btn {
+          background: #000;
+        }
+
+        @media (hover: hover) {
+          .btn:hover {
+            background: red;
+          }
+        }
+
+        .btn:focus {
+          background: red;
+        }"
+      `)
+    })
+
+    it('should handle whitespace variations (space before and after comma)', async () => {
+      await expect(
+        compileCss(
+          css`
+            .btn {
+              background: black;
+
+              @variant hover , focus {
+                background: red;
+              }
+            }
+            @tailwind utilities;
+          `,
+          [],
+        ),
+      ).resolves.toMatchInlineSnapshot(`
+        ".btn {
+          background: #000;
+        }
+
+        @media (hover: hover) {
+          .btn:hover {
+            background: red;
+          }
+        }
+
+        .btn:focus {
+          background: red;
+        }"
+      `)
+    })
+
+    it('should handle nested comma-separated variants', async () => {
+      await expect(
+        compileCss(
+          css`
+            .btn {
+              background: black;
+
+              @variant hover, focus {
+                background: red;
+
+                @variant active, disabled {
+                  background: blue;
+                }
+              }
+            }
+            @tailwind utilities;
+          `,
+          [],
+        ),
+      ).resolves.toMatchInlineSnapshot(`
+        ".btn {
+          background: #000;
+        }
+
+        @media (hover: hover) {
+          .btn:hover {
+            background: red;
+          }
+
+          .btn:hover:active, .btn:hover:disabled {
+            background: #00f;
+          }
+        }
+
+        .btn:focus {
           background: red;
         }
-      }
 
-      .btn:focus {
-        background: red;
-      }"
-    `)
+        .btn:focus:active, .btn:focus:disabled {
+          background: #00f;
+        }"
+      `)
+    })
   })
 
   it('should be possible to use `@variant` with a funky looking variants', async () => {

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { describe, expect, it, test } from 'vitest'
 import { compile, Features, Polyfills } from '.'
+import { cartesian } from './cartesian'
 import type { PluginAPI } from './compat/plugin-api'
 import plugin from './plugin'
 import { compileCss, optimizeCss, run } from './test-utils/run'
@@ -5516,22 +5517,28 @@ describe('@variant', () => {
       )
     })
 
-    it('should handle optional whitespace between `@variant` variants', async () => {
-      let before = ['', ' ', '\t'][(Math.random() * 3) | 0].repeat((Math.random() * 3) | 0)
-      let after = ['', ' ', '\t'][(Math.random() * 3) | 0].repeat((Math.random() * 3) | 0)
+    it.each(
+      Array.from(
+        cartesian(
+          ['', ' ', '  ', '\t', '\t\t'], // Before
+          ['', ' ', '  ', '\t', '\t\t'], // After
+        ),
+      ),
+    )(
+      "should handle optional whitespace ('%s', '%s') between `@variant` variants",
+      async (before, after) => {
+        await expect(
+          compileCss(css`
+            .btn {
+              background: black;
 
-      await expect(
-        compileCss(css`
-          .btn {
-            background: black;
-
-            @variant hover${before},${after}focus {
-              background: red;
+              @variant hover${before},${after}focus {
+                background: red;
+              }
             }
-          }
-          @tailwind utilities;
-        `),
-      ).resolves.toMatchInlineSnapshot(`
+            @tailwind utilities;
+          `),
+        ).resolves.toMatchInlineSnapshot(`
         ".btn {
           background: #000;
         }
@@ -5546,7 +5553,8 @@ describe('@variant', () => {
           background: red;
         }"
       `)
-    })
+      },
+    )
 
     it('should handle variants containing a `,` inside', async () => {
       await expect(

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -5459,6 +5459,38 @@ describe('@variant', () => {
     `)
   })
 
+  it('should be possible to use comma-separated `@variant` rules', async () => {
+    await expect(
+      compileCss(
+        css`
+          .btn {
+            background: black;
+
+            @variant hover, focus {
+              background: red;
+            }
+          }
+          @tailwind utilities;
+        `,
+        [],
+      ),
+    ).resolves.toMatchInlineSnapshot(`
+      ".btn {
+        background: #000;
+      }
+
+      @media (hover: hover) {
+        .btn:hover {
+          background: red;
+        }
+      }
+
+      .btn:focus {
+        background: red;
+      }"
+    `)
+  })
+
   it('should be possible to use `@variant` with a funky looking variants', async () => {
     await expect(
       compileCss(

--- a/packages/tailwindcss/src/index.test.ts
+++ b/packages/tailwindcss/src/index.test.ts
@@ -5462,19 +5462,16 @@ describe('@variant', () => {
   describe('comma-separated `@variant` rules', () => {
     it('should be possible to use comma-separated `@variant` rules', async () => {
       await expect(
-        compileCss(
-          css`
-            .btn {
-              background: black;
+        compileCss(css`
+          .btn {
+            background: black;
 
-              @variant hover, focus {
-                background: red;
-              }
+            @variant hover, focus {
+              background: red;
             }
-            @tailwind utilities;
-          `,
-          [],
-        ),
+          }
+          @tailwind utilities;
+        `),
       ).resolves.toMatchInlineSnapshot(`
         ".btn {
           background: #000;
@@ -5490,163 +5487,106 @@ describe('@variant', () => {
           background: red;
         }"
       `)
-    })
 
-    it('should handle three or more variants', async () => {
-      await expect(
-        compileCss(
-          css`
-            .btn {
-              background: black;
+      expect(
+        await compileCss(css`
+          .btn {
+            background: black;
 
-              @variant hover, focus, active {
-                background: red;
-              }
+            @variant hover, focus {
+              background: red;
             }
-            @tailwind utilities;
-          `,
-          [],
-        ),
-      ).resolves.toMatchInlineSnapshot(`
-        ".btn {
-          background: #000;
-        }
-
-        @media (hover: hover) {
-          .btn:hover {
-            background: red;
           }
-        }
+          @tailwind utilities;
+        `),
+      ).toEqual(
+        await compileCss(css`
+          .btn {
+            background: black;
 
-        .btn:focus, .btn:active {
-          background: red;
-        }"
-      `)
-    })
-
-    it('should handle whitespace variations (no space after comma)', async () => {
-      await expect(
-        compileCss(
-          css`
-            .btn {
-              background: black;
-
-              @variant hover,focus {
-                background: red;
-              }
+            @variant hover {
+              background: red;
             }
-            @tailwind utilities;
-          `,
-          [],
-        ),
-      ).resolves.toMatchInlineSnapshot(`
-        ".btn {
-          background: #000;
-        }
-
-        @media (hover: hover) {
-          .btn:hover {
-            background: red;
+            @variant focus {
+              background: red;
+            }
           }
-        }
-
-        .btn:focus {
-          background: red;
-        }"
-      `)
-    })
-
-    it('should handle whitespace variations (space before and after comma)', async () => {
-      await expect(
-        compileCss(
-          css`
-            .btn {
-              background: black;
-
-              @variant hover , focus {
-                background: red;
-              }
-            }
-            @tailwind utilities;
-          `,
-          [],
-        ),
-      ).resolves.toMatchInlineSnapshot(`
-        ".btn {
-          background: #000;
-        }
-
-        @media (hover: hover) {
-          .btn:hover {
-            background: red;
-          }
-        }
-
-        .btn:focus {
-          background: red;
-        }"
-      `)
-    })
-
-    it('should handle missing variants (trailing comma)', async () => {
-      await expect(
-        compileCss(
-          css`
-            .btn {
-              background: black;
-
-              @variant hover,focus, {
-                background: red;
-              }
-            }
-            @tailwind utilities;
-          `,
-          [],
-        ),
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `[Error: Cannot use \`@variant\` with empty variant]`,
+          @tailwind utilities;
+        `),
       )
     })
 
-    it('should handle missing variants (gap in the middle)', async () => {
-      await expect(
-        compileCss(
-          css`
-            .btn {
-              background: black;
+    it('should handle optional whitespace between `@variant` variants', async () => {
+      let before = ['', ' ', '\t'][(Math.random() * 3) | 0].repeat((Math.random() * 3) | 0)
+      let after = ['', ' ', '\t'][(Math.random() * 3) | 0].repeat((Math.random() * 3) | 0)
 
-              @variant hover,,focus {
-                background: red;
-              }
+      await expect(
+        compileCss(css`
+          .btn {
+            background: black;
+
+            @variant hover${before},${after}focus {
+              background: red;
             }
-            @tailwind utilities;
-          `,
-          [],
-        ),
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `[Error: Cannot use \`@variant\` with empty variant]`,
-      )
+          }
+          @tailwind utilities;
+        `),
+      ).resolves.toMatchInlineSnapshot(`
+        ".btn {
+          background: #000;
+        }
+
+        @media (hover: hover) {
+          .btn:hover {
+            background: red;
+          }
+        }
+
+        .btn:focus {
+          background: red;
+        }"
+      `)
+    })
+
+    it('should handle variants containing a `,` inside', async () => {
+      await expect(
+        compileCss(css`
+          .btn {
+            background: black;
+
+            @variant [&:is(:hover,:focus)], disabled {
+              background: red;
+            }
+          }
+          @tailwind utilities;
+        `),
+      ).resolves.toMatchInlineSnapshot(`
+        ".btn {
+          background: #000;
+        }
+
+        .btn:is(:hover, :focus), .btn:disabled {
+          background: red;
+        }"
+      `)
     })
 
     it('should handle nested comma-separated variants', async () => {
       await expect(
-        compileCss(
-          css`
-            .btn {
-              background: black;
+        compileCss(css`
+          .btn {
+            background: black;
 
-              @variant hover, focus {
-                background: red;
+            @variant hover, focus {
+              background: red;
 
-                @variant active, disabled {
-                  background: blue;
-                }
+              @variant active, disabled {
+                background: blue;
               }
             }
-            @tailwind utilities;
-          `,
-          [],
-        ),
+          }
+          @tailwind utilities;
+        `),
       ).resolves.toMatchInlineSnapshot(`
         ".btn {
           background: #000;
@@ -5670,25 +5610,104 @@ describe('@variant', () => {
           background: #00f;
         }"
       `)
+
+      expect(
+        await compileCss(css`
+          .btn {
+            background: black;
+
+            @variant hover, focus {
+              background: red;
+
+              @variant active, disabled {
+                background: blue;
+              }
+            }
+          }
+          @tailwind utilities;
+        `),
+      ).toEqual(
+        await compileCss(css`
+          .btn {
+            background: black;
+
+            @variant hover {
+              background: red;
+
+              @variant active {
+                background: blue;
+              }
+
+              @variant disabled {
+                background: blue;
+              }
+            }
+
+            @variant focus {
+              background: red;
+
+              @variant active {
+                background: blue;
+              }
+
+              @variant disabled {
+                background: blue;
+              }
+            }
+          }
+          @tailwind utilities;
+        `),
+      )
+    })
+
+    it('should error on invalid variants (trailing comma)', async () => {
+      await expect(
+        compileCss(css`
+          .btn {
+            background: black;
+
+            @variant hover,focus, {
+              background: red;
+            }
+          }
+          @tailwind utilities;
+        `),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[Error: Cannot use \`@variant\` with empty variant]`,
+      )
+    })
+
+    it('should error on invalid variants (double comma)', async () => {
+      await expect(
+        compileCss(css`
+          .btn {
+            background: black;
+
+            @variant hover,,focus {
+              background: red;
+            }
+          }
+          @tailwind utilities;
+        `),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `[Error: Cannot use \`@variant\` with empty variant]`,
+      )
     })
   })
 
   describe('stacked `@variant` rules', () => {
     it('should handle stacked variants', async () => {
       await expect(
-        compileCss(
-          css`
-            .btn {
-              background: black;
+        compileCss(css`
+          .btn {
+            background: black;
 
-              @variant hover:focus {
-                background: red;
-              }
+            @variant hover:focus {
+              background: red;
             }
-            @tailwind utilities;
-          `,
-          [],
-        ),
+          }
+          @tailwind utilities;
+        `),
       ).resolves.toMatchInlineSnapshot(`
         ".btn {
           background: #000;
@@ -5704,19 +5723,16 @@ describe('@variant', () => {
 
     it('should handle stacked variants & comma-separated variants', async () => {
       await expect(
-        compileCss(
-          css`
-            .btn {
-              background: black;
+        compileCss(css`
+          .btn {
+            background: black;
 
-              @variant hover:focus, disabled {
-                background: red;
-              }
+            @variant hover:focus, disabled {
+              background: red;
             }
-            @tailwind utilities;
-          `,
-          [],
-        ),
+          }
+          @tailwind utilities;
+        `),
       ).resolves.toMatchInlineSnapshot(`
         ".btn {
           background: #000;
@@ -5733,6 +5749,128 @@ describe('@variant', () => {
         }"
       `)
     })
+
+    it('should handle variants containing a `:` inside', async () => {
+      await expect(
+        compileCss(css`
+          .btn {
+            background: black;
+
+            @variant [&:is(:hover,:focus)]:disabled, aria-disabled:hover {
+              background: red;
+            }
+          }
+          @tailwind utilities;
+        `),
+      ).resolves.toMatchInlineSnapshot(`
+        ".btn {
+          background: #000;
+        }
+
+        .btn:is(:hover, :focus):disabled {
+          background: red;
+        }
+
+        @media (hover: hover) {
+          .btn[aria-disabled="true"]:hover {
+            background: red;
+          }
+        }"
+      `)
+    })
+  })
+
+  it('should be possible to use compound and stacked variants in `@variant`', async () => {
+    await expect(
+      compileCss(css`
+        .btn {
+          background: black;
+
+          @variant data-a, data-b:data-c {
+            background: red;
+
+            @variant data-d, data-e:data-f {
+              background: blue;
+            }
+          }
+        }
+        @tailwind utilities;
+      `),
+    ).resolves.toMatchInlineSnapshot(`
+      ".btn {
+        background: #000;
+      }
+
+      .btn[data-a] {
+        background: red;
+      }
+
+      .btn[data-a][data-d], .btn[data-a][data-e][data-f] {
+        background: #00f;
+      }
+
+      .btn[data-b][data-c] {
+        background: red;
+      }
+
+      .btn[data-b][data-c][data-d], .btn[data-b][data-c][data-e][data-f] {
+        background: #00f;
+      }"
+    `)
+
+    expect(
+      await compileCss(css`
+        .btn {
+          background: black;
+
+          @variant data-a, data-b:data-c {
+            background: red;
+
+            @variant data-d, data-e:data-f {
+              background: blue;
+            }
+          }
+        }
+        @tailwind utilities;
+      `),
+    ).toEqual(
+      await compileCss(css`
+        .btn {
+          background: black;
+
+          @variant data-a {
+            background: red;
+
+            @variant data-d {
+              background: blue;
+            }
+
+            @variant data-e {
+              @variant data-f {
+                background: blue;
+              }
+            }
+          }
+
+          @variant data-b {
+            @variant data-c {
+              background: red;
+
+              @variant data-d {
+                background: blue;
+              }
+
+              @variant data-e {
+                @variant data-f {
+                  background: blue;
+                }
+              }
+            }
+          }
+        }
+        @tailwind utilities;
+      `),
+    )
   })
 
   it('should be possible to use `@variant` with a funky looking variants', async () => {

--- a/packages/tailwindcss/src/source-maps/source-map.test.ts
+++ b/packages/tailwindcss/src/source-maps/source-map.test.ts
@@ -395,6 +395,31 @@ test('@apply generates source maps', async ({ expect }) => {
   ])
 })
 
+test('@variant generates source maps', async ({ expect }) => {
+  let { sources, annotations } = await run({
+    input: css`
+      .foo {
+        @variant hover {
+          color: red;
+        }
+
+        @variant focus:disabled, hover:aria-expanded {
+          color: blue;
+        }
+      }
+    `,
+  })
+
+  expect(sources).toEqual(['input.css'])
+
+  expect(annotations).toEqual([
+    'input.css: 1:0-5 <- 1:0-5',
+    'input.css: 4:6-16 <- 3:4-14',
+    'input.css: 9:6-17 <- 7:4-15',
+    'input.css: 15:8-19 <- 7:4-15',
+  ])
+})
+
 test('license comments preserve source locations', async ({ expect }) => {
   let { sources, annotations } = await run({
     input: `/*! some comment */`,

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -1212,24 +1212,28 @@ export function substituteAtVariant(ast: AstNode[], designSystem: DesignSystem):
   walk(ast, (variantNode) => {
     if (variantNode.kind !== 'at-rule' || variantNode.name !== '@variant') return
 
-    // Starting with the `&` rule node
-    let node = styleRule('&', variantNode.nodes)
+    let variants = segment(variantNode.params, ',').map((variant) => variant.trim())
+    let nodes: AstNode[] = []
+    for (let variant of variants) {
+      // Starting with the `&` rule node
+      let node = styleRule('&', variantNode.nodes)
 
-    let variant = variantNode.params
+      let variantAst = designSystem.parseVariant(variant)
+      if (variantAst === null) {
+        throw new Error(`Cannot use \`@variant\` with unknown variant: ${variant}`)
+      }
 
-    let variantAst = designSystem.parseVariant(variant)
-    if (variantAst === null) {
-      throw new Error(`Cannot use \`@variant\` with unknown variant: ${variant}`)
-    }
+      let result = applyVariant(node, variantAst, designSystem.variants)
+      if (result === null) {
+        throw new Error(`Cannot use \`@variant\` with variant: ${variant}`)
+      }
 
-    let result = applyVariant(node, variantAst, designSystem.variants)
-    if (result === null) {
-      throw new Error(`Cannot use \`@variant\` with variant: ${variant}`)
+      nodes.push(node)
     }
 
     // Update the variant at-rule node, to be the `&` rule node
     features |= Features.Variants
-    return WalkAction.Replace(node)
+    return WalkAction.Replace(nodes)
   })
   return features
 }

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -1216,7 +1216,7 @@ export function substituteAtVariant(ast: AstNode[], designSystem: DesignSystem):
     let nodes: AstNode[] = []
     for (let variant of variants) {
       // Starting with the `&` rule node
-      let node = styleRule('&', variantNode.nodes)
+      let node = styleRule('&', variantNode.nodes.map(cloneAstNode))
 
       let variantAst = designSystem.parseVariant(variant)
       if (variantAst === null) {

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -1213,11 +1213,21 @@ export function substituteAtVariant(ast: AstNode[], designSystem: DesignSystem):
     if (variantNode.kind !== 'at-rule' || variantNode.name !== '@variant') return
 
     let nodes: AstNode[] = []
-    for (let compoundVariants of segment(variantNode.params, ',')) {
+    let compoundVariants = segment(variantNode.params, ',')
+    for (let [idx, compoundVariant] of compoundVariants.entries()) {
       // Starting with the `&` rule node
-      let node = styleRule('&', variantNode.nodes.map(cloneAstNode))
+      //
+      // Only clone the nodes when we have multiple compound variants to deal
+      // with. The last one can use the original nodes. We do need unique AST
+      // nodes for sourcemap `dst` location information.
+      let node = styleRule(
+        '&',
+        idx === compoundVariants.length - 1
+          ? variantNode.nodes
+          : variantNode.nodes.map(cloneAstNode),
+      )
 
-      let stackedVariants = segment(compoundVariants, ':')
+      let stackedVariants = segment(compoundVariant, ':')
       for (let i = stackedVariants.length - 1; i >= 0; --i) {
         let variant = stackedVariants[i].trim()
 

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -1212,17 +1212,15 @@ export function substituteAtVariant(ast: AstNode[], designSystem: DesignSystem):
   walk(ast, (variantNode) => {
     if (variantNode.kind !== 'at-rule' || variantNode.name !== '@variant') return
 
-    let stacks = segment(variantNode.params, ',').map((variants: string) =>
-      segment(variants, ':')
-        .map((variant) => variant.trim())
-        .reverse(),
-    )
     let nodes: AstNode[] = []
-    for (let variants of stacks) {
+    for (let compoundVariants of segment(variantNode.params, ',')) {
       // Starting with the `&` rule node
       let node = styleRule('&', variantNode.nodes.map(cloneAstNode))
 
-      for (let variant of variants) {
+      let stackedVariants = segment(compoundVariants, ':')
+      for (let i = stackedVariants.length - 1; i >= 0; --i) {
+        let variant = stackedVariants[i].trim()
+
         if (!variant) {
           throw new Error(`Cannot use \`@variant\` with empty variant`)
         }

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -1212,20 +1212,30 @@ export function substituteAtVariant(ast: AstNode[], designSystem: DesignSystem):
   walk(ast, (variantNode) => {
     if (variantNode.kind !== 'at-rule' || variantNode.name !== '@variant') return
 
-    let variants = segment(variantNode.params, ',').map((variant) => variant.trim())
+    let selectors = segment(variantNode.params, ',').map((variants: string) =>
+      segment(variants, ':')
+        .map((variant) => variant.trim())
+        .reverse(),
+    )
     let nodes: AstNode[] = []
-    for (let variant of variants) {
+    for (let variants of selectors) {
       // Starting with the `&` rule node
       let node = styleRule('&', variantNode.nodes.map(cloneAstNode))
 
-      let variantAst = designSystem.parseVariant(variant)
-      if (variantAst === null) {
-        throw new Error(`Cannot use \`@variant\` with unknown variant: ${variant}`)
-      }
+      for (let variant of variants) {
+        if (!variant) {
+          throw new Error(`Cannot use \`@variant\` with empty variant`)
+        }
 
-      let result = applyVariant(node, variantAst, designSystem.variants)
-      if (result === null) {
-        throw new Error(`Cannot use \`@variant\` with variant: ${variant}`)
+        let variantAst = designSystem.parseVariant(variant)
+        if (variantAst === null) {
+          throw new Error(`Cannot use \`@variant\` with unknown variant: ${variant}`)
+        }
+
+        let result = applyVariant(node, variantAst, designSystem.variants)
+        if (result === null) {
+          throw new Error(`Cannot use \`@variant\` with variant: ${variant}`)
+        }
       }
 
       nodes.push(node)

--- a/packages/tailwindcss/src/variants.ts
+++ b/packages/tailwindcss/src/variants.ts
@@ -1212,13 +1212,13 @@ export function substituteAtVariant(ast: AstNode[], designSystem: DesignSystem):
   walk(ast, (variantNode) => {
     if (variantNode.kind !== 'at-rule' || variantNode.name !== '@variant') return
 
-    let selectors = segment(variantNode.params, ',').map((variants: string) =>
+    let stacks = segment(variantNode.params, ',').map((variants: string) =>
       segment(variants, ':')
         .map((variant) => variant.trim())
         .reverse(),
     )
     let nodes: AstNode[] = []
-    for (let variants of selectors) {
+    for (let variants of stacks) {
       // Starting with the `&` rule node
       let node = styleRule('&', variantNode.nodes.map(cloneAstNode))
 


### PR DESCRIPTION
This PR improves and simplifies the `@variant` usage. 

When we originally added support for `@variant`, we wanted to keep things simple, where we could only use a single variant at a time. The original PR did have a more complex system with all these features enabled, but we wanted to make sure that we only introduced the additional complexity when the community felt like it was needed.

But of course we still wanted to make sure that you could do compound and stacked variants, it just required some additional code.

For compound variants, where you want to use variant `a` and variant `b`, you could duplicate the rules as siblings:
```css
.foo {
  @variant a {
    display: flex;
  }

  @variant b {
    display: flex;
  }
}
```

But with this PR, you can comma separate each variant to get the same effect:
```css
.foo {
  @variant a, b {
    display: flex;
  }
}
```
You can think of this as-if we are expanding this syntax into the aforementioned syntax. In other words, we would do the duplication for you.

Additionally, you also want to be able to stack variants. For that you had to nest your `@variant` rules:
```css
.foo {
  @variant a {
    @variant b {
      display: flex;
    }
  }
}
```

Not the end of the world, but it can get pretty nested if you want to use multiple variants. Luckily we already have a syntax for this in normal Tailwind CSS classes: `a:b:flex`. Which is exactly what we can use here as well:
```css
.foo {
  @variant a:b {
    display: flex;
  }
}
```
Again, conceptually you can think of this syntax being expanded into the syntax from above.

Last but not least, we can also combine these:
```css
.foo {
  background: black;

  @variant a, b:c {
    background: red;

    @variant d, e:f {
      background: blue;
    }
  }
}
```
This conceptually translates into the much more verbose version today:
```css
.foo {
  background: black;

  @variant a {
    background: red;

    @variant d {
      background: blue;
    }

    @variant e {
      @variant f {
        background: blue;
      }
    }
  }

  @variant b {
    @variant c {
      background: red;

      @variant d {
        background: blue;
      }

      @variant e {
        @variant f {
          background: blue;
        }
      }
    }
  }
}
```

The biggest downside is that this could potentially easily balloon your CSS file size if you're not careful. Because with this, it's pretty easy to add one more variant that introduces a lot of duplicated CSS.

This feature is completely backwards compatible, you can still nest your `@variant` calls yourself if you want, and combine them with these features if you want.

This is also a continuation of #19526 and #19884, but for some reason I don't have push rights, so I'm creating this new PR instead. I did keep the original commits of those PRs so these contributors are still properly marked as contributors.
<img width="808" height="135" alt="image" src="https://github.com/user-attachments/assets/bee334ab-39d7-4d4d-a48f-afa2253cf17b" />
<img width="349" height="75" alt="image" src="https://github.com/user-attachments/assets/fb68906c-db74-43f7-83e4-918ad3d4a036" />


Closes: #19526
Closes: #19884

## Test plan

1. Added a bunch of new tests to verify this new behavior
2. Added tests that compare the short (new) version, and the long (old) version
3. Added a sourcemap related test to ensure that the src and dst locations are correct
4. Existing tests still pass
