### PR TITLE
Add source map visualization for tests

### DIFF
--- a/packages/tailwindcss/src/source-maps/source-map.test.ts
+++ b/packages/tailwindcss/src/source-maps/source-map.test.ts
@@ -807,14 +807,14 @@ test('license comments with new lines preserve source locations', async ({ expec
 
   expect(annotations).toMatchInlineSnapshot(`
     "
-       output.css            |    input.css
-                             | 
-    1  /*! some              | 1  /*! some 
-       ^ A @ 1:0             |    ^ A @ 1:0
-    1  /*! some              | 2   comment */
-       ^^^^^^^^^ B @ 1:0-2:0 |    ^ B @ 2:0
-    2   comment */           | 2   comment */
-                  ^ C @ 2:11 |               ^ C @ 2:11
+       output.css                |    input.css
+                                 | 
+    1  /*! some                  | 1  /*! some 
+       ^ A @ 1:0                 |    ^ A @ 1:0
+    1  /*! some                  | 2   comment */
+       ^^^^^^^^^ B @ 1:0-2:0     |    ^ B @ 2:0
+    2   comment */               | 2   comment */
+                  ^ C @ 2:11-3:0 |               ^ C @ 2:11
     "
   `)
 })

--- a/packages/tailwindcss/src/source-maps/source-map.test.ts
+++ b/packages/tailwindcss/src/source-maps/source-map.test.ts
@@ -717,12 +717,14 @@ test('@variant generates source maps', async ({ expect }) => {
   let { sources, annotations } = await run({
     input: css`
       .foo {
-        @variant hover {
-          color: red;
-        }
+        color: red;
 
-        @variant focus:disabled, hover:aria-expanded {
-          color: blue;
+        @variant data-a, data-b:data-c {
+          color: green;
+
+          @variant data-d, data-e:data-f {
+            color: blue;
+          }
         }
       }
     `,
@@ -732,37 +734,49 @@ test('@variant generates source maps', async ({ expect }) => {
 
   expect(annotations).toMatchInlineSnapshot(`
     "
-        output.css                      |    input.css
-                                        | 
-     1  .foo {                          | 1  .foo {
-        ^^^^^ A @ 1:0-5                 |    ^^^^^ A @ 1:0-5
-     2    &:hover {                     | 
-     3      @media (hover: hover) {     | 
-                                        | 2    @variant hover {
-     4        color: red;               | 3      color: red;
-              ^^^^^^^^^^ B @ 4:6-16     |        ^^^^^^^^^^ B @ 3:4-14
-                                        | 4    }
-     5      }                           | 
-     6    }                             | 
-     7    &:focus {                     | 
-     8      &:disabled {                | 
-                                        | 6    @variant focus:disabled, hover:aria-expanded {
-     9        color: blue;              | 7      color: blue;
-              ^^^^^^^^^^^ C @ 9:6-17    |        ^^^^^^^^^^^ C @ 7:4-15
-                                        | 8    }
-                                        | 9  }
-    10      }                           | 
-    11    }                             | 
-    12    &:hover {                     | 
-    13      @media (hover: hover) {     | 
-    14        &[aria-expanded="true"] { | 
-    15          color: blue;            | 
-                ^^^^^^^^^^^ C @ 15:8-19 | 
-    16        }                         | 
-    17      }                           | 
-    18    }                             | 
-    19  }                               | 
-    20                                  | 
+        output.css                         |     input.css
+                                           | 
+     1  .foo {                             |  1  .foo {
+        ^^^^^ A @ 1:0-5                    |     ^^^^^ A @ 1:0-5
+     2    color: red;                      |  2    color: red;
+          ^^^^^^^^^^ B @ 2:2-12            |       ^^^^^^^^^^ B @ 2:2-12
+     3    &[data-a] {                      | 
+                                           |  4    @variant data-a, data-b:data-c {
+     4      color: green;                  |  5      color: green;
+            ^^^^^^^^^^^^ C @ 4:4-16        |         ^^^^^^^^^^^^ C @ 5:4-16
+     5      &[data-d] {                    | 
+                                           |  7      @variant data-d, data-e:data-f {
+     6        color: blue;                 |  8        color: blue;
+              ^^^^^^^^^^^ D @ 6:6-17       |           ^^^^^^^^^^^ D @ 8:6-17
+                                           |  9      }
+                                           | 10    }
+                                           | 11  }
+     7      }                              | 
+     8      &[data-e] {                    | 
+     9        &[data-f] {                  | 
+    10          color: blue;               | 
+                ^^^^^^^^^^^ D @ 10:8-19    | 
+    11        }                            | 
+    12      }                              | 
+    13    }                                | 
+    14    &[data-b] {                      | 
+    15      &[data-c] {                    | 
+    16        color: green;                | 
+              ^^^^^^^^^^^^ C @ 16:6-18     | 
+    17        &[data-d] {                  | 
+    18          color: blue;               | 
+                ^^^^^^^^^^^ D @ 18:8-19    | 
+    19        }                            | 
+    20        &[data-e] {                  | 
+    21          &[data-f] {                | 
+    22            color: blue;             | 
+                  ^^^^^^^^^^^ D @ 22:10-21 | 
+    23          }                          | 
+    24        }                            | 
+    25      }                              | 
+    26    }                                | 
+    27  }                                  | 
+    28                                     | 
     "
   `)
 })

--- a/packages/tailwindcss/src/source-maps/source-map.test.ts
+++ b/packages/tailwindcss/src/source-maps/source-map.test.ts
@@ -3,12 +3,13 @@ import dedent from 'dedent'
 import MagicString from 'magic-string'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
-import { SourceMapConsumer, SourceMapGenerator, type RawSourceMap } from 'source-map-js'
+import { SourceMapGenerator, type RawSourceMap } from 'source-map-js'
 import { test } from 'vitest'
 import { compile } from '..'
 import createPlugin from '../plugin'
 import { DefaultMap } from '../utils/default-map'
 import type { DecodedSource, DecodedSourceMap } from './source-map'
+import { visualizeSourceMap } from './visualize-source-map'
 const css = dedent
 
 interface RunOptions {
@@ -42,7 +43,7 @@ async function run({ input, candidates, options }: RunOptions) {
   let map = JSON.parse(rawMap.toString()) as RawSourceMap
 
   let sources = combined.sources
-  let annotations = formattedMappings(map)
+  let annotations = visualizeSourceMap(map, css)
 
   return { css, map, sources, annotations }
 }
@@ -80,72 +81,6 @@ function toRawSourceMap(map: DecodedSourceMap): string {
   return generator.toString()
 }
 
-/**
- * An string annotation that represents a source map
- *
- * It's not meant to be exhaustive just enough to
- * verify that the source map is working and that
- * lines are mapped back to the original source
- *
- * Including when using @apply with multiple classes
- */
-function formattedMappings(map: RawSourceMap) {
-  const smc = new SourceMapConsumer(map)
-  const annotations: Record<
-    number,
-    {
-      original: { start: [number, number]; end: [number, number] }
-      generated: { start: [number, number]; end: [number, number] }
-      source: string
-    }
-  > = {}
-
-  smc.eachMapping((mapping) => {
-    let annotation = (annotations[mapping.generatedLine] = annotations[mapping.generatedLine] || {
-      ...mapping,
-
-      original: {
-        start: [mapping.originalLine, mapping.originalColumn],
-        end: [mapping.originalLine, mapping.originalColumn],
-      },
-
-      generated: {
-        start: [mapping.generatedLine, mapping.generatedColumn],
-        end: [mapping.generatedLine, mapping.generatedColumn],
-      },
-
-      source: mapping.source,
-    })
-
-    annotation.generated.end[0] = mapping.generatedLine
-    annotation.generated.end[1] = mapping.generatedColumn
-
-    annotation.original.end[0] = mapping.originalLine!
-    annotation.original.end[1] = mapping.originalColumn!
-  })
-
-  return Object.values(annotations).map((annotation) => {
-    return `${annotation.source}: ${formatRange(annotation.generated)} <- ${formatRange(annotation.original)}`
-  })
-}
-
-function formatRange(range: { start: [number, number]; end: [number, number] }) {
-  if (range.start[0] === range.end[0]) {
-    // This range is on the same line
-    // and the columns are the same
-    if (range.start[1] === range.end[1]) {
-      return `${range.start[0]}:${range.start[1]}`
-    }
-
-    // This range is on the same line
-    // but the columns are different
-    return `${range.start[0]}:${range.start[1]}-${range.end[1]}`
-  }
-
-  // This range spans multiple lines
-  return `${range.start[0]}:${range.start[1]}-${range.end[0]}:${range.end[1]}`
-}
-
 test('source maps trace back to @import location', async ({ expect }) => {
   let { sources, annotations } = await run({
     input: css`
@@ -170,129 +105,474 @@ test('source maps trace back to @import location', async ({ expect }) => {
   // The output CSS should include annotations linking back to:
   // 1. The class definition `.foo`
   // 2. The `@apply underline` line inside of it
-  expect(annotations).toEqual([
-    'index.css: 1:0-41 <- 1:0-41',
-    'index.css: 2:0-13 <- 3:0-34',
-    'theme.css: 3:2-15 <- 1:0-15',
-    'theme.css: 4:4 <- 2:2-4:0',
-    'theme.css: 5:22 <- 4:22',
-    'theme.css: 6:4 <- 6:2-8:0',
-    'theme.css: 7:13 <- 8:13',
-    'theme.css: 8:4-43 <- 494:2-54',
-    'theme.css: 9:4-48 <- 497:2-59',
-    'index.css: 12:0-12 <- 4:0-37',
-    'preflight.css: 13:2-59 <- 7:0-11:23',
-    'preflight.css: 14:4-26 <- 12:2-24',
-    'preflight.css: 15:4-13 <- 13:2-11',
-    'preflight.css: 16:4-14 <- 14:2-12',
-    'preflight.css: 17:4-19 <- 15:2-17',
-    'preflight.css: 19:2-14 <- 28:0-29:6',
-    'preflight.css: 20:4-20 <- 30:2-18',
-    'preflight.css: 21:4-34 <- 31:2-32',
-    'preflight.css: 22:4-15 <- 32:2-13',
-    'preflight.css: 23:4-159 <- 33:2-42:3',
-    'preflight.css: 24:4-71 <- 43:2-73',
-    'preflight.css: 25:4-75 <- 44:2-77',
-    'preflight.css: 26:4-44 <- 45:2-42',
-    'preflight.css: 28:2-5 <- 54:0-3',
-    'preflight.css: 29:4-13 <- 55:2-11',
-    'preflight.css: 30:4-18 <- 56:2-16',
-    'preflight.css: 31:4-25 <- 57:2-23',
-    'preflight.css: 33:2-22 <- 64:0-20',
-    'preflight.css: 34:4-45 <- 65:2-43',
-    'preflight.css: 35:4-37 <- 66:2-35',
-    'preflight.css: 37:2-25 <- 73:0-78:3',
-    'preflight.css: 38:4-22 <- 79:2-20',
-    'preflight.css: 39:4-24 <- 80:2-22',
-    'preflight.css: 41:2-4 <- 87:0-2',
-    'preflight.css: 42:4-18 <- 88:2-16',
-    'preflight.css: 43:4-36 <- 89:2-34',
-    'preflight.css: 44:4-28 <- 90:2-26',
-    'preflight.css: 46:2-12 <- 97:0-98:7',
-    'preflight.css: 47:4-23 <- 99:2-21',
-    'preflight.css: 49:2-23 <- 109:0-112:4',
-    'preflight.css: 50:4-148 <- 113:2-123:3',
-    'preflight.css: 51:4-76 <- 124:2-78',
-    'preflight.css: 52:4-80 <- 125:2-82',
-    'preflight.css: 53:4-18 <- 126:2-16',
-    'preflight.css: 55:2-8 <- 133:0-6',
-    'preflight.css: 56:4-18 <- 134:2-16',
-    'preflight.css: 58:2-11 <- 141:0-142:4',
-    'preflight.css: 59:4-18 <- 143:2-16',
-    'preflight.css: 60:4-18 <- 144:2-16',
-    'preflight.css: 61:4-22 <- 145:2-20',
-    'preflight.css: 62:4-28 <- 146:2-26',
-    'preflight.css: 64:2-6 <- 149:0-4',
-    'preflight.css: 65:4-19 <- 150:2-17',
-    'preflight.css: 67:2-6 <- 153:0-4',
-    'preflight.css: 68:4-15 <- 154:2-13',
-    'preflight.css: 70:2-8 <- 163:0-6',
-    'preflight.css: 71:4-18 <- 164:2-16',
-    'preflight.css: 72:4-25 <- 165:2-23',
-    'preflight.css: 73:4-29 <- 166:2-27',
-    'preflight.css: 75:2-18 <- 173:0-16',
-    'preflight.css: 76:4-17 <- 174:2-15',
-    'preflight.css: 78:2-11 <- 181:0-9',
-    'preflight.css: 79:4-28 <- 182:2-26',
-    'preflight.css: 81:2-10 <- 189:0-8',
-    'preflight.css: 82:4-22 <- 190:2-20',
-    'preflight.css: 84:2-15 <- 197:0-199:5',
-    'preflight.css: 85:4-20 <- 200:2-18',
-    'preflight.css: 87:2-56 <- 209:0-216:7',
-    'preflight.css: 88:4-18 <- 217:2-16',
-    'preflight.css: 89:4-26 <- 218:2-24',
-    'preflight.css: 91:2-13 <- 225:0-226:6',
-    'preflight.css: 92:4-19 <- 227:2-17',
-    'preflight.css: 93:4-16 <- 228:2-14',
-    'preflight.css: 95:2-68 <- 238:0-243:23',
-    'preflight.css: 96:4-17 <- 244:2-15',
-    'preflight.css: 97:4-34 <- 245:2-32',
-    'preflight.css: 98:4-36 <- 246:2-34',
-    'preflight.css: 99:4-27 <- 247:2-25',
-    'preflight.css: 100:4-18 <- 248:2-16',
-    'preflight.css: 101:4-20 <- 249:2-18',
-    'preflight.css: 102:4-33 <- 250:2-31',
-    'preflight.css: 103:4-14 <- 251:2-12',
-    'preflight.css: 105:2-49 <- 258:0-47',
-    'preflight.css: 106:4-23 <- 259:2-21',
-    'preflight.css: 108:2-56 <- 266:0-54',
-    'preflight.css: 109:4-30 <- 267:2-28',
-    'preflight.css: 111:2-25 <- 274:0-23',
-    'preflight.css: 112:4-26 <- 275:2-24',
-    'preflight.css: 114:2-16 <- 282:0-14',
-    'preflight.css: 115:4-14 <- 283:2-12',
-    'preflight.css: 117:2-92 <- 291:0-292:49',
-    'preflight.css: 118:4-18 <- 293:2-16',
-    'preflight.css: 119:6-25 <- 294:4-61',
-    'preflight.css: 120:6-53 <- 294:4-61',
-    'preflight.css: 121:8-65 <- 294:4-61',
-    'preflight.css: 125:2-11 <- 302:0-9',
-    'preflight.css: 126:4-20 <- 303:2-18',
-    'preflight.css: 128:2-30 <- 310:0-28',
-    'preflight.css: 129:4-28 <- 311:2-26',
-    'preflight.css: 131:2-32 <- 319:0-30',
-    'preflight.css: 132:4-19 <- 320:2-17',
-    'preflight.css: 133:4-23 <- 321:2-21',
-    'preflight.css: 135:2-26 <- 328:0-24',
-    'preflight.css: 136:4-24 <- 329:2-22',
-    'preflight.css: 138:2-41 <- 336:0-39',
-    'preflight.css: 139:4-14 <- 337:2-12',
-    'preflight.css: 141:2-329 <- 340:0-348:39',
-    'preflight.css: 142:4-20 <- 349:2-18',
-    'preflight.css: 144:2-38 <- 356:0-36',
-    'preflight.css: 145:4-18 <- 357:2-16',
-    'preflight.css: 147:2-19 <- 364:0-17',
-    'preflight.css: 148:4-20 <- 365:2-18',
-    'preflight.css: 150:2-96 <- 372:0-374:23',
-    'preflight.css: 151:4-22 <- 375:2-20',
-    'preflight.css: 153:2-59 <- 382:0-383:28',
-    'preflight.css: 154:4-16 <- 384:2-14',
-    'preflight.css: 156:2-47 <- 391:0-45',
-    'preflight.css: 157:4-28 <- 392:2-26',
-    'index.css: 160:0-16 <- 5:0-42',
-    'input.css: 161:0-5 <- 3:0-5',
-    'input.css: 162:2-33 <- 4:9-18',
-  ])
+  expect(annotations).toMatchInlineSnapshot(`
+    "
+         output.css                                                                                      |      original
+                                                                                                         | 
+                                                                                                         |      --- index.css ---
+      1  @layer theme, base, components, utilities;                                                      |   1  @layer theme, base, components, utilities;
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A @ 1:0-41                                            |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A @ 1:0-41
+      2  @layer theme {                                                                                  |   3  @import './theme.css' layer(theme);
+         ^^^^^^^^^^^^^ B @ 2:0-13                                                                        |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ B @ 3:0-34
+                                                                                                         |      --- theme.css ---
+      3    :root, :host {                                                                                |   1  @theme default {
+           ^^^^^^^^^^^^^ C @ 3:2-15                                                                      |      ^^^^^^^^^^^^^^^ C @ 1:0-15
+      4      --font-sans: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'... |   2    --font-sans:
+             ^ D @ 4:4                                                                                   |        ^ D @ 2:2
+      4      --font-sans: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'... |   3      ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI S...
+             ^ E @ 4:4                                                                                   |      ^ E @ 3:0
+      4      --font-sans: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji'... |   4      'Noto Color Emoji';
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^... F @ 4:4-5:0 |      ^ F @ 4:0
+      5      'Noto Color Emoji';                                                                         |   4      'Noto Color Emoji';
+                               ^ G @ 5:22-6:0                                                            |                            ^ G @ 4:22
+                                                                                                         |   5    --font-serif: ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
+      6      --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', '... |   6    --font-mono:
+             ^ H @ 6:4                                                                                   |        ^ H @ 6:2
+      6      --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', '... |   7      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+             ^ I @ 6:4                                                                                   |      ^ I @ 7:0
+      6      --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', '... |   8      monospace;
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^... J @ 6:4-7:0 |      ^ J @ 8:0
+      7      monospace;                                                                                  |   8      monospace;
+                      ^ K @ 7:13-8:0                                                                     |                   ^ K @ 8:13
+      8      --default-font-family: var(--font-sans);                                                    | 494    --default-font-family: --theme(--font-sans, initial);
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ L @ 8:4-43                                          |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ L @ 494:2-54
+                                                                                                         | 495    --default-font-feature-settings: --theme(--font-sans--font-feature-settings, initial);
+                                                                                                         | 496    --default-font-variation-settings: --theme(--font-sans--font-variation-settings, initial);
+      9      --default-mono-font-family: var(--font-mono);                                               | 497    --default-mono-font-family: --theme(--font-mono, initial);
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ M @ 9:4-48                                     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ M @ 497:2-59
+     10    }                                                                                             | 
+     11  }                                                                                               | 
+                                                                                                         |      --- index.css ---
+     12  @layer base {                                                                                   |   4  @import './preflight.css' layer(base);
+         ^^^^^^^^^^^^ N @ 12:0-12                                                                        |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ N @ 4:0-37
+                                                                                                         |      --- preflight.css ---
+     13    *, ::after, ::before, ::backdrop, ::file-selector-button {                                    |   7  *,
+           ^ O @ 13:2                                                                                    |      ^ O @ 7:0
+     13    *, ::after, ::before, ::backdrop, ::file-selector-button {                                    |   8  ::after,
+           ^ P @ 13:2                                                                                    |      ^ P @ 8:0
+     13    *, ::after, ::before, ::backdrop, ::file-selector-button {                                    |   9  ::before,
+           ^ Q @ 13:2                                                                                    |      ^ Q @ 9:0
+     13    *, ::after, ::before, ::backdrop, ::file-selector-button {                                    |  10  ::backdrop,
+           ^ R @ 13:2                                                                                    |      ^ R @ 10:0
+     13    *, ::after, ::before, ::backdrop, ::file-selector-button {                                    |  11  ::file-selector-button {
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ S @ 13:2-59                         |      ^^^^^^^^^^^^^^^^^^^^^^^ S @ 11:0-23
+     14      box-sizing: border-box;                                                                     |  12    box-sizing: border-box; /* 1 */
+             ^^^^^^^^^^^^^^^^^^^^^^ T @ 14:4-26                                                          |        ^^^^^^^^^^^^^^^^^^^^^^ T @ 12:2-24
+     15      margin: 0;                                                                                  |  13    margin: 0; /* 2 */
+             ^^^^^^^^^ U @ 15:4-13                                                                       |        ^^^^^^^^^ U @ 13:2-11
+     16      padding: 0;                                                                                 |  14    padding: 0; /* 2 */
+             ^^^^^^^^^^ V @ 16:4-14                                                                      |        ^^^^^^^^^^ V @ 14:2-12
+     17      border: 0 solid;                                                                            |  15    border: 0 solid; /* 3 */
+             ^^^^^^^^^^^^^^^ W @ 17:4-19                                                                 |        ^^^^^^^^^^^^^^^ W @ 15:2-17
+                                                                                                         |  16  }
+     18    }                                                                                             | 
+     19    html, :host {                                                                                 |  28  html,
+           ^ X @ 19:2                                                                                    |      ^ X @ 28:0
+     19    html, :host {                                                                                 |  29  :host {
+           ^^^^^^^^^^^^ Y @ 19:2-14                                                                      |      ^^^^^^ Y @ 29:0-6
+     20      line-height: 1.5;                                                                           |  30    line-height: 1.5; /* 1 */
+             ^^^^^^^^^^^^^^^^ Z @ 20:4-20                                                                |        ^^^^^^^^^^^^^^^^ Z @ 30:2-18
+     21      -webkit-text-size-adjust: 100%;                                                             |  31    -webkit-text-size-adjust: 100%; /* 2 */
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AA @ 21:4-34                                                 |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AA @ 31:2-32
+     22      tab-size: 4;                                                                                |  32    tab-size: 4; /* 3 */
+             ^^^^^^^^^^^ AB @ 22:4-15                                                                    |        ^^^^^^^^^^^ AB @ 32:2-13
+     23      font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, 'Apple Col... |  33    font-family: --theme(
+             ^ AC @ 23:4                                                                                 |        ^ AC @ 33:2
+     23      font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, 'Apple Col... |  34      --default-font-family,
+             ^ AD @ 23:4                                                                                 |      ^ AD @ 34:0
+     23      font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, 'Apple Col... |  35      ui-sans-serif,
+             ^ AE @ 23:4                                                                                 |      ^ AE @ 35:0
+     23      font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, 'Apple Col... |  36      system-ui,
+             ^ AF @ 23:4                                                                                 |      ^ AF @ 36:0
+     23      font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, 'Apple Col... |  37      sans-serif,
+             ^ AG @ 23:4                                                                                 |      ^ AG @ 37:0
+     23      font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, 'Apple Col... |  38      'Apple Color Emoji',
+             ^ AH @ 23:4                                                                                 |      ^ AH @ 38:0
+     23      font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, 'Apple Col... |  39      'Segoe UI Emoji',
+             ^ AI @ 23:4                                                                                 |      ^ AI @ 39:0
+     23      font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, 'Apple Col... |  40      'Segoe UI Symbol',
+             ^ AJ @ 23:4                                                                                 |      ^ AJ @ 40:0
+     23      font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, 'Apple Col... |  41      'Noto Color Emoji'
+             ^ AK @ 23:4                                                                                 |      ^ AK @ 41:0
+     23      font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, 'Apple Col... |  42    ); /* 4 */
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^... AL @ 23:4-159 |      ^^^ AL @ 42:0-3
+     24      font-feature-settings: var(--default-font-feature-settings, normal);                        |  43    font-feature-settings: --theme(--default-font-feature-settings, normal); /* 5 */
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AM @ 24:4-71            |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AM @ 43:2-73
+     25      font-variation-settings: var(--default-font-variation-settings, normal);                    |  44    font-variation-settings: --theme(--default-font-variation-settings, normal); /* 6 */
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AN @ 25:4-75        |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AN @ 44:2-77
+     26      -webkit-tap-highlight-color: transparent;                                                   |  45    -webkit-tap-highlight-color: transparent; /* 7 */
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AO @ 26:4-44                                       |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AO @ 45:2-42
+                                                                                                         |  46  }
+     27    }                                                                                             | 
+     28    hr {                                                                                          |  54  hr {
+           ^^^ AP @ 28:2-5                                                                               |      ^^^ AP @ 54:0-3
+     29      height: 0;                                                                                  |  55    height: 0; /* 1 */
+             ^^^^^^^^^ AQ @ 29:4-13                                                                      |        ^^^^^^^^^ AQ @ 55:2-11
+     30      color: inherit;                                                                             |  56    color: inherit; /* 2 */
+             ^^^^^^^^^^^^^^ AR @ 30:4-18                                                                 |        ^^^^^^^^^^^^^^ AR @ 56:2-16
+     31      border-top-width: 1px;                                                                      |  57    border-top-width: 1px; /* 3 */
+             ^^^^^^^^^^^^^^^^^^^^^ AS @ 31:4-25                                                          |        ^^^^^^^^^^^^^^^^^^^^^ AS @ 57:2-23
+                                                                                                         |  58  }
+     32    }                                                                                             | 
+     33    abbr:where([title]) {                                                                         |  64  abbr:where([title]) {
+           ^^^^^^^^^^^^^^^^^^^^ AT @ 33:2-22                                                             |      ^^^^^^^^^^^^^^^^^^^^ AT @ 64:0-20
+     34      -webkit-text-decoration: underline dotted;                                                  |  65    -webkit-text-decoration: underline dotted;
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AU @ 34:4-45                                      |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AU @ 65:2-43
+     35      text-decoration: underline dotted;                                                          |  66    text-decoration: underline dotted;
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AV @ 35:4-37                                              |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ AV @ 66:2-35
+                                                                                                         |  67  }
+     36    }                                                                                             | 
+     37    h1, h2, h3, h4, h5, h6 {                                                                      |  73  h1,
+           ^ AW @ 37:2                                                                                   |      ^ AW @ 73:0
+     37    h1, h2, h3, h4, h5, h6 {                                                                      |  74  h2,
+           ^ AX @ 37:2                                                                                   |      ^ AX @ 74:0
+     37    h1, h2, h3, h4, h5, h6 {                                                                      |  75  h3,
+           ^ AY @ 37:2                                                                                   |      ^ AY @ 75:0
+     37    h1, h2, h3, h4, h5, h6 {                                                                      |  76  h4,
+           ^ AZ @ 37:2                                                                                   |      ^ AZ @ 76:0
+     37    h1, h2, h3, h4, h5, h6 {                                                                      |  77  h5,
+           ^ BA @ 37:2                                                                                   |      ^ BA @ 77:0
+     37    h1, h2, h3, h4, h5, h6 {                                                                      |  78  h6 {
+           ^^^^^^^^^^^^^^^^^^^^^^^ BB @ 37:2-25                                                          |      ^^^ BB @ 78:0-3
+     38      font-size: inherit;                                                                         |  79    font-size: inherit;
+             ^^^^^^^^^^^^^^^^^^ BC @ 38:4-22                                                             |        ^^^^^^^^^^^^^^^^^^ BC @ 79:2-20
+     39      font-weight: inherit;                                                                       |  80    font-weight: inherit;
+             ^^^^^^^^^^^^^^^^^^^^ BD @ 39:4-24                                                           |        ^^^^^^^^^^^^^^^^^^^^ BD @ 80:2-22
+                                                                                                         |  81  }
+     40    }                                                                                             | 
+     41    a {                                                                                           |  87  a {
+           ^^ BE @ 41:2-4                                                                                |      ^^ BE @ 87:0-2
+     42      color: inherit;                                                                             |  88    color: inherit;
+             ^^^^^^^^^^^^^^ BF @ 42:4-18                                                                 |        ^^^^^^^^^^^^^^ BF @ 88:2-16
+     43      -webkit-text-decoration: inherit;                                                           |  89    -webkit-text-decoration: inherit;
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ BG @ 43:4-36                                               |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ BG @ 89:2-34
+     44      text-decoration: inherit;                                                                   |  90    text-decoration: inherit;
+             ^^^^^^^^^^^^^^^^^^^^^^^^ BH @ 44:4-28                                                       |        ^^^^^^^^^^^^^^^^^^^^^^^^ BH @ 90:2-26
+                                                                                                         |  91  }
+     45    }                                                                                             | 
+     46    b, strong {                                                                                   |  97  b,
+           ^ BI @ 46:2                                                                                   |      ^ BI @ 97:0
+     46    b, strong {                                                                                   |  98  strong {
+           ^^^^^^^^^^ BJ @ 46:2-12                                                                       |      ^^^^^^^ BJ @ 98:0-7
+     47      font-weight: bolder;                                                                        |  99    font-weight: bolder;
+             ^^^^^^^^^^^^^^^^^^^ BK @ 47:4-23                                                            |        ^^^^^^^^^^^^^^^^^^^ BK @ 99:2-21
+                                                                                                         | 100  }
+     48    }                                                                                             | 
+     49    code, kbd, samp, pre {                                                                        | 109  code,
+           ^ BL @ 49:2                                                                                   |      ^ BL @ 109:0
+     49    code, kbd, samp, pre {                                                                        | 110  kbd,
+           ^ BM @ 49:2                                                                                   |      ^ BM @ 110:0
+     49    code, kbd, samp, pre {                                                                        | 111  samp,
+           ^ BN @ 49:2                                                                                   |      ^ BN @ 111:0
+     49    code, kbd, samp, pre {                                                                        | 112  pre {
+           ^^^^^^^^^^^^^^^^^^^^^ BO @ 49:2-23                                                            |      ^^^^ BO @ 112:0-4
+     50      font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco... | 113    font-family: --theme(
+             ^ BP @ 50:4                                                                                 |        ^ BP @ 113:2
+     50      font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco... | 114      --default-mono-font-family,
+             ^ BQ @ 50:4                                                                                 |      ^ BQ @ 114:0
+     50      font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco... | 115      ui-monospace,
+             ^ BR @ 50:4                                                                                 |      ^ BR @ 115:0
+     50      font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco... | 116      SFMono-Regular,
+             ^ BS @ 50:4                                                                                 |      ^ BS @ 116:0
+     50      font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco... | 117      Menlo,
+             ^ BT @ 50:4                                                                                 |      ^ BT @ 117:0
+     50      font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco... | 118      Monaco,
+             ^ BU @ 50:4                                                                                 |      ^ BU @ 118:0
+     50      font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco... | 119      Consolas,
+             ^ BV @ 50:4                                                                                 |      ^ BV @ 119:0
+     50      font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco... | 120      'Liberation Mono',
+             ^ BW @ 50:4                                                                                 |      ^ BW @ 120:0
+     50      font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco... | 121      'Courier New',
+             ^ BX @ 50:4                                                                                 |      ^ BX @ 121:0
+     50      font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco... | 122      monospace
+             ^ BY @ 50:4                                                                                 |      ^ BY @ 122:0
+     50      font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco... | 123    ); /* 1 */
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^... BZ @ 50:4-148 |      ^^^ BZ @ 123:0-3
+     51      font-feature-settings: var(--default-mono-font-feature-settings, normal);                   | 124    font-feature-settings: --theme(--default-mono-font-feature-settings, normal); /* 2 */
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ CA @ 51:4-76       |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ CA @ 124:2-78
+     52      font-variation-settings: var(--default-mono-font-variation-settings, normal);               | 125    font-variation-settings: --theme(--default-mono-font-variation-settings, normal); /* 3 */
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ CB @ 52:4-80   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^... CB @ 125:2-82
+     53      font-size: 1em;                                                                             | 126    font-size: 1em; /* 4 */
+             ^^^^^^^^^^^^^^ CC @ 53:4-18                                                                 |        ^^^^^^^^^^^^^^ CC @ 126:2-16
+                                                                                                         | 127  }
+     54    }                                                                                             | 
+     55    small {                                                                                       | 133  small {
+           ^^^^^^ CD @ 55:2-8                                                                            |      ^^^^^^ CD @ 133:0-6
+     56      font-size: 80%;                                                                             | 134    font-size: 80%;
+             ^^^^^^^^^^^^^^ CE @ 56:4-18                                                                 |        ^^^^^^^^^^^^^^ CE @ 134:2-16
+                                                                                                         | 135  }
+     57    }                                                                                             | 
+     58    sub, sup {                                                                                    | 141  sub,
+           ^ CF @ 58:2                                                                                   |      ^ CF @ 141:0
+     58    sub, sup {                                                                                    | 142  sup {
+           ^^^^^^^^^ CG @ 58:2-11                                                                        |      ^^^^ CG @ 142:0-4
+     59      font-size: 75%;                                                                             | 143    font-size: 75%;
+             ^^^^^^^^^^^^^^ CH @ 59:4-18                                                                 |        ^^^^^^^^^^^^^^ CH @ 143:2-16
+     60      line-height: 0;                                                                             | 144    line-height: 0;
+             ^^^^^^^^^^^^^^ CI @ 60:4-18                                                                 |        ^^^^^^^^^^^^^^ CI @ 144:2-16
+     61      position: relative;                                                                         | 145    position: relative;
+             ^^^^^^^^^^^^^^^^^^ CJ @ 61:4-22                                                             |        ^^^^^^^^^^^^^^^^^^ CJ @ 145:2-20
+     62      vertical-align: baseline;                                                                   | 146    vertical-align: baseline;
+             ^^^^^^^^^^^^^^^^^^^^^^^^ CK @ 62:4-28                                                       |        ^^^^^^^^^^^^^^^^^^^^^^^^ CK @ 146:2-26
+                                                                                                         | 147  }
+     63    }                                                                                             | 
+     64    sub {                                                                                         | 149  sub {
+           ^^^^ CL @ 64:2-6                                                                              |      ^^^^ CL @ 149:0-4
+     65      bottom: -0.25em;                                                                            | 150    bottom: -0.25em;
+             ^^^^^^^^^^^^^^^ CM @ 65:4-19                                                                |        ^^^^^^^^^^^^^^^ CM @ 150:2-17
+                                                                                                         | 151  }
+     66    }                                                                                             | 
+     67    sup {                                                                                         | 153  sup {
+           ^^^^ CN @ 67:2-6                                                                              |      ^^^^ CN @ 153:0-4
+     68      top: -0.5em;                                                                                | 154    top: -0.5em;
+             ^^^^^^^^^^^ CO @ 68:4-15                                                                    |        ^^^^^^^^^^^ CO @ 154:2-13
+                                                                                                         | 155  }
+     69    }                                                                                             | 
+     70    table {                                                                                       | 163  table {
+           ^^^^^^ CP @ 70:2-8                                                                            |      ^^^^^^ CP @ 163:0-6
+     71      text-indent: 0;                                                                             | 164    text-indent: 0; /* 1 */
+             ^^^^^^^^^^^^^^ CQ @ 71:4-18                                                                 |        ^^^^^^^^^^^^^^ CQ @ 164:2-16
+     72      border-color: inherit;                                                                      | 165    border-color: inherit; /* 2 */
+             ^^^^^^^^^^^^^^^^^^^^^ CR @ 72:4-25                                                          |        ^^^^^^^^^^^^^^^^^^^^^ CR @ 165:2-23
+     73      border-collapse: collapse;                                                                  | 166    border-collapse: collapse; /* 3 */
+             ^^^^^^^^^^^^^^^^^^^^^^^^^ CS @ 73:4-29                                                      |        ^^^^^^^^^^^^^^^^^^^^^^^^^ CS @ 166:2-27
+                                                                                                         | 167  }
+     74    }                                                                                             | 
+     75    :-moz-focusring {                                                                             | 173  :-moz-focusring {
+           ^^^^^^^^^^^^^^^^ CT @ 75:2-18                                                                 |      ^^^^^^^^^^^^^^^^ CT @ 173:0-16
+     76      outline: auto;                                                                              | 174    outline: auto;
+             ^^^^^^^^^^^^^ CU @ 76:4-17                                                                  |        ^^^^^^^^^^^^^ CU @ 174:2-15
+                                                                                                         | 175  }
+     77    }                                                                                             | 
+     78    progress {                                                                                    | 181  progress {
+           ^^^^^^^^^ CV @ 78:2-11                                                                        |      ^^^^^^^^^ CV @ 181:0-9
+     79      vertical-align: baseline;                                                                   | 182    vertical-align: baseline;
+             ^^^^^^^^^^^^^^^^^^^^^^^^ CW @ 79:4-28                                                       |        ^^^^^^^^^^^^^^^^^^^^^^^^ CW @ 182:2-26
+                                                                                                         | 183  }
+     80    }                                                                                             | 
+     81    summary {                                                                                     | 189  summary {
+           ^^^^^^^^ CX @ 81:2-10                                                                         |      ^^^^^^^^ CX @ 189:0-8
+     82      display: list-item;                                                                         | 190    display: list-item;
+             ^^^^^^^^^^^^^^^^^^ CY @ 82:4-22                                                             |        ^^^^^^^^^^^^^^^^^^ CY @ 190:2-20
+                                                                                                         | 191  }
+     83    }                                                                                             | 
+     84    ol, ul, menu {                                                                                | 197  ol,
+           ^ CZ @ 84:2                                                                                   |      ^ CZ @ 197:0
+     84    ol, ul, menu {                                                                                | 198  ul,
+           ^ DA @ 84:2                                                                                   |      ^ DA @ 198:0
+     84    ol, ul, menu {                                                                                | 199  menu {
+           ^^^^^^^^^^^^^ DB @ 84:2-15                                                                    |      ^^^^^ DB @ 199:0-5
+     85      list-style: none;                                                                           | 200    list-style: none;
+             ^^^^^^^^^^^^^^^^ DC @ 85:4-20                                                               |        ^^^^^^^^^^^^^^^^ DC @ 200:2-18
+                                                                                                         | 201  }
+     86    }                                                                                             | 
+     87    img, svg, video, canvas, audio, iframe, embed, object {                                       | 209  img,
+           ^ DD @ 87:2                                                                                   |      ^ DD @ 209:0
+     87    img, svg, video, canvas, audio, iframe, embed, object {                                       | 210  svg,
+           ^ DE @ 87:2                                                                                   |      ^ DE @ 210:0
+     87    img, svg, video, canvas, audio, iframe, embed, object {                                       | 211  video,
+           ^ DF @ 87:2                                                                                   |      ^ DF @ 211:0
+     87    img, svg, video, canvas, audio, iframe, embed, object {                                       | 212  canvas,
+           ^ DG @ 87:2                                                                                   |      ^ DG @ 212:0
+     87    img, svg, video, canvas, audio, iframe, embed, object {                                       | 213  audio,
+           ^ DH @ 87:2                                                                                   |      ^ DH @ 213:0
+     87    img, svg, video, canvas, audio, iframe, embed, object {                                       | 214  iframe,
+           ^ DI @ 87:2                                                                                   |      ^ DI @ 214:0
+     87    img, svg, video, canvas, audio, iframe, embed, object {                                       | 215  embed,
+           ^ DJ @ 87:2                                                                                   |      ^ DJ @ 215:0
+     87    img, svg, video, canvas, audio, iframe, embed, object {                                       | 216  object {
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ DK @ 87:2-56                           |      ^^^^^^^ DK @ 216:0-7
+     88      display: block;                                                                             | 217    display: block; /* 1 */
+             ^^^^^^^^^^^^^^ DL @ 88:4-18                                                                 |        ^^^^^^^^^^^^^^ DL @ 217:2-16
+     89      vertical-align: middle;                                                                     | 218    vertical-align: middle; /* 2 */
+             ^^^^^^^^^^^^^^^^^^^^^^ DM @ 89:4-26                                                         |        ^^^^^^^^^^^^^^^^^^^^^^ DM @ 218:2-24
+                                                                                                         | 219  }
+     90    }                                                                                             | 
+     91    img, video {                                                                                  | 225  img,
+           ^ DN @ 91:2                                                                                   |      ^ DN @ 225:0
+     91    img, video {                                                                                  | 226  video {
+           ^^^^^^^^^^^ DO @ 91:2-13                                                                      |      ^^^^^^ DO @ 226:0-6
+     92      max-width: 100%;                                                                            | 227    max-width: 100%;
+             ^^^^^^^^^^^^^^^ DP @ 92:4-19                                                                |        ^^^^^^^^^^^^^^^ DP @ 227:2-17
+     93      height: auto;                                                                               | 228    height: auto;
+             ^^^^^^^^^^^^ DQ @ 93:4-16                                                                   |        ^^^^^^^^^^^^ DQ @ 228:2-14
+                                                                                                         | 229  }
+     94    }                                                                                             | 
+     95    button, input, select, optgroup, textarea, ::file-selector-button {                           | 238  button,
+           ^ DR @ 95:2                                                                                   |      ^ DR @ 238:0
+     95    button, input, select, optgroup, textarea, ::file-selector-button {                           | 239  input,
+           ^ DS @ 95:2                                                                                   |      ^ DS @ 239:0
+     95    button, input, select, optgroup, textarea, ::file-selector-button {                           | 240  select,
+           ^ DT @ 95:2                                                                                   |      ^ DT @ 240:0
+     95    button, input, select, optgroup, textarea, ::file-selector-button {                           | 241  optgroup,
+           ^ DU @ 95:2                                                                                   |      ^ DU @ 241:0
+     95    button, input, select, optgroup, textarea, ::file-selector-button {                           | 242  textarea,
+           ^ DV @ 95:2                                                                                   |      ^ DV @ 242:0
+     95    button, input, select, optgroup, textarea, ::file-selector-button {                           | 243  ::file-selector-button {
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ DW @ 95:2-68               |      ^^^^^^^^^^^^^^^^^^^^^^^ DW @ 243:0-23
+     96      font: inherit;                                                                              | 244    font: inherit; /* 1 */
+             ^^^^^^^^^^^^^ DX @ 96:4-17                                                                  |        ^^^^^^^^^^^^^ DX @ 244:2-15
+     97      font-feature-settings: inherit;                                                             | 245    font-feature-settings: inherit; /* 1 */
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ DY @ 97:4-34                                                 |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ DY @ 245:2-32
+     98      font-variation-settings: inherit;                                                           | 246    font-variation-settings: inherit; /* 1 */
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ DZ @ 98:4-36                                               |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ DZ @ 246:2-34
+     99      letter-spacing: inherit;                                                                    | 247    letter-spacing: inherit; /* 1 */
+             ^^^^^^^^^^^^^^^^^^^^^^^ EA @ 99:4-27                                                        |        ^^^^^^^^^^^^^^^^^^^^^^^ EA @ 247:2-25
+    100      color: inherit;                                                                             | 248    color: inherit; /* 1 */
+             ^^^^^^^^^^^^^^ EB @ 100:4-18                                                                |        ^^^^^^^^^^^^^^ EB @ 248:2-16
+    101      border-radius: 0;                                                                           | 249    border-radius: 0; /* 2 */
+             ^^^^^^^^^^^^^^^^ EC @ 101:4-20                                                              |        ^^^^^^^^^^^^^^^^ EC @ 249:2-18
+    102      background-color: transparent;                                                              | 250    background-color: transparent; /* 3 */
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ED @ 102:4-33                                                 |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ED @ 250:2-31
+    103      opacity: 1;                                                                                 | 251    opacity: 1; /* 4 */
+             ^^^^^^^^^^ EE @ 103:4-14                                                                    |        ^^^^^^^^^^ EE @ 251:2-12
+                                                                                                         | 252  }
+    104    }                                                                                             | 
+    105    :where(select:is([multiple], [size])) optgroup {                                              | 258  :where(select:is([multiple], [size])) optgroup {
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ EF @ 105:2-49                                 |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ EF @ 258:0-47
+    106      font-weight: bolder;                                                                        | 259    font-weight: bolder;
+             ^^^^^^^^^^^^^^^^^^^ EG @ 106:4-23                                                           |        ^^^^^^^^^^^^^^^^^^^ EG @ 259:2-21
+                                                                                                         | 260  }
+    107    }                                                                                             | 
+    108    :where(select:is([multiple], [size])) optgroup option {                                       | 266  :where(select:is([multiple], [size])) optgroup option {
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ EH @ 108:2-56                          |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ EH @ 266:0-54
+    109      padding-inline-start: 20px;                                                                 | 267    padding-inline-start: 20px;
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^ EI @ 109:4-30                                                    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^ EI @ 267:2-28
+                                                                                                         | 268  }
+    110    }                                                                                             | 
+    111    ::file-selector-button {                                                                      | 274  ::file-selector-button {
+           ^^^^^^^^^^^^^^^^^^^^^^^ EJ @ 111:2-25                                                         |      ^^^^^^^^^^^^^^^^^^^^^^^ EJ @ 274:0-23
+    112      margin-inline-end: 4px;                                                                     | 275    margin-inline-end: 4px;
+             ^^^^^^^^^^^^^^^^^^^^^^ EK @ 112:4-26                                                        |        ^^^^^^^^^^^^^^^^^^^^^^ EK @ 275:2-24
+                                                                                                         | 276  }
+    113    }                                                                                             | 
+    114    ::placeholder {                                                                               | 282  ::placeholder {
+           ^^^^^^^^^^^^^^ EL @ 114:2-16                                                                  |      ^^^^^^^^^^^^^^ EL @ 282:0-14
+    115      opacity: 1;                                                                                 | 283    opacity: 1;
+             ^^^^^^^^^^ EM @ 115:4-14                                                                    |        ^^^^^^^^^^ EM @ 283:2-12
+                                                                                                         | 284  }
+    116    }                                                                                             | 
+    117    @supports (not (-webkit-appearance: -apple-pay-button))  or (contain-intrinsic-size: 1px) {   | 291  @supports (not (-webkit-appearance: -apple-pay-button)) /* Not Safari */ or
+           ^ EN @ 117:2                                                                                  |      ^ EN @ 291:0
+    117    @supports (not (-webkit-appearance: -apple-pay-button))  or (contain-intrinsic-size: 1px) {   | 292    (contain-intrinsic-size: 1px) /* Safari 17+ */ {
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^... EO @ 117:2-92 |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ EO @ 292:0-49
+    118      ::placeholder {                                                                             | 293    ::placeholder {
+             ^^^^^^^^^^^^^^ EP @ 118:4-18                                                                |        ^^^^^^^^^^^^^^ EP @ 293:2-16
+    119        color: currentcolor;                                                                      | 294      color: color-mix(in oklab, currentcolor 50%, transparent);
+               ^^^^^^^^^^^^^^^^^^^ EQ @ 119:6-25                                                         |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ EQ @ 294:4-61
+                                                                                                         | 295    }
+                                                                                                         | 296  }
+    120        @supports (color: color-mix(in lab, red, red)) {                                          | 
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ EQ @ 120:6-53                             | 
+    121          color: color-mix(in oklab, currentcolor 50%, transparent);                              | 
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ EQ @ 121:8-65                 | 
+    122        }                                                                                         | 
+    123      }                                                                                           | 
+    124    }                                                                                             | 
+    125    textarea {                                                                                    | 302  textarea {
+           ^^^^^^^^^ ER @ 125:2-11                                                                       |      ^^^^^^^^^ ER @ 302:0-9
+    126      resize: vertical;                                                                           | 303    resize: vertical;
+             ^^^^^^^^^^^^^^^^ ES @ 126:4-20                                                              |        ^^^^^^^^^^^^^^^^ ES @ 303:2-18
+                                                                                                         | 304  }
+    127    }                                                                                             | 
+    128    ::-webkit-search-decoration {                                                                 | 310  ::-webkit-search-decoration {
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ET @ 128:2-30                                                    |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ET @ 310:0-28
+    129      -webkit-appearance: none;                                                                   | 311    -webkit-appearance: none;
+             ^^^^^^^^^^^^^^^^^^^^^^^^ EU @ 129:4-28                                                      |        ^^^^^^^^^^^^^^^^^^^^^^^^ EU @ 311:2-26
+                                                                                                         | 312  }
+    130    }                                                                                             | 
+    131    ::-webkit-date-and-time-value {                                                               | 319  ::-webkit-date-and-time-value {
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ EV @ 131:2-32                                                  |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ EV @ 319:0-30
+    132      min-height: 1lh;                                                                            | 320    min-height: 1lh; /* 1 */
+             ^^^^^^^^^^^^^^^ EW @ 132:4-19                                                               |        ^^^^^^^^^^^^^^^ EW @ 320:2-17
+    133      text-align: inherit;                                                                        | 321    text-align: inherit; /* 2 */
+             ^^^^^^^^^^^^^^^^^^^ EX @ 133:4-23                                                           |        ^^^^^^^^^^^^^^^^^^^ EX @ 321:2-21
+                                                                                                         | 322  }
+    134    }                                                                                             | 
+    135    ::-webkit-datetime-edit {                                                                     | 328  ::-webkit-datetime-edit {
+           ^^^^^^^^^^^^^^^^^^^^^^^^ EY @ 135:2-26                                                        |      ^^^^^^^^^^^^^^^^^^^^^^^^ EY @ 328:0-24
+    136      display: inline-flex;                                                                       | 329    display: inline-flex;
+             ^^^^^^^^^^^^^^^^^^^^ EZ @ 136:4-24                                                          |        ^^^^^^^^^^^^^^^^^^^^ EZ @ 329:2-22
+                                                                                                         | 330  }
+    137    }                                                                                             | 
+    138    ::-webkit-datetime-edit-fields-wrapper {                                                      | 336  ::-webkit-datetime-edit-fields-wrapper {
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FA @ 138:2-41                                         |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FA @ 336:0-39
+    139      padding: 0;                                                                                 | 337    padding: 0;
+             ^^^^^^^^^^ FB @ 139:4-14                                                                    |        ^^^^^^^^^^ FB @ 337:2-12
+                                                                                                         | 338  }
+    140    }                                                                                             | 
+    141    ::-webkit-datetime-edit, ::-webkit-datetime-edit-year-field, ::-webkit-datetime-edit-month... | 340  ::-webkit-datetime-edit,
+           ^ FC @ 141:2                                                                                  |      ^ FC @ 340:0
+    141    ::-webkit-datetime-edit, ::-webkit-datetime-edit-year-field, ::-webkit-datetime-edit-month... | 341  ::-webkit-datetime-edit-year-field,
+           ^ FD @ 141:2                                                                                  |      ^ FD @ 341:0
+    141    ::-webkit-datetime-edit, ::-webkit-datetime-edit-year-field, ::-webkit-datetime-edit-month... | 342  ::-webkit-datetime-edit-month-field,
+           ^ FE @ 141:2                                                                                  |      ^ FE @ 342:0
+    141    ::-webkit-datetime-edit, ::-webkit-datetime-edit-year-field, ::-webkit-datetime-edit-month... | 343  ::-webkit-datetime-edit-day-field,
+           ^ FF @ 141:2                                                                                  |      ^ FF @ 343:0
+    141    ::-webkit-datetime-edit, ::-webkit-datetime-edit-year-field, ::-webkit-datetime-edit-month... | 344  ::-webkit-datetime-edit-hour-field,
+           ^ FG @ 141:2                                                                                  |      ^ FG @ 344:0
+    141    ::-webkit-datetime-edit, ::-webkit-datetime-edit-year-field, ::-webkit-datetime-edit-month... | 345  ::-webkit-datetime-edit-minute-field,
+           ^ FH @ 141:2                                                                                  |      ^ FH @ 345:0
+    141    ::-webkit-datetime-edit, ::-webkit-datetime-edit-year-field, ::-webkit-datetime-edit-month... | 346  ::-webkit-datetime-edit-second-field,
+           ^ FI @ 141:2                                                                                  |      ^ FI @ 346:0
+    141    ::-webkit-datetime-edit, ::-webkit-datetime-edit-year-field, ::-webkit-datetime-edit-month... | 347  ::-webkit-datetime-edit-millisecond-field,
+           ^ FJ @ 141:2                                                                                  |      ^ FJ @ 347:0
+    141    ::-webkit-datetime-edit, ::-webkit-datetime-edit-year-field, ::-webkit-datetime-edit-month... | 348  ::-webkit-datetime-edit-meridiem-field {
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^... FK @ 141:2-329 |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FK @ 348:0-39
+    142      padding-block: 0;                                                                           | 349    padding-block: 0;
+             ^^^^^^^^^^^^^^^^ FL @ 142:4-20                                                              |        ^^^^^^^^^^^^^^^^ FL @ 349:2-18
+                                                                                                         | 350  }
+    143    }                                                                                             | 
+    144    ::-webkit-calendar-picker-indicator {                                                         | 356  ::-webkit-calendar-picker-indicator {
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FM @ 144:2-38                                            |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FM @ 356:0-36
+    145      line-height: 1;                                                                             | 357    line-height: 1;
+             ^^^^^^^^^^^^^^ FN @ 145:4-18                                                                |        ^^^^^^^^^^^^^^ FN @ 357:2-16
+                                                                                                         | 358  }
+    146    }                                                                                             | 
+    147    :-moz-ui-invalid {                                                                            | 364  :-moz-ui-invalid {
+           ^^^^^^^^^^^^^^^^^ FO @ 147:2-19                                                               |      ^^^^^^^^^^^^^^^^^ FO @ 364:0-17
+    148      box-shadow: none;                                                                           | 365    box-shadow: none;
+             ^^^^^^^^^^^^^^^^ FP @ 148:4-20                                                              |        ^^^^^^^^^^^^^^^^ FP @ 365:2-18
+                                                                                                         | 366  }
+    149    }                                                                                             | 
+    150    button, input:where([type='button'], [type='reset'], [type='submit']), ::file-selector-but... | 372  button,
+           ^ FQ @ 150:2                                                                                  |      ^ FQ @ 372:0
+    150    button, input:where([type='button'], [type='reset'], [type='submit']), ::file-selector-but... | 373  input:where([type='button'], [type='reset'], [type='submit']),
+           ^ FR @ 150:2                                                                                  |      ^ FR @ 373:0
+    150    button, input:where([type='button'], [type='reset'], [type='submit']), ::file-selector-but... | 374  ::file-selector-button {
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^... FS @ 150:2-96 |      ^^^^^^^^^^^^^^^^^^^^^^^ FS @ 374:0-23
+    151      appearance: button;                                                                         | 375    appearance: button;
+             ^^^^^^^^^^^^^^^^^^ FT @ 151:4-22                                                            |        ^^^^^^^^^^^^^^^^^^ FT @ 375:2-20
+                                                                                                         | 376  }
+    152    }                                                                                             | 
+    153    ::-webkit-inner-spin-button, ::-webkit-outer-spin-button {                                    | 382  ::-webkit-inner-spin-button,
+           ^ FU @ 153:2                                                                                  |      ^ FU @ 382:0
+    153    ::-webkit-inner-spin-button, ::-webkit-outer-spin-button {                                    | 383  ::-webkit-outer-spin-button {
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FV @ 153:2-59                       |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FV @ 383:0-28
+    154      height: auto;                                                                               | 384    height: auto;
+             ^^^^^^^^^^^^ FW @ 154:4-16                                                                  |        ^^^^^^^^^^^^ FW @ 384:2-14
+                                                                                                         | 385  }
+    155    }                                                                                             | 
+    156    [hidden]:where(:not([hidden='until-found'])) {                                                | 391  [hidden]:where(:not([hidden='until-found'])) {
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FX @ 156:2-47                                   |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FX @ 391:0-45
+    157      display: none !important;                                                                   | 392    display: none !important;
+             ^^^^^^^^^^^^^^^^^^^^^^^^ FY @ 157:4-28                                                      |        ^^^^^^^^^^^^^^^^^^^^^^^^ FY @ 392:2-26
+                                                                                                         | 393  }
+    158    }                                                                                             | 
+    159  }                                                                                               | 
+                                                                                                         |      --- index.css ---
+    160  @layer utilities;                                                                               |   5  @import './utilities.css' layer(utilities);
+         ^^^^^^^^^^^^^^^^ FZ @ 160:0-16                                                                  |      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ FZ @ 5:0-42
+                                                                                                         |      --- input.css ---
+    161  .foo {                                                                                          |   3  .foo {
+         ^^^^^ GA @ 161:0-5                                                                              |      ^^^^^ GA @ 3:0-5
+    162    text-decoration-line: underline;                                                              |   4    @apply underline;
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ GB @ 162:2-33                                                 |               ^^^^^^^^^ GB @ 4:9-18
+                                                                                                         |   5  }
+    163  }                                                                                               | 
+    164                                                                                                  | 
+    "
+  `)
 })
 
 test('source maps are generated for utilities', async ({ expect }) => {
@@ -325,17 +605,31 @@ test('source maps are generated for utilities', async ({ expect }) => {
   expect(sources.length).toBe(2)
 
   // The output CSS should include annotations linking back to:
-  expect(annotations).toEqual([
-    // @tailwind utilities
-    'utilities.css: 1:0-6 <- 1:0-19',
-    'utilities.css: 2:2-15 <- 1:0-19',
-    'utilities.css: 4:0-8 <- 1:0-19',
-    // color: orange
-    'input.css: 5:2-15 <- 4:2-15',
-    // @tailwind utilities
-    'utilities.css: 7:0-11 <- 1:0-19',
-    'utilities.css: 8:2-13 <- 1:0-19',
-  ])
+  expect(annotations).toMatchInlineSnapshot(`
+    "
+        output.css                 |    original
+                                   | 
+                                   |    --- utilities.css ---
+     1  .flex {                    | 1  @tailwind utilities;
+        ^^^^^^ A @ 1:0-6           |    ^^^^^^^^^^^^^^^^^^^ A @ 1:0-19
+     2    display: flex;           | 
+          ^^^^^^^^^^^^^ A @ 2:2-15 | 
+     3  }                          | 
+     4  .custom {                  | 
+        ^^^^^^^^ A @ 4:0-8         | 
+                                   |    --- input.css ---
+     5    color: orange;           | 4    color: orange;
+          ^^^^^^^^^^^^^ B @ 5:2-15 |      ^^^^^^^^^^^^^ B @ 4:2-15
+                                   | 5  }
+     6  }                          | 
+     7  .custom-js {               | 
+        ^^^^^^^^^^^ A @ 7:0-11     | 
+     8    color: blue;             | 
+          ^^^^^^^^^^^ A @ 8:2-13   | 
+     9  }                          | 
+    10                             | 
+    "
+  `)
 
   expect(output).toMatchInlineSnapshot(`
     ".flex {
@@ -362,11 +656,18 @@ test('utilities have source maps pointing to the utilities node', async ({ expec
 
   expect(sources).toEqual(['input.css'])
 
-  expect(annotations).toEqual([
-    //
-    'input.css: 1:0-11 <- 1:0-19',
-    'input.css: 2:2-33 <- 1:0-19',
-  ])
+  expect(annotations).toMatchInlineSnapshot(`
+    "
+       output.css                                   |    input.css
+                                                    | 
+    1  .underline {                                 | 1  @tailwind utilities;
+       ^^^^^^^^^^^ A @ 1:0-11                       |    ^^^^^^^^^^^^^^^^^^^ A @ 1:0-19
+    2    text-decoration-line: underline;           | 
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A @ 2:2-33 | 
+    3  }                                            | 
+    4                                               | 
+    "
+  `)
 })
 
 test('@apply generates source maps', async ({ expect }) => {
@@ -383,16 +684,33 @@ test('@apply generates source maps', async ({ expect }) => {
 
   expect(sources).toEqual(['input.css'])
 
-  expect(annotations).toEqual([
-    'input.css: 1:0-5 <- 1:0-5',
-    'input.css: 2:2-13 <- 2:2-13',
-    'input.css: 3:2-13 <- 3:9-20',
-    'input.css: 4:2-10 <- 3:21-38',
-    'input.css: 5:4-26 <- 3:21-38',
-    'input.css: 6:6-17 <- 3:21-38',
-    'input.css: 9:2-33 <- 4:9-18',
-    'input.css: 10:2-12 <- 5:2-12',
-  ])
+  expect(annotations).toMatchInlineSnapshot(`
+    "
+        output.css                                   |    input.css
+                                                     | 
+     1  .foo {                                       | 1  .foo {
+        ^^^^^ A @ 1:0-5                              |    ^^^^^ A @ 1:0-5
+     2    color: blue;                               | 2    color: blue;
+          ^^^^^^^^^^^ B @ 2:2-13                     |      ^^^^^^^^^^^ B @ 2:2-13
+     3    color: #000;                               | 3    @apply text-[#000] hover:text-[#f00];
+          ^^^^^^^^^^^ C @ 3:2-13                     |             ^^^^^^^^^^^ C @ 3:9-20
+     4    &:hover {                                  | 3    @apply text-[#000] hover:text-[#f00];
+          ^^^^^^^^ D @ 4:2-10                        |                         ^^^^^^^^^^^^^^^^^ D @ 3:21-38
+     5      @media (hover: hover) {                  | 
+            ^^^^^^^^^^^^^^^^^^^^^^ D @ 5:4-26        | 
+     6        color: #f00;                           | 
+              ^^^^^^^^^^^ D @ 6:6-17                 | 
+     7      }                                        | 
+     8    }                                          | 
+     9    text-decoration-line: underline;           | 4    @apply underline;
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ E @ 9:2-33 |             ^^^^^^^^^ E @ 4:9-18
+    10    color: red;                                | 5    color: red;
+          ^^^^^^^^^^ F @ 10:2-12                     |      ^^^^^^^^^^ F @ 5:2-12
+                                                     | 6  }
+    11  }                                            | 
+    12                                               | 
+    "
+  `)
 })
 
 test('@variant generates source maps', async ({ expect }) => {
@@ -412,12 +730,41 @@ test('@variant generates source maps', async ({ expect }) => {
 
   expect(sources).toEqual(['input.css'])
 
-  expect(annotations).toEqual([
-    'input.css: 1:0-5 <- 1:0-5',
-    'input.css: 4:6-16 <- 3:4-14',
-    'input.css: 9:6-17 <- 7:4-15',
-    'input.css: 15:8-19 <- 7:4-15',
-  ])
+  expect(annotations).toMatchInlineSnapshot(`
+    "
+        output.css                      |    input.css
+                                        | 
+     1  .foo {                          | 1  .foo {
+        ^^^^^ A @ 1:0-5                 |    ^^^^^ A @ 1:0-5
+     2    &:hover {                     | 
+     3      @media (hover: hover) {     | 
+                                        | 2    @variant hover {
+     4        color: red;               | 3      color: red;
+              ^^^^^^^^^^ B @ 4:6-16     |        ^^^^^^^^^^ B @ 3:4-14
+                                        | 4    }
+     5      }                           | 
+     6    }                             | 
+     7    &:focus {                     | 
+     8      &:disabled {                | 
+                                        | 6    @variant focus:disabled, hover:aria-expanded {
+     9        color: blue;              | 7      color: blue;
+              ^^^^^^^^^^^ C @ 9:6-17    |        ^^^^^^^^^^^ C @ 7:4-15
+                                        | 8    }
+                                        | 9  }
+    10      }                           | 
+    11    }                             | 
+    12    &:hover {                     | 
+    13      @media (hover: hover) {     | 
+    14        &[aria-expanded="true"] { | 
+    15          color: blue;            | 
+                ^^^^^^^^^^^ C @ 15:8-19 | 
+    16        }                         | 
+    17      }                           | 
+    18    }                             | 
+    19  }                               | 
+    20                                  | 
+    "
+  `)
 })
 
 test('license comments preserve source locations', async ({ expect }) => {
@@ -427,10 +774,14 @@ test('license comments preserve source locations', async ({ expect }) => {
 
   expect(sources).toEqual(['input.css'])
 
-  expect(annotations).toEqual([
-    //
-    'input.css: 1:0-19 <- 1:0-19',
-  ])
+  expect(annotations).toMatchInlineSnapshot(`
+    "
+       output.css                     |    input.css
+                                      | 
+    1  /*! some comment */            | 1  /*! some comment */
+       ^^^^^^^^^^^^^^^^^^^ A @ 1:0-19 |    ^^^^^^^^^^^^^^^^^^^ A @ 1:0-19
+    "
+  `)
 })
 
 test('license comments with new lines preserve source locations', async ({ expect }) => {
@@ -440,18 +791,25 @@ test('license comments with new lines preserve source locations', async ({ expec
 
   expect(sources).toEqual(['input.css'])
 
-  expect(annotations).toEqual([
-    //
-    'input.css: 1:0 <- 1:0-2:0',
-    'input.css: 2:11 <- 2:11',
-  ])
+  expect(annotations).toMatchInlineSnapshot(`
+    "
+       output.css            |    input.css
+                             | 
+    1  /*! some              | 1  /*! some 
+       ^ A @ 1:0             |    ^ A @ 1:0
+    1  /*! some              | 2   comment */
+       ^^^^^^^^^ B @ 1:0-2:0 |    ^ B @ 2:0
+    2   comment */           | 2   comment */
+                  ^ C @ 2:11 |               ^ C @ 2:11
+    "
+  `)
 })
 
 test('Source locations for `addBase` point to the `@plugin` that generated them', async ({
   expect,
 }) => {
   let { sources, annotations } = await run({
-    input: dedent`
+    input: css`
       @plugin "./plugin.js";
       @config "./config.js";
     `,
@@ -488,13 +846,27 @@ test('Source locations for `addBase` point to the `@plugin` that generated them'
 
   expect(sources).toEqual(['input.css'])
 
-  expect(annotations).toEqual([
-    //
-    'input.css: 1:0-12 <- 1:0-21',
-    'input.css: 2:2-7 <- 1:0-21',
-    'input.css: 3:4-14 <- 1:0-21',
-    'input.css: 6:0-12 <- 2:0-21',
-    'input.css: 7:2-7 <- 2:0-21',
-    'input.css: 8:4-16 <- 2:0-21',
-  ])
+  expect(annotations).toMatchInlineSnapshot(`
+    "
+        output.css                  |    input.css
+                                    | 
+     1  @layer base {               | 1  @plugin "./plugin.js";
+        ^^^^^^^^^^^^ A @ 1:0-12     |    ^^^^^^^^^^^^^^^^^^^^^ A @ 1:0-21
+     2    body {                    | 
+          ^^^^^ A @ 2:2-7           | 
+     3      color: red;             | 
+            ^^^^^^^^^^ A @ 3:4-14   | 
+     4    }                         | 
+     5  }                           | 
+     6  @layer base {               | 2  @config "./config.js";
+        ^^^^^^^^^^^^ B @ 6:0-12     |    ^^^^^^^^^^^^^^^^^^^^^ B @ 2:0-21
+     7    body {                    | 
+          ^^^^^ B @ 7:2-7           | 
+     8      color: green;           | 
+            ^^^^^^^^^^^^ B @ 8:4-16 | 
+     9    }                         | 
+    10  }                           | 
+    11                              | 
+    "
+  `)
 })

--- a/packages/tailwindcss/src/source-maps/translation-map.test.ts
+++ b/packages/tailwindcss/src/source-maps/translation-map.test.ts
@@ -3,6 +3,7 @@ import { assert, expect, test } from 'vitest'
 import { toCss, type AstNode } from '../ast'
 import * as CSS from '../css-parser'
 import { createTranslationMap } from './source-map'
+import { visualizeSourceMapRanges, type SourceMapVisualizationRange } from './visualize-source-map'
 
 async function analyze(input: string) {
   let ast = CSS.parse(input, { from: 'input.css' })
@@ -13,21 +14,26 @@ async function analyze(input: string) {
   })
 
   function format(node: AstNode) {
-    let lines: string[] = []
+    let ranges: SourceMapVisualizationRange[] = []
 
     for (let [oStart, oEnd, gStart, gEnd] of translate(node)) {
-      let src = `${oStart.line}:${oStart.column}-${oEnd.line}:${oEnd.column}`
-
-      let dst = '(none)'
-
-      if (gStart && gEnd) {
-        dst = `${gStart.line}:${gStart.column}-${gEnd.line}:${gEnd.column}`
-      }
-
-      lines.push(`${dst} <- ${src}`)
+      ranges.push({
+        original: {
+          source: 'input.css',
+          start: [oStart.line, oStart.column],
+          end: [oEnd.line, oEnd.column],
+        },
+        generated:
+          gStart && gEnd
+            ? {
+                start: [gStart.line, gStart.column],
+                end: [gEnd.line, gEnd.column],
+              }
+            : null,
+      })
     }
 
-    return lines
+    return visualizeSourceMapRanges({ 'input.css': input }, css, ranges)
   }
 
   return { ast, css, format }
@@ -38,9 +44,13 @@ test('comment, single line', async () => {
 
   assert(ast[0].kind === 'comment')
   expect(format(ast[0])).toMatchInlineSnapshot(`
-    [
-      "1:0-1:10 <- 1:0-1:10",
-    ]
+    "
+       output.css            |    input.css
+                             | 
+    1  /*! foo */            | 1  /*! foo */
+       ^^^^^^^^^^ A @ 1:0-10 |    ^^^^^^^^^^ A @ 1:0-10
+    2                        | 
+    "
   `)
 
   expect(css).toMatchInlineSnapshot(`
@@ -54,9 +64,15 @@ test('comment, multi line', async () => {
 
   assert(ast[0].kind === 'comment')
   expect(format(ast[0])).toMatchInlineSnapshot(`
-    [
-      "1:0-2:7 <- 1:0-2:7",
-    ]
+    "
+       output.css           |    input.css
+                            | 
+    1  /*! foo              | 1  /*! foo 
+       ^^^^^^^^ A @ 1:0-2:7 |    ^^^^^^^^ A @ 1:0-2:7
+    2   bar */              | 2   bar */
+       ^^^^^^^ A            |    ^^^^^^^ A
+    3                       | 
+    "
   `)
 
   expect(css).toMatchInlineSnapshot(`
@@ -72,9 +88,15 @@ test('declaration, normal property, single line', async () => {
   assert(ast[0].kind === 'rule')
   assert(ast[0].nodes[0].kind === 'declaration')
   expect(format(ast[0].nodes[0])).toMatchInlineSnapshot(`
-    [
-      "2:2-2:12 <- 1:7-1:17",
-    ]
+    "
+       output.css              |    input.css
+                               | 
+    1  .foo {                  | 
+    2    color: red;           | 1  .foo { color: red; }
+         ^^^^^^^^^^ A @ 2:2-12 |           ^^^^^^^^^^ A @ 1:7-17
+    3  }                       | 
+    4                          | 
+    "
   `)
 
   expect(css).toMatchInlineSnapshot(`
@@ -99,9 +121,22 @@ test('declaration, normal property, multi line', async () => {
   assert(ast[0].kind === 'rule')
   assert(ast[0].nodes[0].kind === 'declaration')
   expect(format(ast[0].nodes[0])).toMatchInlineSnapshot(`
-    [
-      "2:2-2:46 <- 2:2-5:11",
-    ]
+    "
+       output.css                                                |    input.css
+                                                                 | 
+    1  .foo {                                                    | 
+    2    grid-template-areas: "a b c" "d e f" "g h i";           | 2    grid-template-areas:
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A @ 2:2-46 |      ^^^^^^^^^^^^^^^^^^^^ A @ 2:2-5:11
+                                                                 | 3      "a b c"
+                                                                 |    ^^^^^^^^^^^ A
+                                                                 | 4      "d e f"
+                                                                 |    ^^^^^^^^^^^ A
+                                                                 | 5      "g h i";
+                                                                 |    ^^^^^^^^^^^ A
+                                                                 | 6  }
+    3  }                                                         | 
+    4                                                            | 
+    "
   `)
 
   expect(css).toMatchInlineSnapshot(`
@@ -118,9 +153,15 @@ test('declaration, custom property, single line', async () => {
   assert(ast[0].kind === 'rule')
   assert(ast[0].nodes[0].kind === 'declaration')
   expect(format(ast[0].nodes[0])).toMatchInlineSnapshot(`
-    [
-      "2:2-2:12 <- 1:7-1:17",
-    ]
+    "
+       output.css              |    input.css
+                               | 
+    1  .foo {                  | 
+    2    --foo: bar;           | 1  .foo { --foo: bar; }
+         ^^^^^^^^^^ A @ 2:2-12 |           ^^^^^^^^^^ A @ 1:7-17
+    3  }                       | 
+    4                          | 
+    "
   `)
 
   expect(css).toMatchInlineSnapshot(`
@@ -141,9 +182,18 @@ test('declaration, custom property, multi line', async () => {
   assert(ast[0].kind === 'rule')
   assert(ast[0].nodes[0].kind === 'declaration')
   expect(format(ast[0].nodes[0])).toMatchInlineSnapshot(`
-    [
-      "2:2-3:3 <- 2:2-3:3",
-    ]
+    "
+       output.css               |    input.css
+                                | 
+    1  .foo {                   | 
+    2    --foo: bar             | 2    --foo: bar
+         ^^^^^^^^^^ A @ 2:2-3:3 |      ^^^^^^^^^^ A @ 2:2-3:3
+    3  baz;                     | 3  baz;
+       ^^^ A                    |    ^^^ A
+                                | 4  }
+    4  }                        | 
+    5                           | 
+    "
   `)
 
   expect(css).toMatchInlineSnapshot(`
@@ -161,9 +211,13 @@ test('at rules, bodyless, single line', async () => {
 
   assert(ast[0].kind === 'at-rule')
   expect(format(ast[0])).toMatchInlineSnapshot(`
-    [
-      "1:0-1:15 <- 1:0-1:19",
-    ]
+    "
+       output.css                 |    input.css
+                                  | 
+    1  @layer foo, bar;           | 1  @layer foo,     bar;
+       ^^^^^^^^^^^^^^^ A @ 1:0-15 |    ^^^^^^^^^^^^^^^^^^^ A @ 1:0-19
+    2                             | 
+    "
   `)
 
   expect(css).toMatchInlineSnapshot(`
@@ -182,9 +236,17 @@ test('at rules, bodyless, multi line', async () => {
 
   assert(ast[0].kind === 'at-rule')
   expect(format(ast[0])).toMatchInlineSnapshot(`
-    [
-      "1:0-1:15 <- 1:0-4:0",
-    ]
+    "
+       output.css                 |    input.css
+                                  | 
+    1  @layer foo, bar;           | 1  @layer
+       ^^^^^^^^^^^^^^^ A @ 1:0-15 |    ^^^^^^ A @ 1:0-4:0
+                                  | 2    foo,
+                                  |    ^^^^^^ A
+                                  | 3    bar
+                                  |    ^^^^^ A
+    2                             | 
+    "
   `)
 
   expect(css).toMatchInlineSnapshot(`
@@ -198,9 +260,15 @@ test('at rules, body, single line', async () => {
 
   assert(ast[0].kind === 'at-rule')
   expect(format(ast[0])).toMatchInlineSnapshot(`
-    [
-      "1:0-1:11 <- 1:0-1:11",
-    ]
+    "
+       output.css             |    input.css
+                              | 
+    1  @layer foo {           | 1  @layer foo { color: red; }
+       ^^^^^^^^^^^ A @ 1:0-11 |    ^^^^^^^^^^^ A @ 1:0-11
+    2    color: red;          | 
+    3  }                      | 
+    4                         | 
+    "
   `)
 
   expect(css).toMatchInlineSnapshot(`
@@ -222,9 +290,17 @@ test('at rules, body, multi line', async () => {
 
   assert(ast[0].kind === 'at-rule')
   expect(format(ast[0])).toMatchInlineSnapshot(`
-    [
-      "1:0-1:11 <- 1:0-3:0",
-    ]
+    "
+       output.css             |    input.css
+                              | 
+    1  @layer foo {           | 1  @layer
+       ^^^^^^^^^^^ A @ 1:0-11 |    ^^^^^^ A @ 1:0-3:0
+                              | 2    foo
+                              |    ^^^^^ A
+    2    color: baz;          | 
+    3  }                      | 
+    4                         | 
+    "
   `)
 
   expect(css).toMatchInlineSnapshot(`
@@ -240,9 +316,15 @@ test('style rules, body, single line', async () => {
 
   assert(ast[0].kind === 'rule')
   expect(format(ast[0])).toMatchInlineSnapshot(`
-    [
-      "1:0-1:14 <- 1:0-1:14",
-    ]
+    "
+       output.css                |    input.css
+                                 | 
+    1  .foo:is(.bar) {           | 1  .foo:is(.bar) { color: red; }
+       ^^^^^^^^^^^^^^ A @ 1:0-14 |    ^^^^^^^^^^^^^^ A @ 1:0-14
+    2    color: red;             | 
+    3  }                         | 
+    4                            | 
+    "
   `)
 
   expect(css).toMatchInlineSnapshot(`
@@ -265,9 +347,19 @@ test('style rules, body, multi line', async () => {
 
   assert(ast[0].kind === 'rule')
   expect(format(ast[0])).toMatchInlineSnapshot(`
-    [
-      "1:0-1:16 <- 1:0-3:2",
-    ]
+    "
+       output.css                  |    input.css
+                                   | 
+    1  .foo:is( .bar ) {           | 1  .foo:is(
+       ^^^^^^^^^^^^^^^^ A @ 1:0-16 |    ^^^^^^^^ A @ 1:0-3:2
+                                   | 2    .bar
+                                   |    ^^^^^^ A
+                                   | 3  ) {
+                                   |    ^^ A
+    2    color: red;               | 
+    3  }                           | 
+    4                              | 
+    "
   `)
 
   expect(css).toMatchInlineSnapshot(`

--- a/packages/tailwindcss/src/source-maps/visualize-source-map.test.ts
+++ b/packages/tailwindcss/src/source-maps/visualize-source-map.test.ts
@@ -1,0 +1,261 @@
+import dedent from 'dedent'
+import { SourceMapGenerator, type RawSourceMap } from 'source-map-js'
+import { expect, test } from 'vitest'
+import { visualizeSourceMap, visualizeSourceMapRanges } from './visualize-source-map'
+
+const css = dedent
+
+function sourceMap({
+  sources,
+  mappings,
+}: {
+  sources: Record<string, string>
+  mappings: {
+    source: string
+    original: [line: number, column: number]
+    generated: [line: number, column: number]
+  }[]
+}) {
+  let generator = new SourceMapGenerator()
+
+  for (let mapping of mappings) {
+    generator.addMapping({
+      source: mapping.source,
+      original: {
+        line: mapping.original[0],
+        column: mapping.original[1],
+      },
+      generated: {
+        line: mapping.generated[0],
+        column: mapping.generated[1],
+      },
+    })
+  }
+
+  for (let [source, content] of Object.entries(sources)) {
+    generator.setSourceContent(source, content)
+  }
+
+  return JSON.parse(generator.toString()) as RawSourceMap
+}
+
+test('visualizes single-line ranges', () => {
+  expect(
+    visualizeSourceMapRanges(
+      {
+        // prettier-ignore
+        'input.css': css`.foo { color: red; }`,
+      },
+      css`
+        .foo {
+          color: red;
+        }
+      `,
+      [
+        {
+          original: {
+            source: 'input.css',
+            start: [1, 7],
+            end: [1, 17],
+          },
+          generated: {
+            start: [2, 2],
+            end: [2, 12],
+          },
+        },
+      ],
+    ),
+  ).toMatchInlineSnapshot(`
+    "
+       output.css              |    input.css
+                               | 
+    1  .foo {                  | 
+    2    color: red;           | 1  .foo { color: red; }
+         ^^^^^^^^^^ A @ 2:2-12 |           ^^^^^^^^^^ A @ 1:7-17
+    3  }                       | 
+    "
+  `)
+})
+
+test('visualizes multi-line ranges', () => {
+  expect(
+    visualizeSourceMapRanges(
+      {
+        'input.css': css`
+          /*! foo
+           bar */
+        `,
+      },
+      css`
+        /*! foo
+         bar */
+      `,
+      [
+        {
+          original: {
+            source: 'input.css',
+            start: [1, 0],
+            end: [2, 7],
+          },
+          generated: {
+            start: [1, 0],
+            end: [2, 7],
+          },
+        },
+      ],
+    ),
+  ).toMatchInlineSnapshot(`
+    "
+       output.css          |    input.css
+                           | 
+    1  /*! foo             | 1  /*! foo
+       ^^^^^^^ A @ 1:0-2:7 |    ^^^^^^^ A @ 1:0-2:7
+    2   bar */             | 2   bar */
+       ^^^^^^^ A           |    ^^^^^^^ A
+    "
+  `)
+})
+
+test('visualizes multiple sources', () => {
+  expect(
+    visualizeSourceMapRanges(
+      {
+        'utilities.css': css`
+          @tailwind utilities;
+        `,
+        'input.css': css`
+          @utility custom {
+            color: red;
+          }
+        `,
+      },
+      css`
+        .flex {
+          display: flex;
+        }
+        .custom {
+          color: red;
+        }
+      `,
+      [
+        {
+          original: {
+            source: 'utilities.css',
+            start: [1, 0],
+            end: [1, 19],
+          },
+          generated: {
+            start: [1, 0],
+            end: [1, 6],
+          },
+        },
+        {
+          original: {
+            source: 'utilities.css',
+            start: [1, 0],
+            end: [1, 19],
+          },
+          generated: {
+            start: [2, 2],
+            end: [2, 15],
+          },
+        },
+        {
+          original: {
+            source: 'input.css',
+            start: [2, 2],
+            end: [2, 12],
+          },
+          generated: {
+            start: [5, 2],
+            end: [5, 12],
+          },
+        },
+      ],
+    ),
+  ).toMatchInlineSnapshot(`
+    "
+       output.css                 |    original
+                                  | 
+                                  |    --- utilities.css ---
+    1  .flex {                    | 1  @tailwind utilities;
+       ^^^^^^ A @ 1:0-6           |    ^^^^^^^^^^^^^^^^^^^ A @ 1:0-19
+    2    display: flex;           | 
+         ^^^^^^^^^^^^^ A @ 2:2-15 | 
+    3  }                          | 
+    4  .custom {                  | 
+                                  |    --- input.css ---
+    5    color: red;              | 2    color: red;
+         ^^^^^^^^^^ B @ 5:2-12    |      ^^^^^^^^^^ B @ 2:2-12
+                                  | 3  }
+    6  }                          | 
+    "
+  `)
+})
+
+test('visualizes source-map points as generated segments', () => {
+  let generated = css`
+    /*! foo
+     bar */
+  `
+
+  expect(
+    visualizeSourceMap(
+      sourceMap({
+        sources: {
+          'input.css': css`
+            /*! foo
+             bar */
+          `,
+        },
+        mappings: [
+          { source: 'input.css', original: [1, 0], generated: [1, 0] },
+          { source: 'input.css', original: [2, 0], generated: [2, 0] },
+          { source: 'input.css', original: [2, 7], generated: [2, 7] },
+        ],
+      }),
+      generated,
+    ),
+  ).toMatchInlineSnapshot(`
+    "
+       output.css          |    input.css
+                           | 
+    1  /*! foo             | 1  /*! foo
+       ^^^^^^^ A @ 1:0-2:0 |    ^^^^^^^ A @ 1:0-2:0
+    2   bar */             | 2   bar */
+       ^^^^^^^ B @ 2:0-7   |    ^^^^^^^ B @ 2:0-7
+    "
+  `)
+})
+
+test('visualizes duplicate source-map points without hiding them', () => {
+  expect(
+    visualizeSourceMap(
+      sourceMap({
+        sources: {
+          'input.css': css`
+            aaaa
+            bbbb
+          `,
+        },
+        mappings: [
+          { source: 'input.css', original: [1, 0], generated: [1, 0] },
+          { source: 'input.css', original: [2, 0], generated: [1, 0] },
+          { source: 'input.css', original: [2, 4], generated: [1, 4] },
+        ],
+      }),
+      css`
+        bbbb
+      `,
+    ),
+  ).toMatchInlineSnapshot(`
+    "
+       output.css     |    input.css
+                      | 
+    1  bbbb           | 1  aaaa
+       ^ A @ 1:0      |    ^ A @ 1:0
+    1  bbbb           | 2  bbbb
+       ^^^^ B @ 1:0-4 |    ^^^^ B @ 2:0-4
+    "
+  `)
+})

--- a/packages/tailwindcss/src/source-maps/visualize-source-map.test.ts
+++ b/packages/tailwindcss/src/source-maps/visualize-source-map.test.ts
@@ -193,6 +193,42 @@ test('visualizes multiple sources', () => {
   `)
 })
 
+test('visualizes unmapped source ranges', () => {
+  expect(
+    visualizeSourceMapRanges(
+      {
+        // prettier-ignore
+        'input.css': css`.foo { color: red; }`,
+      },
+      css`
+        .foo {
+          color: red;
+        }
+      `,
+      [
+        {
+          original: {
+            source: 'input.css',
+            start: [1, 7],
+            end: [1, 17],
+          },
+          generated: null,
+        },
+      ],
+    ),
+  ).toMatchInlineSnapshot(`
+    "
+       output.css |    input.css
+                  | 
+       unmapped A | 1  .foo { color: red; }
+                  |           ^^^^^^^^^^ A @ 1:7-17
+    1  .foo {     | 
+    2    color... | 
+    3  }          | 
+    "
+  `)
+})
+
 test('visualizes source-map points as generated segments', () => {
   let generated = css`
     /*! foo
@@ -224,6 +260,27 @@ test('visualizes source-map points as generated segments', () => {
        ^^^^^^^ A @ 1:0-2:0 |    ^^^^^^^ A @ 1:0-2:0
     2   bar */             | 2   bar */
        ^^^^^^^ B @ 2:0-7   |    ^^^^^^^ B @ 2:0-7
+    "
+  `)
+})
+
+test('visualizes final source-map point through end of line', () => {
+  expect(
+    visualizeSourceMap(
+      sourceMap({
+        sources: {
+          'input.css': css`aaaa`,
+        },
+        mappings: [{ source: 'input.css', original: [1, 0], generated: [1, 0] }],
+      }),
+      css`aaaa`,
+    ),
+  ).toMatchInlineSnapshot(`
+    "
+       output.css       |    input.css
+                        | 
+    1  aaaa             | 1  aaaa
+       ^^^^ A @ 1:0-2:0 |    ^ A @ 1:0
     "
   `)
 })

--- a/packages/tailwindcss/src/source-maps/visualize-source-map.ts
+++ b/packages/tailwindcss/src/source-maps/visualize-source-map.ts
@@ -1,0 +1,497 @@
+import { SourceMapConsumer, type RawSourceMap } from 'source-map-js'
+
+import { DefaultMap } from '../utils/default-map'
+
+const COLUMN_WIDTH = 100
+const CONTEXT_LINES = 3
+
+type Range = { start: [number, number]; end: [number, number] }
+
+interface Annotation {
+  original: Range
+  generated: Range
+  source: string
+}
+
+interface SourceMapPoint {
+  original: [number, number]
+  generated: [number, number]
+  source: string
+}
+
+interface SourceVisualization {
+  before: string[]
+  line: string
+  marker: string
+  after: string[]
+}
+
+export interface SourceMapVisualizationRange {
+  original: Range & { source: string }
+  generated: Range | null
+}
+
+/**
+ * Render source map mappings as a side-by-side view of generated and original code.
+ *
+ * For raw source maps this renders the generated segments implied by mapping points,
+ * so duplicate points and unmapped generated lines are visible in snapshots.
+ */
+export function visualizeSourceMap(map: RawSourceMap, css: string) {
+  let smc = new SourceMapConsumer(map)
+  let sourceContents = buildSourceContents(map.sources, map.sourcesContent ?? [])
+  let points: SourceMapPoint[] = []
+
+  smc.eachMapping((mapping) => {
+    if (
+      mapping.source === null ||
+      mapping.originalLine === null ||
+      mapping.originalColumn === null
+    ) {
+      return
+    }
+
+    points.push({
+      original: [mapping.originalLine, mapping.originalColumn],
+      generated: [mapping.generatedLine, mapping.generatedColumn],
+      source: mapping.source,
+    })
+  })
+
+  return renderVisualization(sourceContents, buildAnnotationsFromSourceMapPoints(points), css)
+}
+
+export function visualizeSourceMapRanges(
+  sources: Record<string, string>,
+  generated: string,
+  ranges: SourceMapVisualizationRange[],
+) {
+  let sourceContents = buildSourceContents(Object.keys(sources), Object.values(sources))
+  let annotations: Annotation[] = []
+
+  for (let range of ranges) {
+    if (range.generated === null) continue
+
+    annotations.push({
+      generated: range.generated,
+      original: range.original,
+      source: range.original.source,
+    })
+  }
+
+  return renderVisualization(sourceContents, annotations, generated)
+}
+
+function buildSourceContents(sources: string[], contents: (string | null)[]) {
+  let result = new Map<string, string[]>()
+
+  for (let i = 0; i < sources.length; i++) {
+    let content = contents[i]
+
+    if (content === undefined || content === null) continue
+
+    result.set(sources[i], content.split('\n'))
+  }
+
+  return result
+}
+
+function buildAnnotationsFromSourceMapPoints(points: SourceMapPoint[]) {
+  let annotations: Annotation[] = []
+  let current: Annotation | null = null
+
+  function finish(next: SourceMapPoint | null) {
+    if (current === null) return
+
+    if (
+      samePosition(current.generated.start, current.generated.end) &&
+      next !== null &&
+      next.generated[0] > current.generated.start[0]
+    ) {
+      current.generated.end = [current.generated.start[0] + 1, 0]
+
+      if (
+        next.source === current.source &&
+        next.generated[0] === current.generated.start[0] + 1 &&
+        next.generated[1] === 0 &&
+        next.original[0] === current.original.start[0] + 1 &&
+        next.original[1] === 0
+      ) {
+        current.original.end = next.original
+      }
+    }
+
+    annotations.push(current)
+    current = null
+  }
+
+  for (let point of points) {
+    if (
+      current !== null &&
+      current.source === point.source &&
+      current.generated.start[0] === point.generated[0] &&
+      point.generated[1] > current.generated.end[1] &&
+      comparePosition(current.original.start, point.original) <= 0
+    ) {
+      current.generated.end = point.generated
+      current.original.end = point.original
+      continue
+    }
+
+    finish(point)
+
+    current = {
+      original: {
+        start: point.original,
+        end: point.original,
+      },
+      generated: {
+        start: point.generated,
+        end: point.generated,
+      },
+      source: point.source,
+    }
+  }
+
+  finish(null)
+
+  return annotations
+}
+
+function renderVisualization(
+  sourceContents: Map<string, string[]>,
+  annotationsList: Annotation[],
+  generated: string,
+) {
+  let generatedLines = generated.split('\n')
+  let nextLabelIdx = 0
+  let labelsBySource = new DefaultMap<string, string>(() => annotationLabel(nextLabelIdx++))
+  let labels = annotationsList.map((annotation) => {
+    return labelsBySource.get(sourceKey(annotation.source, annotation.original))
+  })
+  let generatedLineWidth = String(generatedLines.length).length
+  let sourceLineWidth = Math.max(
+    1,
+    ...Array.from(sourceContents.values(), (lines) => String(lines.length).length),
+  )
+  let leftWidth = Math.min(
+    100,
+    Math.max(
+      withLineNumber(generatedLineWidth, 'output.css').length,
+      ...annotationsList.map((annotation, idx) => {
+        let label = labels[idx]
+        let line = withLineNumber(
+          generatedLineWidth,
+          generatedLines[annotation.generated.start[0] - 1] ?? '',
+          annotation.generated.start[0],
+        )
+        let marker = withoutLineNumber(
+          generatedLineWidth,
+          visualizeRange(
+            annotation.generated,
+            label,
+            generatedLines[annotation.generated.start[0] - 1] ?? '',
+          ),
+        )
+        let after = visualizeGeneratedRangeContinuation(
+          generatedLines,
+          generatedLineWidth,
+          annotation.generated,
+          label,
+        )
+
+        return Math.max(line.length, marker.length, ...after.map((line) => line.length))
+      }),
+    ),
+  )
+  let sources = new Set(annotationsList.map((annotation) => annotation.source))
+  let sourceHeader = sources.size === 1 ? (annotationsList[0]?.source ?? 'original') : 'original'
+  let result: string[] = []
+
+  function add(left: string, right: string) {
+    result.push(sideBySide(left, right, leftWidth))
+  }
+
+  add(
+    withLineNumber(generatedLineWidth, 'output.css'),
+    withLineNumber(sourceLineWidth, sourceHeader),
+  )
+  add(withoutLineNumber(generatedLineWidth, ''), withoutLineNumber(sourceLineWidth, ''))
+
+  let lastLine = 0
+  let lastSourceLine = new Map<string, number>()
+  let lastSource: string | null = null
+  let renderedSources = new Set<string>()
+
+  for (let idx = 0; idx < annotationsList.length; idx++) {
+    let annotation = annotationsList[idx]
+    let lineNumber = annotation.generated.start[0]
+
+    for (let i = lastLine + 1; i < lineNumber; i++) {
+      add(
+        withLineNumber(generatedLineWidth, generatedLines[i - 1] ?? '', i),
+        withoutLineNumber(sourceLineWidth, ''),
+      )
+    }
+
+    let label = labels[idx]
+    let endLine = coveredEndLine(annotation.generated)
+    let generatedAfter = visualizeGeneratedRangeContinuation(
+      generatedLines,
+      generatedLineWidth,
+      annotation.generated,
+      label,
+    )
+    let source = visualizeSource(
+      sourceContents,
+      lastSourceLine,
+      renderedSources,
+      sourceLineWidth,
+      annotation.source,
+      annotation.original,
+      label,
+    )
+
+    if (sources.size > 1 && source.line !== '' && annotation.source !== lastSource) {
+      add(
+        withoutLineNumber(generatedLineWidth, ''),
+        withoutLineNumber(sourceLineWidth, `--- ${annotation.source} ---`),
+      )
+      lastSource = annotation.source
+    }
+
+    for (let line of source.before) {
+      add(withoutLineNumber(generatedLineWidth, ''), line)
+    }
+
+    add(
+      withLineNumber(generatedLineWidth, generatedLines[lineNumber - 1] ?? '', lineNumber),
+      source.line,
+    )
+    add(
+      withoutLineNumber(
+        generatedLineWidth,
+        visualizeRange(annotation.generated, label, generatedLines[lineNumber - 1] ?? ''),
+      ),
+      source.marker,
+    )
+
+    for (let i = 0; i < Math.max(generatedAfter.length, source.after.length); i++) {
+      add(generatedAfter[i] ?? withoutLineNumber(generatedLineWidth, ''), source.after[i] ?? '')
+    }
+
+    lastLine = endLine
+  }
+
+  for (let i = lastLine + 1; i <= generatedLines.length; i++) {
+    add(
+      withLineNumber(generatedLineWidth, generatedLines[i - 1] ?? '', i),
+      withoutLineNumber(sourceLineWidth, ''),
+    )
+  }
+
+  return `\n${result.join('\n')}\n`
+}
+
+function sideBySide(left: string, right: string, leftWidth: number) {
+  return `${fitColumn(left, leftWidth)} | ${fitColumn(right, COLUMN_WIDTH, false)}`
+}
+
+function withLineNumber(width: number, value: string, line?: number) {
+  return `${line === undefined ? ' '.repeat(width) : String(line).padStart(width)}  ${value}`
+}
+
+function withoutLineNumber(width: number, value: string) {
+  if (value === '') return ''
+
+  return `${' '.repeat(width)}  ${value}`
+}
+
+function fitColumn(value: string, width: number, pad = true) {
+  if (value.length <= width) {
+    return pad ? value.padEnd(width) : value
+  }
+
+  let markerIdx = value.indexOf(' @ ')
+
+  if (markerIdx !== -1) {
+    let labelIdx = value.lastIndexOf(' ', markerIdx - 1) + 1
+    let suffix = value.slice(labelIdx)
+    let prefixWidth = width - suffix.length - 4
+
+    if (prefixWidth > 0) {
+      let result = `${value.slice(0, prefixWidth)}... ${suffix}`
+
+      return pad ? result.padEnd(width) : result
+    }
+  }
+
+  return `${value.slice(0, width - 3)}...`
+}
+
+function annotationLabel(idx: number) {
+  let label = ''
+
+  for (let current = idx; current >= 0; current = Math.floor(current / 26) - 1) {
+    label = String.fromCharCode(65 + (current % 26)) + label
+  }
+
+  return label
+}
+
+function visualizeRange(range: Range, label: string, line?: string) {
+  let start = range.start[1]
+  let width = (() => {
+    if (line !== undefined && range.start[0] !== range.end[0]) {
+      return Math.max(1, line.length - start)
+    }
+
+    return Math.max(1, range.end[1] - start)
+  })()
+  return `${' '.repeat(start)}${'^'.repeat(width)} ${label} @ ${formatRange(range)}`
+}
+
+function visualizeSource(
+  sourceContents: Map<string, string[]>,
+  lastSourceLine: Map<string, number>,
+  renderedSources: Set<string>,
+  sourceLineWidth: number,
+  source: string,
+  range: Range,
+  label: string,
+): SourceVisualization {
+  let lines = sourceContents.get(source)
+
+  if (lines === undefined) return { before: [], line: '', marker: '', after: [] }
+
+  let startLine = range.start[0]
+  let line = lines[startLine - 1]
+
+  if (line === undefined) return { before: [], line: '', marker: '', after: [] }
+
+  let before: string[] = []
+  let lastLine = lastSourceLine.get(source) ?? 0
+
+  if (lastLine > 0 && startLine > lastLine && startLine - lastLine <= CONTEXT_LINES + 1) {
+    for (let i = lastLine + 1; i < startLine; i++) {
+      let line = lines[i - 1] ?? ''
+
+      if (line.trim() === '') continue
+
+      before.push(withLineNumber(sourceLineWidth, line, i))
+    }
+  }
+
+  let key = sourceKey(source, range)
+
+  if (renderedSources.has(key)) {
+    lastSourceLine.set(source, Math.max(lastLine, startLine))
+
+    return { before: [], line: '', marker: '', after: [] }
+  }
+
+  renderedSources.add(key)
+
+  let endLine = coveredEndLine(range)
+  let after = visualizeSourceRangeContinuation(lines, sourceLineWidth, range, label)
+
+  if (startLine > lastLine) {
+    for (let i = endLine + 1; i <= Math.min(endLine + CONTEXT_LINES, lines.length); i++) {
+      let line = lines[i - 1]
+
+      if (line?.trim() !== '}') break
+
+      after.push(withLineNumber(sourceLineWidth, line, i))
+      endLine = i
+    }
+  }
+
+  lastSourceLine.set(source, Math.max(lastLine, endLine))
+
+  return {
+    before,
+    line: withLineNumber(sourceLineWidth, line, startLine),
+    marker: withoutLineNumber(sourceLineWidth, visualizeRange(range, label, line)),
+    after,
+  }
+}
+
+function visualizeSourceRangeContinuation(
+  lines: string[],
+  sourceLineWidth: number,
+  range: Range,
+  label: string,
+) {
+  let result: string[] = []
+
+  for (let i = range.start[0] + 1; i <= coveredEndLine(range); i++) {
+    let line = lines[i - 1] ?? ''
+
+    result.push(withLineNumber(sourceLineWidth, line, i))
+    result.push(
+      withoutLineNumber(sourceLineWidth, visualizeContinuationRange(range, label, line, i)),
+    )
+  }
+
+  return result
+}
+
+function visualizeGeneratedRangeContinuation(
+  lines: string[],
+  generatedLineWidth: number,
+  range: Range,
+  label: string,
+) {
+  let result: string[] = []
+
+  for (let i = range.start[0] + 1; i <= coveredEndLine(range); i++) {
+    let line = lines[i - 1] ?? ''
+
+    result.push(withLineNumber(generatedLineWidth, line, i))
+    result.push(
+      withoutLineNumber(generatedLineWidth, visualizeContinuationRange(range, label, line, i)),
+    )
+  }
+
+  return result
+}
+
+function coveredEndLine(range: Range) {
+  if (range.start[0] !== range.end[0] && range.end[1] === 0) {
+    return range.end[0] - 1
+  }
+
+  return range.end[0]
+}
+
+function visualizeContinuationRange(range: Range, label: string, line: string, lineNumber: number) {
+  let start = lineNumber === range.start[0] ? range.start[1] : 0
+  let end = lineNumber === range.end[0] ? range.end[1] : line.length
+  let width = Math.max(1, end - start)
+
+  return `${' '.repeat(start)}${'^'.repeat(width)} ${label}`
+}
+
+function sourceKey(source: string, range: Range) {
+  return `${source}:${range.start[0]}:${range.start[1]}:${range.end[0]}:${range.end[1]}`
+}
+
+function samePosition(a: [number, number], b: [number, number]) {
+  return a[0] === b[0] && a[1] === b[1]
+}
+
+function comparePosition(a: [number, number], b: [number, number]) {
+  return a[0] - b[0] || a[1] - b[1]
+}
+
+function formatRange(range: Range): string {
+  if (range.start[0] === range.end[0]) {
+    if (range.start[1] === range.end[1]) {
+      return `${range.start[0]}:${range.start[1]}`
+    }
+
+    return `${range.start[0]}:${range.start[1]}-${range.end[1]}`
+  }
+
+  return `${range.start[0]}:${range.start[1]}-${range.end[0]}:${range.end[1]}`
+}

--- a/packages/tailwindcss/src/source-maps/visualize-source-map.ts
+++ b/packages/tailwindcss/src/source-maps/visualize-source-map.ts
@@ -9,8 +9,12 @@ type Range = { start: [number, number]; end: [number, number] }
 
 interface Annotation {
   original: Range
-  generated: Range
+  generated: Range | null
   source: string
+}
+
+interface MappedAnnotation extends Annotation {
+  generated: Range
 }
 
 interface SourceMapPoint {
@@ -70,8 +74,6 @@ export function visualizeSourceMapRanges(
   let annotations: Annotation[] = []
 
   for (let range of ranges) {
-    if (range.generated === null) continue
-
     annotations.push({
       generated: range.generated,
       original: range.original,
@@ -98,26 +100,26 @@ function buildSourceContents(sources: string[], contents: (string | null)[]) {
 
 function buildAnnotationsFromSourceMapPoints(points: SourceMapPoint[]) {
   let annotations: Annotation[] = []
-  let current: Annotation | null = null
+  let current: MappedAnnotation | null = null
 
   function finish(next: SourceMapPoint | null) {
     if (current === null) return
 
-    if (
-      samePosition(current.generated.start, current.generated.end) &&
-      next !== null &&
-      next.generated[0] > current.generated.start[0]
-    ) {
-      current.generated.end = [current.generated.start[0] + 1, 0]
+    if (samePosition(current.generated.start, current.generated.end)) {
+      if (next === null) {
+        current.generated.end = [current.generated.start[0] + 1, 0]
+      } else if (next.generated[0] > current.generated.start[0]) {
+        current.generated.end = [current.generated.start[0] + 1, 0]
 
-      if (
-        next.source === current.source &&
-        next.generated[0] === current.generated.start[0] + 1 &&
-        next.generated[1] === 0 &&
-        next.original[0] === current.original.start[0] + 1 &&
-        next.original[1] === 0
-      ) {
-        current.original.end = next.original
+        if (
+          next.source === current.source &&
+          next.generated[0] === current.generated.start[0] + 1 &&
+          next.generated[1] === 0 &&
+          next.original[0] === current.original.start[0] + 1 &&
+          next.original[1] === 0
+        ) {
+          current.original.end = next.original
+        }
       }
     }
 
@@ -180,6 +182,11 @@ function renderVisualization(
       withLineNumber(generatedLineWidth, 'output.css').length,
       ...annotationsList.map((annotation, idx) => {
         let label = labels[idx]
+
+        if (annotation.generated === null) {
+          return withoutLineNumber(generatedLineWidth, `unmapped ${label}`).length
+        }
+
         let line = withLineNumber(
           generatedLineWidth,
           generatedLines[annotation.generated.start[0] - 1] ?? '',
@@ -225,6 +232,41 @@ function renderVisualization(
 
   for (let idx = 0; idx < annotationsList.length; idx++) {
     let annotation = annotationsList[idx]
+    let label = labels[idx]
+
+    if (annotation.generated === null) {
+      let source = visualizeSource(
+        sourceContents,
+        lastSourceLine,
+        renderedSources,
+        sourceLineWidth,
+        annotation.source,
+        annotation.original,
+        label,
+      )
+
+      if (sources.size > 1 && source.line !== '' && annotation.source !== lastSource) {
+        add(
+          withoutLineNumber(generatedLineWidth, ''),
+          withoutLineNumber(sourceLineWidth, `--- ${annotation.source} ---`),
+        )
+        lastSource = annotation.source
+      }
+
+      for (let line of source.before) {
+        add(withoutLineNumber(generatedLineWidth, ''), line)
+      }
+
+      add(withoutLineNumber(generatedLineWidth, `unmapped ${label}`), source.line)
+      add(withoutLineNumber(generatedLineWidth, ''), source.marker)
+
+      for (let line of source.after) {
+        add(withoutLineNumber(generatedLineWidth, ''), line)
+      }
+
+      continue
+    }
+
     let lineNumber = annotation.generated.start[0]
 
     for (let i = lastLine + 1; i < lineNumber; i++) {
@@ -234,7 +276,6 @@ function renderVisualization(
       )
     }
 
-    let label = labels[idx]
     let endLine = coveredEndLine(annotation.generated)
     let generatedAfter = visualizeGeneratedRangeContinuation(
       generatedLines,


### PR DESCRIPTION
This PR is an internal change only related to how we visualize source maps. 

As part of this PR (https://github.com/tailwindlabs/tailwindcss/pull/19996) I added a test for source maps related to how `@variant` is processed. And while the result was correct, I had a hard time verifying if this was _actually_ correct. I did the mental mapping of comparing locations from the output to the input.
<img width="495" height="495" alt="image" src="https://github.com/user-attachments/assets/2b1c12cd-43ee-461a-b93b-bafe6ce1cce5" />

With this PR, I want to make that more visual by actually printing the input source(s) and output file and highlight the necessary parts:
<img width="1101" height="1085" alt="image" src="https://github.com/user-attachments/assets/14390026-f211-4cfc-8c6c-3293105f6403" />

I didn't want to get too clever here. But printing line numbers also helps in case we point to different spots on the same line:
<img width="1200" height="981" alt="image" src="https://github.com/user-attachments/assets/e75f7622-eb51-49ee-928e-fdc8672d2c3f" />

And if we point to different files, then we visualize these as well:
<img width="851" height="957" alt="image" src="https://github.com/user-attachments/assets/77e65801-b46b-4579-8659-d919a8750f60" />


If you combine this with snapshot tests, then it's very easy to verify that locations match up correctly. Each source map location is highlighted and references a symbol starting at `A`, `B`, etc.

A change to the source maps _can_ result in a big diff, and even this PR introduces a big diff because of the preflight diffs. But at least you can see how things line up.

## Test plan

1. All tests still pass
2. Added tests for the source map visualizer that is only used in tests
3. No actual source code was touched
