### PR TITLE
docs(postcss): add missing node:path import in base option example

### DIFF
--- a/packages/@tailwindcss-postcss/README.md
+++ b/packages/@tailwindcss-postcss/README.md
@@ -44,8 +44,11 @@ If you're interested in contributing to Tailwind CSS, please read our [contribut
 You can use the `base` option (defaults to the current working directory) to change the directory in which the plugin searches for source files:
 
 ```js
+import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import tailwindcss from '@tailwindcss/postcss'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default {
   plugins: [

--- a/packages/@tailwindcss-postcss/README.md
+++ b/packages/@tailwindcss-postcss/README.md
@@ -44,6 +44,7 @@ If you're interested in contributing to Tailwind CSS, please read our [contribut
 You can use the `base` option (defaults to the current working directory) to change the directory in which the plugin searches for source files:
 
 ```js
+import path from 'node:path'
 import tailwindcss from '@tailwindcss/postcss'
 
 export default {


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create a discussion to first discuss any significant new features.

For more info, check out the contributing guide:

https://github.com/tailwindlabs/tailwindcss/blob/main/.github/CONTRIBUTING.md

-->

## Summary
Adds missing import path from 'node:path' to the PostCSS README base option example so the snippet is copy-paste runnable and doesn’t reference an undefined path
<!--

Provide a summary of the issue and the changes you're making. How does your change solve the problem?

-->

## Test plan
Check README snippet includes import path from 'node:path' before path.resolve(...).
<!--

Explain how you tested your changes. Include the exact commands that you used to verify the change works and include screenshots/screen recordings of the update behavior in the browser if applicable.

-->
