### PR TITLE
fix(scanner): include explicit vendor sources

### DIFF
--- a/crates/oxide/src/scanner/fixtures/ignored-content-dirs.txt
+++ b/crates/oxide/src/scanner/fixtures/ignored-content-dirs.txt
@@ -12,4 +12,5 @@
 .yarn
 __pycache__
 node_modules
+vendor
 venv

--- a/crates/oxide/tests/scanner.rs
+++ b/crates/oxide/tests/scanner.rs
@@ -1475,6 +1475,44 @@ mod scanner {
     }
 
     #[test]
+    fn test_allow_explicit_vendor_paths() {
+        let dir = tempdir().unwrap().into_path();
+
+        create_files_in(
+            &dir,
+            &[
+                (
+                    ".gitignore",
+                    "*\n!/app\n!/app/design/**",
+                ),
+                (
+                    "app/design/index.html",
+                    "content-['app/design/index.html']",
+                ),
+                (
+                    "vendor/acme/theme/index.html",
+                    "content-['vendor/acme/theme/index.html']",
+                ),
+            ],
+        );
+
+        let sources = vec![
+            public_source_entry_from_pattern(dir.clone(), "@source './app/design'"),
+            public_source_entry_from_pattern(dir.clone(), "@source './vendor/acme/theme'"),
+        ];
+
+        let candidates = Scanner::new(sources).scan();
+
+        assert_eq!(
+            candidates,
+            vec![
+                "content-['app/design/index.html']",
+                "content-['vendor/acme/theme/index.html']",
+            ]
+        );
+    }
+
+    #[test]
     fn test_ignore_node_modules_without_gitignore() {
         let ScanResult {
             candidates,


### PR DESCRIPTION
Fixes #19844.

Treat `vendor` as a default ignored content directory so explicit `@source` roots under vendor trees are scanned consistently, even when a repo uses an allow-list .gitignore.

Added a scanner test covering an allow-list .gitignore and an explicit vendor source root.

Verification: git diff --check. Rust test execution wasn't available in this environment because cargo isn't installed.