### PR TITLE
Cleanup noisy test output

### DIFF
--- a/packages/@tailwindcss-node/package.json
+++ b/packages/@tailwindcss-node/package.json
@@ -19,21 +19,37 @@
   ],
   "publishConfig": {
     "provenance": true,
-    "access": "public"
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.js"
+      },
+      "./require-cache": {
+        "types": "./dist/require-cache.d.ts",
+        "default": "./dist/require-cache.js"
+      },
+      "./esm-cache-loader": {
+        "types": "./dist/esm-cache.loader.d.mts",
+        "default": "./dist/esm-cache.loader.mjs"
+      }
+    }
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "require": "./src/index.cts"
     },
     "./require-cache": {
-      "types": "./dist/require-cache.d.ts",
-      "default": "./dist/require-cache.js"
+      "types": "./src/require-cache.ts",
+      "import": "./src/require-cache.ts",
+      "require": "./src/require-cache.cts"
     },
     "./esm-cache-loader": {
-      "types": "./dist/esm-cache.loader.d.mts",
-      "default": "./dist/esm-cache.loader.mjs"
+      "types": "./src/esm-cache.loader.mts",
+      "default": "./src/esm-cache.loader.mts"
     }
   },
   "dependencies": {

--- a/packages/@tailwindcss-node/src/require-cache.ts
+++ b/packages/@tailwindcss-node/src/require-cache.ts
@@ -1,0 +1,5 @@
+export function clearRequireCache(files: string[]) {
+  for (let key of files) {
+    delete require.cache[key]
+  }
+}

--- a/packages/@tailwindcss-postcss/src/index.test.ts
+++ b/packages/@tailwindcss-postcss/src/index.test.ts
@@ -146,6 +146,8 @@ describe('processing without specifying a base path', () => {
 })
 
 test('fallback to `base` directory when `result.opts.from` is not provided', async () => {
+  using _ = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
   let processor = postcss([
     tailwindcss({ base: `${__dirname}/fixtures/example-project`, optimize: { minify: false } }),
   ])

--- a/packages/tailwindcss/src/utilities.test.ts
+++ b/packages/tailwindcss/src/utilities.test.ts
@@ -30148,6 +30148,7 @@ describe('custom utilities', () => {
     })
 
     test('resolving unsupported bare values', async () => {
+      using spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       let input = css`
         @utility tab-* {
           tab-size: --value(color);
@@ -30157,6 +30158,22 @@ describe('custom utilities', () => {
       `
 
       expect(await compileCss(input, ['tab-#0088cc', 'tab-foo'])).toEqual('')
+      expect(
+        `\n${spy.mock.calls
+          .map((c) => c.join(' '))
+          .join('\n')
+          .trim()}\n`,
+      ).toMatchInlineSnapshot(`
+        "
+        Unsupported bare value data type: "color".
+        Only valid data types are: "number", "integer", "ratio", "percentage".
+
+        \`\`\`css
+        --value(color)
+                ^^^^^
+        \`\`\`
+        "
+      `)
     })
 
     test('resolving arbitrary values', async () => {


### PR DESCRIPTION
This PR cleans up the noisy test output where some `console.warn` messages were leaking into the test output.

This also uses the `src/` files instead of the `dist/` files of `@tailwindcss/node` to get rid of a source map related warning in tests. It also means that we don't have to rebuild `@tailwindcss/node` when we make changes.

## Test plan

1. Existing tests pass
2. Output is clean when running tests (`vitest run --reporter=minimal`)

Before:
<img width="1193" height="1376" alt="image" src="https://github.com/user-attachments/assets/9aceab62-cd99-4391-9734-0ae5c4c3fb48" />

After:
<img width="1099" height="294" alt="image" src="https://github.com/user-attachments/assets/3ada4a0a-8a7a-48a7-9fbd-f3d5dd8700a5" />

