### PR TITLE
fix(node): prefer Module#registerHooks over Module#register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet!
+### Fixed
+
+- Remove deprecation warnings by using `Module#registerHooks` instead of `Module#register` on Node 26+ ([#20028](https://github.com/tailwindlabs/tailwindcss/pull/20028))
 
 ## [4.3.0] - 2026-05-08
 

--- a/packages/@tailwindcss-node/package.json
+++ b/packages/@tailwindcss-node/package.json
@@ -29,6 +29,10 @@
       "./require-cache": {
         "types": "./dist/require-cache.d.ts",
         "default": "./dist/require-cache.js"
+      },
+      "./esm-cache-loader": {
+        "types": "./dist/esm-cache.loader.d.mts",
+        "default": "./dist/esm-cache.loader.mjs"
       }
     }
   },
@@ -42,6 +46,10 @@
       "types": "./src/require-cache.ts",
       "import": "./src/require-cache.ts",
       "require": "./src/require-cache.cts"
+    },
+    "./esm-cache-loader": {
+      "types": "./src/esm-cache.loader.mts",
+      "default": "./src/esm-cache.loader.mts"
     }
   },
   "dependencies": {

--- a/packages/@tailwindcss-node/package.json
+++ b/packages/@tailwindcss-node/package.json
@@ -29,10 +29,6 @@
       "./require-cache": {
         "types": "./dist/require-cache.d.ts",
         "default": "./dist/require-cache.js"
-      },
-      "./esm-cache-loader": {
-        "types": "./dist/esm-cache.loader.d.mts",
-        "default": "./dist/esm-cache.loader.mjs"
       }
     }
   },
@@ -46,10 +42,6 @@
       "types": "./src/require-cache.ts",
       "import": "./src/require-cache.ts",
       "require": "./src/require-cache.cts"
-    },
-    "./esm-cache-loader": {
-      "types": "./src/esm-cache.loader.mts",
-      "default": "./src/esm-cache.loader.mts"
     }
   },
   "dependencies": {

--- a/packages/@tailwindcss-node/src/esm-cache.loader.mts
+++ b/packages/@tailwindcss-node/src/esm-cache.loader.mts
@@ -1,22 +1,36 @@
-import { isBuiltin, type ResolveHook } from 'node:module'
+import {
+  isBuiltin,
+  type ResolveFnOutput,
+  type ResolveHook,
+  type ResolveHookContext,
+  type ResolveHookSync,
+} from 'node:module'
 
 export let resolve: ResolveHook = async (specifier, context, nextResolve) => {
   let result = await nextResolve(specifier, context)
+  return processResolve(context, result)
+}
 
-  if (result.url === import.meta.url) return result
-  if (isBuiltin(result.url)) return result
-  if (!context.parentURL) return result
+export let resolveSync: ResolveHookSync = (specifier, context, nextResolve) => {
+  let result = nextResolve(specifier, context)
+  return processResolve(context, result)
+}
+
+function processResolve(context: ResolveHookContext, resolve: ResolveFnOutput) {
+  if (resolve.url === import.meta.url) return resolve
+  if (isBuiltin(resolve.url)) return resolve
+  if (!context.parentURL) return resolve
 
   let parent = new URL(context.parentURL)
 
   let id = parent.searchParams.get('id')
-  if (id === null) return result
+  if (id === null) return resolve
 
-  let url = new URL(result.url)
+  let url = new URL(resolve.url)
   url.searchParams.set('id', id)
 
   return {
-    ...result,
+    ...resolve,
     url: `${url}`,
   }
 }

--- a/packages/@tailwindcss-node/src/esm-cache.loader.mts
+++ b/packages/@tailwindcss-node/src/esm-cache.loader.mts
@@ -16,21 +16,21 @@ export let resolveSync: ResolveHookSync = (specifier, context, nextResolve) => {
   return processResolve(context, result)
 }
 
-function processResolve(context: ResolveHookContext, resolve: ResolveFnOutput) {
-  if (resolve.url === import.meta.url) return resolve
-  if (isBuiltin(resolve.url)) return resolve
-  if (!context.parentURL) return resolve
+function processResolve(context: ResolveHookContext, result: ResolveFnOutput) {
+  if (result.url === import.meta.url) return result
+  if (isBuiltin(result.url)) return result
+  if (!context.parentURL) return result
 
   let parent = new URL(context.parentURL)
 
   let id = parent.searchParams.get('id')
-  if (id === null) return resolve
+  if (id === null) return result
 
-  let url = new URL(resolve.url)
+  let url = new URL(result.url)
   url.searchParams.set('id', id)
 
   return {
-    ...resolve,
+    ...result,
     url: `${url}`,
   }
 }

--- a/packages/@tailwindcss-node/src/index.cts
+++ b/packages/@tailwindcss-node/src/index.cts
@@ -21,6 +21,6 @@ if (!process.versions.bun) {
   if (Module.registerHooks) {
     Module.registerHooks({ resolve: resolveSync })
   } else {
-    Module.register?.('./esm-cache.loader.mjs', pathToFileURL(__filename))
+    Module.register?.(pathToFileURL(require.resolve('@tailwindcss/node/esm-cache-loader')))
   }
 }

--- a/packages/@tailwindcss-node/src/index.cts
+++ b/packages/@tailwindcss-node/src/index.cts
@@ -1,6 +1,7 @@
 import * as Module from 'node:module'
 import { pathToFileURL } from 'node:url'
 import * as env from './env'
+import { resolveSync } from './esm-cache.loader.mjs'
 export * from './compile'
 export * from './instrumentation'
 export * from './normalize-path'
@@ -12,8 +13,14 @@ export { env }
 // not necessary.
 if (!process.versions.bun) {
   // `Module#register` was added in Node v18.19.0 and v20.6.0
+  // `Module#registerHooks` was added in Node v22.15.0 and v23.5.0 and is the preferred API since v25.9.0,
+  // runtime-deprecating `Module#register` since v26
   //
   // Not calling it means that while ESM dependencies don't get reloaded, the
   // actual included files will because they cache bust directly via `?id=…`
-  Module.register?.(pathToFileURL(require.resolve('@tailwindcss/node/esm-cache-loader')))
+  if (Module.registerHooks) {
+    Module.registerHooks({ resolve: resolveSync })
+  } else {
+    Module.register?.('./esm-cache.loader.mjs', pathToFileURL(__filename))
+  }
 }

--- a/packages/@tailwindcss-node/src/index.ts
+++ b/packages/@tailwindcss-node/src/index.ts
@@ -1,4 +1,5 @@
 import * as Module from 'node:module'
+import { pathToFileURL } from 'node:url'
 import * as env from './env'
 import { resolveSync } from './esm-cache.loader.mjs'
 export * from './compile'
@@ -11,6 +12,8 @@ export { env }
 // In Bun, ESM modules will also populate `require.cache`, so the module hook is
 // not necessary.
 if (!process.versions.bun) {
+  let localRequire = Module.createRequire(import.meta.url)
+
   // `Module#register` was added in Node v18.19.0 and v20.6.0
   // `Module#registerHooks` was added in Node v22.15.0 and v23.5.0 and is the preferred API since v25.9.0,
   // runtime-deprecating `Module#register` since v26
@@ -20,6 +23,6 @@ if (!process.versions.bun) {
   if (Module.registerHooks) {
     Module.registerHooks({ resolve: resolveSync })
   } else {
-    Module.register?.('./esm-cache.loader.mjs', import.meta.url)
+    Module.register?.(pathToFileURL(localRequire.resolve('@tailwindcss/node/esm-cache-loader')))
   }
 }

--- a/packages/@tailwindcss-node/src/index.ts
+++ b/packages/@tailwindcss-node/src/index.ts
@@ -1,6 +1,6 @@
 import * as Module from 'node:module'
-import { pathToFileURL } from 'node:url'
 import * as env from './env'
+import { resolveSync } from './esm-cache.loader.mjs'
 export * from './compile'
 export * from './instrumentation'
 export * from './normalize-path'
@@ -11,11 +11,15 @@ export { env }
 // In Bun, ESM modules will also populate `require.cache`, so the module hook is
 // not necessary.
 if (!process.versions.bun) {
-  let localRequire = Module.createRequire(import.meta.url)
-
   // `Module#register` was added in Node v18.19.0 and v20.6.0
+  // `Module#registerHooks` was added in Node v22.15.0 and v23.5.0 and is the preferred API since v25.9.0,
+  // runtime-deprecating `Module#register` since v26
   //
   // Not calling it means that while ESM dependencies don't get reloaded, the
   // actual included files will because they cache bust directly via `?id=…`
-  Module.register?.(pathToFileURL(localRequire.resolve('@tailwindcss/node/esm-cache-loader')))
+  if (Module.registerHooks) {
+    Module.registerHooks({ resolve: resolveSync })
+  } else {
+    Module.register?.('./esm-cache.loader.mjs', import.meta.url)
+  }
 }


### PR DESCRIPTION
<!--

👋 Hey, thanks for your interest in contributing to Tailwind!

**Please ask first before starting work on any significant new features.**

It's never a fun experience to have your pull request declined after investing a lot of time and effort into a new feature. To avoid this from happening, we request that contributors create a discussion to first discuss any significant new features.

For more info, check out the contributing guide:

https://github.com/tailwindlabs/tailwindcss/blob/main/.github/CONTRIBUTING.md

-->

## Summary

<!--

Provide a summary of the issue and the changes you're making. How does your change solve the problem?

-->

Fix this warning when building apps with TailwindCSS with Node 26+:
```
(node:25346) [DEP0205] DeprecationWarning: `module.register()` is deprecated. Use `module.registerHooks()` instead.
    at node:internal/util:129:11
    at Module.register (node:internal/modules/esm/loader:969:3)
    at file:///Users/antoine/Developer/my-app/node_modules/.pnpm/@tailwindcss+node@4.3.0/node_modules/@tailwindcss/node/dist/index.mjs:18:214
    at ...
```

This PR:
- Correctly prefers using `Module#registerHooks` instead of `Module#register` by checking its availability at runtime
- Adjusts the exports of the hooks’ file by creating a synchronous version for the new API
- Remove now unused exports from the `package.json`, relying on the [recommended usage in the docs](https://nodejs.org/docs/latest/api/module.html#registration-of-asynchronous-customization-hooks) for the `Module#register` calls

## Test plan

<!--

Explain how you tested your changes. Include the exact commands that you used to verify the change works and include screenshots/screen recordings of the update behavior in the browser if applicable.

-->

I'd be happy to ensure this works correctly on my end before merging this, but it's not as trivial to test locally as a logic fix. Can you guide me through what I need to do to test this?

I extensively based my change on the docs, following those guides:
- [Fixing imports for `Module#register`](https://nodejs.org/docs/latest/api/module.html#registration-of-asynchronous-customization-hooks)
- [Using the new `Module#registerHooks` function](https://nodejs.org/docs/latest/api/module.html#registration-of-synchronous-customization-hooks)

(and other more detailed sections of the same docs page)

---

Fixes #19893
Closes #19907